### PR TITLE
[Rename] client/transport

### DIFF
--- a/client/benchmark/src/main/java/org/opensearch/client/benchmark/transport/TransportClientBenchmark.java
+++ b/client/benchmark/src/main/java/org/opensearch/client/benchmark/transport/TransportClientBenchmark.java
@@ -37,7 +37,7 @@ import org.elasticsearch.plugin.noop.action.bulk.NoopBulkAction;
 import org.elasticsearch.plugin.noop.action.search.NoopSearchAction;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.transport.client.PreBuiltTransportClient;
+import org.opensearch.transport.client.PreBuiltTransportClient;
 
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;

--- a/client/transport/build.gradle
+++ b/client/transport/build.gradle
@@ -16,10 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-apply plugin: 'elasticsearch.build'
+apply plugin: 'opensearch.build'
 apply plugin: 'nebula.maven-base-publish'
 
-group = 'org.elasticsearch.client'
+group = 'org.opensearch.client'
 
 dependencies {
   api project(":server")

--- a/client/transport/src/main/java/org/opensearch/transport/client/PreBuiltTransportClient.java
+++ b/client/transport/src/main/java/org/opensearch/transport/client/PreBuiltTransportClient.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.transport.client;
+package org.opensearch.transport.client;
 
 import io.netty.util.ThreadDeathWatcher;
 import io.netty.util.concurrent.GlobalEventExecutor;
@@ -28,7 +28,7 @@ import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.opensearch.join.ParentJoinPlugin;
-import org.elasticsearch.percolator.PercolatorPlugin;
+import org.opensearch.percolator.PercolatorPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.opensearch.script.mustache.MustachePlugin;
 import org.opensearch.transport.Netty4Plugin;

--- a/client/transport/src/test/java/org/opensearch/transport/client/PreBuiltTransportClientTests.java
+++ b/client/transport/src/test/java/org/opensearch/transport/client/PreBuiltTransportClientTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.transport.client;
+package org.opensearch.transport.client;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import org.elasticsearch.client.transport.TransportClient;
@@ -25,7 +25,7 @@ import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.opensearch.join.ParentJoinPlugin;
-import org.elasticsearch.percolator.PercolatorPlugin;
+import org.opensearch.percolator.PercolatorPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.opensearch.script.mustache.MustachePlugin;
 import org.opensearch.transport.Netty4Plugin;


### PR DESCRIPTION
*Issue #160 :*

*Description of changes:*
Refactor client/transport module as part of the Elasticsearch to OpenSearch renaming effort.

Signed-off-by: Rabi Panda <adnapibar@gmail.com>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
