### PR TITLE
Add master task throttling

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/master/MasterTaskThrottlingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/master/MasterTaskThrottlingIT.java
@@ -1,0 +1,220 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.master;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.opensearch.action.support.master.MasterThrottlingRetryListener;
+import org.opensearch.cluster.service.MasterTaskThrottlingException;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.cluster.service.MasterTaskThrottler;
+import org.opensearch.threadpool.Scheduler;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.TransportMessageListener;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 0)
+public class MasterTaskThrottlingIT extends OpenSearchIntegTestCase {
+
+    private static final ScheduledThreadPoolExecutor scheduler = Scheduler.initScheduler(Settings.EMPTY);
+
+    /*
+     * This integ test will test end-end master throttling feature for
+     * remote master.
+     *
+     * It will check the number of request coming to master node
+     * should be total number of requests + throttled requests from master.
+     * This will ensure the end-end feature is working as master is throwing
+     * Throttling exception and data node is performing retries on it.
+     *
+     */
+    public void testThrottlingForRemoteMaster() throws Exception {
+        try {
+            internalCluster().beforeTest(random(), 0);
+            String masterNode = internalCluster().startMasterOnlyNode();
+            String dataNode = internalCluster().startDataOnlyNode();
+            int throttlingLimit = randomIntBetween(1, 5);
+            createIndex("test");
+
+            ClusterUpdateSettingsRequest settingsRequest = new ClusterUpdateSettingsRequest();
+            Settings settings = Settings.builder()
+                    .put(MasterTaskThrottler.ENABLE_MASTER_THROTTLING.getKey(), true)
+                    .put("master.throttling.thresholds.put_mapping.value", throttlingLimit)
+                    .build();
+            settingsRequest.transientSettings(settings);
+            assertAcked(client().admin().cluster().updateSettings(settingsRequest).actionGet());
+
+            TransportService masterTransportService = (internalCluster().getInstance(TransportService.class, masterNode));
+            AtomicInteger requestCountOnMaster = new AtomicInteger();
+            AtomicInteger throttledRequest = new AtomicInteger();
+            int totalRequest = randomIntBetween(throttlingLimit, 5 * throttlingLimit);
+            CountDownLatch latch = new CountDownLatch(totalRequest);
+
+            masterTransportService.addMessageListener(new TransportMessageListener() {
+                @Override
+                public void onRequestReceived(long requestId, String action) {
+                    if (action.contains("mapping")) {
+                        requestCountOnMaster.incrementAndGet();
+                    }
+                }
+
+                @Override
+                public void onResponseSent(long requestId, String action, Exception error) {
+                    if (action.contains("mapping")) {
+                        throttledRequest.incrementAndGet();
+                        assertEquals(MasterTaskThrottlingException.class, error.getClass());
+                    }
+                }
+            });
+
+            ActionListener listener = new ActionListener() {
+                @Override
+                public void onResponse(Object o) {
+                    latch.countDown();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    latch.countDown();
+                    throw new AssertionError(e);
+                }
+            };
+
+            Thread[] threads = new Thread[totalRequest];
+            for (int i = 0; i < totalRequest; i++) {
+                PutMappingRequest putMappingRequest = new PutMappingRequest("test")
+                        .type("type")
+                        .source("field" + i, "type=text");
+                threads[i] = new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        internalCluster().client(dataNode).admin().indices().putMapping(putMappingRequest, listener);
+                    }
+                });
+            }
+            for (int i = 0; i < totalRequest; i++) {
+                threads[i].run();
+            }
+            for (int i = 0; i < totalRequest; i++) {
+                threads[i].join();
+            }
+            latch.await();
+
+            assertEquals(totalRequest + throttledRequest.get(), requestCountOnMaster.get());
+            assertBusy(() -> {
+                assertEquals(clusterService().getMasterService().numberOfThrottledPendingTasks(), throttledRequest.get());
+            });
+            assertEquals(MasterThrottlingRetryListener.getRetryingTasksCount(), 0);
+        }
+        finally {
+            ClusterUpdateSettingsRequest settingsRequest = new ClusterUpdateSettingsRequest();
+            Settings settings = Settings.builder()
+                    .put(MasterTaskThrottler.ENABLE_MASTER_THROTTLING.getKey(), (String) null)
+                    .put("master.throttling.thresholds.put_mapping.value", (String) null)
+                    .build();
+            settingsRequest.transientSettings(settings);
+            assertAcked(client().admin().cluster().updateSettings(settingsRequest).actionGet());
+        }
+    }
+
+    /*
+     * This will test the throttling feature for single node.
+     *
+     * Here we will assert the client behaviour that client's request is not
+     * failed, i.e. Throttling exception is not passed to the client.
+     * Data node will internally do the retry and request should pass.
+     *
+     */
+    public void testThrottlingForSingleNode() throws Exception {
+        try {
+            internalCluster().beforeTest(random(), 0);
+            String node = internalCluster().startNode();
+            int throttlingLimit = randomIntBetween(1, 5);
+            createIndex("test");
+
+            ClusterUpdateSettingsRequest settingsRequest = new ClusterUpdateSettingsRequest();
+            Settings settings = Settings.builder()
+                    .put(MasterTaskThrottler.ENABLE_MASTER_THROTTLING.getKey(), true)
+                    .put("master.throttling.thresholds.put_mapping.value", throttlingLimit)
+                    .build();
+            settingsRequest.transientSettings(settings);
+            assertAcked(client().admin().cluster().updateSettings(settingsRequest).actionGet());
+
+            AtomicInteger successfulRequest = new AtomicInteger();
+            int totalRequest = randomIntBetween(throttlingLimit, 3 * throttlingLimit);
+            CountDownLatch latch = new CountDownLatch(totalRequest);
+
+            ActionListener listener = new ActionListener() {
+                @Override
+                public void onResponse(Object o) {
+                    latch.countDown();
+                    successfulRequest.incrementAndGet();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    latch.countDown();
+                    throw new AssertionError(e);
+                }
+            };
+
+            Thread[] threads = new Thread[totalRequest];
+            for (int i = 0; i < totalRequest; i++) {
+                PutMappingRequest putMappingRequest = new PutMappingRequest("test")
+                        .type("type")
+                        .source("field" + i, "type=text");
+                threads[i] = new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        internalCluster().client(node).admin().indices().putMapping(putMappingRequest, listener);
+                    }
+                });
+            }
+            for (int i = 0; i < totalRequest; i++) {
+                threads[i].run();
+            }
+            for (int i = 0; i < totalRequest; i++) {
+                threads[i].join();
+            }
+
+            latch.await();
+            assertEquals(totalRequest, successfulRequest.get());
+            assertEquals(MasterThrottlingRetryListener.getRetryingTasksCount(), 0);
+        }
+        finally {
+            ClusterUpdateSettingsRequest settingsRequest = new ClusterUpdateSettingsRequest();
+            Settings settings = Settings.builder()
+                    .put(MasterTaskThrottler.ENABLE_MASTER_THROTTLING.getKey(), (String) null)
+                    .put("master.throttling.thresholds.put_mapping.value", (String) null)
+                    .build();
+            settingsRequest.transientSettings(settings);
+            assertAcked(client().admin().cluster().updateSettings(settingsRequest).actionGet());
+        }
+    }
+
+    @BeforeClass
+    public static void initTestScheduler() {
+        MasterThrottlingRetryListener.setThrottlingRetryScheduler(scheduler);
+    }
+
+    @AfterClass
+    public static void terminateScheduler() {
+        Scheduler.terminate(scheduler, 10, TimeUnit.SECONDS);
+    }
+}

--- a/server/src/main/java/org/opensearch/OpenSearchException.java
+++ b/server/src/main/java/org/opensearch/OpenSearchException.java
@@ -1049,7 +1049,12 @@ public class OpenSearchException extends RuntimeException implements ToXContentF
                 org.opensearch.transport.NoSeedNodeLeftException.class,
                 org.opensearch.transport.NoSeedNodeLeftException::new,
                 160,
-                Version.V_7_10_0);
+                Version.V_7_10_0),
+        MASTER_TASK_THROTTLED_EXCEPTION(
+            org.opensearch.cluster.service.MasterTaskThrottlingException.class,
+            org.opensearch.cluster.service.MasterTaskThrottlingException::new,
+            161,
+            Version.V_7_10_3);
 
         final Class<? extends OpenSearchException> exceptionClass;
         final CheckedFunction<StreamInput, ? extends OpenSearchException, IOException> constructor;

