### PR TITLE
[DOCS] Repalce all 'elasticsearch' with 'opensearch' in 'docs/java-api'

### DIFF
--- a/docs/java-api/admin/cluster/stored-scripts.asciidoc
+++ b/docs/java-api/admin/cluster/stored-scripts.asciidoc
@@ -2,7 +2,7 @@
 ==== Stored Scripts API
 
 The stored script API allows one to interact with scripts and templates
-stored in Elasticsearch. It can be used to create, update, get,
+stored in OpenSearch. It can be used to create, update, get,
 and delete stored scripts and templates.
 
 [source,java]

--- a/docs/java-api/admin/index.asciidoc
+++ b/docs/java-api/admin/index.asciidoc
@@ -1,7 +1,7 @@
 [[java-admin]]
 == Java API Administration
 
-Elasticsearch provides a full Java API to deal with administration tasks.
+OpenSearch provides a full Java API to deal with administration tasks.
 
 To access them, you need to call `admin()` method from a client to get an `AdminClient`:
 

--- a/docs/java-api/client.asciidoc
+++ b/docs/java-api/client.asciidoc
@@ -48,7 +48,7 @@ client.close();
 --------------------------------------------------
 
 Note that you have to set the cluster name if you use one different than
-"elasticsearch":
+"opensearch":
 
 [source,java]
 --------------------------------------------------

--- a/docs/java-api/docs/bulk.asciidoc
+++ b/docs/java-api/docs/bulk.asciidoc
@@ -16,7 +16,7 @@ bulkRequest.add(client.prepareIndex("twitter", "_doc", "1")
                     .startObject()
                         .field("user", "kimchy")
                         .field("postDate", new Date())
-                        .field("message", "trying out Elasticsearch")
+                        .field("message", "trying out OpenSearch")
                     .endObject()
                   )
         );
@@ -78,7 +78,7 @@ BulkProcessor bulkProcessor = BulkProcessor.builder(
             BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), 3)) <9>
         .build();
 --------------------------------------------------
-<1> Add your Elasticsearch client
+<1> Add your OpenSearch client
 <2> This method is called just before bulk is executed. You can for example see the numberOfActions with
     `request.numberOfActions()`
 <3> This method is called after bulk execution. You can for example check if there was some failing requests
@@ -138,7 +138,7 @@ all bulk requests to complete then returns `true`; if the specified waiting time
 [[java-docs-bulk-processor-tests]]
 ==== Using Bulk Processor in tests
 
-If you are running tests with Elasticsearch and are using the `BulkProcessor` to populate your dataset
+If you are running tests with OpenSearch and are using the `BulkProcessor` to populate your dataset
 you should better set the number of concurrent requests to `0` so the flush operation of the bulk will be executed
 in a synchronous manner:
 

--- a/docs/java-api/docs/index_.asciidoc
+++ b/docs/java-api/docs/index_.asciidoc
@@ -38,7 +38,7 @@ dates according to the
 String json = "{" +
         "\"user\":\"kimchy\"," +
         "\"postDate\":\"2013-01-30\"," +
-        "\"message\":\"trying out Elasticsearch\"" +
+        "\"message\":\"trying out OpenSearch\"" +
     "}";
 --------------------------------------------------
 
@@ -53,7 +53,7 @@ Map is a key:values pair collection. It represents a JSON structure:
 Map<String, Object> json = new HashMap<String, Object>();
 json.put("user","kimchy");
 json.put("postDate",new Date());
-json.put("message","trying out Elasticsearch");
+json.put("message","trying out OpenSearch");
 --------------------------------------------------
 
 
@@ -77,9 +77,9 @@ byte[] json = mapper.writeValueAsBytes(yourbeaninstance);
 
 
 [[java-docs-index-generate-helpers]]
-===== Use Elasticsearch helpers
+===== Use OpenSearch helpers
 
-Elasticsearch provides built-in helpers to generate JSON content.
+OpenSearch provides built-in helpers to generate JSON content.
 
 [source,java]
 --------------------------------------------------
@@ -89,7 +89,7 @@ XContentBuilder builder = jsonBuilder()
     .startObject()
         .field("user", "kimchy")
         .field("postDate", new Date())
-        .field("message", "trying out Elasticsearch")
+        .field("message", "trying out OpenSearch")
     .endObject()
 --------------------------------------------------
 
@@ -124,7 +124,7 @@ IndexResponse response = client.prepareIndex("twitter", "_doc", "1")
                     .startObject()
                         .field("user", "kimchy")
                         .field("postDate", new Date())
