### PR TITLE
Remove ILM policy from GetDataStreamAction Response.

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/DataStream.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/DataStream.java
@@ -39,18 +39,15 @@ public final class DataStream {
     ClusterHealthStatus dataStreamStatus;
     @Nullable
     String indexTemplate;
-    @Nullable
-    String ilmPolicyName;
 
     public DataStream(String name, String timeStampField, List<String> indices, long generation, ClusterHealthStatus dataStreamStatus,
-                      @Nullable String indexTemplate, @Nullable String ilmPolicyName) {
+                      @Nullable String indexTemplate) {
         this.name = name;
         this.timeStampField = timeStampField;
         this.indices = indices;
         this.generation = generation;
         this.dataStreamStatus = dataStreamStatus;
         this.indexTemplate = indexTemplate;
-        this.ilmPolicyName = ilmPolicyName;
     }
 
     public String getName() {
@@ -77,10 +74,6 @@ public final class DataStream {
         return indexTemplate;
     }
 
-    public String getIlmPolicyName() {
-        return ilmPolicyName;
-    }
-
     public static final ParseField NAME_FIELD = new ParseField("name");
     public static final ParseField TIMESTAMP_FIELD_FIELD = new ParseField("timestamp_field");
     public static final ParseField INDICES_FIELD = new ParseField("indices");
@@ -99,8 +92,7 @@ public final class DataStream {
             String statusStr = (String) args[4];
             ClusterHealthStatus status = ClusterHealthStatus.fromString(statusStr);
             String indexTemplate = (String) args[5];
-            String ilmPolicy = (String) args[6];
-            return new DataStream(dataStreamName, timeStampField, indices, generation, status, indexTemplate, ilmPolicy);
+            return new DataStream(dataStreamName, timeStampField, indices, generation, status, indexTemplate);
         });
 
     static {
@@ -126,12 +118,11 @@ public final class DataStream {
             timeStampField.equals(that.timeStampField) &&
             indices.equals(that.indices) &&
             dataStreamStatus == that.dataStreamStatus &&
-            Objects.equals(indexTemplate, that.indexTemplate) &&
-            Objects.equals(ilmPolicyName, that.ilmPolicyName);
+            Objects.equals(indexTemplate, that.indexTemplate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, timeStampField, indices, generation, dataStreamStatus, indexTemplate, ilmPolicyName);
+        return Objects.hash(name, timeStampField, indices, generation, dataStreamStatus, indexTemplate);
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/GetDataStreamResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/GetDataStreamResponseTests.java
@@ -56,8 +56,7 @@ public class GetDataStreamResponseTests extends AbstractResponseTestCase<GetData
         String dataStreamName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         indices.add(new Index(getDefaultBackingIndexName(dataStreamName, generation), UUIDs.randomBase64UUID(random())));
         DataStream dataStream = new DataStream(dataStreamName, createTimestampField("@timestamp"), indices, generation);
-        return new DataStreamInfo(dataStream, ClusterHealthStatus.YELLOW, randomAlphaOfLengthBetween(2, 10),
-            randomAlphaOfLengthBetween(2, 10));
+        return new DataStreamInfo(dataStream, ClusterHealthStatus.YELLOW, randomAlphaOfLengthBetween(2, 10));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/datastream/GetDataStreamAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/datastream/GetDataStreamAction.java
@@ -137,23 +137,19 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
 
             public static final ParseField STATUS_FIELD = new ParseField("status");
             public static final ParseField INDEX_TEMPLATE_FIELD = new ParseField("template");
-            public static final ParseField ILM_POLICY_FIELD = new ParseField("ilm_policy");
 
             DataStream dataStream;
             ClusterHealthStatus dataStreamStatus;
             @Nullable String indexTemplate;
-            @Nullable String ilmPolicyName;
 
-            public DataStreamInfo(DataStream dataStream, ClusterHealthStatus dataStreamStatus, @Nullable String indexTemplate,
-                                  @Nullable String ilmPolicyName) {
+            public DataStreamInfo(DataStream dataStream, ClusterHealthStatus dataStreamStatus, @Nullable String indexTemplate) {
                 this.dataStream = dataStream;
                 this.dataStreamStatus = dataStreamStatus;
                 this.indexTemplate = indexTemplate;
-                this.ilmPolicyName = ilmPolicyName;
             }
 
             public DataStreamInfo(StreamInput in) throws IOException {
-                this(new DataStream(in), ClusterHealthStatus.readFrom(in), in.readOptionalString(), in.readOptionalString());
+                this(new DataStream(in), ClusterHealthStatus.readFrom(in), in.readOptionalString());
             }
 
             public DataStream getDataStream() {
@@ -169,17 +165,12 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
                 return indexTemplate;
             }
 
-            @Nullable
-            public String getIlmPolicy() {
-                return ilmPolicyName;
-            }
 
             @Override
             public void writeTo(StreamOutput out) throws IOException {
                 dataStream.writeTo(out);
                 dataStreamStatus.writeTo(out);
                 out.writeOptionalString(indexTemplate);
-                out.writeOptionalString(ilmPolicyName);
             }
 
             @Override
@@ -193,9 +184,6 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
                 if (indexTemplate != null) {
                     builder.field(INDEX_TEMPLATE_FIELD.getPreferredName(), indexTemplate);
                 }
-                if (ilmPolicyName != null) {
-                    builder.field(ILM_POLICY_FIELD.getPreferredName(), ilmPolicyName);
-                }
                 builder.endObject();
                 return builder;
             }
@@ -207,13 +195,12 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
                 DataStreamInfo that = (DataStreamInfo) o;
                 return dataStream.equals(that.dataStream) &&
                     dataStreamStatus == that.dataStreamStatus &&
-                    Objects.equals(indexTemplate, that.indexTemplate) &&
-                    Objects.equals(ilmPolicyName, that.ilmPolicyName);
+                    Objects.equals(indexTemplate, that.indexTemplate);
             }
 
             @Override
             public int hashCode() {
-                return Objects.hash(dataStream, dataStreamStatus, indexTemplate, ilmPolicyName);
+                return Objects.hash(dataStream, dataStreamStatus, indexTemplate);
             }
         }
 
@@ -299,7 +286,7 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
                 }
                 ClusterStateHealth streamHealth = new ClusterStateHealth(state,
                     dataStream.getIndices().stream().map(Index::getName).toArray(String[]::new));
