### PR TITLE
Update fingerprint calculation algorithm for SSL certificate from SHA-1 to SHA-256

### DIFF
--- a/libs/ssl-config/src/main/java/org/opensearch/common/ssl/SslUtil.java
+++ b/libs/ssl-config/src/main/java/org/opensearch/common/ssl/SslUtil.java
@@ -45,9 +45,9 @@ public final class SslUtil {
     }
 
     public static String calculateFingerprint(X509Certificate certificate) throws CertificateEncodingException {
-        final MessageDigest sha1 = messageDigest("SHA-1");
-        sha1.update(certificate.getEncoded());
-        return toHexString(sha1.digest());
+        final MessageDigest sha256 = messageDigest("SHA-256");
+        sha256.update(certificate.getEncoded());
+        return toHexString(sha256.digest());
     }
 
     static MessageDigest messageDigest(String digestAlgorithm) {


### PR DESCRIPTION
### Description
[Describe what this change achieves]
Unit test to be updated.
But looks like keeping SHA-1 for certificate fingerprint is not a problem:
https://www.thesslstore.com/blog/ssl-certificate-still-sha-1-thumbprint
https://security.stackexchange.com/questions/245628/certificate-sha1-thumbprint-reported-as-a-vulnerability

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
