### PR TITLE
Add URL for lucene snapshots

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/RepositoriesSetupPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/RepositoriesSetupPlugin.java
@@ -95,7 +95,7 @@ public class RepositoriesSetupPlugin implements Plugin<Project> {
             // TODO(cleanup) - Setup own lucene snapshot repo
             MavenArtifactRepository luceneRepo = repos.maven(repo -> {
                 repo.setName("lucene-snapshots");
-                repo.setUrl("https://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/" + revision);
+                repo.setUrl("https://artifacts.opensearch.org/snapshots/lucene/");
             });
             repos.exclusiveContent(exclusiveRepo -> {
                 exclusiveRepo.filter(


### PR DESCRIPTION
### Description
Update RepositoriesSetupPlugin to point to opensearch lucene snapshot repo.  This repo not use the commit hash as a top level directory, but it does include it in the artifact name and version.

example: 
https://artifacts.opensearch.org/snapshots/lucene/org/apache/lucene/lucene-spatial-extras/9.0.0-snapshot-803d131fd08/lucene-spatial-extras-9.0.0-snapshot-803d131fd08.pom

To use:
Update version.properties to desired snapshot version, ex.
lucene            = 9.0.0-snapshot-803d131fd08
 
### Issues Resolved
[#607]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
