### PR TITLE
[Rename] Fix env variables and old es maven repo

### DIFF
--- a/distribution/src/bin/opensearch-cli.bat
+++ b/distribution/src/bin/opensearch-cli.bat
@@ -18,9 +18,9 @@ set OPENSEARCH_JAVA_OPTS=-Xms4m -Xmx64m -XX:+UseSerialGC %OPENSEARCH_JAVA_OPTS%
 
 %JAVA% ^
   %OPENSEARCH_JAVA_OPTS% ^
-  -Des.path.home="%OPENSEARCH_HOME%" ^
-  -Des.path.conf="%OPENSEARCH_PATH_CONF%" ^
-  -Des.distribution.type="%OPENSEARCH_DISTRIBUTION_TYPE%" ^
+  -Dopensearch.path.home="%OPENSEARCH_HOME%" ^
+  -Dopensearch.path.conf="%OPENSEARCH_PATH_CONF%" ^
+  -Dopensearch.distribution.type="%OPENSEARCH_DISTRIBUTION_TYPE%" ^
   -cp "%OPENSEARCH_CLASSPATH%" ^
   "%OPENSEARCH_MAIN_CLASS%" ^
   %*

--- a/distribution/src/bin/opensearch-service.bat
+++ b/distribution/src/bin/opensearch-service.bat
@@ -194,7 +194,7 @@ if "%JVM_SS%" == "" (
 set OTHER_JAVA_OPTS=%OTHER_JAVA_OPTS:"=%
 set OTHER_JAVA_OPTS=%OTHER_JAVA_OPTS:~1%
 
-set OPENSEARCH_PARAMS=-Dopensearch;-Des.path.home="%OPENSEARCH_HOME%";-Des.path.conf="%OPENSEARCH_PATH_CONF%";-Des.distribution.type="%OPENSEARCH_DISTRIBUTION_TYPE%";-Des.bundled_jdk="%OPENSEARCH_BUNDLED_JDK%"
+set OPENSEARCH_PARAMS=-Dopensearch;-Dopensearch.path.home="%OPENSEARCH_HOME%";-Dopensearch.path.conf="%OPENSEARCH_PATH_CONF%";-Dopensearch.distribution.type="%OPENSEARCH_DISTRIBUTION_TYPE%";-Dopensearch.bundled_jdk="%OPENSEARCH_BUNDLED_JDK%"
 
 if "%OPENSEARCH_START_TYPE%" == "" set OPENSEARCH_START_TYPE=manual
 if "%OPENSEARCH_STOP_TIMEOUT%" == "" set OPENSEARCH_STOP_TIMEOUT=0

--- a/distribution/src/bin/opensearch.bat
+++ b/distribution/src/bin/opensearch.bat
@@ -98,9 +98,9 @@ SET KEYSTORE_PASSWORD=!KEYSTORE_PASSWORD:^>=^^^>!
 SET KEYSTORE_PASSWORD=!KEYSTORE_PASSWORD:^\=^^^\!
 
 ECHO.!KEYSTORE_PASSWORD!| %JAVA% %OPENSEARCH_JAVA_OPTS% -Dopensearch ^
-  -Des.path.home="%OPENSEARCH_HOME%" -Des.path.conf="%OPENSEARCH_PATH_CONF%" ^
-  -Des.distribution.type="%OPENSEARCH_DISTRIBUTION_TYPE%" ^
-  -Des.bundled_jdk="%OPENSEARCH_BUNDLED_JDK%" ^
+  -Dopensearch.path.home="%OPENSEARCH_HOME%" -Dopensearch.path.conf="%OPENSEARCH_PATH_CONF%" ^
+  -Dopensearch.distribution.type="%OPENSEARCH_DISTRIBUTION_TYPE%" ^
+  -Dopensearch.bundled_jdk="%OPENSEARCH_BUNDLED_JDK%" ^
   -cp "%OPENSEARCH_CLASSPATH%" "org.opensearch.bootstrap.OpenSearch" !newparams!
 
 endlocal

--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -94,9 +94,9 @@ dependencies {
   /* Right now we just test against the latest version of each major we expect
    * reindex-from-remote to work against. We could randomize the versions but
    * that doesn't seem worth it at this point. */
-  es2 'org.opensearch.distribution.zip:elasticsearch:2.4.5@zip'
-  es1 'org.opensearch:elasticsearch:1.7.6@zip'
-  es090 'org.opensearch:elasticsearch:0.90.13@zip'
+  es2 'org.elasticsearch.distribution.zip:elasticsearch:2.4.5@zip'
+  es1 'org.elasticsearch:elasticsearch:1.7.6@zip'
+  es090 'org.elasticsearch:elasticsearch:0.90.13@zip'
 }
 
 jdks {


### PR DESCRIPTION
This commit fixes some straggling es. environment variables along with a
reference to old elasticsearch versions from an opensearch maven repo that
doesn't exist.

relates #160