### PR TITLE
[Rename] org.elasticsearch.persistent

### DIFF
--- a/server/src/test/java/org/opensearch/persistent/CancelPersistentTaskRequestTests.java
+++ b/server/src/test/java/org/opensearch/persistent/CancelPersistentTaskRequestTests.java
@@ -19,7 +19,7 @@
 package org.opensearch.persistent;
 
 import org.opensearch.common.io.stream.Writeable;
-import org.elasticsearch.persistent.RemovePersistentTaskAction.Request;
+import org.opensearch.persistent.RemovePersistentTaskAction.Request;
 import org.opensearch.test.AbstractWireSerializingTestCase;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiOfLength;


### PR DESCRIPTION
Rename remaining org.elasticsearch.persistent to org.opensearch.persistent

Related to #160 
Signed-off-by: Harold Wang <harowang@amazon.com>