### PR TITLE
[Rename] ElasticsearchConcurrentMergeScheduler class in server module

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -130,7 +130,7 @@ public class InternalEngine extends Engine {
     private volatile long lastDeleteVersionPruneTimeMSec;
 
     private final Translog translog;
-    private final ElasticsearchConcurrentMergeScheduler mergeScheduler;
+    private final OpenSearchConcurrentMergeScheduler mergeScheduler;
 
     private final IndexWriter indexWriter;
 
@@ -2396,7 +2396,7 @@ public class InternalEngine extends Engine {
         return indexWriter.getConfig();
     }
 
-    private final class EngineMergeScheduler extends ElasticsearchConcurrentMergeScheduler {
+    private final class EngineMergeScheduler extends OpenSearchConcurrentMergeScheduler {
         private final AtomicInteger numMergesInFlight = new AtomicInteger(0);
         private final AtomicBoolean isThrottling = new AtomicBoolean();
 

--- a/server/src/main/java/org/elasticsearch/index/engine/OpenSearchConcurrentMergeScheduler.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/OpenSearchConcurrentMergeScheduler.java
@@ -47,7 +47,7 @@ import java.util.Set;
  * An extension to the {@link ConcurrentMergeScheduler} that provides tracking on merge times, total
  * and current merges.
  */
-class ElasticsearchConcurrentMergeScheduler extends ConcurrentMergeScheduler {
+class OpenSearchConcurrentMergeScheduler extends ConcurrentMergeScheduler {
 
     protected final Logger logger;
     private final Settings indexSettings;
@@ -66,7 +66,7 @@ class ElasticsearchConcurrentMergeScheduler extends ConcurrentMergeScheduler {
     private final Set<OnGoingMerge> readOnlyOnGoingMerges = Collections.unmodifiableSet(onGoingMerges);
     private final MergeSchedulerConfig config;
 
-    ElasticsearchConcurrentMergeScheduler(ShardId shardId, IndexSettings indexSettings) {
+    OpenSearchConcurrentMergeScheduler(ShardId shardId, IndexSettings indexSettings) {
         this.config = indexSettings.getMergeSchedulerConfig();
         this.shardId = shardId;
         this.indexSettings = indexSettings.getSettings();


### PR DESCRIPTION
This PR refactors ElasticsearchConcurrentMergeScheduler class in the server
module to OpenSearchConcurrentMergeScheduler. References and usages throughout
the rest of the codebase are fully refactored.

relates #160