### PR TITLE
Create group settings with fallback.

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/Setting.java
+++ b/server/src/main/java/org/opensearch/common/settings/Setting.java
@@ -1009,11 +1009,20 @@ public class Setting<T> implements ToXContentObject {
     private static class GroupSetting extends Setting<Settings> {
         private final String key;
         private final Consumer<Settings> validator;
+        private Setting<Settings> fallbackSetting;
 
         private GroupSetting(String key, Consumer<Settings> validator, Property... properties) {
             super(new GroupKey(key), (s) -> "", (s) -> null, properties);
             this.key = key;
             this.validator = validator;
+            this.fallbackSetting = null;
+        }
+
+        private GroupSetting(String key, Setting<Settings> fallback, Consumer<Settings> validator, Property... properties) {
+            super(new GroupKey(key), fallback, (s) -> null, properties);
+            this.key = key;
+            this.validator = validator;
+            this.fallbackSetting = fallback;
         }
 
         @Override
@@ -1038,6 +1047,9 @@ public class Setting<T> implements ToXContentObject {
         @Override
         public Settings get(Settings settings) {
             Settings byPrefix = settings.getByPrefix(getKey());
+            if (byPrefix.size() == 0 && this.fallbackSetting != null) {
+                byPrefix = fallbackSetting.get(settings);
+            }
             validator.accept(byPrefix);
             return byPrefix;
         }
@@ -1049,7 +1061,11 @@ public class Setting<T> implements ToXContentObject {
                     return true;
                 }
             }
-            return false;
+            if (this.fallbackSetting != null) {
+                return fallbackSetting.exists(settings);
+            } else {
+                return false;
+            }
         }
 
         @Override
@@ -1748,12 +1764,53 @@ public class Setting<T> implements ToXContentObject {
         }
     }
 
+    /**
+     * Creates a group of settings prefixed by a key. 
+     *
+     * @param key the group key for the setting
+     * @param properties properties properties for this setting like scope, filtering...
+     * @return the group setting object
+     */
     public static Setting<Settings> groupSetting(String key, Property... properties) {
         return groupSetting(key, (s) -> {}, properties);
     }
 
+    /**
+     * Creates a group of settings prefixed by a key. 
+     *
+     * @param key the group key for the setting
+     * @param validator a {@link Validator} for validating this setting
+     * @param properties properties properties for this setting like scope, filtering...
+     * @return the group setting object
+     */
     public static Setting<Settings> groupSetting(String key, Consumer<Settings> validator, Property... properties) {
         return new GroupSetting(key, validator, properties);
+    }
+
+    /**
+     * Creates a group of settings prefixed by a key. 
+     *
+     * @param key the group key for the setting
+     * @param fallback a {@link GroupSetting} to use as fallback when no group key values exist 
+     * @param properties properties properties for this setting like scope, filtering...
+     * @return the group setting object
+     */
+    public static Setting<Settings> groupSetting(String key, final Setting<Settings> fallback, Property... properties) {
+        return groupSetting(key, fallback, (s) -> {}, properties);
+   }
+
+    /**
+     * Creates a group of settings prefixed by a key. 
+     *
+     * @param key the group key for the setting
+     * @param fallback a {@link GroupSetting} to use as fallback when no group key values exist 
+     * @param validator a {@link Validator} for validating this setting
+     * @param properties properties properties for this setting like scope, filtering...
+     * @return the group setting object
+     */
+    public static Setting<Settings> groupSetting(String key, final Setting<Settings> fallback, 
+        Consumer<Settings> validator, Property... properties) {        
+        return new GroupSetting(key, fallback, validator, properties);
     }
 
     public static Setting<TimeValue> timeSetting(

--- a/server/src/main/java/org/opensearch/common/settings/Setting.java
+++ b/server/src/main/java/org/opensearch/common/settings/Setting.java
@@ -158,7 +158,7 @@ public class Setting<T> implements ToXContentObject {
     private final Key key;
     protected final Function<Settings, String> defaultValue;
     @Nullable
-    private final Setting<T> fallbackSetting;
+    protected final Setting<T> fallbackSetting;
     private final Function<String, T> parser;
     private final Validator<T> validator;
     private final EnumSet<Property> properties;
@@ -1009,20 +1009,17 @@ public class Setting<T> implements ToXContentObject {
     private static class GroupSetting extends Setting<Settings> {
         private final String key;
         private final Consumer<Settings> validator;
-        private Setting<Settings> fallbackSetting;
 
         private GroupSetting(String key, Consumer<Settings> validator, Property... properties) {
             super(new GroupKey(key), (s) -> "", (s) -> null, properties);
             this.key = key;
             this.validator = validator;
-            this.fallbackSetting = null;
         }
 
         private GroupSetting(String key, Setting<Settings> fallback, Consumer<Settings> validator, Property... properties) {
             super(new GroupKey(key), fallback, (s) -> null, properties);
             this.key = key;
             this.validator = validator;
-            this.fallbackSetting = fallback;
         }
 
         @Override


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Enables fallback in group settings.

Seems a bit hacky to me, but YOLO. One concern is that group settings don't mix in this implementation, so if you have `old.one=x` and `old.two=y` along with `new.one=z`, you don't get a value for `new.two`, it's all or nothing. Not sure if it's an issue, probably not for upgrade purposes.
 
### Issues Resolved

https://github.com/opensearch-project/OpenSearch/issues/719
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
