### PR TITLE
[Rename] Rename the references to xpack and elastic in tests.

### DIFF
--- a/libs/ssl-config/src/test/java/org/opensearch/common/ssl/SslDiagnosticsTests.java
+++ b/libs/ssl-config/src/test/java/org/opensearch/common/ssl/SslDiagnosticsTests.java
@@ -73,14 +73,14 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
         final SSLSession session = session("192.168.1.1");
         final Map<String, List<X509Certificate>> trustIssuers = trust("ca1/ca.crt", "ca2/ca.crt", "ca3/ca.crt");
         final String message = SslDiagnostics.getTrustDiagnosticFailure(chain, SslDiagnostics.PeerType.SERVER, session,
-            "xpack.http.ssl", trustIssuers);
+            "foo.http.ssl", trustIssuers);
         assertThat(message, Matchers.equalTo("failed to establish trust with server at [192.168.1.1];" +
             " the server provided a certificate with subject name [CN=cert1] and fingerprint [3bebe388a66362784afd6c51a9000961a4e10050];" +
             " the certificate has subject alternative names [DNS:localhost,IP:127.0.0.1];" +
             " the certificate is issued by [CN=Test CA 1];" +
             " the certificate is signed by" +
             " (subject [CN=Test CA 1] fingerprint [2b7b0416391bdf86502505c23149022d2213dadc] {trusted issuer})" +
-            " which is self-issued; the [CN=Test CA 1] certificate is trusted in this ssl context ([xpack.http.ssl])"));
+            " which is self-issued; the [CN=Test CA 1] certificate is trusted in this ssl context ([foo.http.ssl])"));
     }
 
     public void testDiagnosticMessageWhenServerProvidesAFullCertChainThatIsntTrusted() throws Exception {
@@ -88,13 +88,13 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
         final SSLSession session = session("192.168.1.1");
         final Map<String, List<X509Certificate>> trustIssuers = trust("ca2/ca.crt", "ca3/ca.crt");
         final String message = SslDiagnostics.getTrustDiagnosticFailure(chain, SslDiagnostics.PeerType.SERVER, session,
-            "xpack.http.ssl", trustIssuers);
+            "foo.http.ssl", trustIssuers);
         assertThat(message, Matchers.equalTo("failed to establish trust with server at [192.168.1.1];" +
             " the server provided a certificate with subject name [CN=cert1] and fingerprint [3bebe388a66362784afd6c51a9000961a4e10050];" +
             " the certificate has subject alternative names [DNS:localhost,IP:127.0.0.1];" +
             " the certificate is issued by [CN=Test CA 1];" +
             " the certificate is signed by (subject [CN=Test CA 1] fingerprint [2b7b0416391bdf86502505c23149022d2213dadc])" +
-            " which is self-issued; the [CN=Test CA 1] certificate is not trusted in this ssl context ([xpack.http.ssl])"));
+            " which is self-issued; the [CN=Test CA 1] certificate is not trusted in this ssl context ([foo.http.ssl])"));
     }
 
     public void testDiagnosticMessageWhenServerFullCertChainIsntTrustedButMimicIssuerExists() throws Exception {
@@ -102,13 +102,13 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
         final SSLSession session = session("192.168.1.1");
         final Map<String, List<X509Certificate>> trustIssuers = trust("ca1-b/ca.crt", "ca2/ca.crt", "ca3/ca.crt");
         final String message = SslDiagnostics.getTrustDiagnosticFailure(chain, SslDiagnostics.PeerType.SERVER, session,
-            "xpack.http.ssl", trustIssuers);
+            "foo.http.ssl", trustIssuers);
         assertThat(message, Matchers.equalTo("failed to establish trust with server at [192.168.1.1];" +
             " the server provided a certificate with subject name [CN=cert1] and fingerprint [3bebe388a66362784afd6c51a9000961a4e10050];" +
             " the certificate has subject alternative names [DNS:localhost,IP:127.0.0.1];" +
             " the certificate is issued by [CN=Test CA 1];" +
             " the certificate is signed by (subject [CN=Test CA 1] fingerprint [2b7b0416391bdf86502505c23149022d2213dadc])" +
-            " which is self-issued; the [CN=Test CA 1] certificate is not trusted in this ssl context ([xpack.http.ssl]);" +
+            " which is self-issued; the [CN=Test CA 1] certificate is not trusted in this ssl context ([foo.http.ssl]);" +
             " this ssl context does trust a certificate with subject [CN=Test CA 1]" +
             " but the trusted certificate has fingerprint [b095bf2526be20783e1f26dfd69c7aae910e3663]"));
     }
