### PR TITLE
WIP: Fix es checkout for versions <= 7.10

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/internal/BwcGitExtension.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/internal/BwcGitExtension.java
@@ -43,6 +43,16 @@ public class BwcGitExtension {
     private Provider<String> bwcBranch;
     private Provider<File> checkoutDir;
 
+    public String getBwcRepo() {
+        // TODO: return 'opensearch-project' after 1.0
+        return "elasticsearch";
+    }
+
+    public String getBwcProject() {
+        // TODO: return 'OpenSearch' after 1.0
+        return "elastic";
+    }
+
     public Provider<Version> getBwcVersion() {
         return bwcVersion;
     }


### PR DESCRIPTION
### Description

Attempting a fix for part of https://github.com/opensearch-project/OpenSearch/issues/786, the checkout failure. We're trying to fetch opensearch-project/OpenSearch, but we need the old ElasticSearch versions. 

I need to double check that we are only using the result of this checkout for the backward compatible version and not to build the current state to compare against. If that were true we would need to check out into two different places.
 
### Issues Resolved

part of #786 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
