### PR TITLE
[Rename] ElasticsearchCorruptionException class in server module

### DIFF
--- a/server/src/main/java/org/elasticsearch/OpenSearchCorruptionException.java
+++ b/server/src/main/java/org/elasticsearch/OpenSearchCorruptionException.java
@@ -21,27 +21,27 @@ package org.elasticsearch;
 import java.io.IOException;
 
 /**
- * This exception is thrown when Elasticsearch detects
+ * This exception is thrown when OpenSearch detects
  * an inconsistency in one of it's persistent files.
  */
-public class ElasticsearchCorruptionException extends IOException {
+public class OpenSearchCorruptionException extends IOException {
 
     /**
-     * Creates a new {@link ElasticsearchCorruptionException}
+     * Creates a new {@link OpenSearchCorruptionException}
      * @param message the exception message.
      */
-    public ElasticsearchCorruptionException(String message) {
+    public OpenSearchCorruptionException(String message) {
         super(message);
     }
 
     /**
-     * Creates a new {@link ElasticsearchCorruptionException} with the given exceptions stacktrace.
+     * Creates a new {@link OpenSearchCorruptionException} with the given exceptions stacktrace.
      * This constructor copies the stacktrace as well as the message from the given
      * {@code Throwable} into this exception.
      *
      * @param ex the exception cause
      */
-    public ElasticsearchCorruptionException(Throwable ex) {
+    public OpenSearchCorruptionException(Throwable ex) {
         super(ex);
     }
 }

--- a/server/src/main/java/org/elasticsearch/gateway/CorruptStateException.java
+++ b/server/src/main/java/org/elasticsearch/gateway/CorruptStateException.java
@@ -18,13 +18,13 @@
  */
 package org.elasticsearch.gateway;
 
-import org.elasticsearch.ElasticsearchCorruptionException;
+import org.elasticsearch.OpenSearchCorruptionException;
 
 /**
  * This exception is thrown when Elasticsearch detects
  * an inconsistency in one of it's persistent states.
  */
-public class CorruptStateException extends ElasticsearchCorruptionException {
+public class CorruptStateException extends OpenSearchCorruptionException {
 
     /**
      * Creates a new {@link CorruptStateException}

--- a/server/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatTests.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.snapshots;
 
-import org.elasticsearch.ElasticsearchCorruptionException;
+import org.elasticsearch.OpenSearchCorruptionException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobMetadata;
@@ -140,7 +140,7 @@ public class BlobStoreFormatTests extends ESTestCase {
         try {
             checksumFormat.read(blobContainer, "test-path", xContentRegistry());
             fail("Should have failed due to corruption");
-        } catch (ElasticsearchCorruptionException ex) {
+        } catch (OpenSearchCorruptionException ex) {
             assertThat(ex.getMessage(), containsString("test-path"));
         } catch (EOFException ex) {
             // This can happen if corrupt the byte length


### PR DESCRIPTION
This PR refactors the ElasticsearchCorruptionException in the server module
to OpenSearchCorruptionException. References and usages throughtout the rest of
the codebase are fully refactored.

relates #160