### PR TITLE
Fix failing rest-api-spec tests as part of renaming.

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/10_basic.yml
@@ -164,7 +164,7 @@
 
   - do:
       warnings:
-        - Creating indices with soft-deletes disabled is deprecated and will be removed in future Elasticsearch versions.
+        - Creating indices with soft-deletes disabled is deprecated and will be removed in future OpenSearch versions.
           Please do not specify value for setting [index.soft_deletes.enabled] of index [test_index].
       indices.create:
         index: test_index

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/20_translog.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/20_translog.yml
@@ -12,7 +12,7 @@
           settings:
             soft_deletes.enabled: false
       warnings:
-        - Creating indices with soft-deletes disabled is deprecated and will be removed in future Elasticsearch versions.
+        - Creating indices with soft-deletes disabled is deprecated and will be removed in future OpenSearch versions.
           Please do not specify value for setting [index.soft_deletes.enabled] of index [test].
   - do:
       cluster.health:
@@ -193,7 +193,7 @@
             soft_deletes.enabled: false
             routing.rebalance.enable: "none" # prevents shard relocations while we are closing an index
       warnings:
-        - Creating indices with soft-deletes disabled is deprecated and will be removed in future Elasticsearch versions.
+        - Creating indices with soft-deletes disabled is deprecated and will be removed in future OpenSearch versions.
           Please do not specify value for setting [index.soft_deletes.enabled] of index [test].
 
   - do:


### PR DESCRIPTION
This commit fixes the following two failing yaml tests (`ClientYamlTestSuiteIT`) in rest-api-spec which are failing as a result of renaming.

- indices.create/10_basic/Create index without soft deletes
- indices.stats/20_translog/Translog stats on closed indices without soft-deletes

Issue #441  

Signed-off-by: Rabi Panda <adnapibar@gmail.com>