### PR TITLE
Fix unit test for removal of x-pack aggregations metrics.

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -640,11 +640,6 @@ public class RestHighLevelClientTests extends ESTestCase {
         int expectedInternalAggregations = InternalAggregationTestCase.getDefaultNamedXContents().size();
         int expectedSuggestions = 3;
 
-        // Explicitly check for metrics from the analytics module because they aren't in InternalAggregationTestCase
-        assertTrue(namedXContents.removeIf(e -> e.name.getPreferredName().equals("string_stats")));
-        assertTrue(namedXContents.removeIf(e -> e.name.getPreferredName().equals("top_metrics")));
-        assertTrue(namedXContents.removeIf(e -> e.name.getPreferredName().equals("inference")));
-
         assertEquals(expectedInternalAggregations + expectedSuggestions, namedXContents.size());
         Map<Class<?>, Integer> categories = new HashMap<>();
         for (NamedXContentRegistry.Entry namedXContent : namedXContents) {


### PR DESCRIPTION
This PR fixes the unit test which failed after removal of the x-pack analytics module aggregations #59.
