### PR TITLE
Replace metadata keys in OpenSearchException during serialization and deserialization

### DIFF
--- a/qa/mixed-cluster/src/test/java/org/opensearch/backwards/ExceptionIT.java
+++ b/qa/mixed-cluster/src/test/java/org/opensearch/backwards/ExceptionIT.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.backwards;
+
+import org.apache.http.util.EntityUtils;
+import org.opensearch.Version;
+import org.opensearch.client.Node;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.test.rest.OpenSearchRestTestCase;
+import org.opensearch.test.rest.yaml.ObjectPath;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+
+public class ExceptionIT extends OpenSearchRestTestCase {
+    public void testOpensearchException() throws Exception {
+        logClusterNodes();
+
+        Request request = new Request("GET", "/no_such_index");
+
+        for (Node node : client().getNodes()) {
+            try {
+                client().setNodes(Collections.singletonList(node));
+                logger.info("node: {}", node.getHost());
+                client().performRequest(request);
+                fail();
+            } catch (ResponseException e) {
+                logger.debug(e.getMessage());
+                Response response = e.getResponse();
+                assertEquals(SC_NOT_FOUND, response.getStatusLine().getStatusCode());
+                assertEquals("no_such_index", ObjectPath.createFromResponse(response).evaluate("error.index"));
+            }
+        }
+    }
+
+    private void logClusterNodes() throws IOException {
+        ObjectPath objectPath = ObjectPath.createFromResponse(client().performRequest(new Request("GET", "_nodes")));
+        Map<String, ?> nodes = objectPath.evaluate("nodes");
+        String master = EntityUtils.toString(client().performRequest(new Request("GET", "_cat/master?h=id")).getEntity()).trim();
+        logger.info("cluster discovered: master id='{}'", master);
+        for (String id : nodes.keySet()) {
+            logger.info("{}: id='{}', name='{}', version={}",
+                objectPath.evaluate("nodes." + id + ".http.publish_address"),
+                id,
+                objectPath.evaluate("nodes." + id + ".name"),
+                Version.fromString(objectPath.evaluate("nodes." + id + ".version"))
+            );
+        }
+    }
+}


### PR DESCRIPTION
### Description
Fix for backward compatibility issue while propagating OpensearchExceptions accros nodes
 
### Issues Resolved
#897
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
