### PR TITLE
Standardize int, long, double and float Setting constructors.

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/Setting.java
+++ b/server/src/main/java/org/opensearch/common/settings/Setting.java
@@ -225,8 +225,10 @@ public class Setting<T> implements ToXContentObject {
      * @param properties   properties for this setting
      */
     public Setting(
-            Key key, Function<Settings, String> defaultValue, Function<String, T> parser, Validator<T> validator, Property... properties) {
-        this(key, null, defaultValue, parser, validator, properties);
+            Key key, Function<Settings, String> defaultValue, Function<String, T> parser, 
+                Validator<T> validator, Property... properties) {
+        this(key, null, defaultValue, parser,
+            validator, properties);
     }
 
     /**
@@ -249,8 +251,10 @@ public class Setting<T> implements ToXContentObject {
      * @param validator    a {@link Validator} for validating this setting
      * @param properties   properties for this setting
      */
-    public Setting(String key, String defaultValue, Function<String, T> parser, Validator<T> validator, Property... properties) {
-        this(new SimpleKey(key), s -> defaultValue, parser, validator, properties);
+    public Setting(String key, String defaultValue, Function<String, T> parser, 
+        Validator<T> validator, Property... properties) {
+        this(new SimpleKey(key), s -> defaultValue, parser,
+            validator, properties);
     }
 
     /**
@@ -1193,8 +1197,10 @@ public class Setting<T> implements ToXContentObject {
         return floatSetting(key, defaultValue, minValue, maxValue, v -> {}, properties);
     }
 
-    public static Setting<Float> floatSetting(String key, float defaultValue, float minValue, float maxValue, Validator<Float> validator, Property... properties) {
-        return new Setting<>(key, Float.toString(defaultValue), (s) -> parseFloat(s, minValue, maxValue, key, isFiltered(properties)), validator, properties);
+    public static Setting<Float> floatSetting(String key, float defaultValue, float minValue, float maxValue, 
+        Validator<Float> validator, Property... properties) {
+        return new Setting<>(key, Float.toString(defaultValue), (s) -> parseFloat(s, minValue, maxValue, key, isFiltered(properties)), 
+            validator, properties);
     }
 
     // Setting<Float> with fallback
@@ -1207,12 +1213,15 @@ public class Setting<T> implements ToXContentObject {
         return floatSetting(key, fallbackSetting, minValue, Float.MAX_VALUE, properties);
     }
 
-    public static Setting<Float> floatSetting(String key, Setting<Float> fallbackSetting, float minValue, float maxValue, Property... properties) {
+    public static Setting<Float> floatSetting(String key, Setting<Float> fallbackSetting, float minValue, float maxValue, 
+        Property... properties) {
         return floatSetting(key, fallbackSetting, minValue, maxValue, v -> {}, properties);
     }
 
-    public static Setting<Float> floatSetting(String key, Setting<Float> fallbackSetting, float minValue, float maxValue, Validator<Float> validator, Property... properties) {
-        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseFloat(s, minValue, maxValue, key, isFiltered(properties)), validator, properties);
+    public static Setting<Float> floatSetting(String key, Setting<Float> fallbackSetting, float minValue, float maxValue, 
+        Validator<Float> validator, Property... properties) {
+        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseFloat(s, minValue, maxValue, key, 
+            isFiltered(properties)), validator, properties);
     }
     
     // Integer
@@ -1252,12 +1261,16 @@ public class Setting<T> implements ToXContentObject {
         return intSetting(key, defaultValue, minValue, maxValue, v -> {}, properties);
     }
 
-    public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, Validator<Integer> validator, Property... properties) {
-        return intSetting(key, defaultValue, minValue, Integer.MAX_VALUE, validator, properties);
+    public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, 
+        Validator<Integer> validator, Property... properties) {
+        return intSetting(key, defaultValue, minValue, Integer.MAX_VALUE,
+            validator, properties);
     }
 
-    public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, int maxValue, Validator<Integer> validator, Property... properties) {
-        return new Setting<>(key, Integer.toString(defaultValue), (s) -> parseInt(s, minValue, maxValue, key, isFiltered(properties)), validator, properties);
+    public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, int maxValue, 
+        Validator<Integer> validator, Property... properties) {
+        return new Setting<>(key, Integer.toString(defaultValue), (s) -> parseInt(s, minValue, maxValue, key, isFiltered(properties)), 
+            validator, properties);
     }
 
     // Setting<Integer> with fallback
@@ -1270,16 +1283,21 @@ public class Setting<T> implements ToXContentObject {
         return intSetting(key, fallbackSetting, minValue, Integer.MAX_VALUE, properties);
     }
 
-    public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, int maxValue, Property... properties) {
+    public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, int maxValue, 
+        Property... properties) {
         return intSetting(key, fallbackSetting, minValue, maxValue, v -> {}, properties);
     }
 
-    public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, Validator<Integer> validator, Property... properties) {
-        return intSetting(key, fallbackSetting, minValue, Integer.MAX_VALUE, validator, properties);
+    public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, 
+        Validator<Integer> validator, Property... properties) {
+        return intSetting(key, fallbackSetting, minValue, Integer.MAX_VALUE,
+            validator, properties);
     }
     
-    public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, int maxValue, Validator<Integer> validator, Property... properties) {
-        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseInt(s, minValue, maxValue, key, isFiltered(properties)), validator, properties);
+    public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, int maxValue, 
+        Validator<Integer> validator, Property... properties) {
+        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseInt(s, minValue, maxValue, key, 
+            isFiltered(properties)), validator, properties);
     }
 
     // Long
@@ -1311,8 +1329,10 @@ public class Setting<T> implements ToXContentObject {
         return longSetting(key, defaultValue, minValue, maxValue, v -> {}, properties);
     }
 
-    public static Setting<Long> longSetting(String key, long defaultValue, long minValue, long maxValue, Validator<Long> validator, Property... properties) {
-        return new Setting<>(key, Long.toString(defaultValue), (s) -> parseLong(s, minValue, maxValue, key, isFiltered(properties)), validator, properties);
+    public static Setting<Long> longSetting(String key, long defaultValue, long minValue, long maxValue, 
+        Validator<Long> validator, Property... properties) {
+        return new Setting<>(key, Long.toString(defaultValue), (s) -> parseLong(s, minValue, maxValue, key, 
+            isFiltered(properties)), validator, properties);
     }
 
     // Setting<Long> with fallback
@@ -1325,16 +1345,21 @@ public class Setting<T> implements ToXContentObject {
         return longSetting(key, fallbackSetting, minValue, Long.MAX_VALUE, properties);
     }
 
-    public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, long minValue, long maxValue, Property... properties) {
+    public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, long minValue, long maxValue, 
+        Property... properties) {
         return longSetting(key, fallbackSetting, minValue, maxValue, v -> {}, properties);
     }
 
-    public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, long minValue, Validator<Long> validator, Property... properties) {
-        return longSetting(key, fallbackSetting, minValue, Long.MAX_VALUE, validator, properties);
+    public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, long minValue, 
+        Validator<Long> validator, Property... properties) {
+        return longSetting(key, fallbackSetting, minValue, Long.MAX_VALUE,
+            validator, properties);
     }
 
-    public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, long minValue, long maxValue, Validator<Long> validator, Property... properties) {
-        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseLong(s, minValue, maxValue, key, isFiltered(properties)), validator, properties);
+    public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, long minValue, long maxValue, 
+        Validator<Long> validator, Property... properties) {
+        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseLong(s, minValue, maxValue, key, 
+            isFiltered(properties)), validator, properties);
     }
 
     // Double
@@ -1366,8 +1391,10 @@ public class Setting<T> implements ToXContentObject {
         return doubleSetting(key, defaultValue, minValue, maxValue, v -> {}, properties);
     }
 
-    public static Setting<Double> doubleSetting(String key, double defaultValue, double minValue, double maxValue, Validator<Double> validator, Property... properties) {
-        return new Setting<>(key, Double.toString(defaultValue), (s) -> parseDouble(s, minValue, maxValue, key, isFiltered(properties)), validator, properties);
+    public static Setting<Double> doubleSetting(String key, double defaultValue, double minValue, double maxValue, 
+        Validator<Double> validator, Property... properties) {
+        return new Setting<>(key, Double.toString(defaultValue), (s) -> parseDouble(s, minValue, maxValue, key, isFiltered(properties)),
+            validator, properties);
     }
 
     // Setting<Double> with fallback
@@ -1380,12 +1407,15 @@ public class Setting<T> implements ToXContentObject {
         return doubleSetting(key, fallbackSetting, minValue, Double.MAX_VALUE, properties);
     }
 
-    public static Setting<Double> doubleSetting(String key, Setting<Double> fallbackSetting, double minValue, double maxValue, Property... properties) {
+    public static Setting<Double> doubleSetting(String key, Setting<Double> fallbackSetting, double minValue, double maxValue, 
+        Property... properties) {
         return doubleSetting(key, fallbackSetting, minValue, maxValue, v -> {}, properties);
     }
 
-    public static Setting<Double> doubleSetting(String key, Setting<Double> fallbackSetting, double minValue, double maxValue, Validator<Double> validator, Property... properties) {
-        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseDouble(s, minValue, maxValue, key, isFiltered(properties)), validator, properties);
+    public static Setting<Double> doubleSetting(String key, Setting<Double> fallbackSetting, double minValue, double maxValue, 
+        Validator<Double> validator, Property... properties) {
+        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseDouble(s, minValue, maxValue, key, 
+            isFiltered(properties)), validator, properties);
     }
     
     /// simpleString
@@ -1394,17 +1424,23 @@ public class Setting<T> implements ToXContentObject {
         return new Setting<>(key, s -> "", Function.identity(), properties);
     }
 
-    public static Setting<String> simpleString(String key, Validator<String> validator, Property... properties) {
-        return new Setting<>(new SimpleKey(key), null, s -> "", Function.identity(), validator, properties);
+    public static Setting<String> simpleString(String key, 
+        Validator<String> validator, Property... properties) {
+        return new Setting<>(new SimpleKey(key), null, s -> "", Function.identity(),
+            validator, properties);
     }
 
-    public static Setting<String> simpleString(String key, Validator<String> validator, Setting<String> fallback, Property... properties) {
-        return new Setting<>(new SimpleKey(key), fallback, fallback::getRaw, Function.identity(), validator, properties);
+    public static Setting<String> simpleString(String key, 
+        Validator<String> validator, Setting<String> fallback, Property... properties) {
+        return new Setting<>(new SimpleKey(key), fallback, fallback::getRaw, Function.identity(),
+            validator, properties);
     }
 
-    public static Setting<String> simpleString(String key, String defaultValue, Validator<String> validator, Property... properties) {
+    public static Setting<String> simpleString(String key, String defaultValue, 
+        Validator<String> validator, Property... properties) {
         validator.validate(defaultValue);
-        return new Setting<>(new SimpleKey(key), null, s -> defaultValue, Function.identity(), validator, properties);
+        return new Setting<>(new SimpleKey(key), null, s -> defaultValue, Function.identity(),
+            validator, properties);
     }
 
     public static Setting<String> simpleString(String key, Setting<String> fallback, Property... properties) {
@@ -1447,14 +1483,18 @@ public class Setting<T> implements ToXContentObject {
         return new Setting<>(key, fallbackSetting, b -> parseBoolean(b, key, isFiltered(properties)), properties);
     }
 
-    public static Setting<Boolean> boolSetting(String key, Setting<Boolean> fallbackSetting, Validator<Boolean> validator,
+    public static Setting<Boolean> boolSetting(String key, Setting<Boolean> fallbackSetting, 
+        Validator<Boolean> validator,
                                                Property... properties) {
         return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, b -> parseBoolean(b, key,
-            isFiltered(properties)), validator, properties);
+            isFiltered(properties)),
+                validator, properties);
     }
 
-    public static Setting<Boolean> boolSetting(String key, boolean defaultValue, Validator<Boolean> validator, Property... properties) {
-        return new Setting<>(key, Boolean.toString(defaultValue), b -> parseBoolean(b, key, isFiltered(properties)), validator, properties);
+    public static Setting<Boolean> boolSetting(String key, boolean defaultValue, 
+        Validator<Boolean> validator, Property... properties) {
+        return new Setting<>(key, Boolean.toString(defaultValue), b -> parseBoolean(b, key, isFiltered(properties)),
+            validator, properties);
     }
 
     public static Setting<Boolean> boolSetting(String key, Function<Settings, String> defaultValueFn, Property... properties) {
@@ -1578,7 +1618,8 @@ public class Setting<T> implements ToXContentObject {
         final Function<String, T> singleValueParser,
         final Validator<List<T>> validator,
         final Property... properties) {
-        return listSetting(key, null, singleValueParser, (s) -> defaultStringValue, validator, properties);
+        return listSetting(key, null, singleValueParser, (s) -> defaultStringValue,
+            validator, properties);
     }
 
     // TODO this one's two argument get is still broken
@@ -1604,7 +1645,8 @@ public class Setting<T> implements ToXContentObject {
         final Function<Settings, List<String>> defaultStringValue,
         final Validator<List<T>> validator,
         final Property... properties) {
-        return listSetting(key, null, singleValueParser, defaultStringValue, validator, properties);
+        return listSetting(key, null, singleValueParser, defaultStringValue,
+            validator, properties);
     }
 
     public static <T> Setting<List<T>> listSetting(
@@ -1629,7 +1671,8 @@ public class Setting<T> implements ToXContentObject {
         Function<String, List<T>> parser = (s) ->
             parseableStringToList(s).stream().map(singleValueParser).collect(Collectors.toList());
 
-        return new ListSetting<>(key, fallbackSetting, defaultStringValue, parser, validator, properties);
+        return new ListSetting<>(key, fallbackSetting, defaultStringValue, parser,
+            validator, properties);
     }
 
     private static List<String> parseableStringToList(String parsableString) {
@@ -1727,7 +1770,8 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<Settings> groupSetting(String key, Consumer<Settings> validator, Property... properties) {
-        return new GroupSetting(key, validator, properties);
+        return new GroupSetting(key,
+            validator, properties);
     }
 
     public static Setting<TimeValue> timeSetting(
@@ -1822,15 +1866,18 @@ public class Setting<T> implements ToXContentObject {
         return new Setting<>(key, fallbackSetting, (s) -> TimeValue.parseTimeValue(s, key), properties);
     }
 
-    public static Setting<TimeValue> timeSetting(String key, Setting<TimeValue> fallBackSetting, Validator<TimeValue> validator, Property... properties) {
-        return new Setting<>(new SimpleKey(key), fallBackSetting, fallBackSetting::getRaw, (s) -> TimeValue.parseTimeValue(s, key), validator, properties);
+    public static Setting<TimeValue> timeSetting(String key, Setting<TimeValue> fallBackSetting, 
+        Validator<TimeValue> validator, Property... properties) {
+        return new Setting<>(new SimpleKey(key), fallBackSetting, fallBackSetting::getRaw, (s) -> TimeValue.parseTimeValue(s, key),
+            validator, properties);
     }
 
     public static Setting<TimeValue> positiveTimeSetting(String key, TimeValue defaultValue, Property... properties) {
         return timeSetting(key, defaultValue, TimeValue.timeValueMillis(0), properties);
     }
 
-    public static Setting<TimeValue> positiveTimeSetting(final String key, final Setting<TimeValue> fallbackSetting, final Property... properties) {
+    public static Setting<TimeValue> positiveTimeSetting(final String key, final Setting<TimeValue> fallbackSetting, 
+        final Property... properties) {
         return timeSetting(key, fallbackSetting, TimeValue.timeValueMillis(0), properties);
     }
 

--- a/server/src/main/java/org/opensearch/common/settings/Setting.java
+++ b/server/src/main/java/org/opensearch/common/settings/Setting.java
@@ -1160,61 +1160,235 @@ public class Setting<T> implements ToXContentObject {
         return new Setting<>(key, s -> Integer.toString(defaultValue.id), s -> Version.fromId(Integer.parseInt(s)), properties);
     }
 
-    public static Setting<Float> floatSetting(String key, float defaultValue, Property... properties) {
-        return new Setting<>(key, (s) -> Float.toString(defaultValue), Float::parseFloat, properties);
-    }
-
-    public static Setting<Float> floatSetting(String key, float defaultValue, float minValue, Property... properties) {
-        return new Setting<>(key, (s) -> Float.toString(defaultValue), (s) -> {
-            float value = Float.parseFloat(s);
-            if (value < minValue) {
-                String err = "Failed to parse value" +
-                    (isFiltered(properties) ? "" : " [" + s + "]") + " for setting [" + key + "] must be >= " + minValue;
-                throw new IllegalArgumentException(err);
-            }
-            return value;
-        }, properties);
-    }
-
     private static boolean isFiltered(Property[] properties) {
         return properties != null && Arrays.asList(properties).contains(Property.Filtered);
     }
 
-    public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, int maxValue, Property... properties) {
-        return new Setting<>(key, (s) -> Integer.toString(defaultValue),
-            (s) -> parseInt(s, minValue, maxValue, key, isFiltered(properties)), properties);
+    // Float
+
+    private static float parseFloat(String s, float minValue, float maxValue, String key, boolean isFiltered) {
+        float value = Float.parseFloat(s);
+        if (value < minValue) {
+            String err = "Failed to parse value" + (isFiltered ? "" : " [" + s + "]") + " for setting [" + key + "] must be >= " + minValue;
+            throw new IllegalArgumentException(err);
+        }
+        if (value > maxValue) {
+            String err = "Failed to parse value" + (isFiltered ? "" : " [" + s + "]") + " for setting [" + key + "] must be <= " + maxValue;
+            throw new IllegalArgumentException(err);
+        }
+        return value;
+    }
+
+    // Setting<Float> with defaultValue
+
+    public static Setting<Float> floatSetting(String key, float defaultValue, Property... properties) {
+        return floatSetting(key, defaultValue, Float.MIN_VALUE, Float.MAX_VALUE, properties);
+    }
+
+    public static Setting<Float> floatSetting(String key, float defaultValue, float minValue, Property... properties) {
+        return floatSetting(key, defaultValue, minValue, Float.MAX_VALUE, properties);
+   }
+
+    public static Setting<Float> floatSetting(String key, float defaultValue, float minValue, float maxValue, Property... properties) {
+        return floatSetting(key, defaultValue, minValue, maxValue, v -> {}, properties);
+    }
+
+    public static Setting<Float> floatSetting(String key, float defaultValue, float minValue, float maxValue, Validator<Float> validator, Property... properties) {
+        return new Setting<>(key, Float.toString(defaultValue), (s) -> parseFloat(s, minValue, maxValue, key, isFiltered(properties)), validator, properties);
+    }
+
+    // Setting<Float> with fallback
+
+    public static Setting<Float> floatSetting(String key, Setting<Float> fallbackSetting, Property... properties) {
+        return floatSetting(key, fallbackSetting, Float.MIN_VALUE, Float.MAX_VALUE, properties);
+    }
+
+    public static Setting<Float> floatSetting(String key, Setting<Float> fallbackSetting, float minValue, Property... properties) {
+        return floatSetting(key, fallbackSetting, minValue, Float.MAX_VALUE, properties);
+    }
+
+    public static Setting<Float> floatSetting(String key, Setting<Float> fallbackSetting, float minValue, float maxValue, Property... properties) {
+        return floatSetting(key, fallbackSetting, minValue, maxValue, v -> {}, properties);
+    }
+
+    public static Setting<Float> floatSetting(String key, Setting<Float> fallbackSetting, float minValue, float maxValue, Validator<Float> validator, Property... properties) {
+        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseFloat(s, minValue, maxValue, key, isFiltered(properties)), validator, properties);
+    }
+    
+    // Integer
+
+    public static int parseInt(String s, int minValue, String key) {
+        return parseInt(s, minValue, Integer.MAX_VALUE, key);
+    }
+
+    public static int parseInt(String s, int minValue, int maxValue, String key) {
+        return parseInt(s, minValue, maxValue, key, false);
+    }
+
+    public static int parseInt(String s, int minValue, int maxValue, String key, boolean isFiltered) {
+        int value = Integer.parseInt(s);
+        if (value < minValue) {
+            String err = "Failed to parse value" + (isFiltered ? "" : " [" + s + "]") + " for setting [" + key + "] must be >= " + minValue;
+            throw new IllegalArgumentException(err);
+        }
+        if (value > maxValue) {
+            String err = "Failed to parse value" + (isFiltered ? "" : " [" + s + "]") + " for setting [" + key + "] must be <= " + maxValue;
+            throw new IllegalArgumentException(err);
+        }
+        return value;
+    }
+
+    // Setting<Integer> with defaultValue
+
+    public static Setting<Integer> intSetting(String key, int defaultValue, Property... properties) {
+        return intSetting(key, defaultValue, Integer.MIN_VALUE, Integer.MAX_VALUE, properties);
     }
 
     public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, Property... properties) {
-        return new Setting<>(key, (s) -> Integer.toString(defaultValue), (s) -> parseInt(s, minValue, key, isFiltered(properties)),
-            properties);
+        return intSetting(key, defaultValue, minValue, Integer.MAX_VALUE, properties);
+   }
+
+    public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, int maxValue, Property... properties) {
+        return intSetting(key, defaultValue, minValue, maxValue, v -> {}, properties);
     }
 
-    public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, Validator<Integer> validator,
-                                              Property... properties) {
-        return new Setting<>(key, Integer.toString(defaultValue), (s) -> parseInt(s, minValue, key, isFiltered(properties)), validator,
-            properties);
+    public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, Validator<Integer> validator, Property... properties) {
+        return intSetting(key, defaultValue, minValue, Integer.MAX_VALUE, validator, properties);
+    }
+
+    public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, int maxValue, Validator<Integer> validator, Property... properties) {
+        return new Setting<>(key, Integer.toString(defaultValue), (s) -> parseInt(s, minValue, maxValue, key, isFiltered(properties)), validator, properties);
+    }
+
+    // Setting<Integer> with fallback
+
+    public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, Property... properties) {
+        return intSetting(key, fallbackSetting, Integer.MIN_VALUE, Integer.MAX_VALUE, properties);
     }
 
     public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, Property... properties) {
-        return new Setting<>(key, fallbackSetting, (s) -> parseInt(s, minValue, key, isFiltered(properties)), properties);
+        return intSetting(key, fallbackSetting, minValue, Integer.MAX_VALUE, properties);
     }
 
-    public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, int maxValue,
-                                              Property... properties) {
-        return new Setting<>(key, fallbackSetting, (s) -> parseInt(s, minValue, maxValue, key, isFiltered(properties)), properties);
+    public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, int maxValue, Property... properties) {
+        return intSetting(key, fallbackSetting, minValue, maxValue, v -> {}, properties);
     }
 
-    public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, Validator<Integer> validator,
-                                              Property... properties) {
-        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw,
-            (s) -> parseInt(s, minValue, key, isFiltered(properties)),validator, properties);
+    public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, Validator<Integer> validator, Property... properties) {
+        return intSetting(key, fallbackSetting, minValue, Integer.MAX_VALUE, validator, properties);
+    }
+    
+    public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, int maxValue, Validator<Integer> validator, Property... properties) {
+        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseInt(s, minValue, maxValue, key, isFiltered(properties)), validator, properties);
+    }
+
+    // Long
+    
+    private static long parseLong(String s, long minValue, long maxValue, String key, boolean isFiltered) {
+        long value = Long.parseLong(s);
+        if (value < minValue) {
+            String err = "Failed to parse value" + (isFiltered ? "" : " [" + s + "]") + " for setting [" + key + "] must be >= " + minValue;
+            throw new IllegalArgumentException(err);
+        }
+        if (value > maxValue) {
+            String err = "Failed to parse value" + (isFiltered ? "" : " [" + s + "]") + " for setting [" + key + "] must be <= " + maxValue;
+            throw new IllegalArgumentException(err);
+        }
+        return value;
+    }    
+
+    // Setting<Long> with defaultValue
+
+    public static Setting<Long> longSetting(String key, long defaultValue, Property... properties) {
+        return longSetting(key, defaultValue, Long.MIN_VALUE, Long.MAX_VALUE, properties);
     }
 
     public static Setting<Long> longSetting(String key, long defaultValue, long minValue, Property... properties) {
-        return new Setting<>(key, (s) -> Long.toString(defaultValue), (s) -> parseLong(s, minValue, key, isFiltered(properties)),
-            properties);
+        return longSetting(key, defaultValue, minValue, Long.MAX_VALUE, properties);
+   }
+
+    public static Setting<Long> longSetting(String key, long defaultValue, long minValue, long maxValue, Property... properties) {
+        return longSetting(key, defaultValue, minValue, maxValue, v -> {}, properties);
     }
+
+    public static Setting<Long> longSetting(String key, long defaultValue, long minValue, long maxValue, Validator<Long> validator, Property... properties) {
+        return new Setting<>(key, Long.toString(defaultValue), (s) -> parseLong(s, minValue, maxValue, key, isFiltered(properties)), validator, properties);
+    }
+
+    // Setting<Long> with fallback
+
+    public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, Property... properties) {
+        return longSetting(key, fallbackSetting, Long.MIN_VALUE, Long.MAX_VALUE, properties);
+    }
+
+    public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, long minValue, Property... properties) {
+        return longSetting(key, fallbackSetting, minValue, Long.MAX_VALUE, properties);
+    }
+
+    public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, long minValue, long maxValue, Property... properties) {
+        return longSetting(key, fallbackSetting, minValue, maxValue, v -> {}, properties);
+    }
+
+    public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, long minValue, Validator<Long> validator, Property... properties) {
+        return longSetting(key, fallbackSetting, minValue, Long.MAX_VALUE, validator, properties);
+    }
+
+    public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, long minValue, long maxValue, Validator<Long> validator, Property... properties) {
+        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseLong(s, minValue, maxValue, key, isFiltered(properties)), validator, properties);
+    }
+
+    // Double
+
+    private static double parseDouble(String s, double minValue, double maxValue, String key, boolean isFiltered) {
+        double value = Double.parseDouble(s);
+        if (value < minValue) {
+            String err = "Failed to parse value" + (isFiltered ? "" : " [" + s + "]") + " for setting [" + key + "] must be >= " + minValue;
+            throw new IllegalArgumentException(err);
+        }
+        if (value > maxValue) {
+            String err = "Failed to parse value" + (isFiltered ? "" : " [" + s + "]") + " for setting [" + key + "] must be <= " + maxValue;
+            throw new IllegalArgumentException(err);
+        }
+        return value;
+    }
+
+    // Setting<Double> with defaultValue
+
+    public static Setting<Double> doubleSetting(String key, double defaultValue, Property... properties) {
+        return doubleSetting(key, defaultValue, Double.MIN_VALUE, Double.MAX_VALUE, properties);
+    }
+
+    public static Setting<Double> doubleSetting(String key, double defaultValue, double minValue, Property... properties) {
+        return doubleSetting(key, defaultValue, minValue, Double.MAX_VALUE, properties);
+    }
+
+    public static Setting<Double> doubleSetting(String key, double defaultValue, double minValue, double maxValue, Property... properties) {
+        return doubleSetting(key, defaultValue, minValue, maxValue, v -> {}, properties);
+    }
+
+    public static Setting<Double> doubleSetting(String key, double defaultValue, double minValue, double maxValue, Validator<Double> validator, Property... properties) {
+        return new Setting<>(key, Double.toString(defaultValue), (s) -> parseDouble(s, minValue, maxValue, key, isFiltered(properties)), validator, properties);
+    }
+
+    // Setting<Double> with fallback
+
+    public static Setting<Double> doubleSetting(String key, Setting<Double> fallbackSetting, Property... properties) {
+        return doubleSetting(key, fallbackSetting, Double.MIN_VALUE, Double.MAX_VALUE, properties);
+    }
+
+    public static Setting<Double> doubleSetting(String key, Setting<Double> fallbackSetting, double minValue, Property... properties) {
+        return doubleSetting(key, fallbackSetting, minValue, Double.MAX_VALUE, properties);
+    }
+
+    public static Setting<Double> doubleSetting(String key, Setting<Double> fallbackSetting, double minValue, double maxValue, Property... properties) {
+        return doubleSetting(key, fallbackSetting, minValue, maxValue, v -> {}, properties);
+    }
+
+    public static Setting<Double> doubleSetting(String key, Setting<Double> fallbackSetting, double minValue, double maxValue, Validator<Double> validator, Property... properties) {
+        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseDouble(s, minValue, maxValue, key, isFiltered(properties)), validator, properties);
+    }
+    
+    /// simpleString
 
     public static Setting<String> simpleString(String key, Property... properties) {
         return new Setting<>(key, s -> "", Function.identity(), properties);
@@ -1257,54 +1431,12 @@ public class Setting<T> implements ToXContentObject {
         return new Setting<>(key, s -> defaultValue, Function.identity(), properties);
     }
 
-    public static int parseInt(String s, int minValue, String key) {
-        return parseInt(s, minValue, Integer.MAX_VALUE, key, false);
-    }
-
-    public static int parseInt(String s, int minValue, String key, boolean isFiltered) {
-        return parseInt(s, minValue, Integer.MAX_VALUE, key, isFiltered);
-    }
-
-    public static int parseInt(String s, int minValue, int maxValue, String key) {
-        return parseInt(s, minValue, maxValue, key, false);
-    }
-
-    public static int parseInt(String s, int minValue, int maxValue, String key, boolean isFiltered) {
-        int value = Integer.parseInt(s);
-        if (value < minValue) {
-            String err = "Failed to parse value" + (isFiltered ? "" : " [" + s + "]") + " for setting [" + key + "] must be >= " + minValue;
-            throw new IllegalArgumentException(err);
-        }
-        if (value > maxValue) {
-            String err = "Failed to parse value" + (isFiltered ? "" : " [" + s + "]") + " for setting [" + key + "] must be <= " + maxValue;
-            throw new IllegalArgumentException(err);
-        }
-        return value;
-    }
-
-    public static long parseLong(String s, long minValue, String key) {
-        return parseLong(s, minValue, key, false);
-    }
-
-    static long parseLong(String s, long minValue, String key, boolean isFiltered) {
-        long value = Long.parseLong(s);
-        if (value < minValue) {
-            String err = "Failed to parse value" + (isFiltered ? "" : " [" + s + "]") + " for setting [" + key + "] must be >= " + minValue;
-            throw new IllegalArgumentException(err);
-        }
-        return value;
-    }
-
     public static TimeValue parseTimeValue(String s, TimeValue minValue, String key) {
         TimeValue timeValue = TimeValue.parseTimeValue(s, null, key);
         if (timeValue.millis() < minValue.millis()) {
             throw new IllegalArgumentException("Failed to parse value [" + s + "] for setting [" + key + "] must be >= " + minValue);
         }
         return timeValue;
-    }
-
-    public static Setting<Integer> intSetting(String key, int defaultValue, Property... properties) {
-        return intSetting(key, defaultValue, Integer.MIN_VALUE, properties);
     }
 
     public static Setting<Boolean> boolSetting(String key, boolean defaultValue, Property... properties) {
@@ -1706,27 +1838,6 @@ public class Setting<T> implements ToXContentObject {
             final TimeValue minValue,
             final Property... properties) {
         return timeSetting(key, fallbackSetting, minValue, properties);
-    }
-
-    public static Setting<Double> doubleSetting(String key, double defaultValue, double minValue, Property... properties) {
-        return doubleSetting(key, defaultValue, minValue, Double.POSITIVE_INFINITY, properties);
-    }
-
-    public static Setting<Double> doubleSetting(String key, double defaultValue, double minValue, double maxValue, Property... properties) {
-        return new Setting<>(key, (s) -> Double.toString(defaultValue), (s) -> {
-            final double d = Double.parseDouble(s);
-            if (d < minValue) {
-                String err = "Failed to parse value" + (isFiltered(properties) ? "" : " [" + s + "]") + " for setting [" + key +
-                    "] must be >= " + minValue;
-                throw new IllegalArgumentException(err);
-            }
-            if (d > maxValue) {
-                String err = "Failed to parse value" + (isFiltered(properties) ? "" : " [" + s + "]") + " for setting [" + key +
-                    "] must be <= " + maxValue;
-                throw new IllegalArgumentException(err);
-            }
-            return d;
-        }, properties);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/common/settings/Setting.java
+++ b/server/src/main/java/org/opensearch/common/settings/Setting.java
@@ -1822,22 +1822,16 @@ public class Setting<T> implements ToXContentObject {
         return new Setting<>(key, fallbackSetting, (s) -> TimeValue.parseTimeValue(s, key), properties);
     }
 
-    public static Setting<TimeValue> timeSetting(String key, Setting<TimeValue> fallBackSetting, Validator<TimeValue> validator,
-                                                 Property... properties) {
-        return new Setting<>(new SimpleKey(key), fallBackSetting, fallBackSetting::getRaw, (s) -> TimeValue.parseTimeValue(s, key),
-            validator, properties);
+    public static Setting<TimeValue> timeSetting(String key, Setting<TimeValue> fallBackSetting, Validator<TimeValue> validator, Property... properties) {
+        return new Setting<>(new SimpleKey(key), fallBackSetting, fallBackSetting::getRaw, (s) -> TimeValue.parseTimeValue(s, key), validator, properties);
     }
 
     public static Setting<TimeValue> positiveTimeSetting(String key, TimeValue defaultValue, Property... properties) {
         return timeSetting(key, defaultValue, TimeValue.timeValueMillis(0), properties);
     }
 
-    public static Setting<TimeValue> positiveTimeSetting(
-            final String key,
-            final Setting<TimeValue> fallbackSetting,
-            final TimeValue minValue,
-            final Property... properties) {
-        return timeSetting(key, fallbackSetting, minValue, properties);
+    public static Setting<TimeValue> positiveTimeSetting(final String key, final Setting<TimeValue> fallbackSetting, final Property... properties) {
+        return timeSetting(key, fallbackSetting, TimeValue.timeValueMillis(0), properties);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/common/settings/Setting.java
+++ b/server/src/main/java/org/opensearch/common/settings/Setting.java
@@ -225,10 +225,8 @@ public class Setting<T> implements ToXContentObject {
      * @param properties   properties for this setting
      */
     public Setting(
-            Key key, Function<Settings, String> defaultValue, Function<String, T> parser, 
-                Validator<T> validator, Property... properties) {
-        this(key, null, defaultValue, parser,
-            validator, properties);
+            Key key, Function<Settings, String> defaultValue, Function<String, T> parser, Validator<T> validator, Property... properties) {
+        this(key, null, defaultValue, parser, validator, properties);
     }
 
     /**
@@ -251,10 +249,8 @@ public class Setting<T> implements ToXContentObject {
      * @param validator    a {@link Validator} for validating this setting
      * @param properties   properties for this setting
      */
-    public Setting(String key, String defaultValue, Function<String, T> parser, 
-        Validator<T> validator, Property... properties) {
-        this(new SimpleKey(key), s -> defaultValue, parser,
-            validator, properties);
+    public Setting(String key, String defaultValue, Function<String, T> parser, Validator<T> validator, Property... properties) {
+        this(new SimpleKey(key), s -> defaultValue, parser, validator, properties);
     }
 
     /**
@@ -1263,8 +1259,7 @@ public class Setting<T> implements ToXContentObject {
 
     public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, 
         Validator<Integer> validator, Property... properties) {
-        return intSetting(key, defaultValue, minValue, Integer.MAX_VALUE,
-            validator, properties);
+        return intSetting(key, defaultValue, minValue, Integer.MAX_VALUE, validator, properties);
     }
 
     public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, int maxValue, 
@@ -1290,8 +1285,7 @@ public class Setting<T> implements ToXContentObject {
 
     public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, 
         Validator<Integer> validator, Property... properties) {
-        return intSetting(key, fallbackSetting, minValue, Integer.MAX_VALUE,
-            validator, properties);
+        return intSetting(key, fallbackSetting, minValue, Integer.MAX_VALUE, validator, properties);
     }
     
     public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, int maxValue, 
@@ -1352,8 +1346,7 @@ public class Setting<T> implements ToXContentObject {
 
     public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, long minValue, 
         Validator<Long> validator, Property... properties) {
-        return longSetting(key, fallbackSetting, minValue, Long.MAX_VALUE,
-            validator, properties);
+        return longSetting(key, fallbackSetting, minValue, Long.MAX_VALUE, validator, properties);
     }
 
     public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, long minValue, long maxValue, 
@@ -1424,23 +1417,17 @@ public class Setting<T> implements ToXContentObject {
         return new Setting<>(key, s -> "", Function.identity(), properties);
     }
 
-    public static Setting<String> simpleString(String key, 
-        Validator<String> validator, Property... properties) {
-        return new Setting<>(new SimpleKey(key), null, s -> "", Function.identity(),
-            validator, properties);
+    public static Setting<String> simpleString(String key, Validator<String> validator, Property... properties) {
+        return new Setting<>(new SimpleKey(key), null, s -> "", Function.identity(), validator, properties);
     }
 
-    public static Setting<String> simpleString(String key, 
-        Validator<String> validator, Setting<String> fallback, Property... properties) {
-        return new Setting<>(new SimpleKey(key), fallback, fallback::getRaw, Function.identity(),
-            validator, properties);
+    public static Setting<String> simpleString(String key, Validator<String> validator, Setting<String> fallback, Property... properties) {
+        return new Setting<>(new SimpleKey(key), fallback, fallback::getRaw, Function.identity(), validator, properties);
     }
 
-    public static Setting<String> simpleString(String key, String defaultValue, 
-        Validator<String> validator, Property... properties) {
+    public static Setting<String> simpleString(String key, String defaultValue, Validator<String> validator, Property... properties) {
         validator.validate(defaultValue);
-        return new Setting<>(new SimpleKey(key), null, s -> defaultValue, Function.identity(),
-            validator, properties);
+        return new Setting<>(new SimpleKey(key), null, s -> defaultValue, Function.identity(), validator, properties);
     }
 
     public static Setting<String> simpleString(String key, Setting<String> fallback, Property... properties) {
@@ -1484,8 +1471,7 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<Boolean> boolSetting(String key, Setting<Boolean> fallbackSetting, 
-        Validator<Boolean> validator,
-                                               Property... properties) {
+        Validator<Boolean> validator, Property... properties) {
         return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, b -> parseBoolean(b, key,
             isFiltered(properties)),
                 validator, properties);
@@ -1618,8 +1604,7 @@ public class Setting<T> implements ToXContentObject {
         final Function<String, T> singleValueParser,
         final Validator<List<T>> validator,
         final Property... properties) {
-        return listSetting(key, null, singleValueParser, (s) -> defaultStringValue,
-            validator, properties);
+        return listSetting(key, null, singleValueParser, (s) -> defaultStringValue, validator, properties);
     }
 
     // TODO this one's two argument get is still broken
@@ -1645,8 +1630,7 @@ public class Setting<T> implements ToXContentObject {
         final Function<Settings, List<String>> defaultStringValue,
         final Validator<List<T>> validator,
         final Property... properties) {
-        return listSetting(key, null, singleValueParser, defaultStringValue,
-            validator, properties);
+        return listSetting(key, null, singleValueParser, defaultStringValue, validator, properties);
     }
 
     public static <T> Setting<List<T>> listSetting(
@@ -1671,8 +1655,7 @@ public class Setting<T> implements ToXContentObject {
         Function<String, List<T>> parser = (s) ->
             parseableStringToList(s).stream().map(singleValueParser).collect(Collectors.toList());
 
-        return new ListSetting<>(key, fallbackSetting, defaultStringValue, parser,
-            validator, properties);
+        return new ListSetting<>(key, fallbackSetting, defaultStringValue, parser, validator, properties);
     }
 
     private static List<String> parseableStringToList(String parsableString) {
@@ -1770,8 +1753,7 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<Settings> groupSetting(String key, Consumer<Settings> validator, Property... properties) {
-        return new GroupSetting(key,
-            validator, properties);
+        return new GroupSetting(key, validator, properties);
     }
 
     public static Setting<TimeValue> timeSetting(

--- a/server/src/main/java/org/opensearch/script/ScriptService.java
+++ b/server/src/main/java/org/opensearch/script/ScriptService.java
@@ -106,8 +106,7 @@ public class ScriptService implements Closeable, ClusterStateApplier {
     public static final Setting.AffixSetting<TimeValue> SCRIPT_CACHE_EXPIRE_SETTING =
         Setting.affixKeySetting(CONTEXT_PREFIX,
             "cache_expire",
-            key -> Setting.positiveTimeSetting(key, SCRIPT_GENERAL_CACHE_EXPIRE_SETTING, TimeValue.timeValueMillis(0),
-                                               Property.NodeScope, Property.Dynamic));
+            key -> Setting.positiveTimeSetting(key, SCRIPT_GENERAL_CACHE_EXPIRE_SETTING, Property.NodeScope, Property.Dynamic));
 
     // Unlimited compilation rate for context-specific script caches
     static final String UNLIMITED_COMPILATION_RATE_KEY = "unlimited";

--- a/server/src/main/java/org/opensearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/opensearch/transport/RemoteClusterService.java
@@ -100,7 +100,6 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
             Setting.positiveTimeSetting(
                     "cluster.remote.initial_connect_timeout",
                     SEARCH_REMOTE_INITIAL_CONNECTION_TIMEOUT_SETTING, // the default needs to be thirty seconds when fallback is removed
-                    TimeValue.timeValueSeconds(30),
                     Setting.Property.NodeScope);
 
     public static final Setting<String> SEARCH_REMOTE_NODE_ATTRIBUTE =

--- a/server/src/test/java/org/opensearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/SettingTests.java
@@ -896,7 +896,22 @@ public class SettingTests extends OpenSearchTestCase {
         assertEquals(fix1.get(Settings.builder().put("abc.qrx", 30).build()), Integer.valueOf(30));
     }
 
-    public void testMinMaxInt() {
+    // Integer
+
+    public void testIntWithDefaultValue() {
+        Setting<Integer> integerSetting = Setting.intSetting("foo.bar", 42);
+        assertEquals(integerSetting.get(Settings.EMPTY), Integer.valueOf(42));
+    }
+
+    public void testIntWithFallbackValue() {
+        Setting<Integer> fallbackSetting = Setting.intSetting("foo.baz", 2);
+        Setting<Integer> integerSetting = Setting.intSetting("foo.bar", fallbackSetting);
+        assertEquals(integerSetting.get(Settings.EMPTY), Integer.valueOf(2));
+        assertEquals(integerSetting.get(Settings.builder().put("foo.bar", 3).build()), Integer.valueOf(3));
+        assertEquals(integerSetting.get(Settings.builder().put("foo.baz", 3).build()), Integer.valueOf(3));
+    }
+
+    public void testIntWithMinMax() {
         Setting<Integer> integerSetting = Setting.intSetting("foo.bar", 1, 0, 10, Property.NodeScope);
         try {
             integerSetting.get(Settings.builder().put("foo.bar", 11).build());
@@ -915,6 +930,111 @@ public class SettingTests extends OpenSearchTestCase {
         assertEquals(5, integerSetting.get(Settings.builder().put("foo.bar", 5).build()).intValue());
         assertEquals(1, integerSetting.get(Settings.EMPTY).intValue());
     }
+
+    // Long
+
+    public void testLongWithDefaultValue() {
+        Setting<Long> longSetting = Setting.longSetting("foo.bar", 42);
+        assertEquals(longSetting.get(Settings.EMPTY), Long.valueOf(42));
+    }
+
+    public void testLongWithFallbackValue() {
+        Setting<Long> fallbackSetting = Setting.longSetting("foo.baz", 2);
+        Setting<Long> longSetting = Setting.longSetting("foo.bar", fallbackSetting);
+        assertEquals(longSetting.get(Settings.EMPTY), Long.valueOf(2));
+        assertEquals(longSetting.get(Settings.builder().put("foo.bar", 3).build()), Long.valueOf(3));
+        assertEquals(longSetting.get(Settings.builder().put("foo.baz", 3).build()), Long.valueOf(3));
+    }
+
+    public void testLongWithMinMax() {
+        Setting<Long> longSetting = Setting.longSetting("foo.bar", 1, 0, 10, Property.NodeScope);
+        try {
+            longSetting.get(Settings.builder().put("foo.bar", 11).build());
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertEquals("Failed to parse value [11] for setting [foo.bar] must be <= 10", ex.getMessage());
+        }
+
+        try {
+            longSetting.get(Settings.builder().put("foo.bar", -1).build());
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertEquals("Failed to parse value [-1] for setting [foo.bar] must be >= 0", ex.getMessage());
+        }
+
+        assertEquals(5, longSetting.get(Settings.builder().put("foo.bar", 5).build()).longValue());
+        assertEquals(1, longSetting.get(Settings.EMPTY).longValue());
+    }    
+
+    // Float
+
+    public void testFloatWithDefaultValue() {
+        Setting<Float> floatSetting = Setting.floatSetting("foo.bar", (float) 42.1);
+        assertEquals(floatSetting.get(Settings.EMPTY), Float.valueOf((float) 42.1));
+    }
+
+    public void testFloatWithFallbackValue() {
+        Setting<Float> fallbackSetting = Setting.floatSetting("foo.baz", (float) 2.1);
+        Setting<Float> floatSetting = Setting.floatSetting("foo.bar", fallbackSetting);
+        assertEquals(floatSetting.get(Settings.EMPTY), Float.valueOf((float) 2.1));
+        assertEquals(floatSetting.get(Settings.builder().put("foo.bar", 3.2).build()), Float.valueOf((float) 3.2));
+        assertEquals(floatSetting.get(Settings.builder().put("foo.baz", 3.2).build()), Float.valueOf((float) 3.2));
+    }
+
+    public void testFloatWithMinMax() {
+        Setting<Float> floatSetting = Setting.floatSetting("foo.bar", (float) 1.2, 0, 10, Property.NodeScope);
+        try {
+            floatSetting.get(Settings.builder().put("foo.bar", (float) 11.3).build());
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertEquals("Failed to parse value [11.3] for setting [foo.bar] must be <= 10.0", ex.getMessage());
+        }
+
+        try {
+            floatSetting.get(Settings.builder().put("foo.bar", (float) -1.4).build());
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertEquals("Failed to parse value [-1.4] for setting [foo.bar] must be >= 0.0", ex.getMessage());
+        }
+
+        assertEquals(5.6, floatSetting.get(Settings.builder().put("foo.bar", (float) 5.6).build()).floatValue(), 0.01);
+        assertEquals(1.2, floatSetting.get(Settings.EMPTY).floatValue(), 0.01);
+    }
+
+    // Double
+
+    public void testDoubleWithDefaultValue() {
+        Setting<Double> doubleSetting = Setting.doubleSetting("foo.bar", 42.1);
+        assertEquals(doubleSetting.get(Settings.EMPTY), Double.valueOf(42.1));
+    }
+
+    public void testDoubleWithFallbackValue() {
+        Setting<Double> fallbackSetting = Setting.doubleSetting("foo.baz", 2.1);
+        Setting<Double> doubleSetting = Setting.doubleSetting("foo.bar", fallbackSetting);
+        assertEquals(doubleSetting.get(Settings.EMPTY), Double.valueOf(2.1));
+        assertEquals(doubleSetting.get(Settings.builder().put("foo.bar", 3.2).build()), Double.valueOf(3.2));
+        assertEquals(doubleSetting.get(Settings.builder().put("foo.baz", 3.2).build()), Double.valueOf(3.2));
+    }
+
+    public void testDoubleWithMinMax() {
+        Setting<Double> doubleSetting = Setting.doubleSetting("foo.bar", 1.2, 0, 10, Property.NodeScope);
+        try {
+            doubleSetting.get(Settings.builder().put("foo.bar", 11.3).build());
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertEquals("Failed to parse value [11.3] for setting [foo.bar] must be <= 10.0", ex.getMessage());
+        }
+
+        try {
+            doubleSetting.get(Settings.builder().put("foo.bar", -1.4).build());
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertEquals("Failed to parse value [-1.4] for setting [foo.bar] must be >= 0.0", ex.getMessage());
+        }
+
+        assertEquals(5.6, doubleSetting.get(Settings.builder().put("foo.bar", 5.6).build()).doubleValue(), 0.01);
+        assertEquals(1.2, doubleSetting.get(Settings.EMPTY).doubleValue(), 0.01);
+    }    
 
     /**
      * Only one single scope can be added to any setting


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Enables an alterative to #643.

- Refactored and corrected inconsistencies between constructors of various types (int, float, double and long). This adds some missing constructors. (There are two ways to create settings: (a) default value, min, max, etc., and (b) fallback value, min, max, etc. Each type now has a single constructor that calls `new Setting<>` for the fallback version, and a single constructor that calls `new Setting<>` for the default version. All other constructors call these two.)

- Corrected a bug where the min value is confused with default value for `positiveTimeSetting` used together with a fallback. I removed that constructor to catch any instances (found one).
  
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
