### PR TITLE
Update DistributionDownloader to fetch snapshots and staging bundles.

### DIFF
--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/fixtures/DistributionDownloadFixture.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/fixtures/DistributionDownloadFixture.groovy
@@ -67,7 +67,10 @@ class DistributionDownloadFixture {
         String fileType = ((platform == OpenSearchDistribution.Platform.LINUX ||
                 platform == OpenSearchDistribution.Platform.DARWIN)) ? "tar.gz" : "zip"
         if (Version.fromString(version).onOrAfter(Version.fromString("1.0.0"))) {
-            return "/releases/core/opensearch/${version}/opensearch-${version}-${platform}-x64.$fileType"
+            if (version.contains("SNAPSHOT")) {
+                return "/snapshots/core/opensearch/${version}/opensearch-min-${version}-${platform}-x64.$fileType"
+            }
+            return "/releases/core/opensearch/${version}/opensearch-min-${version}-${platform}-x64.$fileType"
         } else {
             return "/downloads/elasticsearch/elasticsearch-oss-${version}-${platform}-x86_64.$fileType"
         }


### PR DESCRIPTION
### Description
This change updates DistributionDownloader by registering a second
repository under FAKE_IVY_GROUP to fetch release-candidate bundles.  This repository exists as a fallback and will
only be checked if the release repository does not contain the requested
version.

This change also updates the snapshot repository to point to a new
snapshot repository and changes to fetch -min- versions of the bundles.

Signed-off-by: Marc Handalian <handalm@amazon.com>

With this change steps outlined in #600 will work where a 1.0.0-SNAPSHOT version can be fetched.

The opensearch.version flag used during a plugin build it will determine which repo from snapshots or release to use.

```
./gradlew build -Dopensearch.version=1.0.0-SNAPSHOT  <- fetches from /snapshot/
./gradlew build -Dopensearch.version=1.0.0  <- fetches from /releases/, if not present check /release-candidates/
```
 
### Issues Resolved
[#769]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
