### PR TITLE
Update DistributionDownloader to support fetching arm64 bundles.

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/DistributionDownloadPlugin.java
@@ -234,7 +234,16 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
             extension = distribution.getPlatform() == Platform.WINDOWS ? "zip" : "tar.gz";
 
             if (distroVersion.onOrAfter("1.0.0")) {
-                classifier = ":" + distribution.getPlatform() + "-x64";
+                switch (distribution.getArchitecture()) {
+                    case ARM64:
+                        classifier = ":" + distribution.getPlatform() + "-arm64";
+                        break;
+                    case X64:
+                        classifier = ":" + distribution.getPlatform() + "-x64";
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unsupported architecture: " + distribution.getArchitecture());
+                }
             } else if (distroVersion.onOrAfter("7.0.0")) {
                 classifier = ":" + distribution.getPlatform() + "-x86_64";
             } else {

--- a/buildSrc/src/test/java/org/opensearch/gradle/DistributionDownloadPluginTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/DistributionDownloadPluginTests.java
@@ -142,15 +142,25 @@ public class DistributionDownloadPluginTests extends GradleUnitTestCase {
     public void testLocalCurrentVersionArchives() {
         for (Platform platform : Platform.values()) {
             for (boolean bundledJdk : new boolean[] { true, false }) {
-                // create a new project in each iteration, so that we know we are resolving the only additional project being created
-                Project project = createProject(BWC_MINOR, true);
-                String projectName = projectName(platform.toString(), bundledJdk);
-                projectName += (platform == Platform.WINDOWS ? "-zip" : "-tar");
-                Project archiveProject = ProjectBuilder.builder().withParent(archivesProject).withName(projectName).build();
-                archiveProject.getConfigurations().create("default");
-                archiveProject.getArtifacts().add("default", new File("doesnotmatter"));
-                createDistro(project, "distro", VersionProperties.getOpenSearch(), Type.ARCHIVE, platform, bundledJdk);
-                checkPlugin(project);
+                for (Architecture architecture : Architecture.values()) {
+                    // create a new project in each iteration, so that we know we are resolving the only additional project being created
+                    Project project = createProject(BWC_MINOR, true);
+                    String projectName = projectName(platform.toString(), bundledJdk);
+                    projectName += (platform == Platform.WINDOWS ? "-zip" : "-tar");
+                    Project archiveProject = ProjectBuilder.builder().withParent(archivesProject).withName(projectName).build();
+                    archiveProject.getConfigurations().create("default");
+                    archiveProject.getArtifacts().add("default", new File("doesnotmatter"));
+                    final OpenSearchDistribution distro = createDistro(
+                        project,
+                        "distro",
+                        VersionProperties.getOpenSearch(),
+                        Type.ARCHIVE,
+                        platform,
+                        bundledJdk
+                    );
+                    distro.setArchitecture(architecture);
+                    checkPlugin(project);
+                }
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Update DistributionDownloader to support fetching arm64 bundles.

Before this change if integration tests were executed from arm64 machines it would still fetch bundles with the -x64 classifier.  This fixes that by correctly reading and appending the -arm64 classifier.
 
### Issues Resolved
closes #930 930
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
