### PR TITLE
Fixes precommit task configuration failures due to newly added missin…

### DIFF
--- a/client/rest/src/main/java/org/opensearch/client/NodeSelector.java
+++ b/client/rest/src/main/java/org/opensearch/client/NodeSelector.java
@@ -54,7 +54,7 @@ public interface NodeSelector {
      * <p>
      * Implementers should not rely on the ordering of the nodes.
      *
-     * @param nodes the {@Node}s targeted for the sending requests
+     * @param nodes the {@link Node}s targeted for the sending requests
      */
     void select(Iterable<Node> nodes);
     /*

--- a/client/rest/src/main/java/org/opensearch/client/RestClientBuilder.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClientBuilder.java
@@ -179,7 +179,7 @@ public final class RestClientBuilder {
      * @param pathPrefix the path prefix to be cleaned up.
      * @return the cleaned up path prefix.
      * @throws NullPointerException if {@code pathPrefix} is {@code null}.
-     * @throws IllegalArgumentException if {@pathPrefix} is empty, or ends with more than one '/'.
+     * @throws IllegalArgumentException if {@code pathPrefix} is empty, or ends with more than one '/'.
      */
     public static String cleanPathPrefix(String pathPrefix) {
         Objects.requireNonNull(pathPrefix, "pathPrefix must not be null");

--- a/gradle/missing-javadoc.gradle
+++ b/gradle/missing-javadoc.gradle
@@ -52,20 +52,22 @@ allprojects {
       docroot = file("${buildDir}/site")
     }
 
-    // TODO: Enable missingJavadoc task
+    // TODO: Add missingJavadoc checks to precommit plugin
     // See https://github.com/opendistro-for-elasticsearch/search/issues/221
-    // Once we get the javadocs ready for the code base
-    // we will disable the default javadoc task and use our own
-    // missingJavadoc task below. The default javadoc task
-    // will just invoke 'missingJavadoc' (to allow people to call
-    // conventional task name).
-    tasks.matching { it.name == "javadoc" }.all {
+    // Currently the missingJavadoc task fails due to missing documentation
+    // across multiple modules. Once javadocs are added, we can
+    // add this task to precommit plugin.
+    tasks.withType(MissingJavadocTask).configureEach {
       enabled = true
-      // enabled = false
-      // dependsOn "missingJavadoc"
+      title = "${project.rootProject.name} ${project.name} API"
+
+      // Set up custom doclet.
+      dependsOn configurations.missingdoclet
+      docletpath = configurations.missingdoclet
     }
 
-    task missingJavadoc(type: MissingJavadocTask) {
+
+    tasks.register('missingJavadoc', MissingJavadocTask) {
       description "This task validates and generates Javadoc API documentation for the main source code."
       group "documentation"
 
@@ -76,16 +78,6 @@ allprojects {
 
       outputDir = project.javadoc.destinationDir
     }
-  }
-}
-
-allprojects {
-  project.tasks.withType(MissingJavadocTask) {
-    title = "${project.rootProject.name} ${project.name} API"
-
-    // Set up custom doclet.
-    dependsOn configurations.missingdoclet
-    docletpath = configurations.missingdoclet
   }
 }
 


### PR DESCRIPTION
Fixes precommit task configuration failures due to newly added missingJavadoc task. Also fixes bug (2 errors) in #685 causing javadoc generation failures.

Signed-off-by: Himanshu Setia <setiah@amazon.com>

### Description
The missingJavadoc task was interfering with gradle configuration lifecycle, causing the precommit tasks to be initialized incorrectly. This caused PomValidationTask to fail as it was unable to find pom files in the configured path. This PR fixes those configuration failures.
 
### Issues Resolved
#449 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
