### PR TITLE
[PURIFY] Cleanup build and unblock HLRC integration tests

### DIFF
--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionArchiveCheckPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionArchiveCheckPluginFuncTest.groovy
@@ -79,7 +79,7 @@ class InternalDistributionArchiveCheckPluginFuncTest extends AbstractGradleFuncT
     def "fails on unexpected notice content"() {
         given:
         license(file("LICENSE.txt"))
-        file("NOTICE.txt").text = """OSS Search
+        file("NOTICE.txt").text = """Elasticsearch
 Copyright 2009-2018 Acme Coorp"""
         buildFile << """
             apply plugin:'base'

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -693,18 +693,18 @@ public class ElasticsearchNode implements TestClusterConfiguration {
 
     @Override
     public void user(Map<String, String> userSpec) {
-        Set<String> keys = new HashSet<>(userSpec.keySet());
-        keys.remove("username");
-        keys.remove("password");
-        keys.remove("role");
-        if (keys.isEmpty() == false) {
-            throw new TestClustersException("Unknown keys in user definition " + keys + " for " + this);
-        }
-        Map<String, String> cred = new LinkedHashMap<>();
-        cred.put("useradd", userSpec.getOrDefault("username", "test_user"));
-        cred.put("-p", userSpec.getOrDefault("password", "x-pack-test-password"));
-        cred.put("-r", userSpec.getOrDefault("role", "superuser"));
-        credentials.add(cred);
+        // Set<String> keys = new HashSet<>(userSpec.keySet());
+        // keys.remove("username");
+        // keys.remove("password");
+        // keys.remove("role");
+        // if (keys.isEmpty() == false) {
+        // throw new TestClustersException("Unknown keys in user definition " + keys + " for " + this);
+        // }
+        // Map<String, String> cred = new LinkedHashMap<>();
+        // cred.put("useradd", userSpec.getOrDefault("username", "test_user"));
+        // cred.put("-p", userSpec.getOrDefault("password", "x-pack-test-password"));
+        // cred.put("-r", userSpec.getOrDefault("role", "superuser"));
+        // credentials.add(cred);
     }
 
     private void runElasticsearchBinScriptWithInput(String input, String tool, CharSequence... args) {

--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -82,8 +82,6 @@ testClusters.all {
   systemProperty 'es.scripting.update.ctx_in_params', 'false'
   setting 'reindex.remote.whitelist', '[ "[::1]:*", "127.0.0.1:*" ]'
 
-  setting 'indices.lifecycle.poll_interval', '1000ms'
-  setting 'indices.lifecycle.history_index_enabled', 'false'
   extraConfigFile 'roles.yml', file('roles.yml')
   user username: System.getProperty('tests.rest.cluster.username', 'test_user'),
     password: System.getProperty('tests.rest.cluster.password', 'test-password'),

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
@@ -23,7 +23,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.elasticsearch.client.core.MainResponse;
 
 import java.io.IOException;
-import java.util.EnumSet;
 import java.util.Map;
 
 public class PingAndInfoIT extends ESRestHighLevelClientTestCase {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -99,7 +99,6 @@ import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.Matchers.hasItems;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
@@ -43,7 +43,6 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/core/AcknowledgedResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/core/AcknowledgedResponseTests.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.client.core;
 
 import org.elasticsearch.client.AbstractResponseTestCase;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexServiceTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.cluster.metadata;
 
-import org.elasticsearch.action.admin.indices.datastream.DeleteDataStreamRequestTests;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.DataStreamTestHelper;


### PR DESCRIPTION
This PR cleans up the following:

* Remove unused imports
* Remove ILM settings in hlrc testCluster formation
* Comment out security users settings in ElasticsearchNode creation for build-tools tests

Note: build still fails because there is still a lot of XPack cruft in the test fixtures. But this moves the test failures along a little further.

relates #32 
relates #23 