### PR TITLE
[Rename] refactor `o.e.transport` package in server test module

### DIFF
--- a/server/src/test/java/org/opensearch/transport/ClusterConnectionManagerTests.java
+++ b/server/src/test/java/org/opensearch/transport/ClusterConnectionManagerTests.java
@@ -17,9 +17,20 @@
  * under the License.
  */
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.transport.CloseableConnection;
+import org.elasticsearch.transport.ClusterConnectionManager;
+import org.elasticsearch.transport.ConnectTransportException;
+import org.elasticsearch.transport.ConnectionManager;
+import org.elasticsearch.transport.ConnectionProfile;
+import org.elasticsearch.transport.NodeNotConnectedException;
+import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportConnectionListener;
+import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportRequestOptions;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;

--- a/server/src/test/java/org/opensearch/transport/CompressibleBytesOutputStreamTests.java
+++ b/server/src/test/java/org/opensearch/transport/CompressibleBytesOutputStreamTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressorFactory;
@@ -26,6 +26,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.CompressibleBytesOutputStream;
 
 import java.io.EOFException;
 import java.io.IOException;

--- a/server/src/test/java/org/opensearch/transport/ConnectionProfileTests.java
+++ b/server/src/test/java/org/opensearch/transport/ConnectionProfileTests.java
@@ -16,12 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.ConnectionProfile;
+import org.elasticsearch.transport.TransportRequestOptions;
+import org.elasticsearch.transport.TransportSettings;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;

--- a/server/src/test/java/org/opensearch/transport/InboundAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/transport/InboundAggregatorTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -29,6 +29,11 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.ActionNotFoundTransportException;
+import org.elasticsearch.transport.Header;
+import org.elasticsearch.transport.InboundAggregator;
+import org.elasticsearch.transport.InboundMessage;
+import org.elasticsearch.transport.TransportStatus;
 import org.junit.Before;
 
 import java.io.IOException;

--- a/server/src/test/java/org/opensearch/transport/InboundDecoderTests.java
+++ b/server/src/test/java/org/opensearch/transport/InboundDecoderTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -28,6 +28,13 @@ import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.transport.Header;
+import org.elasticsearch.transport.InboundDecoder;
+import org.elasticsearch.transport.OutboundMessage;
+import org.elasticsearch.transport.TcpHeader;
+import org.elasticsearch.transport.TestRequest;
+import org.elasticsearch.transport.TestResponse;
+import org.elasticsearch.transport.TransportMessage;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/server/src/test/java/org/opensearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/opensearch/transport/InboundHandlerTests.java
@@ -17,13 +17,33 @@
  * under the License.
  */
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.OpenSearchException;
 import org.elasticsearch.Version;
+import org.elasticsearch.transport.FakeTcpChannel;
+import org.elasticsearch.transport.Header;
+import org.elasticsearch.transport.InboundDecoder;
+import org.elasticsearch.transport.InboundHandler;
+import org.elasticsearch.transport.InboundMessage;
+import org.elasticsearch.transport.OutboundHandler;
+import org.elasticsearch.transport.OutboundMessage;
+import org.elasticsearch.transport.RemoteTransportException;
+import org.elasticsearch.transport.RequestHandlerRegistry;
+import org.elasticsearch.transport.StatsTracker;
+import org.elasticsearch.transport.TcpHeader;
+import org.elasticsearch.transport.TestRequest;
+import org.elasticsearch.transport.TestResponse;
+import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportChannel;
+import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportHandshaker;
+import org.elasticsearch.transport.TransportKeepAlive;
+import org.elasticsearch.transport.TransportResponseHandler;
+import org.elasticsearch.transport.TransportStatus;
 import org.opensearch.action.ActionListener;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;

--- a/server/src/test/java/org/opensearch/transport/InboundPipelineTests.java
+++ b/server/src/test/java/org/opensearch/transport/InboundPipelineTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreaker;
@@ -36,6 +36,18 @@ import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.internal.io.Streams;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.FakeTcpChannel;
+import org.elasticsearch.transport.Header;
+import org.elasticsearch.transport.InboundAggregator;
+import org.elasticsearch.transport.InboundDecoder;
+import org.elasticsearch.transport.InboundMessage;
+import org.elasticsearch.transport.InboundPipeline;
+import org.elasticsearch.transport.OutboundMessage;
+import org.elasticsearch.transport.StatsTracker;
+import org.elasticsearch.transport.TcpChannel;
+import org.elasticsearch.transport.TcpHeader;
+import org.elasticsearch.transport.TestRequest;
+import org.elasticsearch.transport.TestResponse;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/server/src/test/java/org/opensearch/transport/OutboundHandlerTests.java
+++ b/server/src/test/java/org/opensearch/transport/OutboundHandlerTests.java
@@ -17,10 +17,24 @@
  * under the License.
  */
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.OpenSearchException;
 import org.elasticsearch.Version;
