### PR TITLE
[DOCS] Rename 'ElasticsearchException' to 'OpenSearchException' in 'java-rest' docs

### DIFF
--- a/docs/java-rest/high-level/document/delete.asciidoc
+++ b/docs/java-rest/high-level/document/delete.asciidoc
@@ -79,7 +79,7 @@ include-tagged::{doc-tests-file}[{api}-notfound]
 --------------------------------------------------
 <1> Do something if the document to be deleted was not found
 
-If there is a version conflict, an `ElasticsearchException` will
+If there is a version conflict, an `OpenSearchException` will
 be thrown:
 
 ["source","java",subs="attributes,callouts,macros"]

--- a/docs/java-rest/high-level/document/get-source.asciidoc
+++ b/docs/java-rest/high-level/document/get-source.asciidoc
@@ -30,7 +30,7 @@ The following arguments can optionally be provided:
 include-tagged::{doc-tests-file}[{api}-request-optional]
 --------------------------------------------------
 <1> `FetchSourceContext` 's first argument `fetchSource` must be `true`, otherwise
-`ElasticsearchException` get thrown
+`OpenSearchException` get thrown
 <2> Arguments of the context `excludes` and `includes` are optional
 (see examples in Get API documentation)
 

--- a/docs/java-rest/high-level/document/get.asciidoc
+++ b/docs/java-rest/high-level/document/get.asciidoc
@@ -107,7 +107,7 @@ returned rather than an exception thrown. Such response does not hold any
 source document and its `isExists` method returns `false`.
 
 When a get request is performed against an index that does not exist, the
-response has `404` status code, an `ElasticsearchException` gets thrown
+response has `404` status code, an `OpenSearchException` gets thrown
 which needs to be handled as follows:
 
 ["source","java",subs="attributes,callouts,macros"]

--- a/docs/java-rest/high-level/document/index.asciidoc
+++ b/docs/java-rest/high-level/document/index.asciidoc
@@ -113,7 +113,7 @@ already existing
 total shards
 <4> Handle the potential failures
 
-If there is a version conflict, an `ElasticsearchException` will
+If there is a version conflict, an `OpenSearchException` will
 be thrown:
 
 ["source","java",subs="attributes,callouts,macros"]

--- a/docs/java-rest/high-level/document/multi-get.asciidoc
+++ b/docs/java-rest/high-level/document/multi-get.asciidoc
@@ -114,7 +114,7 @@ include-tagged::{doc-tests-file}[{api}-indexnotfound]
 --------------------------------------------------
 <1> `getResponse` is null.
 <2> `getFailure` isn't and contains an `Exception`.
-<3> That `Exception` is actually an `ElasticsearchException`
+<3> That `Exception` is actually an `OpenSearchException`
 <4> and it has a status of `NOT_FOUND`. It'd have been an HTTP 404 if this
 wasn't a multi get.
 <5> `getMessage` explains the actual cause, `no such index`.
@@ -128,7 +128,7 @@ include-tagged::{doc-tests-file}[{api}-conflict]
 --------------------------------------------------
 <1> `getResponse` is null.
 <2> `getFailure` isn't and contains an `Exception`.
