### PR TITLE
[Versioning] Fix Version.fromString logic for legacy version

### DIFF
--- a/client/rest-high-level/src/test/java/org/opensearch/client/core/MainResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/core/MainResponseTests.java
@@ -56,7 +56,7 @@ public class MainResponseTests extends AbstractResponseTestCase<org.opensearch.a
         Version version = VersionUtils.randomVersionBetween(random(), LegacyESVersion.V_6_0_1, Version.CURRENT);
         Build build = new Build(
             Build.Type.UNKNOWN, randomAlphaOfLength(8), date, randomBoolean(),
-            version.toString()
+            version.toString(), version.before(Version.V_1_0_0) ? null : "opensearch"
         );
         return new org.opensearch.action.main.MainResponse(nodeName, version, clusterName, clusterUuid , build);
     }

--- a/modules/reindex/src/main/java/org/opensearch/index/reindex/remote/RemoteResponseParsers.java
+++ b/modules/reindex/src/main/java/org/opensearch/index/reindex/remote/RemoteResponseParsers.java
@@ -33,6 +33,7 @@
 package org.opensearch.index.reindex.remote;
 
 import org.apache.lucene.search.TotalHits;
+import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.ParsingException;
@@ -292,11 +293,17 @@ final class RemoteResponseParsers {
             "/", true, a -> (Version) a[0]);
     static {
         ConstructingObjectParser<Version, XContentType> versionParser = new ConstructingObjectParser<>(
-                "version", true, a -> Version.fromString(
-                    ((String) a[0])
+                "version", true, a -> a[0] == null ?
+            LegacyESVersion.fromString(
+                    ((String) a[1])
                         .replace("-SNAPSHOT", "")
-                        .replaceFirst("-(alpha\\d+|beta\\d+|rc\\d+)", "")
-        ));
+                        .replaceFirst("-(alpha\\d+|beta\\d+|rc\\d+)", "")) :
+            Version.fromString(
+                ((String) a[1])
+                    .replace("-SNAPSHOT", "")
+                    .replaceFirst("-(alpha\\d+|beta\\d+|rc\\d+)", ""))
+            );
+        versionParser.declareStringOrNull(optionalConstructorArg(), new ParseField("distribution"));
         versionParser.declareString(constructorArg(), new ParseField("number"));
         MAIN_ACTION_PARSER.declareObject(constructorArg(), versionParser, new ParseField("version"));
     }

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
@@ -50,6 +50,7 @@ import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
 import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
 import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
+import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.Version;
 import org.opensearch.action.bulk.BackoffPolicy;
