### PR TITLE
Fix arm architecture translation issue (#809)

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/Jdk.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/Jdk.java
@@ -234,7 +234,7 @@ public class Jdk implements Buildable, Iterable<File> {
         /*
          * Jdk uses aarch64 from ARM. Translating from arm64 to aarch64 which Jdk understands.
          */
-        return architecture == "arm64" ? "aarch64" : architecture;
+        return "arm64".equals(architecture) ? "aarch64" : architecture;
     }
 
 }


### PR DESCRIPTION
Backporting this change to the release branch, [original PR](https://github.com/opensearch-project/OpenSearch/pull/809). 

---

Found when attempting to build on an `arm64` machine when I recieved an error message below.  Root cause is that string equality in java cannot be done with the `==` sign.

```
unknown architecture [arm64] for jdk [provisioned_runtime], must be one of [aarch64, x64]
```

Signed-off-by: Peter Nied <petern@amazon.com>

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
