### PR TITLE
Remove tagline from cluster info in sever and RHLC

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/core/MainResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/core/MainResponse.java
@@ -30,7 +30,7 @@ public class MainResponse {
     private static final ConstructingObjectParser<MainResponse, Void> PARSER =
         new ConstructingObjectParser<>(MainResponse.class.getName(), true,
             args -> {
-                 return new MainResponse((String) args[0], (Version) args[1], (String) args[2], (String) args[3], (String) args[4]);
+                 return new MainResponse((String) args[0], (Version) args[1], (String) args[2], (String) args[3]);
             }
         );
 
@@ -39,7 +39,6 @@ public class MainResponse {
         PARSER.declareObject(ConstructingObjectParser.constructorArg(), Version.PARSER, new ParseField("version"));
         PARSER.declareString(ConstructingObjectParser.constructorArg(), new ParseField("cluster_name"));
         PARSER.declareString(ConstructingObjectParser.constructorArg(), new ParseField("cluster_uuid"));
-        PARSER.declareString(ConstructingObjectParser.constructorArg(), new ParseField("tagline"));
 
     }
 
@@ -47,14 +46,12 @@ public class MainResponse {
     private final Version version;
     private final String clusterName;
     private final String clusterUuid;
-    private final String tagline;
 
-    public MainResponse(String nodeName, Version version, String clusterName, String clusterUuid, String tagline) {
+    public MainResponse(String nodeName, Version version, String clusterName, String clusterUuid) {
         this.nodeName = nodeName;
         this.version = version;
         this.clusterName = clusterName;
         this.clusterUuid = clusterUuid;
-        this.tagline = tagline;
     }
 
     public String getNodeName() {
@@ -73,10 +70,6 @@ public class MainResponse {
         return clusterUuid;
     }
 
-    public String getTagline() {
-        return tagline;
-    }
-
     public static MainResponse fromXContent(XContentParser parser) {
         return PARSER.apply(parser, null);
     }
@@ -89,13 +82,12 @@ public class MainResponse {
         return nodeName.equals(that.nodeName) &&
             version.equals(that.version) &&
             clusterName.equals(that.clusterName) &&
-            clusterUuid.equals(that.clusterUuid) &&
-            tagline.equals(that.tagline);
+            clusterUuid.equals(that.clusterUuid);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(nodeName, version, clusterName, clusterUuid, tagline);
+        return Objects.hash(nodeName, version, clusterName, clusterUuid);
     }
 
     public static class Version {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -167,7 +167,7 @@ public class RestHighLevelClientTests extends ESTestCase {
     public void testInfo() throws IOException {
         MainResponse testInfo = new MainResponse("nodeName", new MainResponse.Version("number", "buildType", "buildHash",
             "buildDate", true, "luceneVersion", "minimumWireCompatibilityVersion", "minimumIndexCompatibilityVersion"),
-            "clusterName", "clusterUuid", "You Know, for Search");
+            "clusterName", "clusterUuid");
         mockResponse((ToXContentFragment) (builder, params) -> {
             // taken from the server side MainResponse
             builder.field("name", testInfo.getNodeName());
@@ -183,7 +183,6 @@ public class RestHighLevelClientTests extends ESTestCase {
                 .field("minimum_wire_compatibility_version", testInfo.getVersion().getMinimumWireCompatibilityVersion())
                 .field("minimum_index_compatibility_version", testInfo.getVersion().getMinimumIndexCompatibilityVersion())
                 .endObject();
-            builder.field("tagline", testInfo.getTagline());
             return builder;
         });
         MainResponse receivedInfo = restHighLevelClient.info(RequestOptions.DEFAULT);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/core/MainResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/core/MainResponseTests.java
@@ -57,7 +57,6 @@ public class MainResponseTests extends AbstractResponseTestCase<org.elasticsearc
         assertThat(serverTestInstance.getClusterName().value(), equalTo(clientInstance.getClusterName()));
         assertThat(serverTestInstance.getClusterUuid(), equalTo(clientInstance.getClusterUuid()));
         assertThat(serverTestInstance.getNodeName(), equalTo(clientInstance.getNodeName()));
-        assertThat("You Know, for Search", equalTo(clientInstance.getTagline()));
 
         assertThat(serverTestInstance.getBuild().hash(), equalTo(clientInstance.getVersion().getBuildHash()));
         assertThat(serverTestInstance.getVersion().toString(), equalTo(clientInstance.getVersion().getNumber()));

--- a/distribution/docker/src/test/resources/rest-api-spec/test/10_info.yml
+++ b/distribution/docker/src/test/resources/rest-api-spec/test/10_info.yml
@@ -4,7 +4,6 @@
   - is_true:    name
   - is_true:    cluster_name
   - is_true:    cluster_uuid
-  - is_true:    tagline
   - is_true:    version
   - is_true:    version.number
   - match: { version.build_type: "docker" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/info/10_info.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/info/10_info.yml
@@ -4,6 +4,5 @@
     - is_true:    name
     - is_true:    cluster_name
     - is_true:    cluster_uuid
-    - is_true:    tagline
     - is_true:    version
     - is_true:    version.number

--- a/server/src/main/java/org/elasticsearch/action/main/MainResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/main/MainResponse.java
@@ -113,7 +113,6 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
             .field("minimum_wire_compatibility_version", version.minimumCompatibilityVersion().toString())
             .field("minimum_index_compatibility_version", version.minimumIndexCompatibilityVersion().toString())
             .endObject();
-        builder.field("tagline", "You Know, for Search");
         builder.endObject();
         return builder;
     }
@@ -125,7 +124,6 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
         PARSER.declareString((response, value) -> response.nodeName = value, new ParseField("name"));
         PARSER.declareString((response, value) -> response.clusterName = new ClusterName(value), new ParseField("cluster_name"));
         PARSER.declareString((response, value) -> response.clusterUuid = value, new ParseField("cluster_uuid"));
-        PARSER.declareString((response, value) -> {}, new ParseField("tagline"));
         PARSER.declareObject((response, value) -> {
             final String buildType = (String) value.get("build_type");
             response.build =

--- a/server/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
@@ -83,8 +83,7 @@ public class MainResponseTests extends AbstractSerializingTestCase<MainResponse>
                     + "\"build_snapshot\":" + current.isSnapshot() + ","
                     + "\"lucene_version\":\"" + version.luceneVersion.toString() + "\","
                     + "\"minimum_wire_compatibility_version\":\"" + version.minimumCompatibilityVersion().toString() + "\","
-                    + "\"minimum_index_compatibility_version\":\"" + version.minimumIndexCompatibilityVersion().toString() + "\"},"
-                + "\"tagline\":\"You Know, for Search\""
+                    + "\"minimum_index_compatibility_version\":\"" + version.minimumIndexCompatibilityVersion().toString() + "\"}"
           + "}", Strings.toString(builder));
     }
 


### PR DESCRIPTION
*Issue #, if available:*
#362

*Description of changes:*

- Remove `"tagline" : "You Know, for Search"` from the response of cluster info in both "server" and "rest high level client" packages.
- Remove corresponding test

The tagline used to exist only in "server" package, but in was introduced in RHLC package in the commit https://github.com/elastic/elasticsearch/commit/86e4b04301f3ceda0218a271c908fe5123ad7d6f

Testing:
```
./gradlew check                          - No specific failure for the tagline
./gradlew :client:rest-high-level:check  - Passed
./gradlew :server:check                  - Passed
```

Reference:
1. Removing "status code" from the cluster info: https://github.com/elastic/elasticsearch/commit/052645903a8e4d88e8a4c3d7620d1c48d7328e61
2. Adding "build_flavor" into the cluster info: https://github.com/elastic/elasticsearch/commit/e64e6d89961f16ccd898cb317e3bffee82678ca5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.