### PR TITLE
[Rename] Temporarily suppress thirdPartyAudit errors for precommit pass.

### DIFF
--- a/server/src/test/java/org/opensearch/index/mapper/ExternalFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ExternalFieldMapperTests.java
@@ -21,10 +21,8 @@ package org.opensearch.index.mapper;
 
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
-import org.hamcrest.Matchers;
 import org.opensearch.common.geo.GeoPoint;
 import org.opensearch.plugins.Plugin;
-import org.opensearch.index.mapper.MapperServiceTestCase;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/server/src/test/java/org/opensearch/index/shard/IndexingOperationListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexingOperationListenerTests.java
@@ -25,7 +25,6 @@ import org.opensearch.index.engine.InternalEngineTests;
 import org.opensearch.index.mapper.ParsedDocument;
 import org.opensearch.index.mapper.Uid;
 import org.opensearch.index.seqno.SequenceNumbers;
-import org.hamcrest.Matchers;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.ArrayList;

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -60,7 +60,16 @@ thirdPartyAudit.ignoreMissingClasses(
   'org.apache.log4j.Category',
   'org.apache.log4j.Level',
   'org.apache.log4j.Logger',
-  'org.apache.log4j.Priority'
+  'org.apache.log4j.Priority',
+  // TODO - OpenSearch remove this missing classes. Issue: https://github.com/opensearch-project/OpenSearch/issues/420
+  'org.apache.tools.ant.BuildException',
+  'org.apache.tools.ant.DirectoryScanner',
+  'org.apache.tools.ant.Task',
+  'org.apache.tools.ant.types.FileSet',
+)
+// TODO - OpenSearch remove this violation. Issue: https://github.com/opensearch-project/OpenSearch/issues/420
+thirdPartyAudit.ignoreViolations(
+  'org.objenesis.instantiator.sun.UnsafeFactoryInstantiator'
 )
 
 test {


### PR DESCRIPTION
Currently the thirdPartyAudit task is failing for the test:framework module after renaming to OpenSearch. We have created an issue and temporarily suppressed the errors to unblock the precommit.

Issue: https://github.com/opensearch-project/OpenSearch/issues/420

Signed-off-by: Rabi Panda <adnapibar@gmail.com>