### PR TITLE
Backport [1.0] - Update DistributionDownloader to fetch snapshots and staging bundles.…

### DIFF
--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/fixtures/DistributionDownloadFixture.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/fixtures/DistributionDownloadFixture.groovy
@@ -67,7 +67,10 @@ class DistributionDownloadFixture {
         String fileType = ((platform == OpenSearchDistribution.Platform.LINUX ||
                 platform == OpenSearchDistribution.Platform.DARWIN)) ? "tar.gz" : "zip"
         if (Version.fromString(version).onOrAfter(Version.fromString("1.0.0"))) {
-            return "/releases/core/opensearch/${version}/opensearch-${version}-${platform}-x64.$fileType"
+            if (version.contains("SNAPSHOT")) {
+                return "/snapshots/core/opensearch/${version}/opensearch-min-${version}-${platform}-x64.$fileType"
+            }
+            return "/releases/core/opensearch/${version}/opensearch-min-${version}-${platform}-x64.$fileType"
         } else {
             return "/downloads/elasticsearch/elasticsearch-oss-${version}-${platform}-x86_64.$fileType"
         }


### PR DESCRIPTION
… (#904)

This change updates DistributionDownloader by registering a second
repository containing release-candidate bundles.  This repository will
only be checked if the release repository does not contain the requested
version.

This change also updates the snapshot repository to point to a new
snapshot repository.

Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