-                        .field("message", "trying out Elasticsearch")
+                        .field("message", "trying out OpenSearch")
                     .endObject()
                   )
         .get();
@@ -138,7 +138,7 @@ don't have to give an ID:
 String json = "{" +
         "\"user\":\"kimchy\"," +
         "\"postDate\":\"2013-01-30\"," +
-        "\"message\":\"trying out Elasticsearch\"" +
+        "\"message\":\"trying out OpenSearch\"" +
     "}";
 
 IndexResponse response = client.prepareIndex("twitter", "_doc")

--- a/docs/java-api/query-dsl/geo-queries.asciidoc
+++ b/docs/java-api/query-dsl/geo-queries.asciidoc
@@ -1,7 +1,7 @@
 [[java-geo-queries]]
 === Geo queries
 
-Elasticsearch supports two types of geo data:
+OpenSearch supports two types of geo data:
 `geo_point` fields which support lat/lon pairs, and
 `geo_shape` fields, which support points, lines, circles, polygons, multi-polygons etc.
 

--- a/docs/java-api/query-dsl/has-child-query.asciidoc
+++ b/docs/java-api/query-dsl/has-child-query.asciidoc
@@ -7,7 +7,7 @@ When using the `has_child` query it is important to use the `PreBuiltTransportCl
 
 [source,java]
 --------------------------------------------------
-Settings settings = Settings.builder().put("cluster.name", "elasticsearch").build();
+Settings settings = Settings.builder().put("cluster.name", "opensearch").build();
 TransportClient client = new PreBuiltTransportClient(settings);
 client.addTransportAddress(new TransportAddress(new InetSocketAddress(InetAddresses.forString("127.0.0.1"), 9300)));
 --------------------------------------------------

--- a/docs/java-api/query-dsl/has-parent-query.asciidoc
+++ b/docs/java-api/query-dsl/has-parent-query.asciidoc
@@ -7,7 +7,7 @@ When using the `has_parent` query it is important to use the `PreBuiltTransportC
 
 [source,java]
 --------------------------------------------------
-Settings settings = Settings.builder().put("cluster.name", "elasticsearch").build();
+Settings settings = Settings.builder().put("cluster.name", "opensearch").build();
 TransportClient client = new PreBuiltTransportClient(settings);
 client.addTransportAddress(new TransportAddress(new InetSocketAddress(InetAddresses.forString("127.0.0.1"), 9300)));
 --------------------------------------------------

--- a/docs/java-api/query-dsl/joining-queries.asciidoc
+++ b/docs/java-api/query-dsl/joining-queries.asciidoc
@@ -2,7 +2,7 @@
 === Joining queries
 
 Performing full SQL-style joins in a distributed system like OpenSearch is
-prohibitively expensive.  Instead, Elasticsearch offers two forms of join
+prohibitively expensive.  Instead, OpenSearch offers two forms of join
 which are designed to scale horizontally.
 
 <<java-query-dsl-nested-query,`nested` query>>::

--- a/docs/java-api/query-dsl/percolate-query.asciidoc
+++ b/docs/java-api/query-dsl/percolate-query.asciidoc
@@ -7,7 +7,7 @@ See:
 
 [source,java]
 --------------------------------------------------
-Settings settings = Settings.builder().put("cluster.name", "elasticsearch").build();
+Settings settings = Settings.builder().put("cluster.name", "opensearch").build();
 TransportClient client = new PreBuiltTransportClient(settings);
 client.addTransportAddress(new TransportAddress(new InetSocketAddress(InetAddresses.forString("127.0.0.1"), 9300)));
 --------------------------------------------------

--- a/docs/java-api/search.asciidoc
+++ b/docs/java-api/search.asciidoc
@@ -76,7 +76,7 @@ documentation
 [source,java]
 --------------------------------------------------
 SearchRequestBuilder srb1 = client
-    .prepareSearch().setQuery(QueryBuilders.queryStringQuery("elasticsearch")).setSize(1);
+    .prepareSearch().setQuery(QueryBuilders.queryStringQuery("opensearch")).setSize(1);
 SearchRequestBuilder srb2 = client
     .prepareSearch().setQuery(QueryBuilders.matchQuery("name", "kimchy")).setSize(1);
 


### PR DESCRIPTION
*Issue #, if available:*
#238

*Description of changes:*

The PR requests merging the code into `oss-docs` branch.

- Replace all `elasticsearch` with `opensearch` in `docs/java-api`
- Replace all `Elasticsearch` with `OpenSearch` in `docs/java-api`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.