### PR TITLE
Allowing custom folder name for plugin installation

### DIFF
--- a/buildSrc/src/main/groovy/org/opensearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -105,7 +105,7 @@ class PluginBuildPlugin implements Plugin<Project> {
                     'opensearchVersion'   : Version.fromString(VersionProperties.getOpenSearch()).toString(),
                     'javaVersion'         : project.targetCompatibility as String,
                     'classname'           : extension1.classname,
-                    'folderName'          : extension1.folderName,
+                    'customFolderName'    : extension1.customFolderName,
                     'extendedPlugins'     : extension1.extendedPlugins.join(','),
                     'hasNativeController' : extension1.hasNativeController,
                     'requiresKeystore'    : extension1.requiresKeystore

--- a/buildSrc/src/main/groovy/org/opensearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -105,6 +105,7 @@ class PluginBuildPlugin implements Plugin<Project> {
                     'opensearchVersion'   : Version.fromString(VersionProperties.getOpenSearch()).toString(),
                     'javaVersion'         : project.targetCompatibility as String,
                     'classname'           : extension1.classname,
+                    'folderName'          : extension1.folderName,
                     'extendedPlugins'     : extension1.extendedPlugins.join(','),
                     'hasNativeController' : extension1.hasNativeController,
                     'requiresKeystore'    : extension1.requiresKeystore

--- a/buildSrc/src/main/java/org/opensearch/gradle/plugin/PluginPropertiesExtension.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/plugin/PluginPropertiesExtension.java
@@ -51,7 +51,7 @@ public class PluginPropertiesExtension {
 
     private String classname;
 
-    private String folderName = "";
+    private String customFolderName = "";
 
     /** Other plugins this plugin extends through SPI */
     private List<String> extendedPlugins = new ArrayList<>();
@@ -78,12 +78,12 @@ public class PluginPropertiesExtension {
         this.project = project;
     }
 
-    public String getFolderName() {
-        return folderName;
+    public String getCustomFolderName() {
+        return customFolderName;
     }
 
-    public void setFolderName(String folderName) {
-        this.folderName = folderName;
+    public void setCustomFolderName(String customFolderName) {
+        this.customFolderName = customFolderName;
     }
 
     public String getName() {

--- a/buildSrc/src/main/java/org/opensearch/gradle/plugin/PluginPropertiesExtension.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/plugin/PluginPropertiesExtension.java
@@ -51,6 +51,8 @@ public class PluginPropertiesExtension {
 
     private String classname;
 
+    private String folderName = "";
+
     /** Other plugins this plugin extends through SPI */
     private List<String> extendedPlugins = new ArrayList<>();
 
@@ -74,6 +76,14 @@ public class PluginPropertiesExtension {
 
     public PluginPropertiesExtension(Project project) {
         this.project = project;
+    }
+
+    public String getFolderName() {
+        return folderName;
+    }
+
+    public void setFolderName(String folderName) {
+        this.folderName = folderName;
     }
 
     public String getName() {

--- a/buildSrc/src/main/resources/plugin-descriptor.properties
+++ b/buildSrc/src/main/resources/plugin-descriptor.properties
@@ -49,8 +49,8 @@ java.version=${javaVersion}
 opensearch.version=${opensearchVersion}
 ### optional elements for plugins:
 #
-# 'folderName': the custom name of the folder in which the plugin is installed.
-folderName=${folderName}
+# 'custom.foldername': the custom name of the folder in which the plugin is installed.
+custom.foldername=${customFolderName}
 #
 #  'extended.plugins': other plugins this plugin extends through SPI
 extended.plugins=${extendedPlugins}

--- a/buildSrc/src/main/resources/plugin-descriptor.properties
+++ b/buildSrc/src/main/resources/plugin-descriptor.properties
@@ -54,3 +54,6 @@ extended.plugins=${extendedPlugins}
 #
 # 'has.native.controller': whether or not the plugin has a native controller
 has.native.controller=${hasNativeController}
+#
+# 'folderName': the custom name of the folder in which the plugin is installed.
+folderName=${folderName}

--- a/buildSrc/src/main/resources/plugin-descriptor.properties
+++ b/buildSrc/src/main/resources/plugin-descriptor.properties
@@ -49,11 +49,11 @@ java.version=${javaVersion}
 opensearch.version=${opensearchVersion}
 ### optional elements for plugins:
 #
+# 'folderName': the custom name of the folder in which the plugin is installed.
+folderName=${folderName}
+#
 #  'extended.plugins': other plugins this plugin extends through SPI
 extended.plugins=${extendedPlugins}
 #
 # 'has.native.controller': whether or not the plugin has a native controller
 has.native.controller=${hasNativeController}
-#
-# 'folderName': the custom name of the folder in which the plugin is installed.
-folderName=${folderName}

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/InstallPluginCommand.java
@@ -773,20 +773,20 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
     }
 
     // checking for existing version of the plugin
-    private void verifyPluginName(Path pluginPath, String pluginName) throws UserException, IOException {
+    private void verifyPluginName(Path pluginPath, String pluginName, String pluginFolderName) throws UserException, IOException {
         // don't let user install plugin conflicting with module...
         // they might be unavoidably in maven central and are packaged up the same way)
         if (MODULES.contains(pluginName)) {
             throw new UserException(ExitCodes.USAGE, "plugin '" + pluginName + "' cannot be installed as a plugin, it is a system module");
         }
 
-        final Path destination = pluginPath.resolve(pluginName);
+        final Path destination = pluginPath.resolve(pluginFolderName);
         if (Files.exists(destination)) {
             final String message = String.format(
                 Locale.ROOT,
                 "plugin directory [%s] already exists; if you need to update the plugin, " + "uninstall it first using command 'remove %s'",
                 destination,
-                pluginName
+                pluginFolderName
             );
             throw new UserException(PLUGIN_EXISTS, message);
         }
@@ -801,7 +801,7 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
         PluginsService.verifyCompatibility(info);
 
         // checking for existing version of the plugin
-        verifyPluginName(env.pluginsFile(), info.getName());
+        verifyPluginName(env.pluginsFile(), info.getName(), info.getTargetFolderName());
 
         PluginsService.checkForFailedPluginRemovals(env.pluginsFile());
 
@@ -864,14 +864,15 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
         }
         PluginSecurity.confirmPolicyExceptions(terminal, permissions, isBatch);
 
-        final Path destination = env.pluginsFile().resolve(info.getName());
+        String targetFolderName = info.getTargetFolderName();
+        final Path destination = env.pluginsFile().resolve(targetFolderName);
         deleteOnFailure.add(destination);
 
         installPluginSupportFiles(
             info,
             tmpRoot,
-            env.binFile().resolve(info.getName()),
-            env.configFile().resolve(info.getName()),
+            env.binFile().resolve(targetFolderName),
+            env.configFile().resolve(targetFolderName),
             deleteOnFailure
         );
         movePlugin(tmpRoot, destination);

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/InstallPluginCommand.java
@@ -773,31 +773,22 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
     }
 
     // checking for existing version of the plugin
-    private void verifyPluginName(Path pluginPath, String pluginName, String pluginFolderName) throws UserException, IOException {
+    private void verifyPluginName(Path pluginPath, String pluginName) throws UserException, IOException {
         // don't let user install plugin conflicting with module...
         // they might be unavoidably in maven central and are packaged up the same way)
         if (MODULES.contains(pluginName)) {
             throw new UserException(ExitCodes.USAGE, "plugin '" + pluginName + "' cannot be installed as a plugin, it is a system module");
         }
 
-        Path destination = pluginPath.resolve(pluginName);
+        // scan all the installed plugins to see if the plugin being installed already exists
+        // either with the plugin name or a custom folder name
+        Path destination = PluginHelper.verifyIfPluginExists(pluginPath, pluginName);
         if (Files.exists(destination)) {
             final String message = String.format(
                 Locale.ROOT,
                 "plugin directory [%s] already exists; if you need to update the plugin, " + "uninstall it first using command 'remove %s'",
                 destination,
                 pluginName
-            );
-            throw new UserException(PLUGIN_EXISTS, message);
-        }
-
-        destination = pluginPath.resolve(pluginFolderName);
-        if (Files.exists(destination)) {
-            final String message = String.format(
-                Locale.ROOT,
-                "plugin directory [%s] already exists; if you need to update the plugin, " + "uninstall it first using command 'remove %s'",
-                destination,
-                pluginFolderName
             );
             throw new UserException(PLUGIN_EXISTS, message);
         }
@@ -812,7 +803,7 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
         PluginsService.verifyCompatibility(info);
 
         // checking for existing version of the plugin
-        verifyPluginName(env.pluginsFile(), info.getName(), info.getTargetFolderName());
+        verifyPluginName(env.pluginsFile(), info.getName());
 
         PluginsService.checkForFailedPluginRemovals(env.pluginsFile());
 

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/InstallPluginCommand.java
@@ -261,7 +261,7 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
                 final Path extractedZip = unzip(pluginZip, env.pluginsFile());
                 deleteOnFailure.add(extractedZip);
                 final PluginInfo pluginInfo = installPlugin(terminal, isBatch, extractedZip, env, deleteOnFailure);
-                terminal.println("-> Installed " + pluginInfo.getName());
+                terminal.println("-> Installed " + pluginInfo.getName() + " with folder name " + pluginInfo.getTargetFolderName());
                 // swap the entry by plugin id for one with the installed plugin name, it gives a cleaner error message for URL installs
                 deleteOnFailures.remove(pluginId);
                 deleteOnFailures.put(pluginInfo.getName(), deleteOnFailure);
@@ -780,7 +780,18 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
             throw new UserException(ExitCodes.USAGE, "plugin '" + pluginName + "' cannot be installed as a plugin, it is a system module");
         }
 
-        final Path destination = pluginPath.resolve(pluginFolderName);
+        Path destination = pluginPath.resolve(pluginName);
+        if (Files.exists(destination)) {
+            final String message = String.format(
+                Locale.ROOT,
+                "plugin directory [%s] already exists; if you need to update the plugin, " + "uninstall it first using command 'remove %s'",
+                destination,
+                pluginName
+            );
+            throw new UserException(PLUGIN_EXISTS, message);
+        }
+
+        destination = pluginPath.resolve(pluginFolderName);
         if (Files.exists(destination)) {
             final String message = String.format(
                 Locale.ROOT,

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/ListPluginsCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/ListPluginsCommand.java
@@ -75,8 +75,8 @@ class ListPluginsCommand extends EnvironmentAwareCommand {
     }
 
     private void printPlugin(Environment env, Terminal terminal, Path plugin, String prefix) throws IOException {
-        terminal.println(Terminal.Verbosity.SILENT, prefix + plugin.getFileName().toString());
         PluginInfo info = PluginInfo.readFromProperties(env.pluginsFile().resolve(plugin));
+        terminal.println(Terminal.Verbosity.SILENT, prefix + info.getName());
         terminal.println(Terminal.Verbosity.VERBOSE, info.toString(prefix));
         if (info.getOpenSearchVersion().equals(Version.CURRENT) == false) {
             terminal.errorPrintln(

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/PluginHelper.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/PluginHelper.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugins;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A helper class for the plugin-cli tasks.
+ */
+public class PluginHelper {
+
+    /**
+     * Verify if a plugin exists with any folder name.
+     * @param pluginPath   the path for the plugins directory.
+     * @param pluginName   the name of the concerned plugin.
+     * @return             the path of the folder if the plugin exists.
+     * @throws IOException if any I/O exception occurs while performing a file operation
+     */
+    public static Path verifyIfPluginExists(Path pluginPath, String pluginName) throws IOException {
+        List<Path> pluginSubFolders = Files.walk(pluginPath, 1).filter(Files::isDirectory).collect(Collectors.toList());
+        for (Path customPluginFolderPath : pluginSubFolders) {
+            if (customPluginFolderPath != pluginPath
+                && !((customPluginFolderPath.getFileName().toString()).contains(".installing"))
+                && !((customPluginFolderPath.getFileName().toString()).contains(".removing"))) {
+                final PluginInfo info = PluginInfo.readFromProperties(customPluginFolderPath);
+                if (info.getName().equals(pluginName)) {
+                    return customPluginFolderPath;
+                }
+            }
+        }
+        return pluginPath.resolve(pluginName);
+    }
+}

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/RemovePluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/RemovePluginCommand.java
@@ -123,6 +123,7 @@ class RemovePluginCommand extends EnvironmentAwareCommand {
          * to find if the concerned plugin is installed with a custom folder name.
          */
         if (!Files.exists(pluginDir)) {
+            terminal.println("searching in other folders to find if plugin exists with custom folder name");
             pluginDir = PluginHelper.verifyIfPluginExists(env.pluginsFile(), pluginName);
             pluginConfigDir = env.configFile().resolve(pluginDir.getFileName());
             removing = env.pluginsFile().resolve(".removing-" + pluginDir.getFileName());

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/RemovePluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/RemovePluginCommand.java
@@ -114,9 +114,19 @@ class RemovePluginCommand extends EnvironmentAwareCommand {
             );
         }
 
-        final Path pluginDir = env.pluginsFile().resolve(pluginName);
-        final Path pluginConfigDir = env.configFile().resolve(pluginName);
-        final Path removing = env.pluginsFile().resolve(".removing-" + pluginName);
+        Path pluginDir = env.pluginsFile().resolve(pluginName);
+        Path pluginConfigDir = env.configFile().resolve(pluginName);
+        Path removing = env.pluginsFile().resolve(".removing-" + pluginName);
+
+        /*
+         * If the plugin directory is not found with the plugin name, scan the list of all installed plugins
+         * to find if the concerned plugin is installed with a custom folder name.
+         */
+        if (!Files.exists(pluginDir)) {
+            pluginDir = PluginHelper.verifyIfPluginExists(env.pluginsFile(), pluginName);
+            pluginConfigDir = env.configFile().resolve(pluginDir.getFileName());
+            removing = env.pluginsFile().resolve(".removing-" + pluginDir.getFileName());
+        }
 
         terminal.println("-> removing [" + pluginName + "]...");
         /*

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
@@ -576,6 +576,17 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         assertInstallCleaned(env.v2());
     }
 
+    public void testExistingPluginWithCustomFolderName() throws Exception {
+        Tuple<Path, Environment> env = createEnv(fs, temp);
+        Path pluginDir = createPluginDir(temp);
+        String pluginZip = createPluginUrl("fake", pluginDir, "folderName", "fake-folder");
+        installPlugin(pluginZip, env.v1());
+        assertPlugin("fake-folder", pluginDir, env.v2());
+        UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip, env.v1()));
+        assertTrue(e.getMessage(), e.getMessage().contains("already exists"));
+        assertInstallCleaned(env.v2());
+    }
+
     public void testBin() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
@@ -878,7 +878,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Path pluginDir = createPluginDir(temp);
         String pluginZip = createPluginUrl("fake", pluginDir, "folderName", "fake-folder");
         installPlugin(pluginZip, env.v1());
-        assertPlugin("fake", pluginDir, env.v2());
+        assertPlugin("fake-folder", pluginDir, env.v2());
     }
 
     private void installPlugin(MockTerminal terminal, boolean isBatch) throws Exception {

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
@@ -256,11 +256,11 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
     }
 
     /** creates a plugin .zip and returns the url for testing */
-    static String createPluginUrl(String name, Path structure, String... additionalProps) throws IOException {
-        return createPlugin(name, structure, additionalProps).toUri().toURL().toString();
+    static String createPluginUrl(String name, String folderName, Path structure, String... additionalProps) throws IOException {
+        return createPlugin(name, folderName, structure, additionalProps).toUri().toURL().toString();
     }
 
-    static void writePlugin(String name, Path structure, String... additionalProps) throws IOException {
+    static void writePlugin(String name, String folderName, Path structure, String... additionalProps) throws IOException {
         String[] properties = Stream.concat(
             Stream.of(
                 "description",
@@ -274,7 +274,9 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
                 "java.version",
                 System.getProperty("java.specification.version"),
                 "classname",
-                "FakePlugin"
+                "FakePlugin",
+                "folderName",
+                folderName
             ),
             Arrays.stream(additionalProps)
         ).toArray(String[]::new);
@@ -294,8 +296,8 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Files.write(pluginDir.resolve("plugin-security.policy"), securityPolicyContent.toString().getBytes(StandardCharsets.UTF_8));
     }
 
-    static Path createPlugin(String name, Path structure, String... additionalProps) throws IOException {
-        writePlugin(name, structure, additionalProps);
+    static Path createPlugin(String name, String folderName, Path structure, String... additionalProps) throws IOException {
+        writePlugin(name, folderName, structure, additionalProps);
         return writeZip(structure, null);
     }
 
@@ -426,7 +428,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
     public void testSomethingWorks() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
-        String pluginZip = createPluginUrl("fake", pluginDir);
+        String pluginZip = createPluginUrl("fake", null, pluginDir);
         installPlugin(pluginZip, env.v1());
         assertPlugin("fake", pluginDir, env.v2());
     }
@@ -434,8 +436,8 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
     public void testMultipleWorks() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
-        String fake1PluginZip = createPluginUrl("fake1", pluginDir);
-        String fake2PluginZip = createPluginUrl("fake2", pluginDir);
+        String fake1PluginZip = createPluginUrl("fake1", null, pluginDir);
+        String fake2PluginZip = createPluginUrl("fake2", null, pluginDir);
         installPlugins(Arrays.asList(fake1PluginZip, fake2PluginZip), env.v1());
         assertPlugin("fake1", pluginDir, env.v2());
         assertPlugin("fake2", pluginDir, env.v2());
@@ -444,7 +446,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
     public void testDuplicateInstall() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
-        String pluginZip = createPluginUrl("fake", pluginDir);
+        String pluginZip = createPluginUrl("fake", null, pluginDir);
         final UserException e = expectThrows(UserException.class, () -> installPlugins(Arrays.asList(pluginZip, pluginZip), env.v1()));
         assertThat(e, hasToString(containsString("duplicate plugin id [" + pluginZip + "]")));
     }
@@ -452,7 +454,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
     public void testTransaction() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
-        String pluginZip = createPluginUrl("fake", pluginDir);
+        String pluginZip = createPluginUrl("fake", null, pluginDir);
         final FileNotFoundException e = expectThrows(
             FileNotFoundException.class,
             () -> installPlugins(Arrays.asList(pluginZip, pluginZip + "does-not-exist"), env.v1())
@@ -467,7 +469,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
     public void testInstallFailsIfPreviouslyRemovedPluginFailed() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
-        String pluginZip = createPluginUrl("fake", pluginDir);
+        String pluginZip = createPluginUrl("fake", null, pluginDir);
         final Path removing = env.v2().pluginsFile().resolve(".removing-failed");
         Files.createDirectory(removing);
         final IllegalStateException e = expectThrows(IllegalStateException.class, () -> installPlugin(pluginZip, env.v1()));
@@ -482,7 +484,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
     public void testSpaceInUrl() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
-        String pluginZip = createPluginUrl("fake", pluginDir);
+        String pluginZip = createPluginUrl("fake", null, pluginDir);
         Path pluginZipWithSpaces = createTempFile("foo bar", ".zip");
         try (InputStream in = FileSystemUtils.openFileURLStream(new URL(pluginZip))) {
             Files.copy(in, pluginZipWithSpaces, StandardCopyOption.REPLACE_EXISTING);
@@ -522,7 +524,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Path pluginDir = createPluginDir(temp);
         try (PosixPermissionsResetter pluginsAttrs = new PosixPermissionsResetter(env.v2().pluginsFile())) {
             pluginsAttrs.setPermissions(new HashSet<>());
-            String pluginZip = createPluginUrl("fake", pluginDir);
+            String pluginZip = createPluginUrl("fake", null, pluginDir);
             IOException e = expectThrows(IOException.class, () -> installPlugin(pluginZip, env.v1()));
             assertTrue(e.getMessage(), e.getMessage().contains(env.v2().pluginsFile().toString()));
         }
@@ -532,7 +534,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
     public void testBuiltinModule() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
-        String pluginZip = createPluginUrl("lang-painless", pluginDir);
+        String pluginZip = createPluginUrl("lang-painless", null, pluginDir);
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip, env.v1()));
         assertTrue(e.getMessage(), e.getMessage().contains("is a system module"));
         assertInstallCleaned(env.v2());
@@ -544,7 +546,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Tuple<Path, Environment> environment = createEnv(fs, temp);
         Path pluginDirectory = createPluginDir(temp);
         writeJar(pluginDirectory.resolve("other.jar"), "FakePlugin");
-        String pluginZip = createPluginUrl("fake", pluginDirectory); // adds plugin.jar with FakePlugin
+        String pluginZip = createPluginUrl("fake", null, pluginDirectory); // adds plugin.jar with FakePlugin
         IllegalStateException e = expectThrows(
             IllegalStateException.class,
             () -> installPlugin(pluginZip, environment.v1(), defaultCommand)
@@ -557,10 +559,10 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         // these both share the same FakePlugin class
         Path pluginDir1 = createPluginDir(temp);
-        String pluginZip1 = createPluginUrl("fake1", pluginDir1);
+        String pluginZip1 = createPluginUrl("fake1", null, pluginDir1);
         installPlugin(pluginZip1, env.v1());
         Path pluginDir2 = createPluginDir(temp);
-        String pluginZip2 = createPluginUrl("fake2", pluginDir2);
+        String pluginZip2 = createPluginUrl("fake2", null, pluginDir2);
         installPlugin(pluginZip2, env.v1());
         assertPlugin("fake1", pluginDir1, env.v2());
         assertPlugin("fake2", pluginDir2, env.v2());
@@ -569,7 +571,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
     public void testExistingPlugin() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
-        String pluginZip = createPluginUrl("fake", pluginDir);
+        String pluginZip = createPluginUrl("fake", null, pluginDir);
         installPlugin(pluginZip, env.v1());
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip, env.v1()));
         assertTrue(e.getMessage(), e.getMessage().contains("already exists"));
@@ -582,7 +584,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Path binDir = pluginDir.resolve("bin");
         Files.createDirectory(binDir);
         Files.createFile(binDir.resolve("somescript"));
-        String pluginZip = createPluginUrl("fake", pluginDir);
+        String pluginZip = createPluginUrl("fake", null, pluginDir);
         installPlugin(pluginZip, env.v1());
         assertPlugin("fake", pluginDir, env.v2());
     }
@@ -592,7 +594,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Path pluginDir = createPluginDir(temp);
         Path binDir = pluginDir.resolve("bin");
         Files.createFile(binDir);
-        String pluginZip = createPluginUrl("fake", pluginDir);
+        String pluginZip = createPluginUrl("fake", null, pluginDir);
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip, env.v1()));
         assertTrue(e.getMessage(), e.getMessage().contains("not a directory"));
         assertInstallCleaned(env.v2());
@@ -604,7 +606,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Path dirInBinDir = pluginDir.resolve("bin").resolve("foo");
         Files.createDirectories(dirInBinDir);
         Files.createFile(dirInBinDir.resolve("somescript"));
-        String pluginZip = createPluginUrl("fake", pluginDir);
+        String pluginZip = createPluginUrl("fake", null, pluginDir);
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip, env.v1()));
         assertTrue(e.getMessage(), e.getMessage().contains("Directories not allowed in bin dir for plugin"));
         assertInstallCleaned(env.v2());
@@ -616,7 +618,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Path binDir = pluginDir.resolve("bin");
         Files.createDirectory(binDir);
         Files.createFile(binDir.resolve("somescript"));
-        String pluginZip = createPluginUrl("opensearch", pluginDir);
+        String pluginZip = createPluginUrl("opensearch", null, pluginDir);
         FileAlreadyExistsException e = expectThrows(FileAlreadyExistsException.class, () -> installPlugin(pluginZip, env.v1()));
         assertTrue(e.getMessage(), e.getMessage().contains(env.v2().binFile().resolve("opensearch").toString()));
         assertInstallCleaned(env.v2());
@@ -629,7 +631,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Path binDir = pluginDir.resolve("bin");
         Files.createDirectory(binDir);
         Files.createFile(binDir.resolve("somescript"));
-        String pluginZip = createPluginUrl("fake", pluginDir);
+        String pluginZip = createPluginUrl("fake", null, pluginDir);
         try (PosixPermissionsResetter binAttrs = new PosixPermissionsResetter(env.v2().binFile())) {
             Set<PosixFilePermission> perms = binAttrs.getCopyPermissions();
             // make sure at least one execute perm is missing, so we know we forced it during installation
@@ -656,7 +658,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Files.createDirectory(resourcesDir);
         Files.createFile(resourcesDir.resolve("resource"));
 
-        final String pluginZip = createPluginUrl("fake", pluginDir);
+        final String pluginZip = createPluginUrl("fake", null, pluginDir);
 
         installPlugin(pluginZip, env.v1());
         assertPlugin("fake", pluginDir, env.v2());
@@ -707,7 +709,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Path configDir = pluginDir.resolve("config");
         Files.createDirectory(configDir);
         Files.createFile(configDir.resolve("custom.yml"));
-        String pluginZip = createPluginUrl("fake", pluginDir);
+        String pluginZip = createPluginUrl("fake", null, pluginDir);
         installPlugin(pluginZip, env.v1());
         assertPlugin("fake", pluginDir, env.v2());
     }
@@ -722,7 +724,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Files.createDirectory(configDir);
         Files.write(configDir.resolve("custom.yml"), "new config".getBytes(StandardCharsets.UTF_8));
         Files.createFile(configDir.resolve("other.yml"));
-        String pluginZip = createPluginUrl("fake", pluginDir);
+        String pluginZip = createPluginUrl("fake", null, pluginDir);
         installPlugin(pluginZip, env.v1());
         assertPlugin("fake", pluginDir, env.v2());
         List<String> configLines = Files.readAllLines(envConfigDir.resolve("custom.yml"), StandardCharsets.UTF_8);
@@ -737,7 +739,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Files.createDirectories(pluginDir);
         Path configDir = pluginDir.resolve("config");
         Files.createFile(configDir);
-        String pluginZip = createPluginUrl("fake", pluginDir);
+        String pluginZip = createPluginUrl("fake", null, pluginDir);
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip, env.v1()));
         assertTrue(e.getMessage(), e.getMessage().contains("not a directory"));
         assertInstallCleaned(env.v2());
@@ -749,7 +751,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Path dirInConfigDir = pluginDir.resolve("config").resolve("foo");
         Files.createDirectories(dirInConfigDir);
         Files.createFile(dirInConfigDir.resolve("myconfig.yml"));
-        String pluginZip = createPluginUrl("fake", pluginDir);
+        String pluginZip = createPluginUrl("fake", null, pluginDir);
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip, env.v1()));
         assertTrue(e.getMessage(), e.getMessage().contains("Directories not allowed in config dir for plugin"));
         assertInstallCleaned(env.v2());
@@ -856,7 +858,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
     public void testPluginAlreadyInstalled() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
-        String pluginZip = createPluginUrl("fake", pluginDir);
+        String pluginZip = createPluginUrl("fake", null, pluginDir);
         installPlugin(pluginZip, env.v1());
         final UserException e = expectThrows(
             UserException.class,
@@ -873,6 +875,14 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         );
     }
 
+    public void testPluginInstallationWithCustomFolderName() throws Exception {
+        Tuple<Path, Environment> env = createEnv(fs, temp);
+        Path pluginDir = createPluginDir(temp);
+        String pluginZip = createPluginUrl("fake", "custom-folder", pluginDir);
+        installPlugin(pluginZip, env.v1());
+        assertPlugin("custom-folder", pluginDir, env.v2());
+    }
+
     private void installPlugin(MockTerminal terminal, boolean isBatch) throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
@@ -880,7 +890,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         if (isBatch) {
             writePluginSecurityPolicy(pluginDir, "setFactory");
         }
-        String pluginZip = createPlugin("fake", pluginDir).toUri().toURL().toString();
+        String pluginZip = createPlugin("fake", null, pluginDir).toUri().toURL().toString();
         skipJarHellCommand.execute(terminal, Collections.singletonList(pluginZip), isBatch, env.v2());
     }
 
@@ -897,7 +907,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
     ) throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
-        Path pluginZip = createPlugin(name, pluginDir);
+        Path pluginZip = createPlugin(name, null, pluginDir);
         InstallPluginCommand command = new InstallPluginCommand() {
             @Override
             Path downloadZip(Terminal terminal, String urlString, Path tmpDir, boolean isBatch) throws IOException {
@@ -1482,7 +1492,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
         writePluginSecurityPolicy(pluginDir, "setAccessible", "setFactory");
-        String pluginZip = createPluginUrl("fake", pluginDir);
+        String pluginZip = createPluginUrl("fake", null, pluginDir);
 
         assertPolicyConfirmation(env, pluginZip, "plugin requires additional permissions");
         assertPlugin("fake", pluginDir, env.v2());
@@ -1491,7 +1501,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
     public void testPluginWithNativeController() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
-        String pluginZip = createPluginUrl("fake", pluginDir, "has.native.controller", "true");
+        String pluginZip = createPluginUrl("fake", null, pluginDir, "has.native.controller", "true");
 
         final IllegalStateException e = expectThrows(IllegalStateException.class, () -> installPlugin(pluginZip, env.v1()));
         assertThat(e, hasToString(containsString("plugins can not have native controllers")));
@@ -1502,7 +1512,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Path pluginDir = createPluginDir(temp);
         writeJar(pluginDir.resolve("dep1.jar"), "Dep1");
         writeJar(pluginDir.resolve("dep2.jar"), "Dep2");
-        String pluginZip = createPluginUrl("fake-with-deps", pluginDir);
+        String pluginZip = createPluginUrl("fake-with-deps", null, pluginDir);
         installPlugin(pluginZip, env.v1());
         assertPlugin("fake-with-deps", pluginDir, env.v2());
     }

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
@@ -579,7 +579,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
     public void testExistingPluginWithCustomFolderName() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
-        String pluginZip = createPluginUrl("fake", pluginDir, "folderName", "fake-folder");
+        String pluginZip = createPluginUrl("fake", pluginDir, "custom.foldername", "fake-folder");
         installPlugin(pluginZip, env.v1());
         assertPlugin("fake-folder", pluginDir, env.v2());
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip, env.v1()));
@@ -887,7 +887,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
     public void testPluginInstallationWithCustomFolderName() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
-        String pluginZip = createPluginUrl("fake", pluginDir, "folderName", "fake-folder");
+        String pluginZip = createPluginUrl("fake", pluginDir, "custom.foldername", "fake-folder");
         installPlugin(pluginZip, env.v1());
         assertPlugin("fake-folder", pluginDir, env.v2());
     }

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/ListPluginsCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/ListPluginsCommandTests.java
@@ -124,7 +124,7 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
             "1.8",
             "classname",
             classname,
-            "folderName",
+            "custom.foldername",
             "custom-folder",
             "has.native.controller",
             Boolean.toString(hasNativeController)

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/ListPluginsCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/ListPluginsCommandTests.java
@@ -169,7 +169,8 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
                 "Java Version: 1.8",
                 "Native Controller: false",
                 "Extended Plugins: []",
-                " * Classname: org.fake"
+                " * Classname: org.fake",
+                "Folder name: fake_plugin"
             ),
             terminal.getOutput()
         );
