### PR TITLE
Raise an error if elasticsearch.yml is present

### DIFF
--- a/server/src/main/java/org/opensearch/node/InternalSettingsPreparer.java
+++ b/server/src/main/java/org/opensearch/node/InternalSettingsPreparer.java
@@ -81,6 +81,11 @@ public class InternalSettingsPreparer {
         initializeSettings(output, input, properties);
         Environment environment = new Environment(output.build(), configPath);
 
+        if (Files.exists(environment.configFile().resolve("elasticsearch.yml"))) {
+            throw new SettingsException(
+                "elasticsearch.yml was deprecated with opensearch and must be renamed to opensearch.yml");
+        }
+
         if (Files.exists(environment.configFile().resolve("opensearch.yaml"))) {
             throw new SettingsException("opensearch.yaml was deprecated in 5.5.0 and must be renamed to opensearch.yml");
         }

--- a/server/src/test/java/org/opensearch/node/InternalSettingsPreparerTests.java
+++ b/server/src/test/java/org/opensearch/node/InternalSettingsPreparerTests.java
@@ -114,6 +114,17 @@ public class InternalSettingsPreparerTests extends OpenSearchTestCase {
         }
     }
 
+    public void testESConfigFileNotAllowed() throws IOException {
+        InputStream yaml = getClass().getResourceAsStream("/config/opensearch.yml");
+        Path config = homeDir.resolve("config");
+        Files.createDirectory(config);
+        Files.copy(yaml, config.resolve("elasticsearch.yml"));
+        SettingsException e = expectThrows(SettingsException.class,
+            () -> InternalSettingsPreparer.prepareEnvironment(Settings.builder().put(baseEnvSettings).build(),
+                emptyMap(), null, DEFAULT_NODE_NAME_SHOULDNT_BE_CALLED));
+        assertEquals("elasticsearch.yml was deprecated with opensearch and must be renamed to opensearch.yml", e.getMessage());
+    }
+
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/358")
     public void testYamlNotAllowed() throws IOException {
         InputStream yaml = getClass().getResourceAsStream("/config/opensearch.yml");


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
As part of [640](https://github.com/opensearch-project/OpenSearch/issues/640), this will throw an error if an elasticsearch.yml file is present in ../config.

Testing steps taken:

```
tar vfxz opensearch-1.0.0-SNAPSHOT-linux-x64.tar.gz
cd opensearch-1.0.0-SNAPSHOT
./bin/opensearch

<server starts>

cd ../config
touch elasticsearch.yml
../bin/opensearch
```

output:
`Exception in thread "main" SettingsException[elasticsearch.yml was deprecated with opensearch and must be renamed to opensearch.yml]
        at org.opensearch.node.InternalSettingsPreparer.prepareEnvironment(InternalSettingsPreparer.java:85)
        at org.opensearch.cli.EnvironmentAwareCommand.createEnv(EnvironmentAwareCommand.java:113)
        at org.opensearch.cli.EnvironmentAwareCommand.createEnv(EnvironmentAwareCommand.java:104)
        at org.opensearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:99)
        at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:140)
        at org.opensearch.cli.MultiCommand.execute(MultiCommand.java:104)
        at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:140)
        at org.opensearch.cli.Command.main(Command.java:103)
        at org.opensearch.common.settings.KeyStoreCli.main(KeyStoreCli.java:56)`
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/640
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