+import org.elasticsearch.transport.FakeTcpChannel;
+import org.elasticsearch.transport.Header;
+import org.elasticsearch.transport.InboundAggregator;
+import org.elasticsearch.transport.InboundDecoder;
+import org.elasticsearch.transport.InboundPipeline;
+import org.elasticsearch.transport.OutboundHandler;
+import org.elasticsearch.transport.RemoteTransportException;
+import org.elasticsearch.transport.StatsTracker;
+import org.elasticsearch.transport.TestRequest;
+import org.elasticsearch.transport.TestResponse;
+import org.elasticsearch.transport.TransportMessageListener;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportRequestOptions;
+import org.elasticsearch.transport.TransportResponse;
 import org.opensearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.breaker.CircuitBreaker;

--- a/server/src/test/java/org/opensearch/transport/ProxyConnectionStrategyTests.java
+++ b/server/src/test/java/org/opensearch/transport/ProxyConnectionStrategyTests.java
@@ -17,9 +17,15 @@
  * under the License.
  */
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.transport.ClusterConnectionManager;
+import org.elasticsearch.transport.ConnectionProfile;
+import org.elasticsearch.transport.ProxyConnectionStrategy;
+import org.elasticsearch.transport.RemoteConnectionManager;
+import org.elasticsearch.transport.RemoteConnectionStrategy;
+import org.elasticsearch.transport.TransportSettings;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;

--- a/server/src/test/java/org/opensearch/transport/PublishPortTests.java
+++ b/server/src/test/java/org/opensearch/transport/PublishPortTests.java
@@ -17,11 +17,14 @@
  * under the License.
  */
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.common.network.NetworkUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.BindTransportException;
+import org.elasticsearch.transport.TcpTransport;
+import org.elasticsearch.transport.TransportSettings;
 
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;

--- a/server/src/test/java/org/opensearch/transport/RemoteClusterAwareClientTests.java
+++ b/server/src/test/java/org/opensearch/transport/RemoteClusterAwareClientTests.java
@@ -17,9 +17,10 @@
  * under the License.
  */
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.transport.RemoteClusterAwareClient;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.action.admin.cluster.shards.ClusterSearchShardsRequest;

