### PR TITLE
[DOCS] Add TODO in node tool guide to remove x-pack feature in example

### DIFF
--- a/docs/reference/commands/node-tool.asciidoc
+++ b/docs/reference/commands/node-tool.asciidoc
@@ -406,7 +406,7 @@ If your nodes contain persistent cluster settings that prevent the cluster
 from forming, i.e., can't be removed using the <<cluster-update-settings>> API,
 you can run the following commands to remove one or more cluster settings.
 
-// TODO: Add new example here
+// TODO: Add new example here to replace '...'
 [source,txt]
 ----
 node$ ./bin/elasticsearch-node remove-settings ...
@@ -441,7 +441,7 @@ If the on-disk cluster state contains custom metadata that prevents the node
 from starting up and loading the cluster state, you can run the following
 commands to remove this custom metadata.
 
-// TODO: Add new example here
+// TODO: Add new example here to replace '...'
 [source,txt]
 ----
 node$ ./bin/elasticsearch-node remove-customs ...


### PR DESCRIPTION
*Issue #, if available:*
#142

*Description of changes:*

The PR requests merging the code into `oss-docs` branch.

In the guide for `elasticsearch-node` tool (https://www.elastic.co/guide/en/elasticsearch/reference/7.10/node-tool.html#_removing_persistent_cluster_settings_2), the "setting" used in the example comes from x-pack (as well as the example for `custom metadata` in below).
Because I couldn’t find a proper replacement here to guide the user, adding `TODO` in the docs for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
