### PR TITLE
[1.0] Backport support running elasticsearch-oss distribution in test cluster for BWC

### DIFF
--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/fixtures/DistributionDownloadFixture.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/fixtures/DistributionDownloadFixture.groovy
@@ -31,6 +31,7 @@ package org.opensearch.gradle.fixtures
 
 
 import org.opensearch.gradle.OpenSearchDistribution
+import org.opensearch.gradle.Version
 import org.opensearch.gradle.VersionProperties
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
@@ -65,7 +66,11 @@ class DistributionDownloadFixture {
     private static String urlPath(String version, OpenSearchDistribution.Platform platform) {
         String fileType = ((platform == OpenSearchDistribution.Platform.LINUX ||
                 platform == OpenSearchDistribution.Platform.DARWIN)) ? "tar.gz" : "zip"
-        "/releases/core/opensearch/${version}/opensearch-${version}-${platform}-x64.$fileType"
+        if (Version.fromString(version).onOrAfter(Version.fromString("1.0.0"))) {
+            return "/releases/core/opensearch/${version}/opensearch-${version}-${platform}-x64.$fileType"
+        } else {
+            return "/downloads/elasticsearch/elasticsearch-oss-${version}-${platform}-x86_64.$fileType"
+        }
     }
 
     private static byte[] filebytes(String urlPath) throws IOException {


### PR DESCRIPTION
Backport PR: https://github.com/opensearch-project/OpenSearch/pull/764

We need to install elasticsearch in the test cluster nodes to be able to run the BWC tests. This commit makes the following changes to enable that,
- updates DistributionDownloadPlugin to download elasticsearch-oss distributions.
- updates OpenSearchNode to be able to run both OpenSearch and Elasticsearch distributions.

Signed-off-by: Rabi Panda <adnapibar@gmail.com>

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
