### PR TITLE
Version checks are incorrectly returning versions < 1.0.0.

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/BwcVersions.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/BwcVersions.java
@@ -268,9 +268,13 @@ public class BwcVersions {
         // The current version is being worked, is always unreleased
         unreleased.add(currentVersion);
 
-        if (currentVersion.getMajor() == 1 && currentVersion.getMinor() == 0) {
-            // there are no previous unreleased versions before 1.0.0
-        } else {
+        // No unreleased versions for 1.0.0
+        if (currentVersion.equals(Version.fromString("1.0.0"))) {
+            return unmodifiableList(unreleased);
+        }
+
+        // version 1 is the first release, there is no previous "unreleased version":
+        if (currentVersion.getMajor() != 1) {
             // the tip of the previous major is unreleased for sure, be it a minor or a bugfix
             final Version latestOfPreviousMajor = getLatestVersionByKey(this.groupByMajor, currentVersion.getMajor() - 1);
             unreleased.add(latestOfPreviousMajor);
@@ -281,22 +285,22 @@ public class BwcVersions {
                     unreleased.add(previousMinor);
                 }
             }
+        }
 
-            final Map<Integer, List<Version>> groupByMinor = getReleasedMajorGroupedByMinor();
-            int greatestMinor = groupByMinor.keySet().stream().max(Integer::compareTo).orElse(0);
+        final Map<Integer, List<Version>> groupByMinor = getReleasedMajorGroupedByMinor();
+        int greatestMinor = groupByMinor.keySet().stream().max(Integer::compareTo).orElse(0);
 
-            // the last bugfix for this minor series is always unreleased
-            unreleased.add(getLatestVersionByKey(groupByMinor, greatestMinor));
+        // the last bugfix for this minor series is always unreleased
+        unreleased.add(getLatestVersionByKey(groupByMinor, greatestMinor));
 
-            if (groupByMinor.get(greatestMinor).size() == 1) {
-                // we found an unreleased minor
-                unreleased.add(getLatestVersionByKey(groupByMinor, greatestMinor - 1));
-                if (groupByMinor.getOrDefault(greatestMinor - 1, emptyList()).size() == 1) {
-                    // we found that the previous minor is staged but not yet released
-                    // in this case, the minor before that has a bugfix, should there be such a minor
-                    if (greatestMinor >= 2) {
-                        unreleased.add(getLatestVersionByKey(groupByMinor, greatestMinor - 2));
-                    }
+        if (groupByMinor.get(greatestMinor).size() == 1) {
+            // we found an unreleased minor
+            unreleased.add(getLatestVersionByKey(groupByMinor, greatestMinor - 1));
+            if (groupByMinor.getOrDefault(greatestMinor - 1, emptyList()).size() == 1) {
+                // we found that the previous minor is staged but not yet released
+                // in this case, the minor before that has a bugfix, should there be such a minor
+                if (greatestMinor >= 2) {
+                    unreleased.add(getLatestVersionByKey(groupByMinor, greatestMinor - 2));
                 }
             }
         }

--- a/buildSrc/src/main/java/org/opensearch/gradle/BwcVersions.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/BwcVersions.java
@@ -268,8 +268,9 @@ public class BwcVersions {
         // The current version is being worked, is always unreleased
         unreleased.add(currentVersion);
 
-        // version 1 is the first release, there is no previous "unreleased version":
-        if (currentVersion.getMajor() != 1) {
+        if (currentVersion.getMajor() == 1 && currentVersion.getMinor() == 0) {
+            // there are no previous unreleased versions before 1.0.0
+        } else {
             // the tip of the previous major is unreleased for sure, be it a minor or a bugfix
             final Version latestOfPreviousMajor = getLatestVersionByKey(this.groupByMajor, currentVersion.getMajor() - 1);
             unreleased.add(latestOfPreviousMajor);
@@ -280,22 +281,22 @@ public class BwcVersions {
                     unreleased.add(previousMinor);
                 }
             }
-        }
 
-        final Map<Integer, List<Version>> groupByMinor = getReleasedMajorGroupedByMinor();
-        int greatestMinor = groupByMinor.keySet().stream().max(Integer::compareTo).orElse(0);
+            final Map<Integer, List<Version>> groupByMinor = getReleasedMajorGroupedByMinor();
+            int greatestMinor = groupByMinor.keySet().stream().max(Integer::compareTo).orElse(0);
 
-        // the last bugfix for this minor series is always unreleased
-        unreleased.add(getLatestVersionByKey(groupByMinor, greatestMinor));
+            // the last bugfix for this minor series is always unreleased
+            unreleased.add(getLatestVersionByKey(groupByMinor, greatestMinor));
 
-        if (groupByMinor.get(greatestMinor).size() == 1) {
-            // we found an unreleased minor
-            unreleased.add(getLatestVersionByKey(groupByMinor, greatestMinor - 1));
-            if (groupByMinor.getOrDefault(greatestMinor - 1, emptyList()).size() == 1) {
-                // we found that the previous minor is staged but not yet released
-                // in this case, the minor before that has a bugfix, should there be such a minor
-                if (greatestMinor >= 2) {
-                    unreleased.add(getLatestVersionByKey(groupByMinor, greatestMinor - 2));
+            if (groupByMinor.get(greatestMinor).size() == 1) {
+                // we found an unreleased minor
+                unreleased.add(getLatestVersionByKey(groupByMinor, greatestMinor - 1));
+                if (groupByMinor.getOrDefault(greatestMinor - 1, emptyList()).size() == 1) {
+                    // we found that the previous minor is staged but not yet released
+                    // in this case, the minor before that has a bugfix, should there be such a minor
+                    if (greatestMinor >= 2) {
+                        unreleased.add(getLatestVersionByKey(groupByMinor, greatestMinor - 2));
+                    }
                 }
             }
         }
@@ -380,6 +381,9 @@ public class BwcVersions {
         int currentMajor = currentVersion.getMajor();
         int lastMajor = currentMajor == 1 ? 6 : currentMajor - 1;
         List<Version> lastMajorList = groupByMajor.get(lastMajor);
+        if (lastMajorList == null) {
+            throw new IllegalStateException("Expected to find a list of versions for version: " + lastMajor);
+        }
         int minor = lastMajorList.get(lastMajorList.size() - 1).getMinor();
         for (int i = lastMajorList.size() - 1; i > 0 && lastMajorList.get(i).getMinor() == minor; --i) {
             wireCompat.add(lastMajorList.get(i));
@@ -395,7 +399,6 @@ public class BwcVersions {
         wireCompat.addAll(groupByMajor.get(currentMajor));
         wireCompat.remove(currentVersion);
         wireCompat.sort(Version::compareTo);
-
         return unmodifiableList(wireCompat);
     }
 

--- a/buildSrc/src/test/java/org/opensearch/gradle/BwcOpenSearchVersionsTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/BwcOpenSearchVersionsTests.java
@@ -1,0 +1,338 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.gradle;
+
+import org.opensearch.gradle.test.GradleUnitTestCase;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+
+public class BwcOpenSearchVersionsTests extends GradleUnitTestCase {
+
+    private static final Map<String, List<String>> sampleVersions = new HashMap<>();
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    static {
+        // unreleased major and two unreleased minors ( minor in feature freeze )
+        sampleVersions.put("1.0.0", asList("7_0_0", "7_0_1", "7_1_0", "7_1_1", "7_2_0", "7_3_0", "1.0.0"));
+        sampleVersions.put(
+            "7.0.0-alpha1",
+            asList(
+                "6_0_0_alpha1",
+                "6_0_0_alpha2",
+                "6_0_0_beta1",
+                "6_0_0_beta2",
+                "6_0_0_rc1",
+                "6_0_0_rc2",
+                "6_0_0",
+                "6_0_1",
+                "6_1_0",
+                "6_1_1",
+                "6_1_2",
+                "6_1_3",
+                "6_1_4",
+                "6_2_0",
+                "6_2_1",
+                "6_2_2",
+                "6_2_3",
+                "6_2_4",
+                "6_3_0",
+                "6_3_1",
+                "6_3_2",
+                "6_4_0",
+                "6_4_1",
+                "6_4_2",
+                "6_5_0",
+                "7_0_0_alpha1"
+            )
+        );
+        sampleVersions.put(
+            "6.5.0",
+            asList(
+                "5_0_0_alpha1",
+                "5_0_0_alpha2",
+                "5_0_0_alpha3",
+                "5_0_0_alpha4",
+                "5_0_0_alpha5",
+                "5_0_0_beta1",
+                "5_0_0_rc1",
+                "5_0_0",
+                "5_0_1",
+                "5_0_2",
+                "5_1_1",
+                "5_1_2",
+                "5_2_0",
+                "5_2_1",
+                "5_2_2",
+                "5_3_0",
+                "5_3_1",
+                "5_3_2",
+                "5_3_3",
+                "5_4_0",
+                "5_4_1",
+                "5_4_2",
+                "5_4_3",
+                "5_5_0",
+                "5_5_1",
+                "5_5_2",
+                "5_5_3",
+                "5_6_0",
+                "5_6_1",
+                "5_6_2",
+                "5_6_3",
+                "5_6_4",
+                "5_6_5",
+                "5_6_6",
+                "5_6_7",
+                "5_6_1",
+                "5_6_9",
+                "5_6_10",
+                "5_6_11",
+                "5_6_12",
+                "5_6_13",
+                "6_0_0_alpha1",
+                "6_0_0_alpha2",
+                "6_0_0_beta1",
+                "6_0_0_beta2",
+                "6_0_0_rc1",
+                "6_0_0_rc2",
+                "6_0_0",
+                "6_0_1",
+                "6_1_0",
+                "6_1_1",
+                "6_1_2",
+                "6_1_3",
+                "6_1_4",
+                "6_2_0",
+                "6_2_1",
+                "6_2_2",
+                "6_2_3",
+                "6_2_4",
+                "6_3_0",
+                "6_3_1",
+                "6_3_2",
+                "6_4_0",
+                "6_4_1",
+                "6_4_2",
+                "6_5_0"
+            )
+        );
+        sampleVersions.put(
+            "6.6.0",
+            asList(
+                "5_0_0_alpha1",
+                "5_0_0_alpha2",
+                "5_0_0_alpha3",
+                "5_0_0_alpha4",
+                "5_0_0_alpha5",
+                "5_0_0_beta1",
+                "5_0_0_rc1",
+                "5_0_0",
+                "5_0_1",
+                "5_0_2",
+                "5_1_1",
+                "5_1_2",
+                "5_2_0",
+                "5_2_1",
+                "5_2_2",
+                "5_3_0",
+                "5_3_1",
+                "5_3_2",
+                "5_3_3",
+                "5_4_0",
+                "5_4_1",
+                "5_4_2",
+                "5_4_3",
+                "5_5_0",
+                "5_5_1",
+                "5_5_2",
+                "5_5_3",
+                "5_6_0",
+                "5_6_1",
+                "5_6_2",
+                "5_6_3",
+                "5_6_4",
+                "5_6_5",
+                "5_6_6",
+                "5_6_7",
+                "5_6_1",
+                "5_6_9",
+                "5_6_10",
+                "5_6_11",
+                "5_6_12",
+                "5_6_13",
+                "6_0_0_alpha1",
+                "6_0_0_alpha2",
+                "6_0_0_beta1",
+                "6_0_0_beta2",
+                "6_0_0_rc1",
+                "6_0_0_rc2",
+                "6_0_0",
+                "6_0_1",
+                "6_1_0",
+                "6_1_1",
+                "6_1_2",
+                "6_1_3",
+                "6_1_4",
+                "6_2_0",
+                "6_2_1",
+                "6_2_2",
+                "6_2_3",
+                "6_2_4",
+                "6_3_0",
+                "6_3_1",
+                "6_3_2",
+                "6_4_0",
+                "6_4_1",
+                "6_4_2",
+                "6_5_0",
+                "6_6_0"
+            )
+        );
+        sampleVersions.put(
+            "6.4.2",
+            asList(
+                "5_0_0_alpha1",
+                "5_0_0_alpha2",
+                "5_0_0_alpha3",
+                "5_0_0_alpha4",
+                "5_0_0_alpha5",
+                "5_0_0_beta1",
+                "5_0_0_rc1",
+                "5_0_0",
+                "5_0_1",
+                "5_0_2",
+                "5_1_1",
+                "5_1_2",
+                "5_2_0",
+                "5_2_1",
+                "5_2_2",
+                "5_3_0",
+                "5_3_1",
+                "5_3_2",
+                "5_3_3",
+                "5_4_0",
+                "5_4_1",
+                "5_4_2",
+                "5_4_3",
+                "5_5_0",
+                "5_5_1",
+                "5_5_2",
+                "5_5_3",
+                "5_6_0",
+                "5_6_1",
+                "5_6_2",
+                "5_6_3",
+                "5_6_4",
+                "5_6_5",
+                "5_6_6",
+                "5_6_7",
+                "5_6_1",
+                "5_6_9",
+                "5_6_10",
+                "5_6_11",
+                "5_6_12",
+                "5_6_13",
+                "6_0_0_alpha1",
+                "6_0_0_alpha2",
+                "6_0_0_beta1",
+                "6_0_0_beta2",
+                "6_0_0_rc1",
+                "6_0_0_rc2",
+                "6_0_0",
+                "6_0_1",
+                "6_1_0",
+                "6_1_1",
+                "6_1_2",
+                "6_1_3",
+                "6_1_4",
+                "6_2_0",
+                "6_2_1",
+                "6_2_2",
+                "6_2_3",
+                "6_2_4",
+                "6_3_0",
+                "6_3_1",
+                "6_3_2",
+                "6_4_0",
+                "6_4_1",
+                "6_4_2"
+            )
+        );
+        sampleVersions.put("7.1.0", asList("7_1_0", "7_0_0", "6_7_0", "6_6_1", "6_6_0"));
+    }
+
+    public void testWireCompatible() {
+        // TODO
+    }
+
+    public void testWireCompatibleUnreleased() {
+        // TODO
+    }
+
+    public void testIndexCompatible() {
+        // TODO
+    }
+
+    public void testIndexCompatibleUnreleased() {
+        // TODO
+    }
+
+    public void testGetUnreleased() {
+        assertVersionsEquals(asList("1.0.0"), getVersionCollection("1.0.0").getUnreleased());
+    }
+
+    private String formatVersionToLine(final String version) {
+        return " public static final Version V_" + version.replaceAll("\\.", "_") + " ";
+    }
+
+    private void assertVersionsEquals(List<String> expected, List<Version> actual) {
+        assertEquals(expected.stream().map(Version::fromString).collect(Collectors.toList()), actual);
+    }
+
+    private BwcVersions getVersionCollection(String versionString) {
+        List<String> versionMap = sampleVersions.get(versionString);
+        assertNotNull(versionMap);
+        Version version = Version.fromString(versionString);
+        assertNotNull(version);
+        return new BwcVersions(versionMap.stream().map(this::formatVersionToLine).collect(Collectors.toList()), version);
+    }
+}

--- a/buildSrc/src/test/java/org/opensearch/gradle/BwcOpenSearchVersionsTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/BwcOpenSearchVersionsTests.java
@@ -6,36 +6,13 @@
  * compatible open source license.
  */
 
-/*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-/*
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
 package org.opensearch.gradle;
 
 import org.opensearch.gradle.test.GradleUnitTestCase;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +20,13 @@ import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 
+/**
+ * Tests to specifically verify the OpenSearch version 1.x with Legacy ES versions.
+ * This supplements the tests in BwcVersionsTests.
+ *
+ * Currently the versioning logic doesn't work for OpenSearch 2.x as the masking
+ * is only applied specifically for 1.x.
+ */
 public class BwcOpenSearchVersionsTests extends GradleUnitTestCase {
 
     private static final Map<String, List<String>> sampleVersions = new HashMap<>();
@@ -51,273 +35,42 @@ public class BwcOpenSearchVersionsTests extends GradleUnitTestCase {
     public ExpectedException expectedEx = ExpectedException.none();
 
     static {
-        // unreleased major and two unreleased minors ( minor in feature freeze )
-        sampleVersions.put("1.0.0", asList("7_0_0", "7_0_1", "7_1_0", "7_1_1", "7_2_0", "7_3_0", "1.0.0"));
-        sampleVersions.put(
-            "7.0.0-alpha1",
-            asList(
-                "6_0_0_alpha1",
-                "6_0_0_alpha2",
-                "6_0_0_beta1",
-                "6_0_0_beta2",
-                "6_0_0_rc1",
-                "6_0_0_rc2",
-                "6_0_0",
-                "6_0_1",
-                "6_1_0",
-                "6_1_1",
-                "6_1_2",
-                "6_1_3",
-                "6_1_4",
-                "6_2_0",
-                "6_2_1",
-                "6_2_2",
-                "6_2_3",
-                "6_2_4",
-                "6_3_0",
-                "6_3_1",
-                "6_3_2",
-                "6_4_0",
-                "6_4_1",
-                "6_4_2",
-                "6_5_0",
-                "7_0_0_alpha1"
-            )
-        );
-        sampleVersions.put(
-            "6.5.0",
-            asList(
-                "5_0_0_alpha1",
-                "5_0_0_alpha2",
-                "5_0_0_alpha3",
-                "5_0_0_alpha4",
-                "5_0_0_alpha5",
-                "5_0_0_beta1",
-                "5_0_0_rc1",
-                "5_0_0",
-                "5_0_1",
-                "5_0_2",
-                "5_1_1",
-                "5_1_2",
-                "5_2_0",
-                "5_2_1",
-                "5_2_2",
-                "5_3_0",
-                "5_3_1",
-                "5_3_2",
-                "5_3_3",
-                "5_4_0",
-                "5_4_1",
-                "5_4_2",
-                "5_4_3",
-                "5_5_0",
-                "5_5_1",
-                "5_5_2",
-                "5_5_3",
-                "5_6_0",
-                "5_6_1",
-                "5_6_2",
-                "5_6_3",
-                "5_6_4",
-                "5_6_5",
-                "5_6_6",
-                "5_6_7",
-                "5_6_1",
-                "5_6_9",
-                "5_6_10",
-                "5_6_11",
-                "5_6_12",
-                "5_6_13",
-                "6_0_0_alpha1",
-                "6_0_0_alpha2",
-                "6_0_0_beta1",
-                "6_0_0_beta2",
-                "6_0_0_rc1",
-                "6_0_0_rc2",
-                "6_0_0",
-                "6_0_1",
-                "6_1_0",
-                "6_1_1",
-                "6_1_2",
-                "6_1_3",
-                "6_1_4",
-                "6_2_0",
-                "6_2_1",
-                "6_2_2",
-                "6_2_3",
-                "6_2_4",
-                "6_3_0",
-                "6_3_1",
-                "6_3_2",
-                "6_4_0",
-                "6_4_1",
-                "6_4_2",
-                "6_5_0"
-            )
-        );
-        sampleVersions.put(
-            "6.6.0",
-            asList(
-                "5_0_0_alpha1",
-                "5_0_0_alpha2",
-                "5_0_0_alpha3",
-                "5_0_0_alpha4",
-                "5_0_0_alpha5",
-                "5_0_0_beta1",
-                "5_0_0_rc1",
-                "5_0_0",
-                "5_0_1",
-                "5_0_2",
-                "5_1_1",
-                "5_1_2",
-                "5_2_0",
-                "5_2_1",
-                "5_2_2",
-                "5_3_0",
-                "5_3_1",
-                "5_3_2",
-                "5_3_3",
-                "5_4_0",
-                "5_4_1",
-                "5_4_2",
-                "5_4_3",
-                "5_5_0",
-                "5_5_1",
-                "5_5_2",
-                "5_5_3",
-                "5_6_0",
-                "5_6_1",
-                "5_6_2",
-                "5_6_3",
-                "5_6_4",
-                "5_6_5",
-                "5_6_6",
-                "5_6_7",
-                "5_6_1",
-                "5_6_9",
-                "5_6_10",
-                "5_6_11",
-                "5_6_12",
-                "5_6_13",
-                "6_0_0_alpha1",
-                "6_0_0_alpha2",
-                "6_0_0_beta1",
-                "6_0_0_beta2",
-                "6_0_0_rc1",
-                "6_0_0_rc2",
-                "6_0_0",
-                "6_0_1",
-                "6_1_0",
-                "6_1_1",
-                "6_1_2",
-                "6_1_3",
-                "6_1_4",
-                "6_2_0",
-                "6_2_1",
-                "6_2_2",
-                "6_2_3",
-                "6_2_4",
-                "6_3_0",
-                "6_3_1",
-                "6_3_2",
-                "6_4_0",
-                "6_4_1",
-                "6_4_2",
-                "6_5_0",
-                "6_6_0"
-            )
-        );
-        sampleVersions.put(
-            "6.4.2",
-            asList(
-                "5_0_0_alpha1",
-                "5_0_0_alpha2",
-                "5_0_0_alpha3",
-                "5_0_0_alpha4",
-                "5_0_0_alpha5",
-                "5_0_0_beta1",
-                "5_0_0_rc1",
-                "5_0_0",
-                "5_0_1",
-                "5_0_2",
-                "5_1_1",
-                "5_1_2",
-                "5_2_0",
-                "5_2_1",
-                "5_2_2",
-                "5_3_0",
-                "5_3_1",
-                "5_3_2",
-                "5_3_3",
-                "5_4_0",
-                "5_4_1",
-                "5_4_2",
-                "5_4_3",
-                "5_5_0",
-                "5_5_1",
-                "5_5_2",
-                "5_5_3",
-                "5_6_0",
-                "5_6_1",
-                "5_6_2",
-                "5_6_3",
-                "5_6_4",
-                "5_6_5",
-                "5_6_6",
-                "5_6_7",
-                "5_6_1",
-                "5_6_9",
-                "5_6_10",
-                "5_6_11",
-                "5_6_12",
-                "5_6_13",
-                "6_0_0_alpha1",
-                "6_0_0_alpha2",
-                "6_0_0_beta1",
-                "6_0_0_beta2",
-                "6_0_0_rc1",
-                "6_0_0_rc2",
-                "6_0_0",
-                "6_0_1",
-                "6_1_0",
-                "6_1_1",
-                "6_1_2",
-                "6_1_3",
-                "6_1_4",
-                "6_2_0",
-                "6_2_1",
-                "6_2_2",
-                "6_2_3",
-                "6_2_4",
-                "6_3_0",
-                "6_3_1",
-                "6_3_2",
-                "6_4_0",
-                "6_4_1",
-                "6_4_2"
-            )
-        );
-        sampleVersions.put("7.1.0", asList("7_1_0", "7_0_0", "6_7_0", "6_6_1", "6_6_0"));
+        sampleVersions.put("1.0.0", asList("5_6_13", "6_6_1", "6_8_15", "7_0_0", "7_9_1", "7_10_0", "7_10_1", "7_10_2", "1_0_0"));
+        sampleVersions.put("1.1.0", asList("5_6_13", "6_6_1", "6_8_15", "7_0_0", "7_9_1", "7_10_0", "7_10_1", "7_10_2", "1_0_0", "1_1_0"));
     }
 
     public void testWireCompatible() {
-        // TODO
+        assertVersionsEquals(
+            asList("6.8.15", "7.0.0", "7.9.1", "7.10.0", "7.10.1", "7.10.2"),
+            getVersionCollection("1.0.0").getWireCompatible()
+        );
+        assertVersionsEquals(
+            asList("6.8.15", "7.0.0", "7.9.1", "7.10.0", "7.10.1", "7.10.2", "1.0.0"),
+            getVersionCollection("1.1.0").getWireCompatible()
+        );
     }
 
     public void testWireCompatibleUnreleased() {
-        // TODO
+        assertVersionsEquals(Collections.emptyList(), getVersionCollection("1.0.0").getUnreleasedWireCompatible());
     }
 
     public void testIndexCompatible() {
-        // TODO
+        assertVersionsEquals(
+            asList("6.6.1", "6.8.15", "7.0.0", "7.9.1", "7.10.0", "7.10.1", "7.10.2"),
+            getVersionCollection("1.0.0").getIndexCompatible()
+        );
+        assertVersionsEquals(
+            asList("6.6.1", "6.8.15", "7.0.0", "7.9.1", "7.10.0", "7.10.1", "7.10.2", "1.0.0"),
+            getVersionCollection("1.1.0").getIndexCompatible()
+        );
     }
 
     public void testIndexCompatibleUnreleased() {
-        // TODO
+        assertVersionsEquals(Collections.emptyList(), getVersionCollection("1.0.0").getUnreleasedIndexCompatible());
     }
 
     public void testGetUnreleased() {
-        assertVersionsEquals(asList("1.0.0"), getVersionCollection("1.0.0").getUnreleased());
+        assertVersionsEquals(Collections.singletonList("1.0.0"), getVersionCollection("1.0.0").getUnreleased());
     }
 
     private String formatVersionToLine(final String version) {

--- a/server/src/main/java/org/opensearch/LegacyESVersion.java
+++ b/server/src/main/java/org/opensearch/LegacyESVersion.java
@@ -139,7 +139,6 @@ public class LegacyESVersion extends Version {
     public static final LegacyESVersion V_7_10_0 = new LegacyESVersion(7100099, org.apache.lucene.util.Version.LUCENE_8_7_0);
     public static final LegacyESVersion V_7_10_1 = new LegacyESVersion(7100199, org.apache.lucene.util.Version.LUCENE_8_7_0);
     public static final LegacyESVersion V_7_10_2 = new LegacyESVersion(7100299, org.apache.lucene.util.Version.LUCENE_8_7_0);
-    public static final LegacyESVersion V_7_10_3 = new LegacyESVersion(7100399, org.apache.lucene.util.Version.LUCENE_8_7_0);
 
     // todo move back to Version.java if retiring legacy version support
     protected static final ImmutableOpenIntMap<Version> idToVersion;

--- a/test/framework/src/main/java/org/opensearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/opensearch/test/VersionUtils.java
@@ -90,16 +90,19 @@ public class VersionUtils {
             }
         }
 
-        // remove next minor
-        Version lastMinor = moveLastToUnreleased(stableVersions, unreleasedVersions);
-        if (lastMinor.revision == 0) {
-            if (stableVersions.get(stableVersions.size() - 1).size() == 1) {
-                // a minor is being staged, which is also unreleased
-                moveLastToUnreleased(stableVersions, unreleasedVersions);
-            }
-            // remove the next bugfix
-            if (stableVersions.isEmpty() == false) {
-                moveLastToUnreleased(stableVersions, unreleasedVersions);
+        // remove last minor unless the it's the first OpenSearch version.
+        // all Legacy ES versions are released, so we don't exclude any.
+        if (current.equals(Version.V_1_0_0) == false) {
+            Version lastMinor = moveLastToUnreleased(stableVersions, unreleasedVersions);
+            if (lastMinor.revision == 0) {
+                if (stableVersions.get(stableVersions.size() - 1).size() == 1) {
+                    // a minor is being staged, which is also unreleased
+                    moveLastToUnreleased(stableVersions, unreleasedVersions);
+                }
+                // remove the next bugfix
+                if (stableVersions.isEmpty() == false) {
+                    moveLastToUnreleased(stableVersions, unreleasedVersions);
+                }
             }
         }
 


### PR DESCRIPTION
Same as https://github.com/opensearch-project/OpenSearch/pull/791 but into main, where we run all of CI, first. <strike>Not sure what the correct protocol is.</strike>

### Description

The first issue in https://github.com/opensearch-project/OpenSearch/issues/786 is caused by integration tests trying to fetch 7.10.3 from source. This is because the code thinks 7.10.3 has not been released yet. There are two problems fixed in this PR:

- The current unreleased version is 1.0.0 and code needs to understand that 1.0 > 7.x.
- The 7.10.3 version has not been released as of time of the fork, and the code needs to express that 7.10.2 has been released.

There's a new set of tests for versions for OpenSearch 1.0 to avoid conflating with version tests that presume that the next released version will be 8 and that the 7 series is not fully released. Thanks @adnapibar for those!

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