-<3> That `Exception` is actually an `ElasticsearchException`
+<3> That `Exception` is actually an `OpenSearchException`
 <4> and it has a status of `CONFLICT`. It'd have been an HTTP 409 if this
 wasn't a multi get.
 <5> `getMessage` explains the actual cause, `

--- a/docs/java-rest/high-level/document/update.asciidoc
+++ b/docs/java-rest/high-level/document/update.asciidoc
@@ -218,7 +218,7 @@ total shards
 <2> Handle the potential failures
 
 When a `UpdateRequest` is performed against a document that does not exist,
-the response has `404` status code, an `ElasticsearchException` gets thrown
+the response has `404` status code, an `OpenSearchException` gets thrown
 which needs to be handled as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
@@ -227,7 +227,7 @@ include-tagged::{doc-tests-file}[{api}-docnotfound]
 --------------------------------------------------
 <1> Handle the exception thrown because the document not exist
 
-If there is a version conflict, an `ElasticsearchException` will
+If there is a version conflict, an `OpenSearchException` will
 be thrown:
 
 ["source","java",subs="attributes,callouts,macros"]

--- a/docs/java-rest/high-level/execution-no-req.asciidoc
+++ b/docs/java-rest/high-level/execution-no-req.asciidoc
@@ -21,7 +21,7 @@ or similar cases where there is no response coming back from the server.
 
 In cases where the server returns a `4xx` or `5xx` error code, the high-level
 client tries to parse the response body error details instead and then throws
-a generic `ElasticsearchException` and adds the original `ResponseException` as a
+a generic `OpenSearchException` and adds the original `ResponseException` as a
 suppressed exception to it.
 
 [id="{upid}-{api}-async"]

--- a/docs/java-rest/high-level/execution.asciidoc
+++ b/docs/java-rest/high-level/execution.asciidoc
@@ -24,7 +24,7 @@ or similar cases where there is no response coming back from the server.
 
 In cases where the server returns a `4xx` or `5xx` error code, the high-level
 client tries to parse the response body error details instead and then throws
-a generic `ElasticsearchException` and adds the original `ResponseException` as a
+a generic `OpenSearchException` and adds the original `ResponseException` as a
 suppressed exception to it.
 
 [id="{upid}-{api}-async"]

--- a/docs/java-rest/high-level/indices/clear_cache.asciidoc
+++ b/docs/java-rest/high-level/indices/clear_cache.asciidoc
@@ -71,7 +71,7 @@ include-tagged::{doc-tests-file}[{api}-response]
 <3> Number of shards where the clear cache has failed
 <4> A list of failures if the operation failed on one or more shards
 
-By default, if the indices were not found, an `ElasticsearchException` will be thrown:
+By default, if the indices were not found, an `OpenSearchException` will be thrown:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/indices/delete_index.asciidoc
+++ b/docs/java-rest/high-level/indices/delete_index.asciidoc
@@ -56,7 +56,7 @@ include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
 <1> Indicates whether all of the nodes have acknowledged the request
 
-If the index was not found, an `ElasticsearchException` will be thrown:
+If the index was not found, an `OpenSearchException` will be thrown:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/indices/flush.asciidoc
+++ b/docs/java-rest/high-level/indices/flush.asciidoc
@@ -58,7 +58,7 @@ include-tagged::{doc-tests-file}[{api}-response]
 <3> Number of shards where the flush has failed
 <4> A list of failures if the operation failed on one or more shards
 
-By default, if the indices were not found, an `ElasticsearchException` will be thrown:
+By default, if the indices were not found, an `OpenSearchException` will be thrown:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/indices/flush_synced.asciidoc
+++ b/docs/java-rest/high-level/indices/flush_synced.asciidoc
@@ -53,7 +53,7 @@ include-tagged::{doc-tests-file}[{api}-response]
 <10> JSON represented by a Map<String, Object>. Contains shard related information like id, state, version etc.
 for the failed shard copies. If the entire shard failed then this returns an empty map.
 
-By default, if the indices were not found, an `ElasticsearchException` will be thrown:
+By default, if the indices were not found, an `OpenSearchException` will be thrown:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/indices/force_merge.asciidoc
+++ b/docs/java-rest/high-level/indices/force_merge.asciidoc
@@ -64,7 +64,7 @@ include-tagged::{doc-tests-file}[{api}-response]
 <3> Number of shards where the force merge has failed
 <4> A list of failures if the operation failed on one or more shards
 
-By default, if the indices were not found, an `ElasticsearchException` will be thrown:
+By default, if the indices were not found, an `OpenSearchException` will be thrown:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------

--- a/docs/java-rest/high-level/indices/get_alias.asciidoc
+++ b/docs/java-rest/high-level/indices/get_alias.asciidoc
@@ -75,7 +75,7 @@ include-tagged::{doc-tests-file}[{api}-response-error]
 indices or aliases is not found. Otherwise it is `OK`.
 
 <2> If at least one item of specified indices isn't exist client sets
-`ElasticsearchException` and returns empty result.
+`OpenSearchException` and returns empty result.
 
 <3> If at least one item of specified aliases ins't exist client puts
 error description in `error` field and returns partial result if any

--- a/docs/java-rest/high-level/indices/refresh.asciidoc
+++ b/docs/java-rest/high-level/indices/refresh.asciidoc
@@ -46,7 +46,7 @@ include-tagged::{doc-tests-file}[{api}-response]
 <3> Number of shards where the refresh has failed
 <4> A list of failures if the operation failed on one or more shards
 
-By default, if the indices were not found, an `ElasticsearchException` will be thrown:
+By default, if the indices were not found, an `OpenSearchException` will be thrown:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------


### PR DESCRIPTION
*Issue #, if available:*
#238 

*Description of changes:*

The PR requests merging the code into `oss-docs` branch.

- Rename all `ElasticsearchException` to `OpenSearchException`, and all of them are in `docs/java-rest` directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
