### PR TITLE
[DOCS] Remove "voting_only node" (except in 'HA cluster-design' page)

### DIFF
--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -42,10 +42,8 @@ Valid columns are:
 (Default) Used file descriptors percentage, such as `1`.
 
 `node.role`, `r`, `role`, `nodeRole`::
-(Default) Roles of the node. Returned values include `c` (cold node), `d` (data
-node), `h` (hot node), `i` (ingest node), `l` (machine learning node), `m`
-(master-eligible node), `r` (remote cluster client node), `s` (content node),
-`v` (voting-only node), `w` (warm node) and `-` (coordinating node only).
+(Default) Roles of the node. Returned values include `m` (master-eligible node),
+`d` (data node), `i` (ingest node), and `-` (coordinating node only).
 +
 For example, `dim` indicates a master-eligible data and ingest node. See
 <<modules-node>>.

--- a/docs/reference/cluster.asciidoc
+++ b/docs/reference/cluster.asciidoc
@@ -20,14 +20,12 @@ one of the following:
 * an IP address or hostname, to add all matching nodes to the subset.
 * a pattern, using `*` wildcards, which adds all nodes to the subset
   whose name, address or hostname matches the pattern.
-* `master:true`, `data:true`, `ingest:true`, `voting_only:true`, `ml:true`, or
-  `coordinating_only:true`, which respectively add to the subset all
-  master-eligible nodes, all data nodes, all ingest nodes, all voting-only
-  nodes, all machine learning nodes, and all coordinating-only nodes.
-* `master:false`, `data:false`, `ingest:false`, `voting_only:true`, `ml:false`,
-  or `coordinating_only:false`, which respectively remove from the subset all
-  master-eligible nodes, all data nodes, all ingest nodes, all voting-only
-  nodes, all machine learning nodes, and all coordinating-only nodes.
+* `master:true`, `data:true`, `ingest:true` or `coordinating_only:true`, which
+  respectively add to the subset all master-eligible nodes, all data nodes,
+  all ingest nodes, and all coordinating-only nodes.
+* `master:false`, `data:false`, `ingest:false` or `coordinating_only:false`,
+  which respectively remove from the subset all master-eligible nodes, all data
+  nodes, all ingest nodes, and all coordinating-only nodes.
 * a pair of patterns, using `*` wildcards, of the form `attrname:attrvalue`,
   which adds to the subset all nodes with a custom node attribute whose name
   and value match the respective patterns. Custom node attributes are
@@ -45,9 +43,6 @@ any filters are given then they run starting with an empty chosen subset. This
 means that filters such as `master:false` which remove nodes from the chosen
 subset are only useful if they come after some other filters. When used on its
 own, `master:false` selects no nodes.
-
-NOTE: The `voting_only` role requires the {default-dist} of Elasticsearch and
-is not supported in the {oss-dist}.
 
 Here are some examples of the use of node filters with the
 <<cluster-nodes-info,Nodes Info>> APIs.
@@ -72,7 +67,6 @@ GET /_nodes/10.0.0.*
 GET /_nodes/_all,master:false
 GET /_nodes/data:true,ingest:true
 GET /_nodes/coordinating_only:true
-GET /_nodes/master:true,voting_only:false
 # Select nodes by custom attribute (e.g. with something like `node.attr.rack: 2` in the configuration file)
 GET /_nodes/rack:2
 GET /_nodes/ra*:2

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -1217,7 +1217,7 @@ The API returns the following response:
          "coordinating_only": 0,
          "master": 1,
          "ingest": 1,
