### PR TITLE
[1.x] Replace elastic.co with opensearch.org (#611)

### DIFF
--- a/distribution/src/config/opensearch.yml
+++ b/distribution/src/config/opensearch.yml
@@ -8,7 +8,7 @@
 # the most important settings you may want to configure for a production cluster.
 #
 # Please consult the documentation for further information on configuration options:
-# https://www.elastic.co/guide/en/elasticsearch/reference/index.html
+# https://www.opensearch.org
 #
 # ---------------------------------- Cluster -----------------------------------
 #


### PR DESCRIPTION
backport of #611
