### PR TITLE
Add read_only block argument to opensearch-node unsafe-bootstrap command

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
@@ -19,7 +19,6 @@
 package org.opensearch.cluster.coordination;
 
 import joptsimple.OptionSet;
-
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.cli.MockTerminal;
@@ -34,31 +33,38 @@ import org.opensearch.env.TestEnvironment;
 import org.opensearch.gateway.GatewayMetaState;
 import org.opensearch.gateway.PersistedClusterStateService;
 import org.opensearch.indices.IndicesService;
-import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.InternalTestCluster;
+import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
+import static org.hamcrest.Matchers.*;
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.opensearch.gateway.DanglingIndicesState.AUTO_IMPORT_DANGLING_INDICES_SETTING;
 import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
 import static org.opensearch.indices.recovery.RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING;
 import static org.opensearch.test.NodeRoles.nonMasterNode;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0, autoManageMasterNodes = false)
 public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
 
-    private MockTerminal executeCommand(OpenSearchNodeCommand command, Environment environment, int nodeOrdinal, boolean abort)
-            throws Exception {
+    private MockTerminal executeCommand(OpenSearchNodeCommand command, Environment environment, int nodeOrdinal,
+                                        boolean abort, Boolean applyClusterReadOnlyBlock)
+        throws Exception {
         final MockTerminal terminal = new MockTerminal();
-        final OptionSet options = command.getParser().parse("-ordinal", Integer.toString(nodeOrdinal));
+        final OptionSet options;
+        if (Objects.nonNull(applyClusterReadOnlyBlock)) {
+            options = command.getParser().parse("-ordinal", Integer.toString(nodeOrdinal),
+                "-apply-cluster-read-only-block", Boolean.toString(applyClusterReadOnlyBlock));
+        } else {
+            options = command.getParser().parse("-ordinal", Integer.toString(nodeOrdinal));
+        }
         final String input;
 
         if (abort) {
@@ -78,22 +84,22 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
         return terminal;
     }
 
-    private MockTerminal unsafeBootstrap(Environment environment, boolean abort) throws Exception {
-        final MockTerminal terminal = executeCommand(new UnsafeBootstrapMasterCommand(), environment, 0, abort);
+    private MockTerminal unsafeBootstrap(Environment environment, boolean abort, Boolean applyClusterReadOnlyBlock) throws Exception {
+        final MockTerminal terminal = executeCommand(new UnsafeBootstrapMasterCommand(), environment, 0, abort, applyClusterReadOnlyBlock);
         assertThat(terminal.getOutput(), containsString(UnsafeBootstrapMasterCommand.CONFIRMATION_MSG));
         assertThat(terminal.getOutput(), containsString(UnsafeBootstrapMasterCommand.MASTER_NODE_BOOTSTRAPPED_MSG));
         return terminal;
     }
 
     private MockTerminal detachCluster(Environment environment, boolean abort) throws Exception {
-        final MockTerminal terminal = executeCommand(new DetachClusterCommand(), environment, 0, abort);
+        final MockTerminal terminal = executeCommand(new DetachClusterCommand(), environment, 0, abort, null);
         assertThat(terminal.getOutput(), containsString(DetachClusterCommand.CONFIRMATION_MSG));
         assertThat(terminal.getOutput(), containsString(DetachClusterCommand.NODE_DETACHED_MSG));
         return terminal;
     }
 
     private MockTerminal unsafeBootstrap(Environment environment) throws Exception {
-        return unsafeBootstrap(environment, false);
+        return unsafeBootstrap(environment, false, null);
     }
 
     private MockTerminal detachCluster(Environment environment) throws Exception {
@@ -105,10 +111,32 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
         assertThat(ex.getMessage(), containsString(message));
     }
 
+    private void ensureReadOnlyBlock(boolean expected_block_state, String node) {
+        ClusterState state = internalCluster().client(node).admin().cluster().prepareState().setLocal(true)
+            .execute().actionGet().getState();
+        boolean current_block_state = state.metadata().persistentSettings().
+            getAsBoolean(Metadata.SETTING_READ_ONLY_SETTING.getKey(), false);
+        if(current_block_state != expected_block_state) {
+            fail(String.format("Read only setting for the node %s don't match. Expected %s. Actual %s", node,
+                expected_block_state, current_block_state));
+        }
+    }
+
+    private void removeBlock() {
+        try{
+            if (isInternalCluster()) {
+                Settings settings = Settings.builder().putNull(Metadata.SETTING_READ_ONLY_SETTING.getKey()).build()  ;
+                assertAcked(client().admin().cluster().prepareUpdateSettings().setPersistentSettings(settings).get());
+            }
+        } catch (Exception ex) {
+            logger.error("Exception while updating cluster read only settings ", ex);
+        }
+    }
+
     public void testBootstrapNotMasterEligible() {
         final Environment environment = TestEnvironment.newEnvironment(Settings.builder()
-                .put(nonMasterNode(internalCluster().getDefaultSettings()))
-                .build());
+            .put(nonMasterNode(internalCluster().getDefaultSettings()))
+            .build());
         expectThrows(() -> unsafeBootstrap(environment), UnsafeBootstrapMasterCommand.NOT_MASTER_NODE_MSG);
     }
 
@@ -201,7 +229,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
 
         Environment environment = TestEnvironment.newEnvironment(
             Settings.builder().put(internalCluster().getDefaultSettings()).put(dataPathSettings).build());
-        expectThrows(() -> unsafeBootstrap(environment, true), OpenSearchNodeCommand.ABORTED_BY_USER_MSG);
+        expectThrows(() -> unsafeBootstrap(environment, true, null), OpenSearchNodeCommand.ABORTED_BY_USER_MSG);
     }
 
     public void testDetachAbortedByUser() throws IOException {
@@ -222,19 +250,23 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
 
         logger.info("--> start 1st master-eligible node");
         masterNodes.add(internalCluster().startMasterOnlyNode(Settings.builder()
-                .put(DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.getKey(), "0s")
-                .build())); // node ordinal 0
+            .put(DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.getKey(), "0s")
+            .build())); // node ordinal 0
 
         logger.info("--> start one data-only node");
         String dataNode = internalCluster().startDataOnlyNode(Settings.builder()
-                .put(DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.getKey(), "0s")
-                .build()); // node ordinal 1
+            .put(DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.getKey(), "0s")
+            .build()); // node ordinal 1
 
         logger.info("--> start 2nd and 3rd master-eligible nodes and bootstrap");
         masterNodes.addAll(internalCluster().startMasterOnlyNodes(2)); // node ordinals 2 and 3
 
         logger.info("--> wait for all nodes to join the cluster");
         ensureStableCluster(4);