--- a/server/src/test/java/org/opensearch/transport/RemoteClusterAwareTests.java
+++ b/server/src/test/java/org/opensearch/transport/RemoteClusterAwareTests.java
@@ -17,9 +17,10 @@
  * under the License.
  */
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.RemoteClusterAware;
 
 public class RemoteClusterAwareTests extends ESTestCase {
 

--- a/server/src/test/java/org/opensearch/transport/RemoteClusterClientTests.java
+++ b/server/src/test/java/org/opensearch/transport/RemoteClusterClientTests.java
@@ -16,9 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.transport.ActionNotFoundTransportException;
+import org.elasticsearch.transport.ConnectionManager;
+import org.elasticsearch.transport.RemoteClusterConnection;
+import org.elasticsearch.transport.RemoteClusterService;
+import org.elasticsearch.transport.Transport;
 import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
 import org.opensearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Client;
@@ -37,7 +42,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.test.NodeRoles.onlyRole;
 import static org.elasticsearch.test.NodeRoles.removeRoles;
-import static org.elasticsearch.transport.RemoteClusterConnectionTests.startTransport;
+import static org.opensearch.transport.RemoteClusterConnectionTests.startTransport;
 import static org.hamcrest.Matchers.equalTo;
 
 public class RemoteClusterClientTests extends ESTestCase {
@@ -51,7 +56,7 @@ public class RemoteClusterClientTests extends ESTestCase {
 
     public void testConnectAndExecuteRequest() throws Exception {
         Settings remoteSettings = Settings.builder().put(ClusterName.CLUSTER_NAME_SETTING.getKey(), "foo_bar_cluster").build();
-        try (MockTransportService remoteTransport = startTransport("remote_node", Collections.emptyList(), Version.CURRENT, threadPool,
+        try (MockTransportService remoteTransport = RemoteClusterConnectionTests.startTransport("remote_node", Collections.emptyList(), Version.CURRENT, threadPool,
             remoteSettings)) {
             DiscoveryNode remoteNode = remoteTransport.getLocalDiscoNode();
 
@@ -84,7 +89,7 @@ public class RemoteClusterClientTests extends ESTestCase {
         reason = "debug intermittent test failure")
     public void testEnsureWeReconnect() throws Exception {
         Settings remoteSettings = Settings.builder().put(ClusterName.CLUSTER_NAME_SETTING.getKey(), "foo_bar_cluster").build();
-        try (MockTransportService remoteTransport = startTransport("remote_node", Collections.emptyList(), Version.CURRENT, threadPool,
+        try (MockTransportService remoteTransport = RemoteClusterConnectionTests.startTransport("remote_node", Collections.emptyList(), Version.CURRENT, threadPool,
             remoteSettings)) {
             DiscoveryNode remoteNode = remoteTransport.getLocalDiscoNode();
             Settings localSettings = Settings.builder()

--- a/server/src/test/java/org/opensearch/transport/RemoteClusterConnectionTests.java
+++ b/server/src/test/java/org/opensearch/transport/RemoteClusterConnectionTests.java
@@ -16,11 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.Version;
+import org.elasticsearch.transport.NoSuchRemoteClusterException;
+import org.elasticsearch.transport.ProxyConnectionStrategy;
+import org.elasticsearch.transport.RemoteClusterConnection;
+import org.elasticsearch.transport.RemoteConnectionInfo;
+import org.elasticsearch.transport.RemoteConnectionManager;
+import org.elasticsearch.transport.RemoteConnectionStrategy;
+import org.elasticsearch.transport.SniffConnectionStrategy;
+import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportRequestOptions;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.admin.cluster.shards.ClusterSearchShardsAction;
 import org.opensearch.action.admin.cluster.shards.ClusterSearchShardsGroup;

--- a/server/src/test/java/org/opensearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/opensearch/transport/RemoteClusterServiceTests.java
@@ -16,9 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.transport.ConnectionManager;
+import org.elasticsearch.transport.ConnectionProfile;
+import org.elasticsearch.transport.NoSeedNodeLeftException;
+import org.elasticsearch.transport.NoSuchRemoteClusterException;
+import org.elasticsearch.transport.ProxyConnectionStrategy;
+import org.elasticsearch.transport.RemoteClusterAware;
+import org.elasticsearch.transport.RemoteClusterConnection;
+import org.elasticsearch.transport.RemoteClusterService;
+import org.elasticsearch.transport.RemoteConnectionStrategy;
+import org.elasticsearch.transport.SniffConnectionStrategy;
+import org.elasticsearch.transport.TransportConnectionListener;
+import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportSettings;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.OriginalIndices;
 import org.opensearch.action.support.IndicesOptions;

--- a/server/src/test/java/org/opensearch/transport/RemoteClusterSettingsTests.java
+++ b/server/src/test/java/org/opensearch/transport/RemoteClusterSettingsTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;

--- a/server/src/test/java/org/opensearch/transport/RemoteConnectionManagerTests.java
+++ b/server/src/test/java/org/opensearch/transport/RemoteConnectionManagerTests.java
@@ -16,9 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.transport.CloseableConnection;
+import org.elasticsearch.transport.ClusterConnectionManager;
+import org.elasticsearch.transport.ConnectionManager;
+import org.elasticsearch.transport.ConnectionProfile;
+import org.elasticsearch.transport.RemoteConnectionManager;
+import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportRequestOptions;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;

--- a/server/src/test/java/org/opensearch/transport/RemoteConnectionStrategyTests.java
+++ b/server/src/test/java/org/opensearch/transport/RemoteConnectionStrategyTests.java
@@ -18,8 +18,19 @@
  */
 
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
+import org.elasticsearch.transport.ClusterConnectionManager;
+import org.elasticsearch.transport.ConnectionProfile;
+import org.elasticsearch.transport.ProxyConnectionStrategy;
+import org.elasticsearch.transport.RemoteClusterService;
+import org.elasticsearch.transport.RemoteConnectionInfo;
+import org.elasticsearch.transport.RemoteConnectionManager;
+import org.elasticsearch.transport.RemoteConnectionStrategy;
+import org.elasticsearch.transport.SniffConnectionStrategy;
+import org.elasticsearch.transport.TestProfiles;
+import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportService;
 import org.opensearch.action.ActionListener;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;

--- a/server/src/test/java/org/opensearch/transport/SniffConnectionStrategyTests.java
+++ b/server/src/test/java/org/opensearch/transport/SniffConnectionStrategyTests.java
@@ -17,9 +17,15 @@
  * under the License.
  */
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.transport.ClusterConnectionManager;
+import org.elasticsearch.transport.ConnectTransportException;
+import org.elasticsearch.transport.ConnectionProfile;
+import org.elasticsearch.transport.RemoteConnectionManager;
+import org.elasticsearch.transport.RemoteConnectionStrategy;
+import org.elasticsearch.transport.SniffConnectionStrategy;
 import org.opensearch.action.admin.cluster.state.ClusterStateAction;
 import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
 import org.opensearch.action.admin.cluster.state.ClusterStateResponse;

--- a/server/src/test/java/org/opensearch/transport/TcpTransportTests.java
+++ b/server/src/test/java/org/opensearch/transport/TcpTransportTests.java
@@ -17,12 +17,19 @@
  * under the License.
  */
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.OpenSearchException;
 import org.elasticsearch.Version;
+import org.elasticsearch.transport.FakeTcpChannel;
+import org.elasticsearch.transport.OutboundHandler;
+import org.elasticsearch.transport.StatsTracker;
+import org.elasticsearch.transport.TcpChannel;
+import org.elasticsearch.transport.TcpServerChannel;
+import org.elasticsearch.transport.TcpTransport;
+import org.elasticsearch.transport.TransportSettings;
 import org.opensearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.component.Lifecycle;

--- a/server/src/test/java/org/opensearch/transport/TransportActionProxyTests.java
+++ b/server/src/test/java/org/opensearch/transport/TransportActionProxyTests.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.OpenSearchException;
 import org.elasticsearch.ExceptionsHelper;
@@ -28,6 +28,12 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.transport.TransportActionProxy;
+import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportResponseHandler;
+import org.elasticsearch.transport.TransportService;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.junit.Before;

--- a/server/src/test/java/org/opensearch/transport/TransportDecompressorTests.java
+++ b/server/src/test/java/org/opensearch/transport/TransportDecompressorTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.CompositeBytesReference;
@@ -31,6 +31,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.TransportDecompressor;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/server/src/test/java/org/opensearch/transport/TransportHandshakerTests.java
+++ b/server/src/test/java/org/opensearch/transport/TransportHandshakerTests.java
@@ -16,9 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.transport.ConnectTransportException;
+import org.elasticsearch.transport.TcpChannel;
+import org.elasticsearch.transport.TestTransportChannel;
+import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportHandshaker;
+import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportResponseHandler;
 import org.opensearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;

--- a/server/src/test/java/org/opensearch/transport/TransportInfoTests.java
+++ b/server/src/test/java/org/opensearch/transport/TransportInfoTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.transport.BoundTransportAddress;
@@ -26,6 +26,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.TransportInfo;
 
 import java.io.IOException;
 import java.net.InetAddress;

--- a/server/src/test/java/org/opensearch/transport/TransportKeepAliveTests.java
+++ b/server/src/test/java/org/opensearch/transport/TransportKeepAliveTests.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.common.AsyncBiFunction;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -25,6 +25,10 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.ConnectionProfile;
+import org.elasticsearch.transport.FakeTcpChannel;
+import org.elasticsearch.transport.TcpChannel;
+import org.elasticsearch.transport.TransportKeepAlive;
 import org.opensearch.threadpool.TestThreadPool;
 
 import java.io.IOException;

--- a/server/src/test/java/org/opensearch/transport/TransportLoggerTests.java
+++ b/server/src/test/java/org/opensearch/transport/TransportLoggerTests.java
@@ -16,11 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.Version;
+import org.elasticsearch.transport.OutboundMessage;
+import org.elasticsearch.transport.TcpChannel;
+import org.elasticsearch.transport.TransportLogger;
 import org.opensearch.action.admin.cluster.stats.ClusterStatsAction;
 import org.opensearch.action.admin.cluster.stats.ClusterStatsRequest;
 import org.elasticsearch.common.bytes.BytesReference;

--- a/server/src/test/java/org/opensearch/transport/TransportRequestDeduplicatorTests.java
+++ b/server/src/test/java/org/opensearch/transport/TransportRequestDeduplicatorTests.java
@@ -16,9 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportRequestDeduplicator;
 import org.opensearch.action.ActionListener;
 import org.opensearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;

--- a/server/src/test/java/org/opensearch/transport/TransportServiceDeserializationFailureTests.java
+++ b/server/src/test/java/org/opensearch/transport/TransportServiceDeserializationFailureTests.java
@@ -17,9 +17,16 @@
  * under the License.
  */
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportRequestOptions;
+import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportResponseHandler;
+import org.elasticsearch.transport.TransportService;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.cluster.ClusterName;
 import org.elasticsearch.cluster.coordination.DeterministicTaskQueue;

--- a/server/src/test/java/org/opensearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/opensearch/transport/TransportServiceHandshakeTests.java
@@ -17,9 +17,13 @@
  * under the License.
  */
 
-package org.elasticsearch.transport;
+package org.opensearch.transport;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.transport.ConnectTransportException;
+import org.elasticsearch.transport.TestProfiles;
+import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportService;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Client;


### PR DESCRIPTION
…/src/test/java/org/elasticsearch/transport

Issue #160 

This PR moves the classes under [server/src/test/java/org/elasticsearch/transport] to /opensearch/transport. Some additional imports get added by Intellij as a consequence of package change since the test/ files don't fall under the same package name as src/ files. These should be removed automatically once the src/ is moved as part of separate PR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
