### PR TITLE
Fix failing bwc test and cleanup more oss logic

### DIFF
--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionArchiveSetupPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionArchiveSetupPluginFuncTest.groovy
@@ -33,7 +33,7 @@ class InternalDistributionArchiveSetupPluginFuncTest extends AbstractGradleFuncT
     def setup() {
         buildFile << """
         import org.elasticsearch.gradle.tar.SymbolicLinkPreservingTar
-        
+
         plugins {
             id 'elasticsearch.internal-distribution-archive-setup'
         }
@@ -60,7 +60,6 @@ class InternalDistributionArchiveSetupPluginFuncTest extends AbstractGradleFuncT
 
         where:
         buildTaskName       | expectedOutputArchivePath
-        "buildDarwinTar"    | "darwin-tar/build/distributions/elasticsearch.tar.gz"
         "buildOssDarwinTar" | "oss-darwin-tar/build/distributions/elasticsearch-oss.tar.gz"
     }
 
@@ -111,23 +110,23 @@ class InternalDistributionArchiveSetupPluginFuncTest extends AbstractGradleFuncT
                 }
             }
         }
-        
+
         project('consumer') { p ->
             configurations {
                 consumeArchive {}
                 consumeDir {}
             }
-            
+
             dependencies {
                 consumeDir project(path: ':producer-tar', configuration:'extracted')
                 consumeArchive project(path: ':producer-tar', configuration:'default' )
             }
-            
+
             tasks.register("copyDir", Copy) {
                 from(configurations.consumeDir)
                 into('build/dir')
             }
-            
+
             tasks.register("copyArchive", Copy) {
                 from(configurations.consumeArchive)
                 into('build/archives')

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
@@ -57,56 +57,56 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGradleFuncTest 
         result.output.contains("[8.0.1] > Task :distribution:archives:oss-darwin-tar:assemble")
     }
 
-//    def "bwc distribution archives can be resolved as bwc project artifact"() {
-//        setup:
-//        new File(testProjectDir.root, 'remote/build.gradle') << """
-//        
-//        configurations {
-//            dists
-//        }
-//        
-//        dependencies {
-//            dists project(path: ":distribution:bwc:bugfix", configuration:"oss-darwin-tar")
-//        }
-//        
-//        tasks.register("resolveDistributionArchive") {
-//            inputs.files(configurations.dists)
-//            doLast {
-//                configurations.dists.files.each {
-//                    println "distfile " + (it.absolutePath - project.rootDir.absolutePath)
-//                }
-//            }
-//        }
-//        """
-//        when:
-//        def result = gradleRunner(new File(testProjectDir.root, "remote"),
-//                ":resolveDistributionArchive",
-//                "-DtestRemoteRepo=" + remoteGitRepo,
-//                "-Dbwc.remote=origin")
-//                .build()
-//        then:
-//        result.task(":resolveDistributionArchive").outcome == TaskOutcome.SUCCESS
-//        result.task(":distribution:bwc:bugfix:buildBwcOssDarwinTar").outcome == TaskOutcome.SUCCESS
-//
-//        and: "assemble task triggered"
-//        result.output.contains("[8.0.1] > Task :distribution:archives:oss-darwin-tar:assemble")
-//        normalizedOutput(result.output)
-//                .contains("distfile /distribution/bwc/bugfix/build/bwc/checkout-8.0/distribution/archives/oss-darwin-tar/" +
-//                        "build/distributions/elasticsearch-8.0.1-SNAPSHOT-oss-darwin-x86_64.tar.gz")
-//    }
+    def "bwc distribution archives can be resolved as bwc project artifact"() {
+        setup:
+        new File(testProjectDir.root, 'remote/build.gradle') << """
+
+        configurations {
+            dists
+        }
+
+        dependencies {
+            dists project(path: ":distribution:bwc:bugfix", configuration:"oss-darwin-tar")
+        }
+
+        tasks.register("resolveDistributionArchive") {
+            inputs.files(configurations.dists)
+            doLast {
+                configurations.dists.files.each {
+                    println "distfile " + (it.absolutePath - project.rootDir.absolutePath)
+                }
+            }
+        }
+        """
+        when:
+        def result = gradleRunner(new File(testProjectDir.root, "remote"),
+                ":resolveDistributionArchive",
+                "-DtestRemoteRepo=" + remoteGitRepo,
+                "-Dbwc.remote=origin")
+                .build()
+        then:
+        result.task(":resolveDistributionArchive").outcome == TaskOutcome.SUCCESS
+        result.task(":distribution:bwc:bugfix:buildBwcOssDarwinTar").outcome == TaskOutcome.SUCCESS
+
+        and: "assemble task triggered"
+        result.output.contains("[8.0.1] > Task :distribution:archives:oss-darwin-tar:assemble")
+        normalizedOutput(result.output)
+                .contains("distfile /distribution/bwc/bugfix/build/bwc/checkout-8.0/distribution/archives/oss-darwin-tar/" +
+                        "build/distributions/elasticsearch-oss-8.0.1-SNAPSHOT-darwin-x86_64.tar.gz")
+    }
 
     def "bwc expanded distribution folder can be resolved as bwc project artifact"() {
         setup:
         new File(testProjectDir.root, 'remote/build.gradle') << """
-        
+
         configurations {
             expandedDist
         }
-        
+
         dependencies {
             expandedDist project(path: ":distribution:bwc:bugfix", configuration:"expanded-oss-darwin-tar")
         }
-        
+
         tasks.register("resolveExpandedDistribution") {
             inputs.files(configurations.expandedDist)
             doLast {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/RepositoriesSetupPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/RepositoriesSetupPlugin.java
@@ -79,6 +79,7 @@ public class RepositoriesSetupPlugin implements Plugin<Project> {
                 throw new GradleException("Malformed lucene snapshot version: " + luceneVersion);
             }
             String revision = matcher.group(1);
+            // TODO(cleanup) - Setup own lucene snapshot repo
             MavenArtifactRepository luceneRepo = repos.maven(repo -> {
                 repo.setName("lucene-snapshots");
                 repo.setUrl("https://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/" + revision);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -119,7 +119,7 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
 
     private void registerDistributionArchiveArtifact(Project bwcProject, DistributionProject distributionProject, String buildBwcTask) {
         String artifactFileName = distributionProject.getDistFile().getName();
-        String artifactName = artifactFileName.contains("oss") ? "elasticsearch-oss" : "elasticsearch";
+        String artifactName = "elasticsearch-oss";
 
         String suffix = artifactFileName.endsWith("tar.gz") ? "tar.gz" : artifactFileName.substring(artifactFileName.length() - 3);
         int archIndex = artifactFileName.indexOf("x86_64");
@@ -157,7 +157,7 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
             if (bwcVersion.onOrAfter("7.0.0")) {
                 if (name.contains("zip") || name.contains("tar")) {
                     int index = name.lastIndexOf('-');
-                    String baseName = name.startsWith("oss-") ? name.substring(4, index) : name.substring(0, index);
+                    String baseName = name.substring(4, index); // oss-
                     classifier = "-" + baseName + "-x86_64";
                     extension = name.substring(index + 1);
                     if (extension.equals("tar")) {
@@ -168,7 +168,7 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                 } else if (name.contains("rpm")) {
                     classifier = "-x86_64";
                 }
-            } else if (name.contains("oss-")) {
+            } else {
                 extension = name.substring(4);
             }
             return new DistributionProject(name, baseDir, bwcVersion, classifier, extension, checkoutDir);
@@ -228,16 +228,7 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
             this.projectPath = baseDir + "/" + name;
             this.distFile = new File(
                 checkoutDir,
-                baseDir
-                    + "/"
-                    + name
-                    + "/build/distributions/elasticsearch-"
-                    + (name.startsWith("oss") ? "oss-" : "")
-                    + version
-                    + "-SNAPSHOT"
-                    + classifier
-                    + "."
-                    + extension
+                baseDir + "/" + name + "/build/distributions/elasticsearch-oss-" + version + "-SNAPSHOT" + classifier + "." + extension
             );
             // we only ported this down to the 7.x branch.
             if (version.onOrAfter("7.10.0") && (name.endsWith("zip") || name.endsWith("tar"))) {


### PR DESCRIPTION

Squashed commit of the following:

commit bf5a131ab7b8ba6bfdf6676766138cae87ef1ee3
Author: Himanshu Setia <setiah@amazon.com>
Date:   Tue Feb 16 05:17:50 2021 +0000

    Fixing spotlessApply

commit 9930ca36297060c176cff63dfb87a32bb990f8b5
Author: Himanshu Setia <setiah@amazon.com>
Date:   Mon Feb 15 20:30:51 2021 -0800

    fixing "bwc distribution archives can be resolved as bwc project artifact"

commit 5eac87a0d4e6706ddd62855d5c1efc3f29ab9424
Author: Himanshu Setia <setiah@amazon.com>
Date:   Mon Feb 15 18:50:13 2021 -0800

    temporarily enable commented test

commit d0b09f4c9d1007ab2c4276376ebfa16c3bed7c07
Author: Himanshu Setia <setiah@amazon.com>
Date:   Mon Feb 15 18:17:58 2021 -0800

    cleanup unnecessary oss logic

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
