### PR TITLE
[Rename] refactor libs/plugin-cli and libs/secure-sm.

### DIFF
--- a/libs/plugin-classloader/src/main/java/org/opensearch/plugins/ExtendedPluginsClassLoader.java
+++ b/libs/plugin-classloader/src/main/java/org/opensearch/plugins/ExtendedPluginsClassLoader.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.plugins;
+package org.opensearch.plugins;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;

--- a/libs/secure-sm/build.gradle
+++ b/libs/secure-sm/build.gradle
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-apply plugin: 'elasticsearch.publish'
+apply plugin: 'opensearch.publish'
 
 dependencies {
   // do not add non-test compile dependencies to secure-sm without a good reason to do so
@@ -26,7 +26,7 @@ dependencies {
   testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
 
   testImplementation(project(":test:framework")) {
-    exclude group: 'org.elasticsearch', module: 'elasticsearch-secure-sm'
+    exclude group: 'org.opensearch', module: 'opensearch-secure-sm'
   }
 }
 

--- a/libs/secure-sm/src/main/java/org/opensearch/secure_sm/SecureSM.java
+++ b/libs/secure-sm/src/main/java/org/opensearch/secure_sm/SecureSM.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.secure_sm;
+package org.opensearch.secure_sm;
 
 import java.security.AccessController;
 import java.security.Permission;

--- a/libs/secure-sm/src/main/java/org/opensearch/secure_sm/SuppressForbidden.java
+++ b/libs/secure-sm/src/main/java/org/opensearch/secure_sm/SuppressForbidden.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.secure_sm;
+package org.opensearch.secure_sm;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/libs/secure-sm/src/main/java/org/opensearch/secure_sm/ThreadPermission.java
+++ b/libs/secure-sm/src/main/java/org/opensearch/secure_sm/ThreadPermission.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.secure_sm;
+package org.opensearch.secure_sm;
 
 import java.security.BasicPermission;
 

--- a/libs/secure-sm/src/test/java/org/opensearch/secure_sm/SecureSMTests.java
+++ b/libs/secure-sm/src/test/java/org/opensearch/secure_sm/SecureSMTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.secure_sm;
+package org.opensearch.secure_sm;
 
 import junit.framework.TestCase;
 
@@ -60,8 +60,8 @@ public class SecureSMTests extends TestCase {
         assertTrue(SecureSM.classCanExit("com.carrotsearch.ant.tasks.junit4.slave.JvmExit", SecureSM.TEST_RUNNER_PACKAGES));
         assertTrue(SecureSM.classCanExit("org.eclipse.jdt.internal.junit.runner.RemoteTestRunner", SecureSM.TEST_RUNNER_PACKAGES));
         assertTrue(SecureSM.classCanExit("com.intellij.rt.execution.junit.JUnitStarter", SecureSM.TEST_RUNNER_PACKAGES));
-        assertTrue(SecureSM.classCanExit("org.elasticsearch.Foo", new String[]{"org.elasticsearch.Foo"}));
-        assertFalse(SecureSM.classCanExit("org.elasticsearch.Foo", new String[]{"org.elasticsearch.Bar"}));
+        assertTrue(SecureSM.classCanExit("org.opensearch.Foo", new String[]{"org.opensearch.Foo"}));
+        assertFalse(SecureSM.classCanExit("org.opensearch.Foo", new String[]{"org.opensearch.Bar"}));
     }
 
     public void testCreateThread() throws Exception {

--- a/libs/secure-sm/src/test/java/org/opensearch/secure_sm/ThreadPermissionTests.java
+++ b/libs/secure-sm/src/test/java/org/opensearch/secure_sm/ThreadPermissionTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.secure_sm;
+package org.opensearch.secure_sm;
 
 import junit.framework.TestCase;
 

--- a/server/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -27,7 +27,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.http.HttpTransportSettings;
 import org.elasticsearch.plugins.PluginInfo;
 import org.elasticsearch.plugins.PluginsService;
-import org.elasticsearch.secure_sm.SecureSM;
+import org.opensearch.secure_sm.SecureSM;
 import org.elasticsearch.transport.TcpTransport;
 
 import java.io.IOException;

--- a/server/src/main/java/org/elasticsearch/plugins/PluginLoaderIndirection.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginLoaderIndirection.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.plugins;
 
+import org.opensearch.plugins.ExtendedPluginsClassLoader;
+
 import java.util.List;
 
 /**

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -31,7 +31,7 @@ import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.network.IfConfig;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.PluginInfo;
-import org.elasticsearch.secure_sm.SecureSM;
+import org.opensearch.secure_sm.SecureSM;
 import org.junit.Assert;
 
 import java.io.InputStream;


### PR DESCRIPTION
*Issue #160 :*

*Description of changes:*
Refactor the `libs/plugin-cli` and `libs/secure-sm` modules to rename the package names

- `org.elasticsearch.plugins` to `org.opensearch.plugins`
- `org.elasticsearch.secure_sm` to `org.opensearch.secure_sm`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Rabi Panda <adnapibar@gmail.com>