@@ -118,14 +118,14 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
         final SSLSession session = session("192.168.1.1");
         final Map<String, List<X509Certificate>> trustIssuers = trust("ca1/ca.crt", "ca2/ca.crt", "ca3/ca.crt");
         final String message = SslDiagnostics.getTrustDiagnosticFailure(chain, SslDiagnostics.PeerType.SERVER, session,
-            "xpack.http.ssl", trustIssuers);
+            "foo.http.ssl", trustIssuers);
         assertThat(message, Matchers.equalTo("failed to establish trust with server at [192.168.1.1];" +
             " the server provided a certificate with subject name [CN=cert1] and fingerprint [3bebe388a66362784afd6c51a9000961a4e10050];" +
             " the certificate has subject alternative names [DNS:localhost,IP:127.0.0.1];" +
             " the certificate is issued by [CN=Test CA 1]" +
             " but the server did not provide a copy of the issuing certificate in the certificate chain;" +
             " the issuing certificate with fingerprint [2b7b0416391bdf86502505c23149022d2213dadc]" +
-            " is trusted in this ssl context ([xpack.http.ssl])"));
+            " is trusted in this ssl context ([foo.http.ssl])"));
     }
 
     public void testDiagnosticMessageWhenServerProvidesEndCertificateOnlyButTheCertAuthIsNotTrusted() throws Exception {
@@ -133,13 +133,13 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
         final SSLSession session = session("192.168.1.1");
         final Map<String, List<X509Certificate>> trustIssuers = trust("ca2/ca.crt", "ca3/ca.crt");
         final String message = SslDiagnostics.getTrustDiagnosticFailure(chain, SslDiagnostics.PeerType.SERVER, session,
-            "xpack.http.ssl", trustIssuers);
+            "foo.http.ssl", trustIssuers);
         assertThat(message, Matchers.equalTo("failed to establish trust with server at [192.168.1.1];" +
             " the server provided a certificate with subject name [CN=cert1] and fingerprint [3bebe388a66362784afd6c51a9000961a4e10050];" +
             " the certificate has subject alternative names [DNS:localhost,IP:127.0.0.1];" +
             " the certificate is issued by [CN=Test CA 1]" +
             " but the server did not provide a copy of the issuing certificate in the certificate chain;" +
-            " this ssl context ([xpack.http.ssl]) is not configured to trust that issuer"));
+            " this ssl context ([foo.http.ssl]) is not configured to trust that issuer"));
     }
 
     public void testDiagnosticMessageWhenServerProvidesEndCertificateOnlyWithMimicIssuer() throws Exception {
@@ -147,13 +147,13 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
         final SSLSession session = session("192.168.1.1");
         final Map<String, List<X509Certificate>> trustIssuers = trust("ca1-b/ca.crt", "ca2/ca.crt", "ca3/ca.crt");
         final String message = SslDiagnostics.getTrustDiagnosticFailure(chain, SslDiagnostics.PeerType.SERVER, session,
-            "xpack.http.ssl", trustIssuers);
+            "foo.http.ssl", trustIssuers);
         assertThat(message, Matchers.equalTo("failed to establish trust with server at [192.168.1.1];" +
             " the server provided a certificate with subject name [CN=cert1] and fingerprint [3bebe388a66362784afd6c51a9000961a4e10050];" +
             " the certificate has subject alternative names [DNS:localhost,IP:127.0.0.1];" +
             " the certificate is issued by [CN=Test CA 1]" +
             " but the server did not provide a copy of the issuing certificate in the certificate chain;" +
-            " this ssl context ([xpack.http.ssl]) trusts [1] certificate with subject name [CN=Test CA 1]" +
+            " this ssl context ([foo.http.ssl]) trusts [1] certificate with subject name [CN=Test CA 1]" +
             " and fingerprint [b095bf2526be20783e1f26dfd69c7aae910e3663] but the signatures do not match"));
     }
 
