### PR TITLE
Make -Dtests.output= actually work.

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -219,7 +219,7 @@ Print all the logging output from the test runs to the commandline
 even if tests are passing.
 
 ------------------------------
-./gradlew test -Dtests.output=always
+./gradlew test -Dtests.output=true
 ------------------------------
 
 Configure the heap size.

--- a/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchTestBasePlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchTestBasePlugin.java
@@ -198,6 +198,7 @@ public class OpenSearchTestBasePlugin implements Plugin<Project> {
                 logging.setShowExceptions(true);
                 logging.setShowCauses(true);
                 logging.setExceptionFormat("full");
+                logging.setShowStandardStreams(Util.getBooleanProperty("tests.output", false));
             });
 
             if (OS.current().equals(OS.WINDOWS) && System.getProperty("tests.timeoutSuite") == null) {


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

We document in  https://github.com/opensearch-project/OpenSearch/blame/main/TESTING.asciidoc#L222 that one can `-Dtests.output=always` to see logs. That actually works now. I'm open to renaming this option if someone has strong feelings. 
 
https://stackoverflow.com/questions/9356543/logging-while-testing-through-gradle/35457740

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
