### PR TITLE
[Rename] Change license header template to SPDX

### DIFF
--- a/buildSrc/src/main/resources/license-headers/oss-license-header.txt
+++ b/buildSrc/src/main/resources/license-headers/oss-license-header.txt
@@ -1,18 +1,2 @@
-/*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
+// Copyright OpenSearch Contributors.
+// SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
This commit changes the oss-license-header.txt file from the legacy ASLv2 header
to the new SPDX format.