@@ -191,7 +192,8 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
                 "Java Version: 1.8",
                 "Native Controller: true",
                 "Extended Plugins: []",
-                " * Classname: org.fake"
+                " * Classname: org.fake",
+                "Folder name: fake_plugin1"
             ),
             terminal.getOutput()
         );
@@ -215,6 +217,7 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
                 "Native Controller: false",
                 "Extended Plugins: []",
                 " * Classname: org.fake",
+                "Folder name: fake_plugin1",
                 "fake_plugin2",
                 "- Plugin information:",
                 "Name: fake_plugin2",
@@ -224,7 +227,8 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
                 "Java Version: 1.8",
                 "Native Controller: false",
                 "Extended Plugins: []",
-                " * Classname: org.fake2"
+                " * Classname: org.fake2",
+                "Folder name: fake_plugin2"
             ),
             terminal.getOutput()
         );

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/ListPluginsCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/ListPluginsCommandTests.java
@@ -124,6 +124,8 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
             "1.8",
             "classname",
             classname,
+            "folderName",
+            "custom-folder",
             "has.native.controller",
             Boolean.toString(hasNativeController)
         );
@@ -170,7 +172,7 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
                 "Native Controller: false",
                 "Extended Plugins: []",
                 " * Classname: org.fake",
-                "Folder name: fake_plugin"
+                "Folder name: custom-folder"
             ),
             terminal.getOutput()
         );
