### PR TITLE
distribution/packages: Fix RPM architecture name for 64-bit x86

### DIFF
--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -122,7 +122,7 @@ Closure commonPackageConfig(String type, boolean jdk, String architecture) {
     } else {
       assert type == 'rpm' : type
       if (architecture == 'x64') {
-        arch('X86_64')
+        arch('x86_64')
       } else {
         assert architecture == 'arm64' : architecture
         arch('aarch64')


### PR DESCRIPTION
### Description
This fixes the architecture name set for RPMs targeting 64-bit x86.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
