### PR TITLE
Fix Snapshot pattern in DistributionDownloader.

### DIFF
--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/fixtures/DistributionDownloadFixture.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/fixtures/DistributionDownloadFixture.groovy
@@ -68,7 +68,7 @@ class DistributionDownloadFixture {
                 platform == OpenSearchDistribution.Platform.DARWIN)) ? "tar.gz" : "zip"
         if (Version.fromString(version).onOrAfter(Version.fromString("1.0.0"))) {
             if (version.contains("SNAPSHOT")) {
-                return "/snapshots/core/opensearch/${version}/opensearch-min-${version}-${platform}-x64.$fileType"
+                return "/snapshots/core/opensearch/${version}/opensearch-min-${version}-${platform}-x64-latest.$fileType"
             }
             return "/releases/core/opensearch/${version}/opensearch-min-${version}-${platform}-x64.$fileType"
         } else {

--- a/buildSrc/src/main/java/org/opensearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/DistributionDownloadPlugin.java
@@ -79,7 +79,7 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
 
     private static final String RELEASE_PATTERN_LAYOUT = "/core/opensearch/[revision]/[module]-min-[revision](-[classifier]).[ext]";
     private static final String SNAPSHOT_PATTERN_LAYOUT =
-        "/snapshots/core/opensearch/[revision]/[module]-min-[revision](-[classifier]).[ext]";
+        "/snapshots/core/opensearch/[revision]/[module]-min-[revision](-[classifier])-latest.[ext]";
 
     private NamedDomainObjectContainer<OpenSearchDistribution> distributionsContainer;
     private NamedDomainObjectContainer<DistributionResolution> distributionsResolutionStrategiesContainer;


### PR DESCRIPTION
### Description
Snapshots pulled from DistributionDownloader are still broken because it is fetching from the wrong path.
Snapshots are published with a -latest suffix.

Example:
```
https://artifacts.opensearch.org/snapshots/core/opensearch-dashboards/1.0.0-SNAPSHOT/opensearch-dashboards-min-1.0.0-SNAPSHOT-linux-arm64-latest.tar.gz
```
This change updates the pattern to correctly append -latest.

Signed-off-by: Marc Handalian <handalm@amazon.com>


[Describe what this change achieves]
 
### Issues Resolved
closes #769
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
