### PR TITLE
[PURIFY] Add InferenceConfig to org.elasticsearch.client.analytics

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/analytics/InferenceConfig.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/analytics/InferenceConfig.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.client.analytics;
+
+import org.elasticsearch.common.xcontent.ToXContentObject;
+
+public interface InferenceConfig extends ToXContentObject {
+    /**
+     * @return The name of the XContentObject that is to be serialized
+     */
+    String getName();
+}

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/analytics/InferencePipelineAggregationBuilder.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/analytics/InferencePipelineAggregationBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.client.analytics;
 
-import org.elasticsearch.client.ml.inference.trainedmodel.InferenceConfig;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;


### PR DESCRIPTION
This commits adds InferenceConfig back to org.elasticsearch.client.analytics for use in InferencePipelineAggregationBuilder.