### PR TITLE
Backport 1.x - Add cluster setting to spoof version number returned from MainResponse (#847)

### DIFF
--- a/client/rest-high-level/src/test/java/org/opensearch/client/PingAndInfoIT.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/PingAndInfoIT.java
@@ -33,6 +33,7 @@
 package org.opensearch.client;
 
 import org.apache.http.client.methods.HttpGet;
+import org.opensearch.action.main.TransportMainAction;
 import org.opensearch.client.core.MainResponse;
 
 import java.io.IOException;
@@ -61,5 +62,26 @@ public class PingAndInfoIT extends OpenSearchRestHighLevelClientTestCase {
         assertEquals(versionMap.get("build_snapshot"), info.getVersion().isSnapshot());
         assertTrue(versionMap.get("number").toString().startsWith(info.getVersion().getNumber()));
         assertEquals(versionMap.get("lucene_version"), info.getVersion().getLuceneVersion());
+    }
+
+    public void testInfo_overrideResponseVersion() throws IOException {
+        Request overrideResponseVersionRequest = new Request("PUT", "/_cluster/settings");
+        overrideResponseVersionRequest.setOptions(expectWarnings(TransportMainAction.OVERRIDE_MAIN_RESPONSE_VERSION_DEPRECATION_MESSAGE));
+        overrideResponseVersionRequest.setJsonEntity("{\"persistent\":{\"compatibility\": {\"override_main_response_version\":true}}}");
+        client().performRequest(overrideResponseVersionRequest);
+
+        MainResponse info = highLevelClient().info(RequestOptions.DEFAULT);
+        assertEquals("7.10.2", info.getVersion().getNumber());
+
+        // Set back to default version.
+        Request resetResponseVersionRequest = new Request("PUT", "/_cluster/settings");
+        resetResponseVersionRequest.setJsonEntity("{\"persistent\":{\"compatibility\": {\"override_main_response_version\":null}}}");
+        client().performRequest(resetResponseVersionRequest);
+
+        Map<String, Object> infoAsMap = entityAsMap(adminClient().performRequest(new Request(HttpGet.METHOD_NAME, "/")));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> versionMap = (Map<String, Object>) infoAsMap.get("version");
+        info = highLevelClient().info(RequestOptions.DEFAULT);
+        assertTrue(versionMap.get("number").toString().startsWith(info.getVersion().getNumber()));
     }
 }

--- a/server/src/main/java/org/opensearch/action/main/MainResponse.java
+++ b/server/src/main/java/org/opensearch/action/main/MainResponse.java
@@ -55,6 +55,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
     private ClusterName clusterName;
     private String clusterUuid;
     private Build build;
+    private String versionNumber;
 
     MainResponse() {}
 
@@ -68,6 +69,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
         if (in.getVersion().before(LegacyESVersion.V_7_0_0)) {
             in.readBoolean();
         }
+        versionNumber = build.getQualifiedVersion();
     }
 
     public MainResponse(String nodeName, Version version, ClusterName clusterName, String clusterUuid, Build build) {
@@ -76,6 +78,17 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
         this.clusterName = clusterName;
         this.clusterUuid = clusterUuid;
         this.build = build;
+        this.versionNumber = build.getQualifiedVersion();
+    }
+
+    public MainResponse(String nodeName, Version version, ClusterName clusterName, String clusterUuid, Build build,
+                        String versionNumber) {
+        this.nodeName = nodeName;
+        this.version = version;
+        this.clusterName = clusterName;
+        this.clusterUuid = clusterUuid;
+        this.build = build;
+        this.versionNumber = versionNumber;
     }
 
     public String getNodeName() {
@@ -97,6 +110,10 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
 
     public Build getBuild() {
         return build;
+    }
+
+    public String getVersionNumber() {
+        return versionNumber;
     }
 
     @Override
@@ -123,7 +140,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
         builder.field("cluster_uuid", clusterUuid);
         builder.startObject("version")
             .field("distribution", build.getDistribution())
-            .field("number", build.getQualifiedVersion())
+            .field("number", versionNumber)
             .field("build_type", build.type().displayName())
             .field("build_hash", build.hash())
             .field("build_date", build.date())
@@ -163,6 +180,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
                     .replace("-SNAPSHOT", "")
                     .replaceFirst("-(alpha\\d+|beta\\d+|rc\\d+)", "")
             );
+            response.versionNumber = response.version.toString();
         }, (parser, context) -> parser.map(), new ParseField("version"));
     }
 

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -32,6 +32,7 @@
 package org.opensearch.common.settings;
 
 import org.apache.logging.log4j.LogManager;
+import org.opensearch.action.main.TransportMainAction;
 import org.opensearch.watcher.ResourceWatcherService;
 import org.opensearch.action.admin.cluster.configuration.TransportAddVotingConfigExclusionsAction;
 import org.opensearch.action.admin.indices.close.TransportCloseIndexAction;
@@ -577,6 +578,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
             FsHealthService.ENABLED_SETTING,
             FsHealthService.REFRESH_INTERVAL_SETTING,
             FsHealthService.SLOW_PATH_LOGGING_THRESHOLD_SETTING,
+            TransportMainAction.OVERRIDE_MAIN_RESPONSE_VERSION,
             IndexingPressure.MAX_INDEXING_BYTES)));
 
     public static List<SettingUpgrader<?>> BUILT_IN_SETTING_UPGRADERS = Collections.unmodifiableList(Arrays.asList(

--- a/server/src/test/java/org/opensearch/action/main/MainResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/main/MainResponseTests.java
@@ -102,6 +102,15 @@ public class MainResponseTests extends AbstractSerializingTestCase<MainResponse>
           + "}", Strings.toString(builder));
     }
 
+    public void toXContent_overrideMainResponseVersion() throws IOException {
+        String responseVersion = LegacyESVersion.V_7_10_2.toString();
+        MainResponse response = new MainResponse("nodeName", Version.CURRENT,
+            new ClusterName("clusterName"), randomAlphaOfLengthBetween(10, 20), Build.CURRENT, responseVersion);
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertTrue(Strings.toString(builder).contains("\"number\":\"" + responseVersion + "\","));
+    }
+
     @Override
     protected MainResponse mutateInstance(MainResponse mutateInstance) {
         String clusterUuid = mutateInstance.getClusterUuid();


### PR DESCRIPTION
Backport of #847 into 1.x

This change adds a new cluster setting "compatibility.override_main_response_version"
that when enabled spoofs the version.number returned from MainResponse
for REST clients expecting legacy version 7.10.2.

Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