-                dataStreamInfos.add(new Response.DataStreamInfo(dataStream, streamHealth.getStatus(), indexTemplate, ilmPolicyName));
+                dataStreamInfos.add(new Response.DataStreamInfo(dataStream, streamHealth.getStatus(), indexTemplate));
             }
             listener.onResponse(new Response(dataStreamInfos));
         }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/datastream/GetDataStreamsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/datastream/GetDataStreamsResponseTests.java
@@ -40,7 +40,7 @@ public class GetDataStreamsResponseTests extends AbstractWireSerializingTestCase
         List<Response.DataStreamInfo> dataStreams = new ArrayList<>();
         for (int i = 0; i < numDataStreams; i++) {
             dataStreams.add(new Response.DataStreamInfo(DataStreamTests.randomInstance(), ClusterHealthStatus.GREEN,
-                randomAlphaOfLengthBetween(2, 10), randomAlphaOfLengthBetween(2, 10)));
+                randomAlphaOfLengthBetween(2, 10)));
         }
         return new Response(dataStreams);
     }


### PR DESCRIPTION
This PR removes the field ilmpolicy which is part of x-pack code. The ILM related code has already been removed from this repository in #2 

This removal fixes the failing test `org.elasticsearch.client.indices.GetDataStreamResponseTests.testFromXContent` in #23 