--- a/server/src/main/java/org/opensearch/action/bulk/BackoffPolicy.java
+++ b/server/src/main/java/org/opensearch/action/bulk/BackoffPolicy.java
@@ -18,6 +18,7 @@
  */
 package org.opensearch.action.bulk;
 
+import org.opensearch.common.Randomness;
 import org.opensearch.common.unit.TimeValue;
 
 import java.util.Iterator;
@@ -88,6 +89,19 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
      */
     public static BackoffPolicy exponentialBackoff(TimeValue initialDelay, int maxNumberOfRetries) {
         return new ExponentialBackoff((int) checkDelay(initialDelay).millis(), maxNumberOfRetries);
+    }
+
+    /**
+     *  It provides exponential backoff between retries until it reaches maxDelay.
+     *  It uses equal jitter scheme as it is being used for throttled exceptions.
+     *  It will make random distribution and also guarantees a minimum delay.
+     *
+     * @param baseDelay BaseDelay for exponential Backoff
+     * @param maxDelay MaxDelay that can be returned from backoff policy
+     * @return A backoff policy with exponential backoff with equal jitter which can't return delay more than given max delay
+     */
+    public static BackoffPolicy exponentialEqualJitterBackoff(int baseDelay, int maxDelay) {
+        return new ExponentialEqualJitterBackoff(baseDelay, maxDelay);
     }
 
     /**
@@ -164,6 +178,61 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
             int result = start + 10 * ((int) Math.exp(0.8d * (currentlyConsumed)) - 1);
             currentlyConsumed++;
             return TimeValue.timeValueMillis(result);
+        }
+    }
+
+    private static class ExponentialEqualJitterBackoff extends BackoffPolicy {
+        private final int maxDelay;
+        private final int baseDelay;
+
+        private ExponentialEqualJitterBackoff(int baseDelay, int maxDealy) {
+            this.maxDelay = maxDealy;
+            this.baseDelay = baseDelay;
+        }
+
+        @Override
+        public Iterator<TimeValue> iterator() {
+            return new ExponentialEqualJitterBackoffIterator(baseDelay, maxDelay);
+        }
+    }
+
+    private static class ExponentialEqualJitterBackoffIterator implements Iterator<TimeValue> {
+        /**
+         * Maximum retry limit. Avoids integer overflow issues.
+         * Post Max Retries, max delay will be returned with Equal Jitter.
+         *
+         * NOTE: If the value is greater than 30, there can be integer overflow
+         * issues during delay calculation.
+         **/
+        private final int MAX_RETRIES = 30;
+
+        private final int maxDelay;
+        private final int baseDelay;
+        private int retriesAttempted;
+
+        private ExponentialEqualJitterBackoffIterator(int baseDelay, int maxDelay) {
+            this.baseDelay = baseDelay;
+            this.maxDelay = maxDelay;
+        }
+
+        /**
+         * There is not any limit for this BackOff.
+         * This Iterator will always return back off delay.
+         *
+         * @return true
+         */
+        @Override
+        public boolean hasNext() {
+            return true;
+        }
+
+        @Override
+        public TimeValue next() {
+            int retries = Math.min(retriesAttempted, MAX_RETRIES);
+            int exponentialDelay = (int) Math.min((1L << retries) * baseDelay, maxDelay);
+            retriesAttempted++;
+            return TimeValue.timeValueMillis((exponentialDelay/2) +
+                Randomness.get().nextInt(exponentialDelay/2 + 1));
         }
     }
 

--- a/server/src/main/java/org/opensearch/action/support/master/MasterNodeRequest.java
+++ b/server/src/main/java/org/opensearch/action/support/master/MasterNodeRequest.java
@@ -34,6 +34,7 @@ public abstract class MasterNodeRequest<Request extends MasterNodeRequest<Reques
     public static final TimeValue DEFAULT_MASTER_NODE_TIMEOUT = TimeValue.timeValueSeconds(30);
 
     protected TimeValue masterNodeTimeout = DEFAULT_MASTER_NODE_TIMEOUT;
+    protected boolean remoteRequest;
 
     protected MasterNodeRequest() {
     }
@@ -41,12 +42,14 @@ public abstract class MasterNodeRequest<Request extends MasterNodeRequest<Reques
     protected MasterNodeRequest(StreamInput in) throws IOException {
         super(in);
         masterNodeTimeout = in.readTimeValue();
+        remoteRequest = in.readOptionalBoolean();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeTimeValue(masterNodeTimeout);
+        out.writeOptionalBoolean(remoteRequest);
     }
 
     /**
@@ -55,6 +58,11 @@ public abstract class MasterNodeRequest<Request extends MasterNodeRequest<Reques
     @SuppressWarnings("unchecked")
     public final Request masterNodeTimeout(TimeValue timeout) {
         this.masterNodeTimeout = timeout;
+        return (Request) this;
+    }
+
+    public final Request setRemoteRequest(boolean remoteRequest) {
+        this.remoteRequest = remoteRequest;
         return (Request) this;
     }
 
@@ -67,5 +75,9 @@ public abstract class MasterNodeRequest<Request extends MasterNodeRequest<Reques
 
     public final TimeValue masterNodeTimeout() {
         return this.masterNodeTimeout;
+    }
+
+    public final boolean isRemoteRequest() {
+        return this.remoteRequest;
     }
 }

--- a/server/src/main/java/org/opensearch/action/support/master/MasterThrottlingRetryListener.java
+++ b/server/src/main/java/org/opensearch/action/support/master/MasterThrottlingRetryListener.java
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.support.master;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.ActionResponse;
+import org.opensearch.action.bulk.BackoffPolicy;
+import org.opensearch.cluster.metadata.ProcessClusterEventTimeoutException;
+import org.opensearch.cluster.service.MasterTaskThrottlingException;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.threadpool.Scheduler;
+import org.opensearch.transport.TransportException;
+
+import java.util.Iterator;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * ActionListener for retrying the Throttled master tasks.
+ * It schedules the retry on the Throttling Exception from master node and
+ * delegates the response if it receive response from master.
+ *
+ * It uses ExponentialEqualJitterBackoff policy for determining delay between retries.
+ */
+public class MasterThrottlingRetryListener<Request extends MasterNodeRequest<Request>, Response extends ActionResponse>
+        implements ActionListener<Response>  {
+
+    private static final Logger logger = LogManager.getLogger(MasterThrottlingRetryListener.class);
+
+    /**
+     * Base delay in millis.
+     */
+    private final int BASE_DELAY_MILLIS = 10;
+
+    /**
+     * Maximum delay in millis.
+     */
+    private final int MAX_DELAY_MILLIS = 5000;
+
+    private long totalDelay;
+    private final Iterator<TimeValue> backoffDelay;
+    private final ActionListener<Response> listener;
+    private final Request request;
+    private final Runnable runnable;
+    private final String actionName;
+    private final boolean localNodeRequest;
+
+    private static ScheduledThreadPoolExecutor scheduler = Scheduler.initScheduler(Settings.EMPTY);
+
+    public MasterThrottlingRetryListener(
+            String actionName,
+            Request request,
+            Runnable runnable,
+            ActionListener<Response> actionListener) {
+        this.actionName = actionName;
+        this.listener = actionListener;
+        this.request = request;
+        this.runnable = runnable;
+        this.backoffDelay = BackoffPolicy.exponentialEqualJitterBackoff(BASE_DELAY_MILLIS, MAX_DELAY_MILLIS).iterator();
+        /**
+         This is to determine whether request is generated from local node or from remote node.
+         If it is local node's request we need to perform the retries on this node.
+         If it is remote node's request, we will not perform retries on this node and let remote node perform the retries.
+
+         If request is from remote data node, then data node will set remoteRequest flag in {@link MasterNodeRequest}
+         and send request to master, using that on master node we can determine if the request was localRequest or remoteRequest.
+         */
+        this.localNodeRequest = !(request.isRemoteRequest());
+    }
+
+    @Override
+    public void onResponse(Response response) {
+        listener.onResponse(response);
+    }
+
+    @Override
+    public void onFailure(Exception e) {
+
+        if(localNodeRequest && isThrottlingException(e)) {
+            logger.info("Retrying [{}] on throttling exception from master. Error: [{}]",
+                                            actionName, getExceptionMessage(e));
+            long delay = backoffDelay.next().getMillis();
+            if(totalDelay + delay >= request.masterNodeTimeout.getMillis()) {
+                delay = request.masterNodeTimeout.getMillis() - totalDelay;
+                scheduler.schedule(new Runnable() {
+                    @Override
+                    public void run() {
+                        listener.onFailure(new ProcessClusterEventTimeoutException(request.masterNodeTimeout, actionName));
+                    }
+                }, delay, TimeUnit.MILLISECONDS);
+            } else {
+                scheduler.schedule(runnable, delay, TimeUnit.MILLISECONDS);
+            }
+            totalDelay += delay;
+        } else {
+            listener.onFailure(e);
+        }
+    }
+
+    /**
+     * For Testcase purposes.
+     * @param retrySceduler scheduler defined in test cases.
+     */
+    public static void setThrottlingRetryScheduler(ScheduledThreadPoolExecutor retrySceduler) {
+        scheduler = retrySceduler;
+    }
+
+    private boolean isThrottlingException(Exception e) {
+        if(e instanceof TransportException) {
+            return  ((TransportException)e).unwrapCause() instanceof MasterTaskThrottlingException;
+        }
+        return e instanceof MasterTaskThrottlingException;
+    }
+
+    private String getExceptionMessage(Exception e) {
+        if(e instanceof TransportException) {
+            return ((TransportException)e).unwrapCause().getMessage();
+        } else {
+            return e.getMessage();
+        }
+    }
+
+    public static long getRetryingTasksCount() {
+        return scheduler.getActiveCount() + scheduler.getQueue().size();
+    }
+}

