### PR TITLE
Support Backward Compatibility with ElasticSearch 6.8 & 7.x versions

### DIFF
--- a/modules/reindex/src/main/java/org/opensearch/index/reindex/remote/RemoteRequestBuilders.java
+++ b/modules/reindex/src/main/java/org/opensearch/index/reindex/remote/RemoteRequestBuilders.java
@@ -86,7 +86,7 @@ final class RemoteRequestBuilders {
         if (searchRequest.scroll() != null) {
             TimeValue keepAlive = searchRequest.scroll().keepAlive();
             // V_5_0_0
-            if (remoteVersion.before(Version.fromId(5000099))) {
+            if (remoteVersion.before(Version.fromLegacyId(5000099))) {
                 /* Versions of Elasticsearch before 5.0 couldn't parse nanos or micros
                  * so we toss out that resolution, rounding up because more scroll
                  * timeout seems safer than less. */
@@ -105,7 +105,7 @@ final class RemoteRequestBuilders {
         if (searchRequest.source().sorts() != null) {
             boolean useScan = false;
             // Detect if we should use search_type=scan rather than a sort
-            if (remoteVersion.before(Version.fromId(2010099))) {
+            if (remoteVersion.before(Version.fromLegacyId(2010099))) {
                 for (SortBuilder<?> sort : searchRequest.source().sorts()) {
                     if (sort instanceof FieldSortBuilder) {
                         FieldSortBuilder f = (FieldSortBuilder) sort;
@@ -126,10 +126,10 @@ final class RemoteRequestBuilders {
                 request.addParameter("sort", sorts.toString());
             }
         }
-        if (remoteVersion.before(Version.fromId(2000099))) {
+        if (remoteVersion.before(Version.fromLegacyId(2000099))) {
             // Versions before 2.0.0 need prompting to return interesting fields. Note that timestamp isn't available at all....
             searchRequest.source().storedField("_parent").storedField("_routing").storedField("_ttl");
-            if (remoteVersion.before(Version.fromId(1000099))) {
+            if (remoteVersion.before(Version.fromLegacyId(1000099))) {
                 // Versions before 1.0.0 don't support `"_source": true` so we have to ask for the _source in a funny way.
                 if (false == searchRequest.source().storedFields().fieldNames().contains("_source")) {
                     searchRequest.source().storedField("_source");
@@ -142,11 +142,11 @@ final class RemoteRequestBuilders {
                 fields.append(',').append(searchRequest.source().storedFields().fieldNames().get(i));
             }
             // V_5_0_0
-            String storedFieldsParamName = remoteVersion.before(Version.fromId(5000099)) ? "fields" : "stored_fields";
+            String storedFieldsParamName = remoteVersion.before(Version.fromLegacyId(5000099)) ? "fields" : "stored_fields";
             request.addParameter(storedFieldsParamName, fields.toString());
         }
 
-        if (remoteVersion.onOrAfter(Version.fromId(6030099))) {
+        if (remoteVersion.onOrAfter(Version.fromLegacyId(6030099))) {
             // allow_partial_results introduced in 6.3, running remote reindex against earlier versions still silently discards RED shards.
             request.addParameter("allow_partial_search_results", "false");
         }
@@ -172,7 +172,7 @@ final class RemoteRequestBuilders {
             if (searchRequest.source().fetchSource() != null) {
                 entity.field("_source", searchRequest.source().fetchSource());
             } else {
-                if (remoteVersion.onOrAfter(Version.fromId(1000099))) {
+                if (remoteVersion.onOrAfter(Version.fromLegacyId(1000099))) {
                     // Versions before 1.0 don't support `"_source": true` so we have to ask for the source as a stored field.
                     entity.field("_source", true);
                 }
@@ -238,7 +238,7 @@ final class RemoteRequestBuilders {
         Request request = new Request("POST", "/_search/scroll");
 
         // V_5_0_0
-        if (remoteVersion.before(Version.fromId(5000099))) {
+        if (remoteVersion.before(Version.fromLegacyId(5000099))) {
             /* Versions of Elasticsearch before 5.0 couldn't parse nanos or micros
              * so we toss out that resolution, rounding up so we shouldn't end up
              * with 0s. */
@@ -246,7 +246,7 @@ final class RemoteRequestBuilders {
         }
         request.addParameter("scroll", keepAlive.getStringRep());
 
-        if (remoteVersion.before(Version.fromId(2000099))) {
+        if (remoteVersion.before(Version.fromLegacyId(2000099))) {
             // Versions before 2.0.0 extract the plain scroll_id from the body
             request.setEntity(new NStringEntity(scroll, ContentType.TEXT_PLAIN));
             return request;
@@ -266,7 +266,7 @@ final class RemoteRequestBuilders {
     static Request clearScroll(String scroll, Version remoteVersion) {
         Request request = new Request("DELETE", "/_search/scroll");
 
-        if (remoteVersion.before(Version.fromId(2000099))) {
+        if (remoteVersion.before(Version.fromLegacyId(2000099))) {
             // Versions before 2.0.0 extract the plain scroll_id from the body
             request.setEntity(new NStringEntity(scroll, ContentType.TEXT_PLAIN));
             return request;

--- a/modules/reindex/src/main/java/org/opensearch/index/reindex/remote/RemoteScrollableHitSource.java
+++ b/modules/reindex/src/main/java/org/opensearch/index/reindex/remote/RemoteScrollableHitSource.java
@@ -134,7 +134,7 @@ public class RemoteScrollableHitSource extends ScrollableHitSource {
             private void logFailure(Exception e) {
                 if (e instanceof ResponseException) {
                     ResponseException re = (ResponseException) e;
-                            if (remoteVersion.before(Version.fromId(2000099))
+                            if (remoteVersion.before(Version.fromLegacyId(2000099))
                                     && re.getResponse().getStatusLine().getStatusCode() == 404) {
                         logger.debug((Supplier<?>) () -> new ParameterizedMessage(
                                 "Failed to clear scroll [{}] from pre-2.0 OpenSearch. This is normal if the request terminated "

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
@@ -157,7 +157,7 @@ public class RemoteScrollableHitSourceTests extends OpenSearchTestCase {
         assertLookupRemoteVersion(LegacyESVersion.fromId(5000099), "main/5_0_0_alpha_3.json");
         // V_5_0_0 since we no longer consider qualifier in Version
         assertLookupRemoteVersion(LegacyESVersion.fromId(5000099), "main/with_unknown_fields.json");
-        assertLookupRemoteVersion(Version.fromId(1000099 ^ Version.MASK), "main/OpenSearch_1_0_0.json");
+        assertLookupRemoteVersion(Version.fromId(1000099), "main/OpenSearch_1_0_0.json");
     }
 
     private void assertLookupRemoteVersion(Version expected, String s) throws Exception {

--- a/server/src/main/java/org/opensearch/LegacyESVersion.java
+++ b/server/src/main/java/org/opensearch/LegacyESVersion.java
@@ -92,6 +92,7 @@ public class LegacyESVersion extends Version {
     public static final LegacyESVersion V_6_7_0 = new LegacyESVersion(6070099, org.apache.lucene.util.Version.LUCENE_7_7_0);
     public static final LegacyESVersion V_6_7_1 = new LegacyESVersion(6070199, org.apache.lucene.util.Version.LUCENE_7_7_0);
     public static final LegacyESVersion V_6_7_2 = new LegacyESVersion(6070299, org.apache.lucene.util.Version.LUCENE_7_7_0);
+    public static final LegacyESVersion V_6_7_99 = new LegacyESVersion(6079999, org.apache.lucene.util.Version.LUCENE_7_7_0);
     public static final LegacyESVersion V_6_8_0 = new LegacyESVersion(6080099, org.apache.lucene.util.Version.LUCENE_7_7_0);
     public static final LegacyESVersion V_6_8_1 = new LegacyESVersion(6080199, org.apache.lucene.util.Version.LUCENE_7_7_0);
     public static final LegacyESVersion V_6_8_2 = new LegacyESVersion(6080299, org.apache.lucene.util.Version.LUCENE_7_7_0);
@@ -151,7 +152,7 @@ public class LegacyESVersion extends Version {
         for (final Field declaredField : LegacyESVersion.class.getFields()) {
             if (declaredField.getType().equals(Version.class) || declaredField.getType().equals(LegacyESVersion.class)) {
                 final String fieldName = declaredField.getName();
-                if (fieldName.equals("CURRENT") || fieldName.equals("V_EMPTY")) {
+                if (fieldName.equals("CURRENT") || fieldName.equals("V_EMPTY") || fieldName.equals("BC_ES_VERSION")) {
                     continue;
                 }
                 assert fieldName.matches("V_\\d+_\\d+_\\d+(_alpha[1,2]|_beta[1,2]|_rc[1,2])?")
@@ -168,11 +169,7 @@ public class LegacyESVersion extends Version {
                             final int minor = Integer.valueOf(fields[2]) * 10000;
                             final int revision = Integer.valueOf(fields[3]) * 100;
                             final int expectedId;
-                            if (fields[1].equals("1")) {
-                                expectedId = 0x08000000 ^ (major + minor + revision + 99);
-                            } else {
-                                expectedId = (major + minor + revision + 99);
-                            }
+                            expectedId = (major + minor + revision + 99);
                             assert version.id == expectedId :
                                 "expected version [" + fieldName + "] to have id [" + expectedId + "] but was [" + version.id + "]";
                         }
@@ -198,10 +195,7 @@ public class LegacyESVersion extends Version {
     }
 
     protected LegacyESVersion(int id, org.apache.lucene.util.Version luceneVersion) {
-        // flip the 28th bit of the version id
-        // this will be flipped back in the parent class to correctly identify as a legacy version;
-        // giving backwards compatibility with legacy systems
-        super(id ^ 0x08000000, luceneVersion);
+        super(id, luceneVersion);
     }
 
     @Override
@@ -283,10 +277,8 @@ public class LegacyESVersion extends Version {
         }
     }
 
-    /**
-     * this is used to ensure the version id for new versions of OpenSearch are always less than the predecessor versions
-     */
-    protected int maskId(final int id) {
-        return id;
+    @Override
+    protected boolean isLegacyVersion() {
+        return true;
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -367,7 +367,8 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
                 }
             }
         }
-        Version.writeVersion(version, out);
+
+        Version.writeVersion(out.getVersion().onOrBefore(LegacyESVersion.V_7_10_2) ? Version.BC_ES_VERSION : version, out);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/opensearch/transport/TransportHandshaker.java
@@ -31,6 +31,7 @@
 
 package org.opensearch.transport;
 
+import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -105,7 +106,12 @@ final class TransportHandshaker {
             throw new IllegalStateException("Handshake request not fully read for requestId [" + requestId + "], action ["
                 + TransportHandshaker.HANDSHAKE_ACTION_NAME + "], available [" + stream.available() + "]; resetting");
         }
-        channel.sendResponse(new HandshakeResponse(this.version));
+
+        Version version = Version.CURRENT;
+        if(stream.getVersion().equals(LegacyESVersion.V_6_8_0) || stream.getVersion().equals(Version.fromId(5060099))) {
+            version = Version.BC_ES_VERSION;
+        }
+        channel.sendResponse(new HandshakeResponse(version));
     }
 
     TransportResponseHandler<HandshakeResponse> removeHandlerForHandshake(long requestId) {

--- a/server/src/test/java/org/opensearch/VersionTests.java
+++ b/server/src/test/java/org/opensearch/VersionTests.java
@@ -188,7 +188,7 @@ public class VersionTests extends OpenSearchTestCase {
     }
 
     public void testMinCompatVersion() {
-        Version major = LegacyESVersion.fromString("6.8.0");
+        Version major = LegacyESVersion.fromString("6.7.99");
         assertThat(Version.fromString("1.0.0").minimumCompatibilityVersion(), equalTo(major));
         assertThat(Version.fromString("1.2.0").minimumCompatibilityVersion(), equalTo(major));
         assertThat(Version.fromString("1.3.0").minimumCompatibilityVersion(), equalTo(major));
@@ -257,7 +257,7 @@ public class VersionTests extends OpenSearchTestCase {
                 version = new Version(version.id, version.luceneVersion);
             }
             Version parsedVersion = Version.fromString(version.toString());
-            assertEquals(version, parsedVersion);
+            assertEquals(version.id, parsedVersion.id);
         }
 
         expectThrows(IllegalArgumentException.class, () -> {

--- a/server/src/test/java/org/opensearch/VersionTests.java
+++ b/server/src/test/java/org/opensearch/VersionTests.java
@@ -51,7 +51,7 @@ import java.util.Set;
 
 import static org.opensearch.LegacyESVersion.V_6_3_0;
 import static org.opensearch.LegacyESVersion.V_7_0_0;
-import static org.opensearch.Version.MASK;
+import static org.opensearch.LegacyESVersion.V_7_0_0;
 import static org.opensearch.test.VersionUtils.allVersions;
 import static org.opensearch.test.VersionUtils.randomVersion;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -254,9 +254,7 @@ public class VersionTests extends OpenSearchTestCase {
         for (int i = 0; i < iters; i++) {
             Version version = randomVersion(random());
             if (random().nextBoolean()) {
-                version = version.id < MASK ?
-                    new LegacyESVersion(version.id, version.luceneVersion) :
-                    new Version(version.id ^ MASK, version.luceneVersion);
+                version = new Version(version.id, version.luceneVersion);
             }
             Version parsedVersion = Version.fromString(version.toString());
             assertEquals(version, parsedVersion);

--- a/server/src/test/java/org/opensearch/discovery/ZenFaultDetectionTests.java
+++ b/server/src/test/java/org/opensearch/discovery/ZenFaultDetectionTests.java
@@ -83,12 +83,12 @@ public class ZenFaultDetectionTests extends OpenSearchTestCase {
     protected ThreadPool threadPool;
     private CircuitBreakerService circuitBreakerService;
 
-    protected static final Version version0 = Version.fromId(/*0*/99);
+    protected static final Version version0 = Version.fromLegacyId(/*0*/99);
     protected DiscoveryNode nodeA;
     protected MockTransportService serviceA;
     private Settings settingsA;
 
-    protected static final Version version1 = Version.fromId(199);
+    protected static final Version version1 = Version.fromLegacyId(199);
     protected DiscoveryNode nodeB;
     protected MockTransportService serviceB;
     private Settings settingsB;


### PR DESCRIPTION
### Description
It is draft PR to discuss the approach for supporting backward compatibility with ElasticSearch nodes. 
The way version compatibility logic is implemented in 6.8 & 7.x, the OpenSearch has to return a 7.x version for it pass. OpenSearch node will return 7.10.2 if the remote node is ElasticSearch node otherwise 1.0.0

Note: Couple of tests are failed. I did basic sanity by launching mixed cluster using docker to ensure ElasticSearch & OpenSearch nodes are able to connect to each other. Raising it early to get feedback on the approach.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/669
 
### Check List
- [ ] Add logic to return BC ES version during handshake
- [ ] Remove masking logic
- [ ] Add logic to ensure OpenSearch is treated as successor to ES versions
- [ ] Besides handshake, JoinExecutor logic also expects compatible version in DiscoveryNode object otherwise node will fail to connect to master
- [ ] Add checks to fail handshake if ES node >= 7.10.3 (an actual ES node) as those version could be incompatible with OpenSearch
- [ ] Verify any other class which is calling writeVersion if it depends on localNode version
- [ ] All tests pass
- [ ] Run BWC tests
- [ ] Document the behavior of APIs when mixed nodes are present in the cluster
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