@@ -193,7 +195,7 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
                 "Native Controller: true",
                 "Extended Plugins: []",
                 " * Classname: org.fake",
-                "Folder name: fake_plugin1"
+                "Folder name: custom-folder"
             ),
             terminal.getOutput()
         );
@@ -217,7 +219,7 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
                 "Native Controller: false",
                 "Extended Plugins: []",
                 " * Classname: org.fake",
-                "Folder name: fake_plugin1",
+                "Folder name: custom-folder",
                 "fake_plugin2",
                 "- Plugin information:",
                 "Name: fake_plugin2",
@@ -228,7 +230,7 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
                 "Native Controller: false",
                 "Extended Plugins: []",
                 " * Classname: org.fake2",
-                "Folder name: fake_plugin2"
+                "Folder name: custom-folder"
             ),
             terminal.getOutput()
         );

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/RemovePluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/RemovePluginCommandTests.java
@@ -157,7 +157,7 @@ public class RemovePluginCommandTests extends OpenSearchTestCase {
     }
 
     public void testRemovePluginWithCustomFolderName() throws Exception {
-        createPlugin("fake", "folderName", "custom-folder");
+        createPlugin("fake", "custom.foldername", "custom-folder");
         Files.createFile(env.pluginsFile().resolve("custom-folder").resolve("plugin.jar"));
         Files.createDirectory(env.pluginsFile().resolve("custom-folder").resolve("subdir"));
         createPlugin("other");
@@ -274,6 +274,7 @@ public class RemovePluginCommandTests extends OpenSearchTestCase {
             BufferedReader reader = new BufferedReader(new StringReader(terminal.getOutput()));
             BufferedReader errorReader = new BufferedReader(new StringReader(terminal.getErrorOutput()))
         ) {
+            assertEquals("searching in other folders to find if plugin exists with custom folder name", reader.readLine());
             assertEquals("-> removing [fake]...", reader.readLine());
             assertEquals(
                 "ERROR: plugin [fake] not found; run 'opensearch-plugin list' to get list of installed plugins",

--- a/server/src/main/java/org/opensearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginInfo.java
@@ -150,7 +150,11 @@ public class PluginInfo implements Writeable, ToXContentObject {
         }
         out.writeString(classname);
         if (out.getVersion().after(Version.V_1_0_0)) {
-            out.writeString(folderName);
+            if (folderName != null) {
+                out.writeString(folderName);
+            } else {
+                out.writeString(name);
+            }
         }
         if (out.getVersion().onOrAfter(LegacyESVersion.V_6_2_0)) {
             out.writeStringCollection(extendedPlugins);

--- a/server/src/main/java/org/opensearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginInfo.java
@@ -69,7 +69,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
     private final Version opensearchVersion;
     private final String javaVersion;
     private final String classname;
-    private final String folderName;
+    private final String customFolderName;
     private final List<String> extendedPlugins;
     private final boolean hasNativeController;
 
@@ -82,19 +82,19 @@ public class PluginInfo implements Writeable, ToXContentObject {
      * @param opensearchVersion     the version of OpenSearch the plugin was built for
      * @param javaVersion           the version of Java the plugin was built with
      * @param classname             the entry point to the plugin
-     * @param folderName            the custom folder name for the plugin
+     * @param customFolderName      the custom folder name for the plugin
      * @param extendedPlugins       other plugins this plugin extends through SPI
      * @param hasNativeController   whether or not the plugin has a native controller
      */
     public PluginInfo(String name, String description, String version, Version opensearchVersion, String javaVersion,
-                      String classname, String folderName, List<String> extendedPlugins, boolean hasNativeController) {
+                      String classname, String customFolderName, List<String> extendedPlugins, boolean hasNativeController) {
         this.name = name;
         this.description = description;
         this.version = version;
         this.opensearchVersion = opensearchVersion;
         this.javaVersion = javaVersion;
         this.classname = classname;
-        this.folderName = folderName;
+        this.customFolderName = customFolderName;
         this.extendedPlugins = Collections.unmodifiableList(extendedPlugins);
         this.hasNativeController = hasNativeController;
     }
@@ -120,9 +120,9 @@ public class PluginInfo implements Writeable, ToXContentObject {
         }
         this.classname = in.readString();
         if (in.getVersion().after(Version.V_1_0_0)) {
-            folderName = in.readString();
+            customFolderName = in.readString();
         } else {
-            folderName = this.name;
+            customFolderName = this.name;
         }
         if (in.getVersion().onOrAfter(LegacyESVersion.V_6_2_0)) {
             extendedPlugins = in.readStringList();
@@ -150,8 +150,8 @@ public class PluginInfo implements Writeable, ToXContentObject {
         }
         out.writeString(classname);
         if (out.getVersion().after(Version.V_1_0_0)) {
-            if (folderName != null) {
-                out.writeString(folderName);
+            if (customFolderName != null) {
+                out.writeString(customFolderName);
             } else {
                 out.writeString(name);
             }
@@ -222,12 +222,12 @@ public class PluginInfo implements Writeable, ToXContentObject {
                     "property [classname] is missing for plugin [" + name + "]");
         }
 
-        final String folderNameValue = propsMap.remove("folderName");
-        final String folderName;
+        final String customFolderNameValue = propsMap.remove("custom.foldername");
+        final String customFolderName;
         if (esVersion.after(Version.V_1_0_0)) {
-            folderName = folderNameValue;
+            customFolderName = customFolderNameValue;
         } else {
-            folderName = name;
+            customFolderName = name;
         }
 
         final String extendedString = propsMap.remove("extended.plugins");
@@ -271,7 +271,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
         }
 
         return new PluginInfo(name, description, version, esVersion, javaVersionString,
-                              classname, folderName, extendedPlugins, hasNativeController);
+                              classname, customFolderName, extendedPlugins, hasNativeController);
     }
 
     /**
@@ -307,7 +307,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
      * @return the custom folder name for the plugin
      */
     public String getFolderName() {
-        return folderName;
+        return customFolderName;
     }
 
     /**
@@ -361,7 +361,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
      * @return the custom folder name for the plugin if the folder name is specified, else return the id with kebab-case.
      */
     public String getTargetFolderName() {
-        return (this.folderName == null || this.folderName.isEmpty()) ? this.name : this.folderName;
+        return (this.customFolderName == null || this.customFolderName.isEmpty()) ? this.name : this.customFolderName;
     }
 
     @Override
@@ -374,7 +374,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
             builder.field("java_version", javaVersion);
             builder.field("description", description);
             builder.field("classname", classname);
-            builder.field("folderName", folderName);
+            builder.field("custom_foldername", customFolderName);
             builder.field("extended_plugins", extendedPlugins);
             builder.field("has_native_controller", hasNativeController);
         }
@@ -418,7 +418,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
             .append(prefix).append("Native Controller: ").append(hasNativeController).append("\n")
             .append(prefix).append("Extended Plugins: ").append(extendedPlugins).append("\n")
             .append(prefix).append(" * Classname: ").append(classname).append("\n")
-            .append(prefix).append("Folder name: ").append(folderName);
+            .append(prefix).append("Folder name: ").append(customFolderName);
         return information.toString();
     }
 }

--- a/server/src/main/java/org/opensearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginInfo.java
@@ -69,6 +69,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
     private final Version opensearchVersion;
     private final String javaVersion;
     private final String classname;
+    private final String folderName;
     private final List<String> extendedPlugins;
     private final boolean hasNativeController;
 
@@ -81,17 +82,19 @@ public class PluginInfo implements Writeable, ToXContentObject {
      * @param opensearchVersion     the version of OpenSearch the plugin was built for
      * @param javaVersion           the version of Java the plugin was built with
      * @param classname             the entry point to the plugin
+     * @param folderName            the custom folder name for the plugin
      * @param extendedPlugins       other plugins this plugin extends through SPI
      * @param hasNativeController   whether or not the plugin has a native controller
      */
     public PluginInfo(String name, String description, String version, Version opensearchVersion, String javaVersion,
-                      String classname, List<String> extendedPlugins, boolean hasNativeController) {
+                      String classname, String folderName, List<String> extendedPlugins, boolean hasNativeController) {
         this.name = name;
         this.description = description;
         this.version = version;
         this.opensearchVersion = opensearchVersion;
         this.javaVersion = javaVersion;
         this.classname = classname;
+        this.folderName = folderName;
         this.extendedPlugins = Collections.unmodifiableList(extendedPlugins);
         this.hasNativeController = hasNativeController;
     }
@@ -116,6 +119,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
             javaVersion = "1.8";
         }
         this.classname = in.readString();
+        this.folderName = in.readString();
         if (in.getVersion().onOrAfter(LegacyESVersion.V_6_2_0)) {
             extendedPlugins = in.readStringList();
         } else {
@@ -207,6 +211,8 @@ public class PluginInfo implements Writeable, ToXContentObject {
                     "property [classname] is missing for plugin [" + name + "]");
         }
 
+        final String folderName = propsMap.remove("folderName");
+
         final String extendedString = propsMap.remove("extended.plugins");
         final List<String> extendedPlugins;
         if (extendedString == null) {
@@ -248,7 +254,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
         }
 
         return new PluginInfo(name, description, version, esVersion, javaVersionString,
-                              classname, extendedPlugins, hasNativeController);
+                              classname, folderName, extendedPlugins, hasNativeController);
     }
 
     /**
@@ -276,6 +282,15 @@ public class PluginInfo implements Writeable, ToXContentObject {
      */
     public String getClassname() {
         return classname;
+    }
+
+    /**
+     * The custom folder name for the plugin.
+     *
+     * @return the custom folder name for the plugin
+     */
+    public String getFolderName() {
+        return folderName;
     }
 
     /**
@@ -321,6 +336,15 @@ public class PluginInfo implements Writeable, ToXContentObject {
      */
     public boolean hasNativeController() {
         return hasNativeController;
+    }
+
+    /**
+     * The target folder name for the plugin.
+     *
+     * @return the custom folder name for the plugin if the folder name is specified, else return the id with kebab-case.
+     */
+    public String getTargetFolderName() {
+        return (this.folderName == null || this.folderName.isEmpty()) ? this.name : this.folderName;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -136,7 +136,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         for (Class<? extends Plugin> pluginClass : classpathPlugins) {
             Plugin plugin = loadPlugin(pluginClass, settings, configPath);
             PluginInfo pluginInfo = new PluginInfo(pluginClass.getName(), "classpath plugin", "NA", Version.CURRENT, "1.8",
-                                                   pluginClass.getName(), Collections.emptyList(), false);
+                                                   pluginClass.getName(), null, Collections.emptyList(), false);
             if (logger.isTraceEnabled()) {
                 logger.trace("plugin loaded from classpath [{}]", pluginInfo);
             }

--- a/server/src/test/java/org/opensearch/nodesinfo/NodeInfoStreamingTests.java
+++ b/server/src/test/java/org/opensearch/nodesinfo/NodeInfoStreamingTests.java
@@ -161,14 +161,14 @@ public class NodeInfoStreamingTests extends OpenSearchTestCase {
             for (int i = 0; i < numPlugins; i++) {
                 plugins.add(new PluginInfo(randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10),
                     randomAlphaOfLengthBetween(3, 10), VersionUtils.randomVersion(random()), "1.8",
-                    randomAlphaOfLengthBetween(3, 10), Collections.emptyList(), randomBoolean()));
+                    randomAlphaOfLengthBetween(3, 10), null, Collections.emptyList(), randomBoolean()));
             }
             int numModules = randomIntBetween(0, 5);
             List<PluginInfo> modules = new ArrayList<>();
             for (int i = 0; i < numModules; i++) {
                 modules.add(new PluginInfo(randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10),
                     randomAlphaOfLengthBetween(3, 10), VersionUtils.randomVersion(random()), "1.8",
-                    randomAlphaOfLengthBetween(3, 10), Collections.emptyList(), randomBoolean()));
+                    randomAlphaOfLengthBetween(3, 10), null, Collections.emptyList(), randomBoolean()));
             }
             pluginsAndModules = new PluginsAndModules(plugins, modules);
         }

