### PR TITLE
[1.x] [TEST] Fix failing distro tests for linux packages (#569)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,4 +1,4 @@
-OpenSearch
+OpenSearch (https://opensearch.org/)
 Copyright 2021 OpenSearch Contributors
 
 This product includes software developed by

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -387,7 +387,7 @@ def linux_common(config,
 
   # This prevents leftovers from previous tests using the
   # same VM from messing up the current test
-  config.vm.provision 'clean es installs in tmp', run: 'always', type: 'shell', inline: <<-SHELL
+  config.vm.provision 'clean opensearch installs in tmp', run: 'always', type: 'shell', inline: <<-SHELL
     rm -rf /tmp/opensearch*
   SHELL
 

--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/internal/InternalDistributionArchiveCheckPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/internal/InternalDistributionArchiveCheckPluginFuncTest.groovy
@@ -89,7 +89,7 @@ class InternalDistributionArchiveCheckPluginFuncTest extends AbstractGradleFuncT
     def "fails on unexpected notice content"() {
         given:
         license(file("LICENSE.txt"))
-        file("NOTICE.txt").text = """OpenSearch
+        file("NOTICE.txt").text = """OpenSearch (https://opensearch.org/)
 Copyright 2009-2018 Acme Coorp"""
         buildFile << """
             apply plugin:'base'

--- a/buildSrc/src/main/groovy/org/opensearch/gradle/NoticeTask.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/gradle/NoticeTask.groovy
@@ -39,6 +39,9 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermissions
+
 /**
  * A task to create a notice file which includes dependencies' notices.
  */
@@ -149,6 +152,7 @@ class NoticeTask extends DefaultTask {
             }
         }
         outputFile.setText(output.toString(), 'UTF-8')
+        Files.setPosixFilePermissions(outputFile.toPath(), PosixFilePermissions.fromString("rw-r--r--"))
     }
 
     @InputFiles

--- a/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionArchiveCheckPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionArchiveCheckPlugin.java
@@ -103,7 +103,10 @@ public class InternalDistributionArchiveCheckPlugin implements Plugin<Project> {
             task.doLast(new Action<Task>() {
                 @Override
                 public void execute(Task task) {
-                    final List<String> noticeLines = Arrays.asList("OpenSearch", "Copyright 2021 OpenSearch Contributors");
+                    final List<String> noticeLines = Arrays.asList(
+                        "OpenSearch (https://opensearch.org/)",
+                        "Copyright 2021 OpenSearch Contributors"
+                    );
                     final Path noticePath = checkExtraction.get()
                         .getDestinationDir()
                         .toPath()

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -294,7 +294,7 @@ apply plugin: 'nebula.ospackage-base'
 
 // this is package indepdendent configuration
 ospackage {
-  maintainer 'OpenSearch Team'
+  maintainer 'OpenSearch Team <opensearch@amazon.com>'
   summary 'Distributed RESTful search engine built for the cloud'
   packageDescription '''
     Reference documentation can be found at
@@ -341,6 +341,7 @@ Closure commonDebConfig(boolean jdk, String architecture) {
 
     into('/usr/share/lintian/overrides') {
       from('src/deb/lintian/opensearch')
+      fileMode 0644
     }
   }
 }
@@ -361,7 +362,7 @@ Closure commonRpmConfig(boolean jdk, String architecture) {
   return {
     configure(commonPackageConfig('rpm', jdk, architecture))
 
-    license 'ASL 2.0'
+    license 'ASL-2.0'
 
     packageGroup 'Application/Internet'
     requires '/bin/bash'
@@ -499,7 +500,7 @@ subprojects {
         (project.name.contains('deb') && dpkgExists.call(it)) || (project.name.contains('rpm') && rpmExists.call(it))
       }
       doLast {
-        final List<String> noticeLines = Arrays.asList("OpenSearch", "Copyright 2021 OpenSearch Contributors")
+        final List<String> noticeLines = Arrays.asList("OpenSearch (https://opensearch.org/)", "Copyright 2021 OpenSearch Contributors")
         final Path noticePath = packageExtractionDir.toPath().resolve("usr/share/opensearch/NOTICE.txt")
         assertLinesInFile(noticePath, noticeLines)
       }

--- a/qa/os/src/test/java/org/opensearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/opensearch/packaging/test/DockerTests.java
@@ -358,7 +358,7 @@ public class DockerTests extends PackagingTestCase {
         // expected group.
         final Shell localSh = new Shell();
         final String findResults = localSh.run(
-            "docker run --rm --tty " + getImageName(distribution) + " bash -c ' touch data/test && find . -not -gid 0 ' "
+            "docker run --rm --tty " + getImageName() + " bash -c ' touch data/test && find . -not -gid 0 ' "
         ).stdout;
 
         assertThat("Found some files whose GID != 0", findResults, is(emptyString()));

--- a/qa/os/src/test/java/org/opensearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/opensearch/packaging/util/Docker.java
@@ -90,7 +90,7 @@ public class Docker {
      * @param distribution details about the docker image to potentially load.
      */
     public static void ensureImageIsLoaded(Distribution distribution) {
-        Shell.Result result = sh.run("docker image ls --format '{{.Repository}}' " + getImageName(distribution));
+        Shell.Result result = sh.run("docker image ls --format '{{.Repository}}' " + getImageName());
 
         final long count = Arrays.stream(result.stdout.split("\n")).map(String::trim).filter(s -> s.isEmpty() == false).count();
 
@@ -224,7 +224,7 @@ public class Docker {
         }
 
         // Image name
-        args.add(getImageName(distribution));
+        args.add(getImageName());
 
         final String command = String.join(" ", args);
         logger.info("Running command: " + command);
@@ -581,7 +581,7 @@ public class Docker {
     public static Map<String, String> getImageLabels(Distribution distribution) throws Exception {
         // The format below extracts the .Config.Labels value, and prints it as json. Without the json
         // modifier, a stringified Go map is printed instead, which isn't helpful.
-        String labelsJson = sh.run("docker inspect -f '{{json .Config.Labels}}' " + getImageName(distribution)).stdout;
+        String labelsJson = sh.run("docker inspect -f '{{json .Config.Labels}}' " + getImageName()).stdout;
 
         ObjectMapper mapper = new ObjectMapper();
 
@@ -598,7 +598,7 @@ public class Docker {
         return sh.run("docker logs " + containerId);
     }
 
-    public static String getImageName(Distribution distribution) {
-        return ":test";
+    public static String getImageName() {
+        return "opensearch:test";
     }
 }

--- a/qa/os/src/test/java/org/opensearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/opensearch/packaging/util/Packages.java
@@ -137,7 +137,9 @@ public class Packages {
     }
 
     private static Result runPackageManager(Distribution distribution, Shell sh, PackageManagerCommand command) {
-        final String distributionArg = distribution.path.toString();
+        final String distributionArg = command == PackageManagerCommand.QUERY || command == PackageManagerCommand.REMOVE
+            ? "opensearch"
+            : distribution.path.toString();
 
         if (Platforms.isRPM()) {
             String rpmOptions = RPM_OPTIONS.get(command);
@@ -216,7 +218,7 @@ public class Packages {
         if (distribution.packaging == Distribution.Packaging.RPM) {
             assertThat(opensearch.home.resolve("LICENSE.txt"), file(File, "root", "root", p644));
         } else {
-            Path copyrightDir = Paths.get(sh.run("readlink -f /usr/share/doc/").stdout.trim());
+            Path copyrightDir = Paths.get(sh.run("readlink -f /usr/share/doc/opensearch").stdout.trim());
             assertThat(copyrightDir, file(Directory, "root", "root", p755));
             assertThat(copyrightDir.resolve("copyright"), file(File, "root", "root", p644));
         }


### PR DESCRIPTION
**Backport** #569 

### Description
Changes to fix the failing OpenSearch distribution tests for packages (linux-archive, linux-archive-aarch64, debian, rpm, docker) on supported linux distros. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>