--- a/server/src/main/java/org/opensearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/master/TransportMasterNodeAction.java
@@ -107,12 +107,10 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
 
     @Override
     protected void doExecute(Task task, final Request request, ActionListener<Response> listener) {
-        ClusterState state = clusterService.state();
-        logger.trace("starting processing request [{}] with cluster state version [{}]", request, state.version());
         if (task != null) {
             request.setParentTask(clusterService.localNode().getId(), task.getId());
         }
-        new AsyncSingleAction(task, request, listener).doStart(state);
+        new AsyncSingleAction(task, request, listener).start();
     }
 
     class AsyncSingleAction {
@@ -126,8 +124,14 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
         AsyncSingleAction(Task task, Request request, ActionListener<Response> listener) {
             this.task = task;
             this.request = request;
-            this.listener = listener;
+            this.listener = new MasterThrottlingRetryListener(actionName, request, this::start, listener);
             this.startTime = threadPool.relativeTimeInMillis();
+        }
+
+        public void start() {
+            ClusterState state = clusterService.state();
+            logger.trace("starting processing request [{}] with cluster state version [{}]", request, state.version());
+            doStart(state);
         }
 
         protected void doStart(ClusterState clusterState) {
@@ -172,6 +176,7 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
                     } else {
                         DiscoveryNode masterNode = nodes.getMasterNode();
                         final String actionName = getMasterActionName(masterNode);
+                        request.setRemoteRequest(true);
                         transportService.sendRequest(masterNode, actionName, request,
                             new ActionListenerResponseHandler<Response>(listener, TransportMasterNodeAction.this::read) {
                                 @Override

--- a/server/src/main/java/org/opensearch/cluster/service/MasterTaskThrottler.java
+++ b/server/src/main/java/org/opensearch/cluster/service/MasterTaskThrottler.java
@@ -1,0 +1,139 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.service;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.Version;
+import org.opensearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.admin.indices.dangling.delete.DeleteDanglingIndexRequest;
+import org.opensearch.action.admin.indices.mapping.put.PutMappingClusterStateUpdateRequest;
+import org.opensearch.common.metrics.CounterMetric;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.snapshots.UpdateIndexShardSnapshotStatusRequest;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * This class is extension of {@link Throttler} and does throttling of master tasks.
+ *
+ * This class does throttling on task submission to master, it uses class name of request of tasks as key for
+ * throttling. Throttling will be performed over task class level, different task types have different request class, i.e.
+ * Throttling is at the task type level.
+ *
+ * Set "master.throttling.enable" setting to enable/disable this throttling. (Default False)
+ * Set specific setting to for setting the threshold of throttling of particular task type.
+ * e.g : Set "master.throttling.thresholds.put_mapping" to set throttling limit of "put mapping" tasks,
+ *       Set it to default value(-1) to disable the throttling for this task type.
+ *
+ *       We can also provide the class path of request, which we want to throttle. If new task type has introduced and we
+ *       haven't added that in configuration then we can use the class path of request to enable throttling on that type.
+ *       e.g use "org/opensearch/action/admin/indices/create/CreateIndexClusterStateUpdateRequest" as key in setting
+ *       throttling limit for Create index tasks.
+ */
+public class MasterTaskThrottler extends Throttler<Class> {
+    private static final Logger logger = LogManager.getLogger(MasterTaskThrottler.class);
+
+    public static final Setting<Boolean> ENABLE_MASTER_THROTTLING =
+            Setting.boolSetting("master.throttling.enable", false,
+                    Setting.Property.Dynamic, Setting.Property.NodeScope);
+
+    public static final Setting<Settings> THRESHOLD_SETTINGS =
+            Setting.groupSetting("master.throttling.thresholds.", Setting.Property.Dynamic, Setting.Property.NodeScope);
+
+    protected final ConcurrentHashMap<String, Class> taskNameToClassMapping = new ConcurrentHashMap() {
+        {
+            put("put_mapping", PutMappingClusterStateUpdateRequest.class);
+            put("create_index", CreateIndexRequest.class);
+            put("delete_dangling_index", DeleteDanglingIndexRequest.class);
+            put("update_snapshot", UpdateIndexShardSnapshotStatusRequest.class);
+            put("delete_snapshot", DeleteSnapshotRequest.class);
+        }
+    };
+    private final int DEFAULT_THRESHOLD_VALUE = -1; // Disabled throttling
+
+    private CounterMetric throttledTasksCount = new CounterMetric();
+    private final MasterService masterService;
+    public MasterTaskThrottler(final ClusterSettings clusterSettings, final MasterService masterService) {
+        super(false);
+        clusterSettings.addSettingsUpdateConsumer(ENABLE_MASTER_THROTTLING, this::setMasterThrottlingEnable, this::validateEnableSetting);
+        clusterSettings.addSettingsUpdateConsumer(THRESHOLD_SETTINGS, this::updateSetting, this::validateSetting);
+        this.masterService = masterService;
+    }
+
+    private void setMasterThrottlingEnable(boolean enableMasterThrottling) {
+        super.setThrottlingEnabled(enableMasterThrottling);
+    }
+
+    public void validateEnableSetting(final boolean enableMasterThrottling) {
+        if(masterService.state().nodes().getMinNodeVersion().compareTo(Version.V_7_10_3) < 0) {
+            throw new IllegalArgumentException("All the nodes in cluster should be on version later than 7.10.3");
+        }
+    }
+
+    public void validateSetting(final Settings settings) {
+        Map<String, Settings> groups = settings.getAsGroups();
+        for(String key : groups.keySet()) {
+            int threshold = groups.get(key).getAsInt("value", DEFAULT_THRESHOLD_VALUE);
+            if(threshold < DEFAULT_THRESHOLD_VALUE) {
+                throw new IllegalArgumentException("Provide positive integer for limit or -1 for disabling throttling");
+            }
+            if(!taskNameToClassMapping.containsKey(key)) {
+                try {
+                    Class.forName(key.replace("/", "."));
+                } catch (ClassNotFoundException e) {
+                    throw new IllegalArgumentException("Provide valid key, either configured task type or path of class");
+                }
+            }
+        }
+    }
+
+    public void updateSetting(final Settings settings) {
+        Map<String, Settings> groups = settings.getAsGroups();
+        for(String key : groups.keySet()) {
+            if(taskNameToClassMapping.containsKey(key)) {
+                updateLimit(taskNameToClassMapping.get(key), groups.get(key).getAsInt("value", DEFAULT_THRESHOLD_VALUE));
+            } else {
+                try {
+                    updateLimit(Class.forName(key.replace("/", ".")),
+                            groups.get(key).getAsInt("value", DEFAULT_THRESHOLD_VALUE));
+                } catch (ClassNotFoundException e) {
+                    // Ideally it should not throw this exception, as we are already validating this in validateSetting.
+                    logger.error("Failed to apply validated master throttler setting, exception: [{}] ", e.getLocalizedMessage());
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean acquire(final Class type, final int permits) {
+        boolean ableToAcquire = super.acquire(type, permits);
+        if(!ableToAcquire) {
+            throttledTasksCount.inc(permits);
+        }
+        return ableToAcquire;
+    }
+
+    public long throttledTaskCount() {
+        return throttledTasksCount.count();
+    }
+
+    protected void updateLimit(final Class className, final int limit) {
+        assert limit >= DEFAULT_THRESHOLD_VALUE;
+        if(limit == DEFAULT_THRESHOLD_VALUE) {
+            super.removeThrottlingLimit(className);
+        } else {
+            super.updateThrottlingLimit(className, limit);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/cluster/service/MasterTaskThrottlingException.java
+++ b/server/src/main/java/org/opensearch/cluster/service/MasterTaskThrottlingException.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.service;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * Exception raised from master node due to task throttling.
+ */
+public class MasterTaskThrottlingException extends OpenSearchException {
+
+    public MasterTaskThrottlingException(String msg, Object... args) {
+        super(msg, args);
+    }
+
+    public MasterTaskThrottlingException(StreamInput in) throws IOException {
+        super(in);
+    }
+}

--- a/server/src/main/java/org/opensearch/cluster/service/TaskBatcher.java
+++ b/server/src/main/java/org/opensearch/cluster/service/TaskBatcher.java
@@ -60,6 +60,8 @@ public abstract class TaskBatcher {
         final BatchedTask firstTask = tasks.get(0);
         assert tasks.stream().allMatch(t -> t.batchingKey == firstTask.batchingKey) :
             "tasks submitted in a batch should share the same batching key: " + tasks;
+        assert tasks.stream().allMatch(t -> t.getTask().getClass() == firstTask.getTask().getClass()):
+            "tasks submitted in a batch should be of same class: " + tasks;
         // convert to an identity map to check for dups based on task identity
         final Map<Object, BatchedTask> tasksIdentity = tasks.stream().collect(Collectors.toMap(
             BatchedTask::getTask,

--- a/server/src/main/java/org/opensearch/cluster/service/Throttler.java
+++ b/server/src/main/java/org/opensearch/cluster/service/Throttler.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.service;
+
+import org.opensearch.common.AdjustableSemaphore;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Base class for Throttling logic.
+ * It provides throttling functionality over multiple keys.
+ * It provides the functionality of enable/disable throttling using enableThrottling variable.
+ *
+ * @param <T> the type of key on which we want to do throttling.
+ */
+public class Throttler<T> {
+    protected ConcurrentMap<T, AdjustableSemaphore> semaphores = new ConcurrentHashMap<T, AdjustableSemaphore>();
+
+    private boolean throttlingEnabled;
+
+    public Throttler(final boolean throttlingEnabled) {
+        this.throttlingEnabled = throttlingEnabled;
+    }
+
+    /**
+     * Method to acquire permits for a key type.
+     * If throttling is disabled, it will always return True,
+     * else it will return true if permits can be acquired within threshold limits.
+     *
+     * If threshold is not set for key then also it will return True.
+     *
+     * @param type Key for which we want to acquire permits.
+     * @param permits Number of permits to acquire.
+     * @return boolean representing was it able to acquire the permits or not.
+     */
+    public boolean acquire(final T type, final int permits) {
+        assert permits > 0;
+        AdjustableSemaphore semaphore = semaphores.get(type);
+        if(throttlingEnabled && Objects.nonNull(semaphore)) {
+            return semaphore.tryAcquire(permits);
+        }
+        return true;
+    }
+
+    /**
+     * Release the given permits for given type.
+     *
+     * @param type key for which we want to release permits.
+     * @param permits number of permits to release.
+     */
+    public void release(final T type, final int permits) {
+        assert permits > 0;
+        AdjustableSemaphore semaphore = semaphores.get(type);
+        if(throttlingEnabled && Objects.nonNull(semaphore)) {
+            assert semaphore.availablePermits() < semaphore.getMaxPermits();
+            semaphore.release(permits);
+        }
+    }
+
+    /**
+     * Update the Threshold for throttling for given type.
+     *
+     * @param key Key for which we want to update limit.
+     * @param newLimit Updated limit.
+     */
+    public synchronized void updateThrottlingLimit(final T key, final Integer newLimit) {
+        assert newLimit >= 0;
+        if(semaphores.containsKey(key)) {
+            semaphores.get(key).setMaxPermits(newLimit);
+        } else {
+            semaphores.put(key, new AdjustableSemaphore(newLimit));
+        }
+    }
+
+    /**
+     * Remove the threshold for given key.
+     * Throttler will no longer do throttling for given key.
+     *
+     * @param key Key for which we want to remove throttling.
+     */
+    public synchronized void removeThrottlingLimit(final T key) {
+        assert semaphores.containsKey(key);
+        semaphores.remove(key);
+    }
+
+    /**
+     * Set flag for enabling/disabling the throttling logic.
+     * Clear the state of previous semaphores with each update.
+     *
+     * @param throttlingEnabled flag repressing enabled/disabled throttling.
+     */
+    public synchronized void setThrottlingEnabled(final boolean throttlingEnabled) {
+        this.throttlingEnabled = throttlingEnabled;
+        for(T key: semaphores.keySet()) {
+            semaphores.put(key, new AdjustableSemaphore(semaphores.get(key).getMaxPermits()));
+        }
+    }
+
+    public Integer getThrottlingLimit(final T key) {
+        if(semaphores.containsKey(key)) {
+            return semaphores.get(key).getMaxPermits();
+        }
+        return null;
+    }
+
+    public boolean isThrottlingEnabled() {
+        return throttlingEnabled;
+    }
+}

--- a/server/src/main/java/org/opensearch/common/AdjustableSemaphore.java
+++ b/server/src/main/java/org/opensearch/common/AdjustableSemaphore.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common;
+
+import java.util.concurrent.Semaphore;
+
+/**
+ * AdjustableSemaphore is Extended Semphore where we can change maxPermits.
+ */
+public class AdjustableSemaphore extends Semaphore {
+    private final Object maxPermitsMutex = new Object();
+    private int maxPermits;
+
+    public AdjustableSemaphore(int maxPermits) {
+        super(maxPermits);
+        this.maxPermits = maxPermits;
+    }
+
+    /**
+     * Update the maxPermits in semaphore
+     */
+    public void setMaxPermits(int permits) {
+        synchronized (maxPermitsMutex) {
+            final int diff = Math.subtractExact(permits, maxPermits);
+            if (diff > 0) {
+                // add permits
+                release(diff);
+            } else if (diff < 0) {
+                // remove permits
+                reducePermits(Math.negateExact(diff));
+            }
+            maxPermits = permits;
+        }
+    }
+
+    /**
+     * Returns maxPermits.
+     */
+    public int getMaxPermits() {
+        return maxPermits;
+    }
+}

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -63,6 +63,7 @@ import org.opensearch.cluster.routing.allocation.decider.ThrottlingAllocationDec
 import org.opensearch.cluster.service.ClusterApplierService;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.cluster.service.MasterService;
+import org.opensearch.cluster.service.MasterTaskThrottler;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.network.NetworkService;
@@ -561,7 +562,9 @@ public final class ClusterSettings extends AbstractScopedSettings {
             FsHealthService.ENABLED_SETTING,
             FsHealthService.REFRESH_INTERVAL_SETTING,
             FsHealthService.SLOW_PATH_LOGGING_THRESHOLD_SETTING,
-            IndexingPressure.MAX_INDEXING_BYTES)));
+            IndexingPressure.MAX_INDEXING_BYTES,
+            MasterTaskThrottler.ENABLE_MASTER_THROTTLING,
+            MasterTaskThrottler.THRESHOLD_SETTINGS)));
 
     public static List<SettingUpgrader<?>> BUILT_IN_SETTING_UPGRADERS = Collections.unmodifiableList(Arrays.asList(
             SniffConnectionStrategy.SEARCH_REMOTE_CLUSTER_SEEDS_UPGRADER,

--- a/server/src/test/java/org/opensearch/action/bulk/BackoffPolicyTests.java
+++ b/server/src/test/java/org/opensearch/action/bulk/BackoffPolicyTests.java
@@ -63,4 +63,27 @@ public class BackoffPolicyTests extends OpenSearchTestCase {
             assertEquals(expectedRetries, retries.get());
         }
     }
+
+    public void testEqualJitterExponentialBackOffPolicy() {
+        int baseDelay = 10;
+        int maxDelay = 10000;
+        BackoffPolicy policy = BackoffPolicy.exponentialEqualJitterBackoff(baseDelay, maxDelay);
+        Iterator<TimeValue> iterator = policy.iterator();
+
+        // Assert equal jitter
+        int retriesTillMaxDelay = 10;
+        for(int i=0 ; i < retriesTillMaxDelay ; i++) {
+            TimeValue delay = iterator.next();
+            assertTrue(delay.getMillis()>= baseDelay * (1L << i) / 2);
+            assertTrue(delay.getMillis()<= baseDelay * (1L << i));
+        }
+
+        // Now policy should return max delay for next retries.
+        int retriesAfterMaxDelay = randomInt(10);
+        for (int i=0; i<retriesAfterMaxDelay ; i++) {
+            TimeValue delay = iterator.next();
+            assertTrue(delay.getMillis() >= maxDelay/2);
+            assertTrue(delay.getMillis() <= maxDelay);
+        }
+    }
 }

--- a/server/src/test/java/org/opensearch/action/support/master/MasterThrottlingRetryListenerTests.java
+++ b/server/src/test/java/org/opensearch/action/support/master/MasterThrottlingRetryListenerTests.java
@@ -1,0 +1,176 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.support.master;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.cluster.metadata.ProcessClusterEventTimeoutException;
+import org.opensearch.cluster.service.MasterTaskThrottlingException;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.OpenSearchRejectedExecutionException;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.Scheduler;
+
+import java.time.Instant;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+
+/**
+ * Test class of {@link MasterThrottlingRetryListener}
+ */
+public class MasterThrottlingRetryListenerTests extends OpenSearchTestCase {
+    private static ScheduledThreadPoolExecutor throttlingRetryScheduler = Scheduler.initScheduler(Settings.EMPTY);
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        MasterThrottlingRetryListener.setThrottlingRetryScheduler(throttlingRetryScheduler);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        Scheduler.terminate(throttlingRetryScheduler, 30, TimeUnit.SECONDS);
+    }
+
+    public void testRetryForLocalRequest() throws BrokenBarrierException, InterruptedException {
+        TransportMasterNodeActionTests.Request request = new TransportMasterNodeActionTests.Request();
+        PlainActionFuture<TransportMasterNodeActionTests.Response> listener = new PlainActionFuture<>();
+        CyclicBarrier barrier = new CyclicBarrier(2);
+        AtomicBoolean callBackExecuted = new AtomicBoolean();
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    callBackExecuted.set(true);
+                    barrier.await();
+                } catch (Exception e) {
+                    new AssertionError();
+                }
+            }
+        };
+
+        ActionListener taskRetryListener =
+                new MasterThrottlingRetryListener("test", request, runnable, listener);
+
+        taskRetryListener.onFailure(new MasterTaskThrottlingException("Throttling Exception : Limit exceeded for test"));
+        barrier.await();
+        assertTrue(callBackExecuted.get());
+    }
+
+    public void testRetryForRemoteRequest() throws BrokenBarrierException, InterruptedException {
+        TransportMasterNodeActionTests.Request request = new TransportMasterNodeActionTests.Request();
+        request.setRemoteRequest(true);
+        PlainActionFuture<TransportMasterNodeActionTests.Response> listener = new PlainActionFuture<>();
+        AtomicBoolean callBackExecuted = new AtomicBoolean(false);
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    callBackExecuted.set(true);
+                } catch (Exception e) {
+                    new AssertionError();
+                }
+            }
+        };
+
+        ActionListener taskRetryListener =
+                new MasterThrottlingRetryListener("test", request, runnable, listener);
+
+        taskRetryListener.onFailure(new MasterTaskThrottlingException("Throttling Exception : Limit exceeded for test"));
+        Thread.sleep(100); // some buffer time so callback can execute.
+        assertFalse(callBackExecuted.get());
+    }
+
+    public void testTimedOut() throws BrokenBarrierException, InterruptedException {
+
+        CyclicBarrier barrier = new CyclicBarrier(2);
+        AtomicBoolean onFailureExecuted = new AtomicBoolean();
+        AtomicBoolean retryExecuted = new AtomicBoolean();
+        AtomicBoolean firstExecute = new AtomicBoolean(true);
+        int timeOutSec = randomIntBetween(1, 5);
+        final Instant[] startTime = new Instant[1];
+        final Instant[] endTime = new Instant[1];
+
+        ActionListener listener = new ActionListener() {
+            @Override
+            public void onResponse(Object o) {
+                new AssertionError();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                endTime[0] = Instant.now();
+                try {
+                    onFailureExecuted.set(true);
+                    barrier.await();
+                } catch (Exception exe) {
+                    new AssertionError();
+                }
+                assertEquals(ProcessClusterEventTimeoutException.class, e.getClass());
+            }
+        };
+        TransportMasterNodeActionTests.Request request =
+                new TransportMasterNodeActionTests.Request().masterNodeTimeout(TimeValue.timeValueSeconds(timeOutSec));
+
+        class TestRetryClass {
+            ActionListener listener;
+            TestRetryClass(ActionListener listener) {
+                this.listener = new MasterThrottlingRetryListener("test", request, this::execute, listener);
+            }
+            public void execute() {
+                if(firstExecute.getAndSet(false)) {
+                    startTime[0] = Instant.now();
+                }
+                listener.onFailure(new MasterTaskThrottlingException("Throttling Exception : Limit exceeded for test"));
+            }
+        }
+
+        TestRetryClass testRetryClass = new TestRetryClass(listener);
+        testRetryClass.execute();
+
+        barrier.await();
+        assertEquals(timeOutSec, (endTime[0].toEpochMilli() - startTime[0].toEpochMilli())/1000);
+        assertTrue(onFailureExecuted.get());
+        assertFalse(retryExecuted.get());
+    }
+
+    public void testRetryForDifferentException() {
+
+        TransportMasterNodeActionTests.Request request = new TransportMasterNodeActionTests.Request();
+        PlainActionFuture<TransportMasterNodeActionTests.Response> listener = new PlainActionFuture<>();
+        AtomicBoolean callBackExecuted = new AtomicBoolean();
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    callBackExecuted.set(true);
+                } catch (Exception e) {
+                    new AssertionError();
+                }
+            }
+        };
+
+        ActionListener taskRetryListener =
+                new MasterThrottlingRetryListener("test", request, runnable, listener);
+
+        taskRetryListener.onFailure(new Exception());
+        assertFalse(callBackExecuted.get());
+
+        taskRetryListener.onFailure(new OpenSearchRejectedExecutionException("Different Exception"));
+        assertFalse(callBackExecuted.get());
+    }
+}

