### PR TITLE
[License] Update SPDX License Header

### DIFF
--- a/buildSrc/src/main/resources/license-headers/oss-license-header.txt
+++ b/buildSrc/src/main/resources/license-headers/oss-license-header.txt
@@ -1,2 +1,7 @@
-// Copyright OpenSearch Contributors.
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */

--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -77,10 +77,13 @@ if (System.getProperty('idea.active') == 'true') {
           useDefault = 'Apache'
           profiles {
             Apache {
-              keyword = 'Copyright OpenSearch Contributors.'
+              keyword = 'SPDX-License-Identifier: Apache-2.0'
               notice = '''\
-               Copyright OpenSearch Contributors.
-               SPDX-License-Identifier: Apache-2.0'''.stripIndent()
+               SPDX-License-Identifier: Apache-2.0
+
+               The OpenSearch Contributors require contributions made to
+               this file be licensed under the Apache-2.0 license or a
+               compatible open source license.'''.stripIndent()
             }
           }
         }


### PR DESCRIPTION
This PR updates the SPDX License Header for all new files created by OpenSearch contributors to the following:

/*
 * SPDX-License-Identifier: Apache-2.0
 *
 * The OpenSearch Contributors require contributions made to
 * this file be licensed under the Apache-2.0 license or a 
 * compatible open source license.
 */

relates #155 
