### PR TITLE
Mute the keystore-cli failing tests.

### DIFF
--- a/distribution/tools/keystore-cli/src/test/java/org/opensearch/common/settings/KeyStoreWrapperTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/opensearch/common/settings/KeyStoreWrapperTests.java
@@ -454,6 +454,7 @@ public class KeyStoreWrapperTests extends OpenSearchTestCase {
         assertThat(toByteArray(afterSave.getFile("file_setting")), equalTo("file_value".getBytes(StandardCharsets.UTF_8)));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/468")
     public void testLegacyV3() throws GeneralSecurityException, IOException {
         final Path configDir = createTempDir();
         final Path keystore = configDir.resolve("opensearch.keystore");

--- a/distribution/tools/keystore-cli/src/test/java/org/opensearch/common/settings/UpgradeKeyStoreCommandTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/opensearch/common/settings/UpgradeKeyStoreCommandTests.java
@@ -48,6 +48,7 @@ public class UpgradeKeyStoreCommandTests extends KeyStoreCommandTestCase {
         };
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/468")
     public void testKeystoreUpgrade() throws Exception {
         final Path keystore = KeyStoreWrapper.keystorePath(env.configFile());
         try (


### PR DESCRIPTION
### Description

The `opensearch-keystore` tool is currently failing to load and update older versions keystores created using the `elasticsearch-keystore` tool. This results in couple of failing tests for bwc and upgrade of the older versions of keystore files.

This commit mutes these two tests until we make a decision on the minimum supported version.
 
### Issues Resolved

Relates #441 and #468 
 
### Check List
- ~[ ] New functionality includes testing.~
  - ~[ ] All tests pass~
- ~[ ] New functionality has been documented.~
  - ~[ ] New functionality has javadoc added~
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>