@@ -163,13 +163,13 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
         final X509Certificate ca1b = loadCertificate("ca1-b/ca.crt");
         final Map<String, List<X509Certificate>> trustIssuers = trust(ca1b, cloneCertificateAsMock(ca1b));
         final String message = SslDiagnostics.getTrustDiagnosticFailure(chain, SslDiagnostics.PeerType.SERVER, session,
-            "xpack.http.ssl", trustIssuers);
+            "foo.http.ssl", trustIssuers);
         assertThat(message, Matchers.equalTo("failed to establish trust with server at [192.168.1.9];" +
             " the server provided a certificate with subject name [CN=cert1] and fingerprint [3bebe388a66362784afd6c51a9000961a4e10050];" +
             " the certificate has subject alternative names [DNS:localhost,IP:127.0.0.1];" +
             " the certificate is issued by [CN=Test CA 1]" +
             " but the server did not provide a copy of the issuing certificate in the certificate chain;" +
-            " this ssl context ([xpack.http.ssl]) trusts [2] certificates with subject name [CN=Test CA 1]" +
+            " this ssl context ([foo.http.ssl]) trusts [2] certificates with subject name [CN=Test CA 1]" +
             " and fingerprint [b095bf2526be20783e1f26dfd69c7aae910e3663], fingerprint [" + MOCK_FINGERPRINT_1 + "]" +
             " but the signatures do not match"));
     }
@@ -189,7 +189,7 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
         final SSLSession session = session("192.168.1.5");
         final Map<String, List<X509Certificate>> trustIssuers = trust(issuingCA, rootCA);
         final String message = SslDiagnostics.getTrustDiagnosticFailure(chain, SslDiagnostics.PeerType.SERVER, session,
-            "xpack.security.authc.realms.ldap.ldap1.ssl", trustIssuers);
+            "foo.security.authc.realms.ldap.ldap1.ssl", trustIssuers);
         assertThat(message, Matchers.equalTo("failed to establish trust with server at [192.168.1.5];" +
             " the server provided a certificate with subject name [CN=elastic1,OU=windows,DC=example,DC=com]" +
             " and fingerprint [" + MOCK_FINGERPRINT_4 + "];" +
@@ -200,7 +200,7 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
             " signed by (subject [CN=issuing-ca,DC=example,DC=com] fingerprint [" + MOCK_FINGERPRINT_2 + "] {trusted issuer})" +
             " which is issued by [CN=root-ca,DC=example,DC=com] (but that issuer certificate was not provided in the chain);" +
             " the issuing certificate with fingerprint [" + MOCK_FINGERPRINT_1 + "]" +
-            " is trusted in this ssl context ([xpack.security.authc.realms.ldap.ldap1.ssl])"));
+            " is trusted in this ssl context ([foo.security.authc.realms.ldap.ldap1.ssl])"));
     }
 
     public void testDiagnosticMessageWhenServerProvidePartialChainFromUntrustedCA() throws Exception {
@@ -218,7 +218,7 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
         final SSLSession session = session("192.168.1.6");
         final Map<String, List<X509Certificate>> trustIssuers = trust(Collections.emptyList());
         final String message = SslDiagnostics.getTrustDiagnosticFailure(chain, SslDiagnostics.PeerType.SERVER, session,
-            "xpack.security.authc.realms.ldap.ldap1.ssl", trustIssuers);
+            "foo.security.authc.realms.ldap.ldap1.ssl", trustIssuers);
         assertThat(message, Matchers.equalTo("failed to establish trust with server at [192.168.1.6];" +
             " the server provided a certificate with subject name [CN=elastic1,OU=windows,DC=example,DC=com]" +
             " and fingerprint [" + MOCK_FINGERPRINT_4 + "];" +
@@ -228,7 +228,7 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
             " signed by (subject [CN=ca,OU=windows,DC=example,DC=com] fingerprint [" + MOCK_FINGERPRINT_3 + "])" +
             " signed by (subject [CN=issuing-ca,DC=example,DC=com] fingerprint [" + MOCK_FINGERPRINT_2 + "])" +
             " which is issued by [CN=root-ca,DC=example,DC=com] (but that issuer certificate was not provided in the chain);" +
-            " this ssl context ([xpack.security.authc.realms.ldap.ldap1.ssl]) is not configured to trust that issuer"));
+            " this ssl context ([foo.security.authc.realms.ldap.ldap1.ssl]) is not configured to trust that issuer"));
     }
 
     public void testDiagnosticMessageWhenServerProvidesASelfSignedCertThatIsDirectlyTrusted() throws Exception {
@@ -236,12 +236,12 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
         final SSLSession session = session("192.168.1.1");
         final Map<String, List<X509Certificate>> trustIssuers = trust("ca1/ca.crt", "ca2/ca.crt");
         final String message = SslDiagnostics.getTrustDiagnosticFailure(chain, SslDiagnostics.PeerType.SERVER, session,
-            "xpack.http.ssl", trustIssuers);
+            "foo.http.ssl", trustIssuers);
         assertThat(message, Matchers.equalTo("failed to establish trust with server at [192.168.1.1];" +
             " the server provided a certificate with subject name [CN=Test CA 1]" +
             " and fingerprint [2b7b0416391bdf86502505c23149022d2213dadc];" +
             " the certificate does not have any subject alternative names;" +
-            " the certificate is self-issued; the [CN=Test CA 1] certificate is trusted in this ssl context ([xpack.http.ssl])"));
+            " the certificate is self-issued; the [CN=Test CA 1] certificate is trusted in this ssl context ([foo.http.ssl])"));
     }
 
     public void testDiagnosticMessageWhenServerProvidesASelfSignedCertThatIsNotTrusted() throws Exception {
@@ -249,12 +249,12 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
         final SSLSession session = session("192.168.10.10");
         final Map<String, List<X509Certificate>> trustIssuers = Collections.emptyMap();
         final String message = SslDiagnostics.getTrustDiagnosticFailure(chain, SslDiagnostics.PeerType.SERVER, session,
-            "xpack.http.ssl", trustIssuers);
+            "foo.http.ssl", trustIssuers);
         assertThat(message, Matchers.equalTo("failed to establish trust with server at [192.168.10.10];" +
             " the server provided a certificate with subject name [CN=Test CA 1]" +
             " and fingerprint [2b7b0416391bdf86502505c23149022d2213dadc];" +
             " the certificate does not have any subject alternative names;" +
-            " the certificate is self-issued; the [CN=Test CA 1] certificate is not trusted in this ssl context ([xpack.http.ssl])"));
+            " the certificate is self-issued; the [CN=Test CA 1] certificate is not trusted in this ssl context ([foo.http.ssl])"));
     }
 
     public void testDiagnosticMessageWhenServerProvidesASelfSignedCertWithMimicName() throws Exception {
@@ -262,12 +262,12 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
         final SSLSession session = session("192.168.1.1");
         final Map<String, List<X509Certificate>> trustIssuers = trust("ca1-b/ca.crt", "ca2/ca.crt");
         final String message = SslDiagnostics.getTrustDiagnosticFailure(chain, SslDiagnostics.PeerType.SERVER, session,
-            "xpack.http.ssl", trustIssuers);
+            "foo.http.ssl", trustIssuers);
         assertThat(message, Matchers.equalTo("failed to establish trust with server at [192.168.1.1];" +
             " the server provided a certificate with subject name [CN=Test CA 1]" +
             " and fingerprint [2b7b0416391bdf86502505c23149022d2213dadc];" +
             " the certificate does not have any subject alternative names;" +
-            " the certificate is self-issued; the [CN=Test CA 1] certificate is not trusted in this ssl context ([xpack.http.ssl]);" +
+            " the certificate is self-issued; the [CN=Test CA 1] certificate is not trusted in this ssl context ([foo.http.ssl]);" +
             " this ssl context does trust a certificate with subject [CN=Test CA 1]" +
             " but the trusted certificate has fingerprint [b095bf2526be20783e1f26dfd69c7aae910e3663]"));
     }
