### PR TITLE
[TEST] Fix unit test failure in RestHighLevelClientTests

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/DataStream.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/DataStream.java
@@ -87,7 +87,6 @@ public final class DataStream {
     public static final ParseField GENERATION_FIELD = new ParseField("generation");
     public static final ParseField STATUS_FIELD = new ParseField("status");
     public static final ParseField INDEX_TEMPLATE_FIELD = new ParseField("template");
-    public static final ParseField ILM_POLICY_FIELD = new ParseField("ilm_policy");
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<DataStream, Void> PARSER = new ConstructingObjectParser<>("data_stream",
@@ -111,7 +110,6 @@ public final class DataStream {
         PARSER.declareLong(ConstructingObjectParser.constructorArg(), GENERATION_FIELD);
         PARSER.declareString(ConstructingObjectParser.constructorArg(), STATUS_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), INDEX_TEMPLATE_FIELD);
-        PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), ILM_POLICY_FIELD);
     }
 
     public static DataStream fromXContent(XContentParser parser) throws IOException {


### PR DESCRIPTION
*Issue #, if available:*
#23

There are a few test failure show up after running Gradle Task `:client:rest-high-level:test`

*Description of changes:*
 - Fix `testProvidedNamedXContents` by reducing the numbers in assertions

The PR fixes the only one test failure in `RestHighLevelClientTests` class

```
REPRODUCE WITH: ./gradlew ':client:rest-high-level:test' --tests "org.elasticsearch.client.RestHighLevelClientTests.testProvidedNamedXContents" -Dtests.seed=5E1553B2DED480C5 -Dtests.security.manager=true -Dtests.locale=ar-LB -Dtests.timezone=Asia/Bahrain -Druntime.java=15

org.elasticsearch.client.RestHighLevelClientTests > testProvidedNamedXContents FAILED
    java.lang.AssertionError: expected:<75> but was:<13>
        at __randomizedtesting.SeedInfo.seed([5E1553B2DED480C5:E09039D00414E3CA]:0)
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:834)
        at org.junit.Assert.assertEquals(Assert.java:645)
        at org.junit.Assert.assertEquals(Assert.java:631)
        at org.elasticsearch.client.RestHighLevelClientTests.testProvidedNamedXContents(RestHighLevelClientTests.java:664)
```

I print out the "provided names" received in the test, and seems it's caused by the removal of "ml" stuff in x-pack in this [commit](https://github.com/opendistro-for-elasticsearch/search/commit/7505372859c878d9a2ff8b0e3a80b564331ed0fa) :
The acutal 13 names are:
```
children parent matrix_stats precision recall mean_reciprocal_rank dcg expected_reciprocal_rank precision recall mean_reciprocal_rank dcg expected_reciprocal_rank
```
The expected 75 names are:
```
allocate delete forcemerge readonly rollover shrink wait_for_snapshot freeze set_priority migrate searchable_snapshot unfollow outlier_detection regression classification outlier_detection classification regression outlier_detection.auc_roc outlier_detection.precision outlier_detection.recall outlier_detection.confusion_matrix classification.auc_roc classification.accuracy classification.precision classification.recall classification.multiclass_confusion_matrix regression.mse regression.msle regression.huber regression.r_squared outlier_detection.auc_roc outlier_detection.precision outlier_detection.recall outlier_detection.confusion_matrix classification.auc_roc classification.accuracy classification.precision classification.recall classification.multiclass_confusion_matrix regression.mse regression.msle regression.huber regression.r_squared classification_stats outlier_detection_stats regression_stats one_hot_encoding target_mean_encoding frequency_encoding custom_word_embedding n_gram_encoding tree ensemble lang_ident_neural_network classification regression weighted_mode weighted_sum logistic_regression exponent time children parent matrix_stats precision recall mean_reciprocal_rank dcg expected_reciprocal_rank precision recall mean_reciprocal_rank dcg expected_reciprocal_rank
```
As the codes related to x-pack "ml" is removed, I modify the test case to be suitable with the code.

**Testing:**
```
$ ./gradlew ':client:rest-high-level:test' --tests "org.elasticsearch.client.RestHighLevelClientTests.testProvidedNamedXContents"
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 6.6.1
  OS Info               : Mac OS X 10.16 (x86_64)
  JDK Version           : 14 (AdoptOpenJDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/adoptopenjdk-14.jdk/Contents/Home
  Random Testing Seed   : 7D6CCA1DBB898851
  In FIPS 140 mode      : false
=======================================

> Task :client:rest-high-level:compileTestJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

> Task :client:rest-high-level:test
WARNING: Illegal reflective access by org.mockito.cglib.core.ReflectUtils$2 (file:/Users/ftianli/.gradle/caches/modules-2/files-2.1/org.elasticsearch/securemock/1.2/98201d4ad5ac93f6b415ae9172d52b5e7cda490e/securemock-1.2.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)

BUILD SUCCESSFUL in 13s
50 actionable tasks: 3 executed, 47 up-to-date
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
