### PR TITLE
Fix Javadoc errors in module `client/rest`

### DIFF
--- a/client/rest/src/main/java/org/opensearch/client/HasAttributeNodeSelector.java
+++ b/client/rest/src/main/java/org/opensearch/client/HasAttributeNodeSelector.java
@@ -45,6 +45,13 @@ public final class HasAttributeNodeSelector implements NodeSelector {
     private final String key;
     private final String value;
 
+    /**
+     * Create an {link HasAttributeNodeSelector} instance using the provided
+     * attribute key value pair.
+     *
+     * @param key The attribute name.
+     * @param value The attribute value.
+     */
     public HasAttributeNodeSelector(String key, String value) {
         this.key = key;
         this.value = value;

--- a/client/rest/src/main/java/org/opensearch/client/HasAttributeNodeSelector.java
+++ b/client/rest/src/main/java/org/opensearch/client/HasAttributeNodeSelector.java
@@ -46,7 +46,7 @@ public final class HasAttributeNodeSelector implements NodeSelector {
     private final String value;
 
     /**
-     * Create an {link HasAttributeNodeSelector} instance using the provided
+     * Create a {link HasAttributeNodeSelector} instance using the provided
      * attribute key value pair.
      *
      * @param key The attribute name.

--- a/client/rest/src/main/java/org/opensearch/client/HeapBufferedAsyncResponseConsumer.java
+++ b/client/rest/src/main/java/org/opensearch/client/HeapBufferedAsyncResponseConsumer.java
@@ -61,7 +61,9 @@ public class HeapBufferedAsyncResponseConsumer extends AbstractAsyncResponseCons
     private volatile SimpleInputBuffer buf;
 
     /**
-     * Creates a new instance of this consumer with the provided buffer limit
+     * Creates a new instance of this consumer with the provided buffer limit.
+     *
+     * @param bufferLimit the buffer limit. Must be greater than 0.
      */
     public HeapBufferedAsyncResponseConsumer(int bufferLimit) {
         if (bufferLimit <= 0) {

--- a/client/rest/src/main/java/org/opensearch/client/HeapBufferedAsyncResponseConsumer.java
+++ b/client/rest/src/main/java/org/opensearch/client/HeapBufferedAsyncResponseConsumer.java
@@ -64,6 +64,7 @@ public class HeapBufferedAsyncResponseConsumer extends AbstractAsyncResponseCons
      * Creates a new instance of this consumer with the provided buffer limit.
      *
      * @param bufferLimit the buffer limit. Must be greater than 0.
+     * @throws IllegalArgumentException if {@code bufferLimit} is less than or equal to 0.
      */
     public HeapBufferedAsyncResponseConsumer(int bufferLimit) {
         if (bufferLimit <= 0) {

--- a/client/rest/src/main/java/org/opensearch/client/HttpAsyncResponseConsumerFactory.java
+++ b/client/rest/src/main/java/org/opensearch/client/HttpAsyncResponseConsumerFactory.java
@@ -66,6 +66,11 @@ public interface HttpAsyncResponseConsumerFactory {
 
         private final int bufferLimit;
 
+        /**
+         * Creates a {@link HeapBufferedResponseConsumerFactory} instance with the given buffer limit.
+         *
+         * @param bufferLimitBytes the buffer limit to be applied to this instance
+         */
         public HeapBufferedResponseConsumerFactory(int bufferLimitBytes) {
             this.bufferLimit = bufferLimitBytes;
         }

--- a/client/rest/src/main/java/org/opensearch/client/Node.java
+++ b/client/rest/src/main/java/org/opensearch/client/Node.java
@@ -77,6 +77,13 @@ public class Node {
      * Create a {@linkplain Node} with metadata. All parameters except
      * {@code host} are nullable and implementations of {@link NodeSelector}
      * need to decide what to do in their absence.
+     *
+     * @param host       primary host address
+     * @param boundHosts addresses on which the host is listening
+     * @param name       name of the node
+     * @param version    version of OpenSearch
+     * @param roles      roles that the OpenSearch process has on the host
+     * @param attributes attributes declared on the node
      */
     public Node(HttpHost host, Set<HttpHost> boundHosts, String name, String version,
             Roles roles, Map<String, List<String>> attributes) {
@@ -93,6 +100,8 @@ public class Node {
 
     /**
      * Create a {@linkplain Node} without any metadata.
+     *
+     * @param host primary host address
      */
     public Node(HttpHost host) {
         this(host, null, null, null, null, null);
@@ -192,6 +201,11 @@ public class Node {
 
         private final Set<String> roles;
 
+        /**
+         * Create a {@link Roles} instance of the given string set.
+         *
+         * @param roles set of role names.
+         */
         public Roles(final Set<String> roles) {
             this.roles = new TreeSet<>(roles);
         }

--- a/client/rest/src/main/java/org/opensearch/client/NodeSelector.java
+++ b/client/rest/src/main/java/org/opensearch/client/NodeSelector.java
@@ -53,6 +53,8 @@ public interface NodeSelector {
      * {@link RestClient} will call this method with a list of "dead" nodes.
      * <p>
      * Implementers should not rely on the ordering of the nodes.
+     *
+     * @param nodes the {@Node}s targeted for the sending requests
      */
     void select(Iterable<Node> nodes);
     /*

--- a/client/rest/src/main/java/org/opensearch/client/PreferHasAttributeNodeSelector.java
+++ b/client/rest/src/main/java/org/opensearch/client/PreferHasAttributeNodeSelector.java
@@ -47,6 +47,12 @@ public final class PreferHasAttributeNodeSelector implements NodeSelector {
     private final String key;
     private final String value;
 
+    /**
+     * Creates a {@link PreferHasAttributeNodeSelector} instance with the given key value pair.
+     *
+     * @param key attribute key
+     * @param value attribute value
+     */
     public PreferHasAttributeNodeSelector(String key, String value) {
         this.key = key;
         this.value = value;

--- a/client/rest/src/main/java/org/opensearch/client/Request.java
+++ b/client/rest/src/main/java/org/opensearch/client/Request.java
@@ -94,6 +94,12 @@ public final class Request {
         }
     }
 
+    /**
+     * Add query parameters using the provided map of key value pairs.
+     *
+     * @param paramSource a map of key value pairs where the key is the url parameter.
+     * @throws IllegalArgumentException if a parameter with that name has already been set.
+     */
     public void addParameters(Map<String, String> paramSource){
         paramSource.forEach(this::addParameter);
     }
@@ -110,6 +116,8 @@ public final class Request {
     /**
      * Set the body of the request. If not set or set to {@code null} then no
      * body is sent with the request.
+     *
+     * @param entity the {@link HttpEntity} to be set as the body of the request.
      */
     public void setEntity(HttpEntity entity) {
         this.entity = entity;
@@ -121,6 +129,8 @@ public final class Request {
      * {@code Content-Type} will be sent as {@code application/json}.
      * If you need a different content type then use
      * {@link #setEntity(HttpEntity)}.
+     *
+     * @param entity JSON string to be set as the entity body of the request.
      */
     public void setJsonEntity(String entity) {
         setEntity(entity == null ? null : new NStringEntity(entity, ContentType.APPLICATION_JSON));
@@ -137,6 +147,9 @@ public final class Request {
     /**
      * Set the portion of an HTTP request to OpenSearch that can be
      * manipulated without changing OpenSearch's behavior.
+     *
+     * @param options the options to be set.
+     * @throws NullPointerException if {@code options} is null.
      */
     public void setOptions(RequestOptions options) {
         Objects.requireNonNull(options, "options cannot be null");
@@ -146,6 +159,9 @@ public final class Request {
     /**
      * Set the portion of an HTTP request to OpenSearch that can be
      * manipulated without changing OpenSearch's behavior.
+     *
+     * @param options the options to be set.
+     * @throws NullPointerException if {@code options} is null.
      */
     public void setOptions(RequestOptions.Builder options) {
         Objects.requireNonNull(options, "options cannot be null");

--- a/client/rest/src/main/java/org/opensearch/client/RequestOptions.java
+++ b/client/rest/src/main/java/org/opensearch/client/RequestOptions.java
@@ -196,6 +196,10 @@ public final class RequestOptions {
 
         /**
          * Add the provided header to the request.
+         *
+         * @param name  the header name
+         * @param value the header value
+         * @throws NullPointerException if {@code name} or {@code value} is null.
          */
         public Builder addHeader(String name, String value) {
             Objects.requireNonNull(name, "header name cannot be null");
@@ -209,6 +213,9 @@ public final class RequestOptions {
          * {@link HttpAsyncResponseConsumer} callback per retry. Controls how the
          * response body gets streamed from a non-blocking HTTP connection on the
          * client side.
+         *
+         * @param httpAsyncResponseConsumerFactory factory for creating {@link HttpAsyncResponseConsumer}.
+         * @throws NullPointerException if {@code httpAsyncResponseConsumerFactory} is null.
          */
         public void setHttpAsyncResponseConsumerFactory(HttpAsyncResponseConsumerFactory httpAsyncResponseConsumerFactory) {
             this.httpAsyncResponseConsumerFactory =
@@ -231,6 +238,8 @@ public final class RequestOptions {
          * {@linkplain WarningsHandler} to permit only certain warnings or to
          * fail the request if the warnings returned don't
          * <strong>exactly</strong> match some set.
+         *
+         * @param warningsHandler the {@link WarningsHandler} to be used
          */
         public void setWarningsHandler(WarningsHandler warningsHandler) {
             this.warningsHandler = warningsHandler;

--- a/client/rest/src/main/java/org/opensearch/client/Response.java
+++ b/client/rest/src/main/java/org/opensearch/client/Response.java
@@ -96,6 +96,8 @@ public class Response {
      * Returns the value of the first header with a specified name of this message.
      * If there is more than one matching header in the message the first element is returned.
      * If there is no matching header in the message <code>null</code> is returned.
+     *
+     * @param name header name
      */
     public String getHeader(String name) {
         Header header = response.getFirstHeader(name);

--- a/client/rest/src/main/java/org/opensearch/client/ResponseException.java
+++ b/client/rest/src/main/java/org/opensearch/client/ResponseException.java
@@ -47,6 +47,11 @@ public final class ResponseException extends IOException {
 
     private final Response response;
 
+    /**
+     * Creates a ResponseException containing the given {@code Response}.
+     *
+     * @param response The error response.
+     */
     public ResponseException(Response response) throws IOException {
         super(buildMessage(response));
         this.response = response;

--- a/client/rest/src/main/java/org/opensearch/client/ResponseListener.java
+++ b/client/rest/src/main/java/org/opensearch/client/ResponseListener.java
@@ -44,7 +44,9 @@ package org.opensearch.client;
 public interface ResponseListener {
 
     /**
-     * Method invoked if the request yielded a successful response
+     * Method invoked if the request yielded a successful response.
+     *
+     * @param response success response
      */
     void onSuccess(Response response);
 
@@ -52,6 +54,8 @@ public interface ResponseListener {
      * Method invoked if the request failed. There are two main categories of failures: connection failures (usually
      * {@link java.io.IOException}s, or responses that were treated as errors based on their error response code
      * ({@link ResponseException}s).
+     *
+     * @param exception the failure exception
      */
     void onFailure(Exception exception);
 }

--- a/client/rest/src/main/java/org/opensearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClient.java
@@ -195,6 +195,8 @@ public class RestClient implements Closeable {
      * <p>
      * Prefer this to {@link #builder(HttpHost...)} if you have metadata up front about the nodes.
      * If you don't either one is fine.
+     *
+     * @param nodes The nodes that the client will send requests to.
      */
     public static RestClientBuilder builder(Node... nodes) {
         return new RestClientBuilder(nodes == null ? null : Arrays.asList(nodes));
@@ -207,6 +209,8 @@ public class RestClient implements Closeable {
      * You can use this if you do not have metadata up front about the nodes. If you do, prefer
      * {@link #builder(Node...)}.
      * @see Node#Node(HttpHost)
+     *
+     * @param hosts The hosts that the client will send requests to.
      */
     public static RestClientBuilder builder(HttpHost... hosts) {
         if (hosts == null || hosts.length == 0) {
@@ -218,6 +222,8 @@ public class RestClient implements Closeable {
 
     /**
      * Replaces the nodes with which the client communicates.
+     *
+     * @param nodes the new nodes to communicate with.
      */
     public synchronized void setNodes(Collection<Node> nodes) {
         if (nodes == null || nodes.isEmpty()) {
@@ -672,7 +678,14 @@ public class RestClient implements Closeable {
      */
     public static class FailureListener {
         /**
-         * Notifies that the node provided as argument has just failed
+         * Create a {@link FailureListener} instance.
+         */
+        public FailureListener() {}
+
+        /**
+         * Notifies that the node provided as argument has just failed.
+         *
+         * @param node The node which has failed.
          */
         public void onFailure(Node node) {}
     }
@@ -907,6 +920,11 @@ public class RestClient implements Closeable {
      */
     public static class ContentCompressingEntity extends GzipCompressingEntity {
 
+        /**
+         * Creates a {@link ContentCompressingEntity} instances with the provided HTTP entity.
+         *
+         * @param entity the HTTP entity.
+         */
         public ContentCompressingEntity(HttpEntity entity) {
             super(entity);
         }

--- a/client/rest/src/main/java/org/opensearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClient.java
@@ -921,7 +921,7 @@ public class RestClient implements Closeable {
     public static class ContentCompressingEntity extends GzipCompressingEntity {
 
         /**
-         * Creates a {@link ContentCompressingEntity} instances with the provided HTTP entity.
+         * Creates a {@link ContentCompressingEntity} instance with the provided HTTP entity.
          *
          * @param entity the HTTP entity.
          */

--- a/client/rest/src/main/java/org/opensearch/client/RestClientBuilder.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClientBuilder.java
@@ -53,9 +53,24 @@ import java.util.Objects;
  * {@link org.apache.http.nio.client.HttpAsyncClient} in case additional customization is needed.
  */
 public final class RestClientBuilder {
+    /**
+     * The default connection timout in milliseconds.
+     */
     public static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 1000;
+
+    /**
+     * The default socket timeout in milliseconds.
+     */
     public static final int DEFAULT_SOCKET_TIMEOUT_MILLIS = 30000;
+
+    /**
+     * The default maximum of connections per route.
+     */
     public static final int DEFAULT_MAX_CONN_PER_ROUTE = 10;
+
+    /**
+     * The default maximum total connections.
+     */
     public static final int DEFAULT_MAX_CONN_TOTAL = 30;
 
     private static final Header[] EMPTY_HEADERS = new Header[0];
@@ -92,6 +107,7 @@ public final class RestClientBuilder {
      * <p>
      * Request-time headers will always overwrite any default headers.
      *
+     * @param defaultHeaders array of default header
      * @throws NullPointerException if {@code defaultHeaders} or any header is {@code null}.
      */
     public RestClientBuilder setDefaultHeaders(Header[] defaultHeaders) {
@@ -106,6 +122,7 @@ public final class RestClientBuilder {
     /**
      * Sets the {@link RestClient.FailureListener} to be notified for each request failure
      *
+     * @param failureListener the {@link RestClient.FailureListener} for each failure
      * @throws NullPointerException if {@code failureListener} is {@code null}.
      */
     public RestClientBuilder setFailureListener(RestClient.FailureListener failureListener) {
@@ -117,6 +134,7 @@ public final class RestClientBuilder {
     /**
      * Sets the {@link HttpClientConfigCallback} to be used to customize http client configuration
      *
+     * @param httpClientConfigCallback the {@link HttpClientConfigCallback} to be used
      * @throws NullPointerException if {@code httpClientConfigCallback} is {@code null}.
      */
     public RestClientBuilder setHttpClientConfigCallback(HttpClientConfigCallback httpClientConfigCallback) {
@@ -128,6 +146,7 @@ public final class RestClientBuilder {
     /**
      * Sets the {@link RequestConfigCallback} to be used to customize http client configuration
      *
+     * @param requestConfigCallback the {@link RequestConfigCallback} to be used
      * @throws NullPointerException if {@code requestConfigCallback} is {@code null}.
      */
     public RestClientBuilder setRequestConfigCallback(RequestConfigCallback requestConfigCallback) {
@@ -145,6 +164,7 @@ public final class RestClientBuilder {
      * OpenSearch is behind a proxy that provides a base path or a proxy that requires all paths to start with '/';
      * it is not intended for other purposes and it should not be supplied in other scenarios.
      *
+     * @param pathPrefix the path prefix for every request.
      * @throws NullPointerException if {@code pathPrefix} is {@code null}.
      * @throws IllegalArgumentException if {@code pathPrefix} is empty, or ends with more than one '/'.
      */
@@ -153,6 +173,14 @@ public final class RestClientBuilder {
         return this;
     }
 
+    /**
+     * Cleans up the given path prefix to ensure that looks like "/base/path".
+     *
+     * @param pathPrefix the path prefix to be cleaned up.
+     * @return the cleaned up path prefix.
+     * @throws NullPointerException if {@code pathPrefix} is {@code null}.
+     * @throws IllegalArgumentException if {@pathPrefix} is empty, or ends with more than one '/'.
+     */
     public static String cleanPathPrefix(String pathPrefix) {
         Objects.requireNonNull(pathPrefix, "pathPrefix must not be null");
 
@@ -178,6 +206,8 @@ public final class RestClientBuilder {
 
     /**
      * Sets the {@link NodeSelector} to be used for all requests.
+     *
+     * @param nodeSelector the {@link NodeSelector} to be used
      * @throws NullPointerException if the provided nodeSelector is null
      */
     public RestClientBuilder setNodeSelector(NodeSelector nodeSelector) {
@@ -189,6 +219,8 @@ public final class RestClientBuilder {
     /**
      * Whether the REST client should return any response containing at least
      * one warning header as a failure.
+     *
+     * @param strictDeprecationMode flag for enabling strict deprecation mode
      */
     public RestClientBuilder setStrictDeprecationMode(boolean strictDeprecationMode) {
         this.strictDeprecationMode = strictDeprecationMode;
@@ -198,6 +230,8 @@ public final class RestClientBuilder {
     /**
      * Whether the REST client should compress requests using gzip content encoding and add the "Accept-Encoding: gzip"
      * header to receive compressed responses.
+     *
+     * @param compressionEnabled flag for enabling compression
      */
     public RestClientBuilder setCompressionEnabled(boolean compressionEnabled) {
         this.compressionEnabled = compressionEnabled;
@@ -254,6 +288,8 @@ public final class RestClientBuilder {
          * Allows to customize the {@link RequestConfig} that will be used with each request.
          * It is common to customize the different timeout values through this method without losing any other useful default
          * value that the {@link RestClientBuilder} internally sets.
+         *
+         * @param requestConfigBuilder the {@link RestClientBuilder} for customizing the request configuration.
          */
         RequestConfig.Builder customizeRequestConfig(RequestConfig.Builder requestConfigBuilder);
     }
@@ -269,6 +305,8 @@ public final class RestClientBuilder {
          * Commonly used to customize the default {@link org.apache.http.client.CredentialsProvider} for authentication
          * or the {@link SchemeIOSessionStrategy} for communication through ssl without losing any other useful default
          * value that the {@link RestClientBuilder} internally sets, like connection pooling.
+         *
+         * @param httpClientBuilder the {@link HttpClientBuilder} for customizing the client instance.
          */
         HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder);
     }

--- a/client/rest/src/main/java/org/opensearch/client/WarningFailureException.java
+++ b/client/rest/src/main/java/org/opensearch/client/WarningFailureException.java
@@ -47,6 +47,12 @@ public final class WarningFailureException extends RuntimeException {
 
     private final Response response;
 
+    /**
+     * Creates a {@link WarningFailureException} instance.
+     *
+     * @param response the response that contains warnings.
+     * @throws IOException if there a problems building the exception message.
+     */
     public WarningFailureException(Response response) throws IOException {
         super(buildMessage(response));
         this.response = response;
@@ -56,6 +62,8 @@ public final class WarningFailureException extends RuntimeException {
      * Wrap a {@linkplain WarningFailureException} with another one with the current
      * stack trace. This is used during synchronous calls so that the caller
      * ends up in the stack trace of the exception thrown.
+     *
+     * @param e the exception to be wrapped.
      */
     WarningFailureException(WarningFailureException e) {
         super(e.getMessage(), e);

--- a/client/rest/src/main/java/org/opensearch/client/WarningFailureException.java
+++ b/client/rest/src/main/java/org/opensearch/client/WarningFailureException.java
@@ -51,7 +51,7 @@ public final class WarningFailureException extends RuntimeException {
      * Creates a {@link WarningFailureException} instance.
      *
      * @param response the response that contains warnings.
-     * @throws IOException if there a problems building the exception message.
+     * @throws IOException if there is a problem building the exception message.
      */
     public WarningFailureException(Response response) throws IOException {
         super(buildMessage(response));

--- a/client/rest/src/main/java/org/opensearch/client/WarningsHandler.java
+++ b/client/rest/src/main/java/org/opensearch/client/WarningsHandler.java
@@ -39,8 +39,18 @@ import java.util.List;
  * request.
  */
 public interface WarningsHandler {
+
+    /**
+     * Determines whether the given list of warnings should fail the request.
+     *
+     * @param warnings a list of warnings.
+     * @return boolean indicating if the request should fail.
+     */
     boolean warningsShouldFailRequest(List<String> warnings);
 
+    /**
+     * The permissive warnings handler. Warnings will not fail the request.
+     */
     WarningsHandler PERMISSIVE = new WarningsHandler() {
         @Override
         public boolean warningsShouldFailRequest(List<String> warnings) {
@@ -52,6 +62,10 @@ public interface WarningsHandler {
             return "permissive";
         }
     };
+
+    /**
+     * The strict warnings handler. Warnings will fail the request.
+     */
     WarningsHandler STRICT = new WarningsHandler() {
         @Override
         public boolean warningsShouldFailRequest(List<String> warnings) {

--- a/client/rest/src/main/java/org/opensearch/client/package-info.java
+++ b/client/rest/src/main/java/org/opensearch/client/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * REST client that connects to an OpenSearch cluster.
+ */
+package org.opensearch.client;


### PR DESCRIPTION
### Description
Fix Javadoc comments to fix Javadoc errors as described in issue https://github.com/opensearch-project/OpenSearch/issues/221.
 
### Issues Resolved
Fixes Javadoc errors in the `client/rest` module.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