@@ -277,7 +277,7 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
         final SSLSession session = session("192.168.1.2");
         final Map<String, List<X509Certificate>> trustIssuers = Collections.emptyMap();
         final String message = SslDiagnostics.getTrustDiagnosticFailure(chain, SslDiagnostics.PeerType.SERVER, session,
-            "xpack.http.ssl", trustIssuers);
+            "foo.http.ssl", trustIssuers);
         assertThat(message, Matchers.equalTo("failed to establish trust with server at [192.168.1.2];" +
             " the server did not provide a certificate"));
     }
@@ -291,13 +291,13 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
         final SSLSession session = session("192.168.1.3");
         final Map<String, List<X509Certificate>> trustIssuers = trust(certificate);
         final String message = SslDiagnostics.getTrustDiagnosticFailure(chain, SslDiagnostics.PeerType.SERVER, session,
-            "xpack.monitoring.exporters.elastic-cloud.ssl", trustIssuers);
+            "foo.monitoring.exporters.opensearch.ssl", trustIssuers);
         assertThat(message, Matchers.equalTo("failed to establish trust with server at [192.168.1.3];" +
             " the server provided a certificate with subject name [CN=foo,DC=example,DC=com]" +
             " and fingerprint [" + MOCK_FINGERPRINT_1 + "];" +
             " the certificate does not have any DNS/IP subject alternative names;" +
             " the certificate is self-issued;" +
-            " the [CN=foo,DC=example,DC=com] certificate is trusted in this ssl context ([xpack.monitoring.exporters.elastic-cloud.ssl])"));
+            " the [CN=foo,DC=example,DC=com] certificate is trusted in this ssl context ([foo.monitoring.exporters.opensearch.ssl])"));
     }
 
     public void testDiagnosticMessageWhenACertificateHasAnInvalidEncoding() throws Exception {
@@ -309,13 +309,13 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
         final SSLSession session = session("192.168.1.6");
         final Map<String, List<X509Certificate>> trustIssuers = trust(Collections.emptyList());
         final String message = SslDiagnostics.getTrustDiagnosticFailure(chain, SslDiagnostics.PeerType.SERVER, session,
-            "xpack.security.transport.ssl", trustIssuers);
+            "foo.security.transport.ssl", trustIssuers);
         assertThat(message, Matchers.equalTo("failed to establish trust with server at [192.168.1.6];" +
             " the server provided a certificate with subject name [CN=foo,DC=example,DC=com]" +
             " and invalid encoding [java.security.cert.CertificateEncodingException: MOCK INVALID ENCODING];" +
             " the certificate does not have any subject alternative names;" +
             " the certificate is self-issued;" +
-            " the [CN=foo,DC=example,DC=com] certificate is not trusted in this ssl context ([xpack.security.transport.ssl])"));
+            " the [CN=foo,DC=example,DC=com] certificate is not trusted in this ssl context ([foo.security.transport.ssl])"));
     }
 
     public void testDiagnosticMessageForClientCertificate() throws Exception {
@@ -324,14 +324,14 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
         final SSLSession session = session("192.168.1.7");
         final Map<String, List<X509Certificate>> trustIssuers = trust("ca1/ca.crt");
         final String message = SslDiagnostics.getTrustDiagnosticFailure(chain, SslDiagnostics.PeerType.CLIENT, session,
-            "xpack.security.transport.ssl", trustIssuers);
+            "foo.security.transport.ssl", trustIssuers);
         assertThat(message, Matchers.equalTo("failed to establish trust with client at [192.168.1.7];" +
             " the client provided a certificate with subject name [CN=cert1]" +
             " and fingerprint [3bebe388a66362784afd6c51a9000961a4e10050];" +
             " the certificate is issued by [CN=Test CA 1]" +
             " but the client did not provide a copy of the issuing certificate in the certificate chain;" +
             " the issuing certificate with fingerprint [2b7b0416391bdf86502505c23149022d2213dadc]" +
-            " is trusted in this ssl context ([xpack.security.transport.ssl])"));
+            " is trusted in this ssl context ([foo.security.transport.ssl])"));
     }
 
     public void testDiagnosticMessageWhenCaHasNewIssuingCertificate() throws Exception {
@@ -348,7 +348,7 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
         final SSLSession session = session("192.168.1.4");
         final Map<String, List<X509Certificate>> trustIssuers = trust(oldCaCert);
         final String message = SslDiagnostics.getTrustDiagnosticFailure(chain, SslDiagnostics.PeerType.SERVER, session,
-            "xpack.security.authc.realms.saml.saml1.ssl", trustIssuers);
+            "foo.security.authc.realms.saml.saml1.ssl", trustIssuers);
         assertThat(message, Matchers.equalTo("failed to establish trust with server at [192.168.1.4];" +
             " the server provided a certificate with subject name [CN=cert1] and fingerprint [3bebe388a66362784afd6c51a9000961a4e10050];" +
             " the certificate has subject alternative names [DNS:localhost,IP:127.0.0.1];" +
@@ -356,7 +356,7 @@ public class SslDiagnosticsTests extends OpenSearchTestCase {
             " the certificate is signed by (subject [CN=Test CA 1]" +
             " fingerprint [2b7b0416391bdf86502505c23149022d2213dadc] {trusted issuer})" +
             " which is self-issued;" +
-            " the [CN=Test CA 1] certificate is trusted in this ssl context ([xpack.security.authc.realms.saml.saml1.ssl])" +
+            " the [CN=Test CA 1] certificate is trusted in this ssl context ([foo.security.authc.realms.saml.saml1.ssl])" +
             " because we trust a certificate with fingerprint [1f8ac10f23c5b5bc1167bda84b833e5c057a77d2]" +
             " for the same public key"));
     }


### PR DESCRIPTION
### Description

This PR removes some dangling references to xpack and elastic from the tests in ssl-config.

### Check List
- [x] All tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>
