### PR TITLE
Added support for passing http query parameters

### DIFF
--- a/client/rest-high-level/src/test/java/org/opensearch/client/HighLevelRestClientFilterPathIT.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/HighLevelRestClientFilterPathIT.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.client;
+
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class HighLevelRestClientFilterPathIT extends OpenSearchRestHighLevelClientTestCase {
+
+    private static final String SAMPLE_DOCUMENT = "{\"name\":{\"first name\":\"Steve\",\"last name\":\"Jobs\"}}";
+    private static final String FILTER_PATH_PARAM = "filter_path";
+    private static final String FILTER_PATH_PARAM_VALUE = "-hits.hits._index,-hits.hits._type,-hits.hits.matched_queries";
+
+    public void testUsingFilterPathWithHitsIndexResultsIntoEmptyIndexNameInInnerHit() throws IOException {
+        Request doc = new Request(HttpPut.METHOD_NAME, "/company_one/_doc/1");
+        doc.setJsonEntity(SAMPLE_DOCUMENT);
+        client().performRequest(doc);
+        client().performRequest(new Request(HttpPost.METHOD_NAME, "/_refresh"));
+
+        RequestOptions requestOptions = RequestOptions.DEFAULT.toBuilder()
+            .addParameter(FILTER_PATH_PARAM, FILTER_PATH_PARAM_VALUE)
+            .build();
+
+        SearchRequest searchRequest = new SearchRequest("company_one");
+        SearchResponse searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync, requestOptions);
+
+        assertThat(searchResponse.status().getStatus(), equalTo(200));
+        assertEquals(1L, searchResponse.getHits().getTotalHits().value);
+        assertNull(searchResponse.getHits().getHits()[0].getIndex());
+        assertEquals(SAMPLE_DOCUMENT, searchResponse.getHits().getHits()[0].getSourceAsString());
+    }
+
+    public void testNotUsingFilterPathResultsIntoIndexNameInInnerHit() throws IOException {
+        Request doc = new Request(HttpPut.METHOD_NAME, "/company_two/_doc/1");
+        doc.setJsonEntity(SAMPLE_DOCUMENT);
+        client().performRequest(doc);
+        client().performRequest(new Request(HttpPost.METHOD_NAME, "/_refresh"));
+
+        RequestOptions requestOptions = RequestOptions.DEFAULT;
+        SearchRequest searchRequest = new SearchRequest("company_two");
+        SearchResponse searchResponse = execute(searchRequest, highLevelClient()::search, highLevelClient()::searchAsync, requestOptions);
+
+        assertThat(searchResponse.status().getStatus(), equalTo(200));
+        assertEquals(1L, searchResponse.getHits().getTotalHits().value);
+        assertEquals("company_two", searchResponse.getHits().getHits()[0].getIndex());
+        assertEquals(SAMPLE_DOCUMENT, searchResponse.getHits().getHits()[0].getSourceAsString());
+    }
+
+}

--- a/client/rest/src/main/java/org/opensearch/client/RequestOptions.java
+++ b/client/rest/src/main/java/org/opensearch/client/RequestOptions.java
@@ -40,7 +40,9 @@ import org.opensearch.client.HttpAsyncResponseConsumerFactory.HeapBufferedRespon
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -52,15 +54,17 @@ public final class RequestOptions {
      * Default request options.
      */
     public static final RequestOptions DEFAULT = new Builder(
-            Collections.emptyList(), HeapBufferedResponseConsumerFactory.DEFAULT, null, null).build();
+        Collections.emptyList(), Collections.emptyMap(), HeapBufferedResponseConsumerFactory.DEFAULT, null, null).build();
 
     private final List<Header> headers;
