### PR TITLE
Add 'tagline' back to MainResponse in server that was removed in PR #427

### DIFF
--- a/server/src/main/java/org/opensearch/action/main/MainResponse.java
+++ b/server/src/main/java/org/opensearch/action/main/MainResponse.java
@@ -56,6 +56,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
     private String clusterUuid;
     private Build build;
     private String versionNumber;
+    public static final String TAGLINE = "The OpenSearch Project: https://opensearch.org/";
 
     MainResponse() {}
 
@@ -151,6 +152,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
             .field("minimum_wire_compatibility_version", version.minimumCompatibilityVersion().toString())
             .field("minimum_index_compatibility_version", version.minimumIndexCompatibilityVersion().toString())
             .endObject();
+        builder.field("tagline", TAGLINE);
         builder.endObject();
         return builder;
     }
@@ -168,6 +170,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
         PARSER.declareString((response, value) -> response.nodeName = value, new ParseField("name"));
         PARSER.declareString((response, value) -> response.clusterName = new ClusterName(value), new ParseField("cluster_name"));
         PARSER.declareString((response, value) -> response.clusterUuid = value, new ParseField("cluster_uuid"));
+        PARSER.declareString((response, value) -> {}, new ParseField("tagline"));
         PARSER.declareObject((response, value) -> {
             final String buildType = (String) value.get("build_type");
             response.build =

--- a/server/src/test/java/org/opensearch/action/main/MainResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/main/MainResponseTests.java
@@ -48,6 +48,8 @@ import org.opensearch.test.VersionUtils;
 import java.io.IOException;
 import java.util.Date;
 
+import static org.opensearch.action.main.MainResponse.TAGLINE;
+
 public class MainResponseTests extends AbstractSerializingTestCase<MainResponse> {
 
     @Override
@@ -98,7 +100,8 @@ public class MainResponseTests extends AbstractSerializingTestCase<MainResponse>
                     + "\"build_snapshot\":" + current.isSnapshot() + ","
                     + "\"lucene_version\":\"" + version.luceneVersion.toString() + "\","
                     + "\"minimum_wire_compatibility_version\":\"" + version.minimumCompatibilityVersion().toString() + "\","
-                    + "\"minimum_index_compatibility_version\":\"" + version.minimumIndexCompatibilityVersion().toString() + "\"}"
+                    + "\"minimum_index_compatibility_version\":\"" + version.minimumIndexCompatibilityVersion().toString() + "\"},"
+                + "\"tagline\":\"" + TAGLINE + "\""
           + "}", Strings.toString(builder));
     }
 


### PR DESCRIPTION
### Description
Partially replace PR #902 .
PR #902 often fails BWC test. Because BWC test uses the latest snapshot of OpenSearch 1.0.0, where "tagline" is neither in MainResponse of sever side nor of rest-client side, so the test fails when calling "Info API" from REST client requiring "tagline" but to a sever don't response with "tagline".
So I created this PR to only restore "tagline" in sever side, but not in rest-client side, aim to pass the BWC test.

- Add "tagline" field back to "MainResponse" in sever side (not in rest-high-level-client side) that removed in PR #427 .
- Replace with a new tagline "The OpenSearch Project: https://opensearch.org/".
- Turn the tagline into a constant in `server/src/main/java/org/opensearch/action/main/MainResponse.java`.

Current output of the MainResponse:
```
{
  "name" : "node-9200",
  "cluster_name" : "opensearch",
  "cluster_uuid" : "em8tu3VZQCWvzGnouyZVpg",
  "version" : {
    "distribution" : "opensearch",
    "number" : "1.1.0-SNAPSHOT",
    "build_type" : "deb",
    "build_hash" : "1896ab72680760923a85db99a20c42b75408e8f6",
    "build_date" : "2021-06-30T22:07:19.423955Z",
    "build_snapshot" : true,
    "lucene_version" : "8.8.2",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  }
}
```

After the change in the PR:
```
{
  "name" : "node-9200",
  "cluster_name" : "opensearch",
  "cluster_uuid" : "IoY5158sQp6oz5lkCPCVUg",
  "version" : {
    "distribution" : "opensearch",
    "number" : "1.1.0-SNAPSHOT",
    "build_type" : "tar",
    "build_hash" : "79e1180251d26fd98fa88e42d4c4eca1a6768b09",
    "build_date" : "2021-06-30T23:15:13.489461Z",
    "build_snapshot" : true,
    "lucene_version" : "8.8.2",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}
```

### Issues Resolved
#901 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
