### PR TITLE
[Bug] Fix gradle build on Windows failing from a recent change

### DIFF
--- a/buildSrc/src/main/groovy/org/opensearch/gradle/NoticeTask.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/gradle/NoticeTask.groovy
@@ -152,7 +152,9 @@ class NoticeTask extends DefaultTask {
             }
         }
         outputFile.setText(output.toString(), 'UTF-8')
-        Files.setPosixFilePermissions(outputFile.toPath(), PosixFilePermissions.fromString("rw-r--r--"))
+        if (OS.current() != OS.WINDOWS) {
+            Files.setPosixFilePermissions(outputFile.toPath(), PosixFilePermissions.fromString("rw-r--r--"))
+        }
     }
 
     @InputFiles


### PR DESCRIPTION
### Description

A recent change as part of the commit c2e816ec introduced a bug where the build is failing on Windows. The change was made to include the NOTICE.txt file as read-only in the distributions. The code fails on Windows as it's not a POSIX-compliant. This commit adds a check on the current operating system. 

### Issues Resolved

Resolves #757
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>