### PR TITLE
Remove checks for legacy .yaml and .json config files.

### DIFF
--- a/server/src/main/java/org/opensearch/node/InternalSettingsPreparer.java
+++ b/server/src/main/java/org/opensearch/node/InternalSettingsPreparer.java
@@ -81,14 +81,6 @@ public class InternalSettingsPreparer {
         initializeSettings(output, input, properties);
         Environment environment = new Environment(output.build(), configPath);
 
-        if (Files.exists(environment.configFile().resolve("opensearch.yaml"))) {
-            throw new SettingsException("opensearch.yaml was deprecated in 5.5.0 and must be renamed to opensearch.yml");
-        }
-
-        if (Files.exists(environment.configFile().resolve("opensearch.json"))) {
-            throw new SettingsException("opensearch.json was deprecated in 5.5.0 and must be converted to opensearch.yml");
-        }
-
         output = Settings.builder(); // start with a fresh output
         Path path = environment.configFile().resolve("opensearch.yml");
         if (Files.exists(path)) {

--- a/server/src/test/java/org/opensearch/node/InternalSettingsPreparerTests.java
+++ b/server/src/test/java/org/opensearch/node/InternalSettingsPreparerTests.java
@@ -114,28 +114,6 @@ public class InternalSettingsPreparerTests extends OpenSearchTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/358")
-    public void testYamlNotAllowed() throws IOException {
-        InputStream yaml = getClass().getResourceAsStream("/config/opensearch.yml");
-        Path config = homeDir.resolve("config");
-        Files.createDirectory(config);
-        Files.copy(yaml, config.resolve("opensearch.yaml"));
-        SettingsException e = expectThrows(SettingsException.class, () -> InternalSettingsPreparer.prepareEnvironment(
-                Settings.builder().put(baseEnvSettings).build(), emptyMap(), null, DEFAULT_NODE_NAME_SHOULDNT_BE_CALLED));
-        assertEquals("opensearch.yaml was deprecated in 5.5.0 and must be renamed to opensearch.yml", e.getMessage());
-    }
-
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/358")
-    public void testJsonNotAllowed() throws IOException {
-        InputStream yaml = getClass().getResourceAsStream("/config/opensearch.json");
-        Path config = homeDir.resolve("config");
-        Files.createDirectory(config);
-        Files.copy(yaml, config.resolve("opensearch.json"));
-        SettingsException e = expectThrows(SettingsException.class, () -> InternalSettingsPreparer.prepareEnvironment(
-                Settings.builder().put(baseEnvSettings).build(), emptyMap(), null, DEFAULT_NODE_NAME_SHOULDNT_BE_CALLED));
-        assertEquals("opensearch.json was deprecated in 5.5.0 and must be converted to opensearch.yml", e.getMessage());
-    }
-
     public void testSecureSettings() {
         MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("foo", "secret");


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Removes checks for opensearch.yaml/json config files that don't exist.  This was updated from their legacy names to opensearch but does not make sense with opensearch 1.x
 
### Issues Resolved
#358 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
