### PR TITLE
Decouples primaries_recoveries limit from concurrent recoveries limit. 

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
@@ -46,6 +46,7 @@ import org.opensearch.cluster.routing.allocation.ExistingShardsAllocator;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.Randomness;
 import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.util.set.Sets;
 import org.opensearch.index.Index;
 import org.opensearch.index.shard.ShardId;
 
@@ -64,6 +65,7 @@ import java.util.NoSuchElementException;
 import java.util.Queue;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 /**
  * {@link RoutingNodes} represents a copy the routing information contained in the {@link ClusterState cluster state}.
@@ -96,6 +98,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
 
     private final Map<String, ObjectIntHashMap<String>> nodesPerAttributeNames = new HashMap<>();
     private final Map<String, Recoveries> recoveriesPerNode = new HashMap<>();
+    private final Map<String, Recoveries> primaryRecoveriesPerNode = new HashMap<>();
 
     public RoutingNodes(ClusterState clusterState) {
         this(clusterState, true);
@@ -175,11 +178,17 @@ public class RoutingNodes implements Iterable<RoutingNode> {
     }
 
     private void updateRecoveryCounts(final ShardRouting routing, final boolean increment, @Nullable final ShardRouting primary) {
+
         final int howMany = increment ? 1 : -1;
         assert routing.initializing() : "routing must be initializing: " + routing;
         // TODO: check primary == null || primary.active() after all tests properly add ReplicaAfterPrimaryActiveAllocationDecider
         assert primary == null || primary.assignedToNode() :
             "shard is initializing but its primary is not assigned to a node";
+
+        if(routing.primary() && (primary == null || primary == routing)) {
+            Recoveries.getOrAdd(primaryRecoveriesPerNode, routing.currentNodeId()).addIncoming(howMany);
+            return;
+        }
 
         Recoveries.getOrAdd(recoveriesPerNode, routing.currentNodeId()).addIncoming(howMany);
 
@@ -207,6 +216,10 @@ public class RoutingNodes implements Iterable<RoutingNode> {
 
     public int getIncomingRecoveries(String nodeId) {
         return recoveriesPerNode.getOrDefault(nodeId, Recoveries.EMPTY).getIncoming();
+    }
+
+    public int getInitialPrimariesIncomingRecoveries(String nodeId) {
+        return primaryRecoveriesPerNode.getOrDefault(nodeId, Recoveries.EMPTY).getIncoming();
     }
 
     public int getOutgoingRecoveries(String nodeId) {
@@ -1094,7 +1107,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
 
         for (Map.Entry<String, Recoveries> recoveries : routingNodes.recoveriesPerNode.entrySet()) {
             String node = recoveries.getKey();
-            final Recoveries value = recoveries.getValue();
+            Recoveries value = recoveries.getValue();
             int incoming = 0;
             int outgoing = 0;
             RoutingNode routingNode = routingNodes.nodesToShards.get(node);
@@ -1112,10 +1125,14 @@ public class RoutingNodes implements Iterable<RoutingNode> {
                     }
                 }
             }
-            assert incoming == value.incoming : incoming + " != " + value.incoming + " node: " + routingNode;
+
+            int incomingRecoveries = Stream.of(routingNodes.recoveriesPerNode, routingNodes.primaryRecoveriesPerNode)
+                                     .filter(x->x.containsKey(node))
+                                     .mapToInt(x->x.get(node).getIncoming())
+                                     .sum();
+            assert incoming == incomingRecoveries : incoming + " != " + incomingRecoveries + " node: " + routingNode;
             assert outgoing == value.outgoing : outgoing + " != " + value.outgoing + " node: " + routingNode;
         }
-
 
         assert unassignedPrimaryCount == routingNodes.unassignedShards.getNumPrimaries() :
                 "Unassigned primaries is [" + unassignedPrimaryCount + "] but RoutingNodes returned unassigned primaries [" +

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
@@ -184,7 +184,9 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         assert primary == null || primary.assignedToNode() :
             "shard is initializing but its primary is not assigned to a node";
 
+        // Primary shard routing, excluding the relocating primaries.
         if(routing.primary() && (primary == null || primary == routing)) {
+            assert !routing.isRelocationTarget() && !routing.relocating(): "Routing must be a non relocating primary";
             Recoveries.getOrAdd(primaryRecoveriesPerNode, routing.currentNodeId()).addIncoming(howMany);
             return;
         }
@@ -1106,7 +1108,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
 
         for (Map.Entry<String, Recoveries> recoveries : routingNodes.recoveriesPerNode.entrySet()) {
             String node = recoveries.getKey();
-            Recoveries value = recoveries.getValue();
+            final Recoveries value = recoveries.getValue();
             int incoming = 0;
             int outgoing = 0;
             RoutingNode routingNode = routingNodes.nodesToShards.get(node);

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
@@ -46,7 +46,6 @@ import org.opensearch.cluster.routing.allocation.ExistingShardsAllocator;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.Randomness;
 import org.opensearch.common.collect.Tuple;
-import org.opensearch.common.util.set.Sets;
 import org.opensearch.index.Index;
 import org.opensearch.index.shard.ShardId;
 

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
@@ -39,7 +39,6 @@ import org.opensearch.cluster.routing.RoutingNode;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.UnassignedInfo;
 import org.opensearch.cluster.routing.allocation.RoutingAllocation;
-import org.opensearch.cluster.routing.ShardRoutingState;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
@@ -58,7 +58,8 @@ import static org.opensearch.cluster.routing.allocation.decider.Decision.YES;
  * node. The default is {@code 4}</li>
  * <li>{@code cluster.routing.allocation.node_concurrent_recoveries} -
  * restricts the number of total concurrent shards initializing on a single node. The
- * default is {@code 2}</li>
+ * default is {@code 2}. Please note that this limit excludes the initial primaries
+ * recovery operations per node.</li>
  * </ul>
  * <p>
  * If one of the above thresholds is exceeded per node this allocation decider
@@ -135,14 +136,8 @@ public class ThrottlingAllocationDecider extends AllocationDecider {
             // primary is unassigned, means we are going to do recovery from store, snapshot or local shards
             // count *just the primaries* currently doing recovery on the node and check against primariesInitialRecoveries
 
-            int primariesInRecovery = 0;
-            for (ShardRouting shard : node.shardsWithState(ShardRoutingState.INITIALIZING)) {
-                // when a primary shard is INITIALIZING, it can be because of *initial recovery* or *relocation from another node*
-                // we only count initial recoveries here, so we need to make sure that relocating node is null
-                if (shard.primary() && shard.relocatingNodeId() == null) {
-                    primariesInRecovery++;
-                }
-            }
+            int primariesInRecovery = allocation.routingNodes().getInitialPrimariesIncomingRecoveries(node.nodeId());
+
             if (primariesInRecovery >= primariesInitialRecoveries) {
                 // TODO: Should index creation not be throttled for primary shards?
                 return allocation.decision(THROTTLE, NAME,

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/AllocationPriorityTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/AllocationPriorityTests.java
@@ -42,6 +42,9 @@ import org.opensearch.cluster.routing.allocation.AllocationService;
 import org.opensearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
 import org.opensearch.common.settings.Settings;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static org.opensearch.cluster.routing.ShardRoutingState.INITIALIZING;
 
 public class AllocationPriorityTests extends OpenSearchAllocationTestCase {
@@ -95,18 +98,14 @@ public class AllocationPriorityTests extends OpenSearchAllocationTestCase {
         assertEquals(highPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(1).getIndexName());
 
         clusterState = startInitializingShardsAndReroute(allocation, clusterState);
-        assertEquals(2, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size());
-        assertEquals(lowPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(0).getIndexName());
-        assertEquals(lowPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(1).getIndexName());
+        assertEquals(4, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size());
+        List<String> indices = clusterState.getRoutingNodes().shardsWithState(INITIALIZING).stream().map(x->x.getIndexName()).collect(Collectors.toList());
+        assertTrue(indices.contains(lowPriorityName));
+        assertTrue(indices.contains(highPriorityName));
 
         clusterState = startInitializingShardsAndReroute(allocation, clusterState);
         assertEquals(clusterState.getRoutingNodes().shardsWithState(INITIALIZING).toString(),2,
             clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size());
-        assertEquals(highPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(0).getIndexName());
-        assertEquals(highPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(1).getIndexName());
-
-        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
-        assertEquals(2, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size());
         assertEquals(lowPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(0).getIndexName());
         assertEquals(lowPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(1).getIndexName());
 

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/AllocationPriorityTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/AllocationPriorityTests.java
@@ -99,7 +99,8 @@ public class AllocationPriorityTests extends OpenSearchAllocationTestCase {
 
         clusterState = startInitializingShardsAndReroute(allocation, clusterState);
         assertEquals(4, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size());
-        List<String> indices = clusterState.getRoutingNodes().shardsWithState(INITIALIZING).stream().map(x->x.getIndexName()).collect(Collectors.toList());
+        List<String> indices = clusterState.getRoutingNodes().shardsWithState(INITIALIZING).stream().
+            map(x->x.getIndexName()).collect(Collectors.toList());
         assertTrue(indices.contains(lowPriorityName));
         assertTrue(indices.contains(highPriorityName));
 

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/AllocationServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/AllocationServiceTests.java
@@ -213,6 +213,7 @@ public class AllocationServiceTests extends OpenSearchTestCase {
         final RoutingTable routingTable1 = reroutedState1.routingTable();
         // the test harness only permits one recovery per node, so we must have allocated all the high-priority primaries and one of the
         // medium-priority ones
+
         assertThat(routingTable1.shardsWithState(ShardRoutingState.INITIALIZING), empty());
         assertThat(routingTable1.shardsWithState(ShardRoutingState.RELOCATING), empty());
         assertTrue(routingTable1.shardsWithState(ShardRoutingState.STARTED).stream().allMatch(ShardRouting::primary));
@@ -223,22 +224,27 @@ public class AllocationServiceTests extends OpenSearchTestCase {
 
         final ClusterState reroutedState2 = rerouteAndStartShards(allocationService, reroutedState1);
         final RoutingTable routingTable2 = reroutedState2.routingTable();
-        // this reroute starts the one remaining medium-priority primary and both of the low-priority ones, but no replicas
+
+        // this reroute starts the one remaining medium-priority primary and both of the low-priority ones, and also 1 medium priority replica
         assertThat(routingTable2.shardsWithState(ShardRoutingState.INITIALIZING), empty());
         assertThat(routingTable2.shardsWithState(ShardRoutingState.RELOCATING), empty());
-        assertTrue(routingTable2.shardsWithState(ShardRoutingState.STARTED).stream().allMatch(ShardRouting::primary));
         assertTrue(routingTable2.index("highPriority").allPrimaryShardsActive());
         assertTrue(routingTable2.index("mediumPriority").allPrimaryShardsActive());
+        assertThat(routingTable2.index("mediumPriority").shardsWithState(ShardRoutingState.STARTED).size(), equalTo(3));
+        assertThat(routingTable2.index("mediumPriority").shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(1));
         assertTrue(routingTable2.index("lowPriority").allPrimaryShardsActive());
         assertThat(routingTable2.index("invalid").shardsWithState(ShardRoutingState.STARTED), empty());
 
         final ClusterState reroutedState3 = rerouteAndStartShards(allocationService, reroutedState2);
         final RoutingTable routingTable3 = reroutedState3.routingTable();
-        // this reroute starts the two medium-priority replicas since their allocator permits this
+
+        // this reroute starts the one remaining medium-priority replica
         assertThat(routingTable3.shardsWithState(ShardRoutingState.INITIALIZING), empty());
         assertThat(routingTable3.shardsWithState(ShardRoutingState.RELOCATING), empty());
         assertTrue(routingTable3.index("highPriority").allPrimaryShardsActive());
+        assertTrue(routingTable3.index("mediumPriority").allPrimaryShardsActive());
         assertThat(routingTable3.index("mediumPriority").shardsWithState(ShardRoutingState.UNASSIGNED), empty());
+        assertThat(routingTable3.index("mediumPriority").shardsWithState(ShardRoutingState.STARTED).size(), equalTo(4));
         assertTrue(routingTable3.index("lowPriority").allPrimaryShardsActive());
         assertThat(routingTable3.index("invalid").shardsWithState(ShardRoutingState.STARTED), empty());
     }

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/AllocationServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/AllocationServiceTests.java
@@ -225,7 +225,8 @@ public class AllocationServiceTests extends OpenSearchTestCase {
         final ClusterState reroutedState2 = rerouteAndStartShards(allocationService, reroutedState1);
         final RoutingTable routingTable2 = reroutedState2.routingTable();
 
-        // this reroute starts the one remaining medium-priority primary and both of the low-priority ones, and also 1 medium priority replica
+        // this reroute starts the one remaining medium-priority primary and both of the low-priority ones,
+        // and also 1 medium priority replica
         assertThat(routingTable2.shardsWithState(ShardRoutingState.INITIALIZING), empty());
         assertThat(routingTable2.shardsWithState(ShardRoutingState.RELOCATING), empty());
         assertTrue(routingTable2.index("highPriority").allPrimaryShardsActive());

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/ThrottlingAllocationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/ThrottlingAllocationTests.java
@@ -222,7 +222,8 @@ public class ThrottlingAllocationTests extends OpenSearchAllocationTestCase {
         assertThat(clusterState.routingTable().shardsWithState(STARTED).size(), equalTo(0));
         assertThat(clusterState.routingTable().shardsWithState(INITIALIZING).size(), equalTo(5));
         assertThat(clusterState.routingTable().shardsWithState(UNASSIGNED).size(), equalTo(4));
-        assertEquals(clusterState.getRoutingNodes().getIncomingRecoveries("node1"), 5);
+        assertEquals(clusterState.getRoutingNodes().getInitialPrimariesIncomingRecoveries("node1"), 5);
+        assertEquals(clusterState.getRoutingNodes().getIncomingRecoveries("node1"), 0);
 
         logger.info("start initializing, all primaries should be started");
         clusterState = startInitializingShardsAndReroute(strategy, clusterState);


### PR DESCRIPTION
### Description
Node initial primaries recoveries are counted towards total incoming recoveries on a node, which then throttles the replica recoveries into that node. This is incorrect as per the documentation since both limits should be separately counted. This PR attempts to fix this discrepancy by counting the initial primary recoveries separately. As a side effect of this change, I was able to optimize the time taken by ThrottlingAllocationDecider for primary shard allocation decision from the order of total number of initializing primary shards to constant.
 
### Issues Resolved
#504

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
