### PR TITLE
Handle inefficiencies while fetching the delayed unassigned shards during cluster health

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/IndexRoutingTable.java
@@ -46,6 +46,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * The {@link IndexRoutingTable} represents routing information for a single
@@ -263,6 +264,14 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
             shards.addAll(shardRoutingTable.shardsWithState(state));
         }
         return shards;
+    }
+
+    public int shardsMatchingPredicateCount(Predicate<ShardRouting> predicate) {
+        int count = 0;
+        for (IndexShardRoutingTable shardRoutingTable : this) {
+            count += shardRoutingTable.shardsMatchingPredicateCount(predicate);
+        }
+        return count;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/IndexShardRoutingTable.java
@@ -43,6 +43,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import static java.util.Collections.emptyMap;
 
@@ -657,6 +658,16 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
             }
         }
         return shards;
+    }
+
+    public int shardsMatchingPredicateCount(Predicate<ShardRouting> predicate) {
+        int count = 0;
+        for (ShardRouting shardEntry : this) {
+            if (predicate.test(shardEntry)) {
+                count++;
+            }
+        }
+        return count;
     }
 
     public static class Builder {

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
@@ -183,6 +183,14 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
         return shards;
     }
 
+    public int shardsMatchingPredicateCount(Predicate<ShardRouting> predicate) {
+        int count = 0;
+        for (IndexRoutingTable indexRoutingTable : this) {
+            count += indexRoutingTable.shardsMatchingPredicateCount(predicate);
+        }
+        return count;
+    }
+
     /**
      * All the shards (replicas) for all indices in this routing table.
      *

--- a/server/src/main/java/org/opensearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/UnassignedInfo.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Holds additional information as to why the shard is in unassigned state.
@@ -400,13 +401,8 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
      * Returns the number of shards that are unassigned and currently being delayed.
      */
     public static int getNumberOfDelayedUnassigned(ClusterState state) {
-        int count = 0;
-        for (ShardRouting shard : state.routingTable().shardsWithState(ShardRoutingState.UNASSIGNED)) {
-            if (shard.unassignedInfo().isDelayed()) {
-                count++;
-            }
-        }
-        return count;
+        Predicate<ShardRouting> predicate = s -> s.state() == ShardRoutingState.UNASSIGNED && s.unassignedInfo().isDelayed();
+        return state.routingTable().shardsMatchingPredicateCount(predicate);
     }
 
     /**

--- a/server/src/test/java/org/opensearch/cluster/routing/RoutingTableTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/RoutingTableTests.java
@@ -186,6 +186,7 @@ public class RoutingTableTests extends OpenSearchAllocationTestCase {
 
         Predicate<ShardRouting> predicate = s -> s.state() == ShardRoutingState.UNASSIGNED && s.unassignedInfo().isDelayed();
         assertThat(clusterState.routingTable().shardsMatchingPredicateCount(predicate), is(0));
+
         // starting primaries
         clusterState = startInitializingShardsAndReroute(allocation, clusterState);
         // starting replicas

--- a/server/src/test/java/org/opensearch/cluster/routing/RoutingTableTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/RoutingTableTests.java
@@ -37,6 +37,7 @@ import org.junit.Before;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.function.Predicate;
 
 import static org.opensearch.cluster.routing.ShardRoutingState.UNASSIGNED;
 import static org.hamcrest.Matchers.containsString;
@@ -168,6 +169,32 @@ public class RoutingTableTests extends OpenSearchAllocationTestCase {
         startInitializingShards(TEST_INDEX_1);
         startInitializingShards(TEST_INDEX_2);
         assertThat(clusterState.routingTable().shardsWithState(ShardRoutingState.STARTED).size(), is(this.totalNumberOfShards));
+    }
+
+    public void testShardsMatchingPredicateCount(){
+        MockAllocationService allocation = createAllocationService(Settings.EMPTY, new DelayedShardsMockGatewayAllocator());
+        Metadata metadata = Metadata.builder()
+            .put(IndexMetadata.builder("test1").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
+            .put(IndexMetadata.builder("test2").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
+            .build();
+        ClusterState clusterState = ClusterState.builder(org.opensearch.cluster.ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata)
+            .routingTable(RoutingTable.builder().addAsNew(metadata.index("test1")).addAsNew(metadata.index("test2")).build()).build();
+        clusterState = ClusterState.builder(clusterState)
+            .nodes(DiscoveryNodes.builder().add(newNode("node1")).add(newNode("node2"))).build();
+        clusterState = allocation.reroute(clusterState, "reroute");
+
+        Predicate<ShardRouting> predicate = s -> s.state() == ShardRoutingState.UNASSIGNED && s.unassignedInfo().isDelayed();
+        assertThat(clusterState.routingTable().shardsMatchingPredicateCount(predicate), is(0));
+        // starting primaries
+        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+        // starting replicas
+        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
+        // remove node2 and reroute
+        clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).remove("node2")).build();
+        // make sure both replicas are marked as delayed (i.e. not reallocated)
+        clusterState = allocation.disassociateDeadNodes(clusterState, true, "reroute");
+        assertThat(clusterState.routingTable().shardsMatchingPredicateCount(predicate), is(2));
     }
 
     public void testActivePrimaryShardsGrouped() {


### PR DESCRIPTION
Signed-off-by: Meet Shah <meetsh@amazon.com>

### Description
During cluster health, to return the delayed_unassigned_shards count, OS iterates through all of the shards to filter for unassigned shards and adds them to an array and fetches the delayed unassigned shards count from the array. With this change, we iterate through the shards once and maintain a count of shards that match our predicate without creating an array. 

### Testing
./gradlew :server:test -Drepos.mavenLocal=true -Dtests.class=org.opensearch.cluster.routing.*
./gradlew ':server:internalClusterTest' --tests "org.opensearch.cluster.routing.*"
 
### Issues Resolved
closes #506 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
