### PR TITLE
Fixing transport deserialization with oss distribution

### DIFF
--- a/server/src/main/java/org/elasticsearch/Build.java
+++ b/server/src/main/java/org/elasticsearch/Build.java
@@ -186,7 +186,10 @@ public class Build {
         final Type type;
         // The following block is kept for existing BWS tests to pass.
         // TODO - clean up this code when we remove all v6 bwc tests.
-        if (in.getVersion().onOrAfter(Version.V_6_3_0) && in.getVersion().onOrBefore(Version.V_7_0_0)) {
+        // TODO - clean this up when OSS flavor is removed in all of the code base
+        //        (Integ test zip still write OSS as distribution)
+        // See issue: https://github.com/opendistro-for-elasticsearch/search/issues/159
+        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
             flavor = in.readString();
         }
         if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
@@ -211,7 +214,9 @@ public class Build {
     public static void writeBuild(Build build, StreamOutput out) throws IOException {
         // The following block is kept for existing BWS tests to pass.
         // TODO - clean up this code when we remove all v6 bwc tests.
-        if (out.getVersion().onOrAfter(Version.V_6_3_0) && out.getVersion().onOrBefore(Version.V_7_0_0)) {
+        // TODO - clean this up when OSS flavor is removed in all of the code base
+        // See issue: https://github.com/opendistro-for-elasticsearch/search/issues/159
+        if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
             out.writeString("oss");
         }
         if (out.getVersion().onOrAfter(Version.V_6_3_0)) {


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemsarat@amazon.com>

*Issue #159 *

*Description of changes:*
Deserialization of transport messages is failing in integration tests for plugins because the integ-test-zip still builds `oss` flavor and the server doesn't expect those bytes when reading them. 

This change is temporary until we remove `oss` from all the of the repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
