### PR TITLE
[DOCS] Remove usage of '{security-features}' except in docs for 'migration' & 'windows installer' ('oss-docs' branch)

### DIFF
--- a/docs/reference/cat/alias.asciidoc
+++ b/docs/reference/cat/alias.asciidoc
@@ -15,13 +15,6 @@ filter and routing information.
 
 `GET /_cat/aliases`
 
-[[cat-alias-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the
-`view_index_metadata` or `manage` <<privileges-list-indices,index privilege>>
-for any alias you retrieve.
-
 [[cat-alias-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/cat/allocation.asciidoc
+++ b/docs/reference/cat/allocation.asciidoc
@@ -16,12 +16,6 @@ and their disk space.
 
 `GET /_cat/allocation`
 
-[[cat-allocation-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cat-allocation-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/cat/count.asciidoc
+++ b/docs/reference/cat/count.asciidoc
@@ -18,13 +18,6 @@ which have not yet been removed by the merge process.
 
 `GET /_cat/count`
 
-[[cat-count-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `read`
-<<privileges-list-indices,index privilege>> for any data stream, index, or index
-alias you retrieve.
-
 [[cat-count-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/cat/fielddata.asciidoc
+++ b/docs/reference/cat/fielddata.asciidoc
@@ -15,12 +15,6 @@ Returns the amount of heap memory currently used by the
 
 `GET /_cat/fielddata`
 
-[[cat-fielddata-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cat-fielddata-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/cat/health.asciidoc
+++ b/docs/reference/cat/health.asciidoc
@@ -13,12 +13,6 @@ health>> API.
 
 `GET /_cat/health`
 
-[[cat-health-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cat-health-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cat/indices.asciidoc
+++ b/docs/reference/cat/indices.asciidoc
@@ -15,14 +15,6 @@ indices for data streams.
 
 `GET /_cat/indices`
 
-[[cat-indices-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API. You must
-also have the `monitor` or `manage` <<privileges-list-indices,index privilege>>
-for any data stream, index, or index alias you retrieve.
-
 [[cat-indices-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cat/master.asciidoc
+++ b/docs/reference/cat/master.asciidoc
@@ -13,12 +13,6 @@ and name.
 
 `GET /_cat/master`
 
-[[cat-master-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cat-master-api-query-params]]
 ==== {api-query-parms-title}
 

--- a/docs/reference/cat/nodeattrs.asciidoc
+++ b/docs/reference/cat/nodeattrs.asciidoc
@@ -11,12 +11,6 @@ Returns information about custom node attributes.
 
 `GET /_cat/nodeattrs`
 
-[[cat-nodeattrs-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cat-nodeattrs-api-query-params]]
 ==== {api-query-parms-title}
 

--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -11,12 +11,6 @@ Returns information about a cluster's nodes.
 
 `GET /_cat/nodes`
 
-[[cat-nodes-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cat-nodes-api-query-params]]
 ==== {api-query-parms-title}
 

--- a/docs/reference/cat/pending_tasks.asciidoc
+++ b/docs/reference/cat/pending_tasks.asciidoc
@@ -12,12 +12,6 @@ Returns cluster-level changes that have not yet been executed, similar to the
 
 `GET /_cat/pending_tasks`
 
-[[cat-pending-tasks-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cat-pending-tasks-api-query-params]]
 ==== {api-query-parms-title}
 

--- a/docs/reference/cat/plugins.asciidoc
+++ b/docs/reference/cat/plugins.asciidoc
@@ -12,12 +12,6 @@ Returns a list of plugins running on each node of a cluster.
 
 `GET /_cat/plugins`
 
-[[cat-plugins-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cat-plugins-api-query-params]]
 ==== {api-query-parms-title}
 

--- a/docs/reference/cat/recovery.asciidoc
+++ b/docs/reference/cat/recovery.asciidoc
@@ -18,14 +18,6 @@ indices.
 
 `GET /_cat/recovery`
 
-[[cat-recovery-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API. You must
-also have the `monitor` or `manage` <<privileges-list-indices,index privilege>>
-for any data stream, index, or index alias you retrieve.
-
 [[cat-recovery-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cat/repositories.asciidoc
+++ b/docs/reference/cat/repositories.asciidoc
@@ -12,13 +12,6 @@ Returns the <<snapshots-repositories,snapshot repositories>> for a cluster.
 
 `GET /_cat/repositories`
 
-[[cat-repositories-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the
-`monitor_snapshot`, `create_snapshot`, or `manage`
-<<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cat-repositories-query-params]]
 ==== {api-query-parms-title}
 

--- a/docs/reference/cat/segments.asciidoc
+++ b/docs/reference/cat/segments.asciidoc
@@ -18,14 +18,6 @@ indices.
 
 `GET /_cat/segments`
 
-[[cat-segments-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API. You must
-also have the `monitor` or `manage` <<privileges-list-indices,index privilege>>
-for any data stream, index, or index alias you retrieve.
-
 [[cat-segments-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/cat/shards.asciidoc
+++ b/docs/reference/cat/shards.asciidoc
@@ -19,14 +19,6 @@ indices.
 
 `GET /_cat/shards`
 
-[[cat-shards-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API. You must
-also have the `monitor` or `manage` <<privileges-list-indices,index privilege>>
-for any data stream, index, or index alias you retrieve.
-
 [[cat-shards-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/cat/snapshots.asciidoc
+++ b/docs/reference/cat/snapshots.asciidoc
@@ -13,14 +13,6 @@ more repositories. A snapshot is a backup of an index or running {es} cluster.
 
 `GET /_cat/snapshots/<repository>`
 
-[[cat-snapshots-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the
-`monitor_snapshot`, `create_snapshot`, or `manage`
-<<privileges-list-cluster,cluster privilege>> to use this API.
-
-
 [[cat-snapshots-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/cat/tasks.asciidoc
+++ b/docs/reference/cat/tasks.asciidoc
@@ -15,12 +15,6 @@ similar to the <<tasks,task management>> API.
 
 `GET /_cat/tasks`
 
-[[cat-tasks-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cat-tasks-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cat/templates.asciidoc
+++ b/docs/reference/cat/templates.asciidoc
@@ -16,12 +16,6 @@ and <<mapping,field mappings>> to new indices at creation.
 
 `GET /_cat/templates`
 
-[[cat-templates-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cat-templates-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/cat/thread_pool.asciidoc
+++ b/docs/reference/cat/thread_pool.asciidoc
@@ -16,12 +16,6 @@ pools.
 
 `GET /_cat/thread_pool`
 
-[[cat-thread-pool-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cat-thread-pool-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/cluster/allocation-explain.asciidoc
+++ b/docs/reference/cluster/allocation-explain.asciidoc
@@ -12,12 +12,6 @@ Provides explanations for shard allocations in the cluster.
 
 `GET /_cluster/allocation/explain`
 
-[[cluster-allocation-explain-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cluster-allocation-explain-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cluster/get-settings.asciidoc
+++ b/docs/reference/cluster/get-settings.asciidoc
@@ -11,12 +11,6 @@ Returns cluster-wide settings.
 GET /_cluster/settings
 ----
 
-[[cluster-get-settings-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cluster-get-settings-api-request]]
 ==== {api-request-title}
 

--- a/docs/reference/cluster/health.asciidoc
+++ b/docs/reference/cluster/health.asciidoc
@@ -11,12 +11,6 @@ Returns the health status of a cluster.
 
 `GET /_cluster/health/<target>`
 
-[[cluster-health-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cluster-health-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cluster/nodes-hot-threads.asciidoc
+++ b/docs/reference/cluster/nodes-hot-threads.asciidoc
@@ -14,12 +14,6 @@ Returns the hot threads on each selected node in the cluster.
 
 `GET /_nodes/<node_id>/hot_threads`
 
-[[cluster-nodes-hot-threads-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cluster-nodes-hot-threads-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cluster/nodes-info.asciidoc
+++ b/docs/reference/cluster/nodes-info.asciidoc
@@ -18,13 +18,6 @@ Returns cluster nodes information.
 
 `GET /_nodes/<node_id>/<metric>`
 
-[[cluster-nodes-info-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
-
 [[cluster-nodes-info-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cluster/nodes-reload-secure-settings.asciidoc
+++ b/docs/reference/cluster/nodes-reload-secure-settings.asciidoc
@@ -12,12 +12,6 @@ Reloads the keystore on nodes in the cluster.
 `POST /_nodes/reload_secure_settings` +
 `POST /_nodes/<node_id>/reload_secure_settings`
 
-[[cluster-nodes-reload-secure-settings-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `manage`
-<<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cluster-nodes-reload-secure-settings-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -21,12 +21,6 @@ Returns cluster nodes statistics.
 
 `GET /_nodes/<node_id>/stats/<metric>/<index_metric>`
 
-[[cluster-nodes-stats-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cluster-nodes-stats-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cluster/nodes-usage.asciidoc
+++ b/docs/reference/cluster/nodes-usage.asciidoc
@@ -18,12 +18,6 @@ Returns information on the usage of features.
 
 `GET /_nodes/<node_id>/usage/<metric>`
 
-[[cluster-nodes-usage-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cluster-nodes-usage-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cluster/pending.asciidoc
+++ b/docs/reference/cluster/pending.asciidoc
@@ -12,12 +12,6 @@ Returns cluster-level changes that have not yet been executed.
 
 `GET /_cluster/pending_tasks`
 
-[[cluster-pending-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cluster-pending-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cluster/remote-info.asciidoc
+++ b/docs/reference/cluster/remote-info.asciidoc
@@ -12,12 +12,6 @@ Returns configured remote cluster information.
 
 `GET /_remote/info`
 
-[[cluster-remote-info-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cluster-remote-info-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cluster/reroute.asciidoc
+++ b/docs/reference/cluster/reroute.asciidoc
@@ -12,12 +12,6 @@ Changes the allocation of shards in a cluster.
 
 `POST /_cluster/reroute`
 
-[[cluster-reroute-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `manage`
-<<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cluster-reroute-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cluster/state.asciidoc
+++ b/docs/reference/cluster/state.asciidoc
@@ -11,12 +11,6 @@ Returns metadata about the state of the cluster.
 
 `GET /_cluster/state/<metrics>/<target>`
 
-[[cluster-state-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cluster-state-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -14,12 +14,6 @@ Returns cluster statistics.
 
 `GET /_cluster/stats/nodes/<node_filter>`
 
-[[cluster-stats-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cluster-stats-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -15,12 +15,6 @@ Returns information about the tasks currently executing in the cluster.
 
 `GET /_tasks`
 
-[[tasks-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `monitor` or
-`manage` <<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[tasks-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cluster/update-settings.asciidoc
+++ b/docs/reference/cluster/update-settings.asciidoc
@@ -12,12 +12,6 @@ Updates cluster-wide settings.
 
 `PUT /_cluster/settings`
 
-[[cluster-update-settings-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `manage`
-<<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[cluster-update-settings-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/cluster/voting-exclusions.asciidoc
+++ b/docs/reference/cluster/voting-exclusions.asciidoc
@@ -17,12 +17,6 @@ Adds or removes master-eligible nodes from the
 
 `DELETE /_cluster/voting_config_exclusions`
 
-[[voting-config-exclusions-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `manage`
-<<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[voting-config-exclusions-api-desc]]
 ==== {api-description-title}
   

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -103,13 +103,6 @@ PUT /_data_stream/my-data-stream
 // TEST[s/my-data-stream/my-data-stream-alt/]
 
 [discrete]
-[[secure-a-data-stream]]
-=== Secure the data stream
-
-To control access to the data stream and its
-data, use <<data-stream-privileges,{es}'s {security-features}>>.
-
-[discrete]
 [[get-info-about-a-data-stream]]
 === Get information about a data stream
 

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -26,13 +26,6 @@ POST _bulk
 
 `POST /<target>/_bulk`
 
-[[docs-bulk-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the following
-<<privileges-list-indices,index privileges>> for the target data stream, index,
-or index alias:
-
 ** To use the `create` action, you must have the `create_doc`, `create`,
 `index`, or `write` index privilege. Data streams support only the `create`
 action.

--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -49,16 +49,6 @@ POST /my-index-000001/_delete_by_query
 
 `POST /<target>/_delete_by_query`
 
-[[docs-delete-by-query-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the following
-<<privileges-list-indices,index privileges>> for the target data stream, index,
-or index alias:
-
-** `read`
-** `delete` or `write`
-
 [[docs-delete-by-query-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -11,13 +11,6 @@ Removes a JSON document from the specified index.
 
 `DELETE /<index>/_doc/<_id>`
 
-[[docs-delete-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `delete` or
-`write` <<privileges-list-indices,index privilege>> for the target index or
-index alias.
-
 [[docs-delete-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -23,12 +23,6 @@ GET my-index-000001/_doc/0
 
 `HEAD <index>/_source/<_id>`
 
-[[docs-get-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `read`
-<<privileges-list-indices,index privilege>> for the target index or index alias.
-
 [[docs-get-api-desc]]
 ==== {api-description-title}
 You use GET to retrieve a document and its source or stored fields from a

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -33,21 +33,6 @@ IMPORTANT: You cannot add new documents to a data stream using the
 [[docs-index-api-prereqs]]
 ==== {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have the following
-<<privileges-list-indices,index privileges>> for the target data stream, index,
-or index alias:
-
-** To add or overwrite a document using the `PUT /<target>/_doc/<_id>` request
-format, you must have the `create`, `index`, or `write` index privilege.
-
-** To add a document using the `POST /<target>/_doc/`,
-`PUT /<target>/_create/<_id>`, or `POST /<target>/_create/<_id>` request
-formats, you must have the `create_doc`, `create`, `index`, or `write` index
-privilege.
-
-** To automatically create a data stream or index with an index API request, you
-must have the `auto_configure`, `create_index`, or `manage` index privilege.
-
 * Automatic data stream creation requires a matching index template with data
 stream enabled. See <<set-up-a-data-stream>>.
 

--- a/docs/reference/docs/multi-get.asciidoc
+++ b/docs/reference/docs/multi-get.asciidoc
@@ -31,12 +31,6 @@ GET /_mget
 
 `GET /<index>/_mget`
 
-[[docs-multi-get-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `read`
-<<privileges-list-indices,index privilege>> for the target index or index alias.
-
 [[docs-multi-get-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/docs/multi-termvectors.asciidoc
+++ b/docs/reference/docs/multi-termvectors.asciidoc
@@ -35,12 +35,6 @@ POST /_mtermvectors
 
 `POST /<index>/_mtermvectors`
 
-[[docs-multi-termvectors-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `read`
-<<privileges-list-indices,index privilege>> for the target index or index alias.
-
 [[docs-multi-termvectors-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -71,23 +71,6 @@ POST _reindex
 [[docs-reindex-api-prereqs]]
 ==== {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have the the following
-security privileges:
-
-** The `read` <<privileges-list-indices,index privilege>> for the source data
-stream, index, or index alias.
-
-** The `write` index privilege for the destination data stream, index, or index
-alias.
-
-** To automatically create a data stream or index with an reindex API request,
-you must have the `auto_configure`, `create_index`, or `manage` index
-privilege for the destination data stream, index, or index alias.
-
-** If reindexing from a remote cluster, the `source.remote.user` must have the
-`monitor` <<privileges-list-cluster,cluster privilege>> and the `read` index
-privilege for the source data stream, index, or index alias.
-
 * If reindexing from a remote cluster, you must explicitly allow the remote host
 in the `reindex.remote.whitelist` setting of `elasticsearch.yml`. See
 <<reindex-from-remote>>.

--- a/docs/reference/docs/termvectors.asciidoc
+++ b/docs/reference/docs/termvectors.asciidoc
@@ -17,12 +17,6 @@ GET /my-index-000001/_termvectors/1
 
 `GET /<index>/_termvectors/<_id>`
 
-[[docs-termvectors-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `read`
-<<privileges-list-indices,index privilege>> for the target index or index alias.
-
 [[docs-termvectors-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -46,16 +46,6 @@ POST my-index-000001/_update_by_query?conflicts=proceed
 
 `POST /<target>/_update_by_query`
 
-[[docs-update-by-query-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the following
-<<privileges-list-indices,index privileges>> for the target data stream, index,
-or index alias:
-
-** `read`
-** `index` or `write`
-
 [[docs-update-by-query-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -11,13 +11,6 @@ Updates a document using the specified script.
 
 `POST /<index>/_update/<_id>`
 
-[[docs-update-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `index` or
-`write` <<privileges-list-indices,index privilege>> for the target index or
-index alias.
-
 [[update-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -207,8 +207,7 @@ This example uses the following variables:
 `<VERB>`:: The appropriate HTTP method or verb. For example, `GET`, `POST`,
 `PUT`, `HEAD`, or `DELETE`.
 `<PROTOCOL>`:: Either `http` or `https`. Use the latter if you have an HTTPS
-proxy in front of {es} or you use {es} {security-features} to encrypt HTTP
-communications.
+proxy in front of {es}.
 `<HOST>`:: The hostname of any node in your {es} cluster. Alternatively, use
 +localhost+ for a node on your local machine.
 `<PORT>`:: The port running the {es} HTTP service, which defaults to `9200`.
@@ -217,11 +216,6 @@ communications.
 `<QUERY_STRING>`:: Any optional query-string parameters. For example, `?pretty`
 will _pretty-print_  the JSON response to make it easier to read.
 `<BODY>`:: A JSON-encoded request body (if necessary).
-
-If the {es} {security-features} are enabled, you must also provide a valid user
-name (and password) that has authority to run the API. For example, use the
-`-u` or `--u` cURL command parameter. For details about which security
-privileges are required to run each API, see <<rest-apis>>.
 
 {es} responds to each API request with an HTTP status code like `200 OK`. With
 the exception of `HEAD` requests, it also returns a JSON-encoded response body. 

--- a/docs/reference/high-availability/backup-cluster-config.asciidoc
+++ b/docs/reference/high-availability/backup-cluster-config.asciidoc
@@ -49,11 +49,7 @@ configuration files.
 ====
 
 * Transient settings are not considered for backup.
-* {es} {security-features} store configuration data such as role definitions and
-API keys inside a dedicate special index. This "system" data,
-complements the <<secure-settings, security settings>> configuration and should
-be <<backup-security-index-configuration, backed up as well>>.
-* Other {stack} components, like Kibana and {ml-cap}, store their configuration
+* Other {stack} components, like Kibana, store their configuration
 data inside other dedicated indices. From the {es} perspective these are just data
 so you can use the regular <<backup-cluster-data, data backup>> process.
 

--- a/docs/reference/high-availability/backup-cluster-data.asciidoc
+++ b/docs/reference/high-availability/backup-cluster-data.asciidoc
@@ -7,21 +7,3 @@
 To back up your cluster's data, you can use the <<modules-snapshots,snapshot API>>.
 
 include::../snapshot-restore/index.asciidoc[tag=snapshot-intro]
-
-[TIP]
-====
-If your cluster has {es} {security-features} enabled, when you back up your data
-the snapshot API call must be authorized.
-
-The `snapshot_user` role is a reserved role that can be assigned to the user
-who is calling the snapshot endpoint. This is the only role necessary if all the user
-does is periodic snapshots as part of the backup procedure. This role includes
-the privileges to list all the existing snapshots (of any repository) as
-well as list and view settings of all indices, including the `.security` index.
-It does *not* grant privileges to create repositories, restore snapshots, or
-search within indices. Hence, the user can view and snapshot all indices, but cannot
-access or modify any data.
-
-For more information, see <<security-privileges>>
-and <<built-in-roles>>.
-====

--- a/docs/reference/high-availability/restore-cluster-data.asciidoc
+++ b/docs/reference/high-availability/restore-cluster-data.asciidoc
@@ -5,11 +5,3 @@
 ++++
 
 include::../snapshot-restore/index.asciidoc[tag=restore-intro]
-
-[TIP]
-====
-If your cluster has {es} {security-features} enabled, the restore API requires the `manage` cluster privilege. There is no bespoke role for the restore process. This privilege is very permissive and should only
-be granted to users in the "administrator" category. Specifically, it allows
-malicious users to exfiltrate data to a location of their choosing. Automated
-tools should not run as users with this privilege.
-====

--- a/docs/reference/indices/create-data-stream.asciidoc
+++ b/docs/reference/indices/create-data-stream.asciidoc
@@ -40,12 +40,6 @@ DELETE /_index_template/template
 
 `PUT /_data_stream/<data-stream>`
 
-[[indices-create-data-stream-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `create_index`
-or `manage` <<privileges-list-indices,index privilege>> for the data stream.
-
 [[indices-create-data-stream-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/indices/data-stream-stats.asciidoc
+++ b/docs/reference/indices/data-stream-stats.asciidoc
@@ -51,13 +51,6 @@ DELETE /_index_template/*
 GET /_data_stream/my-data-stream/_stats
 ----
 
-[[data-stream-stats-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the
-`monitor` or `manage` <<privileges-list-indices,index privilege>>
-for the data stream.
-
 [[data-stream-stats-api-request]]
 ==== {api-request-title}
 

--- a/docs/reference/indices/delete-data-stream.asciidoc
+++ b/docs/reference/indices/delete-data-stream.asciidoc
@@ -39,13 +39,6 @@ DELETE /_index_template/template
 
 `DELETE /_data_stream/<data-stream>`
 
-[[delete-data-stream-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the `delete_index`
-or `manage` <<privileges-list-indices,index privilege>> for the data stream.
-
-
 [[delete-data-stream-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -44,13 +44,6 @@ GET /_data_stream/my-data-stream
 
 `GET /_data_stream/<data-stream>`
 
-[[get-data-stream-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the
-`view_index_metadata` or `manage` <<privileges-list-indices,index privilege>>
-for the data stream.
-
 [[get-data-stream-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/ingest/apis/delete-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/delete-pipeline.asciidoc
@@ -35,13 +35,6 @@ DELETE /_ingest/pipeline/my-pipeline-id
 
 `DELETE /_ingest/pipeline/<pipeline>`
 
-[[delete-pipeline-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the
-`manage_pipeline`, `manage_ingest_pipelines`, or `manage`
-<<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[delete-pipeline-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/ingest/apis/get-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/get-pipeline.asciidoc
@@ -41,13 +41,6 @@ GET /_ingest/pipeline/my-pipeline-id
 
 `GET /_ingest/pipeline`
 
-[[get-pipeline-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the
-`manage_pipeline`, `manage_ingest_pipelines`, or `manage`
-<<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[get-pipeline-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/ingest/apis/put-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/put-pipeline.asciidoc
@@ -29,14 +29,6 @@ PUT _ingest/pipeline/my-pipeline-id
 
 `PUT /_ingest/pipeline/<pipeline>`
 
-[[put-pipeline-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the
-`manage_pipeline`, `manage_ingest_pipelines`, or `manage`
-<<privileges-list-cluster,cluster privilege>> to use this API.
-
-
 [[put-pipeline-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/ingest/apis/simulate-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/simulate-pipeline.asciidoc
@@ -62,13 +62,6 @@ POST /_ingest/pipeline/my-pipeline-id/_simulate
 
 `GET /_ingest/pipeline/_simulate`
 
-[[simulate-pipeline-api-prereqs]]
-==== {api-prereq-title}
-
-* If the {es} {security-features} are enabled, you must have the
-`manage_pipeline`, `manage_ingest_pipelines`, or `manage`
-<<privileges-list-cluster,cluster privilege>> to use this API.
-
 [[simulate-pipeline-api-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/scripting/using.asciidoc
+++ b/docs/reference/scripting/using.asciidoc
@@ -137,14 +137,6 @@ The same script in the normal form:
 Scripts may be stored in and retrieved from the cluster state using the
 `_scripts` end-point.
 
-If the {es} {security-features} are enabled, you must have the following
-privileges to create, retrieve, and delete stored scripts:
-
-* cluster: `all` or `manage`
-
-For more information, see <<security-privileges>>.
-
-
 [discrete]
 ==== Request examples
 

--- a/docs/reference/upgrade/cluster_restart.asciidoc
+++ b/docs/reference/upgrade/cluster_restart.asciidoc
@@ -62,11 +62,6 @@ Use the `elasticsearch-plugin` script to install the upgraded version of each
 installed {es} plugin. All plugins must be upgraded when you upgrade
 a node.
 
-. If you use {es} {security-features} to define realms, verify that your realm
-settings are up-to-date. The format of realm settings changed in version 7.0, in
-particular, the placement of the realm type changed. See
-<<realm-settings,Realm settings>>. 
-
 . *Start each upgraded node.*
 +
 --

--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -91,11 +91,6 @@ Use the `elasticsearch-plugin` script to install the upgraded version of each
 installed {es} plugin. All plugins must be upgraded when you upgrade
 a node.
 
-. If you use {es} {security-features} to define realms, verify that your realm
-settings are up-to-date. The format of realm settings changed in version 7.0, in
-particular, the placement of the realm type changed. See
-<<realm-settings,Realm settings>>. 
-
 . *Start the upgraded node.*
 +
 --


### PR DESCRIPTION
*Issue #, if available:*
#88

*Description of changes:*
This PR requests merging the code into `oss-docs` branch.

- Removes all usage of `{security-features}` in the Docs folder, which is a main remaining reference related to x-pack feature

`{security-features}` that used in the migration guide from 7.x version, and guide for windows installer is not removed, as those part of docs is probably not needed for us.

Note: A previous PR https://github.com/opendistro-for-elasticsearch/search/pull/115 was closed by mistake, so open the new PR.

Testing:
```
$ ./gradlew :docs:check
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 6.6.1
  OS Info               : Linux 5.4.0-1037-aws (amd64)
  JDK Version           : 14 (JDK)
  JAVA_HOME             : /usr/lib/jvm/java-14-openjdk-amd64
  Random Testing Seed   : BF72F606D09E62CF
  In FIPS 140 mode      : false
=======================================

BUILD SUCCESSFUL in 7m 27s
268 actionable tasks: 8 executed, 260 up-to-date
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
