### PR TITLE
[Backport-1.x] Decouples primaries_recoveries limit from concurrent recoveries limits

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
@@ -63,6 +63,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Queue;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
@@ -96,6 +97,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
 
     private final Map<String, ObjectIntHashMap<String>> nodesPerAttributeNames = new HashMap<>();
     private final Map<String, Recoveries> recoveriesPerNode = new HashMap<>();
+    private final Map<String, Recoveries> primaryRecoveriesPerNode = new HashMap<>();
 
     public RoutingNodes(ClusterState clusterState) {
         this(clusterState, true);
@@ -175,11 +177,19 @@ public class RoutingNodes implements Iterable<RoutingNode> {
     }
 
     private void updateRecoveryCounts(final ShardRouting routing, final boolean increment, @Nullable final ShardRouting primary) {
+
         final int howMany = increment ? 1 : -1;
         assert routing.initializing() : "routing must be initializing: " + routing;
         // TODO: check primary == null || primary.active() after all tests properly add ReplicaAfterPrimaryActiveAllocationDecider
         assert primary == null || primary.assignedToNode() :
             "shard is initializing but its primary is not assigned to a node";
+
+        // Primary shard routing, excluding the relocating primaries.
+        if(routing.primary() && (primary == null || primary == routing)) {
+            assert routing.relocatingNodeId() == null: "Routing must be a non relocating primary";
+            Recoveries.getOrAdd(primaryRecoveriesPerNode, routing.currentNodeId()).addIncoming(howMany);
+            return;
+        }
 
         Recoveries.getOrAdd(recoveriesPerNode, routing.currentNodeId()).addIncoming(howMany);
 
@@ -207,6 +217,10 @@ public class RoutingNodes implements Iterable<RoutingNode> {
 
     public int getIncomingRecoveries(String nodeId) {
         return recoveriesPerNode.getOrDefault(nodeId, Recoveries.EMPTY).getIncoming();
+    }
+
+    public int getInitialPrimariesIncomingRecoveries(String nodeId) {
+        return primaryRecoveriesPerNode.getOrDefault(nodeId, Recoveries.EMPTY).getIncoming();
     }
 
     public int getOutgoingRecoveries(String nodeId) {
@@ -1092,30 +1106,10 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             }
         }
 
-        for (Map.Entry<String, Recoveries> recoveries : routingNodes.recoveriesPerNode.entrySet()) {
-            String node = recoveries.getKey();
-            final Recoveries value = recoveries.getValue();
-            int incoming = 0;
-            int outgoing = 0;
-            RoutingNode routingNode = routingNodes.nodesToShards.get(node);
-            if (routingNode != null) { // node might have dropped out of the cluster
-                for (ShardRouting routing : routingNode) {
-                    if (routing.initializing()) {
-                        incoming++;
-                    }
-                    if (routing.primary() && routing.isRelocationTarget() == false) {
-                        for (ShardRouting assigned : routingNodes.assignedShards.get(routing.shardId())) {
-                            if (assigned.initializing() && assigned.recoverySource().getType() == RecoverySource.Type.PEER) {
-                                outgoing++;
-                            }
-                        }
-                    }
-                }
-            }
-            assert incoming == value.incoming : incoming + " != " + value.incoming + " node: " + routingNode;
-            assert outgoing == value.outgoing : outgoing + " != " + value.outgoing + " node: " + routingNode;
-        }
-
+        assertRecoveriesPerNode(routingNodes, routingNodes.recoveriesPerNode, true,
+            x -> !isNonRelocatingPrimary(x));
+        assertRecoveriesPerNode(routingNodes, routingNodes.primaryRecoveriesPerNode, false,
+            x -> isNonRelocatingPrimary(x));
 
         assert unassignedPrimaryCount == routingNodes.unassignedShards.getNumPrimaries() :
                 "Unassigned primaries is [" + unassignedPrimaryCount + "] but RoutingNodes returned unassigned primaries [" +
@@ -1133,6 +1127,39 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             routingNodes.getRelocatingShardCount() + "] but expected [" + relocating + "]";
 
         return true;
+    }
+
+    private static void assertRecoveriesPerNode(RoutingNodes routingNodes, Map<String, Recoveries> recoveriesPerNode,
+                                                boolean verifyOutgoingRecoveries,
+                                                Function<ShardRouting, Boolean> incomingCountFilter) {
+        for (Map.Entry<String, Recoveries> recoveries : recoveriesPerNode.entrySet()) {
+            String node = recoveries.getKey();
+            final Recoveries value = recoveries.getValue();
+            int incoming = 0;
+            int outgoing = 0;
+            RoutingNode routingNode = routingNodes.nodesToShards.get(node);
+            if (routingNode != null) { // node might have dropped out of the cluster
+                for (ShardRouting routing : routingNode) {
+                    if (routing.initializing() && incomingCountFilter.apply(routing))
+                            incoming++;
+
+                    if (verifyOutgoingRecoveries && routing.primary() && routing.isRelocationTarget() == false) {
+                        for (ShardRouting assigned : routingNodes.assignedShards.get(routing.shardId())) {
+                            if (assigned.initializing() && assigned.recoverySource().getType() == RecoverySource.Type.PEER) {
+                                outgoing++;
+                            }
+                        }
+                    }
+                }
+            }
+
+            assert incoming == value.incoming : incoming + " != " + value.incoming + " node: " + routingNode;
+            assert outgoing == value.outgoing : outgoing + " != " + value.outgoing + " node: " + routingNode;
+        }
+    }
+
+    private static boolean isNonRelocatingPrimary(ShardRouting routing) {
+        return routing.primary() && routing.relocatingNodeId() == null;
     }
 
     private void ensureMutable() {

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/AllocationPriorityTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/AllocationPriorityTests.java
@@ -42,6 +42,9 @@ import org.opensearch.cluster.routing.allocation.AllocationService;
 import org.opensearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
 import org.opensearch.common.settings.Settings;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static org.opensearch.cluster.routing.ShardRoutingState.INITIALIZING;
 
 public class AllocationPriorityTests extends OpenSearchAllocationTestCase {
@@ -95,18 +98,15 @@ public class AllocationPriorityTests extends OpenSearchAllocationTestCase {
         assertEquals(highPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(1).getIndexName());
 
         clusterState = startInitializingShardsAndReroute(allocation, clusterState);
-        assertEquals(2, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size());
-        assertEquals(lowPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(0).getIndexName());
-        assertEquals(lowPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(1).getIndexName());
+        assertEquals(4, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size());
+        List<String> indices = clusterState.getRoutingNodes().shardsWithState(INITIALIZING).stream().
+            map(x->x.getIndexName()).collect(Collectors.toList());
+        assertTrue(indices.contains(lowPriorityName));
+        assertTrue(indices.contains(highPriorityName));
 
         clusterState = startInitializingShardsAndReroute(allocation, clusterState);
         assertEquals(clusterState.getRoutingNodes().shardsWithState(INITIALIZING).toString(),2,
             clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size());
-        assertEquals(highPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(0).getIndexName());
-        assertEquals(highPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(1).getIndexName());
-
-        clusterState = startInitializingShardsAndReroute(allocation, clusterState);
-        assertEquals(2, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size());
         assertEquals(lowPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(0).getIndexName());
         assertEquals(lowPriorityName, clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(1).getIndexName());
 

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/ThrottlingAllocationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/ThrottlingAllocationTests.java
@@ -222,7 +222,8 @@ public class ThrottlingAllocationTests extends OpenSearchAllocationTestCase {
         assertThat(clusterState.routingTable().shardsWithState(STARTED).size(), equalTo(0));
         assertThat(clusterState.routingTable().shardsWithState(INITIALIZING).size(), equalTo(5));
         assertThat(clusterState.routingTable().shardsWithState(UNASSIGNED).size(), equalTo(4));
-        assertEquals(clusterState.getRoutingNodes().getIncomingRecoveries("node1"), 5);
+        assertEquals(clusterState.getRoutingNodes().getInitialPrimariesIncomingRecoveries("node1"), 5);
+        assertEquals(clusterState.getRoutingNodes().getIncomingRecoveries("node1"), 0);
 
         logger.info("start initializing, all primaries should be started");
         clusterState = startInitializingShardsAndReroute(strategy, clusterState);


### PR DESCRIPTION
Backports  (#546) in 1.x

### Description
Node initial primaries recoveries are counted towards total incoming recoveries on a node, which then throttles the replica recoveries into that node. This is incorrect as per the documentation since both limits should be separately counted. This PR attempts to fix this discrepancy by counting the initial primary recoveries separately. As a side effect of this change, I was able to optimize the time taken by ThrottlingAllocationDecider for primary shard allocation decision from the order of total number of initializing primary shards to constant.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