+
+        List<String> currentClusterNodes = new ArrayList<>(masterNodes);
+        currentClusterNodes.add(dataNode);
+        currentClusterNodes.forEach(node-> ensureReadOnlyBlock(false, node));
 
         logger.info("--> create index test");
         createIndex("test");
@@ -252,7 +284,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
         logger.info("--> ensure NO_MASTER_BLOCK on data-only node");
         assertBusy(() -> {
             ClusterState state = internalCluster().client(dataNode).admin().cluster().prepareState().setLocal(true)
-                    .execute().actionGet().getState();
+                .execute().actionGet().getState();
             assertTrue(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
         });
 
@@ -276,7 +308,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
                 metadata.coordinationMetadata().term(), metadata.version())));
 
         logger.info("--> start 1st master-eligible node");
-        internalCluster().startMasterOnlyNode(master1DataPathSettings);
+        String masterNode2 = internalCluster().startMasterOnlyNode(master1DataPathSettings);
 
         logger.info("--> detach-cluster on data-only node");
         Environment environmentData = TestEnvironment.newEnvironment(
@@ -289,10 +321,15 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
         logger.info("--> ensure there is no NO_MASTER_BLOCK and unsafe-bootstrap is reflected in cluster state");
         assertBusy(() -> {
             ClusterState state = internalCluster().client(dataNode2).admin().cluster().prepareState().setLocal(true)
-                    .execute().actionGet().getState();
+                .execute().actionGet().getState();
             assertFalse(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
             assertTrue(state.metadata().persistentSettings().getAsBoolean(UnsafeBootstrapMasterCommand.UNSAFE_BOOTSTRAP.getKey(), false));
         });
+
+        List<String> bootstrappedNodes = new ArrayList<>();
+        bootstrappedNodes.add(dataNode2);
+        bootstrappedNodes.add(masterNode2);
+        bootstrappedNodes.forEach(node-> ensureReadOnlyBlock(true, node));
 
         logger.info("--> ensure index test is green");
         ensureGreen("test");
@@ -308,9 +345,10 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
         detachCluster(environmentMaster3, false);
 
         logger.info("--> start 2nd and 3rd master-eligible nodes and ensure 4 nodes stable cluster");
-        internalCluster().startMasterOnlyNode(master2DataPathSettings);
-        internalCluster().startMasterOnlyNode(master3DataPathSettings);
+        bootstrappedNodes.addAll(internalCluster().startMasterOnlyNodes(2));
         ensureStableCluster(4);
+        bootstrappedNodes.forEach(node-> ensureReadOnlyBlock(true, node));
+        removeBlock();
     }
 
     public void testAllMasterEligibleNodesFailedDanglingIndexImport() throws Exception {
@@ -385,13 +423,13 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
         detachCluster(environment);
 
         String node = internalCluster().startMasterOnlyNode(Settings.builder()
-                // give the cluster 2 seconds to elect the master (it should not)
-                .put(DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.getKey(), "2s")
-                .put(masterNodeDataPathSettings)
-                .build());
+            // give the cluster 2 seconds to elect the master (it should not)
+            .put(DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.getKey(), "2s")
+            .put(masterNodeDataPathSettings)
+            .build());
 
         ClusterState state = internalCluster().client().admin().cluster().prepareState().setLocal(true)
-                .execute().actionGet().getState();
+            .execute().actionGet().getState();
         assertTrue(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
 
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(node));
@@ -402,12 +440,14 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
         String masterNode = internalCluster().startMasterOnlyNode();
         Settings masterNodeDataPathSettings = internalCluster().dataPathSettings(masterNode);
         ClusterUpdateSettingsRequest req = new ClusterUpdateSettingsRequest().persistentSettings(
-                Settings.builder().put(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(), "1234kb"));
+            Settings.builder().put(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(), "1234kb"));
         internalCluster().client().admin().cluster().updateSettings(req).get();
 
         ClusterState state = internalCluster().client().admin().cluster().prepareState().execute().actionGet().getState();
         assertThat(state.metadata().persistentSettings().get(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey()),
-                equalTo("1234kb"));
+            equalTo("1234kb"));
+
+        ensureReadOnlyBlock(false, masterNode);
 
         internalCluster().stopCurrentMasterNode();
 
