### PR TITLE
Remove all elastic.co references from javadocs

### DIFF
--- a/client/rest-high-level/src/main/java/org/opensearch/client/ClusterClient.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/ClusterClient.java
@@ -57,7 +57,7 @@ import static java.util.Collections.singleton;
 /**
  * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Cluster API.
  * <p>
- * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html">Cluster API on elastic.co</a>
+ *
  */
 public final class ClusterClient {
     private final RestHighLevelClient restHighLevelClient;
@@ -68,8 +68,7 @@ public final class ClusterClient {
 
     /**
      * Updates cluster wide specific settings using the Cluster Update Settings API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-update-settings.html"> Cluster Update Settings
-     * API on elastic.co</a>
+     *
      * @param clusterUpdateSettingsRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -83,8 +82,7 @@ public final class ClusterClient {
 
     /**
      * Asynchronously updates cluster wide specific settings using the Cluster Update Settings API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-update-settings.html"> Cluster Update Settings
-     * API on elastic.co</a>
+     *
      * @param clusterUpdateSettingsRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -99,8 +97,7 @@ public final class ClusterClient {
 
     /**
      * Get the cluster wide settings using the Cluster Get Settings API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-get-settings.html"> Cluster Get Settings
-     * API on elastic.co</a>
+     *
      * @param clusterGetSettingsRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -114,8 +111,7 @@ public final class ClusterClient {
 
     /**
      * Asynchronously get the cluster wide settings using the Cluster Get Settings API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-get-settings.html"> Cluster Get Settings
-     * API on elastic.co</a>
+     *
      * @param clusterGetSettingsRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -130,8 +126,7 @@ public final class ClusterClient {
 
     /**
      * Get cluster health using the Cluster Health API.
-     * See
-     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html"> Cluster Health API on elastic.co</a>
+     *
      * <p>
      * If timeout occurred, {@link ClusterHealthResponse} will have isTimedOut() == true and status() == RestStatus.REQUEST_TIMEOUT
      * @param healthRequest the request
@@ -146,8 +141,7 @@ public final class ClusterClient {
 
     /**
      * Asynchronously get cluster health using the Cluster Health API.
-     * See
-     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html"> Cluster Health API on elastic.co</a>
+     *
      * If timeout occurred, {@link ClusterHealthResponse} will have isTimedOut() == true and status() == RestStatus.REQUEST_TIMEOUT
      * @param healthRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -162,8 +156,7 @@ public final class ClusterClient {
 
     /**
      * Get the remote cluster information using the Remote cluster info API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-remote-info.html"> Remote cluster info
-     * API on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -176,8 +169,7 @@ public final class ClusterClient {
 
     /**
      * Asynchronously get remote cluster information using the Remote cluster info API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-remote-info.html"> Remote cluster info
-     * API on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion

--- a/client/rest-high-level/src/main/java/org/opensearch/client/ClusterClient.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/ClusterClient.java
@@ -56,8 +56,6 @@ import static java.util.Collections.singleton;
 
 /**
  * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Cluster API.
- * <p>
- *
  */
 public final class ClusterClient {
     private final RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/main/java/org/opensearch/client/IndicesClient.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/IndicesClient.java
@@ -101,7 +101,6 @@ import static java.util.Collections.singleton;
 
 /**
  * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Indices API.
- * <p>
  */
 public final class IndicesClient {
     private final RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/main/java/org/opensearch/client/IndicesClient.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/IndicesClient.java
@@ -102,7 +102,6 @@ import static java.util.Collections.singleton;
 /**
  * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Indices API.
  * <p>
- * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices.html">Indices API on elastic.co</a>
  */
 public final class IndicesClient {
     private final RestHighLevelClient restHighLevelClient;
@@ -113,8 +112,7 @@ public final class IndicesClient {
 
     /**
      * Deletes an index using the Delete Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-index.html">
-     * Delete Index API on elastic.co</a>
+     *
      * @param deleteIndexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -127,8 +125,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously deletes an index using the Delete Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-index.html">
-     * Delete Index API on elastic.co</a>
+     *
      * @param deleteIndexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -143,8 +140,7 @@ public final class IndicesClient {
 
     /**
      * Creates an index using the Create Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html">
-     * Create Index API on elastic.co</a>
+     *
      * @param createIndexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -158,8 +154,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously creates an index using the Create Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html">
-     * Create Index API on elastic.co</a>
+     *
      * @param createIndexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -174,8 +169,6 @@ public final class IndicesClient {
 
     /**
      * Creates a data stream using the Create Data Stream API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-data-streams.html">
-     * Data Streams API on elastic.co</a>
      *
      * @param createDataStreamRequest the request
      * @param options                 the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be
@@ -191,8 +184,6 @@ public final class IndicesClient {
 
     /**
      * Asynchronously creates a data stream using the Create Data Stream API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-data-streams.html">
-     * Data Streams API on elastic.co</a>
      *
      * @param createDataStreamRequest the request
      * @param options                 the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be
@@ -209,8 +200,6 @@ public final class IndicesClient {
 
     /**
      * Deletes a data stream using the Delete Data Stream API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-data-streams.html">
-     * Data Streams API on elastic.co</a>
      *
      * @param deleteDataStreamRequest the request
      * @param options                 the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be
@@ -226,8 +215,6 @@ public final class IndicesClient {
 
     /**
      * Asynchronously deletes a data stream using the Delete Data Stream API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-data-streams.html">
-     * Data Streams API on elastic.co</a>
      *
      * @param deleteDataStreamRequest the request
      * @param options                 the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be
@@ -243,8 +230,6 @@ public final class IndicesClient {
 
     /**
      * Gets one or more data streams using the Get Data Stream API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html"> Data Streams API on
-     * elastic.co</a>
      *
      * @param dataStreamRequest the request
      * @param options           the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -258,8 +243,6 @@ public final class IndicesClient {
 
     /**
      * Asynchronously gets one or more data streams using the Get Data Stream API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html"> Data Streams API on
-     * elastic.co</a>
      *
      * @param dataStreamRequest the request
      * @param options           the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -274,8 +257,6 @@ public final class IndicesClient {
 
     /**
      * Gets statistics about one or more data streams using the Get Data Streams Stats API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html"> Data Streams API on
-     * elastic.co</a>
      *
      * @param dataStreamsStatsRequest the request
      * @param options                 the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be
@@ -291,8 +272,6 @@ public final class IndicesClient {
 
     /**
      * Asynchronously gets statistics about one or more data streams using the Get Data Streams Stats API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html"> Data Streams API on
-     * elastic.co</a>
      *
      * @param dataStreamsStatsRequest the request
      * @param options                 the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be
@@ -308,8 +287,7 @@ public final class IndicesClient {
 
     /**
      * Creates an index using the Create Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html">
-     * Create Index API on elastic.co</a>
+     *
      * @param createIndexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -330,8 +308,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously creates an index using the Create Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html">
-     * Create Index API on elastic.co</a>
+     *
      * @param createIndexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -352,8 +329,7 @@ public final class IndicesClient {
 
     /**
      * Updates the mappings on an index using the Put Mapping API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html">
-     * Put Mapping API on elastic.co</a>
+     *
      * @param putMappingRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -366,8 +342,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously updates the mappings on an index using the Put Mapping API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html">
-     * Put Mapping API on elastic.co</a>
+     *
      * @param putMappingRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -381,8 +356,7 @@ public final class IndicesClient {
 
     /**
      * Updates the mappings on an index using the Put Mapping API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html">
-     * Put Mapping API on elastic.co</a>
+     *
      * @param putMappingRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -400,8 +374,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously updates the mappings on an index using the Put Mapping API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html">
-     * Put Mapping API on elastic.co</a>
+     *
      * @param putMappingRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -421,8 +394,7 @@ public final class IndicesClient {
 
     /**
      * Retrieves the mappings on an index or indices using the Get Mapping API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-mapping.html">
-     * Get Mapping API on elastic.co</a>
+     *
      * @param getMappingsRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -438,8 +410,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously retrieves the mappings on an index on indices using the Get Mapping API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-mapping.html">
-     * Get Mapping API on elastic.co</a>
+     *
      * @param getMappingsRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -457,8 +428,7 @@ public final class IndicesClient {
 
     /**
      * Retrieves the mappings on an index or indices using the Get Mapping API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-mapping.html">
-     * Get Mapping API on elastic.co</a>
+     *
      * @param getMappingsRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -481,8 +451,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously retrieves the mappings on an index on indices using the Get Mapping API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-mapping.html">
-     * Get Mapping API on elastic.co</a>
+     *
      * @param getMappingsRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -506,8 +475,7 @@ public final class IndicesClient {
 
     /**
      * Retrieves the field mappings on an index or indices using the Get Field Mapping API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-field-mapping.html">
-     * Get Field Mapping API on elastic.co</a>
+     *
      * @param getFieldMappingsRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -527,8 +495,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously retrieves the field mappings on an index on indices using the Get Field Mapping API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-field-mapping.html">
-     * Get Field Mapping API on elastic.co</a>
+     *
      * @param getFieldMappingsRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -551,8 +518,7 @@ public final class IndicesClient {
 
     /**
      * Retrieves the field mappings on an index or indices using the Get Field Mapping API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-field-mapping.html">
-     * Get Field Mapping API on elastic.co</a>
+     *
      * @param getFieldMappingsRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -567,8 +533,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously retrieves the field mappings on an index or indices using the Get Field Mapping API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-field-mapping.html">
-     * Get Field Mapping API on elastic.co</a>
+     *
      * @param getFieldMappingsRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -583,8 +548,7 @@ public final class IndicesClient {
 
     /**
      * Updates aliases using the Index Aliases API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html">
-     * Index Aliases API on elastic.co</a>
+     *
      * @param indicesAliasesRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -597,8 +561,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously updates aliases using the Index Aliases API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html">
-     * Index Aliases API on elastic.co</a>
+     *
      * @param indicesAliasesRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -613,8 +576,7 @@ public final class IndicesClient {
 
     /**
      * Opens an index using the Open Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html">
-     * Open Index API on elastic.co</a>
+     *
      * @param openIndexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -627,8 +589,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously opens an index using the Open Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html">
-     * Open Index API on elastic.co</a>
+     *
      * @param openIndexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -641,8 +602,7 @@ public final class IndicesClient {
 
     /**
      * Closes an index using the Close Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html">
-     * Close Index API on elastic.co</a>
+     *
      * @param closeIndexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -655,8 +615,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously closes an index using the Close Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html">
-     * Close Index API on elastic.co</a>
+     *
      * @param closeIndexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -672,8 +631,7 @@ public final class IndicesClient {
 
     /**
      * Checks if one or more aliases exist using the Aliases Exist API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html">
-     * Indices Aliases API on elastic.co</a>
+     *
      * @param getAliasesRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -686,8 +644,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously checks if one or more aliases exist using the Aliases Exist API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html">
-     * Indices Aliases API on elastic.co</a>
+     *
      * @param getAliasesRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -700,7 +657,7 @@ public final class IndicesClient {
 
     /**
      * Refresh one or more indices using the Refresh API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html"> Refresh API on elastic.co</a>
+     *
      * @param refreshRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -713,7 +670,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously refresh one or more indices using the Refresh API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html"> Refresh API on elastic.co</a>
+     *
      * @param refreshRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -726,7 +683,7 @@ public final class IndicesClient {
 
     /**
      * Flush one or more indices using the Flush API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-flush.html"> Flush API on elastic.co</a>
+     *
      * @param flushRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -739,7 +696,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously flush one or more indices using the Flush API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-flush.html"> Flush API on elastic.co</a>
+     *
      * @param flushRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -752,8 +709,7 @@ public final class IndicesClient {
 
     /**
      * Initiate a synced flush manually using the synced flush API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush-api.html">
-     *     Synced flush API on elastic.co</a>
+     *
      * @param syncedFlushRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -769,8 +725,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously initiate a synced flush manually using the synced flush API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush-api.html">
-     *     Synced flush API on elastic.co</a>
+     *
      * @param syncedFlushRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -787,8 +742,7 @@ public final class IndicesClient {
 
     /**
      * Retrieve the settings of one or more indices.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-settings.html">
-     * Indices Get Settings API on elastic.co</a>
+     *
      * @param getSettingsRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -801,8 +755,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously retrieve the settings of one or more indices.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-settings.html">
-     * Indices Get Settings API on elastic.co</a>
+     *
      * @param getSettingsRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -816,8 +769,7 @@ public final class IndicesClient {
 
     /**
      * Retrieve information about one or more indexes
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-index.html">
-     * Indices Get Index API on elastic.co</a>
+     *
      * @param getIndexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -830,8 +782,7 @@ public final class IndicesClient {
 
     /**
      * Retrieve information about one or more indexes
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-index.html">
-     * Indices Get Index API on elastic.co</a>
+     *
      * @param getIndexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -845,8 +796,7 @@ public final class IndicesClient {
 
     /**
      * Retrieve information about one or more indexes
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-index.html">
-     * Indices Get Index API on elastic.co</a>
+     *
      * @param getIndexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -863,8 +813,7 @@ public final class IndicesClient {
 
     /**
      * Retrieve information about one or more indexes
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-index.html">
-     * Indices Get Index API on elastic.co</a>
+     *
      * @param getIndexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -881,8 +830,7 @@ public final class IndicesClient {
 
     /**
      * Force merge one or more indices using the Force Merge API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html">
-     * Force Merge API on elastic.co</a>
+     *
      * @param forceMergeRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -896,8 +844,7 @@ public final class IndicesClient {
 
     /**
      * Force merge one or more indices using the Force Merge API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html">
-     * Force Merge API on elastic.co</a>
+     *
      * @param forceMergeRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -910,8 +857,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously force merge one or more indices using the Force Merge API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html">
-     * Force Merge API on elastic.co</a>
+     *
      * @param forceMergeRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -926,8 +872,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously force merge one or more indices using the Force Merge API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html">
-     * Force Merge API on elastic.co</a>
+     *
      * @param forceMergeRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -942,8 +887,7 @@ public final class IndicesClient {
 
     /**
      * Clears the cache of one or more indices using the Clear Cache API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-clearcache.html">
-     * Clear Cache API on elastic.co</a>
+     *
      * @param clearIndicesCacheRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -957,8 +901,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously clears the cache of one or more indices using the Clear Cache API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-clearcache.html">
-     * Clear Cache API on elastic.co</a>
+     *
      * @param clearIndicesCacheRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -973,8 +916,7 @@ public final class IndicesClient {
 
     /**
      * Checks if the index (indices) exists or not.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-exists.html">
-     * Indices Exists API on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -992,8 +934,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously checks if the index (indices) exists or not.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-exists.html">
-     * Indices Exists API on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1012,8 +953,7 @@ public final class IndicesClient {
 
     /**
      * Checks if the index (indices) exists or not.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-exists.html">
-     * Indices Exists API on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1034,8 +974,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously checks if the index (indices) exists or not.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-exists.html">
-     * Indices Exists API on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1058,8 +997,7 @@ public final class IndicesClient {
 
     /**
      * Shrinks an index using the Shrink Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-shrink-index.html">
-     * Shrink Index API on elastic.co</a>
+     *
      * @param resizeRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1072,8 +1010,7 @@ public final class IndicesClient {
 
     /**
      * Shrinks an index using the Shrink Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-shrink-index.html">
-     * Shrink Index API on elastic.co</a>
+     *
      * @param resizeRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1089,8 +1026,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously shrinks an index using the Shrink index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-shrink-index.html">
-     * Shrink Index API on elastic.co</a>
+     *
      * @param resizeRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1103,8 +1039,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously shrinks an index using the Shrink index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-shrink-index.html">
-     * Shrink Index API on elastic.co</a>
+     *
      * @param resizeRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1120,8 +1055,7 @@ public final class IndicesClient {
 
     /**
      * Splits an index using the Split Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-split-index.html">
-     * Split Index API on elastic.co</a>
+     *
      * @param resizeRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1134,8 +1068,7 @@ public final class IndicesClient {
 
     /**
      * Splits an index using the Split Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-split-index.html">
-     * Split Index API on elastic.co</a>
+     *
      * @param resizeRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1151,8 +1084,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously splits an index using the Split Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-split-index.html">
-     * Split Index API on elastic.co</a>
+     *
      * @param resizeRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1165,8 +1097,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously splits an index using the Split Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-split-index.html">
-     * Split Index API on elastic.co</a>
+     *
      * @param resizeRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1182,8 +1113,7 @@ public final class IndicesClient {
 
     /**
      * Clones an index using the Clone Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-clone-index.html">
-     * Clone Index API on elastic.co</a>
+     *
      * @param resizeRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1196,8 +1126,7 @@ public final class IndicesClient {
 
     /**
      * Clones an index using the Clone Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-clone-index.html">
-     * Clone Index API on elastic.co</a>
+     *
      * @param resizeRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1213,8 +1142,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously clones an index using the Clone Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-clone-index.html">
-     * Clone Index API on elastic.co</a>
+     *
      * @param resizeRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1227,8 +1155,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously clones an index using the Clone Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-clone-index.html">
-     * Clone Index API on elastic.co</a>
+     *
      * @param resizeRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1244,8 +1171,7 @@ public final class IndicesClient {
 
     /**
      * Rolls over an index using the Rollover Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-rollover-index.html">
-     * Rollover Index API on elastic.co</a>
+     *
      * @param rolloverRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1258,8 +1184,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously rolls over an index using the Rollover Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-rollover-index.html">
-     * Rollover Index API on elastic.co</a>
+     *
      * @param rolloverRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1273,8 +1198,7 @@ public final class IndicesClient {
 
     /**
      * Rolls over an index using the Rollover Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-rollover-index.html">
-     * Rollover Index API on elastic.co</a>
+     *
      * @param rolloverRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1293,8 +1217,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously rolls over an index using the Rollover Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-rollover-index.html">
-     * Rollover Index API on elastic.co</a>
+     *
      * @param rolloverRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1314,8 +1237,7 @@ public final class IndicesClient {
 
     /**
      * Gets one or more aliases using the Get Index Aliases API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html"> Indices Aliases API on
-     * elastic.co</a>
+     *
      * @param getAliasesRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1328,8 +1250,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously gets one or more aliases using the Get Index Aliases API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html"> Indices Aliases API on
-     * elastic.co</a>
+     *
      * @param getAliasesRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1344,8 +1265,7 @@ public final class IndicesClient {
 
     /**
      * Updates specific index level settings using the Update Indices Settings API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html"> Update Indices Settings
-     * API on elastic.co</a>
+     *
      * @param updateSettingsRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1358,8 +1278,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously updates specific index level settings using the Update Indices Settings API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html"> Update Indices Settings
-     * API on elastic.co</a>
+     *
      * @param updateSettingsRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1375,8 +1294,7 @@ public final class IndicesClient {
 
     /**
      * Puts an index template using the Index Templates API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
+     *
      * @param putIndexTemplateRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1394,8 +1312,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously puts an index template using the Index Templates API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
+     *
      * @param putIndexTemplateRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1416,8 +1333,7 @@ public final class IndicesClient {
 
     /**
      * Puts an index template using the Index Templates API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
+     *
      * @param putIndexTemplateRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1432,8 +1348,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously puts an index template using the Index Templates API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
+     *
      * @param putIndexTemplateRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1448,8 +1363,7 @@ public final class IndicesClient {
 
     /**
      * Puts an index template using the Index Templates API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
+     *
      * @param putIndexTemplateRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1463,8 +1377,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously puts an index template using the Index Templates API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
+     *
      * @param putIndexTemplateRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1478,8 +1391,7 @@ public final class IndicesClient {
 
     /**
      * Simulates matching index name against the existing index templates in the system.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
+     *
      *
      * @param simulateIndexTemplateRequest the request
      * @param options                      the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be
@@ -1495,8 +1407,6 @@ public final class IndicesClient {
 
     /**
      * Asynchronously simulates matching index name against the existing index templates in the system.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
      *
      * @param simulateIndexTemplateRequest the request
      * @param options                      the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be
@@ -1513,8 +1423,7 @@ public final class IndicesClient {
     /**
      * Validate a potentially expensive query without executing it.
      * <p>
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-validate.html"> Validate Query API
-     * on elastic.co</a>
+     *
      * @param validateQueryRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1530,8 +1439,7 @@ public final class IndicesClient {
     /**
      * Asynchronously validate a potentially expensive query without executing it.
      * <p>
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-validate.html"> Validate Query API
-     * on elastic.co</a>
+     *
      * @param validateQueryRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1547,8 +1455,7 @@ public final class IndicesClient {
     /**
      * Gets index templates using the Index Templates API. The mappings will be returned in a legacy deprecated format, where the
      * mapping definition is nested under the type name.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
+     *
      * @param getIndexTemplatesRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1567,8 +1474,7 @@ public final class IndicesClient {
 
     /**
      * Gets index templates using the Index Templates API
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
+     *
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param getIndexTemplatesRequest the request
      * @return the response
@@ -1582,8 +1488,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously gets index templates using the Index Templates API
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
+     *
      * @param getIndexTemplatesRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1597,8 +1502,7 @@ public final class IndicesClient {
 
     /**
      * Gets index templates using the Index Templates API
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
+     *
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param getIndexTemplatesRequest the request
      * @return the response
@@ -1614,8 +1518,7 @@ public final class IndicesClient {
     /**
      * Asynchronously gets index templates using the Index Templates API. The mappings will be returned in a legacy deprecated format,
      * where the mapping definition is nested under the type name.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
+     *
      * @param getIndexTemplatesRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1635,8 +1538,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously gets index templates using the Index Templates API
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
+     *
      * @param getIndexTemplatesRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1714,8 +1616,6 @@ public final class IndicesClient {
     /**
      * Calls the analyze API
      *
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html">Analyze API on elastic.co</a>
-     *
      * @param request   the request
      * @param options   the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      */
@@ -1727,7 +1627,6 @@ public final class IndicesClient {
     /**
      * Asynchronously calls the analyze API
      *
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html">Analyze API on elastic.co</a>
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1741,8 +1640,6 @@ public final class IndicesClient {
 
     /**
      * Delete an index template using the Index Templates API
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
      *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -1755,8 +1652,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously delete an index template using the Index Templates API
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
+     *
      * @param request  the request
      * @param options  the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1770,8 +1666,6 @@ public final class IndicesClient {
 
     /**
      * Delete an index template using the Index Templates API
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
      *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -1785,8 +1679,7 @@ public final class IndicesClient {
 
     /**
      * Asynchronously delete an index template using the Index Templates API
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html"> Index Templates API
-     * on elastic.co</a>
+     *
      * @param request  the request
      * @param options  the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion

--- a/client/rest-high-level/src/main/java/org/opensearch/client/IngestClient.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/IngestClient.java
@@ -51,7 +51,7 @@ import static java.util.Collections.emptySet;
 /**
  * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Ingest API.
  * <p>
- * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html">Ingest API on elastic.co</a>
+ *
  */
 public final class IngestClient {
 
@@ -63,8 +63,7 @@ public final class IngestClient {
 
     /**
      * Add a pipeline or update an existing pipeline.
-     * See
-     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/put-pipeline-api.html"> Put Pipeline API on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -77,8 +76,7 @@ public final class IngestClient {
 
     /**
      * Asynchronously add a pipeline or update an existing pipeline.
-     * See
-     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/put-pipeline-api.html"> Put Pipeline API on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -91,8 +89,7 @@ public final class IngestClient {
 
     /**
      * Get an existing pipeline.
-     * See
-     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/get-pipeline-api.html"> Get Pipeline API on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -105,8 +102,7 @@ public final class IngestClient {
 
     /**
      * Asynchronously get an existing pipeline.
-     * See
-     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html"> Get Pipeline API on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -119,9 +115,7 @@ public final class IngestClient {
 
     /**
      * Delete an existing pipeline.
-     * See
-     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-pipeline-api.html">
-     *     Delete Pipeline API on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -134,9 +128,7 @@ public final class IngestClient {
 
     /**
      * Asynchronously delete an existing pipeline.
-     * See
-     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-pipeline-api.html">
-     *     Delete Pipeline API on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -152,9 +144,7 @@ public final class IngestClient {
     /**
      * Simulate a pipeline on a set of documents provided in the request
      * <p>
-     * See
-     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html">
-     *     Simulate Pipeline API on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -168,9 +158,7 @@ public final class IngestClient {
     /**
      * Asynchronously simulate a pipeline on a set of documents provided in the request
      * <p>
-     * See
-     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html">
-     *     Simulate Pipeline API on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion

--- a/client/rest-high-level/src/main/java/org/opensearch/client/IngestClient.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/IngestClient.java
@@ -50,7 +50,6 @@ import static java.util.Collections.emptySet;
 
 /**
  * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Ingest API.
- * <p>
  *
  */
 public final class IngestClient {

--- a/client/rest-high-level/src/main/java/org/opensearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/RestHighLevelClient.java
@@ -704,7 +704,6 @@ public class RestHighLevelClient implements Closeable {
     /**
      * Checks for the existence of a document with a "_source" field. Returns true if it exists, false otherwise.
      *
-     * on elastic.co</a>
      * @param getRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return <code>true</code> if the document and _source field exists, <code>false</code> otherwise
@@ -720,7 +719,6 @@ public class RestHighLevelClient implements Closeable {
     /**
      * Asynchronously checks for the existence of a document with a "_source" field. Returns true if it exists, false otherwise.
      *
-     * on elastic.co</a>
      * @param getRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -737,7 +735,6 @@ public class RestHighLevelClient implements Closeable {
     /**
      * Checks for the existence of a document with a "_source" field. Returns true if it exists, false otherwise.
      *
-     * on elastic.co</a>
      * @param getSourceRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return <code>true</code> if the document and _source field exists, <code>false</code> otherwise
@@ -750,7 +747,6 @@ public class RestHighLevelClient implements Closeable {
     /**
      * Asynchronously checks for the existence of a document with a "_source" field. Returns true if it exists, false otherwise.
      *
-     * on elastic.co</a>
      * @param getSourceRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -765,7 +761,6 @@ public class RestHighLevelClient implements Closeable {
     /**
      * Retrieves the source field only of a document using GetSource API.
      *
-     * on elastic.co</a>
      * @param getSourceRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -778,7 +773,6 @@ public class RestHighLevelClient implements Closeable {
     /**
      * Asynchronously retrieves the source field only of a document using GetSource API.
      *
-     * on elastic.co</a>
      * @param getSourceRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion

--- a/client/rest-high-level/src/main/java/org/opensearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/RestHighLevelClient.java
@@ -323,7 +323,6 @@ public class RestHighLevelClient implements Closeable {
     /**
      * Provides an {@link IndicesClient} which can be used to access the Indices API.
      *
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices.html">Indices API on elastic.co</a>
      */
     public final IndicesClient indices() {
         return indicesClient;
@@ -331,8 +330,6 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Provides a {@link ClusterClient} which can be used to access the Cluster API.
-     *
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html">Cluster API on elastic.co</a>
      */
     public final ClusterClient cluster() {
         return clusterClient;
@@ -340,8 +337,6 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Provides a {@link IngestClient} which can be used to access the Ingest API.
-     *
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html">Ingest API on elastic.co</a>
      */
     public final IngestClient ingest() {
         return ingestClient;
@@ -349,8 +344,6 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Provides a {@link SnapshotClient} which can be used to access the Snapshot API.
-     *
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html">Snapshot API on elastic.co</a>
      */
     public final SnapshotClient snapshot() {
         return snapshotClient;
@@ -358,8 +351,6 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Provides a {@link TasksClient} which can be used to access the Tasks API.
-     *
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html">Task Management API on elastic.co</a>
      */
     public final TasksClient tasks() {
         return tasksClient;
@@ -367,7 +358,6 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Executes a bulk request using the Bulk API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html">Bulk API on elastic.co</a>
      * @param bulkRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -378,7 +368,6 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously executes a bulk request using the Bulk API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html">Bulk API on elastic.co</a>
      * @param bulkRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -391,7 +380,6 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Executes a reindex request.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html">Reindex API on elastic.co</a>
      * @param reindexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -404,7 +392,6 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Submits a reindex task.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html">Reindex API on elastic.co</a>
      * @param reindexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the submission response
@@ -417,7 +404,6 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously executes a reindex request.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html">Reindex API on elastic.co</a>
      * @param reindexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -432,8 +418,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Executes a update by query request.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html">
-     *     Update By Query API on elastic.co</a>
+     *
      * @param updateByQueryRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -446,8 +431,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Submits a update by query task.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html">
-     *     Update By Query API on elastic.co</a>
+     *
      * @param updateByQueryRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the submission response
@@ -461,8 +445,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously executes an update by query request.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html">
-     *     Update By Query API on elastic.co</a>
+     *
      * @param updateByQueryRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -477,8 +460,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Executes a delete by query request.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html">
-     *     Delete By Query API on elastic.co</a>
+     *
      * @param deleteByQueryRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -491,8 +473,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Submits a delete by query task
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html">
-     *      Delete By Query API on elastic.co</a>
+     *
      * @param deleteByQueryRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the submission response
@@ -506,8 +487,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously executes a delete by query request.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html">
-     *     Delete By Query API on elastic.co</a>
+     *
      * @param deleteByQueryRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -522,8 +502,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Executes a delete by query rethrottle request.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html">
-     *     Delete By Query API on elastic.co</a>
+     *
      * @param rethrottleRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -535,8 +514,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously execute an delete by query rethrottle request.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html">
-     *     Delete By Query API on elastic.co</a>
+     *
      * @param rethrottleRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -550,8 +528,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Executes a update by query rethrottle request.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html">
-     *     Update By Query API on elastic.co</a>
+     *
      * @param rethrottleRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -563,8 +540,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously execute an update by query rethrottle request.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html">
-     *     Update By Query API on elastic.co</a>
+     *
      * @param rethrottleRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -578,8 +554,6 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Executes a reindex rethrottling request.
-     * See the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html#docs-reindex-rethrottle">
-     * Reindex rethrottling API on elastic.co</a>
      *
      * @param rethrottleRequest the request
      * @param options           the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -592,8 +566,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Executes a reindex rethrottling request.
-     * See the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html#docs-reindex-rethrottle">
-     * Reindex rethrottling API on elastic.co</a>
+     *
      * @param rethrottleRequest the request
      * @param options           the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener          the listener to be notified upon request completion
@@ -627,7 +600,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Retrieves a document by id using the Get API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html">Get API on elastic.co</a>
+     *
      * @param getRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -638,7 +611,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously retrieves a document by id using the Get API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html">Get API on elastic.co</a>
+     *
      * @param getRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -651,7 +624,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Retrieves multiple documents by id using the Multi Get API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html">Multi Get API on elastic.co</a>
+     *
      * @param multiGetRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -665,7 +638,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Retrieves multiple documents by id using the Multi Get API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html">Multi Get API on elastic.co</a>
+     *
      * @param multiGetRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -677,7 +650,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously retrieves multiple documents by id using the Multi Get API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html">Multi Get API on elastic.co</a>
+     *
      * @param multiGetRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -692,7 +665,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously retrieves multiple documents by id using the Multi Get API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html">Multi Get API on elastic.co</a>
+     *
      * @param multiGetRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -706,7 +679,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Checks for the existence of a document. Returns true if it exists, false otherwise.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html">Get API on elastic.co</a>
+     *
      * @param getRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return <code>true</code> if the document exists, <code>false</code> otherwise
@@ -717,7 +690,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously checks for the existence of a document. Returns true if it exists, false otherwise.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html">Get API on elastic.co</a>
+     *
      * @param getRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -730,7 +703,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Checks for the existence of a document with a "_source" field. Returns true if it exists, false otherwise.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html#_source">Source exists API
+     *
      * on elastic.co</a>
      * @param getRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -746,7 +719,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously checks for the existence of a document with a "_source" field. Returns true if it exists, false otherwise.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html#_source">Source exists API
+     *
      * on elastic.co</a>
      * @param getRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -763,7 +736,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Checks for the existence of a document with a "_source" field. Returns true if it exists, false otherwise.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html#_source">Source exists API
+     *
      * on elastic.co</a>
      * @param getSourceRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -776,7 +749,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously checks for the existence of a document with a "_source" field. Returns true if it exists, false otherwise.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html#_source">Source exists API
+     *
      * on elastic.co</a>
      * @param getSourceRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -791,7 +764,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Retrieves the source field only of a document using GetSource API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html#_source">Get Source API
+     *
      * on elastic.co</a>
      * @param getSourceRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -804,7 +777,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously retrieves the source field only of a document using GetSource API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html#_source">Get Source API
+     *
      * on elastic.co</a>
      * @param getSourceRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -819,7 +792,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Index a document using the Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html">Index API on elastic.co</a>
+     *
      * @param indexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -831,7 +804,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously index a document using the Index API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html">Index API on elastic.co</a>
+     *
      * @param indexRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -844,7 +817,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Executes a count request using the Count API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-count.html">Count API on elastic.co</a>
+     *
      * @param countRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -856,7 +829,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously executes a count request using the Count API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-count.html">Count API on elastic.co</a>
+     *
      * @param countRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -869,7 +842,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Updates a document using the Update API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html">Update API on elastic.co</a>
+     *
      * @param updateRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -880,7 +853,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously updates a document using the Update API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html">Update API on elastic.co</a>
+     *
      * @param updateRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -893,7 +866,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Deletes a document by id using the Delete API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html">Delete API on elastic.co</a>
+     *
      * @param deleteRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -905,7 +878,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously deletes a document by id using the Delete API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html">Delete API on elastic.co</a>
+     *
      * @param deleteRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -918,7 +891,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Executes a search request using the Search API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html">Search API on elastic.co</a>
+     *
      * @param searchRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -934,7 +907,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously executes a search using the Search API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html">Search API on elastic.co</a>
+     *
      * @param searchRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -952,8 +925,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Executes a multi search using the msearch API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html">Multi search API on
-     * elastic.co</a>
+     *
      * @param multiSearchRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -966,8 +938,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Executes a multi search using the msearch API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html">Multi search API on
-     * elastic.co</a>
+     *
      * @param multiSearchRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -979,8 +950,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously executes a multi search using the msearch API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html">Multi search API on
-     * elastic.co</a>
+     *
      * @param searchRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -995,8 +965,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously executes a multi search using the msearch API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html">Multi search API on
-     * elastic.co</a>
+     *
      * @param searchRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1010,9 +979,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Executes a search using the Search Scroll API.
-     * See <a
-     * href="https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll">Search
-     * Scroll API on elastic.co</a>
+     *
      * @param searchScrollRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1025,9 +992,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Executes a search using the Search Scroll API.
-     * See <a
-     * href="https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll">Search
-     * Scroll API on elastic.co</a>
+     *
      * @param searchScrollRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1039,9 +1004,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously executes a search using the Search Scroll API.
-     * See <a
-     * href="https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll">Search
-     * Scroll API on elastic.co</a>
+     *
      * @param searchScrollRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1056,9 +1019,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously executes a search using the Search Scroll API.
-     * See <a
-     * href="https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll">Search
-     * Scroll API on elastic.co</a>
+     *
      * @param searchScrollRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1072,9 +1033,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Clears one or more scroll ids using the Clear Scroll API.
-     * See <a
-     * href="https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#_clear_scroll_api">
-     * Clear Scroll API on elastic.co</a>
+     *
      * @param clearScrollRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1086,9 +1045,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously clears one or more scroll ids using the Clear Scroll API.
-     * See <a
-     * href="https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#_clear_scroll_api">
-     * Clear Scroll API on elastic.co</a>
+     *
      * @param clearScrollRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1102,8 +1059,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Executes a request using the Search Template API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html">Search Template API
-     * on elastic.co</a>.
+     *
      * @param searchTemplateRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1117,8 +1073,6 @@ public class RestHighLevelClient implements Closeable {
     /**
      * Asynchronously executes a request using the Search Template API.
      *
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html">Search Template API
-     * on elastic.co</a>.
      * @return cancellable that may be used to cancel the request
      */
     public final Cancellable searchTemplateAsync(SearchTemplateRequest searchTemplateRequest, RequestOptions options,
@@ -1129,7 +1083,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Executes a request using the Explain API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-explain.html">Explain API on elastic.co</a>
+     *
      * @param explainRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1147,7 +1101,6 @@ public class RestHighLevelClient implements Closeable {
     /**
      * Asynchronously executes a request using the Explain API.
      *
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-explain.html">Explain API on elastic.co</a>
      * @param explainRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1167,9 +1120,6 @@ public class RestHighLevelClient implements Closeable {
     /**
      * Calls the Term Vectors API
      *
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-termvectors.html">Term Vectors API on
-     * elastic.co</a>
-     *
      * @param request   the request
      * @param options   the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      */
@@ -1181,8 +1131,6 @@ public class RestHighLevelClient implements Closeable {
     /**
      * Asynchronously calls the Term Vectors API
      *
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-termvectors.html">Term Vectors API on
-     * elastic.co</a>
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1199,9 +1147,6 @@ public class RestHighLevelClient implements Closeable {
     /**
      * Calls the Multi Term Vectors API
      *
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-termvectors.html">Multi Term Vectors API
-     * on elastic.co</a>
-     *
      * @param request   the request
      * @param options   the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      */
@@ -1214,8 +1159,6 @@ public class RestHighLevelClient implements Closeable {
     /**
      * Asynchronously calls the Multi Term Vectors API
      *
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-termvectors.html">Multi Term Vectors API
-     * on elastic.co</a>
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1230,8 +1173,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Executes a request using the Ranking Evaluation API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html">Ranking Evaluation API
-     * on elastic.co</a>
+     *
      * @param rankEvalRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1245,8 +1187,6 @@ public class RestHighLevelClient implements Closeable {
     /**
      * Executes a request using the Multi Search Template API.
      *
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-search-template.html">Multi Search Template API
-     * on elastic.co</a>.
      */
     public final MultiSearchTemplateResponse msearchTemplate(MultiSearchTemplateRequest multiSearchTemplateRequest,
                                                              RequestOptions options) throws IOException {
@@ -1257,8 +1197,6 @@ public class RestHighLevelClient implements Closeable {
     /**
      * Asynchronously executes a request using the Multi Search Template API
      *
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-search-template.html">Multi Search Template API
-     * on elastic.co</a>.
      * @return cancellable that may be used to cancel the request
      */
     public final Cancellable msearchTemplateAsync(MultiSearchTemplateRequest multiSearchTemplateRequest,
@@ -1270,8 +1208,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously executes a request using the Ranking Evaluation API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html">Ranking Evaluation API
-     * on elastic.co</a>
+     *
      * @param rankEvalRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1286,8 +1223,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Executes a request using the Field Capabilities API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-field-caps.html">Field Capabilities API
-     * on elastic.co</a>.
+     *
      * @param fieldCapabilitiesRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1300,8 +1236,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Get stored script by id.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting-using.html">
-     *     How to use scripts on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1313,8 +1248,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously get stored script by id.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting-using.html">
-     *     How to use scripts on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1328,8 +1262,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Delete stored script by id.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting-using.html">
-     *     How to use scripts on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1341,8 +1274,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously delete stored script by id.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting-using.html">
-     *     How to use scripts on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1356,8 +1288,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Puts an stored script using the Scripting API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting-using.html"> Scripting API
-     * on elastic.co</a>
+     *
      * @param putStoredScriptRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -1370,8 +1301,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously puts an stored script using the Scripting API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting-using.html"> Scripting API
-     * on elastic.co</a>
+     *
      * @param putStoredScriptRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -1385,8 +1315,7 @@ public class RestHighLevelClient implements Closeable {
 
     /**
      * Asynchronously executes a request using the Field Capabilities API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-field-caps.html">Field Capabilities API
-     * on elastic.co</a>.
+     *
      * @param fieldCapabilitiesRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion

--- a/client/rest-high-level/src/main/java/org/opensearch/client/SnapshotClient.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/SnapshotClient.java
@@ -62,7 +62,7 @@ import static java.util.Collections.emptySet;
 /**
  * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Snapshot API.
  * <p>
- * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html">Snapshot API on elastic.co</a>
+ *
  */
 public final class SnapshotClient {
     private final RestHighLevelClient restHighLevelClient;
@@ -74,8 +74,7 @@ public final class SnapshotClient {
     /**
      * Gets a list of snapshot repositories. If the list of repositories is empty or it contains a single element "_all", all
      * registered repositories are returned.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
+     *
      * @param getRepositoriesRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -90,8 +89,7 @@ public final class SnapshotClient {
     /**
      * Asynchronously gets a list of snapshot repositories. If the list of repositories is empty or it contains a single element "_all", all
      * registered repositories are returned.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
+     *
      * @param getRepositoriesRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -106,8 +104,7 @@ public final class SnapshotClient {
 
     /**
      * Creates a snapshot repository.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
+     *
      * @param putRepositoryRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -120,8 +117,7 @@ public final class SnapshotClient {
 
     /**
      * Asynchronously creates a snapshot repository.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
+     *
      * @param putRepositoryRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -136,8 +132,7 @@ public final class SnapshotClient {
 
     /**
      * Deletes a snapshot repository.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
+     *
      * @param deleteRepositoryRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -151,8 +146,7 @@ public final class SnapshotClient {
 
     /**
      * Asynchronously deletes a snapshot repository.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
+     *
      * @param deleteRepositoryRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -167,8 +161,7 @@ public final class SnapshotClient {
 
     /**
      * Verifies a snapshot repository.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
+     *
      * @param verifyRepositoryRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -182,8 +175,7 @@ public final class SnapshotClient {
 
     /**
      * Asynchronously verifies a snapshot repository.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
+     *
      * @param verifyRepositoryRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -198,8 +190,7 @@ public final class SnapshotClient {
 
     /**
      * Cleans up a snapshot repository.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
+     *
      * @param cleanupRepositoryRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -213,8 +204,7 @@ public final class SnapshotClient {
 
     /**
      * Asynchronously cleans up a snapshot repository.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
+     *
      * @param cleanupRepositoryRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -229,8 +219,7 @@ public final class SnapshotClient {
     /**
      * Creates a snapshot.
      * <p>
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
+     *
      */
     public CreateSnapshotResponse create(CreateSnapshotRequest createSnapshotRequest, RequestOptions options)
         throws IOException {
@@ -241,8 +230,7 @@ public final class SnapshotClient {
     /**
      * Asynchronously creates a snapshot.
      * <p>
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
+     *
      * @return cancellable that may be used to cancel the request
      */
     public Cancellable createAsync(CreateSnapshotRequest createSnapshotRequest, RequestOptions options,
@@ -255,8 +243,7 @@ public final class SnapshotClient {
     /**
      * Clones a snapshot.
      * <p>
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
+     *
      */
     public AcknowledgedResponse clone(CloneSnapshotRequest cloneSnapshotRequest, RequestOptions options)
             throws IOException {
@@ -267,8 +254,7 @@ public final class SnapshotClient {
     /**
      * Asynchronously clones a snapshot.
      * <p>
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
+     *
      * @return cancellable that may be used to cancel the request
      */
     public Cancellable cloneAsync(CloneSnapshotRequest cloneSnapshotRequest, RequestOptions options,
@@ -280,8 +266,6 @@ public final class SnapshotClient {
 
     /**
      * Get snapshots.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
      *
      * @param getSnapshotsRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -295,8 +279,7 @@ public final class SnapshotClient {
 
     /**
      * Asynchronously get snapshots.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
+     *
      *  @param getSnapshotsRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -311,8 +294,7 @@ public final class SnapshotClient {
 
     /**
      * Gets the status of requested snapshots.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
+     *
      * @param snapshotsStatusRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -326,8 +308,7 @@ public final class SnapshotClient {
 
     /**
      * Asynchronously gets the status of requested snapshots.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
+     *
      * @param snapshotsStatusRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -342,8 +323,6 @@ public final class SnapshotClient {
 
     /**
      * Restores a snapshot.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
      *
      * @param restoreSnapshotRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -357,8 +336,6 @@ public final class SnapshotClient {
 
     /**
      * Asynchronously restores a snapshot.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
      *
      * @param restoreSnapshotRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -374,8 +351,6 @@ public final class SnapshotClient {
 
     /**
      * Deletes a snapshot.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
      *
      * @param deleteSnapshotRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
@@ -390,8 +365,6 @@ public final class SnapshotClient {
 
     /**
      * Asynchronously deletes a snapshot.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html"> Snapshot and Restore
-     * API on elastic.co</a>
      *
      * @param deleteSnapshotRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized

--- a/client/rest-high-level/src/main/java/org/opensearch/client/SnapshotClient.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/SnapshotClient.java
@@ -61,7 +61,6 @@ import static java.util.Collections.emptySet;
 
 /**
  * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Snapshot API.
- * <p>
  *
  */
 public final class SnapshotClient {
@@ -218,8 +217,6 @@ public final class SnapshotClient {
 
     /**
      * Creates a snapshot.
-     * <p>
-     *
      */
     public CreateSnapshotResponse create(CreateSnapshotRequest createSnapshotRequest, RequestOptions options)
         throws IOException {
@@ -242,8 +239,6 @@ public final class SnapshotClient {
 
     /**
      * Clones a snapshot.
-     * <p>
-     *
      */
     public AcknowledgedResponse clone(CloneSnapshotRequest cloneSnapshotRequest, RequestOptions options)
             throws IOException {

--- a/client/rest-high-level/src/main/java/org/opensearch/client/TasksClient.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/TasksClient.java
@@ -47,8 +47,6 @@ import static java.util.Collections.emptySet;
 
 /**
  * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Tasks API.
- * <p>
- *
  */
 public final class TasksClient {
     private final RestHighLevelClient restHighLevelClient;

--- a/client/rest-high-level/src/main/java/org/opensearch/client/TasksClient.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/TasksClient.java
@@ -48,7 +48,7 @@ import static java.util.Collections.emptySet;
 /**
  * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Tasks API.
  * <p>
- * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html">Task Management API on elastic.co</a>
+ *
  */
 public final class TasksClient {
     private final RestHighLevelClient restHighLevelClient;
@@ -59,8 +59,7 @@ public final class TasksClient {
 
     /**
      * Get current tasks using the Task Management API.
-     * See
-     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html"> Task Management API on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -73,8 +72,7 @@ public final class TasksClient {
 
     /**
      * Asynchronously get current tasks using the Task Management API.
-     * See
-     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html"> Task Management API on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion
@@ -87,8 +85,7 @@ public final class TasksClient {
 
     /**
      * Get a task using the Task Management API.
-     * See
-     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html"> Task Management API on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -101,8 +98,7 @@ public final class TasksClient {
 
     /**
      * Get a task using the Task Management API.
-     * See
-     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html"> Task Management API on elastic.co</a>
+     *
      * @param request the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener an actionlistener that takes an optional response (404s are returned as an empty Optional)
@@ -118,8 +114,6 @@ public final class TasksClient {
     /**
      * Cancel one or more cluster tasks using the Task Management API.
      *
-     * See
-     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html"> Task Management API on elastic.co</a>
      * @param cancelTasksRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @return the response
@@ -139,8 +133,6 @@ public final class TasksClient {
     /**
      * Asynchronously cancel one or more cluster tasks using the Task Management API.
      *
-     * See
-     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html"> Task Management API on elastic.co</a>
      * @param cancelTasksRequest the request
      * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
      * @param listener the listener to be notified upon request completion

--- a/server/src/main/java/org/opensearch/index/query/SimpleQueryStringBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SimpleQueryStringBuilder.java
@@ -87,10 +87,6 @@ import java.util.Objects;
  * {@code fields} - fields to search, defaults to _all if not set, allows
  * boosting a field with ^n
  *
- * For more detailed explanation of the query string syntax see also the <a
- * href=
- * "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html"
- * > online documentation</a>.
  */
 public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQueryStringBuilder> {
 


### PR DESCRIPTION
### Description
This PR removes all href references of `elastic.co/*` from javadocs comments.
 
### Issues Resolved
#583 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

 Signed-off-by: Abbas Hussain <abbas_10690@yahoo.com>
