### PR TITLE
[Backport 1.x] Add Snapshot maven repository #829

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,14 @@ subprojects {
           name = 'test'
           url = "${rootProject.buildDir}/local-test-repo"
         }
+        maven {
+          name = 'Snapshots'
+          url = 'https://aws.oss.sonatype.org/content/repositories/snapshots'
+          credentials {
+            username "$System.env.SONATYPE_USERNAME"
+            password "$System.env.SONATYPE_PASSWORD"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
### Description
This change backports #829 to 1.x so that we can publish snapshots to our maven repository - https://aws.oss.sonatype.org/content/repositories/snapshots/
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