--- a/server/src/test/java/org/opensearch/action/support/master/TransportMasterNodeActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/master/TransportMasterNodeActionTests.java
@@ -40,6 +40,7 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.cluster.service.MasterTaskThrottlingException;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.settings.Settings;
@@ -53,6 +54,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.transport.CapturingTransport;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.threadpool.Scheduler;
 import org.opensearch.transport.ConnectTransportException;
 import org.opensearch.transport.TransportService;
 import org.junit.After;
@@ -67,6 +69,10 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import static org.opensearch.test.ClusterServiceUtils.createClusterService;
 import static org.opensearch.test.ClusterServiceUtils.setState;
@@ -82,6 +88,7 @@ public class TransportMasterNodeActionTests extends OpenSearchTestCase {
     private DiscoveryNode localNode;
     private DiscoveryNode remoteNode;
     private DiscoveryNode[] allNodes;
+    private static ScheduledThreadPoolExecutor throttlingRetryScheduler = Scheduler.initScheduler(Settings.EMPTY);
 
     @BeforeClass
     public static void beforeClass() {
@@ -103,6 +110,7 @@ public class TransportMasterNodeActionTests extends OpenSearchTestCase {
         remoteNode = new DiscoveryNode("remote_node", buildNewFakeTransportAddress(), Collections.emptyMap(),
                 Collections.singleton(DiscoveryNodeRole.MASTER_ROLE), Version.CURRENT);
         allNodes = new DiscoveryNode[]{localNode, remoteNode};
+        MasterThrottlingRetryListener.setThrottlingRetryScheduler(throttlingRetryScheduler);
     }
 
     @After
@@ -115,6 +123,7 @@ public class TransportMasterNodeActionTests extends OpenSearchTestCase {
     @AfterClass
     public static void afterClass() {
         ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+        Scheduler.terminate(throttlingRetryScheduler, 30, TimeUnit.SECONDS);
         threadPool = null;
     }
 
@@ -128,7 +137,7 @@ public class TransportMasterNodeActionTests extends OpenSearchTestCase {
     }
 
     public static class Request extends MasterNodeRequest<Request> {
-        Request() {}
+        public Request() {}
 
         Request(StreamInput in) throws IOException {
             super(in);
@@ -479,5 +488,74 @@ public class TransportMasterNodeActionTests extends OpenSearchTestCase {
         transport.handleResponse(capturedRequest.requestId, response);
         assertTrue(listener.isDone());
         assertThat(listener.get(), equalTo(response));
+    }
+
+    public void testThrottlingRetryLocalMaster() throws InterruptedException, BrokenBarrierException {
+        Request request = new Request();
+        PlainActionFuture<Response> listener = new PlainActionFuture<>();
+        AtomicBoolean exception = new AtomicBoolean(true);
+        AtomicBoolean retried = new AtomicBoolean(false);
+        CyclicBarrier barrier = new CyclicBarrier(2);
+        setState(clusterService, ClusterStateCreationUtils.state(localNode, localNode, new DiscoveryNode[]{localNode}));
+
+        TransportMasterNodeAction action =  new Action("internal:testAction", transportService, clusterService, threadPool) {
+            @Override
+            protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener) {
+                if(exception.getAndSet(false)) {
+                    throw new MasterTaskThrottlingException("Throttling Exception : Limit exceeded for test");
+                } else {
+                    try{
+                        retried.set(true);
+                        barrier.await();
+                    } catch (Exception e) {
+                        throw new AssertionError();
+                    }
+                }
+            }
+        };
+        action.execute(request, listener);
+
+        barrier.await();
+        assertTrue(retried.get());
+        assertFalse(exception.get());
+    }
+
+    public void testThrottlingRetryRemoteMaster() throws ExecutionException, InterruptedException {
+        Request request = new Request().masterNodeTimeout(TimeValue.timeValueSeconds(60));
+        DiscoveryNode masterNode = this.remoteNode;
+        setState(
+            clusterService,
+            // use a random base version so it can go down when simulating a restart.
+            ClusterState.builder(ClusterStateCreationUtils.state(localNode, masterNode, new DiscoveryNode[]{localNode, masterNode}))
+                .version(randomIntBetween(0, 10))
+        );
+
+        PlainActionFuture<Response> listener = new PlainActionFuture<>();
+        TransportMasterNodeAction action = new Action("internal:testAction", transportService, clusterService, threadPool);
+        action.execute(request, listener);
+
+        CapturingTransport.CapturedRequest[] capturedRequests = transport.getCapturedRequestsAndClear();
+        assertThat(capturedRequests.length, equalTo(1));
+        CapturingTransport.CapturedRequest capturedRequest = capturedRequests[0];
+        assertTrue(capturedRequest.node.isMasterNode());
+        assertThat(capturedRequest.request, equalTo(request));
+        assertThat(capturedRequest.action, equalTo("internal:testAction"));
+        transport.handleRemoteError(capturedRequest.requestId,
+            new MasterTaskThrottlingException("Throttling Exception : Limit exceeded for test"));
+
+        assertFalse(listener.isDone());
+
+        //waiting for retry to trigger
+        Thread.sleep(100);
+
+        // Retry for above throttling exception
+        capturedRequests = transport.getCapturedRequestsAndClear();
+        assertThat(capturedRequests.length, equalTo(1));
+        capturedRequest = capturedRequests[0];
+        Response response = new Response();
+        transport.handleResponse(capturedRequest.requestId, response);
+
+        assertTrue(listener.isDone());
+        listener.get();
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/service/MasterServiceTests.java
@@ -648,6 +648,223 @@ public class MasterServiceTests extends OpenSearchTestCase {
         }
     }
 
+    public void testThrottlingForTaskSubmission() throws InterruptedException {
+        int throttlingLimit = randomIntBetween(1, 10);
+        int taskId = 1;
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+        final CountDownLatch latch = new CountDownLatch(1);
+        class Task {
+            private final int id;
+
+            Task(int id) {
+                this.id = id;
+            }
+        }
+
+        class TaskExecutor implements ClusterStateTaskExecutor<Task> {
+            private AtomicInteger published = new AtomicInteger();
+
+            @Override
+            public ClusterTasksResult<Task> execute(ClusterState currentState, List<Task> tasks) throws Exception {
+                latch.countDown();
+                barrier.await();
+                return ClusterTasksResult.<Task>builder().successes(tasks).build(currentState);
+            }
+
+            @Override
+            public void clusterStatePublished(ClusterChangedEvent clusterChangedEvent) {
+                published.incrementAndGet();
+            }
+        }
+
+        MasterService masterService = createMasterService(true);
+        masterService.masterTaskThrottler.setThrottlingEnabled(true);
+        masterService.masterTaskThrottler.updateThrottlingLimit(Task.class, throttlingLimit);
+
+        final ClusterStateTaskListener listener = new ClusterStateTaskListener() {
+            @Override
+            public void onFailure(String source, Exception e) { }
+
+            @Override
+            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+            }
+        };
+
+        TaskExecutor executor = new TaskExecutor();
+        // submit one task which will be execution, post that will submit throttlingLimit tasks.
+        try {
+            masterService.submitStateUpdateTask(
+                "testTask",
+                new Task(taskId++),
+                ClusterStateTaskConfig.build(randomFrom(Priority.values())),
+                executor,
+                listener);
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+        // wait till task enter in execution.
+        latch.await();
+
+        for(int i = 0; i < throttlingLimit; i++) {
+            try {
+                masterService.submitStateUpdateTask(
+                    "testTask",
+                    new Task(taskId++),
+                    ClusterStateTaskConfig.build(randomFrom(Priority.values())),
+                    executor,
+                    listener);
+            } catch (Exception e) {
+                throw new AssertionError(e);
+            }
+        }
+
+        // we have one task in execution and tasks in queue so next task should throttled.
+        final AtomicReference<MasterTaskThrottlingException> assertionRef = new AtomicReference<>();
+        try {
+            masterService.submitStateUpdateTask(
+                "testTask",
+                new Task(taskId++),
+                ClusterStateTaskConfig.build(randomFrom(Priority.values())),
+                executor,
+                listener);
+        } catch (MasterTaskThrottlingException e ){
+            assertionRef.set(e);
+        }
+        assertNotNull(assertionRef.get());
+        masterService.close();
+    }
+
+    public void testThrottlingForMultipleTaskTypes() throws InterruptedException {
+        int throttlingLimitForTask1 = randomIntBetween(1, 5);
+        int throttlingLimitForTask2 = randomIntBetween(1, 5);
+        int throttlingLimitForTask3 = randomIntBetween(1, 5);
+        int numberOfTask1 = randomIntBetween(throttlingLimitForTask1, 10);
+        int numberOfTask2 = randomIntBetween(throttlingLimitForTask2, 10);
+        int numberOfTask3 = randomIntBetween(throttlingLimitForTask3, 10);
+        class Task {
+        }
+        class Task1 extends Task {
+        }
+        class Task2 extends Task {
+        }
+        class Task3 extends Task {
+        }
+
+        class TaskExecutor implements ClusterStateTaskExecutor<Task> {
+            @Override
+            public ClusterTasksResult<Task> execute(ClusterState currentState, List<Task> tasks) throws Exception {
+                Thread.sleep(randomInt(1000));
+                return ClusterTasksResult.<Task>builder().successes(tasks).build(currentState);
+            }
+
+            @Override
+            public void clusterStatePublished(ClusterChangedEvent clusterChangedEvent) { }
+        }
+
+        MasterService masterService = createMasterService(true);
+        masterService.masterTaskThrottler.setThrottlingEnabled(true);
+        // configuring limits for Task1 and Task3. All task submission of Task2 should pass.
+        masterService.masterTaskThrottler.updateThrottlingLimit(Task1.class, throttlingLimitForTask1);
+        masterService.masterTaskThrottler.updateThrottlingLimit(Task3.class, throttlingLimitForTask3);
+        final CountDownLatch latch = new CountDownLatch(numberOfTask1 + numberOfTask2 + numberOfTask3);
+        AtomicInteger throttledTask1 = new AtomicInteger();
+        AtomicInteger throttledTask2 = new AtomicInteger();
+        AtomicInteger throttledTask3 = new AtomicInteger();
+        AtomicInteger succeededTask1 = new AtomicInteger();
+        AtomicInteger succeededTask2 = new AtomicInteger();
+        AtomicInteger timedOutTask3 = new AtomicInteger();
+
+
+        final ClusterStateTaskListener listener = new ClusterStateTaskListener() {
+            @Override
+            public void onFailure(String source, Exception e) {
+                // Task3's timeout should have called this.
+                assertEquals("Task3", source);
+                timedOutTask3.incrementAndGet();
+                latch.countDown();
+            }
+
+            @Override
+            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                if(source.equals("Task1")) {
+                    succeededTask1.incrementAndGet();
+                } else if(source.equals("Task2")) {
+                    succeededTask2.incrementAndGet();
+                }
+                latch.countDown();
+            }
+        };
+        TaskExecutor executor = new TaskExecutor();
+        List<Thread> threads = new ArrayList<Thread>();
+        for(int i = 0; i< numberOfTask1; i++) {
+            threads.add(new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        masterService.submitStateUpdateTask(
+                            "Task1",
+                            new Task1(),
+                            ClusterStateTaskConfig.build(randomFrom(Priority.values())),
+                            executor,
+                            listener);
+                    } catch (MasterTaskThrottlingException e) {
+                        // Exception should be RejactedExecutionException.
+                        throttledTask1.incrementAndGet();
+                        latch.countDown();
+                    }
+                }
+            }));
+        }
+        for(int i = 0; i< numberOfTask2; i++) {
+            threads.add(new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        masterService.submitStateUpdateTask(
+                            "Task2",
+                            new Task2(),
+                            ClusterStateTaskConfig.build(randomFrom(Priority.values())),
+                            executor,
+                            listener);
+                    } catch (MasterTaskThrottlingException e) {
+                        throttledTask2.incrementAndGet();
+                        latch.countDown();
+                    }
+                }
+            }));
+        }
+        for(int i = 0; i< numberOfTask3; i++) {
+            threads.add(new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        masterService.submitStateUpdateTask(
+                            "Task3",
+                            new Task3(),
+                            ClusterStateTaskConfig.build(randomFrom(Priority.values()), new TimeValue(0)),
+                            executor,
+                            listener);
+                    } catch (MasterTaskThrottlingException e) {
+                        throttledTask3.incrementAndGet();
+                        latch.countDown();
+                    }
+                }
+            }));
+        }
+        for(Thread thread : threads) {
+            thread.start();
+        }
+
+        // await for latch to clear
+        latch.await();
+
+        assertEquals(numberOfTask1, throttledTask1.get() + succeededTask1.get());
+        assertEquals(numberOfTask2, succeededTask2.get());
+        assertEquals(0, throttledTask2.get());
+        assertEquals(numberOfTask3, throttledTask3.get() + timedOutTask3.get());
+        masterService.close();
+    }
+
     public void testBlockingCallInClusterStateTaskListenerFails() throws InterruptedException {
         assumeTrue("assertions must be enabled for this test to work", BaseFuture.class.desiredAssertionStatus());
         final CountDownLatch latch = new CountDownLatch(1);

--- a/server/src/test/java/org/opensearch/cluster/service/MasterTaskThrottlerTests.java
+++ b/server/src/test/java/org/opensearch/cluster/service/MasterTaskThrottlerTests.java
@@ -1,0 +1,253 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.service;
+
+import org.opensearch.Version;
+import org.opensearch.action.support.replication.ClusterStateCreationUtils;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodeRole;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.snapshots.UpdateIndexShardSnapshotStatusRequest;
+import org.opensearch.test.ClusterServiceUtils;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import static org.opensearch.test.ClusterServiceUtils.setState;
+
+/**
+ * Contains tests for {@link MasterTaskThrottler}
+ */
+public class MasterTaskThrottlerTests extends OpenSearchTestCase {
+
+    private static ThreadPool threadPool;
+    private ClusterService clusterService;
+    private DiscoveryNode localNode;
+    private DiscoveryNode[] allNodes;
+
+    @BeforeClass
+    public static void beforeClass() {
+        threadPool = new TestThreadPool("TransportMasterNodeActionTests");
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        clusterService = ClusterServiceUtils.createClusterService(threadPool);
+        localNode = new DiscoveryNode("local_node", buildNewFakeTransportAddress(), Collections.emptyMap(),
+            Collections.singleton(DiscoveryNodeRole.MASTER_ROLE), Version.V_7_10_3);
+        allNodes = new DiscoveryNode[]{localNode};
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        clusterService.close();
+    }
+
+
+    @AfterClass
+    public static void afterClass() {
+        ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+        threadPool = null;
+    }
+
+
+    public void testDefaults() {
+        ClusterSettings clusterSettings =
+                new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        MasterTaskThrottler throttler = new MasterTaskThrottler(clusterSettings, clusterService.getMasterService());
+        assertFalse(throttler.isThrottlingEnabled());
+        for(String key : throttler.taskNameToClassMapping.keySet()) {
+            assertNull(throttler.getThrottlingLimit(throttler.taskNameToClassMapping.get(key)));
+        }
+    }
+
+    public void testValidateEnableThrottlingForDifferentVersion() {
+        DiscoveryNode masterNode = new DiscoveryNode("local_master_node", buildNewFakeTransportAddress(), Collections.emptyMap(),
+                Collections.singleton(DiscoveryNodeRole.MASTER_ROLE), Version.V_7_10_3);
+        DiscoveryNode dataNode = new DiscoveryNode("local_data_node", buildNewFakeTransportAddress(), Collections.emptyMap(),
+            Collections.singleton(DiscoveryNodeRole.DATA_ROLE), Version.V_7_1_0);
+        setState(clusterService, ClusterStateCreationUtils.state(masterNode, masterNode, new DiscoveryNode[]{masterNode, dataNode}));
+
+        ClusterSettings clusterSettings =
+            new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        MasterTaskThrottler throttler = new MasterTaskThrottler(clusterSettings, clusterService.getMasterService());
+
+        AtomicBoolean exceptionThrown = new AtomicBoolean();
+        try {
+            throttler.validateEnableSetting(true);
+        } catch (IllegalArgumentException e){
+            exceptionThrown.set(true);
+        }
+        assertTrue(exceptionThrown.get());
+    }
+
+    public void testValidateEnableThrottlingForHappyCase() {
+        DiscoveryNode masterNode = new DiscoveryNode("local_master_node", buildNewFakeTransportAddress(), Collections.emptyMap(),
+            Collections.singleton(DiscoveryNodeRole.MASTER_ROLE), Version.V_7_10_3);
+        DiscoveryNode dataNode = new DiscoveryNode("local_data_node", buildNewFakeTransportAddress(), Collections.emptyMap(),
+            Collections.singleton(DiscoveryNodeRole.DATA_ROLE), Version.V_7_10_3);
+        setState(clusterService, ClusterStateCreationUtils.state(masterNode, masterNode, new DiscoveryNode[]{masterNode, dataNode}));
+
+        ClusterSettings clusterSettings =
+            new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        MasterTaskThrottler throttler = new MasterTaskThrottler(clusterSettings, clusterService.getMasterService());
+
+        AtomicBoolean exceptionThrown = new AtomicBoolean();
+        try {
+            throttler.validateEnableSetting(true);
+        } catch (IllegalArgumentException e){
+            exceptionThrown.set(true);
+        }
+        assertFalse(exceptionThrown.get());
+    }
+
+    public void testUpdateEnableThrottling() {
+        setState(clusterService, ClusterStateCreationUtils.state(localNode, localNode, new DiscoveryNode[]{localNode}));
+        ClusterSettings clusterSettings =
+                new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        MasterTaskThrottler throttler = new MasterTaskThrottler(clusterSettings, clusterService.getMasterService());
+
+        Settings newSettings = Settings.builder()
+                .put(MasterTaskThrottler.ENABLE_MASTER_THROTTLING.getKey(), true)
+                .build();
+        clusterSettings.applySettings(newSettings);
+        assertTrue(throttler.isThrottlingEnabled());
+    }
+
+    public void testFlippingEnableThrottling() {
+        setState(clusterService, ClusterStateCreationUtils.state(localNode, localNode, new DiscoveryNode[]{localNode}));
+
+        ClusterSettings clusterSettings =
+                new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        MasterTaskThrottler throttler = new MasterTaskThrottler(clusterSettings, clusterService.getMasterService());
+
+        // set some limit for update snapshot tasks
+        int limit = randomIntBetween(1, 10);
+
+        Settings newSettings = Settings.builder()
+                .put(MasterTaskThrottler.ENABLE_MASTER_THROTTLING.getKey(), true)
+                .put("master.throttling.thresholds.update_snapshot.value", limit)
+                .build();
+        clusterSettings.applySettings(newSettings);
+        assertTrue(throttler.isThrottlingEnabled());
+        assertEquals(limit, throttler.getThrottlingLimit(UpdateIndexShardSnapshotStatusRequest.class).intValue());
+
+        newSettings = Settings.builder()
+                .put(MasterTaskThrottler.ENABLE_MASTER_THROTTLING.getKey(), false)
+                .build();
+        clusterSettings.applySettings(newSettings);
+
+        newSettings = Settings.builder()
+                .put(MasterTaskThrottler.ENABLE_MASTER_THROTTLING.getKey(), true)
+                .build();
+        clusterSettings.applySettings(newSettings);
+
+        assertEquals(limit, throttler.getThrottlingLimit(UpdateIndexShardSnapshotStatusRequest.class).intValue());
+    }
+
+    public void testUpdateThrottlingLimit() {
+        ClusterSettings clusterSettings =
+                new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        MasterTaskThrottler throttler = new MasterTaskThrottler(clusterSettings, clusterService.getMasterService());
+        throttler.setThrottlingEnabled(true);
+
+        // set some limit for update snapshot tasks
+        int newLimit = randomIntBetween(1, 10);
+
+        Settings newSettings = Settings.builder()
+                .put("master.throttling.thresholds.update_snapshot.value", newLimit)
+                .build();
+        clusterSettings.applySettings(newSettings);
+        assertEquals(newLimit, throttler.getThrottlingLimit(UpdateIndexShardSnapshotStatusRequest.class).intValue());
+
+        // set update snapshot task limit to default
+        newSettings = Settings.builder()
+                .put("master.throttling.thresholds.update_snapshot.values", -1)
+                .build();
+        clusterSettings.applySettings(newSettings);
+        assertNull(throttler.getThrottlingLimit(UpdateIndexShardSnapshotStatusRequest.class));
+    }
+
+    public void testUpdateLimitWithClassPath() {
+        ClusterSettings clusterSettings =
+                new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        MasterTaskThrottler throttler = new MasterTaskThrottler(clusterSettings, clusterService.getMasterService());
+        throttler.setThrottlingEnabled(true);
+
+        // set some limit for update snapshot tasks
+        int newLimit = randomIntBetween(1, 10);
+
+        Settings newSettings = Settings.builder()
+                .put("master.throttling.thresholds.org/opensearch/cluster/service/MasterTaskThrottlerTests$TestTask.value", newLimit)
+                .build();
+        clusterSettings.applySettings(newSettings);
+        assertEquals(newLimit, throttler.getThrottlingLimit(TestTask.class).intValue());
+    }
+
+    public void testValidateSetting() {
+        ClusterSettings clusterSettings =
+                new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        MasterTaskThrottler throttler = new MasterTaskThrottler(clusterSettings, clusterService.getMasterService());
+
+        Settings newSettings = Settings.builder()
+                .put("master.throttling.thresholds.update_snapshot.values", -5)
+                .build();
+        AtomicBoolean exceptionThrown = new AtomicBoolean();
+        try {
+            throttler.validateSetting(newSettings);
+        } catch (IllegalArgumentException e){
+            exceptionThrown.set(true);
+        }
+        assertTrue(exceptionThrown.getAndSet(false));
+
+        newSettings = Settings.builder()
+                .put("master.throttling.thresholds.randomClassPath.values", 5)
+                .build();
+
+        try {
+            throttler.validateSetting(newSettings);
+        } catch (IllegalArgumentException e){
+            exceptionThrown.set(true);
+        }
+        assertTrue(exceptionThrown.get());
+    }
+
+    public void testUpdateLimit() {
+        ClusterSettings clusterSettings =
+                new ClusterSettings(Settings.builder().build(), ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        MasterTaskThrottler throttler = new MasterTaskThrottler(clusterSettings, clusterService.getMasterService());
+        throttler.setThrottlingEnabled(true);
+
+        throttler.updateLimit(TestTask.class, 5);
+        assertEquals(5, throttler.getThrottlingLimit(TestTask.class).intValue());
+        throttler.updateLimit(TestTask.class, -1);
+        assertNull(throttler.getThrottlingLimit(TestTask.class));
+    }
+
+    public class TestTask {
+        private final int id;
+
+        TestTask(int id) {
+            this.id = id;
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/cluster/service/ThrottlerTests.java
+++ b/server/src/test/java/org/opensearch/cluster/service/ThrottlerTests.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.service;
+
+import org.opensearch.common.AdjustableSemaphore;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Contains tests of {@link Throttler}
+ */
+public class ThrottlerTests extends OpenSearchTestCase {
+
+    public void testDisabledThrottling() {
+        Throttler throttler = new Throttler(true);
+        throttler.updateThrottlingLimit("testKey", 1);
+        throttler.setThrottlingEnabled(false);
+        boolean firstCall = throttler.acquire("testKey", 5);
+        assertTrue(firstCall);
+    }
+
+    public void testThrottling() {
+        Throttler throttler = new Throttler(true);
+        throttler.updateThrottlingLimit("testKey", 5);
+        boolean firstCall = throttler.acquire("testKey", 1);
+        assertTrue(firstCall);
+
+        boolean secondCall = throttler.acquire("testKey", 2);
+        assertTrue(secondCall);
+
+        boolean thirdCall = throttler.acquire("testKey", 4);
+        assertFalse(thirdCall);
+
+        // will remove used value
+        throttler.release("testKey", 2);
+        boolean fourthCall = throttler.acquire("testKey", 4);
+        assertTrue(fourthCall);
+
+
+        boolean fifthCall = throttler.acquire("testKey", 1);
+        assertFalse(fifthCall);
+
+        // update limit and check
+        throttler.updateThrottlingLimit("testKey", 6);
+        boolean sixthCall = throttler.acquire("testKey", 1);
+        assertTrue(sixthCall);
+    }
+
+    public void testAcquireWithFlippingOfThrottlingFlag() throws Exception {
+        String test_task = "test";
+        Throttler<String> throttler = new Throttler(true);
+        throttler.updateThrottlingLimit(test_task, 1);
+        assertTrue(throttler.acquire(test_task, 1));
+        assertFalse(throttler.acquire(test_task, 1));
+
+        throttler.setThrottlingEnabled(false);
+        throttler.setThrottlingEnabled(true);
+        assertEquals(1, throttler.getThrottlingLimit(test_task).intValue());
+        assertTrue(throttler.acquire(test_task, 1));
+        assertFalse(throttler.acquire(test_task, 1));
+
+    }
+
+    public void testThrottlingWithoutLimit() {
+        Throttler throttler = new Throttler(true);
+        boolean firstCall = throttler.acquire("testKey", 1);
+        assertTrue(firstCall);
+
+        boolean secondCall = throttler.acquire("testKey", 2000);
+        assertTrue(secondCall);
+    }
+
+    public void testRemoveThrottlingLimit() {
+        Throttler throttler = new Throttler(true);
+        throttler.updateThrottlingLimit("testKey", 5);
+
+        boolean firstCall = throttler.acquire("testKey", 1);
+        assertTrue(firstCall);
+
+        boolean secondCall = throttler.acquire("testKey", 5);
+        assertFalse(secondCall);
+
+        throttler.removeThrottlingLimit("testKey");
+        boolean thirdCall = throttler.acquire("testKey", 500);
+        assertTrue(thirdCall);
+    }
+
+    public void testUpdateLimitForThrottlingSemaphore() {
+        int initialLimit = randomInt(10);
+        AdjustableSemaphore semaphore = new AdjustableSemaphore(initialLimit);
+        assertEquals(initialLimit, semaphore.availablePermits());
+
+        int newIncreasedLimit = randomIntBetween(initialLimit, 20);
+        semaphore.setMaxPermits(newIncreasedLimit);
+        assertEquals(newIncreasedLimit, semaphore.availablePermits());
+
+        int newDecreasedLimit = randomInt(newIncreasedLimit-1);
+        semaphore.setMaxPermits(newDecreasedLimit);
+        assertEquals(newDecreasedLimit, semaphore.availablePermits());
+    }
+}


### PR DESCRIPTION
### Description
Adding throttling functionality of tasks on master nodes. Master will reject tasks from data nodes based on throttling config and data nodes will retry with exponential backoff on those tasks to submit on master node.

It can be enabled/disabled by dynamic setting, we can add throttling config for task type using dynamic setting as well.

**Command for enabling/disabling.**
`curl -X PUT "localhost:9200/_cluster/settings?pretty" -H 'Content-Type: application/json' -d'
 {
   "persistent": {
     "master.throttling.enable": "true"
   }
 }
 '`

**Commands for adding throttling config:**
For adding throttling config for any of the task type, we will need to find class path for underlying request object and provide that path in config. 

For e.g. for adding limit for put-mapping task type, 
PutMappingClusterStateUpdateRequest is underlying request object to master for "put-mapping" tasks.

`curl -XPUT "localhost:9200/_cluster/settings?pretty" -H 'Content-Type: application/json' -d' {
    "persistent": {
        "master.throttling.thresholds" : {
            "org/opensearch/action/admin/indices/mapping/put/PutMappingClusterStateUpdateRequest" : {
                "value" : 10
            }
        }    
    }  
}' 
`
 
### Issues Resolved
closes #479
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
  - [x] Newly introduced tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


Signed-off-by: Dhwanil Patel dhwanilpatel96@gmail.com
