### PR TITLE
Provide support for renaming settings.

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/GenericSettingUpgrader.java
+++ b/server/src/main/java/org/opensearch/common/settings/GenericSettingUpgrader.java
@@ -13,6 +13,49 @@
 
 package org.opensearch.common.settings;
 
+/**
+ * A generic setting upgrader between two settings of the same type.
+ * Typically used to rename settings between different versions of plugins.
+ * 
+ * For example, the following code upgrades {@code num_retries} to {@code retry_count}.
+ *
+ * <pre>
+ * public class MyPluginSettings {
+ *  
+ *  // new
+ *  public static final Setting&#60;Integer&#62; RETRY_COUNT = Setting.intSetting(
+ *      "retry_count", 3, Setting.Property.NodeScope);
+ * 
+ *  // old
+ *  public static final Setting&#60;Integer&#62; NUM_RETRIES = RETRY_COUNT.withKey(
+ *      "num_retries");
+ * }
+ * 
+ * public class MyPlugin extends Plugin implements ExtensiblePlugin {
+ * 
+ *  &#64;Override
+ *  public List&#60;Setting&#60;?&#62;&#62; getSettings() {
+ *      List&#60;Setting&#60;?&#62;&#62; settingList = new ArrayList&#60;&#62;();
+ *      settingList.add(MyPluginSettings.RETRY_COUNT); // new
+ *      settingList.add(MyPluginSettings.NUM_RETRIES); // old
+ *      return settingList;
+ *  }
+ * 
+ *  &#64;Override
+ *  public List&#60;Setting&#60;?&#62;&#62; getSettingUpgraders() {
+ *      List&#60;SettingUpgrader&#60;?&#62;&#62; settingUpgraders = new ArrayList&#60;&#62;();
+ *      settingUpgraders.add(new GenericSettingUpgrader&#60;&#62;(
+ *          MyPluginSettings.NUM_RETRIES, // old
+ *          MyPluginSettings.RETRY_COUNT  // new
+ *      ));
+ *      return settingUpgraders;
+ *  }
+ * 
+ * }
+ * }</pre>
+ *  
+ * @param <T> setting type
+ */
 public class GenericSettingUpgrader<T> implements SettingUpgrader<T> {
     protected final Setting<T> from;
     protected final Setting<T> to;

--- a/server/src/main/java/org/opensearch/common/settings/GenericSettingUpgrader.java
+++ b/server/src/main/java/org/opensearch/common/settings/GenericSettingUpgrader.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.common.settings;
+
+public class GenericSettingUpgrader<T> implements SettingUpgrader<T> {
+    protected final Setting<T> from;
+    protected final Setting<T> to;
+
+    public GenericSettingUpgrader(Setting<T> from, Setting<T> to) {
+        this.from = from;
+        this.to = to;
+    }
+
+    @Override
+    public Setting<T> getSetting() {
+        return this.from;
+    }
+
+    @Override
+    public String getKey(final String key) {
+        return to.getKey();
+    }
+}

--- a/server/src/main/java/org/opensearch/common/settings/Setting.java
+++ b/server/src/main/java/org/opensearch/common/settings/Setting.java
@@ -205,14 +205,36 @@ public class Setting<T> implements ToXContentObject {
     }
 
     /**
-     * Creates a new Setting instance
-     * @param key the settings key for this setting.
-     * @param defaultValue a default value function that returns the default values string representation.
-     * @param parser a parser that parses the string rep into a complex datatype.
-     * @param properties properties for this setting like scope, filtering...
+     * Creates a new Setting instance.
+     * @param key the settings key for this setting
+     * @param defaultValue a default value function that returns the default values string representation
+     * @param parser a parser that parses the string rep into a complex datatype
+     * @param properties properties for this setting like scope, filtering, etc.
      */
     public Setting(Key key, Function<Settings, String> defaultValue, Function<String, T> parser, Property... properties) {
         this(key, defaultValue, parser, v -> {}, properties);
+    }
+
+    /**
+     * Creates a Setting with a new name based on another setting.
+     * 
+     * @param key the settings key for this setting
+     * @param setting another setting to copy from
+     */
+    public Setting(Key key, Setting<T> setting) {
+        this.key = key;
+        this.fallbackSetting = setting.fallbackSetting;
+        this.defaultValue = setting.defaultValue;
+        this.parser = setting.parser;
+        this.validator = setting.validator;
+        this.properties = setting.properties;
+    }
+
+    /**
+     * Creates a copy of this Setting with a new key.
+     */
+    public Setting<T> withKey(String key) {
+        return new Setting<T>(new SimpleKey(key), this);
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

OpenSearch provides a mechanism for upgrading node settings through upgraders. When an upgrader finds a legacy setting instead of a new one, it replaces it with the new setting and removes the old setting from runtime. I attempted to repurpose those to provide a simple way for plugin authors to rename settings from, for example, `opendistro.jobscheduler.retry_count` to `opensearch.jobscheduler.retry_count`.

When a node is upgraded (or on start of a newer version), upgraders are invoked. Plugins that listen to settings changes will notice. See https://github.com/opensearch-project/job-scheduler/pull/19 for how this is used in the job-scheduler plugin.
 
### Other Ideas

I considered something completely magical that `s/opendistro/opensearch/g` in Settings, but that feels too magical and will inevitably lead to bugs.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
