### PR TITLE
[BUG] Fix cat.health test failures in pre 1.0.0 mixed cluster test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.health/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.health/10_basic.yml
@@ -1,5 +1,8 @@
 ---
 "Help":
+  - skip:
+        version: " - 7.9.99"
+        reason: "discovered_master added in OpenSearch 1.0.0"
   - do:
       cat.health:
         help: true
@@ -27,7 +30,9 @@
 
 ---
 "Empty cluster":
-
+  - skip:
+      version: " - 7.9.99"
+      reason: "discovered_master added in OpenSearch 1.0.0"
   - do:
       cat.health: {}
 
@@ -56,7 +61,9 @@
 
 ---
 "With ts parameter":
-
+  - skip:
+      version: " - 7.9.99"
+      reason: "discovered_master added in OpenSearch 1.0.0"
   - do:
       cat.health:
         ts: false

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.health/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.health/10_basic.yml
@@ -1,7 +1,7 @@
 ---
 "Help":
   - skip:
-        version: " - 7.9.99"
+        version: " - 7.10.99"
         reason: "discovered_master added in OpenSearch 1.0.0"
   - do:
       cat.health:
@@ -31,7 +31,7 @@
 ---
 "Empty cluster":
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.10.99"
       reason: "discovered_master added in OpenSearch 1.0.0"
   - do:
       cat.health: {}
@@ -62,7 +62,7 @@
 ---
 "With ts parameter":
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.10.99"
       reason: "discovered_master added in OpenSearch 1.0.0"
   - do:
       cat.health:

--- a/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
@@ -2013,7 +2013,8 @@ public abstract class AbstractSimpleTransportTestCase extends OpenSearchTestCase
                 TransportRequestOptions.Type.REG,
                 TransportRequestOptions.Type.STATE);
             try (Transport.Connection connection = serviceA.openConnection(node, builder.build())) {
-                assertEquals(connection.getVersion(), version);
+                // OpenSearch 1.0+ in bwc mode should only "upgrade" to Legacy v7.10.2
+                assertEquals(connection.getVersion(), version.onOrAfter(Version.V_1_0_0) ? LegacyESVersion.V_7_10_2 : version);
             }
         }
     }


### PR DESCRIPTION
Fixes the cat.health yaml failures when running in a bwc mixed cluster with legacy (pre 1.0.0) nodes.

closes #912 
closes #922