### PR TITLE
Bring back the REST specs for data streams.

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create_data_stream.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create_data_stream.json
@@ -1,0 +1,30 @@
+{
+  "indices.create_data_stream":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
+      "description":"Creates or updates a data stream"
+    },
+    "stability":"experimental",
+    "url":{
+      "paths":[
+        {
+          "path":"/_data_stream/{name}",
+          "methods":[
+            "PUT"
+          ],
+          "parts":{
+            "name":{
+              "type":"string",
+              "description":"The name of the data stream"
+            }
+          }
+        }
+      ]
+    },
+    "params":{
+    },
+    "body":{
+      "description":"The data stream definition"
+    }
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.data_streams_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.data_streams_stats.json
@@ -1,0 +1,31 @@
+{
+  "indices.data_streams_stats":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
+      "description":"Provides statistics on operations happening in a data stream."
+    },
+    "stability":"experimental",
+    "url":{
+      "paths":[
+        {
+          "path":"/_data_stream/_stats",
+          "methods":[
+            "GET"
+          ]
+        },
+        {
+          "path":"/_data_stream/{name}/_stats",
+          "methods":[
+            "GET"
+          ],
+          "parts":{
+            "name":{
+              "type":"list",
+              "description":"A comma-separated list of data stream names; use `_all` or empty string to perform the operation on all data streams"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_stream.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_stream.json
@@ -1,0 +1,26 @@
+{
+  "indices.delete_data_stream":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
+      "description":"Deletes a data stream."
+    },
+    "stability":"experimental",
+    "url":{
+      "paths":[
+        {
+          "path":"/_data_stream/{name}",
+          "methods":[
+            "DELETE"
+          ],
+          "parts":{
+            "name":{
+              "type":"list",
+              "description":"A comma-separated list of data streams to delete; use `*` to delete all data streams"
+            }
+          }
+        }
+      ]
+    },
+    "params":{}
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream.json
@@ -1,0 +1,33 @@
+{
+  "indices.get_data_stream":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
+      "description":"Returns data streams."
+    },
+    "stability":"experimental",
+    "url":{
+      "paths":[
+        {
+          "path":"/_data_stream",
+          "methods":[
+            "GET"
+          ]
+        },
+        {
+          "path":"/_data_stream/{name}",
+          "methods":[
+            "GET"
+          ],
+          "parts":{
+            "name":{
+              "type":"list",
+              "description":"A comma-separated list of data streams to get; use `*` to get all data streams"
+            }
+          }
+        }
+      ]
+    },
+    "params":{
+    }
+  }
+}


### PR DESCRIPTION
Add back the REST specs for data streams which were moved to x-pack as part of the commit fe12217c

Resolves #77 