### PR TITLE
[1.x][backport]Make default number of shards configurable

### DIFF
--- a/qa/evil-tests/src/test/java/org/opensearch/cluster/metadata/EvilSystemPropertyTests.java
+++ b/qa/evil-tests/src/test/java/org/opensearch/cluster/metadata/EvilSystemPropertyTests.java
@@ -35,26 +35,47 @@ import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 
+import static org.opensearch.cluster.metadata.IndexMetadata.DEFAULT_NUMBER_OF_SHARDS;
+import static org.opensearch.cluster.metadata.IndexMetadata.MAX_NUMBER_OF_SHARDS;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
+
 public class EvilSystemPropertyTests extends OpenSearchTestCase {
 
     @SuppressForbidden(reason = "manipulates system properties for testing")
-    public void testMaxNumShards() {
+    public void testNumShards() {
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () ->
             IndexMetadata.buildNumberOfShardsSetting()
-                .get(Settings.builder().put("index.number_of_shards", 1025).build()));
-        assertEquals("Failed to parse value [1025] for setting [index.number_of_shards] must be <= 1024", exception.getMessage());
+                .get(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1025).build()));
+        assertEquals("Failed to parse value [1025] for setting [" + SETTING_NUMBER_OF_SHARDS + "] must be <= 1024", exception.getMessage());
 
-        Integer numShards = IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.get(Settings.builder().put("index.number_of_shards", 100).build());
+        Integer numShards = IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.get(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 100).build());
         assertEquals(100, numShards.intValue());
         int limit = randomIntBetween(1, 10);
-        System.setProperty("opensearch.index.max_number_of_shards", Integer.toString(limit));
+        System.setProperty(MAX_NUMBER_OF_SHARDS, Integer.toString(limit));
         try {
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
                 IndexMetadata.buildNumberOfShardsSetting()
                     .get(Settings.builder().put("index.number_of_shards", 11).build()));
             assertEquals("Failed to parse value [11] for setting [index.number_of_shards] must be <= " + limit, e.getMessage());
+            System.clearProperty(MAX_NUMBER_OF_SHARDS);
+
+            Integer defaultFromSetting = IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getDefault(Settings.EMPTY);
+            assertEquals(1, defaultFromSetting.intValue());
+
+            int randomDefault = randomIntBetween(1, 10);
+            System.setProperty(DEFAULT_NUMBER_OF_SHARDS, Integer.toString(randomDefault));
+            defaultFromSetting = IndexMetadata.buildNumberOfShardsSetting().getDefault(Settings.EMPTY);
+            assertEquals(randomDefault, defaultFromSetting.intValue());
+
+            randomDefault = randomIntBetween(1, 10);
+            System.setProperty(MAX_NUMBER_OF_SHARDS, Integer.toString(randomDefault));
+            System.setProperty(DEFAULT_NUMBER_OF_SHARDS, Integer.toString(randomDefault + 1));
+            e = expectThrows(IllegalArgumentException.class, IndexMetadata::buildNumberOfShardsSetting);
+            assertEquals(DEFAULT_NUMBER_OF_SHARDS + " value [" + (randomDefault + 1) + "] must between " +
+                "1 and " + MAX_NUMBER_OF_SHARDS + " [" + randomDefault + "]", e.getMessage());
         } finally {
-            System.clearProperty("opensearch.index.max_number_of_shards");
+            System.clearProperty(MAX_NUMBER_OF_SHARDS);
+            System.clearProperty(DEFAULT_NUMBER_OF_SHARDS);
         }
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -795,7 +795,7 @@ public class MetadataCreateIndexService {
         if (indexVersionCreated.before(LegacyESVersion.V_7_0_0)) {
             numberOfShards = 5;
         } else {
-            numberOfShards = 1;
+            numberOfShards = INDEX_NUMBER_OF_SHARDS_SETTING.getDefault(Settings.EMPTY);
         }
         return numberOfShards;
     }


### PR DESCRIPTION
The default number of primary shards for a new index, when the number of shards are not provided in the request, can be configured for the cluster. This is a backport commit of pull #625

Signed-off-by: Arunabh Singh <arunabs@amazon.com>

### Description
Adding a way to modify the default number of shards for indices whose creation requests do not have the number of shards setting explicitly provided. This will be useful in cases where for such indices the cluster manager wants to have a default value other than the hardcoded value of 1 shard. Assumption is that most of the users will not need to modify this property but adding it as an option for cloud providers and for cases where most create requests don’t provide the number of shards explicitly.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/678
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