@@ -149,14 +150,15 @@ public class RemoteScrollableHitSourceTests extends OpenSearchTestCase {
     }
 
     public void testLookupRemoteVersion() throws Exception {
-        assertLookupRemoteVersion(Version.fromString("0.20.5"), "main/0_20_5.json");
-        assertLookupRemoteVersion(Version.fromString("0.90.13"), "main/0_90_13.json");
-        assertLookupRemoteVersion(Version.fromString("1.7.5"), "main/1_7_5.json");
-        assertLookupRemoteVersion(Version.fromId(2030399), "main/2_3_3.json");
+        assertLookupRemoteVersion(LegacyESVersion.fromString("0.20.5"), "main/0_20_5.json");
+        assertLookupRemoteVersion(LegacyESVersion.fromString("0.90.13"), "main/0_90_13.json");
+        assertLookupRemoteVersion(LegacyESVersion.fromString("1.7.5"), "main/1_7_5.json");
+        assertLookupRemoteVersion(LegacyESVersion.fromId(2030399), "main/2_3_3.json");
         // assert for V_5_0_0 (no qualifier) since we no longer consider qualifier in Version since 7
-        assertLookupRemoteVersion(Version.fromId(5000099), "main/5_0_0_alpha_3.json");
+        assertLookupRemoteVersion(LegacyESVersion.fromId(5000099), "main/5_0_0_alpha_3.json");
         // V_5_0_0 since we no longer consider qualifier in Version
-        assertLookupRemoteVersion(Version.fromId(5000099), "main/with_unknown_fields.json");
+        assertLookupRemoteVersion(LegacyESVersion.fromId(5000099), "main/with_unknown_fields.json");
+        assertLookupRemoteVersion(Version.fromId(1000099 ^ Version.MASK), "main/OpenSearch_1_0_0.json");
     }
 
     private void assertLookupRemoteVersion(Version expected, String s) throws Exception {

--- a/modules/reindex/src/test/resources/responses/main/OpenSearch_1_0_0.json
+++ b/modules/reindex/src/test/resources/responses/main/OpenSearch_1_0_0.json
@@ -1,0 +1,13 @@
+{
+  "name" : "Ruphos",
+  "cluster_name" : "distribution_run",
+  "version" : {
+    "distribution" : "opensearch",
+    "number" : "1.0.0",
+    "build_hash" : "42e092f",
+    "build_date" : "2016-05-26T16:55:45.405Z",
+    "build_snapshot" : true,
+    "lucene_version" : "8.8.2"
+  },
+  "tagline" : "You Know, for Better Search"
+}

--- a/server/src/main/java/org/opensearch/Version.java
+++ b/server/src/main/java/org/opensearch/Version.java
@@ -35,8 +35,6 @@ package org.opensearch;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.Strings;
 import org.opensearch.common.SuppressForbidden;
-import org.opensearch.common.collect.ImmutableOpenIntMap;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.settings.Settings;
@@ -75,66 +73,12 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_1_0_0 = new Version(1000099, org.apache.lucene.util.Version.LUCENE_8_7_0);
     public static final Version CURRENT = V_1_0_0;
 
-    private static final ImmutableOpenIntMap<Version> idToVersion;
-    private static final ImmutableOpenMap<String, Version> stringToVersion;
-
-    static {
-        final ImmutableOpenIntMap.Builder<Version> builder = ImmutableOpenIntMap.builder();
-        final ImmutableOpenMap.Builder<String, Version> builderByString = ImmutableOpenMap.builder();
-
-        for (final Field declaredField : LegacyESVersion.class.getFields()) {
-            if (declaredField.getType().equals(Version.class) || declaredField.getType().equals(LegacyESVersion.class)) {
-                final String fieldName = declaredField.getName();
-                if (fieldName.equals("CURRENT") || fieldName.equals("V_EMPTY")) {
-                    continue;
-                }
-                assert fieldName.matches("V_\\d+_\\d+_\\d+(_alpha[1,2]|_beta[1,2]|_rc[1,2])?")
-                    : "expected Version field [" + fieldName + "] to match V_\\d+_\\d+_\\d+";
-                try {
-                    final Version version = (Version) declaredField.get(null);
-                    if (Assertions.ENABLED) {
-                        final String[] fields = fieldName.split("_");
-                        if (fields.length == 5) {
-                            assert (fields[1].equals("1") || fields[1].equals("6")) && fields[2].equals("0") :
-                                "field " + fieldName + " should not have a build qualifier";
-                        } else {
-                            final int major = Integer.valueOf(fields[1]) * 1000000;
-                            final int minor = Integer.valueOf(fields[2]) * 10000;
-                            final int revision = Integer.valueOf(fields[3]) * 100;
-                            final int expectedId;
-                            if (fields[1].equals("1")) {
-                                expectedId = 0x08000000 ^ (major + minor + revision + 99);
-                            } else {
-                                expectedId = (major + minor + revision + 99);
-                            }
-                            assert version.id == expectedId :
-                                "expected version [" + fieldName + "] to have id [" + expectedId + "] but was [" + version.id + "]";
-                        }
-                    }
-                    final Version maybePrevious = builder.put(version.id, version);
-                    builderByString.put(version.toString(), version);
-                    assert maybePrevious == null :
-                        "expected [" + version.id + "] to be uniquely mapped but saw [" + maybePrevious + "] and [" + version + "]";
-                } catch (final IllegalAccessException e) {
-                    assert false : "Version field [" + fieldName + "] should be public";
-                }
-            }
-        }
-        assert CURRENT.luceneVersion.equals(org.apache.lucene.util.Version.LATEST) : "Version must be upgraded to ["
-            + org.apache.lucene.util.Version.LATEST + "] is still set to [" + CURRENT.luceneVersion + "]";
-
-        builder.put(V_EMPTY_ID, V_EMPTY);
-        builderByString.put(V_EMPTY.toString(), V_EMPTY);
-        idToVersion = builder.build();
-        stringToVersion = builderByString.build();
-    }
-
     public static Version readVersion(StreamInput in) throws IOException {
         return fromId(in.readVInt());
     }
 
     public static Version fromId(int id) {
-        final Version known = idToVersion.get(id);
+        final Version known = LegacyESVersion.idToVersion.get(id);
         if (known != null) {
             return known;
         }
@@ -219,7 +163,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
         if (!Strings.hasLength(version)) {
             return Version.CURRENT;
         }
-        final Version cached = stringToVersion.get(version);
+        final Version cached = LegacyESVersion.stringToVersion.get(version);
         if (cached != null) {
             return cached;
         }
@@ -239,13 +183,13 @@ public class Version implements Comparable<Version>, ToXContentFragment {
 
         try {
             final int rawMajor = Integer.parseInt(parts[0]);
-            if (rawMajor >= 5 && snapshot) { // we don't support snapshot as part of the version here anymore
-                throw new IllegalArgumentException("illegal version format - snapshots are only supported until version 2.x");
+            if (snapshot == true) { // we don't support snapshot as part of the version here anymore
+                throw new IllegalArgumentException("illegal version format - snapshot labels are not supported");
             }
-            if (rawMajor >=7 && parts.length == 4) { // we don't support qualifier as part of the version anymore
-                throw new IllegalArgumentException("illegal version format - qualifiers are only supported until version 6.x");
+            if (parts.length == 4) { // we don't support qualifier
+                throw new IllegalArgumentException("illegal version format - qualifiers are not supported");
             }
-            final int betaOffset = rawMajor < 5 ? 0 : 25;
+            final int betaOffset = 25;
             //we reverse the version id calculation based on some assumption as we can't reliably reverse the modulo
             final int major = rawMajor * 1000000;
             final int minor = Integer.parseInt(parts[1]) * 10000;
@@ -256,7 +200,6 @@ public class Version implements Comparable<Version>, ToXContentFragment {
             if (parts.length == 4) {
                 String buildStr = parts[3];
                 if (buildStr.startsWith("alpha")) {
-                    assert rawMajor >= 5 : "major must be >= 5 but was " + major;
                     build = Integer.parseInt(buildStr.substring(5));
                     assert build < 25 : "expected a alpha build but " + build + " >= 25";
                 } else if (buildStr.startsWith("Beta") || buildStr.startsWith("beta")) {
@@ -269,7 +212,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
                 }
             }
 
-            return fromId(major + minor + revision + build);
+            return fromId((major + minor + revision + build) ^ MASK);
 
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("unable to parse version " + version, e);
@@ -360,7 +303,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
         return res;
     }
 
-    private Version computeMinCompatVersion() {
+    protected Version computeMinCompatVersion() {
         if (major == 1) {
             return Version.fromId(6080099);
         } else if (major == 6) {
@@ -382,7 +325,14 @@ public class Version implements Comparable<Version>, ToXContentFragment {
             return bwcVersion == null ? this : bwcVersion;
         }
 
-        return Version.min(this, fromId((int) major * 1000000 + 0 * 10000 + 99));
+        return Version.min(this, fromId(maskId((int) major * 1000000 + 0 * 10000 + 99)));
+    }
+
+    /**
+     * this is used to ensure the version id for new versions of OpenSearch are always less than the predecessor versions
+     */
+    protected int maskId(final int id) {
+        return MASK ^ id;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/main/MainResponse.java
+++ b/server/src/main/java/org/opensearch/action/main/MainResponse.java
@@ -118,6 +118,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
         builder.field("cluster_name", clusterName.value());
         builder.field("cluster_uuid", clusterUuid);
         builder.startObject("version")
+            .field("distribution", build.getDistribution())
             .field("number", build.getQualifiedVersion())
             .field("build_type", build.type().displayName())
             .field("build_hash", build.hash())
@@ -150,7 +151,8 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
                             (String) value.get("build_hash"),
                             (String) value.get("build_date"),
                             (boolean) value.get("build_snapshot"),
-                            (String) value.get("number")
+                            (String) value.get("number"),
+                            (String) value.get("distribution")
                     );
             response.version = Version.fromString(
                 ((String) value.get("number"))

--- a/server/src/test/java/org/opensearch/BuildTests.java
+++ b/server/src/test/java/org/opensearch/BuildTests.java
@@ -68,28 +68,33 @@ public class BuildTests extends OpenSearchTestCase {
     public void testIsProduction() {
         Build build = new Build(
             Build.CURRENT.type(), Build.CURRENT.hash(), Build.CURRENT.date(),
-            Build.CURRENT.isSnapshot(), Math.abs(randomInt()) + "." + Math.abs(randomInt()) + "." + Math.abs(randomInt())
+            Build.CURRENT.isSnapshot(), Math.abs(randomInt()) + "." + Math.abs(randomInt()) + "." + Math.abs(randomInt()),
+            Build.CURRENT.getDistribution()
         );
         assertTrue(build.getQualifiedVersion(), build.isProductionRelease());
 
         assertFalse(new Build(
             Build.CURRENT.type(), Build.CURRENT.hash(), Build.CURRENT.date(),
-            Build.CURRENT.isSnapshot(), "7.0.0-alpha1"
+            Build.CURRENT.isSnapshot(), "7.0.0-alpha1",
+            Build.CURRENT.getDistribution()
         ).isProductionRelease());
 
         assertFalse(new Build(
             Build.CURRENT.type(), Build.CURRENT.hash(), Build.CURRENT.date(),
-            Build.CURRENT.isSnapshot(), "7.0.0-alpha1-SNAPSHOT"
+            Build.CURRENT.isSnapshot(), "7.0.0-alpha1-SNAPSHOT",
+            Build.CURRENT.getDistribution()
         ).isProductionRelease());
 
         assertFalse(new Build(
             Build.CURRENT.type(), Build.CURRENT.hash(), Build.CURRENT.date(),
-            Build.CURRENT.isSnapshot(), "7.0.0-SNAPSHOT"
+            Build.CURRENT.isSnapshot(), "7.0.0-SNAPSHOT",
+            Build.CURRENT.getDistribution()
         ).isProductionRelease());
 
         assertFalse(new Build(
             Build.CURRENT.type(), Build.CURRENT.hash(), Build.CURRENT.date(),
-            Build.CURRENT.isSnapshot(), "Unknown"
+            Build.CURRENT.isSnapshot(), "Unknown",
+            Build.CURRENT.getDistribution()
         ).isProductionRelease());
     }
 
@@ -97,7 +102,7 @@ public class BuildTests extends OpenSearchTestCase {
         Build build = Build.CURRENT;
 
         Build another = new Build(
-            build.type(), build.hash(), build.date(), build.isSnapshot(), build.getQualifiedVersion()
+            build.type(), build.hash(), build.date(), build.isSnapshot(), build.getQualifiedVersion(), build.getDistribution()
         );
         assertEquals(build, another);
         assertEquals(build.hashCode(), another.hashCode());
@@ -106,28 +111,28 @@ public class BuildTests extends OpenSearchTestCase {
                 Arrays.stream(Build.Type.values()).filter(f -> !f.equals(build.type())).collect(Collectors.toSet());
         final Build.Type otherType = randomFrom(otherTypes);
         Build differentType = new Build(
-            otherType, build.hash(), build.date(), build.isSnapshot(), build.getQualifiedVersion()
+            otherType, build.hash(), build.date(), build.isSnapshot(), build.getQualifiedVersion(), build.getDistribution()
         );
         assertNotEquals(build, differentType);
 
         Build differentHash = new Build(
             build.type(), randomAlphaOfLengthBetween(3, 10), build.date(), build.isSnapshot(),
-            build.getQualifiedVersion()
+            build.getQualifiedVersion(), build.getDistribution()
         );
         assertNotEquals(build, differentHash);
 
         Build differentDate = new Build(
-            build.type(), build.hash(), "1970-01-01", build.isSnapshot(), build.getQualifiedVersion()
+            build.type(), build.hash(), "1970-01-01", build.isSnapshot(), build.getQualifiedVersion(), build.getDistribution()
         );
         assertNotEquals(build, differentDate);
 
         Build differentSnapshot = new Build(
-            build.type(), build.hash(), build.date(), !build.isSnapshot(), build.getQualifiedVersion()
+            build.type(), build.hash(), build.date(), !build.isSnapshot(), build.getQualifiedVersion(), build.getDistribution()
         );
         assertNotEquals(build, differentSnapshot);
 
         Build differentVersion = new Build(
-            build.type(), build.hash(), build.date(), build.isSnapshot(), "1.2.3"
+            build.type(), build.hash(), build.date(), build.isSnapshot(), "1.2.3", build.getDistribution()
         );
         assertNotEquals(build, differentVersion);
     }
@@ -169,7 +174,8 @@ public class BuildTests extends OpenSearchTestCase {
     public void testSerialization() {
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(new WriteableBuild(new Build(
                 randomFrom(Build.Type.values()),
-                randomAlphaOfLength(6), randomAlphaOfLength(6), randomBoolean(), randomAlphaOfLength(6))),
+                randomAlphaOfLength(6), randomAlphaOfLength(6), randomBoolean(), randomAlphaOfLength(6),
+                randomAlphaOfLength(10))),
             // Note: the cast of the Copy- and MutateFunction is needed for some IDE (specifically Eclipse 4.10.0) to infer the right type
             (WriteableBuild b) -> copyWriteable(b, writableRegistry(), WriteableBuild::new, Version.CURRENT),
             (WriteableBuild b) -> {
@@ -177,19 +183,24 @@ public class BuildTests extends OpenSearchTestCase {
                     case 1:
                         return new WriteableBuild(new Build(
                             randomValueOtherThan(b.build.type(), () -> randomFrom(Build.Type.values())),
-                            b.build.hash(), b.build.date(), b.build.isSnapshot(), b.build.getQualifiedVersion()));
+                            b.build.hash(), b.build.date(), b.build.isSnapshot(), b.build.getQualifiedVersion(),
+                            b.build.getDistribution()));
                     case 2:
                         return new WriteableBuild(new Build(b.build.type(),
-                            randomStringExcept(b.build.hash()), b.build.date(), b.build.isSnapshot(), b.build.getQualifiedVersion()));
+                            randomStringExcept(b.build.hash()), b.build.date(), b.build.isSnapshot(), b.build.getQualifiedVersion(),
+                            b.build.getDistribution()));
                     case 3:
                         return new WriteableBuild(new Build(b.build.type(),
-                            b.build.hash(), randomStringExcept(b.build.date()), b.build.isSnapshot(), b.build.getQualifiedVersion()));
+                            b.build.hash(), randomStringExcept(b.build.date()), b.build.isSnapshot(), b.build.getQualifiedVersion(),
+                            b.build.getDistribution()));
                     case 4:
                         return new WriteableBuild(new Build(b.build.type(),
-                            b.build.hash(), b.build.date(), b.build.isSnapshot() == false, b.build.getQualifiedVersion()));
+                            b.build.hash(), b.build.date(), b.build.isSnapshot() == false, b.build.getQualifiedVersion(),
+                            b.build.getDistribution()));
                     case 5:
                         return new WriteableBuild(new Build(b.build.type(),
-                            b.build.hash(), b.build.date(), b.build.isSnapshot(), randomStringExcept(b.build.getQualifiedVersion())));
+                            b.build.hash(), b.build.date(), b.build.isSnapshot(), randomStringExcept(b.build.getQualifiedVersion()),
+                            b.build.getDistribution()));
                 }
                 throw new AssertionError();
             });
@@ -197,7 +208,8 @@ public class BuildTests extends OpenSearchTestCase {
 
     public void testSerializationBWC() throws IOException {
         final WriteableBuild dockerBuild = new WriteableBuild(new Build(Build.Type.DOCKER,
-            randomAlphaOfLength(6), randomAlphaOfLength(6), randomBoolean(), randomAlphaOfLength(6)));
+            randomAlphaOfLength(6), randomAlphaOfLength(6), randomBoolean(), randomAlphaOfLength(6),
+            "other"));
 
         final List<Version> versions = Version.getDeclaredVersions(LegacyESVersion.class);
         final Version pre63Version =
@@ -208,11 +220,15 @@ public class BuildTests extends OpenSearchTestCase {
             .filter(v -> v.onOrAfter(LegacyESVersion.V_6_7_0) && v.before(LegacyESVersion.V_7_0_0)).collect(Collectors.toList()));
         final Version post70Version =
             randomFrom(versions.stream().filter(v -> v.onOrAfter(LegacyESVersion.V_7_0_0)).collect(Collectors.toList()));
+        final Version post10OpenSearchVersion =
+            randomFrom(versions.stream().filter(v -> v.onOrAfter(Version.V_1_0_0)).collect(Collectors.toList()));
 
         final WriteableBuild pre63 = copyWriteable(dockerBuild, writableRegistry(), WriteableBuild::new, pre63Version);
         final WriteableBuild post63pre67 = copyWriteable(dockerBuild, writableRegistry(), WriteableBuild::new, post63Pre67Version);
         final WriteableBuild post67pre70 = copyWriteable(dockerBuild, writableRegistry(), WriteableBuild::new, post67Pre70Version);
         final WriteableBuild post70 = copyWriteable(dockerBuild, writableRegistry(), WriteableBuild::new, post70Version);
+        final WriteableBuild post10OpenSearch = copyWriteable(dockerBuild, writableRegistry(), WriteableBuild::new,
+            post10OpenSearchVersion);
 
         assertThat(pre63.build.type(), equalTo(Build.Type.UNKNOWN));
         assertThat(post63pre67.build.type(), equalTo(Build.Type.TAR));
@@ -223,6 +239,9 @@ public class BuildTests extends OpenSearchTestCase {
         assertThat(post63pre67.build.getQualifiedVersion(), equalTo(post63Pre67Version.toString()));
         assertThat(post67pre70.build.getQualifiedVersion(), equalTo(post67Pre70Version.toString()));
         assertThat(post70.build.getQualifiedVersion(), equalTo(dockerBuild.build.getQualifiedVersion()));
+        assertThat(post70.build.getDistribution(), equalTo(dockerBuild.build.getDistribution()));
+        assertThat(post10OpenSearch.build.getQualifiedVersion(), equalTo(dockerBuild.build.getQualifiedVersion()));
+        assertThat(post10OpenSearch.build.getDistribution(), equalTo(dockerBuild.build.getDistribution()));
     }
 
     public void testTypeParsing() {

--- a/server/src/test/java/org/opensearch/VersionTests.java
+++ b/server/src/test/java/org/opensearch/VersionTests.java
@@ -80,10 +80,10 @@ public class VersionTests extends OpenSearchTestCase {
         assertThat(V_6_3_0.onOrAfter(V_6_3_0), is(true));
         assertThat(V_7_0_0.onOrAfter(V_6_3_0), is(true));
 
-        assertTrue(Version.fromString("5.0.0-alpha2").onOrAfter(Version.fromString("5.0.0-alpha1")));
-        assertTrue(Version.fromString("5.0.0").onOrAfter(Version.fromString("5.0.0-beta2")));
-        assertTrue(Version.fromString("5.0.0-rc1").onOrAfter(Version.fromString("5.0.0-beta24")));
-        assertTrue(Version.fromString("5.0.0-alpha24").before(Version.fromString("5.0.0-beta0")));
+        assertTrue(LegacyESVersion.fromString("5.0.0-alpha2").onOrAfter(LegacyESVersion.fromString("5.0.0-alpha1")));
+        assertTrue(LegacyESVersion.fromString("5.0.0").onOrAfter(LegacyESVersion.fromString("5.0.0-beta2")));
+        assertTrue(LegacyESVersion.fromString("5.0.0-rc1").onOrAfter(LegacyESVersion.fromString("5.0.0-beta24")));
+        assertTrue(LegacyESVersion.fromString("5.0.0-alpha24").before(LegacyESVersion.fromString("5.0.0-beta0")));
 
         assertThat(V_6_3_0, is(lessThan(V_7_0_0)));
         assertThat(V_6_3_0.compareTo(V_6_3_0), is(0));
@@ -92,7 +92,7 @@ public class VersionTests extends OpenSearchTestCase {
 
     public void testMin() {
         assertEquals(VersionUtils.getPreviousVersion(), Version.min(Version.CURRENT, VersionUtils.getPreviousVersion()));
-        assertEquals(Version.fromString("1.0.1"), Version.min(Version.fromString("1.0.1"), Version.CURRENT));
+        assertEquals(LegacyESVersion.fromString("7.0.1"), Version.min(LegacyESVersion.fromString("7.0.1"), Version.CURRENT));
         Version version = VersionUtils.randomVersion(random());
         Version version1 = VersionUtils.randomVersion(random());
         if (version.id <= version1.id) {
@@ -104,7 +104,7 @@ public class VersionTests extends OpenSearchTestCase {
 
     public void testMax() {
         assertEquals(Version.CURRENT, Version.max(Version.CURRENT, VersionUtils.getPreviousVersion()));
-        assertEquals(Version.CURRENT, Version.max(Version.fromString("1.0.1"), Version.CURRENT));
+        assertEquals(Version.CURRENT, Version.max(LegacyESVersion.fromString("1.0.1"), Version.CURRENT));
         Version version = VersionUtils.randomVersion(random());
         Version version1 = VersionUtils.randomVersion(random());
         if (version.id >= version1.id) {
@@ -184,17 +184,17 @@ public class VersionTests extends OpenSearchTestCase {
     }
 
     public void testMinCompatVersion() {
-        Version major = Version.fromString("2.0.0");
-        assertThat(Version.fromString("2.0.0").minimumCompatibilityVersion(), equalTo(major));
-        assertThat(Version.fromString("2.2.0").minimumCompatibilityVersion(), equalTo(major));
-        assertThat(Version.fromString("2.3.0").minimumCompatibilityVersion(), equalTo(major));
+        Version major = LegacyESVersion.fromString("6.8.0");
+        assertThat(Version.fromString("1.0.0").minimumCompatibilityVersion(), equalTo(major));
+        assertThat(Version.fromString("1.2.0").minimumCompatibilityVersion(), equalTo(major));
+        assertThat(Version.fromString("1.3.0").minimumCompatibilityVersion(), equalTo(major));
 
         Version major5x = Version.fromString("5.0.0");
         assertThat(Version.fromString("5.0.0").minimumCompatibilityVersion(), equalTo(major5x));
         assertThat(Version.fromString("5.2.0").minimumCompatibilityVersion(), equalTo(major5x));
         assertThat(Version.fromString("5.3.0").minimumCompatibilityVersion(), equalTo(major5x));
 
-        Version major56x = Version.fromString("5.6.0");
+        Version major56x = LegacyESVersion.fromString("5.6.0");
         assertThat(LegacyESVersion.V_6_5_0.minimumCompatibilityVersion(), equalTo(major56x));
         assertThat(LegacyESVersion.V_6_3_1.minimumCompatibilityVersion(), equalTo(major56x));
 
@@ -209,20 +209,20 @@ public class VersionTests extends OpenSearchTestCase {
 
     public void testToString() {
         // with 2.0.beta we lowercase
-        assertEquals("2.0.0-beta1", Version.fromString("2.0.0-beta1").toString());
-        assertEquals("5.0.0-alpha1", Version.fromId(5000001).toString());
+        assertEquals("2.0.0-beta1", LegacyESVersion.fromString("2.0.0-beta1").toString());
+        assertEquals("5.0.0-alpha1", LegacyESVersion.fromId(5000001).toString());
         assertEquals("2.3.0", Version.fromString("2.3.0").toString());
-        assertEquals("0.90.0.Beta1", Version.fromString("0.90.0.Beta1").toString());
-        assertEquals("1.0.0.Beta1", Version.fromString("1.0.0.Beta1").toString());
-        assertEquals("2.0.0-beta1", Version.fromString("2.0.0-beta1").toString());
-        assertEquals("5.0.0-beta1", Version.fromString("5.0.0-beta1").toString());
-        assertEquals("5.0.0-alpha1", Version.fromString("5.0.0-alpha1").toString());
+        assertEquals("0.90.0.Beta1", LegacyESVersion.fromString("0.90.0.Beta1").toString());
+        assertEquals("1.0.0.Beta1", LegacyESVersion.fromString("1.0.0.Beta1").toString());
+        assertEquals("2.0.0-beta1", LegacyESVersion.fromString("2.0.0-beta1").toString());
+        assertEquals("5.0.0-beta1", LegacyESVersion.fromString("5.0.0-beta1").toString());
+        assertEquals("5.0.0-alpha1", LegacyESVersion.fromString("5.0.0-alpha1").toString());
     }
 
     public void testIsBeta() {
-        assertTrue(Version.fromString("2.0.0-beta1").isBeta());
-        assertTrue(Version.fromString("1.0.0.Beta1").isBeta());
-        assertTrue(Version.fromString("0.90.0.Beta1").isBeta());
+        assertTrue(LegacyESVersion.fromString("2.0.0-beta1").isBeta());
+        assertTrue(LegacyESVersion.fromString("1.0.0.Beta1").isBeta());
+        assertTrue(LegacyESVersion.fromString("0.90.0.Beta1").isBeta());
     }
 
 
@@ -230,18 +230,18 @@ public class VersionTests extends OpenSearchTestCase {
         assertTrue(new LegacyESVersion(5000001, org.apache.lucene.util.Version.LUCENE_7_0_0).isAlpha());
         assertFalse(new LegacyESVersion(4000002, org.apache.lucene.util.Version.LUCENE_7_0_0).isAlpha());
         assertTrue(new LegacyESVersion(4000002, org.apache.lucene.util.Version.LUCENE_7_0_0).isBeta());
-        assertTrue(Version.fromString("5.0.0-alpha14").isAlpha());
-        assertEquals(5000014, Version.fromString("5.0.0-alpha14").id);
-        assertTrue(Version.fromId(5000015).isAlpha());
+        assertTrue(LegacyESVersion.fromString("5.0.0-alpha14").isAlpha());
+        assertEquals(5000014, LegacyESVersion.fromString("5.0.0-alpha14").id);
+        assertTrue(LegacyESVersion.fromId(5000015).isAlpha());
 
         for (int i = 0 ; i < 25; i++) {
-            assertEquals(Version.fromString("5.0.0-alpha" + i).id, Version.fromId(5000000 + i).id);
-            assertEquals("5.0.0-alpha" + i, Version.fromId(5000000 + i).toString());
+            assertEquals(LegacyESVersion.fromString("5.0.0-alpha" + i).id, LegacyESVersion.fromId(5000000 + i).id);
+            assertEquals("5.0.0-alpha" + i, LegacyESVersion.fromId(5000000 + i).toString());
         }
 
         for (int i = 0 ; i < 25; i++) {
-            assertEquals(Version.fromString("5.0.0-beta" + i).id, Version.fromId(5000000 + i + 25).id);
-            assertEquals("5.0.0-beta" + i, Version.fromId(5000000 + i + 25).toString());
+            assertEquals(LegacyESVersion.fromString("5.0.0-beta" + i).id, LegacyESVersion.fromId(5000000 + i + 25).id);
+            assertEquals("5.0.0-beta" + i, LegacyESVersion.fromId(5000000 + i + 25).toString());
         }
     }
 
@@ -263,10 +263,10 @@ public class VersionTests extends OpenSearchTestCase {
         });
         assertSame(Version.CURRENT, Version.fromString(Version.CURRENT.toString()));
 
-        assertEquals(Version.fromString("2.0.0-SNAPSHOT"), Version.fromId(2000099));
+        assertEquals(LegacyESVersion.fromString("2.0.0-SNAPSHOT"), LegacyESVersion.fromId(2000099));
 
         expectThrows(IllegalArgumentException.class, () -> {
-            Version.fromString("5.0.0-SNAPSHOT");
+            LegacyESVersion.fromString("5.0.0-SNAPSHOT");
         });
     }
 

--- a/server/src/test/java/org/opensearch/action/main/MainResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/main/MainResponseTests.java
@@ -59,7 +59,7 @@ public class MainResponseTests extends AbstractSerializingTestCase<MainResponse>
         Version version = VersionUtils.randomVersionBetween(random(), LegacyESVersion.V_6_0_1, Version.CURRENT);
         Build build = new Build(
             Build.Type.UNKNOWN, randomAlphaOfLength(8), date, randomBoolean(),
-            version.toString()
+            version.toString(), version.onOrAfter(Version.V_1_0_0) ? randomAlphaOfLength(10) : ""
         );
         return new MainResponse(nodeName, version, clusterName, clusterUuid , build);
     }
@@ -79,7 +79,7 @@ public class MainResponseTests extends AbstractSerializingTestCase<MainResponse>
         final Build current = Build.CURRENT;
         Build build = new Build(
             current.type(), current.hash(), current.date(), current.isSnapshot(),
-            current.getQualifiedVersion()
+            current.getQualifiedVersion(), current.getDistribution()
         );
         Version version = Version.CURRENT;
         MainResponse response = new MainResponse("nodeName", version, new ClusterName("clusterName"), clusterUUID, build);
@@ -90,6 +90,7 @@ public class MainResponseTests extends AbstractSerializingTestCase<MainResponse>
                 + "\"cluster_name\":\"clusterName\","
                 + "\"cluster_uuid\":\"" + clusterUUID + "\","
                 + "\"version\":{"
+                    + "\"distribution\":\"" + build.getDistribution() + "\","
                     + "\"number\":\"" + build.getQualifiedVersion() + "\","
                     + "\"build_type\":\"" + current.type().displayName() + "\","
                     + "\"build_hash\":\"" + current.hash() + "\","
@@ -119,7 +120,7 @@ public class MainResponseTests extends AbstractSerializingTestCase<MainResponse>
                 // toggle the snapshot flag of the original Build parameter
                 build = new Build(
                     Build.Type.UNKNOWN, build.hash(), build.date(), !build.isSnapshot(),
-                    build.getQualifiedVersion()
+                    build.getQualifiedVersion(), build.getDistribution()
                 );
                 break;
             case 3:

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataIndexUpgradeServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataIndexUpgradeServiceTests.java
@@ -124,7 +124,7 @@ public class MetadataIndexUpgradeServiceTests extends OpenSearchTestCase {
         MetadataIndexUpgradeService service = getMetadataIndexUpgradeService();
         Version minCompat = Version.CURRENT.minimumIndexCompatibilityVersion();
         Version indexUpgraded = VersionUtils.randomVersionBetween(random(), minCompat, VersionUtils.getPreviousVersion(Version.CURRENT));
-        Version indexCreated = Version.fromString((minCompat.major - 1) + "." + randomInt(5) + "." + randomInt(5));
+        Version indexCreated = LegacyESVersion.fromString((minCompat.major - 1) + "." + randomInt(5) + "." + randomInt(5));
         final IndexMetadata metadata = newIndexMeta("foo", Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_UPGRADED, indexUpgraded)
             .put(IndexMetadata.SETTING_VERSION_CREATED, indexCreated)

--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodesTests.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodesTests.java
@@ -33,6 +33,7 @@
 package org.opensearch.cluster.node;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.transport.TransportAddress;
@@ -406,17 +407,17 @@ public class DiscoveryNodesTests extends OpenSearchTestCase {
         DiscoveryNodes.Builder discoBuilder = DiscoveryNodes.builder();
         discoBuilder.add(new DiscoveryNode("name_" + 1, "node_" + 1, buildNewFakeTransportAddress(), Collections.emptyMap(),
             new HashSet<>(randomSubsetOf(DiscoveryNodeRole.BUILT_IN_ROLES)),
-            Version.fromString("5.1.0")));
+            LegacyESVersion.fromString("5.1.0")));
         discoBuilder.add(new DiscoveryNode("name_" + 2, "node_" + 2, buildNewFakeTransportAddress(), Collections.emptyMap(),
             new HashSet<>(randomSubsetOf(DiscoveryNodeRole.BUILT_IN_ROLES)),
-            Version.fromString("6.3.0")));
+            LegacyESVersion.fromString("6.3.0")));
         discoBuilder.add(new DiscoveryNode("name_" + 3, "node_" + 3, buildNewFakeTransportAddress(), Collections.emptyMap(),
             new HashSet<>(randomSubsetOf(DiscoveryNodeRole.BUILT_IN_ROLES)),
             Version.fromString("1.1.0")));
         discoBuilder.localNodeId("name_1");
         discoBuilder.masterNodeId("name_2");
         DiscoveryNodes build = discoBuilder.build();
-        assertEquals( Version.fromString("6.3.0"), build.getMaxNodeVersion());
-        assertEquals( Version.fromString("1.1.0"), build.getMinNodeVersion());
+        assertEquals( Version.fromString("1.1.0"), build.getMaxNodeVersion());
+        assertEquals( LegacyESVersion.fromString("5.1.0"), build.getMinNodeVersion());
     }
 }

--- a/server/src/test/java/org/opensearch/common/lucene/uid/VersionsTests.java
+++ b/server/src/test/java/org/opensearch/common/lucene/uid/VersionsTests.java
@@ -219,20 +219,20 @@ public class VersionsTests extends OpenSearchTestCase {
         List<Version> allVersions = VersionUtils.allVersions();
 
         // should have the same Lucene version as the latest 6.x version
-        Version version = Version.fromString("6.88.50");
+        Version version = LegacyESVersion.fromString("6.88.50");
         assertEquals(allVersions.get(Collections.binarySearch(allVersions, LegacyESVersion.V_7_0_0) - 1).luceneVersion,
                 version.luceneVersion);
 
         // between two known versions, should use the lucene version of the previous version
-        version = Version.fromString("6.2.50");
+        version = LegacyESVersion.fromString("6.2.50");
         assertEquals(VersionUtils.getPreviousVersion(LegacyESVersion.V_6_2_4).luceneVersion, version.luceneVersion);
 
         // too old version, major should be the oldest supported lucene version minus 1
-        version = Version.fromString("5.2.1");
+        version = LegacyESVersion.fromString("5.2.1");
         assertEquals(LegacyESVersion.V_6_0_0.luceneVersion.major - 1, version.luceneVersion.major);
 
         // future version, should be the same version as today
-        version = Version.fromString("8.77.1");
+        version = Version.fromString("2.77.1");
         assertEquals(Version.CURRENT.luceneVersion, version.luceneVersion);
     }
 }

--- a/server/src/test/java/org/opensearch/index/analysis/PreConfiguredTokenFilterTests.java
+++ b/server/src/test/java/org/opensearch/index/analysis/PreConfiguredTokenFilterTests.java
@@ -131,7 +131,7 @@ public class PreConfiguredTokenFilterTests extends OpenSearchTestCase {
                 pctf.get(indexSettings, TestEnvironment.newEnvironment(emptyNodeSettings), "lucene_version", settings1);
         assertSame(tff_v1_1, tff_v1_2);
 
-        byte major = VersionUtils.getFirstVersion().major;
+        byte major = VersionUtils.getPreviousVersion().major;
         Version version2 = Version.fromString(major - 1 + ".0.0");
         Settings settings2 = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version2)
                 .build();

--- a/server/src/test/java/org/opensearch/transport/InboundDecoderTests.java
+++ b/server/src/test/java/org/opensearch/transport/InboundDecoderTests.java
@@ -316,7 +316,7 @@ public class InboundDecoderTests extends OpenSearchTestCase {
             + version.minimumCompatibilityVersion() + "]", ise.getMessage());
 
         // For handshake we are compatible with N-2
-        ise = InboundDecoder.ensureVersionCompatibility(Version.fromString("5.6.0"), version, true);
+        ise = InboundDecoder.ensureVersionCompatibility(Version.fromString("6.8.0"), version, true);
         assertNull(ise);
 
         ise = InboundDecoder.ensureVersionCompatibility(Version.fromString("5.6.0"), version, false);

--- a/test/framework/src/test/java/org/opensearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/VersionUtilsTests.java
@@ -199,45 +199,13 @@ public class VersionUtilsTests extends OpenSearchTestCase {
             TestStableBranchBehindStableBranch.V_5_5_0)));
     }
 
