### PR TITLE
Remove extra greater-thans from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ Here are the principles we use to guide our development.  From [opensearch.org](
 >
 >**1. Great software**. If it doesn’t solve your problems, everything else is moot. It’s going to be software you love to use.
 >
->**2. Open source like we mean it**. We are invested in this being a successful open source project for the long term. It’s all Apache 2.0. There’s no Contributor License >Agreement. Easy.
+>**2. Open source like we mean it**. We are invested in this being a successful open source project for the long term. It’s all Apache 2.0. There’s no Contributor License Agreement. Easy.
 >
->**3. A level playing field**. We will not tweak the software so that it runs better for any vendor (including AWS) at the expense of others. If this happens, call it out and we >will fix it as a community.
+>**3. A level playing field**. We will not tweak the software so that it runs better for any vendor (including AWS) at the expense of others. If this happens, call it out and we will fix it as a community.
 >
 >**4. Used everywhere**. Our goal is for as many people as possible to use it in their business, their software, and their projects. Use it however you want. Surprise us!
 >
 >**5. Made with your input**. We will ask for public input on direction, requirements, and implementation for any feature we build.
 >
->**6. Open to contributions**. Great open source software is built together, with a diverse community of contributors. If you want to get involved at any level - big, small, or >huge - we will find a way to make that happen. We don’t know what that looks like yet, and we look forward to figuring it out together.
+>**6. Open to contributions**. Great open source software is built together, with a diverse community of contributors. If you want to get involved at any level - big, small, or huge - we will find a way to make that happen. We don’t know what that looks like yet, and we look forward to figuring it out together.
 >
 >**7. Respectful, approachable, and friendly**. This will be a community where you will be heard, accepted, and valued, whether you are a new or experienced user or contributor.
 >


### PR DESCRIPTION
Signed-off-by: Kyle Conroy <kyle@conroy.org>

### Description
Reading through the front page of the project I noticed a few extra characters had made it into the README.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
