### PR TITLE
[Backport 1.x] Remove distribution from main response in compatibility mode (#898)

### DIFF
--- a/server/src/main/java/org/opensearch/action/main/MainResponse.java
+++ b/server/src/main/java/org/opensearch/action/main/MainResponse.java
@@ -138,9 +138,11 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
         builder.field("name", nodeName);
         builder.field("cluster_name", clusterName.value());
         builder.field("cluster_uuid", clusterUuid);
-        builder.startObject("version")
-            .field("distribution", build.getDistribution())
-            .field("number", versionNumber)
+        builder.startObject("version");
+        if (isCompatibilityModeDisabled()) {
+            builder.field("distribution", build.getDistribution());
+        }
+            builder.field("number", versionNumber)
             .field("build_type", build.type().displayName())
             .field("build_hash", build.hash())
             .field("build_date", build.date())
@@ -151,6 +153,12 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
             .endObject();
         builder.endObject();
         return builder;
+    }
+
+    private boolean isCompatibilityModeDisabled() {
+        // if we are not in compatibility mode (spoofing versionNumber), then
+        // build.getQualifiedVersion is always used.
+        return build.getQualifiedVersion().equals(versionNumber);
     }
 
     private static final ObjectParser<MainResponse, Void> PARSER = new ObjectParser<>(MainResponse.class.getName(), true,

--- a/server/src/test/java/org/opensearch/action/main/MainResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/main/MainResponseTests.java
@@ -109,6 +109,7 @@ public class MainResponseTests extends AbstractSerializingTestCase<MainResponse>
         XContentBuilder builder = XContentFactory.jsonBuilder();
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
         assertTrue(Strings.toString(builder).contains("\"number\":\"" + responseVersion + "\","));
+        assertFalse(Strings.toString(builder).contains("\"distribution\":\"" + Build.CURRENT.getDistribution() + "\","));
     }
 
     @Override


### PR DESCRIPTION
This Change removes version.distribution when the version.number is
overridden with the cluster setting compatibility.override_main_response_version.

Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
