### PR TITLE
[BUG] fix MainResponse to spoof version number for legacy clients

### DIFF
--- a/server/src/main/java/org/opensearch/action/main/MainResponse.java
+++ b/server/src/main/java/org/opensearch/action/main/MainResponse.java
@@ -102,7 +102,11 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(nodeName);
-        Version.writeVersion(version, out);
+        if (out.getVersion().before(Version.V_1_0_0)) {
+            Version.writeVersion(LegacyESVersion.V_7_10_2, out);
+        } else {
+            Version.writeVersion(version, out);
+        }
         clusterName.writeTo(out);
         out.writeString(clusterUuid);
         Build.writeBuild(build, out);


### PR DESCRIPTION
This commit changes MainResponse to spoof OpenSearch 1.x version numbers as
Legacy version number 7.10.2 for legacy transport clients.

relates #693 

Signed-off-by: Nicholas Walter Knize <nknize@apache.org>
