### PR TITLE
Verbose plugin not found exception

### DIFF
--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -42,7 +42,6 @@ import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.util.SPIClassIterator;
 import org.opensearch.Build;
-import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.opensearch.bootstrap.JarHell;
@@ -662,6 +661,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
                 return null;
             });
 
+            logger.debug("Loading plugin [" + name + "]");
             Class<? extends Plugin> pluginClass = loadPluginClass(bundle.plugin.getClassname(), loader);
             if (loader != pluginClass.getClassLoader()) {
                 throw new IllegalStateException("Plugin [" + name + "] must reference a class loader local Plugin class ["
@@ -700,8 +700,8 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
     private Class<? extends Plugin> loadPluginClass(String className, ClassLoader loader) {
         try {
             return Class.forName(className, false, loader).asSubclass(Plugin.class);
-        } catch (ClassNotFoundException | NoClassDefFoundError e) {
-            throw new OpenSearchException("Could not find plugin class [" + className + "]", e);
+        } catch (Throwable t) {
+            throw new RuntimeException("Unable to load plugin class [" + className + "]", t);
         }
     }
 

--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -42,6 +42,7 @@ import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.util.SPIClassIterator;
 import org.opensearch.Build;
+import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.opensearch.bootstrap.JarHell;
@@ -701,7 +702,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         try {
             return Class.forName(className, false, loader).asSubclass(Plugin.class);
         } catch (Throwable t) {
-            throw new RuntimeException("Unable to load plugin class [" + className + "]", t);
+            throw new OpenSearchException("Unable to load plugin class [" + className + "]", t);
         }
     }
 

--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -662,7 +662,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
                 return null;
             });
 
-            logger.debug("Loading plugin [" + name + "]");
+            logger.debug("Loading plugin [" + name + "]...");
             Class<? extends Plugin> pluginClass = loadPluginClass(bundle.plugin.getClassname(), loader);
             if (loader != pluginClass.getClassLoader()) {
                 throw new IllegalStateException("Plugin [" + name + "] must reference a class loader local Plugin class ["

--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -700,7 +700,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
     private Class<? extends Plugin> loadPluginClass(String className, ClassLoader loader) {
         try {
             return Class.forName(className, false, loader).asSubclass(Plugin.class);
-        } catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException | NoClassDefFoundError e) {
             throw new OpenSearchException("Could not find plugin class [" + className + "]", e);
         }
     }


### PR DESCRIPTION
### Description
Add Plugin Name to make class loading errors more verbose.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/824
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
