### PR TITLE
[1.x] Speedup snapshot stale indices delete (#613)

### DIFF
--- a/test/framework/src/main/java/org/opensearch/snapshots/mockstore/MockRepository.java
+++ b/test/framework/src/main/java/org/opensearch/snapshots/mockstore/MockRepository.java
@@ -154,6 +154,7 @@ public class MockRepository extends FsRepository {
     private volatile boolean throwReadErrorAfterUnblock = false;
 
     private volatile boolean blocked = false;
+    private volatile boolean setThrowExceptionWhileDelete;
 
     public MockRepository(RepositoryMetadata metadata, Environment environment,
                           NamedXContentRegistry namedXContentRegistry, ClusterService clusterService,
@@ -255,6 +256,10 @@ public class MockRepository extends FsRepository {
 
     public void setFailReadsAfterUnblock(boolean failReadsAfterUnblock) {
         this.failReadsAfterUnblock = failReadsAfterUnblock;
+    }
+
+    public void setThrowExceptionWhileDelete(boolean throwError) {
+        setThrowExceptionWhileDelete = throwError;
     }
 
     public boolean blocked() {
@@ -425,6 +430,9 @@ public class MockRepository extends FsRepository {
             @Override
             public DeleteResult delete() throws IOException {
                 DeleteResult deleteResult = DeleteResult.ZERO;
+                if (setThrowExceptionWhileDelete) {
+                    throw new IOException("Random exception");
+                }
                 for (BlobContainer child : children().values()) {
                     deleteResult = deleteResult.add(child.delete());
                 }


### PR DESCRIPTION
backport of #613 

Instead of snapshot delete of stale indices being a single threaded operation this PR makes 
it a multithreaded operation and delete multiple stale indices in parallel using SNAPSHOT 
threadpool's workers.