### PR TITLE
Fix arm architecture translation issue

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/Jdk.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/Jdk.java
@@ -234,7 +234,7 @@ public class Jdk implements Buildable, Iterable<File> {
         /*
          * Jdk uses aarch64 from ARM. Translating from arm64 to aarch64 which Jdk understands.
          */
-        return architecture == "arm64" ? "aarch64" : architecture;
+        return "arm64".equals(architecture) ? "aarch64" : architecture;
     }
 
 }


### PR DESCRIPTION
### Description
Found when attempting to build on an `arm64` machine when I recieved an error message below.  Root cause is that string equality in java cannot be done with the `==` sign.

```
unknown architecture [arm64] for jdk [provisioned_runtime], must be one of [aarch64, x64]
```
 
### Issues Resolved
Fixes arm64 build issue
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