--- a/server/src/test/java/org/opensearch/nodesinfo/NodeInfoStreamingTests.java
+++ b/server/src/test/java/org/opensearch/nodesinfo/NodeInfoStreamingTests.java
@@ -159,16 +159,18 @@ public class NodeInfoStreamingTests extends OpenSearchTestCase {
             int numPlugins = randomIntBetween(0, 5);
             List<PluginInfo> plugins = new ArrayList<>();
             for (int i = 0; i < numPlugins; i++) {
-                plugins.add(new PluginInfo(randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10),
+                String name = randomAlphaOfLengthBetween(3, 10);
+                plugins.add(new PluginInfo(name, randomAlphaOfLengthBetween(3, 10),
                     randomAlphaOfLengthBetween(3, 10), VersionUtils.randomVersion(random()), "1.8",
-                    randomAlphaOfLengthBetween(3, 10), null, Collections.emptyList(), randomBoolean()));
+                    randomAlphaOfLengthBetween(3, 10), name, Collections.emptyList(), randomBoolean()));
             }
             int numModules = randomIntBetween(0, 5);
             List<PluginInfo> modules = new ArrayList<>();
             for (int i = 0; i < numModules; i++) {
-                modules.add(new PluginInfo(randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10),
+                String name = randomAlphaOfLengthBetween(3, 10); 
+                modules.add(new PluginInfo(name, randomAlphaOfLengthBetween(3, 10),
                     randomAlphaOfLengthBetween(3, 10), VersionUtils.randomVersion(random()), "1.8",
-                    randomAlphaOfLengthBetween(3, 10), null, Collections.emptyList(), randomBoolean()));
+                    randomAlphaOfLengthBetween(3, 10), name, Collections.emptyList(), randomBoolean()));
             }
             pluginsAndModules = new PluginsAndModules(plugins, modules);
         }

