### PR TITLE
[DOCS] Rename `elasticsearch` or `ES` that used as the software name

### DIFF
--- a/docs/plugins/analysis-smartcn.asciidoc
+++ b/docs/plugins/analysis-smartcn.asciidoc
@@ -2,7 +2,7 @@
 === Smart Chinese Analysis Plugin
 
 The Smart Chinese Analysis plugin integrates Lucene's Smart Chinese analysis
-module into {opensearch}.
+module into opensearch.
 
 It provides an analyzer for Chinese or mixed Chinese-English text. This
 analyzer uses probabilistic knowledge to find the optimal word segmentation

--- a/docs/plugins/analysis-stempel.asciidoc
+++ b/docs/plugins/analysis-stempel.asciidoc
@@ -2,7 +2,7 @@
 === Stempel Polish Analysis Plugin
 
 The Stempel Analysis plugin integrates Lucene's Stempel analysis
-module for Polish into {opensearch}.
+module for Polish into opensearch.
 
 :plugin_name: analysis-stempel
 include::install_remove.asciidoc[]

--- a/docs/plugins/analysis-ukrainian.asciidoc
+++ b/docs/plugins/analysis-ukrainian.asciidoc
@@ -1,7 +1,7 @@
 [[analysis-ukrainian]]
 === Ukrainian Analysis Plugin
 
-The Ukrainian Analysis plugin integrates Lucene's UkrainianMorfologikAnalyzer into {opensearch}.
+The Ukrainian Analysis plugin integrates Lucene's UkrainianMorfologikAnalyzer into opensearch.
 
 It provides stemming for Ukrainian using the https://github.com/morfologik/morfologik-stemming[Morfologik project].
 

--- a/docs/plugins/store-smb.asciidoc
+++ b/docs/plugins/store-smb.asciidoc
@@ -14,7 +14,7 @@ open index segment files is with a write only flag. This is the _correct_ way to
 used for writes and allows different FS implementations to optimize for it. Sadly, in windows with SMB, this disables
 the cache manager, causing writes to be slow. This has been described in
 https://issues.apache.org/jira/browse/LUCENE-6176[LUCENE-6176], but it affects each and every Java program out there!.
-This need and must be fixed outside of {opensearch} and/or Lucene, either in windows or OpenJDK. For now, we are providing an
+This need and must be fixed outside of OpenSearch and/or Lucene, either in windows or OpenJDK. For now, we are providing an
 experimental support to open the files with read flag, but this should be considered experimental and the correct way
 to fix it is in OpenJDK or Windows.
 


### PR DESCRIPTION
*Issue #, if available:*
#238 

*Description of changes:*

The PR is an replacement of PR #259 

The PR requests merging the code into `oss-docs` branch.

Usually when referring to the software, it is written as `Elasticsearch`, but here are some exceptions, and I renamed them accordingly.
- Rename these `elasticsearch` and an `ES` to `opensearch` or `OpenSearch`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
