### PR TITLE
clean up rpm artifact naming

### DIFF
--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -129,12 +129,17 @@ Closure commonPackageConfig(String type, boolean jdk, String architecture) {
       }
     }
     // Follow opensearch's file naming convention
-    String jdkString = jdk ? "" : "no-jdk-"
+    String jdkString = jdk ? "" : "-no-jdk"
     String prefix = "${architecture == 'aarch64' ? 'aarch64-' : ''}${jdk ? '' : 'no-jdk-'}${type}"
     destinationDirectory = file("${prefix}/build/distributions")
 
     // SystemPackagingTask overrides default archive task convention mappings, but doesn't provide a setter so we have to override the convention mapping itself
-    conventionMapping.archiveFile = { objects.fileProperty().fileValue(file("${destinationDirectory.get()}/${packageName}-${project.version}-${jdkString}${archString}.${type}")) }
+    // Deb convention uses a '-' for final separator before architecture, rpm uses a '.'
+    if (type == 'deb') {
+      conventionMapping.archiveFile = { objects.fileProperty().fileValue(file("${destinationDirectory.get()}/${packageName}-${project.version}${jdkString}-${archString}.${type}")) }
+    } else {
+      conventionMapping.archiveFile = { objects.fileProperty().fileValue(file("${destinationDirectory.get()}/${packageName}-${project.version}${jdkString}.${archString}.${type}")) }
+    }
 
     String packagingFiles = "build/packaging/${jdk ? '' : 'no-jdk-'}${type}"
 


### PR DESCRIPTION
### Description
The naming logic for the RPM artifact was not in line with community expectations. Deb files have a standard of:  
  
foo-ARCH.deb

RPM files have a standard of:  
  
foo.ARCH.rpm

To fix this, I adjusted one string (jdkString) to not assume it can always have a trailing -. I gave that string a - prefix, and removed the hardcoded dash from the conventionMapping.archiveFile definition. Finally, I conditionalized the conventionMapping.archiveFile so that the final separator before architecture is a '-' for deb files and a '.' for rpm files.

Local testing results in deb and rpm files named according to community expectations.
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
