### PR TITLE
Revert back refresh policy in RequestConverters.

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -271,6 +271,7 @@ final class RequestConverters {
         Params parameters = new Params();
         parameters.withPreference(getRequest.preference());
         parameters.withRouting(getRequest.routing());
+        parameters.withRefresh(getRequest.refresh());
         parameters.withRealtime(getRequest.realtime());
         parameters.withStoredFields(getRequest.storedFields());
         parameters.withVersion(getRequest.version());
@@ -292,6 +293,7 @@ final class RequestConverters {
         Params parameters = new Params();
         parameters.withPreference(getSourceRequest.preference());
         parameters.withRouting(getSourceRequest.routing());
+        parameters.withRefresh(getSourceRequest.refresh());
         parameters.withRealtime(getSourceRequest.realtime());
         parameters.withFetchSourceContext(getSourceRequest.fetchSourceContext());
 
@@ -313,6 +315,7 @@ final class RequestConverters {
         Params parameters = new Params();
         parameters.withPreference(multiGetRequest.preference());
         parameters.withRealtime(multiGetRequest.realtime());
+        parameters.withRefresh(multiGetRequest.refresh());
         request.addParameters(parameters.asMap());
         request.setEntity(createEntity(multiGetRequest, REQUEST_BODY_CONTENT_TYPE));
         return request;
@@ -588,6 +591,7 @@ final class RequestConverters {
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
         Params params = new Params()
             .withWaitForCompletion(waitForCompletion)
+            .withRefresh(reindexRequest.isRefresh())
             .withTimeout(reindexRequest.getTimeout())
             .withWaitForActiveShards(reindexRequest.getWaitForActiveShards())
             .withRequestsPerSecond(reindexRequest.getRequestsPerSecond())
@@ -608,6 +612,7 @@ final class RequestConverters {
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
         Params params = new Params()
             .withRouting(deleteByQueryRequest.getRouting())
+            .withRefresh(deleteByQueryRequest.isRefresh())
             .withTimeout(deleteByQueryRequest.getTimeout())
             .withWaitForActiveShards(deleteByQueryRequest.getWaitForActiveShards())
             .withRequestsPerSecond(deleteByQueryRequest.getRequestsPerSecond())
@@ -639,6 +644,7 @@ final class RequestConverters {
         Params params = new Params()
             .withRouting(updateByQueryRequest.getRouting())
             .withPipeline(updateByQueryRequest.getPipeline())
+            .withRefresh(updateByQueryRequest.isRefresh())
             .withTimeout(updateByQueryRequest.getTimeout())
             .withWaitForActiveShards(updateByQueryRequest.getWaitForActiveShards())
             .withRequestsPerSecond(updateByQueryRequest.getRequestsPerSecond())
@@ -904,6 +910,13 @@ final class RequestConverters {
         Params withRealtime(boolean realtime) {
             if (realtime == false) {
                 return putParam("realtime", Boolean.FALSE.toString());
+            }
+            return this;
+        }
+
+        Params withRefresh(boolean refresh) {
+            if (refresh) {
+                return withRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
             }
             return this;
         }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -199,6 +199,13 @@ public class RequestConvertersTests extends ESTestCase {
                 expectedParams.put("realtime", "false");
             }
         }
+        if (randomBoolean()) {
+            boolean refresh = randomBoolean();
+            getRequest.refresh(refresh);
+            if (refresh) {
+                expectedParams.put("refresh", "true");
+            }
+        }
         Request request = RequestConverters.sourceExists(getRequest);
         assertEquals(HttpHead.METHOD_NAME, request.getMethod());
         String type = getRequest.type();
@@ -235,6 +242,13 @@ public class RequestConvertersTests extends ESTestCase {
                 expectedParams.put("realtime", "false");
             }
         }
+        if (randomBoolean()) {
+            boolean refresh = randomBoolean();
+            getRequest.refresh(refresh);
+            if (refresh) {
+                expectedParams.put("refresh", "true");
+            }
+        }
         Request request = RequestConverters.getSource(getRequest);
         assertEquals(HttpGet.METHOD_NAME, request.getMethod());
         assertEquals("/" + index + "/_source/" + id, request.getEndpoint());
@@ -255,6 +269,12 @@ public class RequestConvertersTests extends ESTestCase {
             multiGetRequest.realtime(randomBoolean());
             if (multiGetRequest.realtime() == false) {
                 expectedParams.put("realtime", "false");
+            }
+        }
+        if (randomBoolean()) {
+            multiGetRequest.refresh(randomBoolean());
+            if (multiGetRequest.refresh()) {
+                expectedParams.put("refresh", "true");
             }
         }
 
@@ -307,6 +327,7 @@ public class RequestConvertersTests extends ESTestCase {
         Map<String, String> expectedParams = new HashMap<>();
 
         setRandomTimeout(deleteRequest::timeout, ReplicationRequest.DEFAULT_TIMEOUT, expectedParams);
+        setRandomRefreshPolicy(deleteRequest::setRefreshPolicy, expectedParams);
         setRandomVersion(deleteRequest, expectedParams);
         setRandomVersionType(deleteRequest::versionType, expectedParams);
         setRandomIfSeqNoAndTerm(deleteRequest, expectedParams);
@@ -368,6 +389,13 @@ public class RequestConvertersTests extends ESTestCase {
                 getRequest.realtime(realtime);
                 if (realtime == false) {
                     expectedParams.put("realtime", "false");
+                }
+            }
+            if (randomBoolean()) {
+                boolean refresh = randomBoolean();
+                getRequest.refresh(refresh);
+                if (refresh) {
+                    expectedParams.put("refresh", "true");
                 }
             }
             if (randomBoolean()) {
@@ -693,6 +721,7 @@ public class RequestConvertersTests extends ESTestCase {
         }
 
         setRandomTimeout(indexRequest::timeout, ReplicationRequest.DEFAULT_TIMEOUT, expectedParams);
+        setRandomRefreshPolicy(indexRequest::setRefreshPolicy, expectedParams);
 
         // There is some logic around _create endpoint and version/version type
         if (indexRequest.opType() == DocWriteRequest.OpType.CREATE) {
@@ -829,6 +858,13 @@ public class RequestConvertersTests extends ESTestCase {
         } else {
             expectedParams.put("timeout", ReplicationRequest.DEFAULT_TIMEOUT.getStringRep());
         }
+        if (randomBoolean()) {
+            WriteRequest.RefreshPolicy refreshPolicy = randomFrom(WriteRequest.RefreshPolicy.values());
+            updateRequest.setRefreshPolicy(refreshPolicy);
+            if (refreshPolicy != WriteRequest.RefreshPolicy.NONE) {
+                expectedParams.put("refresh", refreshPolicy.getValue());
+            }
+        }
         setRandomWaitForActiveShards(updateRequest::waitForActiveShards, expectedParams);
         setRandomIfSeqNoAndTerm(updateRequest, new HashMap<>()); // if* params are passed in the body
         if (randomBoolean()) {
@@ -931,6 +967,7 @@ public class RequestConvertersTests extends ESTestCase {
             expectedParams.put("timeout", BulkShardRequest.DEFAULT_TIMEOUT.getStringRep());
         }
 
+        setRandomRefreshPolicy(bulkRequest::setRefreshPolicy, expectedParams);
 
         XContentType xContentType = randomFrom(XContentType.JSON, XContentType.SMILE);
 
@@ -2199,6 +2236,16 @@ public class RequestConvertersTests extends ESTestCase {
             setter.accept(activeShardCount);
             if (defaultActiveShardCount.equals(activeShardCount) == false) {
                 expectedParams.put("wait_for_active_shards", waitForActiveShardsString);
+            }
+        }
+    }
+
+    private static void setRandomRefreshPolicy(Consumer<WriteRequest.RefreshPolicy> setter, Map<String, String> expectedParams) {
+        if (randomBoolean()) {
+            WriteRequest.RefreshPolicy refreshPolicy = randomFrom(WriteRequest.RefreshPolicy.values());
+            setter.accept(refreshPolicy);
+            if (refreshPolicy != WriteRequest.RefreshPolicy.NONE) {
+                expectedParams.put("refresh", refreshPolicy.getValue());
             }
         }
     }


### PR DESCRIPTION
This PR reverts back the deleted code (#16, #54) related to refresh policies.

Issue #52 