--- a/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
@@ -79,7 +79,7 @@ public class PluginInfoTests extends OpenSearchTestCase {
             "opensearch.version", Version.V_1_0_0.toString(),
             "java.version", System.getProperty("java.specification.version"),
             "classname", "FakePlugin",
-            "folderName", "custom-folder");
+            "custom.foldername", "custom-folder");
         PluginInfo info = PluginInfo.readFromProperties(pluginDir);
         assertEquals("my_plugin", info.getName());
         assertEquals("fake desc", info.getDescription());
@@ -98,7 +98,7 @@ public class PluginInfoTests extends OpenSearchTestCase {
             "opensearch.version", Version.CURRENT.toString(),
             "java.version", System.getProperty("java.specification.version"),
             "classname", "FakePlugin",
-            "folderName", "custom-folder");
+            "custom.foldername", "custom-folder");
         PluginInfo info = PluginInfo.readFromProperties(pluginDir);
         assertEquals("my_plugin", info.getName());
         assertEquals("fake desc", info.getDescription());

--- a/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
@@ -76,7 +76,7 @@ public class PluginInfoTests extends OpenSearchTestCase {
             "description", "fake desc",
             "name", "my_plugin",
             "version", "1.0",
-            "opensearch.version", Version.CURRENT.toString(),
+            "opensearch.version", Version.V_1_0_0.toString(),
             "java.version", System.getProperty("java.specification.version"),
             "classname", "FakePlugin",
             "folderName", "custom-folder");
