### PR TITLE
[DOCKER] add apt update to test fixture krb5kdc

### DIFF
--- a/test/fixtures/krb5kdc-fixture/Dockerfile
+++ b/test/fixtures/krb5kdc-fixture/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:14.04
 RUN apt update -y
+RUN apt upgrade -y
 ADD . /fixture
 RUN echo kerberos.build.opensearch.org > /etc/hostname && echo "127.0.0.1 kerberos.build.opensearch.org" >> /etc/hosts
 RUN bash /fixture/src/main/resources/provision/installkdc.sh

--- a/test/fixtures/krb5kdc-fixture/Dockerfile
+++ b/test/fixtures/krb5kdc-fixture/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:14.04
+RUN apt update -y
 ADD . /fixture
 RUN echo kerberos.build.opensearch.org > /etc/hostname && echo "127.0.0.1 kerberos.build.opensearch.org" >> /etc/hosts
 RUN bash /fixture/src/main/resources/provision/installkdc.sh


### PR DESCRIPTION
This PR adds an apt update to the krb5kdc test fixture docker file.