### PR TITLE
[1.0] distribution/packages: Fix RPM architecture name for 64-bit x86

### DIFF
--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -122,7 +122,7 @@ Closure commonPackageConfig(String type, boolean jdk, String architecture) {
     } else {
       assert type == 'rpm' : type
       if (architecture == 'x64') {
-        arch('X86_64')
+        arch('x86_64')
       } else {
         assert architecture == 'arm64' : architecture
         arch('aarch64')


### PR DESCRIPTION
### Description

Backport of #770

RPM uses the "x86_64" name for 64-bit x86, which is in-line with GCC
and other compilers.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>

Co-authored-by: Neal Gompa (ニール・ゴンパ) <ngompa13@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
