### PR TITLE
[TEST] Fix failing packaging tests for OpenSearch distributions.

### DIFF
--- a/distribution/archives/build.gradle
+++ b/distribution/archives/build.gradle
@@ -66,7 +66,7 @@ CopySpec archiveFiles(CopySpec modulesFiles, String distributionType, String pla
         }
       }
       from(rootProject.projectDir) {
-        include 'README.asciidoc'
+        include 'README.md'
       }
       from(rootProject.file('licenses')) {
         include 'APACHE-LICENSE-2.0.txt'

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -154,7 +154,7 @@ Closure commonPackageConfig(String type, boolean jdk, String architecture) {
         with binFiles(type, jdk)
       }
       from(rootProject.projectDir) {
-        include 'README.asciidoc'
+        include 'README.md'
         fileMode 0644
       }
       into('lib') {

--- a/qa/os/src/test/java/org/opensearch/packaging/util/Archives.java
+++ b/qa/os/src/test/java/org/opensearch/packaging/util/Archives.java
@@ -200,7 +200,7 @@ public class Archives {
         Stream.of("opensearch.yml", "jvm.options", "log4j2.properties")
             .forEach(configFile -> assertThat(es.config(configFile), file(File, owner, owner, p660)));
 
-        Stream.of("NOTICE.txt", "LICENSE.txt", "README.asciidoc")
+        Stream.of("NOTICE.txt", "LICENSE.txt", "README.md")
             .forEach(doc -> assertThat(es.home.resolve(doc), file(File, owner, owner, p644)));
     }
 

--- a/qa/os/src/test/java/org/opensearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/opensearch/packaging/util/Docker.java
@@ -528,7 +528,7 @@ public class Docker {
             "opensearch-node"
         ).forEach(executable -> assertPermissionsAndOwnership(es.bin(executable), p755));
 
-        Stream.of("LICENSE.txt", "NOTICE.txt", "README.asciidoc").forEach(doc -> assertPermissionsAndOwnership(es.home.resolve(doc), p644));
+        Stream.of("LICENSE.txt", "NOTICE.txt", "README.md").forEach(doc -> assertPermissionsAndOwnership(es.home.resolve(doc), p644));
 
         // These are installed to help users who are working with certificates.
         Stream.of("zip", "unzip").forEach(cliPackage -> {

--- a/qa/os/src/test/java/org/opensearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/opensearch/packaging/util/Packages.java
@@ -209,7 +209,7 @@ public class Packages {
         Stream.of("opensearch", "opensearch-plugin", "opensearch-keystore", "opensearch-shard", "opensearch-shard")
             .forEach(executable -> assertThat(opensearch.bin(executable), file(File, "root", "root", p755)));
 
-        Stream.of("NOTICE.txt", "README.asciidoc")
+        Stream.of("NOTICE.txt", "README.md")
             .forEach(doc -> assertThat(opensearch.home.resolve(doc), file(File, "root", "root", p644)));
 
         assertThat(opensearch.envFile, file(File, "root", "opensearch", p660));

--- a/qa/os/src/test/java/org/opensearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/opensearch/packaging/util/Packages.java
@@ -209,8 +209,7 @@ public class Packages {
         Stream.of("opensearch", "opensearch-plugin", "opensearch-keystore", "opensearch-shard", "opensearch-shard")
             .forEach(executable -> assertThat(opensearch.bin(executable), file(File, "root", "root", p755)));
 
-        Stream.of("NOTICE.txt", "README.md")
-            .forEach(doc -> assertThat(opensearch.home.resolve(doc), file(File, "root", "root", p644)));
+        Stream.of("NOTICE.txt", "README.md").forEach(doc -> assertThat(opensearch.home.resolve(doc), file(File, "root", "root", p644)));
 
         assertThat(opensearch.envFile, file(File, "root", "opensearch", p660));
 


### PR DESCRIPTION
### Description

While creating the archives and packages, the build tries to copy the non-existent file `README.asciidoc` instead of `README.md`. Consequently, the packaging tests fail during verification time. This commit addresses the issue by fixing the name.
 
### Issues Resolved

Relates #538 
 
### Check List
- [x] All tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>