### PR TITLE
Remove reference to an EC2 instance type.

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -2,32 +2,40 @@
 
 So you want to contribute code to OpenSearch? Excellent! We're glad you're here. Here's what you need to do.
 
-- [Getting Started](#getting-started)
+- [Developer Guide](#developer-guide)
+  - [Getting Started](#getting-started)
     - [Git Clone OpenSearch Repo](#git-clone-opensearch-repo)
     - [Install Prerequisites](#install-prerequisites)
+      - [JDK 14](#jdk-14)
+      - [Docker](#docker)
     - [Run Tests](#run-tests)
     - [Run OpenSearch](#run-opensearch)
-- [Use an Editor](#use-an-editor)
+  - [Use an Editor](#use-an-editor)
     - [IntelliJ IDEA](#intellij-idea)
     - [Visual Studio Code](#visual-studio-code)
     - [Eclipse](#eclipse)
-- [Project Layout](#project-layout)
-    - [docs](#docs)
-    - [distribution](#distribution)
-    - [libs](#libs)
-    - [modules](#modules)
-    - [plugins](#plugins)
-    - [qa](#qa)
-    - [server](#server)
-    - [test](#test)
-- [Java Language Formatting Guidelines](#java-language-formatting-guidelines)
+  - [Project Layout](#project-layout)
+    - [`docs`](#docs)
+    - [`distribution`](#distribution)
+    - [`libs`](#libs)
+    - [`modules`](#modules)
+    - [`plugins`](#plugins)
+    - [`qa`](#qa)
+    - [`server`](#server)
+    - [`test`](#test)
+  - [Java Language Formatting Guidelines](#java-language-formatting-guidelines)
     - [Editor / IDE Support](#editor--ide-support)
     - [Formatting Failures](#formatting-failures)
-- [Gradle Build](#gradle-build)
+  - [Gradle Build](#gradle-build)
     - [Configurations](#configurations)
-- [Misc](#misc)
+      - [implementation](#implementation)
+      - [api](#api)
+      - [runtimeOnly](#runtimeonly)
+      - [compileOnly](#compileonly)
+      - [testImplementation](#testimplementation)
+  - [Misc](#misc)
     - [git-secrets](#git-secrets)
-- [Submitting Changes](#submitting-changes)
+  - [Submitting Changes](#submitting-changes)
 
 ## Getting Started
 
@@ -62,7 +70,7 @@ To run the full suite of tests you will also need `JAVA8_HOME`, `JAVA9_HOME`, `J
 
 OpenSearch uses a Gradle wrapper for its build. Run `gradlew` on Unix systems, or `gradlew.bat` on Windows in the root of the repository.
 
-Start by running the test suite with `gradlew check`. This should complete without errors and takes ~15 minutes on a c5.18xlarge.
+Start by running the test suite with `gradlew check`. This should complete without errors.
 
 ```
 ./gradlew check

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,7 +1,3 @@
-# Developer Guide
-
-So you want to contribute code to OpenSearch? Excellent! We're glad you're here. Here's what you need to do.
-
 - [Developer Guide](#developer-guide)
   - [Getting Started](#getting-started)
     - [Git Clone OpenSearch Repo](#git-clone-opensearch-repo)
@@ -36,6 +32,10 @@ So you want to contribute code to OpenSearch? Excellent! We're glad you're here.
   - [Misc](#misc)
     - [git-secrets](#git-secrets)
   - [Submitting Changes](#submitting-changes)
+
+# Developer Guide
+
+So you want to contribute code to OpenSearch? Excellent! We're glad you're here. Here's what you need to do.
 
 ## Getting Started
 


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Let's remove calling out an EC2 instance type, avoid AWS-specific things.

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
