### PR TITLE
[Rename] org.elasticsearch.monitor

### DIFF
--- a/server/src/test/java/org/opensearch/common/settings/MemorySizeSettingsTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/MemorySizeSettingsTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.indices.IndicesQueryCache;
 import org.elasticsearch.indices.IndicesRequestCache;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
-import org.elasticsearch.monitor.jvm.JvmInfo;
+import org.opensearch.monitor.jvm.JvmInfo;
 import org.opensearch.test.OpenSearchTestCase;
 
 import static org.hamcrest.Matchers.notNullValue;

--- a/server/src/test/java/org/opensearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
@@ -28,7 +28,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.ByteSizeUnit;
 import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.common.unit.TimeValue;
-import org.elasticsearch.monitor.jvm.JvmInfo;
+import org.opensearch.monitor.jvm.JvmInfo;
 import org.opensearch.search.aggregations.MultiBucketConsumerService;
 import org.opensearch.test.OpenSearchTestCase;
 

--- a/server/src/test/java/org/opensearch/monitor/fs/FsHealthServiceTests.java
+++ b/server/src/test/java/org/opensearch/monitor/fs/FsHealthServiceTests.java
@@ -50,8 +50,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.elasticsearch.monitor.StatusInfo.Status.HEALTHY;
-import static org.elasticsearch.monitor.StatusInfo.Status.UNHEALTHY;
+import static org.opensearch.monitor.StatusInfo.Status.HEALTHY;
+import static org.opensearch.monitor.StatusInfo.Status.UNHEALTHY;
 import static org.opensearch.node.Node.NODE_NAME_SETTING;
 import static org.hamcrest.Matchers.is;
 
@@ -126,7 +126,7 @@ public class FsHealthServiceTests extends OpenSearchTestCase {
         }
     }
 
-    @TestLogging(value = "org.elasticsearch.monitor.fs:WARN", reason = "to ensure that we log on hung IO at WARN level")
+    @TestLogging(value = "org.opensearch.monitor.fs:WARN", reason = "to ensure that we log on hung IO at WARN level")
     public void testLoggingOnHungIO() throws Exception {
         long slowLogThreshold = randomLongBetween(100, 200);
         final Settings settings = Settings.builder().put(FsHealthService.SLOW_PATH_LOGGING_THRESHOLD_SETTING.getKey(),

--- a/server/src/test/java/org/opensearch/monitor/process/ProcessProbeTests.java
+++ b/server/src/test/java/org/opensearch/monitor/process/ProcessProbeTests.java
@@ -23,7 +23,7 @@ import org.apache.lucene.util.Constants;
 import org.opensearch.bootstrap.BootstrapInfo;
 import org.opensearch.test.OpenSearchTestCase;
 
-import static org.elasticsearch.monitor.jvm.JvmInfo.jvmInfo;
+import static org.opensearch.monitor.jvm.JvmInfo.jvmInfo;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;

--- a/test/framework/src/main/java/org/opensearch/test/InternalSettingsPlugin.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalSettingsPlugin.java
@@ -25,7 +25,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.monitor.fs.FsService;
+import org.opensearch.monitor.fs.FsService;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.transport.RemoteConnectionStrategy;
 


### PR DESCRIPTION
Rename remaining org.elasticsearch.monitor to org.opensearch.monitor

relates #160

Signed-off-by: Harold Wang <harowang@amazon.com>