### PR TITLE
Fix #649: Properly escape @ in JavaDoc.

### DIFF
--- a/server/src/main/java/org/opensearch/plugins/AnalysisPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/AnalysisPlugin.java
@@ -60,14 +60,14 @@ import static java.util.Collections.emptyMap;
  * An additional extension point for {@link Plugin}s that extends OpenSearch's analysis functionality. To add an additional
  * {@link TokenFilter} just implement the interface and implement the {@link #getTokenFilters()} method:
  *
- * <pre>{@code
+ * <pre>
  * public class AnalysisPhoneticPlugin extends Plugin implements AnalysisPlugin {
  *     &#64;Override
- *     public Map<String, AnalysisProvider<TokenFilterFactory>> getTokenFilters() {
+ *     public Map&#60;String, AnalysisProvider&#60;TokenFilterFactory&#62;&#62; getTokenFilters() {
  *         return singletonMap("phonetic", PhoneticTokenFilterFactory::new);
  *     }
  * }
- * }</pre>
+ * </pre>
  *
  * OpenSearch doesn't have any automatic mechanism to share these components between indexes. If any component is heavy enough to warrant
  * such sharing then it is the Plugin's responsibility to do it in their {@link AnalysisProvider} implementation. We recommend against doing

--- a/server/src/main/java/org/opensearch/plugins/DiscoveryPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/DiscoveryPlugin.java
@@ -49,14 +49,14 @@ import java.util.function.Supplier;
  * An additional extension point for {@link Plugin}s that extends OpenSearch's discovery functionality. To add an additional
  * {@link NetworkService.CustomNameResolver} just implement the interface and implement the {@link #getCustomNameResolver(Settings)} method:
  *
- * <pre>{@code
+ * <pre>
  * public class MyDiscoveryPlugin extends Plugin implements DiscoveryPlugin {
  *     &#64;Override
  *     public NetworkService.CustomNameResolver getCustomNameResolver(Settings settings) {
  *         return new YourCustomNameResolverInstance(settings);
  *     }
  * }
- * }</pre>
+ * </pre>
  */
 public interface DiscoveryPlugin {
 


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

JavaDoc is annoying about escaping @. Read https://reflectoring.io/howto-format-code-snippets-in-javadoc/ for details. This corrects escaping for the examples where `@` renders incorrectly.
 
### Issues Resolved

Closes #649

<img width="736" alt="Screen Shot 2021-05-04 at 5 51 53 PM" src="https://user-images.githubusercontent.com/542335/117074807-d8df0880-ad01-11eb-88fd-75dacc40d08e.png">
 
### Check List
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