-    public static class TestUnstableBranch {
-        public static final Version V_5_3_0 = Version.fromString("5.3.0");
-        public static final Version V_5_3_1 = Version.fromString("5.3.1");
-        public static final Version V_5_3_2 = Version.fromString("5.3.2");
-        public static final Version V_5_4_0 = Version.fromString("5.4.0");
-        public static final Version V_6_0_0_alpha1 = Version.fromString("6.0.0-alpha1");
-        public static final Version V_6_0_0_alpha2 = Version.fromString("6.0.0-alpha2");
-        public static final Version V_6_0_0_beta1 = Version.fromString("6.0.0-beta1");
-        public static final Version CURRENT = V_6_0_0_beta1;
-    }
-
-    public void testResolveReleasedVersionsForUnstableBranch() {
-        Tuple<List<Version>, List<Version>> t = VersionUtils.resolveReleasedVersions(TestUnstableBranch.CURRENT,
-                TestUnstableBranch.class);
-        List<Version> released = t.v1();
-        List<Version> unreleased = t.v2();
-
-        assertThat(released, equalTo(Arrays.asList(
-            TestUnstableBranch.V_5_3_0,
-            TestUnstableBranch.V_5_3_1,
-            TestUnstableBranch.V_6_0_0_alpha1,
-            TestUnstableBranch.V_6_0_0_alpha2)));
-        assertThat(unreleased, equalTo(Arrays.asList(
-            TestUnstableBranch.V_5_3_2,
-            TestUnstableBranch.V_5_4_0,
-            TestUnstableBranch.V_6_0_0_beta1)));
-    }
-
     public static class TestNewMajorRelease {
-        public static final Version V_5_6_0 = Version.fromString("5.6.0");
-        public static final Version V_5_6_1 = Version.fromString("5.6.1");
-        public static final Version V_5_6_2 = Version.fromString("5.6.2");
-        public static final Version V_6_0_0_alpha1 = Version.fromString("6.0.0-alpha1");
-        public static final Version V_6_0_0_alpha2 = Version.fromString("6.0.0-alpha2");
-        public static final Version V_6_0_0_beta1 = Version.fromString("6.0.0-beta1");
-        public static final Version V_6_0_0_beta2 = Version.fromString("6.0.0-beta2");
-        public static final Version V_6_0_0 = Version.fromString("6.0.0");
-        public static final Version V_6_0_1 = Version.fromString("6.0.1");
-        public static final Version CURRENT = V_6_0_1;
+        public static final Version V_4_6_0 = Version.fromString("4.6.0");
+        public static final Version V_4_6_1 = Version.fromString("4.6.1");
+        public static final Version V_4_6_2 = Version.fromString("4.6.2");
+        public static final Version V_5_0_0 = Version.fromString("5.0.0");
+        public static final Version V_5_0_1 = Version.fromString("5.0.1");
+        public static final Version CURRENT = V_5_0_1;
     }
 
     public void testResolveReleasedVersionsAtNewMajorRelease() {
@@ -247,67 +215,51 @@ public class VersionUtilsTests extends OpenSearchTestCase {
         List<Version> unreleased = t.v2();
 
         assertThat(released, equalTo(Arrays.asList(
-            TestNewMajorRelease.V_5_6_0,
-            TestNewMajorRelease.V_5_6_1,
-            TestNewMajorRelease.V_6_0_0_alpha1,
-            TestNewMajorRelease.V_6_0_0_alpha2,
-            TestNewMajorRelease.V_6_0_0_beta1,
-            TestNewMajorRelease.V_6_0_0_beta2,
-            TestNewMajorRelease.V_6_0_0)));
+            TestNewMajorRelease.V_4_6_0,
+            TestNewMajorRelease.V_4_6_1,
+            TestNewMajorRelease.V_5_0_0)));
         assertThat(unreleased, equalTo(Arrays.asList(
-            TestNewMajorRelease.V_5_6_2,
-            TestNewMajorRelease.V_6_0_1)));
+            TestNewMajorRelease.V_4_6_2,
+            TestNewMajorRelease.V_5_0_1)));
     }
 