-         "voting_only": 0
+         "remote_cluster_client": 1
       },
       "versions": [
          "{version}"
@@ -1322,7 +1322,6 @@ The API returns the following response:
 // TESTRESPONSE[s/"network_types": \{[^\}]*\}/"network_types": $body.$_path/]
 // TESTRESPONSE[s/"discovery_types": \{[^\}]*\}/"discovery_types": $body.$_path/]
 // TESTRESPONSE[s/"processor_stats": \{[^\}]*\}/"processor_stats": $body.$_path/]
-// TESTRESPONSE[s/"count": \{[^\}]*\}/"count": $body.$_path/]
 // TESTRESPONSE[s/"packaging_types": \[[^\]]*\]/"packaging_types": $body.$_path/]
 // TESTRESPONSE[s/"field_types": \[[^\]]*\]/"field_types": $body.$_path/]
 // TESTRESPONSE[s/: true|false/: $body.$_path/]
@@ -1334,10 +1333,7 @@ The API returns the following response:
 //    see an exhaustive list anyway.
 // 2. Similarly, ignore the contents of `network_types`, `discovery_types`, and
 //    `packaging_types`.
-// 3. Ignore the contents of the (nodes) count object, as what's shown here
-//    depends on the license. Voting-only nodes are e.g. only shown when this
-//    test runs with a basic license.
-// 4. All of the numbers and strings on the right hand side of *every* field in
+// 3. All of the numbers and strings on the right hand side of *every* field in
 //    the response are ignored. So we're really only asserting things about the
 //    the shape of this response, not the values in it.
 

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -86,10 +86,6 @@ creating or deleting an index, tracking which nodes are part of the cluster,
 and deciding which shards to allocate to which nodes. It is important for
 cluster health to have a stable master node.
 
-Any master-eligible node that is not a <<voting-only-node,voting-only node>> may
-be elected to become the master node by the <<modules-discovery,master election
-process>>.
-
 IMPORTANT: Master nodes must have access to the `data/` directory (just like
 `data` nodes) as this is where the cluster state is persisted between node
 restarts.
@@ -115,57 +111,6 @@ To create a dedicated master-eligible node, set:
 [source,yaml]
 -------------------
 node.roles: [ master ]
--------------------
-
-[[voting-only-node]]
-===== Voting-only master-eligible node
-
-A voting-only master-eligible node is a node that participates in
-<<modules-discovery,master elections>> but which will not act as the cluster's
-elected master node. In particular, a voting-only node can serve as a tiebreaker
-in elections.
-
-It may seem confusing to use the term "master-eligible" to describe a
-voting-only node since such a node is not actually eligible to become the master
-at all. This terminology is an unfortunate consequence of history:
-master-eligible nodes are those nodes that participate in elections and perform
-certain tasks during cluster state publications, and voting-only nodes have the
-same responsibilities even if they can never become the elected master.
-
-To configure a master-eligible node as a voting-only node, include `master` and
-`voting_only` in the list of roles. For example to create a voting-only data
-node:
-
-[source,yaml]
--------------------
-node.roles: [ data, master, voting_only ]
--------------------
-
-IMPORTANT: The `voting_only` role requires the {default-dist} of {es} and is not
-supported in the {oss-dist}. If you use the {oss-dist} and add the `voting_only`
-role then the node will fail to start.  Also note that only nodes with the
-`master` role can be marked as having the `voting_only` role.
-
-High availability (HA) clusters require at least three master-eligible nodes, at
-least two of which are not voting-only nodes. Such a cluster will be able to
-elect a master node even if one of the nodes fails.
-
-Since voting-only nodes never act as the cluster's elected master, they may
-require less heap and a less powerful CPU than the true master nodes.
-However all master-eligible nodes, including voting-only nodes, require
-reasonably fast persistent storage and a reliable and low-latency network
-connection to the rest of the cluster, since they are on the critical path for
-<<cluster-state-publishing,publishing cluster state updates>>.
-
-Voting-only master-eligible nodes may also fill other roles in your cluster.
-For instance, a node may be both a data node and a voting-only master-eligible
-node. A _dedicated_ voting-only master-eligible nodes is a voting-only
-master-eligible node that fills no other roles in the cluster. To create a
-dedicated voting-only master-eligible node in the {default-dist}, set:
-
-[source,yaml]
--------------------
-node.roles: [ master, voting_only ]
 -------------------
 
 [[data-node]]


### PR DESCRIPTION
*Issue #, if available:*
#88

*Description of changes:*
The PR requests merging the code into `oss-docs` branch.

- Remove description for "voting_only node" feature in the docs, except in `docs/reference/high-availability/cluster-design` because it needs to be rewritten carefully later.
- All the changes are based on Elastic's commits when introducing "voting_only node": https://github.com/elastic/elasticsearch/commit/e689b20eba8a583c0a3a7783e06b00a97cbdee63 https://github.com/elastic/elasticsearch/commit/f375e550ed36156485b75623a1af3b7bc23c0b47

Testing:
```
./gradlew :docs:check
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 6.6.1
  OS Info               : Linux 5.4.0-1038-aws (amd64)
  JDK Version           : 14 (JDK)
  JAVA_HOME             : /usr/lib/jvm/java-14-openjdk-amd64
  Random Testing Seed   : A794126A09F9109E
  In FIPS 140 mode      : false
=======================================

BUILD SUCCESSFUL in 7m 58s
268 actionable tasks: 268 executed
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
