### PR TITLE
Catch runtime exceptions to make class loader race conditions easier to debug.

### DIFF
--- a/server/src/main/java/org/opensearch/LegacyESVersion.java
+++ b/server/src/main/java/org/opensearch/LegacyESVersion.java
@@ -183,6 +183,8 @@ public class LegacyESVersion extends Version {
                         "expected [" + version.id + "] to be uniquely mapped but saw [" + maybePrevious + "] and [" + version + "]";
                 } catch (final IllegalAccessException e) {
                     assert false : "Version field [" + fieldName + "] should be public";
+                } catch (final RuntimeException e) {
+                    assert false : "Version field [" + fieldName + "] threw [" + e + "] during initialization";
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Not sure we need this, but thought I'd PR anyway.

I came from https://github.com/opensearch-project/anomaly-detection/issues/15 to find that the issue was fixed in https://github.com/opensearch-project/OpenSearch/pull/604. However, it took me a while to wrap my head around the problem and to find the explanation buried inside a comment: https://github.com/opensearch-project/OpenSearch/pull/604/files#r618861212. The root cause is a class loader race condition, where the static block requires fields of `LegacyESVersion` to be non-null, but `Version` is loaded before `LegacyESVersion`, since `LegacyESVersion` inherits from Version. Kudos @nknize for spotting this.

Before this change you would get a `NullPointerException` error.

```
    java.lang.ExceptionInInitializerError
        at org.opensearch.index.store.StoreStats.<clinit>(StoreStats.java:54)
        at jdk.internal.reflect.GeneratedSerializationConstructorAccessor14.newInstance(Unknown Source)
        ...

        Caused by:
        java.lang.NullPointerException
            at org.opensearch.Version.<clinit>(Version.java:114)
            ... 22 more
```

With this change you can at least see which field is causing the problem. 

```
  2> java.lang.AssertionError: Version field [V_6_0_0_alpha1] threw [java.lang.NullPointerException] during initialization
        at org.opensearch.Version.<clinit>(Version.java:121)
        at org.opensearch.index.store.StoreStats.<clinit>(StoreStats.java:54)
```
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
