### PR TITLE
TEST BUG: MergeSchedulerSettingsTests fails always on small machines

### DIFF
--- a/server/src/test/java/org/opensearch/index/MergeSchedulerSettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/MergeSchedulerSettingsTests.java
@@ -192,5 +192,14 @@ public class MergeSchedulerSettingsTests extends OpenSearchTestCase {
         exc = expectThrows(IllegalArgumentException.class,
             () -> finalSettings.updateIndexMetadata(createMetadata(-1, 3, 8)));
         assertThat(exc.getMessage(), containsString("maxThreadCount (= 4) should be <= maxMergeCount (= 3)"));
+
+        // assertions above may provoke warnings if node.processors exceeds numCpus
+        // we explicitly test with values of 2 and 8
+        int numCpus = Runtime.getRuntime().availableProcessors();
+        String[] warnings = new String[] {
+            "setting [node.processors] to value [2] which is more than available processors [" + numCpus + "] is deprecated",
+            "setting [node.processors] to value [8] which is more than available processors [" + numCpus + "] is deprecated"
+        };
+        allowedWarnings(warnings);
     }
 }


### PR DESCRIPTION
MergeSchedulerSettingsTests tweaks the `node.processors` setting: sets it explicitly to values of `2` and `8`. 

On a machine with only `4` threads (e.g. my 2-core thinkpad), the test fails, because it creates unexpected warnings about `node.processors` being set higher than the number of cpus.

The problem can be reproduced always, by pretending to be single core:
```
./gradlew ':server:test' --tests "org.opensearch.index.MergeSchedulerSettingsTests.testMaxThreadAndMergeCount" -Dtests.jvm.argline="-XX:ActiveProcessorCount=1"

2> java.lang.AssertionError: unexpected warning headers
    Expected: an empty collection
         but: <[299 OpenSearch-7.10.3-SNAPSHOT-unknown "setting [node.processors] to value [2] which is more than available processors [1] is deprecated", 299 OpenSearch-7.10.3-SNAPSHOT-unknown "setting [node.processors] to value [8] which is more than available processors [1] is deprecated"]>
        at __randomizedtesting.SeedInfo.seed([708A64B680F01AE7:435CBB01D2879CB1]:0)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
        at org.junit.Assert.assertThat(Assert.java:956)
        at org.opensearch.test.OpenSearchTestCase.ensureNoWarnings(OpenSearchTestCase.java:449)
        at org.opensearch.test.OpenSearchTestCase.after(OpenSearchTestCase.java:412)
    ...
```

Instead, allow the test to provoke these specific warnings.

Signed-off-by: Robert Muir <rmuir@apache.org>