### PR TITLE
[Rename] build.gradle in test module

### DIFF
--- a/test/build.gradle
+++ b/test/build.gradle
@@ -18,5 +18,5 @@
  */
 
 subprojects {
-  group = 'org.elasticsearch.test'
+  group = 'org.opensearch.test'
 }


### PR DESCRIPTION
This PR refactors the build.gradle file in the test module from o.e.test to
o.opensearch.test namespace.

relates #160