### PR TITLE
Updating the Ivy repository to point to real url for Releases

### DIFF
--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/fixtures/DistributionDownloadFixture.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/fixtures/DistributionDownloadFixture.groovy
@@ -65,7 +65,7 @@ class DistributionDownloadFixture {
     private static String urlPath(String version, OpenSearchDistribution.Platform platform) {
         String fileType = ((platform == OpenSearchDistribution.Platform.LINUX ||
                 platform == OpenSearchDistribution.Platform.DARWIN)) ? "tar.gz" : "zip"
-        "/downloads/opensearch/opensearch-${version}-${platform}-x86_64.$fileType"
+        "/releases/core/opensearch/${version}/opensearch-${version}-${platform}-x86_64.$fileType"
     }
 
     private static byte[] filebytes(String urlPath) throws IOException {

--- a/buildSrc/src/main/java/org/opensearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/DistributionDownloadPlugin.java
@@ -156,7 +156,7 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
             repo.setName(name);
             repo.setUrl(url);
             repo.metadataSources(IvyArtifactRepository.MetadataSources::artifact);
-            repo.patternLayout(layout -> layout.artifact("/downloads/opensearch/[module]-[revision](-[classifier]).[ext]"));
+            repo.patternLayout(layout -> layout.artifact("/releases/core/opensearch/[revision]/[module]-[revision](-[classifier]).[ext]"));
         });
         project.getRepositories().exclusiveContent(exclusiveContentRepository -> {
             exclusiveContentRepository.filter(config -> config.includeGroup(group));
@@ -168,7 +168,7 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
         if (project.getRepositories().findByName(DOWNLOAD_REPO_NAME) != null) {
             return;
         }
-        addIvyRepo(project, DOWNLOAD_REPO_NAME, "https://artifacts-no-kpi.opensearch.org", FAKE_IVY_GROUP);
+        addIvyRepo(project, DOWNLOAD_REPO_NAME, "https://artifacts.opensearch.org", FAKE_IVY_GROUP);
         addIvyRepo(project, SNAPSHOT_REPO_NAME, "https://snapshots-no-kpi.opensearch.org", FAKE_SNAPSHOT_IVY_GROUP);
     }
 


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Updating the Ivy repository to point to real URL for Releases.

Snapshot releases are not yet supported by the infrastructure.

For example 1.0.0-alpha1 would be:
`https://artifacts.opensearch.org/releases/core/opensearch/1.0.0-alpha1/opensearch-1.0.0-alpha1-linux-x86_64.tar.gz`

### Issues Resolved
#600 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
