### PR TITLE
Update hadoop-minicluster version for test fixture.

### DIFF
--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -31,5 +31,5 @@
 apply plugin: 'opensearch.java'
 
 dependencies {
-  api "org.apache.hadoop:hadoop-minicluster:2.8.5"
+  api "org.apache.hadoop:hadoop-minicluster:3.3.0"
 }


### PR DESCRIPTION
### Description
The `hadoop-minicluster:2.8.5` which is used for integration tests, has dependencies (listed below) which have been flagged for having security vulnerabilities.

```
netty-3.7.0.Final.jar
commons-beanutils-1.7.0.jar
zookeeper-3.4.6.jar
jackson-mapper-asl-1.9.2.jar
nimbus-jose-jwt-4.41.1.jar
```
Update `hadoop-minicluster` to the latest version `3.3.0`

### Issue
Resolves #646 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>