### PR TITLE
Remove `client/sniffer` from Javadoc exemption list

### DIFF
--- a/gradle/missing-javadoc.gradle
+++ b/gradle/missing-javadoc.gradle
@@ -91,7 +91,6 @@ configure([
   project(":client:benchmark"),
   project(":client:client-benchmark-noop-api-plugin"),
   project(":client:rest-high-level"),
-  project(":client:sniffer"),
   project(":client:test"),
   project(":client:transport"),
   project(":distribution:tools:java-version-checker"),


### PR DESCRIPTION
Signed-off-by: Gregor Zurowski <gregor@zurowski.org>

### Description
All Javadoc errors were fixed in #802. This change removes `client/sniffer` from the Javadoc exemption list for the Gradle build.
 
### Issues Resolved
Removing `client/sniffer` from exemption list as mentioned by @setiah in https://github.com/opensearch-project/OpenSearch/pull/802#issuecomment-854264028.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
