### PR TITLE
Add an optional system property to set the version returned from main response to 7.10.2

### DIFF
--- a/qa/evil-tests/src/test/java/org/opensearch/action/main/EvilSystemPropertyTests.java
+++ b/qa/evil-tests/src/test/java/org/opensearch/action/main/EvilSystemPropertyTests.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.main;
+
+import java.io.IOException;
+
+import org.opensearch.Build;
+import org.opensearch.LegacyESVersion;
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.common.Strings;
+import org.opensearch.common.SuppressForbidden;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class EvilSystemPropertyTests extends OpenSearchTestCase {
+
+    @SuppressForbidden(reason = "manipulates system properties for testing")
+    public void testToXContent_responseVersionOverride() throws IOException {
+        System.setProperty("opensearch.http.override_main_response_version", "true");
+        try {
+            MainResponse response = new MainResponse("nodeName", Version.CURRENT,
+                new ClusterName("clusterName"), randomAlphaOfLengthBetween(10, 20), Build.CURRENT);
+            XContentBuilder builder = XContentFactory.jsonBuilder();
+            response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            assertTrue(Strings.toString(builder).contains("\"number\":\"" + LegacyESVersion.V_7_10_2.toString() + "\","));
+        } finally {
+            System.clearProperty("opensearch.http.override_main_response_version");
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/action/main/MainResponse.java
+++ b/server/src/main/java/org/opensearch/action/main/MainResponse.java
@@ -37,6 +37,7 @@ import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.cluster.ClusterName;
+import org.opensearch.common.Booleans;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -55,6 +56,11 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
     private ClusterName clusterName;
     private String clusterUuid;
     private Build build;
+
+    // OVERRIDE_RESPONSE_VERSION exists to provide support for clients expecting legacy ES versions
+    // to be returned from the main rest endpoint.  This setting will be removed in future versions of OpenSearch.
+    private static boolean OVERRIDE_MAIN_RESPONSE_VERSION =
+        Booleans.parseBoolean(System.getProperty("opensearch.http.override_main_response_version"), false);
 
     MainResponse() {}
 
@@ -123,7 +129,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
         builder.field("cluster_uuid", clusterUuid);
         builder.startObject("version")
             .field("distribution", build.getDistribution())
-            .field("number", build.getQualifiedVersion())
+            .field("number", OVERRIDE_MAIN_RESPONSE_VERSION ? LegacyESVersion.V_7_10_2 : build.getQualifiedVersion())
             .field("build_type", build.type().displayName())
             .field("build_hash", build.hash())
             .field("build_date", build.date())


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Add an optional system property, opensearch.http.override_main_response_version,  that spoofs the version.number returned from MainResponse to 7.10.2 instead of the opensearch build version.
 
```
Test steps:
1. Start with param set:
OPENSEARCH_JAVA_OPTS="$OPENSEARCH_JAVA_OPTS -Dopensearch.http.override_main_response_version=true" ./bin/opensearch
2. curl -X GET "localhost:9200/?pretty"

{
  "name" : "test",
  "cluster_name" : "opensearch",
  "cluster_uuid" : "CHsbWvhASVW_uCQVnpC06g",
  "version" : {
    "distribution" : "opensearch",
    "number" : "7.10.2",
    "build_type" : "tar",
    "build_hash" : "9f54032a505381591b57375cd7c906496b977a97",
    "build_date" : "2021-06-04T19:48:23.702201Z",
    "build_snapshot" : true,
    "lucene_version" : "8.8.2",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  }
}

```

### Issues Resolved
[693]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
