### PR TITLE
Speedup snapshot stale indices delete

### DIFF
--- a/test/framework/src/main/java/org/opensearch/snapshots/mockstore/MockRepository.java
+++ b/test/framework/src/main/java/org/opensearch/snapshots/mockstore/MockRepository.java
@@ -154,6 +154,7 @@ public class MockRepository extends FsRepository {
     private volatile boolean throwReadErrorAfterUnblock = false;
 
     private volatile boolean blocked = false;
+    private volatile boolean setThrowExceptionWhileDelete;
 
     public MockRepository(RepositoryMetadata metadata, Environment environment,
                           NamedXContentRegistry namedXContentRegistry, ClusterService clusterService,
@@ -255,6 +256,10 @@ public class MockRepository extends FsRepository {
 
     public void setFailReadsAfterUnblock(boolean failReadsAfterUnblock) {
         this.failReadsAfterUnblock = failReadsAfterUnblock;
+    }
+
+    public void setThrowExceptionWhileDelete(boolean throwError) {
+        setThrowExceptionWhileDelete = throwError;
     }
 
     public boolean blocked() {
@@ -425,6 +430,9 @@ public class MockRepository extends FsRepository {
             @Override
             public DeleteResult delete() throws IOException {
                 DeleteResult deleteResult = DeleteResult.ZERO;
+                if (setThrowExceptionWhileDelete) {
+                    throw new IOException("Random exception");
+                }
                 for (BlobContainer child : children().values()) {
                     deleteResult = deleteResult.add(child.delete());
                 }


### PR DESCRIPTION
Fix for issue: https://github.com/elastic/elasticsearch/issues/61513

### Description
Current implementation cleanupStaleIndices() of snapshot deletion is very slow . Snapshot deletion code deletes each stale indices from repository one after another sequentially .

With this code changes instead of making snapshot delete of stale indices a single threaded operation we make it multithreaded operation and delete multiple stale indices in parallel using SNAPSHOT thread pool's workers.

I have added more tests to make sure outage scenario and failover scenario is handled. 

### Issues Resolved
https://github.com/elastic/elasticsearch/pull/64513
 
### Check List
- [ Y] New functionality includes testing.
  - [ Y] All tests pass
- [Y] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
