### PR TITLE
[1.x] Remove URL content from Reindex error response

### DIFF
--- a/modules/reindex/src/main/java/org/opensearch/index/reindex/remote/RemoteScrollableHitSource.java
+++ b/modules/reindex/src/main/java/org/opensearch/index/reindex/remote/RemoteScrollableHitSource.java
@@ -186,8 +186,9 @@ public class RemoteScrollableHitSource extends ScrollableHitSource {
                             }
                             if (xContentType == null) {
                                 try {
+                                    logger.debug("Response didn't include Content-Type: " + bodyMessage(response.getEntity()));
                                     throw new OpenSearchException(
-                                        "Response didn't include Content-Type: " + bodyMessage(response.getEntity()));
+                                        "Response didn't include supported Content-Type, remote is likely not an OpenSearch instance");
                                 } catch (IOException e) {
                                     OpenSearchException ee = new OpenSearchException("Error extracting body from response");
                                     ee.addSuppressed(e);

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
@@ -94,7 +94,6 @@ import java.util.stream.Stream;
 
 import static org.opensearch.common.unit.TimeValue.timeValueMillis;
 import static org.opensearch.common.unit.TimeValue.timeValueMinutes;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -472,7 +471,7 @@ public class RemoteScrollableHitSourceTests extends OpenSearchTestCase {
     public void testNoContentTypeIsError() {
         RuntimeException e = expectListenerFailure(RuntimeException.class, (RejectAwareActionListener<Version> listener) ->
                 sourceWithMockedRemoteCall(false, null, "main/0_20_5.json").lookupRemoteVersion(listener));
-        assertThat(e.getMessage(), containsString("Response didn't include Content-Type: body={"));
+        assertEquals(e.getMessage(), "Response didn't include supported Content-Type, remote is likely not an OpenSearch instance");
     }
 
     public void testInvalidJsonThinksRemoteIsNotES() throws IOException {


### PR DESCRIPTION
Backport #630

Signed-off-by: Sooraj Sinha <soosinha@amazon.com>

### Description
This change reduces the verbosity of the error response in remote reindex. Currently if a non Opensearch URL is specified in the remote info, then the entire HTML content of the URL is returned as the error response.
This change removes the URL response body from error response and instead logs it to the service log.
 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