@@ -95,7 +95,7 @@ public class PluginInfoTests extends OpenSearchTestCase {
             "description", "fake desc",
             "name", "my_plugin",
             "version", "1.0",
-            "opensearch.version", Version.fromString("1.1.0").toString(),
+            "opensearch.version", Version.CURRENT.toString(),
             "java.version", System.getProperty("java.specification.version"),
             "classname", "FakePlugin",
             "folderName", "custom-folder");

--- a/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
@@ -70,6 +70,25 @@ public class PluginInfoTests extends OpenSearchTestCase {
         assertThat(info.getExtendedPlugins(), empty());
     }
 
+    public void testReadFromPropertiesWithFolderName() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(pluginDir,
+            "description", "fake desc",
+            "name", "my_plugin",
+            "version", "1.0",
+            "opensearch.version", Version.CURRENT.toString(),
+            "java.version", System.getProperty("java.specification.version"),
+            "classname", "FakePlugin",
+            "folderName", "custom-folder");
+        PluginInfo info = PluginInfo.readFromProperties(pluginDir);
+        assertEquals("my_plugin", info.getName());
+        assertEquals("fake desc", info.getDescription());
+        assertEquals("1.0", info.getVersion());
+        assertEquals("FakePlugin", info.getClassname());
+        assertEquals("custom-folder", info.getTargetFolderName());
+        assertThat(info.getExtendedPlugins(), empty());
+    }
+
     public void testReadFromPropertiesNameMissing() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         PluginTestUtil.writePluginProperties(pluginDir);
