### PR TITLE
[1.x] distribution/packages: Fix filename format for deb archives (#621)

### DIFF
--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -134,9 +134,9 @@ Closure commonPackageConfig(String type, boolean jdk, String architecture) {
     destinationDirectory = file("${prefix}/build/distributions")
 
     // SystemPackagingTask overrides default archive task convention mappings, but doesn't provide a setter so we have to override the convention mapping itself
-    // Deb convention uses a '-' for final separator before architecture, rpm uses a '.'
+    // Deb convention uses a '_' for final separator before architecture, rpm uses a '.'
     if (type == 'deb') {
-      conventionMapping.archiveFile = { objects.fileProperty().fileValue(file("${destinationDirectory.get()}/${packageName}-${project.version}${jdkString}-${archString}.${type}")) }
+      conventionMapping.archiveFile = { objects.fileProperty().fileValue(file("${destinationDirectory.get()}/${packageName}_${project.version}${jdkString}_${archString}.${type}")) }
     } else {
       conventionMapping.archiveFile = { objects.fileProperty().fileValue(file("${destinationDirectory.get()}/${packageName}-${project.version}${jdkString}.${archString}.${type}")) }
     }


### PR DESCRIPTION
Backport #621

This fixes the filename of the generated Debian package to follow the standard filename format similar to what dpkg itself would create.

Debian packages are formatted with the following filename structure:

name_[epoch:]version-release_arch.deb

Make generated Debian packages follow this convention.

Signed-off-by: Neal Gompa <ngompa13@gmail.com> 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
