### PR TITLE
Remove license option in gradlew command

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -66,9 +66,6 @@ To for example start the open source distribution:
 ./gradlew run -Drun.distribution=oss
 -------------------------------------
 
-This enables security and other paid features and adds a superuser with the username: `elastic-admin` and
-password: `elastic-password`.
-
 ==== Other useful arguments
 
 - In order to start a node with a different max heap space add: `-Dtests.heap.size=4G`


### PR DESCRIPTION
*Issue #27 , if available:*

*Description of changes:*
Remove license option in gradlew command in TESTING.asciidoc

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
