### PR TITLE
[PURIFY] remove all trace of x-pack monitoring

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
@@ -51,38 +51,4 @@ public class PingAndInfoIT extends ESRestHighLevelClientTestCase {
         assertTrue(versionMap.get("number").toString().startsWith(info.getVersion().getNumber()));
         assertEquals(versionMap.get("lucene_version"), info.getVersion().getLuceneVersion());
     }
-
-    public void testXPackInfo() throws IOException {
-        XPackInfoRequest request = new XPackInfoRequest();
-        request.setCategories(EnumSet.allOf(XPackInfoRequest.Category.class));
-        request.setVerbose(true);
-        XPackInfoResponse info = highLevelClient().xpack().info(request, RequestOptions.DEFAULT);
-
-        MainResponse mainResponse = highLevelClient().info(RequestOptions.DEFAULT);
-
-        assertEquals(mainResponse.getVersion().getBuildHash(), info.getBuildInfo().getHash());
-
-        assertEquals("trial", info.getLicenseInfo().getType());
-        assertEquals("trial", info.getLicenseInfo().getMode());
-        assertEquals(LicenseStatus.ACTIVE, info.getLicenseInfo().getStatus());
-
-        FeatureSet monitoring = info.getFeatureSetsInfo().getFeatureSets().get("monitoring");
-        assertTrue(monitoring.available());
-        assertTrue(monitoring.enabled());
-        assertNull(monitoring.nativeCodeInfo());
-    }
-
-    public void testXPackInfoEmptyRequest() throws IOException {
-        XPackInfoResponse info = highLevelClient().xpack().info(new XPackInfoRequest(), RequestOptions.DEFAULT);
-
-        /*
-         * The default in the transport client is non-verbose and returning
-         * no categories which is the opposite of the default when you use
-         * the API over REST. We don't want to break the transport client
-         * even though it doesn't feel like a good default.
-         */
-        assertNull(info.getBuildInfo());
-        assertNull(info.getLicenseInfo());
-        assertNull(info.getFeatureSetsInfo());
-    }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MiscellaneousDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MiscellaneousDocumentationIT.java
@@ -146,50 +146,6 @@ public class MiscellaneousDocumentationIT extends ESRestHighLevelClientTestCase 
         }
     }
 
-    public void testXPackUsage() throws Exception {
-        RestHighLevelClient client = highLevelClient();
-        {
-            //tag::x-pack-usage-execute
-            XPackUsageRequest request = new XPackUsageRequest();
-            XPackUsageResponse response = client.xpack().usage(request, RequestOptions.DEFAULT);
-            //end::x-pack-usage-execute
-
-            //tag::x-pack-usage-response
-            Map<String, Map<String, Object>> usages = response.getUsages();
-            Map<String, Object> monitoringUsage = usages.get("monitoring");
-            assertThat(monitoringUsage.get("available"), is(true));
-            assertThat(monitoringUsage.get("enabled"), is(true));
-            assertThat(monitoringUsage.get("collection_enabled"), is(false));
-            //end::x-pack-usage-response
-        }
-        {
-            XPackUsageRequest request = new XPackUsageRequest();
-            // tag::x-pack-usage-execute-listener
-            ActionListener<XPackUsageResponse> listener = new ActionListener<XPackUsageResponse>() {
-                @Override
-                public void onResponse(XPackUsageResponse response) {
-                    // <1>
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    // <2>
-                }
-            };
-            // end::x-pack-usage-execute-listener
-
-            // Replace the empty listener by a blocking listener in test
-            final CountDownLatch latch = new CountDownLatch(1);
-            listener = new LatchedActionListener<>(listener, latch);
-
-            // tag::x-pack-usage-execute-async
-            client.xpack().usageAsync(request, RequestOptions.DEFAULT, listener); // <1>
-            // end::x-pack-usage-execute-async
-
-            assertTrue(latch.await(30L, TimeUnit.SECONDS));
-        }
-    }
-
     public void testInitializationFromClientBuilder() throws IOException {
         //tag::rest-high-level-client-init
         RestHighLevelClient client = new RestHighLevelClient(

--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -128,7 +128,6 @@ def projectPathsToExclude = [
   ':x-pack:plugin:identity-provider',
   ':x-pack:plugin:mapper-constant-keyword',
   ':x-pack:plugin:mapper-flattened',
-  ':x-pack:plugin:monitoring',
   ':x-pack:plugin:ql',
   ':x-pack:plugin:search-business-rules',
   ':x-pack:plugin:spatial',

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1160,9 +1160,6 @@ public abstract class ESRestTestCase extends ESTestCase {
      * Is this template one that is automatically created by xpack?
      */
     protected static boolean isXPackTemplate(String name) {
-        if (name.startsWith(".monitoring-")) {
-            return true;
-        }
         if (name.startsWith(".transform-")) {
             return true;
         }


### PR DESCRIPTION
This commit removes all trace of Elastic licensed monitoring

relates #2