### PR TITLE
[Rename] refactor libs/dissect.

### DIFF
--- a/libs/dissect/build.gradle
+++ b/libs/dissect/build.gradle
@@ -19,7 +19,7 @@
 
 dependencies {
   testImplementation(project(":test:framework")) {
-    exclude group: 'org.elasticsearch', module: 'elasticsearch-dissect'
+    exclude group: 'org.opensearch', module: 'opensearch-dissect'
   }
   testImplementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
   testImplementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"

--- a/libs/dissect/src/main/java/org/opensearch/dissect/DissectException.java
+++ b/libs/dissect/src/main/java/org/opensearch/dissect/DissectException.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.dissect;
+package org.opensearch.dissect;
 
 /**
  * Parent class for all dissect related exceptions. Consumers may catch this exception or more specific child exceptions.

--- a/libs/dissect/src/main/java/org/opensearch/dissect/DissectKey.java
+++ b/libs/dissect/src/main/java/org/opensearch/dissect/DissectKey.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.dissect;
+package org.opensearch.dissect;
 
 import java.util.EnumSet;
 import java.util.regex.Matcher;

--- a/libs/dissect/src/main/java/org/opensearch/dissect/DissectMatch.java
+++ b/libs/dissect/src/main/java/org/opensearch/dissect/DissectMatch.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.dissect;
+package org.opensearch.dissect;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/libs/dissect/src/main/java/org/opensearch/dissect/DissectParser.java
+++ b/libs/dissect/src/main/java/org/opensearch/dissect/DissectParser.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.dissect;
+package org.opensearch.dissect;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;

--- a/libs/dissect/src/test/java/org/opensearch/dissect/DissectKeyTests.java
+++ b/libs/dissect/src/test/java/org/opensearch/dissect/DissectKeyTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.dissect;
+package org.opensearch.dissect;
 
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.CoreMatchers;

--- a/libs/dissect/src/test/java/org/opensearch/dissect/DissectMatchTests.java
+++ b/libs/dissect/src/test/java/org/opensearch/dissect/DissectMatchTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.dissect;
+package org.opensearch.dissect;
 
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.test.ESTestCase;

--- a/libs/dissect/src/test/java/org/opensearch/dissect/DissectParserTests.java
+++ b/libs/dissect/src/test/java/org/opensearch/dissect/DissectParserTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.dissect;
+package org.opensearch.dissect;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/modules/ingest-common/src/main/java/org/opensearch/ingest/common/DissectProcessor.java
+++ b/modules/ingest-common/src/main/java/org/opensearch/ingest/common/DissectProcessor.java
@@ -19,7 +19,7 @@
 
 package org.opensearch.ingest.common;
 
-import org.elasticsearch.dissect.DissectParser;
+import org.opensearch.dissect.DissectParser;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.ConfigurationUtils;
 import org.elasticsearch.ingest.IngestDocument;

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/DissectProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/DissectProcessorFactoryTests.java
@@ -20,7 +20,7 @@
 package org.opensearch.ingest.common;
 
 import org.elasticsearch.OpenSearchParseException;
-import org.elasticsearch.dissect.DissectException;
+import org.opensearch.dissect.DissectException;
 import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/DissectProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/DissectProcessorTests.java
@@ -20,7 +20,7 @@
 package org.opensearch.ingest.common;
 
 import org.elasticsearch.common.collect.MapBuilder;
-import org.elasticsearch.dissect.DissectException;
+import org.opensearch.dissect.DissectException;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.ingest.RandomDocumentPicks;
@@ -34,7 +34,7 @@ import static org.elasticsearch.ingest.IngestDocumentMatcher.assertIngestDocumen
 import static org.hamcrest.Matchers.equalTo;
 
 /**
- * Basic tests for the {@link DissectProcessor}. See the {@link org.elasticsearch.dissect.DissectParser} test suite for a comprehensive
+ * Basic tests for the {@link DissectProcessor}. See the {@link org.opensearch.dissect.DissectParser} test suite for a comprehensive
  * set of dissect tests.
  */
 public class DissectProcessorTests extends ESTestCase {


### PR DESCRIPTION
*Issue #160 :*

*Description of changes:*

Refactor the `libs/dissect` module to rename the package name from `org.elasticsearch.dissect` to `org.opensearch.dissect` as part of the rename to OpenSearch work.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Rabi Panda <adnapibar@gmail.com>