### PR TITLE
[DOCS] Replace some 'elastic' with 'opensearch'

### DIFF
--- a/docs/java-rest/high-level/document/reindex.asciidoc
+++ b/docs/java-rest/high-level/document/reindex.asciidoc
@@ -109,7 +109,7 @@ in JSON.
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request-remote]
 --------------------------------------------------
-<1> set remote elastic cluster
+<1> set remote opensearch cluster
 
 +{request}+ also helps in automatically parallelizing using `sliced-scroll` to
 slice on `_id`. Use `setSlices` to specify the number of slices to use.

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -149,7 +149,7 @@ they resolve to given the current time is 22nd March 2024 noon utc.
 To use the characters `{` and `}` in the static part of an index name template, escape them
 with a backslash `\`, for example:
 
- * `<elastic\\{ON\\}-{now/M}>` resolves to `elastic{ON}-2024.03.01`
+ * `<opensearch\\{ON\\}-{now/M}>` resolves to `opensearch{ON}-2024.03.01`
 
 The following example shows a search request that searches the Logstash indices for the past
 three days, assuming the indices use the default Logstash index name format,

--- a/docs/reference/setup/install/brew.asciidoc
+++ b/docs/reference/setup/install/brew.asciidoc
@@ -9,7 +9,7 @@ Elastic Homebrew repository:
 
 [source,sh]
 -------------------------
-brew tap elastic/tap
+brew tap opensearch/tap
 -------------------------
 
 Once you've tapped the Elastic Homebrew repo, you can use `brew install` to
@@ -17,7 +17,7 @@ install the default distribution of {es}:
 
 [source,sh]
 -------------------------
-brew install elastic/tap/opensearch-full
+brew install opensearch/tap/opensearch-full
 -------------------------
 
 This installs the most recently released default distribution of {es}.

--- a/docs/reference/setup/install/docker-compose.yml
+++ b/docs/reference/setup/install/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     ports:
       - 9200:9200
     networks:
-      - elastic
+      - opensearch
   es02:
     image: {docker-image}
     container_name: es02
@@ -37,7 +37,7 @@ services:
     volumes:
       - data02:/usr/share/opensearch/data
     networks:
-      - elastic
+      - opensearch
   es03:
     image: {docker-image}
     container_name: es03
@@ -55,7 +55,7 @@ services:
     volumes:
       - data03:/usr/share/opensearch/data    
     networks:
-      - elastic
+      - opensearch
 
 volumes:
   data01:
@@ -66,5 +66,5 @@ volumes:
     driver: local    
 
 networks:
-  elastic:
+  opensearch:
     driver: bridge


### PR DESCRIPTION
*Issue #, if available:*
#238

*Description of changes:*

The PR requests merging the code into `oss-docs` branch.

- Replace `elastic` (in lower cases) with `opensearch`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.