### PR TITLE
Rename the 'oss' distribution used in test clusters.

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -64,17 +64,6 @@ NOTE: If you have imported the project into IntelliJ according to the instructio
 link:/DEVELOPER_GUIDE.md#importing-the-project-into-intellij-idea[DEVELOPER_GUIDE.md] then a debug run configuration
 named "Debug OpenSearch" will be created for you and configured appropriately.
 
-==== Distribution
-
-By default a node is started with the zip distribution.
-In order to start with a different distribution use the `-Drun.distribution` argument.
-
-To for example start the open source distribution:
-
--------------------------------------
-./gradlew run
--------------------------------------
-
 ==== Other useful arguments
 
 - In order to start a node with a different max heap space add: `-Dtests.heap.size=4G`

--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/TestClustersPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/TestClustersPluginFuncTest.groovy
@@ -61,7 +61,7 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
         buildFile << """
             testClusters {
               myCluster {
-                testDistribution = 'oss'
+                testDistribution = 'archive'
               }
             }
 
@@ -87,7 +87,7 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
         buildFile << """
             testClusters {
               myCluster {
-                testDistribution = 'oss'
+                testDistribution = 'archive'
                 extraJarFile(file('${someJar().absolutePath}'))
               }
             }

--- a/buildSrc/src/main/groovy/org/opensearch/gradle/doc/DocsTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/gradle/doc/DocsTestPlugin.groovy
@@ -45,7 +45,7 @@ class DocsTestPlugin implements Plugin<Project> {
         project.pluginManager.apply('opensearch.standalone-rest-test')
         project.pluginManager.apply('opensearch.rest-test')
 
-        String distribution = System.getProperty('tests.distribution', 'oss')
+        String distribution = System.getProperty('tests.distribution', 'archive')
         // The distribution can be configured with -Dtests.distribution on the command line
         project.testClusters.integTest.testDistribution = distribution.toUpperCase()
 

--- a/buildSrc/src/main/groovy/org/opensearch/gradle/test/ClusterConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/gradle/test/ClusterConfiguration.groovy
@@ -39,7 +39,7 @@ class ClusterConfiguration {
     private final Project project
 
     @Input
-    String distribution = 'oss'
+    String distribution = 'archive'
 
     @Input
     int numNodes = 1

--- a/buildSrc/src/main/groovy/org/opensearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/gradle/test/ClusterFormationTasks.groovy
@@ -100,7 +100,7 @@ class ClusterFormationTasks {
         Configuration currentDistro = project.configurations.create("${prefix}_opensearchDistro")
         Configuration bwcDistro = project.configurations.create("${prefix}_opensearchBwcDistro")
         Configuration bwcPlugins = project.configurations.create("${prefix}_opensearchBwcPlugins")
-        if (System.getProperty('tests.distribution', 'oss') == 'integ-test-zip') {
+        if (System.getProperty('tests.distribution', 'archive') == 'integ-test-zip') {
             throw new Exception("tests.distribution=integ-test-zip is not supported")
         }
         configureDistributionDependency(project, config.distribution, currentDistro, VersionProperties.getOpenSearch())

--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/TestDistribution.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/TestDistribution.java
@@ -36,5 +36,5 @@ package org.opensearch.gradle.testclusters;
  */
 public enum TestDistribution {
     INTEG_TEST,
-    OSS
+    ARCHIVE
 }

--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -90,7 +90,7 @@ RestIntegTestTask asyncIntegTest = tasks.create("asyncIntegTest", RestIntegTestT
 check.dependsOn(asyncIntegTest)
 
 testClusters.all {
-  testDistribution = 'OSS'
+  testDistribution = 'ARCHIVE'
   systemProperty 'opensearch.scripting.update.ctx_in_params', 'false'
   setting 'reindex.remote.whitelist', '[ "[::1]:*", "127.0.0.1:*" ]'
 

--- a/gradle/run.gradle
+++ b/gradle/run.gradle
@@ -33,7 +33,7 @@ apply plugin: 'opensearch.testclusters'
 
 testClusters {
   runTask {
-    testDistribution = System.getProperty('run.distribution', 'oss')
+    testDistribution = 'archive'
   }
 }
 

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -104,7 +104,7 @@ dependencies {
 
 testClusters {
   generateContextCluster {
-    testDistribution = 'OSS'
+    testDistribution = 'ARCHIVE'
   }
 }
 

--- a/plugins/examples/painless-whitelist/build.gradle
+++ b/plugins/examples/painless-whitelist/build.gradle
@@ -44,7 +44,7 @@ dependencies {
 }
 
 testClusters.all {
-  testDistribution = 'oss'
+  testDistribution = 'archive'
 }
 
 test.enabled = false

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -16,13 +16,13 @@ subprojects { Project subproj ->
   subproj.tasks.withType(RestIntegTestTask) {
     if (subproj.extensions.findByName("${it.name}Cluster")) {
       subproj.extensions.configure("${it.name}Cluster") { cluster ->
-        cluster.distribution = System.getProperty('tests.distribution', 'oss')
+        cluster.distribution = System.getProperty('tests.distribution', 'archive')
       }
     }
   }
   plugins.withType(TestClustersPlugin).whenPluginAdded {
     testClusters.all {
-      String configuredTestDistribution = System.getProperty('tests.distribution', 'oss').toUpperCase()
+      String configuredTestDistribution = System.getProperty('tests.distribution', 'archive').toUpperCase()
       testDistribution = configuredTestDistribution
     }
   }


### PR DESCRIPTION
### Description
For test clusters, we are using the archive(zip, tar) distributions. Currently the distribution is named as "oss" and misleading. In this PR we rename the distribution to "archive".

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>