### PR TITLE
Lower build requirement from Java 14+ to Java 11+

### DIFF
--- a/.ci/java-versions.properties
+++ b/.ci/java-versions.properties
@@ -13,7 +13,7 @@
 # build and test OpenSearch for this branch. Valid Java versions
 # are 'java' or 'openjdk' followed by the major release number.
 
-OPENSEARCH_BUILD_JAVA=openjdk14
+OPENSEARCH_BUILD_JAVA=openjdk11
 OPENSEARCH_RUNTIME_JAVA=java8
 GRADLE_TASK=build
 GRADLE_EXTRA_ARGS=

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -2,7 +2,7 @@
   - [Getting Started](#getting-started)
     - [Git Clone OpenSearch Repo](#git-clone-opensearch-repo)
     - [Install Prerequisites](#install-prerequisites)
-      - [JDK 14](#jdk-14)
+      - [JDK 11](#jdk-11)
       - [Docker](#docker)
     - [Run Tests](#run-tests)
     - [Run OpenSearch](#run-opensearch)
@@ -16,6 +16,7 @@
     - [`libs`](#libs)
     - [`modules`](#modules)
     - [`plugins`](#plugins)
+    - [`sandbox`](#sandbox)
     - [`qa`](#qa)
     - [`server`](#server)
     - [`test`](#test)
@@ -45,20 +46,11 @@ Fork [opensearch-project/OpenSearch](https://github.com/opensearch-project/OpenS
 
 ### Install Prerequisites
 
-#### JDK 14
+#### JDK 11
 
-OpenSearch builds using Java 14 at a minimum. This means you must have a JDK 14 installed with the environment variable `JAVA_HOME` referencing the path to Java home for your JDK 14 installation, e.g. `JAVA_HOME=/usr/lib/jvm/jdk-14`.
+OpenSearch builds using Java 11 at a minimum. This means you must have a JDK 11 installed with the environment variable `JAVA_HOME` referencing the path to Java home for your JDK 11 installation, e.g. `JAVA_HOME=/usr/lib/jvm/jdk-11`.
 
-One easy way to get Java 14 on *nix is to use [sdkman](https://sdkman.io/).
-
-```bash
-curl -s "https://get.sdkman.io" | bash
-source ~/.sdkman/bin/sdkman-init.sh
-sdk install java 14.0.2-open
-sdk use java 14.0.2-open
-```
-
-By default, tests use the same runtime as `JAVA_HOME`. However, since OpenSearch supports JDK 8, the build supports compiling with JDK 14 and testing on a different version of JDK runtime. To do this, set `RUNTIME_JAVA_HOME` pointing to the Java home of another JDK installation, e.g. `RUNTIME_JAVA_HOME=/usr/lib/jvm/jdk-8`.
+By default, tests use the same runtime as `JAVA_HOME`. However, since OpenSearch supports JDK 8, the build supports compiling with JDK 11 and testing on a different version of JDK runtime. To do this, set `RUNTIME_JAVA_HOME` pointing to the Java home of another JDK installation, e.g. `RUNTIME_JAVA_HOME=/usr/lib/jvm/jdk-8`.
 
 To run the full suite of tests you will also need `JAVA8_HOME`, `JAVA9_HOME`, `JAVA10_HOME`, `JAVA11_HOME`, and `JAVA12_HOME`.
 

--- a/build.gradle
+++ b/build.gradle
@@ -227,6 +227,41 @@ tasks.register("branchConsistency") {
 }
 
 allprojects {
+  // configure compiler options
+  tasks.withType(JavaCompile).configureEach { JavaCompile compile ->
+    compile.options.compilerArgs << '-Werror'
+    compile.options.compilerArgs << '-Xlint:auxiliaryclass'
+    compile.options.compilerArgs << '-Xlint:cast'
+    compile.options.compilerArgs << '-Xlint:classfile'
+    compile.options.compilerArgs << '-Xlint:dep-ann'
+    compile.options.compilerArgs << '-Xlint:divzero'
+    compile.options.compilerArgs << '-Xlint:empty'
+    compile.options.compilerArgs << '-Xlint:exports'
+    compile.options.compilerArgs << '-Xlint:fallthrough'
+    compile.options.compilerArgs << '-Xlint:finally'
+    compile.options.compilerArgs << '-Xlint:module'
+    compile.options.compilerArgs << '-Xlint:opens'
+    compile.options.compilerArgs << '-Xlint:overloads'
+    compile.options.compilerArgs << '-Xlint:overrides'
+    compile.options.compilerArgs << '-Xlint:processing'
+    compile.options.compilerArgs << '-Xlint:rawtypes'
+    compile.options.compilerArgs << '-Xlint:removal'
+    compile.options.compilerArgs << '-Xlint:requires-automatic'
+    compile.options.compilerArgs << '-Xlint:requires-transitive-automatic'
+    compile.options.compilerArgs << '-Xlint:static'
+    compile.options.compilerArgs << '-Xlint:unchecked'
+    compile.options.compilerArgs << '-Xlint:varargs'
+    compile.options.compilerArgs << '-Xlint:preview'
+    // TODO: disabled warnings: path, serial, options, deprecation, try
+    // -path because gradle will send in paths that don't always exist.
+    // -missing because we have tons of missing @returns and @param.
+    // -serial because we don't use java serialization.
+    compile.options.compilerArgs << '-Xdoclint:accessibility'
+    compile.options.compilerArgs << '-Xdoclint:html'
+    compile.options.compilerArgs << '-Xdoclint:reference'
+    compile.options.compilerArgs << '-Xdoclint:syntax'
+  }
+
   // ignore missing javadocs
   tasks.withType(Javadoc).configureEach { Javadoc javadoc ->
     // the -quiet here is because of a bug in gradle, in that adding a string option

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -232,6 +232,12 @@ if (project != rootProject) {
     }
   }
 
+  // disable fail-on-warnings for this specific task which trips Java 11 bug
+  // https://bugs.openjdk.java.net/browse/JDK-8209058
+  tasks.named("compileTestFixturesJava").configure {
+    options.compilerArgs -= '-Werror'
+  }
+
   tasks.register("integTest", Test) {
     inputs.dir(file("src/testKit")).withPropertyName("testkit dir").withPathSensitivity(PathSensitivity.RELATIVE)
     systemProperty 'test.version_under_test', version

--- a/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchJavaPlugin.java
@@ -160,19 +160,8 @@ public class OpenSearchJavaPlugin implements Plugin<Project> {
         project.afterEvaluate(p -> {
             project.getTasks().withType(JavaCompile.class).configureEach(compileTask -> {
                 CompileOptions compileOptions = compileTask.getOptions();
-                /*
-                 * -path because gradle will send in paths that don't always exist.
-                 * -missing because we have tons of missing @returns and @param.
-                 * -serial because we don't use java serialization.
-                 */
-                // don't even think about passing args with -J-xxx, oracle will ask you to submit a bug report :)
-                // fail on all javac warnings.
                 // TODO Discuss moving compileOptions.getCompilerArgs() to use provider api with Gradle team.
                 List<String> compilerArgs = compileOptions.getCompilerArgs();
-                compilerArgs.add("-Werror");
-                compilerArgs.add("-Xlint:all,-path,-serial,-options,-deprecation,-try");
-                compilerArgs.add("-Xdoclint:all");
-                compilerArgs.add("-Xdoclint:-missing");
                 // either disable annotation processor completely (default) or allow to enable them if an annotation processor is explicitly
                 // defined
                 if (compilerArgs.contains("-processor") == false) {

--- a/distribution/tools/java-version-checker/build.gradle
+++ b/distribution/tools/java-version-checker/build.gradle
@@ -12,6 +12,8 @@
 apply plugin: 'opensearch.build'
 
 targetCompatibility = JavaVersion.VERSION_1_7
+// targetting very old java versions enables a warning by default on newer JDK: disable it.
+compileJava.options.compilerArgs += '-Xlint:-options'
 
 // java_version_checker do not depend on core so only JDK signatures should be checked
 tasks.named('forbiddenApisMain').configure {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -144,7 +144,9 @@ dependencies {
 }
 
 tasks.withType(JavaCompile).configureEach {
-    options.compilerArgs << "-Xlint:-cast,-rawtypes,-unchecked"
+  options.compilerArgs -= '-Xlint:cast'
+  options.compilerArgs -= '-Xlint:rawtypes'
+  options.compilerArgs -= '-Xlint:unchecked'
 }
 
 tasks.named("internalClusterTest").configure {

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -49,8 +49,10 @@ dependencies {
   api "org.elasticsearch:mocksocket:${versions.mocksocket}"
 }
 
-compileJava.options.compilerArgs << '-Xlint:-cast,-rawtypes,-unchecked'
-compileTestJava.options.compilerArgs << '-Xlint:-rawtypes'
+compileJava.options.compilerArgs -= '-Xlint:cast'
+compileJava.options.compilerArgs -= '-Xlint:rawtypes'
+compileJava.options.compilerArgs -= '-Xlint:unchecked'
+compileTestJava.options.compilerArgs -= '-Xlint:rawtypes'
 
 // the main files are actually test files, so use the appropriate forbidden api sigs
 tasks.named('forbiddenApisMain').configure {


### PR DESCRIPTION
### Description

This is a rebased version of https://github.com/opensearch-project/OpenSearch/pull/636 on which I made a mess.
  
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
