### PR TITLE
Only run pre-commit checks in GitHub actions.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-name: Search Sanity Checks
+name: Search CI
 on:
   push:
     branches:


### PR DESCRIPTION
This is to run a quick sanity check on code formatting, licensing headers etc.  

Relates #24 