### PR TITLE
[Rename] Remove final references to legacy keystore

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.reload_secure_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.reload_secure_settings.json
@@ -34,7 +34,7 @@
       }
     },
     "body": {
-      "description": "An object containing the password for the elasticsearch keystore",
+      "description": "An object containing the password for the opensearch keystore",
       "required": false
     }
   }


### PR DESCRIPTION
This PR refactors a remaining reference to the legacy keystore. This is likely not used but left for posterity.
