### PR TITLE
Remove distribution from main response in compatibility mode

### DIFF
--- a/server/src/main/java/org/opensearch/action/main/MainResponse.java
+++ b/server/src/main/java/org/opensearch/action/main/MainResponse.java
@@ -138,9 +138,11 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
         builder.field("name", nodeName);
         builder.field("cluster_name", clusterName.value());
         builder.field("cluster_uuid", clusterUuid);
-        builder.startObject("version")
-            .field("distribution", build.getDistribution())
-            .field("number", versionNumber)
+        builder.startObject("version");
+        if (isCompatibilityModeDisabled()) {
+            builder.field("distribution", build.getDistribution());
+        }
+            builder.field("number", versionNumber)
             .field("build_type", build.type().displayName())
             .field("build_hash", build.hash())
             .field("build_date", build.date())
@@ -151,6 +153,12 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
             .endObject();
         builder.endObject();
         return builder;
+    }
+
+    private boolean isCompatibilityModeDisabled() {
+        // if we are not in compatibility mode (spoofing versionNumber), then
+        // build.getQualifiedVersion is always used.
+        return build.getQualifiedVersion().equals(versionNumber);
     }
 
     private static final ObjectParser<MainResponse, Void> PARSER = new ObjectParser<>(MainResponse.class.getName(), true,

--- a/server/src/test/java/org/opensearch/action/main/MainResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/main/MainResponseTests.java
@@ -109,6 +109,7 @@ public class MainResponseTests extends AbstractSerializingTestCase<MainResponse>
         XContentBuilder builder = XContentFactory.jsonBuilder();
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
         assertTrue(Strings.toString(builder).contains("\"number\":\"" + responseVersion + "\","));
+        assertFalse(Strings.toString(builder).contains("\"distribution\":\"" + Build.CURRENT.getDistribution() + "\","));
     }
 
     @Override


### PR DESCRIPTION
This Change removes version.distribution when the version.number is
overridden with the cluster setting compatibility.override_main_response_version.

Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Removes the distribution property when in compatibility mode with 7.10.2.

curl without setting:
```
 curl localhost:9200/
{
  "name" : "runTask-0",
  "cluster_name" : "runTask",
  "cluster_uuid" : "vAOiFtLXSDqYXeCuItQGLA",
  "version" : {
    "distribution" : "opensearch",
    "number" : "1.0.0-SNAPSHOT",
    "build_type" : "tar",
    "build_hash" : "457f8e746edf13c3e519fd2622521787b822a478",
    "build_date" : "2021-06-29T04:15:13.028108Z",
    "build_snapshot" : true,
    "lucene_version" : "8.8.2",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  }
}
```

turn on compatibility setting

```
curl -X PUT "localhost:9200/_cluster/settings?pretty" -H 'Content-Type: application/json' -d '{"persistent":{"compatibility":{"override_main_response_version":true}}}'
{
  "acknowledged" : true,
  "persistent" : {
    "compatibility" : {
      "override_main_response_version" : "true"
    }
  },
  "transient" : { }
}
```

```
curl localhost:9200/
{
  "name" : "runTask-0",
  "cluster_name" : "runTask",
  "cluster_uuid" : "vAOiFtLXSDqYXeCuItQGLA",
  "version" : {
    "number" : "7.10.2",
    "build_type" : "tar",
    "build_hash" : "457f8e746edf13c3e519fd2622521787b822a478",
    "build_date" : "2021-06-29T04:15:13.028108Z",
    "build_snapshot" : true,
    "lucene_version" : "8.8.2",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  }
}
```

### Issues Resolved
[#880]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
