### PR TITLE
Restore tagline to MainResponse in server and RHLC

### DIFF
--- a/client/rest-high-level/src/main/java/org/opensearch/client/core/MainResponse.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/core/MainResponse.java
@@ -43,7 +43,7 @@ public class MainResponse {
     private static final ConstructingObjectParser<MainResponse, Void> PARSER =
         new ConstructingObjectParser<>(MainResponse.class.getName(), true,
             args -> {
-                 return new MainResponse((String) args[0], (Version) args[1], (String) args[2], (String) args[3]);
+                 return new MainResponse((String) args[0], (Version) args[1], (String) args[2], (String) args[3], (String) args[4]);
             }
         );
 
@@ -52,6 +52,7 @@ public class MainResponse {
         PARSER.declareObject(ConstructingObjectParser.constructorArg(), Version.PARSER, new ParseField("version"));
         PARSER.declareString(ConstructingObjectParser.constructorArg(), new ParseField("cluster_name"));
         PARSER.declareString(ConstructingObjectParser.constructorArg(), new ParseField("cluster_uuid"));
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), new ParseField("tagline"));
 
     }
 
@@ -59,12 +60,14 @@ public class MainResponse {
     private final Version version;
     private final String clusterName;
     private final String clusterUuid;
+    private final String tagline;
 
-    public MainResponse(String nodeName, Version version, String clusterName, String clusterUuid) {
+    public MainResponse(String nodeName, Version version, String clusterName, String clusterUuid, String tagline) {
         this.nodeName = nodeName;
         this.version = version;
         this.clusterName = clusterName;
         this.clusterUuid = clusterUuid;
+        this.tagline = tagline;
     }
 
     public String getNodeName() {
@@ -83,6 +86,10 @@ public class MainResponse {
         return clusterUuid;
     }
 
+    public String getTagline() {
+        return tagline;
+    }
+
     public static MainResponse fromXContent(XContentParser parser) {
         return PARSER.apply(parser, null);
     }
@@ -95,12 +102,13 @@ public class MainResponse {
         return nodeName.equals(that.nodeName) &&
             version.equals(that.version) &&
             clusterName.equals(that.clusterName) &&
-            clusterUuid.equals(that.clusterUuid);
+            clusterUuid.equals(that.clusterUuid) &&
+            tagline.equals(that.tagline);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(nodeName, version, clusterName, clusterUuid);
+        return Objects.hash(nodeName, version, clusterName, clusterUuid, tagline);
     }
 
     public static class Version {

--- a/client/rest-high-level/src/test/java/org/opensearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/RestHighLevelClientTests.java
@@ -180,7 +180,7 @@ public class RestHighLevelClientTests extends OpenSearchTestCase {
     public void testInfo() throws IOException {
         MainResponse testInfo = new MainResponse("nodeName", new MainResponse.Version("number", "buildType", "buildHash",
             "buildDate", true, "luceneVersion", "minimumWireCompatibilityVersion", "minimumIndexCompatibilityVersion"),
-            "clusterName", "clusterUuid");
+            "clusterName", "clusterUuid", "The OpenSearch Project: https://opensearch.org/");
         mockResponse((ToXContentFragment) (builder, params) -> {
             // taken from the server side MainResponse
             builder.field("name", testInfo.getNodeName());
@@ -196,6 +196,7 @@ public class RestHighLevelClientTests extends OpenSearchTestCase {
                 .field("minimum_wire_compatibility_version", testInfo.getVersion().getMinimumWireCompatibilityVersion())
                 .field("minimum_index_compatibility_version", testInfo.getVersion().getMinimumIndexCompatibilityVersion())
                 .endObject();
+            builder.field("tagline", testInfo.getTagline());
             return builder;
         });
         MainResponse receivedInfo = restHighLevelClient.info(RequestOptions.DEFAULT);

--- a/client/rest-high-level/src/test/java/org/opensearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/RestHighLevelClientTests.java
@@ -108,6 +108,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.opensearch.action.main.MainResponse.TAGLINE;
 import static org.opensearch.common.xcontent.XContentHelper.toXContent;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -180,7 +181,7 @@ public class RestHighLevelClientTests extends OpenSearchTestCase {
     public void testInfo() throws IOException {
         MainResponse testInfo = new MainResponse("nodeName", new MainResponse.Version("number", "buildType", "buildHash",
             "buildDate", true, "luceneVersion", "minimumWireCompatibilityVersion", "minimumIndexCompatibilityVersion"),
-            "clusterName", "clusterUuid", "The OpenSearch Project: https://opensearch.org/");
+            "clusterName", "clusterUuid", TAGLINE);
         mockResponse((ToXContentFragment) (builder, params) -> {
             // taken from the server side MainResponse
             builder.field("name", testInfo.getNodeName());

--- a/client/rest-high-level/src/test/java/org/opensearch/client/core/MainResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/core/MainResponseTests.java
@@ -71,6 +71,7 @@ public class MainResponseTests extends AbstractResponseTestCase<org.opensearch.a
         assertThat(serverTestInstance.getClusterName().value(), equalTo(clientInstance.getClusterName()));
         assertThat(serverTestInstance.getClusterUuid(), equalTo(clientInstance.getClusterUuid()));
         assertThat(serverTestInstance.getNodeName(), equalTo(clientInstance.getNodeName()));
+        assertThat("The OpenSearch Project: https://opensearch.org/", equalTo(clientInstance.getTagline()));
 
         assertThat(serverTestInstance.getBuild().hash(), equalTo(clientInstance.getVersion().getBuildHash()));
         assertThat(serverTestInstance.getVersion().toString(), equalTo(clientInstance.getVersion().getNumber()));

--- a/client/rest-high-level/src/test/java/org/opensearch/client/core/MainResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/core/MainResponseTests.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.util.Date;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.action.main.MainResponse.TAGLINE;
 
 public class MainResponseTests extends AbstractResponseTestCase<org.opensearch.action.main.MainResponse, MainResponse> {
     @Override
@@ -71,7 +72,7 @@ public class MainResponseTests extends AbstractResponseTestCase<org.opensearch.a
         assertThat(serverTestInstance.getClusterName().value(), equalTo(clientInstance.getClusterName()));
         assertThat(serverTestInstance.getClusterUuid(), equalTo(clientInstance.getClusterUuid()));
         assertThat(serverTestInstance.getNodeName(), equalTo(clientInstance.getNodeName()));
-        assertThat("The OpenSearch Project: https://opensearch.org/", equalTo(clientInstance.getTagline()));
+        assertThat(TAGLINE, equalTo(clientInstance.getTagline()));
 
         assertThat(serverTestInstance.getBuild().hash(), equalTo(clientInstance.getVersion().getBuildHash()));
         assertThat(serverTestInstance.getVersion().toString(), equalTo(clientInstance.getVersion().getNumber()));

--- a/distribution/docker/src/test/resources/rest-api-spec/test/10_info.yml
+++ b/distribution/docker/src/test/resources/rest-api-spec/test/10_info.yml
@@ -4,6 +4,7 @@
   - is_true:    name
   - is_true:    cluster_name
   - is_true:    cluster_uuid
+  - is_true:    tagline
   - is_true:    version
   - is_true:    version.number
   - match: { version.build_type: "docker" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/info/10_info.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/info/10_info.yml
@@ -4,5 +4,6 @@
     - is_true:    name
     - is_true:    cluster_name
     - is_true:    cluster_uuid
+    - is_true:    tagline
     - is_true:    version
     - is_true:    version.number

--- a/server/src/main/java/org/opensearch/action/main/MainResponse.java
+++ b/server/src/main/java/org/opensearch/action/main/MainResponse.java
@@ -149,6 +149,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
             .field("minimum_wire_compatibility_version", version.minimumCompatibilityVersion().toString())
             .field("minimum_index_compatibility_version", version.minimumIndexCompatibilityVersion().toString())
             .endObject();
+        builder.field("tagline", "The OpenSearch Project: https://opensearch.org/");
         builder.endObject();
         return builder;
     }
@@ -160,6 +161,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
         PARSER.declareString((response, value) -> response.nodeName = value, new ParseField("name"));
         PARSER.declareString((response, value) -> response.clusterName = new ClusterName(value), new ParseField("cluster_name"));
         PARSER.declareString((response, value) -> response.clusterUuid = value, new ParseField("cluster_uuid"));
+        PARSER.declareString((response, value) -> {}, new ParseField("tagline"));
         PARSER.declareObject((response, value) -> {
             final String buildType = (String) value.get("build_type");
             response.build =

--- a/server/src/main/java/org/opensearch/action/main/MainResponse.java
+++ b/server/src/main/java/org/opensearch/action/main/MainResponse.java
@@ -56,6 +56,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
     private String clusterUuid;
     private Build build;
     private String versionNumber;
+    public static final String TAGLINE = "The OpenSearch Project: https://opensearch.org/";
 
     MainResponse() {}
 
@@ -149,7 +150,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
             .field("minimum_wire_compatibility_version", version.minimumCompatibilityVersion().toString())
             .field("minimum_index_compatibility_version", version.minimumIndexCompatibilityVersion().toString())
             .endObject();
-        builder.field("tagline", "The OpenSearch Project: https://opensearch.org/");
+        builder.field("tagline", TAGLINE);
         builder.endObject();
         return builder;
     }

--- a/server/src/test/java/org/opensearch/action/main/MainResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/main/MainResponseTests.java
@@ -98,7 +98,8 @@ public class MainResponseTests extends AbstractSerializingTestCase<MainResponse>
                     + "\"build_snapshot\":" + current.isSnapshot() + ","
                     + "\"lucene_version\":\"" + version.luceneVersion.toString() + "\","
                     + "\"minimum_wire_compatibility_version\":\"" + version.minimumCompatibilityVersion().toString() + "\","
-                    + "\"minimum_index_compatibility_version\":\"" + version.minimumIndexCompatibilityVersion().toString() + "\"}"
+                    + "\"minimum_index_compatibility_version\":\"" + version.minimumIndexCompatibilityVersion().toString() + "\"},"
+                + "\"tagline\":\"The OpenSearch Project: https://opensearch.org/\""
           + "}", Strings.toString(builder));
     }
 

--- a/server/src/test/java/org/opensearch/action/main/MainResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/main/MainResponseTests.java
@@ -48,6 +48,8 @@ import org.opensearch.test.VersionUtils;
 import java.io.IOException;
 import java.util.Date;
 
+import static org.opensearch.action.main.MainResponse.TAGLINE;
+
 public class MainResponseTests extends AbstractSerializingTestCase<MainResponse> {
 
     @Override
@@ -99,7 +101,7 @@ public class MainResponseTests extends AbstractSerializingTestCase<MainResponse>
                     + "\"lucene_version\":\"" + version.luceneVersion.toString() + "\","
                     + "\"minimum_wire_compatibility_version\":\"" + version.minimumCompatibilityVersion().toString() + "\","
                     + "\"minimum_index_compatibility_version\":\"" + version.minimumIndexCompatibilityVersion().toString() + "\"},"
-                + "\"tagline\":\"The OpenSearch Project: https://opensearch.org/\""
+                + "\"tagline\":\"" + TAGLINE + "\""
           + "}", Strings.toString(builder));
     }
 


### PR DESCRIPTION
### Description
- Revert PR #427 to add "tagline" field back to "MainResponse" in both sever and rest-high-level-client sides.
- Replace with a new tagline "The OpenSearch Project: https://opensearch.org/".
- Turn the tagline into a constant in `server/src/main/java/org/opensearch/action/main/MainResponse.java`.
 
**Note**: Adding the tagline back to RestHighLevelClient side will be a breaking change to prevent OpenSearch RHLC "post RC-1" calling Info API from OpenSearch sever before 1.0.0-rc1.

Current output of the MainResponse:
```
{
  "name" : "node-9200",
  "cluster_name" : "opensearch",
  "cluster_uuid" : "em8tu3VZQCWvzGnouyZVpg",
  "version" : {
    "distribution" : "opensearch",
    "number" : "1.1.0-SNAPSHOT",
    "build_type" : "deb",
    "build_hash" : "1896ab72680760923a85db99a20c42b75408e8f6",
    "build_date" : "2021-06-30T22:07:19.423955Z",
    "build_snapshot" : true,
    "lucene_version" : "8.8.2",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  }
}
```

After the change in the PR:
```
{
  "name" : "node-9200",
  "cluster_name" : "opensearch",
  "cluster_uuid" : "IoY5158sQp6oz5lkCPCVUg",
  "version" : {
    "distribution" : "opensearch",
    "number" : "1.1.0-SNAPSHOT",
    "build_type" : "tar",
    "build_hash" : "79e1180251d26fd98fa88e42d4c4eca1a6768b09",
    "build_date" : "2021-06-30T23:15:13.489461Z",
    "build_snapshot" : true,
    "lucene_version" : "8.8.2",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}
```

### Issues Resolved
Resolve #901 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
