### PR TITLE
Speedup lang-painless tests

### DIFF
--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -68,8 +68,6 @@ restResources {
 tasks.named("test").configure {
   // in WhenThingsGoWrongTests we intentionally generate an out of memory error, this prevents the heap from being dumped to disk
   jvmArgs '-XX:-OmitStackTraceInFastThrow', '-XX:-HeapDumpOnOutOfMemoryError'
-  // TODO: painless tests unexpectedly run extremely slow without C2
-  jvmArgs -= '-XX:TieredStopAtLevel=1'
 }
 
 /* Build Javadoc for the Java classes in Painless's public API that are in the

--- a/modules/lang-painless/src/main/java/org/opensearch/painless/antlr/package-info.java
+++ b/modules/lang-painless/src/main/java/org/opensearch/painless/antlr/package-info.java
@@ -26,7 +26,7 @@
  */
 
 /**
- * Lexer, parser, and tree {@link Walker} responsible for turning the code
+ * Lexer, parser, and tree walker responsible for turning the code
  * generating nodes in {@link org.opensearch.painless.node}.
  */
 /*

--- a/modules/lang-painless/src/main/java/org/opensearch/painless/api/Augmentation.java
+++ b/modules/lang-painless/src/main/java/org/opensearch/painless/api/Augmentation.java
@@ -508,15 +508,16 @@ public class Augmentation {
     }
 
     /**
-     * Encode a String in Base64. Use {@link Base64.Encoder#encodeToString(byte[])} if you have to encode bytes rather than a string.
+     * Encode a String in Base64.
+     * Use {@link java.util.Base64.Encoder#encodeToString(byte[])} if you have to encode bytes rather than a string.
      */
     public static String encodeBase64(String receiver) {
         return Base64.getEncoder().encodeToString(receiver.getBytes(StandardCharsets.UTF_8));
     }
 
     /**
-     * Decode some Base64 bytes and build a UTF-8 encoded string. Use {@link Base64.Decoder#decode(String)} if you'd prefer bytes to work
-     * with bytes.
+     * Decode some Base64 bytes and build a UTF-8 encoded string.
+     * Use {@link java.util.Base64.Decoder#decode(String)} if you'd prefer bytes to work with bytes.
      */
     public static String decodeBase64(String receiver) {
         return new String(Base64.getDecoder().decode(receiver.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);

--- a/modules/lang-painless/src/test/java/org/opensearch/painless/BasicStatementTests.java
+++ b/modules/lang-painless/src/test/java/org/opensearch/painless/BasicStatementTests.java
@@ -32,6 +32,9 @@
 
 package org.opensearch.painless;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.painless.spi.Whitelist;
 import org.opensearch.script.ScriptContext;
 
@@ -44,11 +47,23 @@ import java.util.Map;
 import static java.util.Collections.emptyMap;
 
 public class BasicStatementTests extends ScriptTestCase {
+    private static PainlessScriptEngine SCRIPT_ENGINE;
 
-    protected Map<ScriptContext<?>, List<Whitelist>> scriptContexts() {
-        Map<ScriptContext<?>, List<Whitelist>> contexts = super.scriptContexts();
+    @BeforeClass
+    public static void beforeClass() {
+        Map<ScriptContext<?>, List<Whitelist>> contexts = newDefaultContexts();
         contexts.put(OneArg.CONTEXT, Whitelist.BASE_WHITELISTS);
-        return contexts;
+        SCRIPT_ENGINE = new PainlessScriptEngine(Settings.EMPTY, contexts);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        SCRIPT_ENGINE = null;
+    }
+
+    @Override
+    protected PainlessScriptEngine getEngine() {
+        return SCRIPT_ENGINE;
     }
 
     public void testIfStatement() {
@@ -295,16 +310,16 @@ public class BasicStatementTests extends ScriptTestCase {
                 "List rtn = new ArrayList(); rtn.add(0); test(rtn); rtn"));
 
         ArrayList<Integer> input = new ArrayList<>();
-        scriptEngine.compile("testOneArg", "if (arg.isEmpty()) {arg.add(1); return;} arg.add(2);",
+        getEngine().compile("testOneArg", "if (arg.isEmpty()) {arg.add(1); return;} arg.add(2);",
                 OneArg.CONTEXT, emptyMap()).newInstance().execute(input);
         assertEquals(Collections.singletonList(1), input);
         input = new ArrayList<>();
-        scriptEngine.compile("testOneArg", "if (arg.isEmpty()) {arg.add(1); return} arg.add(2);",
+        getEngine().compile("testOneArg", "if (arg.isEmpty()) {arg.add(1); return} arg.add(2);",
                 OneArg.CONTEXT, emptyMap()).newInstance().execute(input);
         assertEquals(Collections.singletonList(1), input);
         input = new ArrayList<>();
         input.add(0);
-        scriptEngine.compile("testOneArg", "if (arg.isEmpty()) {arg.add(1); return} arg.add(2);",
+        getEngine().compile("testOneArg", "if (arg.isEmpty()) {arg.add(1); return} arg.add(2);",
                 OneArg.CONTEXT, emptyMap()).newInstance().execute(input);
         assertEquals(expected, input);
     }

--- a/modules/lang-painless/src/test/java/org/opensearch/painless/Debugger.java
+++ b/modules/lang-painless/src/test/java/org/opensearch/painless/Debugger.java
@@ -33,6 +33,7 @@
 package org.opensearch.painless;
 
 import org.opensearch.painless.action.PainlessExecuteAction.PainlessTestScript;
+import org.opensearch.painless.lookup.PainlessLookup;
 import org.opensearch.painless.lookup.PainlessLookupBuilder;
 import org.opensearch.painless.spi.Whitelist;
 import org.objectweb.asm.util.Textifier;
@@ -48,13 +49,15 @@ final class Debugger {
         return toString(PainlessTestScript.class, source, new CompilerSettings());
     }
 
+    private static final PainlessLookup LOOKUP = PainlessLookupBuilder.buildFromWhitelists(Whitelist.BASE_WHITELISTS);
+
     /** compiles to bytecode, and returns debugging output */
     static String toString(Class<?> iface, String source, CompilerSettings settings) {
         StringWriter output = new StringWriter();
         PrintWriter outputWriter = new PrintWriter(output);
         Textifier textifier = new Textifier();
         try {
-            new Compiler(iface, null, null, PainlessLookupBuilder.buildFromWhitelists(Whitelist.BASE_WHITELISTS))
+            new Compiler(iface, null, null, LOOKUP)
                     .compile("<debugging>", source, settings, textifier);
         } catch (RuntimeException e) {
             textifier.print(outputWriter);


### PR DESCRIPTION
This PR follows up on #580 to fix performance issues with `lang-painless` tests.
There are ~1000 painless test methods and each one was inefficiently creating a new script engine (re-parsing whitelists and such).
On my machine the change gives ~ 2x speedup for the `lang-painless` tests.

Now the tests that need to tweak script engine settings create a class level fixture (BeforeClass/AfterClass) that is used across all the test methods in that suite. It is also a conceptual simplification: all the test methods within a file use the same settings.

RegexLimitTests was split into two suites (limit=1 and limit=2) rather than dynamically applying different settings.

C2 compiler is no longer needed for tests to be fast, instead tests runfaster with C1 only as expected, like the rest of the unit tests.

Signed-off-by: Robert Muir <rmuir@apache.org>