@@ -416,11 +456,42 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
         detachCluster(environment);
         unsafeBootstrap(environment);
 
-        internalCluster().startMasterOnlyNode(masterNodeDataPathSettings);
+        String masterNode2 = internalCluster().startMasterOnlyNode(masterNodeDataPathSettings);
         ensureGreen();
+        ensureReadOnlyBlock(true, masterNode2);
 
         state = internalCluster().client().admin().cluster().prepareState().execute().actionGet().getState();
         assertThat(state.metadata().settings().get(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey()),
-                equalTo("1234kb"));
+            equalTo("1234kb"));
+        removeBlock();
+    }
+
+    public void testUnsafeBootstrapWithApplyClusterReadOnlyBlockAsFalse() throws Exception {
+        internalCluster().setBootstrapMasterNodeIndex(0);
+        String masterNode = internalCluster().startMasterOnlyNode();
+        Settings masterNodeDataPathSettings = internalCluster().dataPathSettings(masterNode);
+        ClusterUpdateSettingsRequest req = new ClusterUpdateSettingsRequest().persistentSettings(
+            Settings.builder().put(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(), "1234kb"));
+        internalCluster().client().admin().cluster().updateSettings(req).get();
+
+        ClusterState state = internalCluster().client().admin().cluster().prepareState().execute().actionGet().getState();
+        assertThat(state.metadata().persistentSettings().get(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey()),
+            equalTo("1234kb"));
+
+        ensureReadOnlyBlock(false, masterNode);
+
+        internalCluster().stopCurrentMasterNode();
+
+        final Environment environment = TestEnvironment.newEnvironment(
+            Settings.builder().put(internalCluster().getDefaultSettings()).put(masterNodeDataPathSettings).build());
+        unsafeBootstrap(environment, false, false);
+
+        String masterNode2 = internalCluster().startMasterOnlyNode(masterNodeDataPathSettings);
+        ensureGreen();
+        ensureReadOnlyBlock(false, masterNode2);
+
+        state = internalCluster().client().admin().cluster().prepareState().execute().actionGet().getState();
+        assertThat(state.metadata().settings().get(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey()),
+            equalTo("1234kb"));
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/coordination/UnsafeBootstrapMasterCommand.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/UnsafeBootstrapMasterCommand.java
@@ -70,8 +70,8 @@ public class UnsafeBootstrapMasterCommand extends OpenSearchNodeCommand {
 
     UnsafeBootstrapMasterCommand() {
         super("Forces the successful election of the current node after the permanent loss of the half or more master-eligible nodes");
-        applyClusterReadOnlyBlockOption = parser.accepts("apply-cluster-read-only-block", "Optional cluster.blocks.read_only setting, true if not specified")
-            .withRequiredArg().ofType(Boolean.class);
+        applyClusterReadOnlyBlockOption = parser.accepts("apply-cluster-read-only-block", "Optional cluster.blocks.read_only setting, false if not specified")
+            .withOptionalArg().ofType(Boolean.class);
     }
 
     @Override
@@ -92,7 +92,7 @@ public class UnsafeBootstrapMasterCommand extends OpenSearchNodeCommand {
 
         Boolean applyClusterReadOnlyBlock = applyClusterReadOnlyBlockOption.value(options);
         if(Objects.isNull(applyClusterReadOnlyBlock)) {
-            applyClusterReadOnlyBlock = true;
+            applyClusterReadOnlyBlock = false;
         }
 
         final Tuple<Long, ClusterState> state = loadTermAndClusterState(persistedClusterStateService, env);
@@ -122,6 +122,7 @@ public class UnsafeBootstrapMasterCommand extends OpenSearchNodeCommand {
             .put(UNSAFE_BOOTSTRAP.getKey(), true)
             .put(Metadata.SETTING_READ_ONLY_SETTING.getKey(), applyClusterReadOnlyBlock)
             .build();
+
         Metadata.Builder newMetadata = Metadata.builder(metadata)
             .clusterUUID(Metadata.UNKNOWN_CLUSTER_UUID)
             .generateClusterUuidIfNeeded()

--- a/server/src/main/java/org/opensearch/cluster/coordination/UnsafeBootstrapMasterCommand.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/UnsafeBootstrapMasterCommand.java
@@ -20,6 +20,7 @@ package org.opensearch.cluster.coordination;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
 import org.opensearch.OpenSearchException;
 import org.opensearch.cli.Terminal;
 import org.opensearch.cluster.ClusterState;
@@ -38,6 +39,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Locale;
+import java.util.Objects;
 
 public class UnsafeBootstrapMasterCommand extends OpenSearchNodeCommand {
 
@@ -64,8 +66,12 @@ public class UnsafeBootstrapMasterCommand extends OpenSearchNodeCommand {
     static final Setting<String> UNSAFE_BOOTSTRAP =
             ClusterService.USER_DEFINED_METADATA.getConcreteSetting("cluster.metadata.unsafe-bootstrap");
 
+    private OptionSpec<Boolean> applyClusterReadOnlyBlockOption;
+
     UnsafeBootstrapMasterCommand() {
         super("Forces the successful election of the current node after the permanent loss of the half or more master-eligible nodes");
+        applyClusterReadOnlyBlockOption = parser.accepts("apply-cluster-read-only-block", "Optional cluster.blocks.read_only setting, true if not specified")
+            .withRequiredArg().ofType(Boolean.class);
     }
 
     @Override
@@ -83,6 +89,11 @@ public class UnsafeBootstrapMasterCommand extends OpenSearchNodeCommand {
     protected void processNodePaths(Terminal terminal, Path[] dataPaths, int nodeLockId, OptionSet options, Environment env)
         throws IOException {
         final PersistedClusterStateService persistedClusterStateService = createPersistedClusterStateService(env.settings(), dataPaths);
+
+        Boolean applyClusterReadOnlyBlock = applyClusterReadOnlyBlockOption.value(options);
+        if(Objects.isNull(applyClusterReadOnlyBlock)) {
+            applyClusterReadOnlyBlock = true;
+        }
 
         final Tuple<Long, ClusterState> state = loadTermAndClusterState(persistedClusterStateService, env);
         final ClusterState oldClusterState = state.v2();
@@ -109,6 +120,7 @@ public class UnsafeBootstrapMasterCommand extends OpenSearchNodeCommand {
         Settings persistentSettings = Settings.builder()
             .put(metadata.persistentSettings())
             .put(UNSAFE_BOOTSTRAP.getKey(), true)
+            .put(Metadata.SETTING_READ_ONLY_SETTING.getKey(), applyClusterReadOnlyBlock)
             .build();
         Metadata.Builder newMetadata = Metadata.builder(metadata)
             .clusterUUID(Metadata.UNKNOWN_CLUSTER_UUID)


### PR DESCRIPTION
### Description
This change will add one optional argument to opensearch-node unsafe-bootstrap command known as apply-cluster-read-only-block. It will apply read only block to cluster based on its value (true or false) after successful bootstrap.

Usage : `./bin/opensearch-node unsafe-bootstrap --apply-cluster-read-only-block true` 

### Issues Resolved
closes: #492 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