-    public static class TestVersionBumpIn6x {
-        public static final Version V_5_6_0 = Version.fromString("5.6.0");
-        public static final Version V_5_6_1 = Version.fromString("5.6.1");
-        public static final Version V_5_6_2 = Version.fromString("5.6.2");
-        public static final Version V_6_0_0_alpha1 = Version.fromString("6.0.0-alpha1");
-        public static final Version V_6_0_0_alpha2 = Version.fromString("6.0.0-alpha2");
-        public static final Version V_6_0_0_beta1 = Version.fromString("6.0.0-beta1");
-        public static final Version V_6_0_0_beta2 = Version.fromString("6.0.0-beta2");
-        public static final Version V_6_0_0 = Version.fromString("6.0.0");
-        public static final Version V_6_0_1 = Version.fromString("6.0.1");
-        public static final Version V_6_1_0 = Version.fromString("6.1.0");
-        public static final Version CURRENT = V_6_1_0;
+    public static class TestVersionBumpIn2x {
+        public static final Version V_1_6_0 = Version.fromString("1.6.0");
+        public static final Version V_1_6_1 = Version.fromString("1.6.1");
+        public static final Version V_1_6_2 = Version.fromString("1.6.2");
+        public static final Version V_2_0_0 = Version.fromString("2.0.0");
+        public static final Version V_2_0_1 = Version.fromString("2.0.1");
+        public static final Version V_2_1_0 = Version.fromString("2.1.0");
+        public static final Version CURRENT = V_2_1_0;
     }
 
-    public void testResolveReleasedVersionsAtVersionBumpIn6x() {
-        Tuple<List<Version>, List<Version>> t = VersionUtils.resolveReleasedVersions(TestVersionBumpIn6x.CURRENT,
-            TestVersionBumpIn6x.class);
+    public void testResolveReleasedVersionsAtVersionBumpIn2x() {
+        Tuple<List<Version>, List<Version>> t = VersionUtils.resolveReleasedVersions(TestVersionBumpIn2x.CURRENT,
+            TestVersionBumpIn2x.class);
         List<Version> released = t.v1();
         List<Version> unreleased = t.v2();
 
         assertThat(released, equalTo(Arrays.asList(
-            TestVersionBumpIn6x.V_5_6_0,
-            TestVersionBumpIn6x.V_5_6_1,
-            TestVersionBumpIn6x.V_6_0_0_alpha1,
-            TestVersionBumpIn6x.V_6_0_0_alpha2,
-            TestVersionBumpIn6x.V_6_0_0_beta1,
-            TestVersionBumpIn6x.V_6_0_0_beta2,
-            TestVersionBumpIn6x.V_6_0_0)));
+            TestVersionBumpIn2x.V_1_6_0,
+            TestVersionBumpIn2x.V_1_6_1,
+            TestVersionBumpIn2x.V_2_0_0)));
         assertThat(unreleased, equalTo(Arrays.asList(
-            TestVersionBumpIn6x.V_5_6_2,
-            TestVersionBumpIn6x.V_6_0_1,
-            TestVersionBumpIn6x.V_6_1_0)));
+            TestVersionBumpIn2x.V_1_6_2,
+            TestVersionBumpIn2x.V_2_0_1,
+            TestVersionBumpIn2x.V_2_1_0)));
     }
 
     public static class TestNewMinorBranchIn6x {
-        public static final Version V_5_6_0 = Version.fromString("5.6.0");
-        public static final Version V_5_6_1 = Version.fromString("5.6.1");
-        public static final Version V_5_6_2 = Version.fromString("5.6.2");
-        public static final Version V_6_0_0_alpha1 = Version.fromString("6.0.0-alpha1");
-        public static final Version V_6_0_0_alpha2 = Version.fromString("6.0.0-alpha2");
-        public static final Version V_6_0_0_beta1 = Version.fromString("6.0.0-beta1");
-        public static final Version V_6_0_0_beta2 = Version.fromString("6.0.0-beta2");
-        public static final Version V_6_0_0 = Version.fromString("6.0.0");
-        public static final Version V_6_0_1 = Version.fromString("6.0.1");
-        public static final Version V_6_1_0 = Version.fromString("6.1.0");
-        public static final Version V_6_1_1 = Version.fromString("6.1.1");
-        public static final Version V_6_1_2 = Version.fromString("6.1.2");
-        public static final Version V_6_2_0 = Version.fromString("6.2.0");
-        public static final Version CURRENT = V_6_2_0;
+        public static final Version V_1_6_0 = Version.fromString("1.6.0");
+        public static final Version V_1_6_1 = Version.fromString("1.6.1");
+        public static final Version V_1_6_2 = Version.fromString("1.6.2");
+        public static final Version V_2_0_0 = Version.fromString("2.0.0");
+        public static final Version V_2_0_1 = Version.fromString("2.0.1");
+        public static final Version V_2_1_0 = Version.fromString("2.1.0");
+        public static final Version V_2_1_1 = Version.fromString("2.1.1");
+        public static final Version V_2_1_2 = Version.fromString("2.1.2");
+        public static final Version V_2_2_0 = Version.fromString("2.2.0");
+        public static final Version CURRENT = V_2_2_0;
     }
 
     public void testResolveReleasedVersionsAtNewMinorBranchIn6x() {
@@ -317,20 +269,16 @@ public class VersionUtilsTests extends OpenSearchTestCase {
         List<Version> unreleased = t.v2();
 
         assertThat(released, equalTo(Arrays.asList(
-            TestNewMinorBranchIn6x.V_5_6_0,
-            TestNewMinorBranchIn6x.V_5_6_1,
-            TestNewMinorBranchIn6x.V_6_0_0_alpha1,
-            TestNewMinorBranchIn6x.V_6_0_0_alpha2,
-            TestNewMinorBranchIn6x.V_6_0_0_beta1,
-            TestNewMinorBranchIn6x.V_6_0_0_beta2,
-            TestNewMinorBranchIn6x.V_6_0_0,
-            TestNewMinorBranchIn6x.V_6_0_1,
-            TestNewMinorBranchIn6x.V_6_1_0,
-            TestNewMinorBranchIn6x.V_6_1_1)));
+            TestNewMinorBranchIn6x.V_1_6_0,
+            TestNewMinorBranchIn6x.V_1_6_1,
+            TestNewMinorBranchIn6x.V_2_0_0,
+            TestNewMinorBranchIn6x.V_2_0_1,
+            TestNewMinorBranchIn6x.V_2_1_0,
+            TestNewMinorBranchIn6x.V_2_1_1)));
         assertThat(unreleased, equalTo(Arrays.asList(
-            TestNewMinorBranchIn6x.V_5_6_2,
-            TestNewMinorBranchIn6x.V_6_1_2,
-            TestNewMinorBranchIn6x.V_6_2_0)));
+            TestNewMinorBranchIn6x.V_1_6_2,
+            TestNewMinorBranchIn6x.V_2_1_2,
+            TestNewMinorBranchIn6x.V_2_2_0)));
     }
 
     /**

--- a/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/DoSectionTests.java
@@ -540,24 +540,24 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
     public void testNodeSelectorByVersion() throws IOException {
         parser = createParser(YamlXContent.yamlXContent,
                 "node_selector:\n" +
-                "    version: 5.2.0-6.0.0\n" +
+                "    version: 1.2.0-2.0.0\n" +
                 "indices.get_field_mapping:\n" +
                 "    index: test_index"
         );
 
         DoSection doSection = DoSection.parse(parser);
         assertNotSame(NodeSelector.ANY, doSection.getApiCallSection().getNodeSelector());
-        Node v170 = nodeWithVersion("1.7.0");
-        Node v521 = nodeWithVersion("5.2.1");
-        Node v550 = nodeWithVersion("5.5.0");
-        Node v612 = nodeWithVersion("6.1.2");
+        Node v120 = nodeWithVersion("1.1.0");
+        Node v121 = nodeWithVersion("1.2.1");
+        Node v150 = nodeWithVersion("1.5.0");
+        Node v212 = nodeWithVersion("2.1.2");
         List<Node> nodes = new ArrayList<>();
-        nodes.add(v170);
-        nodes.add(v521);
-        nodes.add(v550);
-        nodes.add(v612);
+        nodes.add(v120);
+        nodes.add(v121);
+        nodes.add(v150);
+        nodes.add(v212);
         doSection.getApiCallSection().getNodeSelector().select(nodes);
-        assertEquals(Arrays.asList(v521, v550), nodes);
+        assertEquals(Arrays.asList(v121, v150), nodes);
         ClientYamlTestExecutionContext context = mock(ClientYamlTestExecutionContext.class);
         ClientYamlTestResponse mockResponse = mock(ClientYamlTestResponse.class);
         when(context.callApi("indices.get_field_mapping", singletonMap("index", "test_index"),
@@ -646,7 +646,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
     public void testNodeSelectorByTwoThings() throws IOException {
         parser = createParser(YamlXContent.yamlXContent,
                 "node_selector:\n" +
-                "    version: 5.2.0-6.0.0\n" +
+                "    version: 1.2.0-2.0.0\n" +
                 "    attribute:\n" +
                 "        attr: val\n" +
                 "indices.get_field_mapping:\n" +
@@ -655,9 +655,9 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
 
         DoSection doSection = DoSection.parse(parser);
         assertNotSame(NodeSelector.ANY, doSection.getApiCallSection().getNodeSelector());
-        Node both = nodeWithVersionAndAttributes("5.2.1", singletonMap("attr", singletonList("val")));
-        Node badVersion = nodeWithVersionAndAttributes("5.1.1", singletonMap("attr", singletonList("val")));
-        Node badAttr = nodeWithVersionAndAttributes("5.2.1", singletonMap("notattr", singletonList("val")));
+        Node both = nodeWithVersionAndAttributes("1.2.1", singletonMap("attr", singletonList("val")));
+        Node badVersion = nodeWithVersionAndAttributes("1.1.1", singletonMap("attr", singletonList("val")));
+        Node badAttr = nodeWithVersionAndAttributes("1.2.1", singletonMap("notattr", singletonList("val")));
         List<Node> nodes = new ArrayList<>();
         nodes.add(both);
         nodes.add(badVersion);


### PR DESCRIPTION
### Description
This PR fixes the Version.fromString logic to identify legacy versions. It
also adds an optional "distribution" field to the MainRespose for OpenSearch
version 1.0.0+. Any preceeding versions that do not contain the distribution
label will be handeled as legacy versions appropriately. This is tested in
remote reindex integration tests.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
