### PR TITLE
[1.x] Pass interceptor to super constructor (#876)

### DIFF
--- a/modules/reindex/src/main/java/org/opensearch/index/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/opensearch/index/reindex/Reindexer.java
@@ -238,8 +238,7 @@ public class Reindexer {
                  * external versioning.
                  */
                 request.getDestination().versionType() != VersionType.INTERNAL,
-                false, logger, client, threadPool, request, listener, scriptService, sslConfig);
-            this.interceptor = interceptor;
+                false, logger, client, threadPool, request, listener, scriptService, sslConfig, interceptor);
         }
 
         @Override


### PR DESCRIPTION
### Description
Backport #876 to 1.x branch

The interceptor that was added in this #547, is not being applied as it is not set in the Rest client created to connect to remote cluster.
This change rebuilds the Rest client after the interceptor has been initialized. Once pushed to main branch, this should be ported to 1.0 branch.
 
### Issues Resolved
fixes #890 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
