### PR TITLE
Add Snapshot maven repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,14 @@ subprojects {
           name = 'test'
           url = "${rootProject.buildDir}/local-test-repo"
         }
+        maven {
+          name = 'Snapshots'
+          url = 'https://aws.oss.sonatype.org/content/repositories/snapshots'
+          credentials {
+            username "$System.env.SONATYPE_USERNAME"
+            password "$System.env.SONATYPE_PASSWORD"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Add sonatype repository to push snapshots.  This is an immediate solution to pushing OpenSearch artifacts to https://aws.oss.sonatype.org/content/repositories/snapshots for plugins to consume.  This will be executed via maven-publish plugin's generated task -

```
./gradlew publishAllPublicationsToSnapshotsRepository.
```

It is dependent on credentials via environment variables 
- SONATYPE_USER
- SONATYPE_PASSWORD

This will be executed via CI to generate daily snapshots.

Next steps here are to define how to publish for any opensearch repo without copying this into each repository.
 
### Issues Resolved
[20](https://github.com/opensearch-project/opensearch-build/issues/20)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
