### PR TITLE
[Rename] Replace nio and netty test endpoint

### DIFF
--- a/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -368,7 +368,7 @@ public class Netty4HttpServerTransportTests extends OpenSearchTestCase {
 
         final Settings settings = createBuilderWithPort()
             .put(SETTING_CORS_ENABLED.getKey(), true)
-            .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), "elastic.co").build();
+            .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), "test-cors.org").build();
 
         try (Netty4HttpServerTransport transport = new Netty4HttpServerTransport(settings, networkService, bigArrays, threadPool,
             xContentRegistry(), dispatcher, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
@@ -379,13 +379,13 @@ public class Netty4HttpServerTransportTests extends OpenSearchTestCase {
             // Test pre-flight request
             try (Netty4HttpClient client = new Netty4HttpClient()) {
                 final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.OPTIONS, "/");
-                request.headers().add(CorsHandler.ORIGIN, "elastic.co");
+                request.headers().add(CorsHandler.ORIGIN, "test-cors.org");
                 request.headers().add(CorsHandler.ACCESS_CONTROL_REQUEST_METHOD, "POST");
 
                 final FullHttpResponse response = client.send(remoteAddress.address(), request);
                 try {
                     assertThat(response.status(), equalTo(HttpResponseStatus.OK));
-                    assertThat(response.headers().get(CorsHandler.ACCESS_CONTROL_ALLOW_ORIGIN), equalTo("elastic.co"));
+                    assertThat(response.headers().get(CorsHandler.ACCESS_CONTROL_ALLOW_ORIGIN), equalTo("test-cors.org"));
                     assertThat(response.headers().get(CorsHandler.VARY), equalTo(CorsHandler.ORIGIN));
                     assertTrue(response.headers().contains(CorsHandler.DATE));
                 } finally {
@@ -396,7 +396,7 @@ public class Netty4HttpServerTransportTests extends OpenSearchTestCase {
             // Test short-circuited request
             try (Netty4HttpClient client = new Netty4HttpClient()) {
                 final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
-                request.headers().add(CorsHandler.ORIGIN, "elastic2.co");
+                request.headers().add(CorsHandler.ORIGIN, "google.com");
 
                 final FullHttpResponse response = client.send(remoteAddress.address(), request);
                 try {

--- a/plugins/transport-nio/src/test/java/org/opensearch/http/nio/NioHttpServerTransportTests.java
+++ b/plugins/transport-nio/src/test/java/org/opensearch/http/nio/NioHttpServerTransportTests.java
@@ -240,7 +240,7 @@ public class NioHttpServerTransportTests extends OpenSearchTestCase {
 
         final Settings settings = createBuilderWithPort()
             .put(SETTING_CORS_ENABLED.getKey(), true)
-            .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), "elastic.co")
+            .put(SETTING_CORS_ALLOW_ORIGIN.getKey(), "test-cors.org")
             .build();
 
         try (NioHttpServerTransport transport = new NioHttpServerTransport(settings, networkService, bigArrays, pageRecycler,
@@ -252,13 +252,13 @@ public class NioHttpServerTransportTests extends OpenSearchTestCase {
             // Test pre-flight request
             try (NioHttpClient client = new NioHttpClient()) {
                 final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.OPTIONS, "/");
-                request.headers().add(CorsHandler.ORIGIN, "elastic.co");
+                request.headers().add(CorsHandler.ORIGIN, "test-cors.org");
                 request.headers().add(CorsHandler.ACCESS_CONTROL_REQUEST_METHOD, "POST");
 
                 final FullHttpResponse response = client.send(remoteAddress.address(), request);
                 try {
                     assertThat(response.status(), equalTo(HttpResponseStatus.OK));
-                    assertThat(response.headers().get(CorsHandler.ACCESS_CONTROL_ALLOW_ORIGIN), equalTo("elastic.co"));
+                    assertThat(response.headers().get(CorsHandler.ACCESS_CONTROL_ALLOW_ORIGIN), equalTo("test-cors.org"));
                     assertThat(response.headers().get(CorsHandler.VARY), equalTo(CorsHandler.ORIGIN));
                     assertTrue(response.headers().contains(CorsHandler.DATE));
                 } finally {
@@ -269,7 +269,7 @@ public class NioHttpServerTransportTests extends OpenSearchTestCase {
             // Test short-circuited request
             try (NioHttpClient client = new NioHttpClient()) {
                 final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
-                request.headers().add(CorsHandler.ORIGIN, "elastic2.co");
+                request.headers().add(CorsHandler.ORIGIN, "google.com");
 
                 final FullHttpResponse response = client.send(remoteAddress.address(), request);
                 try {


### PR DESCRIPTION
### Description
[Describe what this change achieves]
 
Replace Nio and Netty test end point from elastic.co to test-cors.org

### Issues Resolved
[List any issues this PR will resolve]
 #106 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

Signed-off-by: Harold Wang <harowang@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
