### PR TITLE
Added a maintainers file based on the maintainers list that CEHENKLE posted

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,13 @@
+# OpenSearch Maintainers
+
+## Maintainers
+| Maintainer | GitHub ID | Affiliation |
+| --------------- | --------- | ----------- |
+| Abbas Hussain | [abbashus](https://github.com/abbashus) | Amazon |
+| Charlotte | [CEHENKLE](https://github.com/CEHENKLE) | Amazon |
+| Harold Wang | [harold-wang](https://github.com/harold-wang) | Amazon |
+| Himanshu Setia | [setiah](https://github.com/setiah) | Amazon |
+| Nick Knize | [nknize](https://github.com/nknize) | Amazon | 
+| Rabi Panda | [adnapibar](adnapibar) | Amazon |
+| Sarat Vemulapalli | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon |
+| Tianli Feng | [tlfeng](https://github.com/tlfeng) | Amazon |


### PR DESCRIPTION
As @ke4qqq suggested, I converted the list of current maintainers found in [this forum post](https://discuss.opendistrocommunity.dev/t/preparing-opensearch-and-opensearch-dashboards-for-release/5567) for the OpenSearch section to a new maintainers file. 

If this looks good and is merged, I can do something similar in the OpenSearch Dashboards repo.

As I mentioned in the forums, I'm also happy to help out with governance and related docs like this one :)

Signed-off-by: Dawn M. Foster <fosterd@vmware.com>

