### PR TITLE
Add a method to use fallback setting to set the memory size

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/Setting.java
+++ b/server/src/main/java/org/opensearch/common/settings/Setting.java
@@ -1206,9 +1206,9 @@ public class Setting<T> implements ToXContentObject {
         return floatSetting(key, defaultValue, minValue, maxValue, v -> {}, properties);
     }
 
-    public static Setting<Float> floatSetting(String key, float defaultValue, float minValue, float maxValue, 
+    public static Setting<Float> floatSetting(String key, float defaultValue, float minValue, float maxValue,
         Validator<Float> validator, Property... properties) {
-        return new Setting<>(key, Float.toString(defaultValue), (s) -> parseFloat(s, minValue, maxValue, key, isFiltered(properties)), 
+        return new Setting<>(key, Float.toString(defaultValue), (s) -> parseFloat(s, minValue, maxValue, key, isFiltered(properties)),
             validator, properties);
     }
 
@@ -1222,17 +1222,17 @@ public class Setting<T> implements ToXContentObject {
         return floatSetting(key, fallbackSetting, minValue, Float.MAX_VALUE, properties);
     }
 
-    public static Setting<Float> floatSetting(String key, Setting<Float> fallbackSetting, float minValue, float maxValue, 
+    public static Setting<Float> floatSetting(String key, Setting<Float> fallbackSetting, float minValue, float maxValue,
         Property... properties) {
         return floatSetting(key, fallbackSetting, minValue, maxValue, v -> {}, properties);
     }
 
-    public static Setting<Float> floatSetting(String key, Setting<Float> fallbackSetting, float minValue, float maxValue, 
+    public static Setting<Float> floatSetting(String key, Setting<Float> fallbackSetting, float minValue, float maxValue,
         Validator<Float> validator, Property... properties) {
-        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseFloat(s, minValue, maxValue, key, 
+        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseFloat(s, minValue, maxValue, key,
             isFiltered(properties)), validator, properties);
     }
-    
+
     // Integer
 
     public static int parseInt(String s, int minValue, String key) {
@@ -1270,14 +1270,14 @@ public class Setting<T> implements ToXContentObject {
         return intSetting(key, defaultValue, minValue, maxValue, v -> {}, properties);
     }
 
-    public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, 
+    public static Setting<Integer> intSetting(String key, int defaultValue, int minValue,
         Validator<Integer> validator, Property... properties) {
         return intSetting(key, defaultValue, minValue, Integer.MAX_VALUE, validator, properties);
     }
 
-    public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, int maxValue, 
+    public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, int maxValue,
         Validator<Integer> validator, Property... properties) {
-        return new Setting<>(key, Integer.toString(defaultValue), (s) -> parseInt(s, minValue, maxValue, key, isFiltered(properties)), 
+        return new Setting<>(key, Integer.toString(defaultValue), (s) -> parseInt(s, minValue, maxValue, key, isFiltered(properties)),
             validator, properties);
     }
 
@@ -1291,24 +1291,24 @@ public class Setting<T> implements ToXContentObject {
         return intSetting(key, fallbackSetting, minValue, Integer.MAX_VALUE, properties);
     }
 
-    public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, int maxValue, 
+    public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, int maxValue,
         Property... properties) {
         return intSetting(key, fallbackSetting, minValue, maxValue, v -> {}, properties);
     }
 
-    public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, 
+    public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue,
         Validator<Integer> validator, Property... properties) {
         return intSetting(key, fallbackSetting, minValue, Integer.MAX_VALUE, validator, properties);
     }
-    
-    public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, int maxValue, 
+
+    public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, int maxValue,
         Validator<Integer> validator, Property... properties) {
-        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseInt(s, minValue, maxValue, key, 
+        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseInt(s, minValue, maxValue, key,
             isFiltered(properties)), validator, properties);
     }
 
     // Long
-    
+
     private static long parseLong(String s, long minValue, long maxValue, String key, boolean isFiltered) {
         long value = Long.parseLong(s);
         if (value < minValue) {
@@ -1320,7 +1320,7 @@ public class Setting<T> implements ToXContentObject {
             throw new IllegalArgumentException(err);
         }
         return value;
-    }    
+    }
 
     // Setting<Long> with defaultValue
 
@@ -1336,9 +1336,9 @@ public class Setting<T> implements ToXContentObject {
         return longSetting(key, defaultValue, minValue, maxValue, v -> {}, properties);
     }
 
-    public static Setting<Long> longSetting(String key, long defaultValue, long minValue, long maxValue, 
+    public static Setting<Long> longSetting(String key, long defaultValue, long minValue, long maxValue,
         Validator<Long> validator, Property... properties) {
-        return new Setting<>(key, Long.toString(defaultValue), (s) -> parseLong(s, minValue, maxValue, key, 
+        return new Setting<>(key, Long.toString(defaultValue), (s) -> parseLong(s, minValue, maxValue, key,
             isFiltered(properties)), validator, properties);
     }
 
@@ -1352,19 +1352,19 @@ public class Setting<T> implements ToXContentObject {
         return longSetting(key, fallbackSetting, minValue, Long.MAX_VALUE, properties);
     }
 
-    public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, long minValue, long maxValue, 
+    public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, long minValue, long maxValue,
         Property... properties) {
         return longSetting(key, fallbackSetting, minValue, maxValue, v -> {}, properties);
     }
 
-    public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, long minValue, 
+    public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, long minValue,
         Validator<Long> validator, Property... properties) {
         return longSetting(key, fallbackSetting, minValue, Long.MAX_VALUE, validator, properties);
     }
 
-    public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, long minValue, long maxValue, 
+    public static Setting<Long> longSetting(String key, Setting<Long> fallbackSetting, long minValue, long maxValue,
         Validator<Long> validator, Property... properties) {
-        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseLong(s, minValue, maxValue, key, 
+        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseLong(s, minValue, maxValue, key,
             isFiltered(properties)), validator, properties);
     }
 
@@ -1397,7 +1397,7 @@ public class Setting<T> implements ToXContentObject {
         return doubleSetting(key, defaultValue, minValue, maxValue, v -> {}, properties);
     }
 
-    public static Setting<Double> doubleSetting(String key, double defaultValue, double minValue, double maxValue, 
+    public static Setting<Double> doubleSetting(String key, double defaultValue, double minValue, double maxValue,
         Validator<Double> validator, Property... properties) {
         return new Setting<>(key, Double.toString(defaultValue), (s) -> parseDouble(s, minValue, maxValue, key, isFiltered(properties)),
             validator, properties);
@@ -1413,17 +1413,17 @@ public class Setting<T> implements ToXContentObject {
         return doubleSetting(key, fallbackSetting, minValue, Double.MAX_VALUE, properties);
     }
 
-    public static Setting<Double> doubleSetting(String key, Setting<Double> fallbackSetting, double minValue, double maxValue, 
+    public static Setting<Double> doubleSetting(String key, Setting<Double> fallbackSetting, double minValue, double maxValue,
         Property... properties) {
         return doubleSetting(key, fallbackSetting, minValue, maxValue, v -> {}, properties);
     }
 
-    public static Setting<Double> doubleSetting(String key, Setting<Double> fallbackSetting, double minValue, double maxValue, 
+    public static Setting<Double> doubleSetting(String key, Setting<Double> fallbackSetting, double minValue, double maxValue,
         Validator<Double> validator, Property... properties) {
-        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseDouble(s, minValue, maxValue, key, 
+        return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, (s) -> parseDouble(s, minValue, maxValue, key,
             isFiltered(properties)), validator, properties);
     }
-    
+
     /// simpleString
 
     public static Setting<String> simpleString(String key, Property... properties) {
@@ -1483,14 +1483,14 @@ public class Setting<T> implements ToXContentObject {
         return new Setting<>(key, fallbackSetting, b -> parseBoolean(b, key, isFiltered(properties)), properties);
     }
 
-    public static Setting<Boolean> boolSetting(String key, Setting<Boolean> fallbackSetting, 
+    public static Setting<Boolean> boolSetting(String key, Setting<Boolean> fallbackSetting,
         Validator<Boolean> validator, Property... properties) {
         return new Setting<>(new SimpleKey(key), fallbackSetting, fallbackSetting::getRaw, b -> parseBoolean(b, key,
             isFiltered(properties)),
                 validator, properties);
     }
 
-    public static Setting<Boolean> boolSetting(String key, boolean defaultValue, 
+    public static Setting<Boolean> boolSetting(String key, boolean defaultValue,
         Validator<Boolean> validator, Property... properties) {
         return new Setting<>(key, Boolean.toString(defaultValue), b -> parseBoolean(b, key, isFiltered(properties)),
             validator, properties);
@@ -1601,6 +1601,20 @@ public class Setting<T> implements ToXContentObject {
      */
     public static Setting<ByteSizeValue> memorySizeSetting(String key, String defaultPercentage, Property... properties) {
         return new Setting<>(key, (s) -> defaultPercentage, (s) -> MemorySizeValue.parseBytesSizeValueOrHeapRatio(s, key), properties);
+    }
+
+    /**
+     * Creates a setting which specifies a memory size. This can either be
+     * specified as an absolute bytes value or as a percentage of the heap
+     * memory.
+     *
+     * @param key the key for the setting
+     * @param fallback a memory size setting to use as fallback
+     * @param properties properties properties for this setting like scope, filtering...
+     * @return the setting object
+     */
+    public static Setting<ByteSizeValue> memorySizeSetting(String key, Setting<ByteSizeValue> fallbackSetting, Property... properties) {
+        return new Setting<>(key, fallbackSetting, (s) -> MemorySizeValue.parseBytesSizeValueOrHeapRatio(s, key), properties);
     }
 
     public static <T> Setting<List<T>> listSetting(
@@ -1762,7 +1776,7 @@ public class Setting<T> implements ToXContentObject {
     }
 
     /**
-     * Creates a group of settings prefixed by a key. 
+     * Creates a group of settings prefixed by a key.
      *
      * @param key the group key for the setting
      * @param properties properties properties for this setting like scope, filtering...
@@ -1773,7 +1787,7 @@ public class Setting<T> implements ToXContentObject {
     }
 
     /**
-     * Creates a group of settings prefixed by a key. 
+     * Creates a group of settings prefixed by a key.
      *
      * @param key the group key for the setting
      * @param validator a {@link Validator} for validating this setting
@@ -1785,10 +1799,10 @@ public class Setting<T> implements ToXContentObject {
     }
 
     /**
-     * Creates a group of settings prefixed by a key. 
+     * Creates a group of settings prefixed by a key.
      *
      * @param key the group key for the setting
-     * @param fallback a {@link GroupSetting} to use as fallback when no group key values exist 
+     * @param fallback a {@link GroupSetting} to use as fallback when no group key values exist
      * @param properties properties properties for this setting like scope, filtering...
      * @return the group setting object
      */
@@ -1797,16 +1811,16 @@ public class Setting<T> implements ToXContentObject {
    }
 
     /**
-     * Creates a group of settings prefixed by a key. 
+     * Creates a group of settings prefixed by a key.
      *
      * @param key the group key for the setting
-     * @param fallback a {@link GroupSetting} to use as fallback when no group key values exist 
+     * @param fallback a {@link GroupSetting} to use as fallback when no group key values exist
      * @param validator a {@link Validator} for validating this setting
      * @param properties properties properties for this setting like scope, filtering...
      * @return the group setting object
      */
-    public static Setting<Settings> groupSetting(String key, final Setting<Settings> fallback, 
-        Consumer<Settings> validator, Property... properties) {        
+    public static Setting<Settings> groupSetting(String key, final Setting<Settings> fallback,
+        Consumer<Settings> validator, Property... properties) {
         return new GroupSetting(key, fallback, validator, properties);
     }
 
@@ -1902,7 +1916,7 @@ public class Setting<T> implements ToXContentObject {
         return new Setting<>(key, fallbackSetting, (s) -> TimeValue.parseTimeValue(s, key), properties);
     }
 
-    public static Setting<TimeValue> timeSetting(String key, Setting<TimeValue> fallBackSetting, 
+    public static Setting<TimeValue> timeSetting(String key, Setting<TimeValue> fallBackSetting,
         Validator<TimeValue> validator, Property... properties) {
         return new Setting<>(new SimpleKey(key), fallBackSetting, fallBackSetting::getRaw, (s) -> TimeValue.parseTimeValue(s, key),
             validator, properties);
@@ -1912,7 +1926,7 @@ public class Setting<T> implements ToXContentObject {
         return timeSetting(key, defaultValue, TimeValue.timeValueMillis(0), properties);
     }
 
-    public static Setting<TimeValue> positiveTimeSetting(final String key, final Setting<TimeValue> fallbackSetting, 
+    public static Setting<TimeValue> positiveTimeSetting(final String key, final Setting<TimeValue> fallbackSetting,
         final Property... properties) {
         return timeSetting(key, fallbackSetting, TimeValue.timeValueMillis(0), properties);
     }

--- a/server/src/test/java/org/opensearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/SettingTests.java
@@ -179,6 +179,22 @@ public class SettingTests extends OpenSearchTestCase {
         assertEquals(new ByteSizeValue((int) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.2)), value.get());
     }
 
+    public void testMemorySizeWithFallbackValue() {
+        Setting<ByteSizeValue> fallbackSetting = Setting.memorySizeSetting("a.byte.size", "20%", Property.Dynamic, Property.NodeScope);
+        Setting<ByteSizeValue> memorySizeSetting = Setting.memorySizeSetting("b.byte.size", fallbackSetting, Property.Dynamic, Property.NodeScope);
+        AtomicReference<ByteSizeValue> value = new AtomicReference<>(null);
+        ClusterSettings.SettingUpdater<ByteSizeValue> settingUpdater = memorySizeSetting.newUpdater(value::set, logger);
+
+        ByteSizeValue memorySizeValue = memorySizeSetting.get(Settings.EMPTY);
+        assertEquals(memorySizeValue.getBytes(), JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.2, 1.0);
+
+        assertTrue(settingUpdater.apply(Settings.builder().put("a.byte.size", "30%").build(), Settings.EMPTY));
+        assertEquals(new ByteSizeValue((int) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.3)), value.get());
+
+        assertTrue(settingUpdater.apply(Settings.builder().put("b.byte.size", "40%").build(), Settings.EMPTY));
+        assertEquals(new ByteSizeValue((int) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.4)), value.get());
+    }
+
     public void testSimpleUpdate() {
         Setting<Boolean> booleanSetting = Setting.boolSetting("foo.bar", false, Property.Dynamic, Property.NodeScope);
         AtomicReference<Boolean> atomicBoolean = new AtomicReference<>(null);
@@ -517,10 +533,10 @@ public class SettingTests extends OpenSearchTestCase {
     public void testGroupSettingFallback() {
         Setting<Settings> fallbackSetting = Setting.groupSetting("old.bar.", Property.Dynamic, Property.NodeScope);
         assertFalse(fallbackSetting.exists(Settings.EMPTY));
-        
+
         Setting<Settings> groupSetting = Setting.groupSetting("new.bar.", fallbackSetting, Property.Dynamic, Property.NodeScope);
         assertFalse(groupSetting.exists(Settings.EMPTY));
-        
+
         Settings values = Settings.builder()
             .put("old.bar.1.value", "value 1")
             .put("old.bar.2.value", "value 2")
@@ -984,7 +1000,7 @@ public class SettingTests extends OpenSearchTestCase {
 
         assertEquals(5, longSetting.get(Settings.builder().put("foo.bar", 5).build()).longValue());
         assertEquals(1, longSetting.get(Settings.EMPTY).longValue());
-    }    
+    }
 
     // Float
 
@@ -1054,7 +1070,7 @@ public class SettingTests extends OpenSearchTestCase {
 
         assertEquals(5.6, doubleSetting.get(Settings.builder().put("foo.bar", 5.6).build()).doubleValue(), 0.01);
         assertEquals(1.2, doubleSetting.get(Settings.EMPTY).doubleValue(), 0.01);
-    }    
+    }
 
     /**
      * Only one single scope can be added to any setting


### PR DESCRIPTION
Signed off by: Chloe Zhang <chloezh1102@gmail.com>

### Description
Found a missing interface when doing the SQL plugin backwards compatibility work. So this PR is to add an overwritten method to use the fallback memory size setting to set the memory size.

Not urgent since we have workaround in plugin setting backward compatibility, but would be better to have it to keep code consistent.

 
### Issues Resolved
NA
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
