### PR TITLE
Remove testcase testSearchWithBasicLicensedQuery

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
@@ -1380,17 +1380,6 @@ public class SearchIT extends ESRestHighLevelClientTestCase {
         assertEquals(3, countResponse.getCount());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opendistro-for-elasticsearch/search/issues/61")
-    public void testSearchWithBasicLicensedQuery() throws IOException {
-        SearchRequest searchRequest = new SearchRequest("index");
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        searchRequest.source(searchSourceBuilder);
-        SearchResponse searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync);
-        assertSearchHeader(searchResponse);
-        assertFirstHit(searchResponse, hasId("2"));
-        assertSecondHit(searchResponse, hasId("1"));
-    }
-
     private static void assertCountHeader(CountResponse countResponse) {
         assertEquals(0, countResponse.getSkippedShards());
         assertEquals(0, countResponse.getFailedShards());


### PR DESCRIPTION
*Issue #60 , if available:*

*Description of changes:*
Remove testcase testSearchWithBasicLicensedQuery since basic license is no longer applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
