### PR TITLE
[DOCS] Remove data-stream tests from 'exclude' list in build.gradle

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -80,14 +80,7 @@ buildRestTests.docs = fileTree(projectDir) {
   // Just syntax examples
   exclude 'README.asciidoc'
   // Broken code snippet tests
-  exclude 'reference/data-streams'
-  exclude 'reference/indices/create-data-stream.asciidoc'
-  exclude 'reference/indices/data-stream-stats.asciidoc'
-  exclude 'reference/indices/delete-data-stream.asciidoc'
-  exclude 'reference/indices/get-data-stream.asciidoc'
-  exclude 'reference/indices/put-index-template.asciidoc'
-  exclude 'reference/indices/resolve.asciidoc'
-  exclude 'reference/indices/rollover-index.asciidoc'
+
   if (Boolean.parseBoolean(System.getProperty("tests.fips.enabled"))) {
     // We don't install/support this plugin in FIPS 140
     exclude 'plugins/ingest-attachment.asciidoc'


### PR DESCRIPTION
*Issue #, if available:*
#142 

*Description of changes:*

The PR requests merging the code into `oss-docs` branch.

In PR #226, "Data Stream" are removed from the documents, the code snippet tests of "Data Stream" can be removed from the `exclude` list in `docs/build.gradle`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
