### PR TITLE
[TEST] Fix Feature Flags in Test Framework and SortTemplates yaml failure

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.templates/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.templates/10_basic.yml
@@ -230,8 +230,8 @@
     - match:
         $body: |
               /^
-                  test   \s+ \[t\*\]  \s+   \n \n
-                  test_1 \s+ \[te\*\] \s+ 1 \n \n
+                  test   \s+ \[t\*\]  \s+   \n
+                  test_1 \s+ \[te\*\] \s+ 1 \n
               $/
 
     - do:
@@ -242,8 +242,8 @@
     - match:
         $body: |
               /^
-                  test_1 \s+ \[te\*\]   \s+ 1\n \n
-                  test   \s+ \[t\*\]    \s+  \n \n
+                  test_1 \s+ \[te\*\]   \s+ 1\n
+                  test   \s+ \[t\*\]    \s+  \n
 
               $/
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/SkipSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/SkipSection.java
@@ -71,7 +71,17 @@ public class SkipSection {
                 } else if ("reason".equals(currentFieldName)) {
                     reason = parser.text();
                 } else if ("features".equals(currentFieldName)) {
-                    features.add(parser.text());
+                    String f = parser.text();
+                    // split on ','
+                    String[] fs = f.split(",");
+                    if (fs != null) {
+                        // add each feature, separately:
+                        for (String feature : fs) {
+                            features.add(feature.trim());
+                        }
+                    } else {
+                        features.add(f);
+                    }
                 }
                 else {
                     throw new ParsingException(parser.getTokenLocation(),


### PR DESCRIPTION
This PR adds parse logic to correctly parse feature flags in the test framework. It also fixes a test failure in cat.templates/Sort Templates yaml test.

closes #79 