+    private final Map<String, String> parameters;
     private final HttpAsyncResponseConsumerFactory httpAsyncResponseConsumerFactory;
     private final WarningsHandler warningsHandler;
     private final RequestConfig requestConfig;
 
     private RequestOptions(Builder builder) {
         this.headers = Collections.unmodifiableList(new ArrayList<>(builder.headers));
+        this.parameters = Collections.unmodifiableMap(builder.parameters);
         this.httpAsyncResponseConsumerFactory = builder.httpAsyncResponseConsumerFactory;
         this.warningsHandler = builder.warningsHandler;
         this.requestConfig = builder.requestConfig;
@@ -70,7 +74,7 @@ public final class RequestOptions {
      * Create a builder that contains these options but can be modified.
      */
     public Builder toBuilder() {
-        return new Builder(headers, httpAsyncResponseConsumerFactory, warningsHandler, requestConfig);
+        return new Builder(headers, parameters, httpAsyncResponseConsumerFactory, warningsHandler, requestConfig);
     }
 
     /**
@@ -78,6 +82,13 @@ public final class RequestOptions {
      */
     public List<Header> getHeaders() {
         return headers;
+    }
+
+    /**
+     * Parameters to attach to the request.
+     */
+    public Map<String, String> getParameters() {
+        return parameters;
     }
 
     /**
@@ -175,13 +186,16 @@ public final class RequestOptions {
      */
     public static class Builder {
         private final List<Header> headers;
+        private final Map<String, String> parameters;
         private HttpAsyncResponseConsumerFactory httpAsyncResponseConsumerFactory;
         private WarningsHandler warningsHandler;
         private RequestConfig requestConfig;
 
-        private Builder(List<Header> headers, HttpAsyncResponseConsumerFactory httpAsyncResponseConsumerFactory,
-                WarningsHandler warningsHandler, RequestConfig requestConfig) {
+        private Builder(List<Header> headers, Map<String, String> parameters,
+                        HttpAsyncResponseConsumerFactory httpAsyncResponseConsumerFactory,
+                        WarningsHandler warningsHandler, RequestConfig requestConfig) {
             this.headers = new ArrayList<>(headers);
+            this.parameters = new HashMap<>(parameters);
             this.httpAsyncResponseConsumerFactory = httpAsyncResponseConsumerFactory;
             this.warningsHandler = warningsHandler;
             this.requestConfig = requestConfig;
@@ -201,6 +215,16 @@ public final class RequestOptions {
             Objects.requireNonNull(name, "header name cannot be null");
             Objects.requireNonNull(value, "header value cannot be null");
             this.headers.add(new ReqHeader(name, value));
+            return this;
+        }
+
+        /**
+         * Add the provided parameter to the request.
+         */
+        public Builder addParameter(String key, String value) {
+            Objects.requireNonNull(key, "parameter key cannot be null");
+            Objects.requireNonNull(value, "parameter value cannot be null");
+            this.parameters.merge(key, value, (existingValue, newValue) -> String.join(",", existingValue, newValue));
             return this;
         }
 

--- a/client/rest/src/main/java/org/opensearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClient.java
@@ -752,6 +752,7 @@ public class RestClient implements Closeable {
         InternalRequest(Request request) {
             this.request = request;
             Map<String, String> params = new HashMap<>(request.getParameters());
+            params.putAll(request.getOptions().getParameters());
             //ignore is a special parameter supported by the clients, shouldn't be sent to es
             String ignoreString = params.remove("ignore");
             this.ignoreErrorCodes = getIgnoreErrorCodes(ignoreString, request.getMethod());

--- a/client/rest/src/test/java/org/opensearch/client/RequestOptionsTests.java
+++ b/client/rest/src/test/java/org/opensearch/client/RequestOptionsTests.java
@@ -38,7 +38,9 @@ import org.opensearch.client.HttpAsyncResponseConsumerFactory.HeapBufferedRespon
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -50,6 +52,7 @@ import static org.mockito.Mockito.mock;
 public class RequestOptionsTests extends RestClientTestCase {
     public void testDefault() {
         assertEquals(Collections.<Header>emptyList(), RequestOptions.DEFAULT.getHeaders());
+        assertEquals(Collections.<String, String>emptyMap(), RequestOptions.DEFAULT.getParameters());
         assertEquals(HttpAsyncResponseConsumerFactory.DEFAULT, RequestOptions.DEFAULT.getHttpAsyncResponseConsumerFactory());
         assertEquals(RequestOptions.DEFAULT, RequestOptions.DEFAULT.toBuilder().build());
     }
@@ -102,6 +105,35 @@ public class RequestOptionsTests extends RestClientTestCase {
         builder.setHttpAsyncResponseConsumerFactory(factory);
         RequestOptions options = builder.build();
         assertSame(factory, options.getHttpAsyncResponseConsumerFactory());
+    }
+
+    public void testAddParameters() {
+        try {
+            randomBuilder().addParameter(null, randomAsciiLettersOfLengthBetween(3, 10));
+            fail("expected failure");
+        } catch (NullPointerException e) {
+            assertEquals("parameter key cannot be null", e.getMessage());
+        }
+
+        try {
+            randomBuilder().addParameter(randomAsciiLettersOfLengthBetween(3, 10), null);
+            fail("expected failure");
+        } catch (NullPointerException e) {
+            assertEquals("parameter value cannot be null", e.getMessage());
+        }
+
+        RequestOptions.Builder builder = RequestOptions.DEFAULT.toBuilder();
+        int numParameters = between(0, 5);
+        Map<String, String> parameters = new HashMap<>();
+        for (int i = 0; i < numParameters; i++) {
+            String key = randomAsciiAlphanumOfLengthBetween(5, 10);
+            String value = randomAsciiAlphanumOfLength(3);
+
+            parameters.put(key, value);
+            builder.addParameter(key, value);
+        }
+        RequestOptions options = builder.build();
+        assertEquals(parameters, options.getParameters());
     }
 
     public void testSetRequestBuilder() {


### PR DESCRIPTION
This PR is an implementation for this issue: https://github.com/opensearch-project/OpenSearch/issues/535

It will give the end user the capability of supplying custom http query parameters to the RestHighLevelClient. This option was already possible with the LowLevelRestClient.

So why do we want this option in the RHLC? This client has useful features such as mapping the response to a SearchResponse. When using the LLRC the end user needs to add custom mappers to generate the SearchResponse object out of the http entity. So for mapping a json back to a SearchResponse with aggregations, suggestions the end user will need the different `NamedXContentRegistry `

The end user may even end up copying the whole content of [RestHighLevelClient#getDefaultNamedXContents()](https://github.com/opensearch-project/OpenSearch/blob/9a0050c45416dcbe77e66f91101cd2e30e5f19ca/client/rest-high-level/src/main/java/org/opensearch/client/RestHighLevelClient.java#L1766)


**Below is the original content of the issue mentioned earlier to give some additional context to this PR:**

**Describe the feature**:
_Support for setting url query paramters within the RequestOptions object_

Recently I came to a point where I wanted a smaller search response. The reason why I wanted it was because of network latency, big search responses and not needed fields within the search response. By discarding specific fields the response would be smaller measured in kb.

This option is unfortunately not possible with the RestHighLevelClient and also not possible to add as a property to a SearchRequest. And adding that option to the SearchRequest would mean a change for the specification of the SearchRequest. But I have the feeling that something like that is not a part of the search request.

If we grab an example which I have used at kibana, it would look like this:
```
GET twitter/_search?filter_path=-hits.hits._index
{
  "query": {
    "match_all": {}
  }
}
```

Lets translate this request to a basic search request with the RestHighLevelClient (without filter path):
```
RestClientBuilder clientBuilder = RestClient.builder(new HttpHost("localhost", 9200));
RestHighLevelClient client = new RestHighLevelClient(clientBuilder);

SearchRequest searchRequest = new SearchRequest();
SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
    .query(new MatchAllQueryBuilder());
searchRequest.source(sourceBuilder)
    .indices("twitter");

SearchResponse response = client.search(searchRequest, RequestOptions.DEFAULT);
```
Let's translate this request to a request to execute with the LowLevelClient including filter_path while preserving the capability of sending a SearchRequest and getting back a SearchResponse
```
RestClientBuilder clientBuilder = RestClient.builder(new HttpHost("localhost", 9200));
RestHighLevelClient client = new RestHighLevelClient(clientBuilder);

SearchRequest searchRequest = new SearchRequest();
SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
    .query(new MatchAllQueryBuilder());
searchRequest.source(sourceBuilder)
    .indices("twitter");

Request request = new Request(HttpPost.METHOD_NAME, "/" + String.join(",", searchRequest.indices()) + "/_search");
request.setOptions(RequestOptions.DEFAULT);
request.addParameter("filter_path","-hits.hits._index");

HttpEntity httpEntity = new NStringEntity(searchRequest.source().toString(), ContentType.APPLICATION_JSON);
request.setEntity(httpEntity);

Response response = client.getLowLevelClient().performRequest(request)

List<NamedXContentRegistry.Entry> entries = new ArrayList<>();
entries.add(new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(StringTerms.NAME), (parser, content) -> ParsedStringTerms.fromXContent(parser, (String) content)));
entries.add(new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(TopHitsAggregationBuilder.NAME), (parser, content) -> ParsedTopHits.fromXContent(parser, (String) content)));
entries.add(new NamedXContentRegistry.Entry(Suggest.Suggestion.class, new ParseField("term"), (parser, content) -> TermSuggestion.fromXContent(parser, (String) content)));
entries.add(new NamedXContentRegistry.Entry(Suggest.Suggestion.class, new ParseField("phrase"), (parser, content) -> PhraseSuggestion.fromXContent(parser, (String) content)));

NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(entries);

String content = EntityUtils.toString(response.getEntity());
XContentParser parser = JsonXContent.jsonXContent.createParser(namedXContentRegistry, null, content);
SearchResponse searchResponse = SearchResponse.fromXContent(parser);
```
This would return me all documents from the twitter index without the index name within the hits.
As you can see there is a lot code needed to just use the filter_path while maintaining the SearchRequest and SearchResponse at a highlevel of our code base.

It would be great if there would be support or a new feature to enable RequestOptions to also support query parameter. Now the RequestOptions just only supports headers. Request options with query parameters could look like this:
```
RequestOptions.DEFAULT.toBuilder()
    .addParameter("filter_path","-hits.hits._index");
```