### PR TITLE
Fix opensearch-env always sources the environment from hardcoded file

### DIFF
--- a/distribution/src/bin/opensearch-env
+++ b/distribution/src/bin/opensearch-env
@@ -78,7 +78,9 @@ fi
 
 export HOSTNAME=$HOSTNAME
 
-${source.path.env}
+if [ -z "$OPENSEARCH_PATH_CONF" ]; then
+  ${source.path.env}
+fi
 
 if [ -z "$OPENSEARCH_PATH_CONF" ]; then
   echo "OPENSEARCH_PATH_CONF must be set to the configuration path"


### PR DESCRIPTION
### Description
Fix line 81 of opensearch-env always sources the environment from hardcoded file. Let users override the value of OPENSEARCH_PATH_CONF. 
 
### Issues Resolved
#633 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
