### PR TITLE
Use the correct domain to fix failing integration tests.

### DIFF
--- a/plugins/repository-gcs/src/test/java/org/opensearch/repositories/gcs/GoogleCloudStorageClientSettingsTests.java
+++ b/plugins/repository-gcs/src/test/java/org/opensearch/repositories/gcs/GoogleCloudStorageClientSettingsTests.java
@@ -153,10 +153,9 @@ public class GoogleCloudStorageClientSettingsTests extends OpenSearchTestCase {
         secureSettings.setFile(CREDENTIALS_FILE_SETTING.getConcreteSettingForNamespace(clientName).getKey(), credentials.v2());
 
         String endpoint;
-        // TODO: use openearch.co, will update once finalized
         if (randomBoolean()) {
-            endpoint = randomFrom("http://www.opensearch.co", "http://metadata.google.com:88/oauth", "https://www.googleapis.com",
-                    "https://www.opensearch.co:443", "http://localhost:8443", "https://www.googleapis.com/oauth/token");
+            endpoint = randomFrom("http://www.opensearch.org", "http://metadata.google.com:88/oauth", "https://www.googleapis.com",
+                    "https://www.opensearch.org:443", "http://localhost:8443", "https://www.googleapis.com/oauth/token");
             settings.put(ENDPOINT_SETTING.getConcreteSettingForNamespace(clientName).getKey(), endpoint);
         } else {
             endpoint = ENDPOINT_SETTING.getDefault(Settings.EMPTY);

--- a/plugins/repository-gcs/src/test/java/org/opensearch/repositories/gcs/GoogleCloudStorageServiceTests.java
+++ b/plugins/repository-gcs/src/test/java/org/opensearch/repositories/gcs/GoogleCloudStorageServiceTests.java
@@ -62,9 +62,8 @@ public class GoogleCloudStorageServiceTests extends OpenSearchTestCase {
         final TimeValue connectTimeValue = TimeValue.timeValueNanos(randomIntBetween(0, 2000000));
         final TimeValue readTimeValue = TimeValue.timeValueNanos(randomIntBetween(0, 2000000));
         final String applicationName = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
-        // TODO: use www.opensearch.co now, will update once finalized
         final String endpoint = randomFrom("http://", "https://")
-                + randomFrom("www.opensearch.co", "www.googleapis.com", "localhost/api", "google.com/oauth")
+                + randomFrom("www.opensearch.org", "www.googleapis.com", "localhost/api", "google.com/oauth")
                 + ":" + randomIntBetween(1, 65535);
         final String projectIdName = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
         final Settings settings = Settings.builder()

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/20_repository_create.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/20_repository_create.yml
@@ -13,7 +13,7 @@
               uri: "hdfs://localhost:9998"
               path: "/user/opensearch/test/repository_create"
               security:
-                principal: "opensearch@BUILD.OPENSEARCH.CO"
+                principal: "opensearch@BUILD.OPENSEARCH.ORG"
 
     # Get repository
     - do:

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/20_repository_delete.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/20_repository_delete.yml
@@ -13,7 +13,7 @@
               uri: "hdfs://localhost:9998"
               path: "/user/opensearch/foo/bar"
               security:
-                principal: "opensearch@BUILD.OPENSEARCH.CO"
+                principal: "opensearch@BUILD.OPENSEARCH.ORG"
 
     # Get repository
     - do:
@@ -44,7 +44,7 @@
               uri: "hdfs://localhost:9998"
               path: "/user/opensearch/foo/bar"
               security:
-                principal: "opensearch@BUILD.OPENSEARCH.CO"
+                principal: "opensearch@BUILD.OPENSEARCH.ORG"
 
     # Get repository again
     - do:

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/20_repository_verify.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/20_repository_verify.yml
@@ -12,7 +12,7 @@
               uri: "hdfs://localhost:9998"
               path: "/user/opensearch/test/repository_verify"
               security:
-                principal: "opensearch@BUILD.OPENSEARCH.CO"
+                principal: "opensearch@BUILD.OPENSEARCH.ORG"
 
     # Verify repository
     - do:

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/30_snapshot.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/30_snapshot.yml
@@ -14,7 +14,7 @@
             uri: "hdfs://localhost:9998"
             path: "/user/opensearch/test/snapshot"
             security:
-              principal: "opensearch@BUILD.OPENSEARCH.CO"
+              principal: "opensearch@BUILD.OPENSEARCH.ORG"
 
   # Create index
   - do:

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/30_snapshot_get.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/30_snapshot_get.yml
@@ -14,7 +14,7 @@
             uri: "hdfs://localhost:9998"
             path: "/user/opensearch/test/snapshot_get"
             security:
-              principal: "opensearch@BUILD.OPENSEARCH.CO"
+              principal: "opensearch@BUILD.OPENSEARCH.ORG"
 
   # Create index
   - do:

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/30_snapshot_readonly.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/30_snapshot_readonly.yml
@@ -14,7 +14,7 @@
             uri: "hdfs://localhost:9998"
             path: "/user/opensearch/existing/readonly-repository"
             security:
-              principal: "opensearch@BUILD.OPENSEARCH.CO"
+              principal: "opensearch@BUILD.OPENSEARCH.ORG"
             readonly: true
 
   # List snapshot info

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/40_restore.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/40_restore.yml
@@ -15,7 +15,7 @@
             uri: "hdfs://localhost:9998"
             path: "/user/opensearch/test/restore"
             security:
-              principal: "opensearch@BUILD.OPENSEARCH.CO"
+              principal: "opensearch@BUILD.OPENSEARCH.ORG"
 
   # Create index
   - do:


### PR DESCRIPTION
### Description

This commit fixes a renaming issue (opensearch.co -> opensearch.org) which was causing few integration test failures (reproduce with `/.gradlew :plugins:repository-hdfs:integTestSecure`)

### Issues Resolved

Relates #441 
 
### Check List
- [x] All tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>