@@ -199,7 +218,7 @@ public class PluginInfoTests extends OpenSearchTestCase {
 
     public void testSerialize() throws Exception {
         PluginInfo info = new PluginInfo("c", "foo", "dummy", Version.CURRENT, "1.8", "dummyclass",
-                                         Collections.singletonList("foo"), randomBoolean());
+                                         null, Collections.singletonList("foo"), randomBoolean());
         BytesStreamOutput output = new BytesStreamOutput();
         info.writeTo(output);
         ByteBuffer buffer = ByteBuffer.wrap(output.bytes().toBytesRef().bytes);
@@ -212,15 +231,15 @@ public class PluginInfoTests extends OpenSearchTestCase {
     public void testPluginListSorted() {
         List<PluginInfo> plugins = new ArrayList<>();
         plugins.add(new PluginInfo("c", "foo", "dummy", Version.CURRENT, "1.8", "dummyclass",
-            Collections.emptyList(), randomBoolean()));
+            null, Collections.emptyList(), randomBoolean()));
         plugins.add(new PluginInfo("b", "foo", "dummy", Version.CURRENT, "1.8", "dummyclass",
-            Collections.emptyList(), randomBoolean()));
+            null, Collections.emptyList(), randomBoolean()));
         plugins.add(new PluginInfo( "e", "foo", "dummy", Version.CURRENT, "1.8", "dummyclass",
-            Collections.emptyList(), randomBoolean()));
+            null, Collections.emptyList(), randomBoolean()));
         plugins.add(new PluginInfo("a", "foo", "dummy", Version.CURRENT, "1.8", "dummyclass",
-            Collections.emptyList(), randomBoolean()));
+            null, Collections.emptyList(), randomBoolean()));
         plugins.add(new PluginInfo("d", "foo", "dummy", Version.CURRENT, "1.8", "dummyclass",
-            Collections.emptyList(), randomBoolean()));
+            null, Collections.emptyList(), randomBoolean()));
         PluginsAndModules pluginsInfo = new PluginsAndModules(plugins, Collections.emptyList());
 
         final List<PluginInfo> infos = pluginsInfo.getPluginInfos();

--- a/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
@@ -70,13 +70,32 @@ public class PluginInfoTests extends OpenSearchTestCase {
         assertThat(info.getExtendedPlugins(), empty());
     }
 
-    public void testReadFromPropertiesWithFolderName() throws Exception {
+    public void testReadFromPropertiesWithFolderNameAndVersionBefore() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         PluginTestUtil.writePluginProperties(pluginDir,
             "description", "fake desc",
             "name", "my_plugin",
             "version", "1.0",
             "opensearch.version", Version.CURRENT.toString(),
+            "java.version", System.getProperty("java.specification.version"),
+            "classname", "FakePlugin",
+            "folderName", "custom-folder");
+        PluginInfo info = PluginInfo.readFromProperties(pluginDir);
+        assertEquals("my_plugin", info.getName());
+        assertEquals("fake desc", info.getDescription());
+        assertEquals("1.0", info.getVersion());
+        assertEquals("FakePlugin", info.getClassname());
+        assertEquals("my_plugin", info.getTargetFolderName());
+        assertThat(info.getExtendedPlugins(), empty());
+    }
+
+    public void testReadFromPropertiesWithFolderNameAndVersionAfter() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(pluginDir,
+            "description", "fake desc",
+            "name", "my_plugin",
+            "version", "1.0",
+            "opensearch.version", Version.fromString("1.1.0").toString(),
             "java.version", System.getProperty("java.specification.version"),
             "classname", "FakePlugin",
             "folderName", "custom-folder");
@@ -218,7 +237,7 @@ public class PluginInfoTests extends OpenSearchTestCase {
 
     public void testSerialize() throws Exception {
         PluginInfo info = new PluginInfo("c", "foo", "dummy", Version.CURRENT, "1.8", "dummyclass",
-                                         null, Collections.singletonList("foo"), randomBoolean());
+                                         "c", Collections.singletonList("foo"), randomBoolean());
         BytesStreamOutput output = new BytesStreamOutput();
         info.writeTo(output);
         ByteBuffer buffer = ByteBuffer.wrap(output.bytes().toBytesRef().bytes);

--- a/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
@@ -323,7 +323,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
     public void testSortBundlesCycleSelfReference() throws Exception {
         Path pluginDir = createTempDir();
         PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("foo"), false);
+            "MyPlugin", null, Collections.singletonList("foo"), false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
         IllegalStateException e = expectThrows(IllegalStateException.class, () ->
             PluginsService.sortBundles(Collections.singleton(bundle))
@@ -335,16 +335,16 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order, so we get know the beginning of the cycle
         PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Arrays.asList("bar", "other"), false);
+            "MyPlugin", null, Arrays.asList("bar", "other"), false);
         bundles.add(new PluginsService.Bundle(info, pluginDir));
         PluginInfo info2 = new PluginInfo("bar", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("baz"), false);
+            "MyPlugin", null, Collections.singletonList("baz"), false);
         bundles.add(new PluginsService.Bundle(info2, pluginDir));
         PluginInfo info3 = new PluginInfo("baz", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("foo"), false);
+            "MyPlugin", null, Collections.singletonList("foo"), false);
         bundles.add(new PluginsService.Bundle(info3, pluginDir));
         PluginInfo info4 = new PluginInfo("other", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.emptyList(), false);
+            "MyPlugin", null, Collections.emptyList(), false);
         bundles.add(new PluginsService.Bundle(info4, pluginDir));
 
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> PluginsService.sortBundles(bundles));
@@ -354,7 +354,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
     public void testSortBundlesSingle() throws Exception {
         Path pluginDir = createTempDir();
         PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.emptyList(), false);
+            "MyPlugin", null, Collections.emptyList(), false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
         List<PluginsService.Bundle> sortedBundles = PluginsService.sortBundles(Collections.singleton(bundle));
         assertThat(sortedBundles, Matchers.contains(bundle));
@@ -364,15 +364,15 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
         PluginInfo info1 = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.emptyList(), false);
+            "MyPlugin", null, Collections.emptyList(), false);
         PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
         bundles.add(bundle1);
         PluginInfo info2 = new PluginInfo("bar", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.emptyList(), false);
+            "MyPlugin", null, Collections.emptyList(), false);
         PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
         bundles.add(bundle2);
         PluginInfo info3 = new PluginInfo("baz", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.emptyList(), false);
+            "MyPlugin", null, Collections.emptyList(), false);
         PluginsService.Bundle bundle3 = new PluginsService.Bundle(info3, pluginDir);
         bundles.add(bundle3);
         List<PluginsService.Bundle> sortedBundles = PluginsService.sortBundles(bundles);
@@ -382,7 +382,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
     public void testSortBundlesMissingDep() throws Exception {
         Path pluginDir = createTempDir();
         PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("dne"), false);
+            "MyPlugin", "", Collections.singletonList("dne"), false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
             PluginsService.sortBundles(Collections.singleton(bundle))
@@ -394,19 +394,19 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
         PluginInfo info1 = new PluginInfo("grandparent", "desc", "1.0",Version.CURRENT, "1.8",
-            "MyPlugin", Collections.emptyList(), false);
+            "MyPlugin", null, Collections.emptyList(), false);
         PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
         bundles.add(bundle1);
         PluginInfo info2 = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("common"), false);
