### PR TITLE
[Backport] [1.x] Fix resource leak issues suggested by Amazon CodeGuru (#816)

### DIFF
--- a/buildSrc/src/integTest/java/org/opensearch/gradle/tar/SymbolicLinkPreservingTarIT.java
+++ b/buildSrc/src/integTest/java/org/opensearch/gradle/tar/SymbolicLinkPreservingTarIT.java
@@ -107,7 +107,10 @@ public class SymbolicLinkPreservingTarIT extends GradleIntegrationTestCase {
 
     private void assertTar(final String extension, final FileInputStreamWrapper wrapper, boolean preserveFileTimestamps)
         throws IOException {
-        try (TarArchiveInputStream tar = new TarArchiveInputStream(wrapper.apply(new FileInputStream(getOutputFile(extension))))) {
+        try (
+            FileInputStream fis = new FileInputStream(getOutputFile(extension));
+            TarArchiveInputStream tar = new TarArchiveInputStream(wrapper.apply(fis))
+        ) {
             TarArchiveEntry entry = tar.getNextTarEntry();
             boolean realFolderEntry = false;
             boolean fileEntry = false;

--- a/buildSrc/src/main/java/org/opensearch/gradle/VersionProperties.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/VersionProperties.java
@@ -101,11 +101,10 @@ public class VersionProperties {
 
     private static Properties getVersionProperties() {
         Properties props = new Properties();
-        InputStream propsStream = VersionProperties.class.getResourceAsStream("/version.properties");
-        if (propsStream == null) {
-            throw new IllegalStateException("/version.properties resource missing");
-        }
-        try {
+        try (InputStream propsStream = VersionProperties.class.getResourceAsStream("/version.properties")) {
+            if (propsStream == null) {
+                throw new IllegalStateException("/version.properties resource missing");
+            }
             props.load(propsStream);
         } catch (IOException e) {
             throw new IllegalStateException("Failed to load version properties", e);

--- a/buildSrc/src/main/java/org/opensearch/gradle/precommit/LicenseAnalyzer.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/precommit/LicenseAnalyzer.java
@@ -209,8 +209,8 @@ public class LicenseAnalyzer {
         }
 
         public boolean matches(File licenseFile) {
-            try {
-                String content = String.join("\n", IOUtils.readLines(new FileInputStream(licenseFile), "UTF-8")).replaceAll("\\*", " ");
+            try (FileInputStream fis = new FileInputStream(licenseFile)) {
+                String content = String.join("\n", IOUtils.readLines(fis, "UTF-8")).replaceAll("\\*", " ");
                 return pattern.matcher(content).find();
             } catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/modules/lang-painless/src/main/java/org/opensearch/painless/api/Json.java
+++ b/modules/lang-painless/src/main/java/org/opensearch/painless/api/Json.java
@@ -39,6 +39,7 @@ import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.io.OutputStream;
 
 public class Json {
     /**
@@ -83,6 +84,8 @@ public class Json {
         }
         builder.value(data);
         builder.flush();
-        return builder.getOutputStream().toString();
+        try (OutputStream out = builder.getOutputStream()) {
+            return out.toString();
+        }
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoFilterIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoFilterIT.java
@@ -115,19 +115,20 @@ public class GeoFilterIT extends OpenSearchIntegTestCase {
     }
 
     private static byte[] unZipData(String path) throws IOException {
-        InputStream is = Streams.class.getResourceAsStream(path);
-        if (is == null) {
-            throw new FileNotFoundException("Resource [" + path + "] not found in classpath");
+        try (InputStream is = Streams.class.getResourceAsStream(path)) {
+            if (is == null) {
+                throw new FileNotFoundException("Resource [" + path + "] not found in classpath");
+            }
+
+            try (
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                GZIPInputStream in = new GZIPInputStream(is)
+            ) {
+                Streams.copy(in, out);
+
+                return out.toByteArray();
+            }
         }
-
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        GZIPInputStream in = new GZIPInputStream(is);
-        Streams.copy(in, out);
-
-        is.close();
-        out.close();
-
-        return out.toByteArray();
     }
 
     public void testShapeBuilders() {

--- a/server/src/internalClusterTest/java/org/opensearch/versioning/ConcurrentSeqNoVersioningIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/versioning/ConcurrentSeqNoVersioningIT.java
@@ -729,7 +729,9 @@ public class ConcurrentSeqNoVersioningIT extends AbstractDisruptionTestCase {
         if (args.length < 3) {
             System.err.println("usage: <file> <primaryTerm> <seqNo>");
         } else {
-            runLinearizabilityChecker(new FileInputStream(args[0]), Long.parseLong(args[1]), Long.parseLong(args[2]));
+            try (FileInputStream fis = new FileInputStream(args[0])) {
+                runLinearizabilityChecker(fis, Long.parseLong(args[1]), Long.parseLong(args[2]));
+            }
         }
     }
 


### PR DESCRIPTION
### Description
Backport #816 to `1.x` branch:

* Address resource leak issue suggested by Amazon CodeGuru Reviewer:

* Add try-with-resources block to automatically close the resources after using to avoid resource leak, in `SymbolicLinkPreservingTarIT`, `LicenseAnalyzer`, `SymbolicLinkPreservingUntarTransform`, `ConcurrentSeqNoVersioningIT` in `VersionProperties`, `GeoFilterIT`, `XContentHelper`,  `Json` and `IndexShard` class

* Add try-finally block to close the resources after using to avoid resource leak, in `ServerChannelContext` class.

* Add try-catch block to close the resources when exception occurs in `FsBlobContainer` class (when XContentFactory.xContentType throws an exception)

* Close resources when assertion error occurs, in `ServerChannelContext` class.
 
Testing:
`./gradlew check` passed.

### Issues Resolved
None
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
