### PR TITLE
Add Remote Reindex SPI extension

### DIFF
--- a/modules/reindex/src/main/java/org/opensearch/index/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/opensearch/index/reindex/AbstractAsyncBulkByScrollAction.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.index.reindex;
 
+import java.util.Optional;
+import org.apache.http.HttpRequestInterceptor;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.action.ActionListener;
@@ -112,6 +114,7 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
     protected final ThreadPool threadPool;
     protected final ScriptService scriptService;
     protected final ReindexSslConfig sslConfig;
+    protected Optional<HttpRequestInterceptor> interceptor;
 
     /**
      * The request for this action. Named mainRequest because we create lots of <code>request</code> variables all representing child
@@ -152,6 +155,7 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
         this.threadPool = threadPool;
         this.mainRequest = mainRequest;
         this.listener = listener;
+        this.interceptor = Optional.empty();
         BackoffPolicy backoffPolicy = buildBackoffPolicy();
         bulkRetry = new Retry(BackoffPolicy.wrap(backoffPolicy, worker::countBulkRetry), threadPool);
         scrollSource = buildScrollableResultSource(backoffPolicy);

--- a/modules/reindex/src/main/java/org/opensearch/index/reindex/TransportReindexAction.java
+++ b/modules/reindex/src/main/java/org/opensearch/index/reindex/TransportReindexAction.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.index.reindex;
 
+import java.util.Optional;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.AutoCreateIndex;
@@ -43,6 +44,7 @@ import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.index.reindex.spi.RemoteReindexExtension;
 import org.opensearch.script.ScriptService;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
@@ -56,6 +58,7 @@ import static java.util.Collections.emptyList;
 public class TransportReindexAction extends HandledTransportAction<ReindexRequest, BulkByScrollResponse> {
     public static final Setting<List<String>> REMOTE_CLUSTER_WHITELIST =
             Setting.listSetting("reindex.remote.whitelist", emptyList(), Function.identity(), Property.NodeScope);
+    public static Optional<RemoteReindexExtension> remoteExtension = Optional.empty();
 
     private final ReindexValidator reindexValidator;
     private final Reindexer reindexer;
@@ -66,7 +69,7 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
             AutoCreateIndex autoCreateIndex, Client client, TransportService transportService, ReindexSslConfig sslConfig) {
         super(ReindexAction.NAME, transportService, actionFilters, ReindexRequest::new);
         this.reindexValidator = new ReindexValidator(settings, clusterService, indexNameExpressionResolver, autoCreateIndex);
-        this.reindexer = new Reindexer(clusterService, client, threadPool, scriptService, sslConfig);
+        this.reindexer = new Reindexer(clusterService, client, threadPool, scriptService, sslConfig, remoteExtension);
     }
 
     @Override

--- a/modules/reindex/src/main/java/org/opensearch/index/reindex/spi/ReindexRestInterceptorProvider.java
+++ b/modules/reindex/src/main/java/org/opensearch/index/reindex/spi/ReindexRestInterceptorProvider.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.index.reindex.spi;
+
+import java.util.Optional;
+import org.apache.http.HttpRequestInterceptor;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.index.reindex.ReindexRequest;
+
+public interface ReindexRestInterceptorProvider {
+    /**
+     * @param request Reindex request.
+     * @param threadContext Current thread context.
+     * @return HttpRequestInterceptor object.
+     */
+    Optional<HttpRequestInterceptor> getRestInterceptor(ReindexRequest request, ThreadContext threadContext);
+}

--- a/modules/reindex/src/main/java/org/opensearch/index/reindex/spi/RemoteReindexExtension.java
+++ b/modules/reindex/src/main/java/org/opensearch/index/reindex/spi/RemoteReindexExtension.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.index.reindex.spi;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.index.reindex.ReindexRequest;
+
+/**
+ * This interface provides an extension point for {@link org.opensearch.index.reindex.ReindexPlugin}.
+ * This interface can be implemented to provide a custom Rest interceptor and {@link ActionListener}
+ * The Rest interceptor can be used to pre-process any reindex request and perform any action
+ * on the response. The ActionListener listens to the success and failure events on every reindex request
+ * and can be used to take any actions based on the success or failure.
+ */
+public interface RemoteReindexExtension {
+    /**
+     * Get an InterceptorProvider.
+     * @return ReindexRestInterceptorProvider implementation.
+     */
+    ReindexRestInterceptorProvider getInterceptorProvider();
+
+    /**
+     * Get a wrapper of ActionListener which is can used to perform any action based on
+     * the success/failure of the remote reindex call.
+     * @return ActionListener wrapper implementation.
+     */
+    ActionListener<BulkByScrollResponse> getRemoteReindexActionListener(ActionListener<BulkByScrollResponse> listener,
+        ReindexRequest reindexRequest);
+}
+


### PR DESCRIPTION
### Description
This change extends the remote reindex SPI to allow adding a custom interceptor.
This interceptor can be plugged in to perform any processing on the request or response like signing the request using IAM.
 
### Issues Resolved
closes: #511 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
