### PR TITLE
[Rename] modules/repository-url

### DIFF
--- a/modules/repository-url/build.gradle
+++ b/modules/repository-url/build.gradle
@@ -17,17 +17,17 @@
  * under the License.
  */
 
-import org.elasticsearch.gradle.PropertyNormalization
-import org.elasticsearch.gradle.info.BuildParams
-import org.elasticsearch.gradle.test.AntFixture
+import org.opensearch.gradle.PropertyNormalization
+import org.opensearch.gradle.info.BuildParams
+import org.opensearch.gradle.test.AntFixture
 
-apply plugin: 'elasticsearch.yaml-rest-test'
-apply plugin: 'elasticsearch.internal-cluster-test'
+apply plugin: 'opensearch.yaml-rest-test'
+apply plugin: 'opensearch.internal-cluster-test'
 
 
 esplugin {
   description 'Module for URL repository'
-  classname 'org.elasticsearch.plugin.repository.url.URLRepositoryPlugin'
+  classname 'org.opensearch.plugin.repository.url.URLRepositoryPlugin'
 }
 
 restResources {
@@ -47,7 +47,7 @@ task urlFixture(type: AntFixture) {
   }
   env 'CLASSPATH', "${-> project.sourceSets.test.runtimeClasspath.asPath}"
   executable = "${BuildParams.runtimeJavaHome}/bin/java"
-  args 'org.elasticsearch.repositories.url.URLFixture', baseDir, "${repositoryDir.absolutePath}"
+  args 'org.opensearch.repositories.url.URLFixture', baseDir, "${repositoryDir.absolutePath}"
 }
 yamlRestTest {
   dependsOn urlFixture

--- a/modules/repository-url/src/internalClusterTest/java/org/opensearch/repositories/url/URLSnapshotRestoreIT.java
+++ b/modules/repository-url/src/internalClusterTest/java/org/opensearch/repositories/url/URLSnapshotRestoreIT.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.repositories.url;
+package org.opensearch.repositories.url;
 
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
@@ -26,7 +26,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
-import org.elasticsearch.plugin.repository.url.URLRepositoryPlugin;
+import org.opensearch.plugin.repository.url.URLRepositoryPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.snapshots.SnapshotState;

--- a/modules/repository-url/src/main/java/org/opensearch/common/blobstore/url/URLBlobContainer.java
+++ b/modules/repository-url/src/main/java/org/opensearch/common/blobstore/url/URLBlobContainer.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.common.blobstore.url;
+package org.opensearch.common.blobstore.url;
 
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.blobstore.BlobContainer;

--- a/modules/repository-url/src/main/java/org/opensearch/common/blobstore/url/URLBlobStore.java
+++ b/modules/repository-url/src/main/java/org/opensearch/common/blobstore/url/URLBlobStore.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.common.blobstore.url;
+package org.opensearch.common.blobstore.url;
 
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;

--- a/modules/repository-url/src/main/java/org/opensearch/plugin/repository/url/URLRepositoryPlugin.java
+++ b/modules/repository-url/src/main/java/org/opensearch/plugin/repository/url/URLRepositoryPlugin.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.plugin.repository.url;
+package org.opensearch.plugin.repository.url;
 
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Setting;
@@ -27,7 +27,7 @@ import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.RepositoryPlugin;
 import org.elasticsearch.repositories.Repository;
-import org.elasticsearch.repositories.url.URLRepository;
+import org.opensearch.repositories.url.URLRepository;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/modules/repository-url/src/main/java/org/opensearch/repositories/url/URLRepository.java
+++ b/modules/repository-url/src/main/java/org/opensearch/repositories/url/URLRepository.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.repositories.url;
+package org.opensearch.repositories.url;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -26,7 +26,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
-import org.elasticsearch.common.blobstore.url.URLBlobStore;
+import org.opensearch.common.blobstore.url.URLBlobStore;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.util.URIPattern;

--- a/modules/repository-url/src/test/java/org/opensearch/common/blobstore/url/URLBlobStoreTests.java
+++ b/modules/repository-url/src/test/java/org/opensearch/common/blobstore/url/URLBlobStoreTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.common.blobstore.url;
+package org.opensearch.common.blobstore.url;
 
 import com.sun.net.httpserver.HttpServer;
 import org.elasticsearch.common.SuppressForbidden;

--- a/modules/repository-url/src/test/java/org/opensearch/repositories/url/URLFixture.java
+++ b/modules/repository-url/src/test/java/org/opensearch/repositories/url/URLFixture.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.repositories.url;
+package org.opensearch.repositories.url;
 
 import org.elasticsearch.test.fixture.AbstractHttpFixture;
 import org.elasticsearch.common.SuppressForbidden;

--- a/modules/repository-url/src/test/java/org/opensearch/repositories/url/URLRepositoryTests.java
+++ b/modules/repository-url/src/test/java/org/opensearch/repositories/url/URLRepositoryTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.repositories.url;
+package org.opensearch.repositories.url;
 
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.common.settings.ClusterSettings;

--- a/modules/repository-url/src/yamlRestTest/java/org/opensearch/repositories/url/RepositoryURLClientYamlTestSuiteIT.java
+++ b/modules/repository-url/src/yamlRestTest/java/org/opensearch/repositories/url/RepositoryURLClientYamlTestSuiteIT.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.repositories.url;
+package org.opensearch.repositories.url;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;


### PR DESCRIPTION
*Issue #160 :*

*Description of changes:*
This commit refactors the repository-url module as part of the Elasticsearch to OpenSearch renaming.

Signed-off-by: Rabi Panda <adnapibar@gmail.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
