### PR TITLE
[TEST] fix RequestConvertersTests failure

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -199,13 +199,6 @@ public class RequestConvertersTests extends ESTestCase {
                 expectedParams.put("realtime", "false");
             }
         }
-        if (randomBoolean()) {
-            boolean refresh = randomBoolean();
-            getRequest.refresh(refresh);
-            if (refresh) {
-                expectedParams.put("refresh", "true");
-            }
-        }
         Request request = RequestConverters.sourceExists(getRequest);
         assertEquals(HttpHead.METHOD_NAME, request.getMethod());
         String type = getRequest.type();
@@ -242,13 +235,6 @@ public class RequestConvertersTests extends ESTestCase {
                 expectedParams.put("realtime", "false");
             }
         }
-        if (randomBoolean()) {
-            boolean refresh = randomBoolean();
-            getRequest.refresh(refresh);
-            if (refresh) {
-                expectedParams.put("refresh", "true");
-            }
-        }
         Request request = RequestConverters.getSource(getRequest);
         assertEquals(HttpGet.METHOD_NAME, request.getMethod());
         assertEquals("/" + index + "/_source/" + id, request.getEndpoint());
@@ -269,12 +255,6 @@ public class RequestConvertersTests extends ESTestCase {
             multiGetRequest.realtime(randomBoolean());
             if (multiGetRequest.realtime() == false) {
                 expectedParams.put("realtime", "false");
-            }
-        }
-        if (randomBoolean()) {
-            multiGetRequest.refresh(randomBoolean());
-            if (multiGetRequest.refresh()) {
-                expectedParams.put("refresh", "true");
             }
         }
 
@@ -389,13 +369,6 @@ public class RequestConvertersTests extends ESTestCase {
                 getRequest.realtime(realtime);
                 if (realtime == false) {
                     expectedParams.put("realtime", "false");
-                }
-            }
-            if (randomBoolean()) {
-                boolean refresh = randomBoolean();
-                getRequest.refresh(refresh);
-                if (refresh) {
-                    expectedParams.put("refresh", "true");
                 }
             }
             if (randomBoolean()) {


### PR DESCRIPTION
*Issue #, if available:*
#23 

[**Update**: There is another approach to deal with the failure, see issue #52]
There are 4 flaky tests failure in "REST Hight Level Client Tests" (Gradle Task `:client:rest-high-level:test`)

```
> Task :client:rest-high-level:test

REPRODUCE WITH: ./gradlew ':client:rest-high-level:test' --tests "org.elasticsearch.client.RequestConvertersTests.testSourceExistsWithType" -Dtests.seed=6441E51410EE961B -Dtests.security.manager=true -Dtests.locale=es-US -Dtests.timezone=SystemV/MST7 -Druntime.java=15

org.elasticsearch.client.RequestConvertersTests > testSourceExistsWithType FAILED
    java.lang.AssertionError: expected:<{realtime=false, refresh=true}> but was:<{realtime=false}>
        at __randomizedtesting.SeedInfo.seed([6441E51410EE961B:D80B1368D804414D]:0)
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:834)
        at org.junit.Assert.assertEquals(Assert.java:118)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at org.elasticsearch.client.RequestConvertersTests.doTestSourceExists(RequestConvertersTests.java:218)
        at org.elasticsearch.client.RequestConvertersTests.testSourceExistsWithType(RequestConvertersTests.java:172)

REPRODUCE WITH: ./gradlew ':client:rest-high-level:test' --tests "org.elasticsearch.client.RequestConvertersTests.testGetSource" -Dtests.seed=6441E51410EE961B -Dtests.security.manager=true -Dtests.locale=es-US -Dtests.timezone=SystemV/MST7 -Druntime.java=15

org.elasticsearch.client.RequestConvertersTests > testGetSource FAILED
    java.lang.AssertionError: expected:<{routing=bdpSOmeC, preference=haod, refresh=true}> but was:<{routing=bdpSOmeC, preference=haod}>
        at __randomizedtesting.SeedInfo.seed([6441E51410EE961B:FE48ED1D9D674ADC]:0)
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:834)
        at org.junit.Assert.assertEquals(Assert.java:118)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at org.elasticsearch.client.RequestConvertersTests.doTestGetSource(RequestConvertersTests.java:256)
        at org.elasticsearch.client.RequestConvertersTests.testGetSource(RequestConvertersTests.java:176)

REPRODUCE WITH: ./gradlew ':client:rest-high-level:test' --tests "org.elasticsearch.client.RequestConvertersTests.testMultiGet" -Dtests.seed=6441E51410EE961B -Dtests.security.manager=true -Dtests.locale=es-US -Dtests.timezone=SystemV/MST7 -Druntime.java=15

org.elasticsearch.client.RequestConvertersTests > testMultiGet FAILED
    java.lang.AssertionError: expected:<{refresh=true}> but was:<{}>
        at __randomizedtesting.SeedInfo.seed([6441E51410EE961B:538FF24A8A03B08C]:0)
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:834)
        at org.junit.Assert.assertEquals(Assert.java:118)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at org.elasticsearch.client.RequestConvertersTests.testMultiGet(RequestConvertersTests.java:305)

REPRODUCE WITH: ./gradlew ':client:rest-high-level:test' --tests "org.elasticsearch.client.RequestConvertersTests.testSourceExists" -Dtests.seed=6441E51410EE961B -Dtests.security.manager=true -Dtests.locale=es-US -Dtests.timezone=SystemV/MST7 -Druntime.java=15

org.elasticsearch.client.RequestConvertersTests > testSourceExists FAILED
    java.lang.AssertionError: expected:<{routing=OlPIq, refresh=true}> but was:<{routing=OlPIq}>
        at __randomizedtesting.SeedInfo.seed([6441E51410EE961B:A1A97D003C3A0640]:0)
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:834)
        at org.junit.Assert.assertEquals(Assert.java:118)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at org.elasticsearch.client.RequestConvertersTests.doTestSourceExists(RequestConvertersTests.java:218)
        at org.elasticsearch.client.RequestConvertersTests.testSourceExists(RequestConvertersTests.java:167)
```

*Description of changes:*

- Remove the tests of validating `refresh` parameter in `getSourceRequest` and `multiGetRequest`

The PR aims to fix the unit tests in class `RequestConvertersTests`

The failure is due to the removal of x-pack security (PR https://github.com/opendistro-for-elasticsearch/search/pull/16), where "refresh" parameter is removed from several kinds of requests, such as getRequest, getSourceRequest and multiGetRequest ([commit](https://github.com/opendistro-for-elasticsearch/search/pull/16/files#diff-49bf8155f9175c236f4ab90b94678f018c58e6b65c43a2b76f161dd406000cddL275))

**Testing:**
```
$ ./gradlew ':client:rest-high-level:test' --tests "org.elasticsearch.client.RequestConvertersTests"
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 6.6.1
  OS Info               : Mac OS X 10.16 (x86_64)
  JDK Version           : 14 (AdoptOpenJDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/adoptopenjdk-14.jdk/Contents/Home
  Random Testing Seed   : ED42825F8526BABC
  In FIPS 140 mode      : false
=======================================

> Task :client:rest-high-level:compileTestJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

BUILD SUCCESSFUL in 7s
50 actionable tasks: 2 executed, 48 up-to-date
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
