### PR TITLE
[Build] Remove max heap size and enable build cache in gradle properties.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,8 @@
 
 org.gradle.warning.mode=none
 org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Xss2m
-options.forkOptions.memoryMaximumSize=2g
+org.gradle.caching=true
+org.gradle.jvmargs=-Xms3g -XX:+HeapDumpOnOutOfMemoryError -Xss2m
 
 # Disable duplicate project id detection
 # See https://docs.gradle.org/current/userguide/upgrading_version_6.html#duplicate_project_names_may_cause_publication_to_fail


### PR DESCRIPTION
### Description

Make the following changes to the `gradle.properties` for performance improvement. 

- remove the limit on max heap size used by the gradle daemon and instead replace this with an initial heap size Xms3g. Most machines nowadays have enough memory.
- enable the build cache, so gradle can use it whenever possible and improve the build performance.

Remove the unused property `options.forkOptions.memoryMaximumSize`.
 
### Issues Resolved
[List any issues this PR will resolve]
NA

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>