### PR TITLE
Replace elastic.co with opensearch.org in opensearch.yml

### DIFF
--- a/distribution/src/config/opensearch.yml
+++ b/distribution/src/config/opensearch.yml
@@ -8,7 +8,7 @@
 # the most important settings you may want to configure for a production cluster.
 #
 # Please consult the documentation for further information on configuration options:
-# https://www.elastic.co/guide/en/elasticsearch/reference/index.html
+# https://www.opensearch.org
 #
 # ---------------------------------- Cluster -----------------------------------
 #


### PR DESCRIPTION
Signed-off-by: Abbas Hussain <abbas_10690@yahoo.com>

### Description
Cleans up `distribution/src/config/opensearch.yml` by replacing _elastic.co_ to _opensearch.org_
 
### Issues Resolved
#609 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