+            "MyPlugin", null, Collections.singletonList("common"), false);
         PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
         bundles.add(bundle2);
         PluginInfo info3 = new PluginInfo("bar", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("common"), false);
+            "MyPlugin", null, Collections.singletonList("common"), false);
         PluginsService.Bundle bundle3 = new PluginsService.Bundle(info3, pluginDir);
         bundles.add(bundle3);
         PluginInfo info4 = new PluginInfo("common", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("grandparent"), false);
+            "MyPlugin", null, Collections.singletonList("grandparent"), false);
         PluginsService.Bundle bundle4 = new PluginsService.Bundle(info4, pluginDir);
         bundles.add(bundle4);
         List<PluginsService.Bundle> sortedBundles = PluginsService.sortBundles(bundles);
@@ -417,11 +417,11 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
         PluginInfo info1 = new PluginInfo("dep", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.emptyList(), false);
+            "MyPlugin", null, Collections.emptyList(), false);
         PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
         bundles.add(bundle1);
         PluginInfo info2 = new PluginInfo("myplugin", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("dep"), false);
+            "MyPlugin", null, Collections.singletonList("dep"), false);
         PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
         bundles.add(bundle2);
         List<PluginsService.Bundle> sortedBundles = PluginsService.sortBundles(bundles);
@@ -480,7 +480,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
         transitiveDeps.put("dep", Collections.singleton(dupJar.toUri().toURL()));
         PluginInfo info1 = new PluginInfo("myplugin", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("dep"), false);
+            "MyPlugin", null, Collections.singletonList("dep"), false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
         IllegalStateException e = expectThrows(IllegalStateException.class, () ->
             PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps));
@@ -499,7 +499,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         transitiveDeps.put("dep1", Collections.singleton(dupJar.toUri().toURL()));
         transitiveDeps.put("dep2", Collections.singleton(dupJar.toUri().toURL()));
         PluginInfo info1 = new PluginInfo("myplugin", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Arrays.asList("dep1", "dep2"), false);
+            "MyPlugin", null, Arrays.asList("dep1", "dep2"), false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
         IllegalStateException e = expectThrows(IllegalStateException.class, () ->
             PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps));
@@ -516,7 +516,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         Path pluginJar = pluginDir.resolve("plugin.jar");
         makeJar(pluginJar, Level.class);
         PluginInfo info1 = new PluginInfo("myplugin", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.emptyList(), false);
+            "MyPlugin", null, Collections.emptyList(), false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
         IllegalStateException e = expectThrows(IllegalStateException.class, () ->
             PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, new HashMap<>()));
@@ -535,7 +535,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
         transitiveDeps.put("dep", Collections.singleton(depJar.toUri().toURL()));
         PluginInfo info1 = new PluginInfo("myplugin", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Collections.singletonList("dep"), false);
+            "MyPlugin", null, Collections.singletonList("dep"), false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
         IllegalStateException e = expectThrows(IllegalStateException.class, () ->
             PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps));
@@ -558,7 +558,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         transitiveDeps.put("dep1", Collections.singleton(dep1Jar.toUri().toURL()));
         transitiveDeps.put("dep2", Collections.singleton(dep2Jar.toUri().toURL()));
         PluginInfo info1 = new PluginInfo("myplugin", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Arrays.asList("dep1", "dep2"), false);
+            "MyPlugin", null, Arrays.asList("dep1", "dep2"), false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
         IllegalStateException e = expectThrows(IllegalStateException.class, () ->
             PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps));
@@ -581,7 +581,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         transitiveDeps.put("dep1", Collections.singleton(dep1Jar.toUri().toURL()));
         transitiveDeps.put("dep2", Collections.singleton(dep2Jar.toUri().toURL()));
         PluginInfo info1 = new PluginInfo("myplugin", "desc", "1.0", Version.CURRENT, "1.8",
-            "MyPlugin", Arrays.asList("dep1", "dep2"), false);
+            "MyPlugin", null, Arrays.asList("dep1", "dep2"), false);
         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
         PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps);
         Set<URL> deps = transitiveDeps.get("myplugin");
@@ -630,14 +630,14 @@ public class PluginsServiceTests extends OpenSearchTestCase {
 
     public void testIncompatibleOpenSearchVersion() throws Exception {
         PluginInfo info = new PluginInfo("my_plugin", "desc", "1.0", LegacyESVersion.V_6_0_0,
-            "1.8", "FakePlugin", Collections.emptyList(), false);
+            "1.8", "FakePlugin", null, Collections.emptyList(), false);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginsService.verifyCompatibility(info));
         assertThat(e.getMessage(), containsString("was built for OpenSearch version 6.0.0"));
     }
 
     public void testIncompatibleJavaVersion() throws Exception {
         PluginInfo info = new PluginInfo("my_plugin", "desc", "1.0", Version.CURRENT,
-            "1000000.0", "FakePlugin", Collections.emptyList(), false);
+            "1000000.0", "FakePlugin", null, Collections.emptyList(), false);
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> PluginsService.verifyCompatibility(info));
         assertThat(e.getMessage(), containsString("my_plugin requires Java"));
     }
@@ -761,7 +761,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
     public void testExtensiblePlugin() {
         TestExtensiblePlugin extensiblePlugin = new TestExtensiblePlugin();
         PluginsService.loadExtensions(Collections.singletonList(
-            Tuple.tuple(new PluginInfo("extensible", null, null, null, null, null, Collections.emptyList(), false), extensiblePlugin)
+            Tuple.tuple(new PluginInfo("extensible", null, null, null, null, null, null, Collections.emptyList(), false), extensiblePlugin)
         ));
 
         assertThat(extensiblePlugin.extensions, notNullValue());
@@ -770,8 +770,9 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         extensiblePlugin = new TestExtensiblePlugin();
         TestPlugin testPlugin = new TestPlugin();
         PluginsService.loadExtensions(Arrays.asList(
-            Tuple.tuple(new PluginInfo("extensible", null, null, null, null, null, Collections.emptyList(), false), extensiblePlugin),
-            Tuple.tuple(new PluginInfo("test", null, null, null, null, null, Collections.singletonList("extensible"), false), testPlugin)
+            Tuple.tuple(new PluginInfo("extensible", null, null, null, null, null, null, Collections.emptyList(), false), extensiblePlugin),
+            Tuple.tuple(new PluginInfo("test", null, null, null, null, null, null, Collections.singletonList("extensible"), false), 
+              testPlugin)
         ));
 
         assertThat(extensiblePlugin.extensions, notNullValue());


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
This PR allows the user to add a custom folder name for plugin cli installation. This custom folder name can be specified in the plugin properties file for the plugin, when this property is specified, the plugin would be installed with the custom folder name otherwise it will be installed with the name of the plugin. This feature would be available for versions after 1.0.0. 

The feature includes:
1. Support for custom folder name for plugin installation after 1.0.0 versions with backwards compatibility.
2. The `install` plugin command will display the folder name where the plugin is being installed.
3. The `list` plugin command will continue to display the plugin name to maintain backwards compatibility.
4. The `remove` plugin command will continue to take in the plugin name to remove it even though the plugin is installed in a custom folder to maintain backwards compatibility.
5. During installation or removal, when checking if a plugin already exists, any folder previously installed with the plugin name or custom name would be determined.

### Testing
* For manual testing, I added the `customFolderName` property in [`build.gradle`](https://github.com/opensearch-project/job-scheduler/blob/main/build.gradle#L73) for `job-scheduler` plugin as follows: 
```
opensearchplugin {    
  name 'opensearch-job-scheduler'    
  description 'OpenSearch Job Scheduler plugin'    
  classname 'org.opensearch.jobscheduler.JobSchedulerPlugin'
  customFolderName 'custom-folder'
}
```
1. When installing the plugin with the above properties using `./opensearch-plugin install <path to build file>`, this resulted in the plugin being installed in folder: `custom-folder` with an output message as follows:
```
-> Installed opensearch-job-scheduler with folder name custom-folder
```
2. When the plugins are being listed using `./opensearch-plugin list`, this resulted in the output: `opensearch-job-scheduler`.
3. To remove the plugin, I used `./opensearch-plugin remove opensearch-job-scheduler`.

### Issues Resolved
#686 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
