### PR TITLE
Handle inefficiencies while fetching the delayed unassigned shards during cluster health

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/IndexRoutingTable.java
@@ -59,6 +59,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * The {@link IndexRoutingTable} represents routing information for a single
@@ -276,6 +277,14 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
             shards.addAll(shardRoutingTable.shardsWithState(state));
         }
         return shards;
+    }
+
+    public int shardsMatchingPredicateCount(Predicate<ShardRouting> predicate) {
+        int count = 0;
+        for (IndexShardRoutingTable shardRoutingTable : this) {
+            count += shardRoutingTable.shardsMatchingPredicateCount(predicate);
+        }
+        return count;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/IndexShardRoutingTable.java
@@ -56,6 +56,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import static java.util.Collections.emptyMap;
 
@@ -670,6 +671,16 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
             }
         }
         return shards;
+    }
+
+    public int shardsMatchingPredicateCount(Predicate<ShardRouting> predicate) {
+        int count = 0;
+        for (ShardRouting shardEntry : this) {
+            if (predicate.test(shardEntry)) {
+                count++;
+            }
+        }
+        return count;
     }
 
     public static class Builder {

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
@@ -196,6 +196,14 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
         return shards;
     }
 
+    public int shardsMatchingPredicateCount(Predicate<ShardRouting> predicate) {
+        int count = 0;
+        for (IndexRoutingTable indexRoutingTable : this) {
+            count += indexRoutingTable.shardsMatchingPredicateCount(predicate);
+        }
+        return count;
+    }
+
     /**
      * All the shards (replicas) for all indices in this routing table.
      *

--- a/server/src/main/java/org/opensearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/UnassignedInfo.java
@@ -58,6 +58,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Holds additional information as to why the shard is in unassigned state.
@@ -413,13 +414,8 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
      * Returns the number of shards that are unassigned and currently being delayed.
      */
     public static int getNumberOfDelayedUnassigned(ClusterState state) {
-        int count = 0;
-        for (ShardRouting shard : state.routingTable().shardsWithState(ShardRoutingState.UNASSIGNED)) {
-            if (shard.unassignedInfo().isDelayed()) {
-                count++;
-            }
-        }
-        return count;
+        Predicate<ShardRouting> predicate = s -> s.state() == ShardRoutingState.UNASSIGNED && s.unassignedInfo().isDelayed();
+        return state.routingTable().shardsMatchingPredicateCount(predicate);
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Meet Shah <meetshsh@gmail.com>

### Description
During cluster health, to return the delayed_unassigned_shards count, OS iterates through all of the shards to filter for unassigned shards and adds them to an array and fetches the delayed unassigned shards count from the array. With this change, we iterate through the shards once and maintain a count of shards that match our predicate without creating an array.

### Testing
./gradlew ':server:internalClusterTest' --tests "org.opensearch.cluster.routing.*"
 
### Issues Resolved
closes #506 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
