### PR TITLE
Merge 'main' into 'javadoc' branch after test failures are almost fixed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,7 +224,9 @@ allprojects {
     // other packages (e.g org.opensearch.client) will point to server rather than
     // their own artifacts.
     if (project.plugins.hasPlugin(BuildPlugin) || project.plugins.hasPlugin(PluginBuildPlugin)) {
-      String artifactsHost = VersionProperties.getOpenSearch().endsWith("-SNAPSHOT") ? "https://snapshots.elastic.co" : "https://artifacts.elastic.co"
+      String artifactsHost = VersionProperties.getOpenSearch().endsWith("-SNAPSHOT")
+        ? "https://artifacts.opensearch.org/snapshots/"
+        : "https://artifacts.opensearch.org/releases/"
       Closure sortClosure = { a, b -> b.group <=> a.group }
       Closure depJavadocClosure = { shadowed, dep ->
         if ((dep instanceof ProjectDependency) == false) {

--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -114,7 +114,7 @@ abstract class AbstractGradleFuncTest extends Specification {
     void setupLocalGitRepo() {
         //TODO: cleanup
         execute("git init")
-        execute('git config user.email "build-tool@elastic.co"')
+        execute('git config user.email "build-tool@opensearch.org"')
         execute('git config user.name "Build tool"')
         execute("git add .")
         execute('git commit -m "Initial"')

--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
@@ -140,7 +140,7 @@ class InternalDistributionBwcSetupPluginFuncTest extends AbstractGradleFuncTest 
         fakeRemote.file + "/.git"
         gradleRunner(workingRemoteGit, "wrapper").build()
         execute("git init", workingRemoteGit)
-        execute('git config user.email "build-tool@elastic.co"', workingRemoteGit)
+        execute('git config user.email "build-tool@opensearch.org"', workingRemoteGit)
         execute('git config user.name "Build tool"', workingRemoteGit)
         execute("git add .", workingRemoteGit)
         execute('git commit -m"Initial"', workingRemoteGit)

--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
@@ -103,7 +103,7 @@ class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest 
         then:
         result.task(":distribution:bwc:minor:buildBwcExpandedTask").outcome == TaskOutcome.SUCCESS
         result.task(":setupDistro").outcome == TaskOutcome.SUCCESS
-        assertExtractedDistroIsCreated("distribution/bwc/minor/build/install/elastic-distro",
+        assertExtractedDistroIsCreated("distribution/bwc/minor/build/install/opensearch-distro",
                 'bwc-marker.txt')
     }
 
@@ -158,7 +158,7 @@ class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest 
             configurations.create("expanded-oss-linux-tar")
             def expandedTask = tasks.register("buildBwcExpandedTask", Copy) {
                 from('bwc-marker.txt')
-                into('build/install/elastic-distro')
+                into('build/install/opensearch-distro')
             }
             artifacts {
                 it.add("expanded-oss-linux-tar", file('build/install')) {

--- a/buildSrc/src/integTest/java/org/opensearch/gradle/BuildPluginIT.java
+++ b/buildSrc/src/integTest/java/org/opensearch/gradle/BuildPluginIT.java
@@ -57,13 +57,13 @@ public class BuildPluginIT extends GradleIntegrationTestCase {
     }
 
     public void testInsecureMavenRepository() throws IOException {
-        final String name = "elastic-maven";
-        final String url = "http://s3.amazonaws.com/artifacts.elastic.co/maven";
+        final String name = "opensearch-maven";
+        final String url = "http://s3.amazonaws.com/artifacts.opensearch.org/maven";
         // add an insecure maven repository to the build.gradle
         final List<String> lines = Arrays.asList(
             "repositories {",
             "  maven {",
-            "    name \"elastic-maven\"",
+            "    name \"opensearch-maven\"",
             "    url \"" + url + "\"\n",
             "  }",
             "}"
@@ -72,13 +72,13 @@ public class BuildPluginIT extends GradleIntegrationTestCase {
     }
 
     public void testInsecureIvyRepository() throws IOException {
-        final String name = "elastic-ivy";
-        final String url = "http://s3.amazonaws.com/artifacts.elastic.co/ivy";
+        final String name = "opensearch-ivy";
+        final String url = "http://s3.amazonaws.com/artifacts.opensearch.org/ivy";
         // add an insecure ivy repository to the build.gradle
         final List<String> lines = Arrays.asList(
             "repositories {",
             "  ivy {",
-            "    name \"elastic-ivy\"",
+            "    name \"opensearch-ivy\"",
             "    url \"" + url + "\"\n",
             "  }",
             "}"

--- a/buildSrc/src/main/java/org/opensearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/DistributionDownloadPlugin.java
@@ -155,8 +155,8 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
         if (project.getRepositories().findByName(DOWNLOAD_REPO_NAME) != null) {
             return;
         }
-        addIvyRepo(project, DOWNLOAD_REPO_NAME, "https://artifacts-no-kpi.elastic.co", FAKE_IVY_GROUP);
-        addIvyRepo(project, SNAPSHOT_REPO_NAME, "https://snapshots-no-kpi.elastic.co", FAKE_SNAPSHOT_IVY_GROUP);
+        addIvyRepo(project, DOWNLOAD_REPO_NAME, "https://artifacts-no-kpi.opensearch.org", FAKE_IVY_GROUP);
+        addIvyRepo(project, SNAPSHOT_REPO_NAME, "https://snapshots-no-kpi.opensearch.org", FAKE_SNAPSHOT_IVY_GROUP);
     }
 
     /**

--- a/client/sniffer/src/test/java/org/opensearch/client/sniff/OpenSearchNodesSnifferParseTests.java
+++ b/client/sniffer/src/test/java/org/opensearch/client/sniff/OpenSearchNodesSnifferParseTests.java
@@ -137,7 +137,7 @@ public class OpenSearchNodesSnifferParseTests extends RestClientTestCase {
         HttpEntity entity = new InputStreamEntity(in, ContentType.APPLICATION_JSON);
         List<Node> nodes = OpenSearchNodesSniffer.readHosts(entity, Scheme.HTTP, new JsonFactory());
 
-        assertEquals("elastic.test", nodes.get(0).getHost().getHostName());
+        assertEquals("opensearch.test", nodes.get(0).getHost().getHostName());
         assertEquals(9200, nodes.get(0).getHost().getPort());
         assertEquals("http", nodes.get(0).getHost().getSchemeName());
     }

--- a/client/sniffer/src/test/resources/es7_nodes_publication_address_format.json
+++ b/client/sniffer/src/test/resources/es7_nodes_publication_address_format.json
@@ -20,9 +20,9 @@
       "attributes": { },
       "http": {
         "bound_address": [
-            "elastic.test:9200"
+            "opensearch.test:9200"
         ],
-        "publish_address": "elastic.test/127.0.0.1:9200",
+        "publish_address": "opensearch.test/127.0.0.1:9200",
         "max_content_length_in_bytes": 104857600
       }
     }

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -474,7 +474,7 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
  *  <dd>The default directory from which to load configuration. This is used in
  *    the packaging scripts, but in that context it is always
  *    /etc/opensearch. Its also used in bin/opensearch-plugin, where it is
- *    /etc/opensearch for the os packages but $OPENSEARCHHOME/config otherwise.</dd>
+ *    /etc/opensearch for the os packages but $OPENSEARCH_HOME/config otherwise.</dd>
  *  <dt>path.env</dt>
  *  <dd>The env file sourced before bin/opensearch to set environment
  *    variables. Think /etc/defaults/opensearch.</dd>

--- a/distribution/licenses/openjdk-NOTICE.txt
+++ b/distribution/licenses/openjdk-NOTICE.txt
@@ -2,4 +2,4 @@ Copyright (c) 1995, 2013, Oracle and/or its affiliates.
 
 OpenJDK is licensed under the GPLv2+CE. A copy of that license is included in
 this distribution immediately below this notice. You can find a copy of the
-OpenJDK source through the downloads page at https://elastic.co.
+OpenJDK source through the downloads page at https://opensearch.org.

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -458,6 +458,7 @@ subprojects {
           licenseFilename = "APACHE-LICENSE-2.0.txt"
           final List<String> header = Arrays.asList("Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/",
             "Copyright: Elasticsearch B.V. <info@elastic.co>",
+            "Copyright: OpenSearch Contributors",
             "License: " + expectedLicense)
           final List<String> licenseLines = Files.readAllLines(rootDir.toPath().resolve("licenses/" + licenseFilename))
           final List<String> expectedLines = header + licenseLines.collect { " " + it }

--- a/distribution/packages/src/deb/copyright
+++ b/distribution/packages/src/deb/copyright
@@ -1,4 +1,5 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Copyright: Elasticsearch B.V. <info@elastic.co>
+Copyright: OpenSearch Contributors
 License: ${license.name}
 ${license.text}

--- a/distribution/packages/src/deb/lintian/opensearch
+++ b/distribution/packages/src/deb/lintian/opensearch
@@ -44,6 +44,3 @@ hardening-no-pie usr/share/opensearch/jdk/lib/*
 
 # the system java version that lintian assumes is far behind what opensearch uses
 unknown-java-class-version
-
-# elastic licensed modules contain elastic license
-extra-license-file usr/share/opensearch/modules/*

--- a/distribution/src/bin/opensearch-env-from-file
+++ b/distribution/src/bin/opensearch-env-from-file
@@ -14,7 +14,7 @@ set -e -o pipefail
 # This script is intended to be sourced, not executed, and modifies the
 # environment.
 
-for VAR_NAME_FILE in ELASTIC_PASSWORD_FILE KEYSTORE_PASSWORD_FILE ; do
+for VAR_NAME_FILE in OPENSEARCH_PASSWORD_FILE KEYSTORE_PASSWORD_FILE ; do
   if [[ -n "${!VAR_NAME_FILE}" ]]; then
     VAR_NAME="${VAR_NAME_FILE%_FILE}"
 

--- a/distribution/src/bin/opensearch-service.bat
+++ b/distribution/src/bin/opensearch-service.bat
@@ -200,7 +200,7 @@ if "%OPENSEARCH_START_TYPE%" == "" set OPENSEARCH_START_TYPE=manual
 if "%OPENSEARCH_STOP_TIMEOUT%" == "" set OPENSEARCH_STOP_TIMEOUT=0
 
 if "%SERVICE_DISPLAY_NAME%" == "" set SERVICE_DISPLAY_NAME=OpenSearch %OPENSEARCH_VERSION% (%SERVICE_ID%)
-if "%SERVICE_DESCRIPTION%" == "" set SERVICE_DESCRIPTION=OpenSearch %OPENSEARCH_VERSION% Windows Service - https://elastic.co
+if "%SERVICE_DESCRIPTION%" == "" set SERVICE_DESCRIPTION=OpenSearch %OPENSEARCH_VERSION% Windows Service - https://opensearch.org
 
 if not "%SERVICE_USERNAME%" == "" (
 	if not "%SERVICE_PASSWORD%" == "" (

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/160_urldecode.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/160_urldecode.yml
@@ -28,11 +28,11 @@ teardown:
         id: 1
         pipeline: "1"
         body: {
-          my_url: "https%3a%2f%2felastic.co%2f"
+          my_url: "https%3a%2f%2fopensearch.org%2f"
         }
 
   - do:
       get:
         index: test
         id: 1
-  - match: { _source.my_url: "https://elastic.co/" }
+  - match: { _source.my_url: "https://opensearch.org/" }

--- a/plugins/examples/rest-handler/src/javaRestTest/java/org/opensearch/example/resthandler/ExampleFixtureIT.java
+++ b/plugins/examples/rest-handler/src/javaRestTest/java/org/opensearch/example/resthandler/ExampleFixtureIT.java
@@ -49,7 +49,7 @@ public class ExampleFixtureIT extends OpenSearchTestCase {
             BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8))
         ) {
             writer.write("GET / HTTP/1.1\r\n");
-            writer.write("Host: elastic.co\r\n\r\n");
+            writer.write("Host: opensearch.org\r\n\r\n");
             writer.flush();
 
             final List<String> lines = new ArrayList<>();

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -72,7 +72,7 @@ dependencies {
   // Set the keytab files in the classpath so that we can access them from test code without the security manager
   // freaking out.
   if (isEclipse == false) {
-    testRuntimeOnly files(project(':test:fixtures:krb5kdc-fixture').ext.krb5Keytabs("hdfs", "hdfs_hdfs.build.elastic.co.keytab").parent)
+    testRuntimeOnly files(project(':test:fixtures:krb5kdc-fixture').ext.krb5Keytabs("hdfs", "hdfs_hdfs.build.opensearch.org.keytab").parent)
   }
 }
 
@@ -139,9 +139,9 @@ for (String fixtureName : ['hdfsFixture', 'haHdfsFixture', 'secureHdfsFixture', 
 
     // If it's a secure fixture, then set the principal name and keytab locations to use for auth.
     if (fixtureName.equals('secureHdfsFixture') || fixtureName.equals('secureHaHdfsFixture')) {
-      miniHDFSArgs.add("hdfs/hdfs.build.elastic.co@${realm}")
+      miniHDFSArgs.add("hdfs/hdfs.build.opensearch.org@${realm}")
       miniHDFSArgs.add(
-        project(':test:fixtures:krb5kdc-fixture').ext.krb5Keytabs("hdfs", "hdfs_hdfs.build.elastic.co.keytab")
+        project(':test:fixtures:krb5kdc-fixture').ext.krb5Keytabs("hdfs", "hdfs_hdfs.build.opensearch.org.keytab")
       )
     }
 
@@ -201,12 +201,12 @@ for (String integTestTaskName : ['integTestHa', 'integTestSecure', 'integTestSec
 
       if (integTestTaskName.contains("Secure")) {
         if (disabledIntegTestTaskNames.contains(integTestTaskName) == false) {
-          nonInputProperties.systemProperty "test.krb5.principal.es", "elasticsearch@${realm}"
-          nonInputProperties.systemProperty "test.krb5.principal.hdfs", "hdfs/hdfs.build.elastic.co@${realm}"
+          nonInputProperties.systemProperty "test.krb5.principal.es", "opensearch@${realm}"
+          nonInputProperties.systemProperty "test.krb5.principal.hdfs", "hdfs/hdfs.build.opensearch.org@${realm}"
           jvmArgs "-Djava.security.krb5.conf=${krb5conf}"
           nonInputProperties.systemProperty(
             "test.krb5.keytab.hdfs",
-            project(':test:fixtures:krb5kdc-fixture').ext.krb5Keytabs("hdfs", "hdfs_hdfs.build.elastic.co.keytab")
+            project(':test:fixtures:krb5kdc-fixture').ext.krb5Keytabs("hdfs", "hdfs_hdfs.build.opensearch.org.keytab")
           )
         }
       }

--- a/test/fixtures/krb5kdc-fixture/Dockerfile
+++ b/test/fixtures/krb5kdc-fixture/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 ADD . /fixture
-RUN echo kerberos.build.elastic.co > /etc/hostname && echo "127.0.0.1 kerberos.build.elastic.co" >> /etc/hosts
+RUN echo kerberos.build.opensearch.org > /etc/hostname && echo "127.0.0.1 kerberos.build.opensearch.org" >> /etc/hosts
 RUN bash /fixture/src/main/resources/provision/installkdc.sh
 
 EXPOSE 88

--- a/test/fixtures/krb5kdc-fixture/src/main/resources/provision/installkdc.sh
+++ b/test/fixtures/krb5kdc-fixture/src/main/resources/provision/installkdc.sh
@@ -91,7 +91,7 @@ cat << EOF > /etc/krb5kdc/kadm5.acl
 EOF
 
 # Create admin principal
-kadmin.local -q "addprinc -pw elastic admin/admin@$REALM_NAME"
+kadmin.local -q "addprinc -pw opensearch admin/admin@$REALM_NAME"
 kadmin.local -q "ktadd -k /etc/admin.keytab admin/admin@$REALM_NAME"
 
 # Create a link so addprinc.sh is on path


### PR DESCRIPTION
### Description
There are a bunch of new commits that are in `main` branch, but not in `javadoc` branch.
According to issue # 441, in `main` branch, nearly all the test failures are fixed, besides, some variables were renamed.
This PR requests to merge current `main` branch to `javadoc` branch, so that `javadoc` branch can have the above enhancements.
 
### Issues Resolved
- No
 
### Check List
~~- [ ] New functionality includes testing.~~
  ~~- [ ] All tests pass~~
~~- [ ] New functionality has been documented.~~
  ~~- [ ] New functionality has javadoc added~~
~~- [ ] Commits are signed per the DCO using --signoff~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
