### PR TITLE
Fix Javadoc errors in `client/sniffer`

### DIFF
--- a/buildSrc/reaper/src/main/java/org/elasticsearch/gradle/reaper/package-info.java
+++ b/buildSrc/reaper/src/main/java/org/elasticsearch/gradle/reaper/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to OpenSearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. OpenSearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * Adding a sample package level javadoc to pass javadoc validation
+ * on reaper package.
+ * TODO - Need to add package description
+ */
+package org.elasticsearch.gradle.reaper;

--- a/client/sniffer/src/main/java/org/opensearch/client/sniff/OpenSearchNodesSniffer.java
+++ b/client/sniffer/src/main/java/org/opensearch/client/sniff/OpenSearchNodesSniffer.java
@@ -69,6 +69,9 @@ public final class OpenSearchNodesSniffer implements NodesSniffer {
 
     private static final Log logger = LogFactory.getLog(OpenSearchNodesSniffer.class);
 
+    /**
+     * The default sniff request timeout (in milliseconds).
+     */
     public static final long DEFAULT_SNIFF_REQUEST_TIMEOUT = TimeUnit.SECONDS.toMillis(1);
 
     private final RestClient restClient;
@@ -310,8 +313,19 @@ public final class OpenSearchNodesSniffer implements NodesSniffer {
         }
     }
 
+    /**
+     * The supported host schemes.
+     */
     public enum Scheme {
-        HTTP("http"), HTTPS("https");
+        /**
+         * The HTTP host scheme.
+         */
+        HTTP("http"),
+
+        /**
+         * The HTTPS host scheme.
+         */
+        HTTPS("https");
 
         private final String name;
 

--- a/client/sniffer/src/main/java/org/opensearch/client/sniff/SniffOnFailureListener.java
+++ b/client/sniffer/src/main/java/org/opensearch/client/sniff/SniffOnFailureListener.java
@@ -49,12 +49,18 @@ public class SniffOnFailureListener extends RestClient.FailureListener {
     private volatile Sniffer sniffer;
     private final AtomicBoolean set;
 
+    /**
+     * Creates a {@code SniffOnFailureListener} instance. The {@link Sniffer} needs to be set
+     * through {@link #setSniffer(Sniffer)} after instantiation.
+     */
     public SniffOnFailureListener() {
         this.set = new AtomicBoolean(false);
     }
 
     /**
-     * Sets the {@link Sniffer} instance used to perform sniffing
+     * Sets the {@link Sniffer} instance used to perform sniffing.
+     *
+     * @param sniffer The {@link Sniffer} instance to be used.
      * @throws IllegalStateException if the sniffer was already set, as it can only be set once
      */
     public void setSniffer(Sniffer sniffer) {

--- a/client/sniffer/src/main/java/org/opensearch/client/sniff/SnifferBuilder.java
+++ b/client/sniffer/src/main/java/org/opensearch/client/sniff/SnifferBuilder.java
@@ -41,7 +41,15 @@ import java.util.concurrent.TimeUnit;
  * Sniffer builder. Helps creating a new {@link Sniffer}.
  */
 public final class SnifferBuilder {
+
+    /**
+     * The default sniff interval (in milliseconds).
+     */
     public static final long DEFAULT_SNIFF_INTERVAL = TimeUnit.MINUTES.toMillis(5);
+
+    /**
+     * The default delay of a sniff execution after a failure (in milliseconds).
+     */
     public static final long DEFAULT_SNIFF_AFTER_FAILURE_DELAY = TimeUnit.MINUTES.toMillis(1);
 
     private final RestClient restClient;
@@ -60,6 +68,8 @@ public final class SnifferBuilder {
     /**
      * Sets the interval between consecutive ordinary sniff executions in milliseconds. Will be honoured when
      * sniffOnFailure is disabled or when there are no failures between consecutive sniff executions.
+     *
+     * @param sniffIntervalMillis the interval between sniff executions in milliseconds.
      * @throws IllegalArgumentException if sniffIntervalMillis is not greater than 0
      */
     public SnifferBuilder setSniffIntervalMillis(int sniffIntervalMillis) {
@@ -71,7 +81,9 @@ public final class SnifferBuilder {
     }
 
     /**
-     * Sets the delay of a sniff execution scheduled after a failure (in milliseconds)
+     * Sets the delay of a sniff execution scheduled after a failure (in milliseconds).
+     *
+     * @param sniffAfterFailureDelayMillis the sniff delay in milliseconds.
      */
     public SnifferBuilder setSniffAfterFailureDelayMillis(int sniffAfterFailureDelayMillis) {
         if (sniffAfterFailureDelayMillis <= 0) {
@@ -85,6 +97,8 @@ public final class SnifferBuilder {
      * Sets the {@link NodesSniffer} to be used to read hosts. A default instance of {@link OpenSearchNodesSniffer}
      * is created when not provided. This method can be used to change the configuration of the {@link OpenSearchNodesSniffer},
      * or to provide a different implementation (e.g. in case hosts need to taken from a different source).
+     *
+     * @param nodesSniffer the {@link NodesSniffer} instance to be used.
      */
     public SnifferBuilder setNodesSniffer(NodesSniffer nodesSniffer) {
         Objects.requireNonNull(nodesSniffer, "nodesSniffer cannot be null");

--- a/client/sniffer/src/main/java/org/opensearch/client/sniff/package-info.java
+++ b/client/sniffer/src/main/java/org/opensearch/client/sniff/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Support for sniffing nodes.
+ */
+package org.opensearch.client.sniff;


### PR DESCRIPTION
### Description
Fix Javadoc comments to fix Javadoc errors as described in issue #221.
 
### Issues Resolved
Fixes Javadoc errors in the client/rest module.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
