### PR TITLE
[1.x] BWC - fix mixedCluster and rolling upgrades (#775)

### DIFF
--- a/client/rest/src/main/java/org/opensearch/client/Response.java
+++ b/client/rest/src/main/java/org/opensearch/client/Response.java
@@ -154,7 +154,7 @@ public class Response {
      * @return {@code true} if the input string matches the specification
      */
     private static boolean matchWarningHeaderPatternByPrefix(final String s) {
-        return s.startsWith("299 OpenSearch-");
+        return s.startsWith("299 OpenSearch-") || s.startsWith("299 Elasticsearch-");
     }
 
     /**

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/90_remote.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/90_remote.yml
@@ -391,6 +391,7 @@
 
   - do:
       # sometimes IIS is listening on port 0. In that case we fail in other ways and this test isn't useful.
+      # make sure to stop any local webservers if running this test locally otherwise an s_s_l handshake exception may occur
       catch: /connect_exception|IIS Windows Server/
       reindex:
         body:

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -38,6 +38,9 @@ apply plugin: 'opensearch.standalone-test'
 apply from : "$rootDir/gradle/bwc-test.gradle"
 
 for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
+  if (bwcVersion.before('6.3.0')) {
+    continue;
+  }
   String baseName = "v${bwcVersion}"
 
   testClusters {

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -76,6 +76,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
       println "Upgrade complete, endpoints are: ${-> testClusters."${baseName}".allHttpSocketURI.join(",")}"
       println "Upgrading another node to create a mixed cluster"
       testClusters."${baseName}".nextNodeToNextVersion()
+      println "Upgrading complete, endpoints are: ${-> testClusters."${baseName}".allHttpSocketURI.join(",")}"
 
       nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
       nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")

--- a/qa/repository-multi-version/build.gradle
+++ b/qa/repository-multi-version/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 }
 
 for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
+  if (bwcVersion.before('6.3.0')) {
+    continue;
+  }
   String baseName = "v${bwcVersion}"
   String oldClusterName = "${baseName}-old"
   String newClusterName = "${baseName}-new"

--- a/qa/verify-version-constants/build.gradle
+++ b/qa/verify-version-constants/build.gradle
@@ -38,6 +38,9 @@ apply plugin: 'opensearch.standalone-test'
 apply from : "$rootDir/gradle/bwc-test.gradle"
 
 for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
+  if (bwcVersion.before('6.3.0')) {
+    continue;
+  }
   String baseName = "v${bwcVersion}"
 
   testClusters {

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.validate_query/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.validate_query/10_basic.yml
@@ -85,4 +85,4 @@ setup:
           match_all: {}
 
   - is_false: valid
-  - match: {error: 'org.opensearch.common.ParsingException: request does not support [match_all]'}
+  - match: {error: '/request\sdoes\snot\ssupport\s\[match_all\]/'}

--- a/server/src/main/java/org/opensearch/Version.java
+++ b/server/src/main/java/org/opensearch/Version.java
@@ -177,7 +177,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
         String[] parts = version.split("[.-]");
         // todo: add back optional build number
         if (parts.length != 3) {
-            throw new IllegalArgumentException("the version needs to contain major, minor, and revision" + version);
+            throw new IllegalArgumentException("the version needs to contain major, minor, and revision: " + version);
         }
 
         try {
@@ -287,7 +287,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
 
     protected Version computeMinCompatVersion() {
         if (major == 1) {
-            return Version.fromId(6080099);
+            return LegacyESVersion.V_6_8_0;
         } else if (major == 6) {
             // force the minimum compatibility for version 6 to 5.6 since we don't reference version 5 anymore
             return Version.fromId(5060099);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/info/NodeInfo.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/info/NodeInfo.java
@@ -184,7 +184,11 @@ public class NodeInfo extends BaseNodeResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeVInt(version.id);
+        if (out.getVersion().before(Version.V_1_0_0)) {
+            out.writeVInt(LegacyESVersion.V_7_10_2.id);
+        } else {
+            out.writeVInt(version.id);
+        }
         Build.writeBuild(build, out);
         if (totalIndexingBuffer == null) {
             out.writeBoolean(false);

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -367,7 +367,11 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
                 }
             }
         }
-        Version.writeVersion(version, out);
+        if (out.getVersion().before(Version.V_1_0_0)) {
+            Version.writeVersion(LegacyESVersion.V_7_10_2, out);
+        } else {
+            Version.writeVersion(version, out);
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/common/logging/HeaderWarning.java
+++ b/server/src/main/java/org/opensearch/common/logging/HeaderWarning.java
@@ -60,7 +60,7 @@ public class HeaderWarning {
      */
     public static final Pattern WARNING_HEADER_PATTERN = Pattern.compile(
         "299 " + // warn code
-            "OpenSearch-" + // warn agent
+            "(?:Elasticsearch-|OpenSearch-)" + // warn agent (note: Elasticsearch needed for bwc mixedCluster testing)
             "\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|rc)\\d+)?(?:-SNAPSHOT)?-" + // warn agent
             "(?:[a-f0-9]{7}(?:[a-f0-9]{33})?|unknown) " + // warn agent
             "\"((?:\t| |!|[\\x23-\\x5B]|[\\x5D-\\x7E]|[\\x80-\\xFF]|\\\\|\\\\\")*)\"( " + // quoted warning value, captured

--- a/server/src/test/java/org/opensearch/discovery/ZenFaultDetectionTests.java
+++ b/server/src/test/java/org/opensearch/discovery/ZenFaultDetectionTests.java
@@ -83,12 +83,12 @@ public class ZenFaultDetectionTests extends OpenSearchTestCase {
     protected ThreadPool threadPool;
     private CircuitBreakerService circuitBreakerService;
 
-    protected static final Version version0 = Version.fromId(/*0*/99);
+    protected static final Version version0 = Version.fromId(6080099);
     protected DiscoveryNode nodeA;
     protected MockTransportService serviceA;
     private Settings settingsA;
 
-    protected static final Version version1 = Version.fromId(199);
+    protected static final Version version1 = Version.fromId(7100099);
     protected DiscoveryNode nodeB;
     protected MockTransportService serviceB;
     private Settings settingsB;

--- a/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
@@ -38,6 +38,7 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
 import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.Constants;
+import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchException;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.Version;
@@ -2002,7 +2003,8 @@ public abstract class AbstractSimpleTransportTestCase extends OpenSearchTestCase
             service.start();
             service.acceptIncomingRequests();
             TransportAddress address = service.boundAddress().publishAddress();
-            DiscoveryNode node = new DiscoveryNode("TS_TPC", "TS_TPC", address, emptyMap(), emptySet(), Version.fromString("2.0.0"));
+            DiscoveryNode node = new DiscoveryNode("TS_TPC", "TS_TPC", address, emptyMap(), emptySet(),
+                LegacyESVersion.fromString("2.0.0"));
             ConnectionProfile.Builder builder = new ConnectionProfile.Builder();
             builder.addConnections(1,
                 TransportRequestOptions.Type.BULK,
@@ -2047,7 +2049,9 @@ public abstract class AbstractSimpleTransportTestCase extends OpenSearchTestCase
             PlainActionFuture<Transport.Connection> future = PlainActionFuture.newFuture();
             serviceA.getOriginalTransport().openConnection(node, connectionProfile, future);
             try (Transport.Connection connection = future.actionGet()) {
-                assertEquals(connection.getVersion(), Version.CURRENT);
+                // OpenSearch sends a handshake version spoofed as Legacy version 7_10_2
+                // todo change for OpenSearch 2.0.0
+                assertEquals(LegacyESVersion.V_7_10_2, connection.getVersion());
             }
         }
     }


### PR DESCRIPTION
This commit fixes mixedCluster and rolling upgrades by spoofing OpenSearch
version 1.0.0 as Legacy version 7.10.2. With this commit an OpenSearch 1.x node
can join a legacy (<= 7.10.2) cluster and rolling upgrades work as expected.
Mixed clusters will not work beyond the duration of the upgrade since shards
cannot be replicated from upgraded nodes to nodes running older versions.

fixes #669 
