### PR TITLE
[Rename] modules/geo

### DIFF
--- a/modules/geo/build.gradle
+++ b/modules/geo/build.gradle
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-apply plugin: 'elasticsearch.yaml-rest-test'
+apply plugin: 'opensearch.yaml-rest-test'
 
 esplugin {
-  description 'Placeholder plugin for geospatial features in ES. only registers geo_shape field mapper for now'
-  classname 'org.elasticsearch.geo.GeoPlugin'
+  description 'Placeholder plugin for geospatial features in OpenSearch. only registers geo_shape field mapper for now'
+  classname 'org.opensearch.geo.GeoPlugin'
 }
 
 restResources {

--- a/modules/geo/src/main/java/org/opensearch/geo/GeoPlugin.java
+++ b/modules/geo/src/main/java/org/opensearch/geo/GeoPlugin.java
@@ -17,22 +17,20 @@
  * under the License.
  */
 
-package org.elasticsearch.geo;
+package org.opensearch.geo;
 
-import com.carrotsearch.randomizedtesting.annotations.Name;
-import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
-import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.plugins.MapperPlugin;
+import org.elasticsearch.plugins.Plugin;
 
-/** Runs yaml rest tests */
-public class GeoClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+import java.util.Collections;
+import java.util.Map;
 
-    public GeoClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
-        super(testCandidate);
-    }
+public class GeoPlugin extends Plugin implements MapperPlugin {
 
-    @ParametersFactory
-    public static Iterable<Object[]> parameters() throws Exception {
-        return ESClientYamlSuiteTestCase.createParameters();
+    @Override
+    public Map<String, Mapper.TypeParser> getMappers() {
+        return Collections.singletonMap(GeoShapeFieldMapper.CONTENT_TYPE, new GeoShapeFieldMapper.TypeParser());
     }
 }

--- a/modules/geo/src/yamlRestTest/java/org/opensearch/geo/GeoClientYamlTestSuiteIT.java
+++ b/modules/geo/src/yamlRestTest/java/org/opensearch/geo/GeoClientYamlTestSuiteIT.java
@@ -17,20 +17,22 @@
  * under the License.
  */
 
-package org.elasticsearch.geo;
+package org.opensearch.geo;
 
-import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
-import org.elasticsearch.index.mapper.Mapper;
-import org.elasticsearch.plugins.MapperPlugin;
-import org.elasticsearch.plugins.Plugin;
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 
-import java.util.Collections;
-import java.util.Map;
+/** Runs yaml rest tests */
+public class GeoClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
-public class GeoPlugin extends Plugin implements MapperPlugin {
+    public GeoClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
+        super(testCandidate);
+    }
 
-    @Override
-    public Map<String, Mapper.TypeParser> getMappers() {
-        return Collections.singletonMap(GeoShapeFieldMapper.CONTENT_TYPE, new GeoShapeFieldMapper.TypeParser());
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws Exception {
+        return ESClientYamlSuiteTestCase.createParameters();
     }
 }

--- a/modules/percolator/src/internalClusterTest/java/org/elasticsearch/percolator/PercolatorQuerySearchIT.java
+++ b/modules/percolator/src/internalClusterTest/java/org/elasticsearch/percolator/PercolatorQuerySearchIT.java
@@ -31,7 +31,7 @@ import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.geo.GeoPlugin;
+import org.opensearch.geo.GeoPlugin;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.query.MatchPhraseQueryBuilder;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;


### PR DESCRIPTION
*Issue #160 :*

*Description of changes:*

This PR refactors the geo module as part of the renaming Elasticsearch to OpenSearch effort.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
