### PR TITLE
Add Shard Indexing Pressure Memory Manager (#478)

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -32,6 +32,12 @@
 package org.opensearch.common.settings;
 
 import org.apache.logging.log4j.LogManager;
+import org.opensearch.index.IndexModule;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.IndexingPressure;
+import org.opensearch.index.ShardIndexingPressureMemoryManager;
+import org.opensearch.index.ShardIndexingPressureSettings;
+import org.opensearch.index.ShardIndexingPressureStore;
 import org.opensearch.watcher.ResourceWatcherService;
 import org.opensearch.action.admin.cluster.configuration.TransportAddVotingConfigExclusionsAction;
 import org.opensearch.action.admin.indices.close.TransportCloseIndexAction;
@@ -98,11 +104,6 @@ import org.opensearch.gateway.DanglingIndicesState;
 import org.opensearch.gateway.GatewayService;
 import org.opensearch.gateway.PersistedClusterStateService;
 import org.opensearch.http.HttpTransportSettings;
-import org.opensearch.index.IndexModule;
-import org.opensearch.index.IndexSettings;
-import org.opensearch.index.IndexingPressure;
-import org.opensearch.index.ShardIndexingPressureSettings;
-import org.opensearch.index.ShardIndexingPressureStore;
 import org.opensearch.indices.IndexingMemoryController;
 import org.opensearch.indices.IndicesQueryCache;
 import org.opensearch.indices.IndicesRequestCache;
@@ -581,7 +582,14 @@ public final class ClusterSettings extends AbstractScopedSettings {
             ShardIndexingPressureSettings.SHARD_INDEXING_PRESSURE_ENFORCED,
             ShardIndexingPressureSettings.REQUEST_SIZE_WINDOW,
             ShardIndexingPressureSettings.SHARD_MIN_LIMIT,
-            ShardIndexingPressureStore.MAX_COLD_STORE_SIZE)));
+            ShardIndexingPressureStore.MAX_COLD_STORE_SIZE,
+            ShardIndexingPressureMemoryManager.LOWER_OPERATING_FACTOR,
+            ShardIndexingPressureMemoryManager.OPTIMAL_OPERATING_FACTOR,
+            ShardIndexingPressureMemoryManager.UPPER_OPERATING_FACTOR,
+            ShardIndexingPressureMemoryManager.NODE_SOFT_LIMIT,
+            ShardIndexingPressureMemoryManager.THROUGHPUT_DEGRADATION_LIMITS,
+            ShardIndexingPressureMemoryManager.SUCCESSFUL_REQUEST_ELAPSED_TIMEOUT,
+            ShardIndexingPressureMemoryManager.MAX_OUTSTANDING_REQUESTS)));
 
     public static List<SettingUpgrader<?>> BUILT_IN_SETTING_UPGRADERS = Collections.unmodifiableList(Arrays.asList(
             SniffConnectionStrategy.SEARCH_REMOTE_CLUSTER_SEEDS_UPGRADER,

--- a/server/src/main/java/org/opensearch/index/ShardIndexingPressureMemoryManager.java
+++ b/server/src/main/java/org/opensearch/index/ShardIndexingPressureMemoryManager.java
@@ -1,0 +1,552 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.ShardIndexingPressureTracker.PerformanceTracker;
+import org.opensearch.index.ShardIndexingPressureTracker.StatsTracker;
+import org.opensearch.index.shard.ShardId;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * The Shard Indexing Pressure Memory Manager is the construct responsible for increasing and decreasing the allocated shard limit
+ * based on incoming requests. A shard limits defines the maximum memory that a shard can occupy in the heap for request objects.
+ *
+ * Based on the overall memory utilization on the node, and current traffic needs shard limits will be modified:
+ *
+ * 1. If the limits assigned to a shard is breached (Primary Parameter) while the node level overall occupancy across all shards
+ * is not greater than primary_parameter.node.soft_limit, MemoryManager will increase the shard limits without any deeper evaluation.
+ * 2. If the limits assigned to the shard is breached(Primary Parameter) and the node level overall occupancy across all shards
+ * is greater than primary_parameter.node.soft_limit, then MemoryManager will evaluate deeper parameters for shards to identify any
+ * issues, such as throughput degradation (Secondary Parameter - 1) and time since last request was successful (Secondary Parameter - 2).
+ * This helps identify detect any duress state with the shard, requesting more memory.
+ *
+ * Secondary Parameters covered above:
+ * 1. ThroughputDegradationLimitsBreached - When the moving window throughput average has increased by a factor compared to
+ * the historical throughput average. If the factor by which it has increased is greater than the degradation limit threshold, this
+ * parameter is considered to be breached.
+ * 2. LastSuccessfulRequestDurationLimitsBreached - When the time since the last successful request completed is greater than the max
+ * timeout threshold value, while there a number of outstanding requests greater than the max outstanding requests then this parameter
+ * is considered to be breached.
+ *
+ * MemoryManager attempts to increase of decrease the shard limits in case the shard utilization goes below operating_factor.lower or
+ * goes above operating_factor.upper of current shard limits. MemoryManager attempts to update the new shard limit such that the new value
+ * remains withing the operating_factor.optimal range of current shard utilization.
+ *
+ */
+public class ShardIndexingPressureMemoryManager {
+    private final Logger logger = LogManager.getLogger(getClass());
+
+    /**
+     * Operating factor can be evaluated using currentShardBytes/shardLimits. Outcome of this expression is categorized as
+     * lower, optimal and upper boundary, and appropriate action is taken once they breach the value mentioned below.
+     */
+    public static final Setting<Double> LOWER_OPERATING_FACTOR =
+        Setting.doubleSetting("shard_indexing_pressure.operating_factor.lower", 0.75d, 0.0d,
+            Setting.Property.NodeScope, Setting.Property.Dynamic);
+    public static final Setting<Double> OPTIMAL_OPERATING_FACTOR =
+        Setting.doubleSetting("shard_indexing_pressure.operating_factor.optimal", 0.85d, 0.0d,
+            Setting.Property.NodeScope, Setting.Property.Dynamic);
+    public static final Setting<Double> UPPER_OPERATING_FACTOR =
+        Setting.doubleSetting("shard_indexing_pressure.operating_factor.upper", 0.95d, 0.0d,
+            Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+    /**
+     * This is the max time that can be elapsed after any request is processed successfully. Appropriate action is taken
+     * once the below mentioned value is breached.
+     */
+    public static final Setting<Integer> SUCCESSFUL_REQUEST_ELAPSED_TIMEOUT =
+        Setting.intSetting("shard_indexing_pressure.secondary_parameter.successful_request.elapsed_timeout", 300000,
+            Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+    /**
+     * This is the max outstanding request that are present after any request is processed successfully. Appropriate
+     * action is taken once the below mentioned value is breached.
+     */
+    public static final Setting<Integer> MAX_OUTSTANDING_REQUESTS =
+        Setting.intSetting("shard_indexing_pressure.secondary_parameter.successful_request.max_outstanding_requests",
+            100, Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+    /**
+     * Degradation limits can be evaluated using average throughput last N requests
+     * and N being {@link ShardIndexingPressureSettings#REQUEST_SIZE_WINDOW} divided by lifetime average throughput.
+     * Appropriate action is taken once the outcome of above expression breaches the below mentioned factor
+     */
+    public static final Setting<Double> THROUGHPUT_DEGRADATION_LIMITS =
+        Setting.doubleSetting("shard_indexing_pressure.secondary_parameter.throughput.degradation_factor", 5.0d, 1.0d,
+            Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+    /**
+     * The secondary parameter accounting factor tells when the secondary parameter is considered. i.e. If the current
+     * node level memory utilization divided by the node limits is greater than 70% then appropriate action is taken.
+     */
+    public static final Setting<Double> NODE_SOFT_LIMIT =
+        Setting.doubleSetting("shard_indexing_pressure.primary_parameter.node.soft_limit", 0.7d, 0.0d,
+            Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+    public final AtomicLong totalNodeLimitsBreachedRejections = new AtomicLong();
+    public final AtomicLong totalLastSuccessfulRequestLimitsBreachedRejections = new AtomicLong();
+    public final AtomicLong totalThroughputDegradationLimitsBreachedRejections = new AtomicLong();
+
+    private final ShardIndexingPressureSettings shardIndexingPressureSettings;
+    private final ShardIndexingPressureStore shardIndexingPressureStore;
+
+    private volatile double lowerOperatingFactor;
+    private volatile double optimalOperatingFactor;
+    private volatile double upperOperatingFactor;
+
+    private volatile int successfulRequestElapsedTimeout;
+    private volatile int maxOutstandingRequests;
+
+    private volatile double primaryAndCoordinatingThroughputDegradationLimits;
+    private volatile double replicaThroughputDegradationLimits;
+
+    private volatile double nodeSoftLimit;
+
+    public ShardIndexingPressureMemoryManager(ShardIndexingPressureSettings shardIndexingPressureSettings,
+                                              ClusterSettings clusterSettings, Settings settings) {
+        this.shardIndexingPressureSettings = shardIndexingPressureSettings;
+        this.shardIndexingPressureStore = new ShardIndexingPressureStore(shardIndexingPressureSettings, clusterSettings, settings);
+
+        this.lowerOperatingFactor = LOWER_OPERATING_FACTOR.get(settings).doubleValue();
+        clusterSettings.addSettingsUpdateConsumer(LOWER_OPERATING_FACTOR, this::setLowerOperatingFactor);
+
+        this.optimalOperatingFactor = OPTIMAL_OPERATING_FACTOR.get(settings).doubleValue();
+        clusterSettings.addSettingsUpdateConsumer(OPTIMAL_OPERATING_FACTOR, this::setOptimalOperatingFactor);
+
+        this.upperOperatingFactor = UPPER_OPERATING_FACTOR.get(settings).doubleValue();
+        clusterSettings.addSettingsUpdateConsumer(UPPER_OPERATING_FACTOR, this::setUpperOperatingFactor);
+
+        this.successfulRequestElapsedTimeout = SUCCESSFUL_REQUEST_ELAPSED_TIMEOUT.get(settings).intValue();
+        clusterSettings.addSettingsUpdateConsumer(SUCCESSFUL_REQUEST_ELAPSED_TIMEOUT, this::setSuccessfulRequestElapsedTimeout);
+
+        this.maxOutstandingRequests = MAX_OUTSTANDING_REQUESTS.get(settings).intValue();
+        clusterSettings.addSettingsUpdateConsumer(MAX_OUTSTANDING_REQUESTS, this::setMaxOutstandingRequests);
+
+        this.primaryAndCoordinatingThroughputDegradationLimits = THROUGHPUT_DEGRADATION_LIMITS.get(settings).doubleValue();
+        this.replicaThroughputDegradationLimits = this.primaryAndCoordinatingThroughputDegradationLimits * 1.5;
+        clusterSettings.addSettingsUpdateConsumer(THROUGHPUT_DEGRADATION_LIMITS, this::setThroughputDegradationLimits);
+
+        this.nodeSoftLimit = NODE_SOFT_LIMIT.get(settings).doubleValue();
+        clusterSettings.addSettingsUpdateConsumer(NODE_SOFT_LIMIT, this::setNodeSoftLimit);
+    }
+
+    /**
+     * Checks if the node level memory threshold is breached for primary operations.
+     */
+    boolean isPrimaryNodeLimitBreached(ShardIndexingPressureTracker tracker, long nodeTotalBytes) {
+
+        if(nodeTotalBytes > this.shardIndexingPressureSettings.getNodePrimaryAndCoordinatingLimits()) {
+            logger.debug("Node limits breached for primary operation [node_total_bytes={}, " +
+                    "node_primary_and_coordinating_limits={}]", nodeTotalBytes,
+                this.shardIndexingPressureSettings.getNodePrimaryAndCoordinatingLimits());
+            tracker.getPrimaryOperationTracker().getRejectionTracker().incrementNodeLimitsBreachedRejections();
+            totalNodeLimitsBreachedRejections.incrementAndGet();
+
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the shard level memory threshold is breached for primary operations.
+     */
+    boolean isPrimaryShardLimitBreached(ShardIndexingPressureTracker tracker, long nodeTotalBytes, long requestStartTime) {
+
+        // Memory limits is breached when the current utilization is greater than operating_factor.upper of total shard limits.
+        long shardCombinedBytes = tracker.getCommonOperationTracker().getCurrentCombinedCoordinatingAndPrimaryBytes();
+        long shardPrimaryAndCoordinatingLimits = tracker.getPrimaryAndCoordinatingLimits();
+        boolean shardMemoryLimitsBreached = ((double)shardCombinedBytes / shardPrimaryAndCoordinatingLimits) > this.upperOperatingFactor;
+
+        if(shardMemoryLimitsBreached) {
+            // Secondary Parameters (i.e. LastSuccessfulRequestDuration and Throughput) is taken into consideration when
+            // the current node utilization is greater than primary_parameter.node.soft_limit of total node limits.
+            if(((double)nodeTotalBytes / this.shardIndexingPressureSettings.getNodePrimaryAndCoordinatingLimits()) < this.nodeSoftLimit) {
+                boolean isShardLimitsIncreased = this.increaseShardPrimaryAndCoordinatingLimits(tracker);
+                if(isShardLimitsIncreased == false) {
+                    tracker.getPrimaryOperationTracker().getRejectionTracker().incrementNodeLimitsBreachedRejections();
+                    totalNodeLimitsBreachedRejections.incrementAndGet();
+                }
+                return !isShardLimitsIncreased;
+            } else {
+                boolean shardLastSuccessfulRequestDurationLimitsBreached =
+                    this.evaluateLastSuccessfulRequestDurationLimitsBreached(tracker.getPrimaryOperationTracker().getPerformanceTracker(),
+                        requestStartTime);
+
+                if(shardLastSuccessfulRequestDurationLimitsBreached) {
+                    tracker.getPrimaryOperationTracker().getRejectionTracker()
+                        .incrementLastSuccessfulRequestLimitsBreachedRejections();
+                    totalLastSuccessfulRequestLimitsBreachedRejections.incrementAndGet();
+                    return true;
+                }
+
+                boolean shardThroughputDegradationLimitsBreached =
+                    this.evaluateThroughputDegradationLimitsBreached(tracker.getPrimaryOperationTracker().getPerformanceTracker(),
+                        tracker.getPrimaryOperationTracker().getStatsTracker(),
+                        primaryAndCoordinatingThroughputDegradationLimits);
+
+                if (shardThroughputDegradationLimitsBreached) {
+                    tracker.getPrimaryOperationTracker().getRejectionTracker()
+                        .incrementThroughputDegradationLimitsBreachedRejections();
+                    totalThroughputDegradationLimitsBreachedRejections.incrementAndGet();
+                    return true;
+                }
+
+                boolean isShardLimitsIncreased = this.increaseShardPrimaryAndCoordinatingLimits(tracker);
+                if(isShardLimitsIncreased == false) {
+                    tracker.getPrimaryOperationTracker().getRejectionTracker().incrementNodeLimitsBreachedRejections();
+                    totalNodeLimitsBreachedRejections.incrementAndGet();
+                }
+
+                return !isShardLimitsIncreased;
+            }
+        } else {
+            return false;
+        }
+    }
+
+    boolean isCoordinatingNodeLimitBreached(ShardIndexingPressureTracker tracker, long nodeTotalBytes) {
+
+        //Checks if the node level threshold is breached.
+        if(nodeTotalBytes > this.shardIndexingPressureSettings.getNodePrimaryAndCoordinatingLimits()) {
+            logger.debug("Node limits breached for coordinating operation [node_total_bytes={} , " +
+                    "node_primary_and_coordinating_limits={}]", nodeTotalBytes,
+                this.shardIndexingPressureSettings.getNodePrimaryAndCoordinatingLimits());
+            tracker.getCoordinatingOperationTracker().getRejectionTracker().incrementNodeLimitsBreachedRejections();
+            totalNodeLimitsBreachedRejections.incrementAndGet();
+
+            return true;
+        }
+        return false;
+    }
+
+    boolean isCoordinatingShardLimitBreached(ShardIndexingPressureTracker tracker, long nodeTotalBytes, long requestStartTime) {
+
+        //Shard memory limit is breached when the current utilization is greater than operating_factor.upper of total shard limits.
+        long shardCombinedBytes = tracker.getCommonOperationTracker().getCurrentCombinedCoordinatingAndPrimaryBytes();
+        long shardPrimaryAndCoordinatingLimits = tracker.getPrimaryAndCoordinatingLimits();
+        boolean shardMemoryLimitsBreached = ((double)shardCombinedBytes / shardPrimaryAndCoordinatingLimits) > this.upperOperatingFactor;
+
+        if(shardMemoryLimitsBreached) {
+            /*
+            Secondary Parameters(i.e. LastSuccessfulRequestDuration and Throughput) is taken into consideration when
+            the current node utilization is greater than primary_parameter.node.soft_limit of total node limits.
+             */
+            if(((double)nodeTotalBytes / this.shardIndexingPressureSettings.getNodePrimaryAndCoordinatingLimits()) < this.nodeSoftLimit) {
+                boolean isShardLimitsIncreased = this.increaseShardPrimaryAndCoordinatingLimits(tracker);
+                if(isShardLimitsIncreased == false) {
+                    tracker.getCoordinatingOperationTracker().getRejectionTracker().incrementNodeLimitsBreachedRejections();
+                    totalNodeLimitsBreachedRejections.incrementAndGet();
+                }
+
+                return !isShardLimitsIncreased;
+            } else {
+                boolean shardLastSuccessfulRequestDurationLimitsBreached =
+                    this.evaluateLastSuccessfulRequestDurationLimitsBreached(tracker.getCoordinatingOperationTracker()
+                        .getPerformanceTracker(), requestStartTime);
+
+                if(shardLastSuccessfulRequestDurationLimitsBreached) {
+                    tracker.getCoordinatingOperationTracker().getRejectionTracker()
+                        .incrementLastSuccessfulRequestLimitsBreachedRejections();
+                    totalLastSuccessfulRequestLimitsBreachedRejections.incrementAndGet();
+                    return true;
+                }
+
+                boolean shardThroughputDegradationLimitsBreached =
+                    this.evaluateThroughputDegradationLimitsBreached(tracker.getCoordinatingOperationTracker().getPerformanceTracker(),
+                        tracker.getCoordinatingOperationTracker().getStatsTracker(),
+                        primaryAndCoordinatingThroughputDegradationLimits);
+
+                if (shardThroughputDegradationLimitsBreached) {
+                    tracker.getCoordinatingOperationTracker().getRejectionTracker()
+                        .incrementThroughputDegradationLimitsBreachedRejections();
+                    totalThroughputDegradationLimitsBreachedRejections.incrementAndGet();
+                    return true;
+                }
+
+                boolean isShardLimitsIncreased =
+                    this.increaseShardPrimaryAndCoordinatingLimits(tracker);
+                if(isShardLimitsIncreased == false) {
+                    tracker.getCoordinatingOperationTracker().getRejectionTracker().incrementNodeLimitsBreachedRejections();
+                    totalNodeLimitsBreachedRejections.incrementAndGet();
+                }
+
+                return !isShardLimitsIncreased;
+            }
+        } else {
+            return false;
+        }
+    }
+
+    boolean isReplicaNodeLimitBreached(ShardIndexingPressureTracker tracker, long nodeReplicaBytes) {
+
+        //Checks if the node level threshold is breached.
+        if(nodeReplicaBytes > this.shardIndexingPressureSettings.getNodeReplicaLimits()) {
+            logger.debug("Node limits breached for replica operation [node_replica_bytes={} , " +
+                "node_replica_limits={}]", nodeReplicaBytes, this.shardIndexingPressureSettings.getNodeReplicaLimits());
+            tracker.getReplicaOperationTracker().getRejectionTracker().incrementNodeLimitsBreachedRejections();
+            totalNodeLimitsBreachedRejections.incrementAndGet();
+
+            return true;
+        }
+        return false;
+    }
+
+    boolean isReplicaShardLimitBreached(ShardIndexingPressureTracker tracker, long nodeReplicaBytes, long requestStartTime) {
+
+        //Memory limits is breached when the current utilization is greater than operating_factor.upper of total shard limits.
+        long shardReplicaBytes = tracker.getReplicaOperationTracker().getStatsTracker().getCurrentBytes();
+        long shardReplicaLimits = tracker.getReplicaLimits();
+        final boolean shardMemoryLimitsBreached =
+            ((double)shardReplicaBytes / shardReplicaLimits) > this.upperOperatingFactor;
+
+        if(shardMemoryLimitsBreached) {
+            /*
+            Secondary Parameters(i.e. LastSuccessfulRequestDuration and Throughput) is taken into consideration when
+            the current node utilization is greater than primary_parameter.node.soft_limit of total node limits.
+             */
+            if(((double)nodeReplicaBytes / this.shardIndexingPressureSettings.getNodeReplicaLimits()) < this.nodeSoftLimit)  {
+                boolean isShardLimitsIncreased = this.increaseShardReplicaLimits(tracker);
+                if(isShardLimitsIncreased == false) {
+                    tracker.getReplicaOperationTracker().getRejectionTracker().incrementNodeLimitsBreachedRejections();
+                    totalNodeLimitsBreachedRejections.incrementAndGet();
+                }
+
+                return !isShardLimitsIncreased;
+            } else {
+                boolean shardLastSuccessfulRequestDurationLimitsBreached =
+                    this.evaluateLastSuccessfulRequestDurationLimitsBreached(tracker.getReplicaOperationTracker().getPerformanceTracker(),
+                        requestStartTime);
+
+                if(shardLastSuccessfulRequestDurationLimitsBreached) {
+                    tracker.getReplicaOperationTracker().getRejectionTracker().incrementLastSuccessfulRequestLimitsBreachedRejections();
+                    totalLastSuccessfulRequestLimitsBreachedRejections.incrementAndGet();
+                    return  true;
+                }
+
+                boolean shardThroughputDegradationLimitsBreached =
+                    this.evaluateThroughputDegradationLimitsBreached(tracker.getReplicaOperationTracker().getPerformanceTracker(),
+                        tracker.getReplicaOperationTracker().getStatsTracker(),
+                        replicaThroughputDegradationLimits);
+
+                if (shardThroughputDegradationLimitsBreached) {
+                    tracker.getReplicaOperationTracker().getRejectionTracker().incrementThroughputDegradationLimitsBreachedRejections();
+                    totalThroughputDegradationLimitsBreachedRejections.incrementAndGet();
+                    return true;
+                }
+
+                boolean isShardLimitsIncreased = this.increaseShardReplicaLimits(tracker);
+                if(isShardLimitsIncreased == false) {
+                    tracker.getReplicaOperationTracker().getRejectionTracker().incrementNodeLimitsBreachedRejections();
+                    totalNodeLimitsBreachedRejections.incrementAndGet();
+                }
+
+                return !isShardLimitsIncreased;
+            }
+        } else {
+            return false;
+        }
+    }
+
+    private boolean increaseShardPrimaryAndCoordinatingLimits(ShardIndexingPressureTracker tracker) {
+        long shardPrimaryAndCoordinatingLimits;
+        long newShardPrimaryAndCoordinatingLimits;
+        do {
+            shardPrimaryAndCoordinatingLimits = tracker.getPrimaryAndCoordinatingLimits();
+            long shardCombinedBytes = tracker.getCommonOperationTracker().getCurrentCombinedCoordinatingAndPrimaryBytes();
+            newShardPrimaryAndCoordinatingLimits = (long)(shardCombinedBytes / this.optimalOperatingFactor);
+
+            long totalPrimaryAndCoordinatingLimitsExceptCurrentShard = shardIndexingPressureStore.getShardIndexingPressureHotStore()
+                .entrySet().stream()
+                .filter(entry -> (tracker.getShardId() != entry.getKey()))
+                .map(Map.Entry::getValue)
+                .mapToLong(ShardIndexingPressureTracker::getPrimaryAndCoordinatingLimits).sum();
+
+            if(((double)shardCombinedBytes / shardPrimaryAndCoordinatingLimits) > this.upperOperatingFactor) {
+                if (totalPrimaryAndCoordinatingLimitsExceptCurrentShard + newShardPrimaryAndCoordinatingLimits >
+                    this.shardIndexingPressureSettings.getNodePrimaryAndCoordinatingLimits()) {
+                    logger.debug("Failed to increase the Primary And Coordinating Limits [shard_detail=[{}][{}}], " +
+                            "shard_max_primary_and_coordinating_bytes={}, " +
+                            "total_max_primary_and_coordinating_bytes_except_current_shard={}, " +
+                            "expected_shard_max_primary_and_coordinating_bytes={}, node_max_coordinating_and_primary_bytes={}]",
+                        tracker.getShardId().getIndexName(), tracker.getShardId().id(), shardPrimaryAndCoordinatingLimits,
+                        totalPrimaryAndCoordinatingLimitsExceptCurrentShard, newShardPrimaryAndCoordinatingLimits,
+                        this.shardIndexingPressureSettings.getNodePrimaryAndCoordinatingLimits());
+                    return false;
+                }
+            } else {
+                return true;
+            }
+        } while(!tracker.compareAndSetPrimaryAndCoordinatingLimits(shardPrimaryAndCoordinatingLimits,
+            newShardPrimaryAndCoordinatingLimits));
+
+        logger.debug("Increased the Primary And Coordinating Limits [" +
+                "shard_detail=[{}][{}], old_shard_max_primary_and_coordinating_bytes={}, " +
+                "new_shard_max_primary_and_coordinating_bytes={}]",
+            tracker.getShardId().getIndexName(), tracker.getShardId().id(),
+            shardPrimaryAndCoordinatingLimits, newShardPrimaryAndCoordinatingLimits);
+        return true;
+    }
+
+    void decreaseShardPrimaryAndCoordinatingLimits(ShardIndexingPressureTracker tracker) {
+        long shardPrimaryAndCoordinatingLimits;
+        long newShardPrimaryAndCoordinatingLimits;
+        do {
+            shardPrimaryAndCoordinatingLimits = tracker.getPrimaryAndCoordinatingLimits();
+            long shardCombinedBytes = tracker.getCommonOperationTracker().getCurrentCombinedCoordinatingAndPrimaryBytes();
+            newShardPrimaryAndCoordinatingLimits = Math.max((long) (shardCombinedBytes / this.optimalOperatingFactor),
+                this.shardIndexingPressureSettings.getShardPrimaryAndCoordinatingBaseLimits());
+
+            if (((double)shardCombinedBytes / shardPrimaryAndCoordinatingLimits) > this.lowerOperatingFactor) {
+                logger.debug("Primary And Coordinating Limits Already Decreased [" +
+                        "shard_detail=[{}][{}], " + "shard_max_primary_and_coordinating_bytes={}, " +
+                        "expected_shard_max_primary_and_coordinating_bytes={}]",
+                    tracker.getShardId().getIndexName(), tracker.getShardId().id(), shardPrimaryAndCoordinatingLimits,
+                    newShardPrimaryAndCoordinatingLimits);
+                return;
+            }
+        } while(!tracker.compareAndSetPrimaryAndCoordinatingLimits(shardPrimaryAndCoordinatingLimits,
+            newShardPrimaryAndCoordinatingLimits));
+
+        logger.debug("Decreased the Primary And Coordinating Limits [shard_detail=[{}][{}], " +
+                "shard_max_primary_and_coordinating_bytes={}, new_shard_max_primary_and_coordinating_bytes={}]",
+            tracker.getShardId().getIndexName(), tracker.getShardId().id(),
+            shardPrimaryAndCoordinatingLimits, newShardPrimaryAndCoordinatingLimits);
+    }
+
+    private boolean increaseShardReplicaLimits(ShardIndexingPressureTracker tracker) {
+        long shardReplicaLimits;
+        long newShardReplicaLimits;
+        do {
+            shardReplicaLimits = tracker.getReplicaLimits();
+            long shardReplicaBytes = tracker.getReplicaOperationTracker().getStatsTracker().getCurrentBytes();
+            newShardReplicaLimits = (long)(shardReplicaBytes / this.optimalOperatingFactor);
+
+            long totalReplicaLimitsExceptCurrentShard = shardIndexingPressureStore.getShardIndexingPressureHotStore()
+                .entrySet().stream()
+                .filter(entry -> (tracker.getShardId() != entry.getKey()))
+                .map(Map.Entry::getValue)
+                .mapToLong(ShardIndexingPressureTracker::getReplicaLimits).sum();
+
+            if(((double)shardReplicaBytes / shardReplicaLimits) > this.upperOperatingFactor) {
+                if (totalReplicaLimitsExceptCurrentShard + newShardReplicaLimits >
+                    this.shardIndexingPressureSettings.getNodeReplicaLimits()) {
+                    logger.debug("Failed to increase the Replica Limits [shard_detail=[{}][{}], " +
+                            "shard_max_replica_bytes={}, total_max_replica_except_current_shard={}}, " +
+                            "expected_shard_max_replica_bytes={}, node_max_replica_bytes={}]",
+                        tracker.getShardId().getIndexName(), tracker.getShardId().id(), shardReplicaLimits,
+                        totalReplicaLimitsExceptCurrentShard, newShardReplicaLimits,
+                        this.shardIndexingPressureSettings.getNodeReplicaLimits());
+                    return false;
+                }
+            } else {
+                return true;
+            }
+        } while(!tracker.compareAndSetReplicaLimits(shardReplicaLimits, newShardReplicaLimits));
+
+        logger.debug("Increased the Replica Limits [shard_detail=[{}][{}], " +
+                "old_shard_max_replica_bytes={}, new_expected_shard_max_replica_bytes={}]",
+            tracker.getShardId().getIndexName(), tracker.getShardId().id(),
+            shardReplicaLimits, newShardReplicaLimits);
+
+        return true;
+    }
+
+    void decreaseShardReplicaLimits(ShardIndexingPressureTracker tracker) {
+
+        long shardReplicaLimits;
+        long newShardReplicaLimits;
+        do {
+            shardReplicaLimits = tracker.getReplicaLimits();
+            long shardReplicaBytes = tracker.getReplicaOperationTracker().getStatsTracker().getCurrentBytes();
+            newShardReplicaLimits = Math.max((long) (shardReplicaBytes / this.optimalOperatingFactor),
+                this.shardIndexingPressureSettings.getShardReplicaBaseLimits());
+
+            if (((double)shardReplicaBytes / shardReplicaLimits) > this.lowerOperatingFactor) {
+                logger.debug("Replica Limits Already Increased [shard_detail=[{}][{}], " +
+                    "shard_max_replica_bytes={}, expected_shard_max_replica_bytes={}]",
+                tracker.getShardId().getIndexName(), tracker.getShardId().id(), shardReplicaLimits,
+                newShardReplicaLimits);
+                return;
+            }
+        } while(!tracker.compareAndSetReplicaLimits(shardReplicaLimits, newShardReplicaLimits));
+
+        logger.debug("Decreased the Replica Limits [shard_detail=[{}}][{}}], " +
+                "shard_max_replica_bytes={}, expected_shard_max_replica_bytes={}]",
+            tracker.getShardId().getIndexName(), tracker.getShardId().id(), shardReplicaLimits,
+            newShardReplicaLimits);
+    }
+
+    ShardIndexingPressureTracker getShardIndexingPressureTracker(ShardId shardId) {
+        return shardIndexingPressureStore.getShardIndexingPressureTracker(shardId);
+    }
+
+    Map<ShardId, ShardIndexingPressureTracker> getShardIndexingPressureHotStore() {
+        return shardIndexingPressureStore.getShardIndexingPressureHotStore();
+    }
+
+    /**
+     * Throughput of last N request divided by the total lifetime requests throughput is greater than the acceptable
+     * degradation limits then we say this parameter has breached the threshold.
+     */
+    private boolean  evaluateThroughputDegradationLimitsBreached(PerformanceTracker performanceTracker, StatsTracker statsTracker,
+                                                                 double degradationLimits) {
+        double throughputMovingAverage =  Double.longBitsToDouble(performanceTracker.getThroughputMovingAverage());
+        long throughputMovingQueueSize = performanceTracker.getThroughputMovingQueueSize();
+        double throughputHistoricalAverage = (double)statsTracker.getTotalBytes() / performanceTracker.getLatencyInMillis();
+        return throughputMovingAverage > 0 && throughputMovingQueueSize >= shardIndexingPressureSettings.getRequestSizeWindow() &&
+            throughputHistoricalAverage / throughputMovingAverage > degradationLimits;
+    }
+
+    /**
+     * The difference in the current timestamp and last successful request timestamp is greater than
+     * successful request elapsed timeout value and the total number of outstanding requests is greater than
+     * the maximum outstanding request count value then we say this parameter has breached the threshold.
+     */
+    private boolean evaluateLastSuccessfulRequestDurationLimitsBreached(PerformanceTracker performanceTracker, long requestStartTime) {
+        return (performanceTracker.getLastSuccessfulRequestTimestamp() > 0) &&
+            (((requestStartTime - performanceTracker.getLastSuccessfulRequestTimestamp()) > this.successfulRequestElapsedTimeout &&
+                performanceTracker.getTotalOutstandingRequests() > this.maxOutstandingRequests));
+    }
+
+    private void setLowerOperatingFactor(double lowerOperatingFactor) {
+        this.lowerOperatingFactor = lowerOperatingFactor;
+    }
+
+    private void setOptimalOperatingFactor(double optimalOperatingFactor) {
+        this.optimalOperatingFactor = optimalOperatingFactor;
+    }
+
+    private void setUpperOperatingFactor(double upperOperatingFactor) {
+        this.upperOperatingFactor = upperOperatingFactor;
+    }
+
+    private void setSuccessfulRequestElapsedTimeout(int successfulRequestElapsedTimeout) {
+        this.successfulRequestElapsedTimeout = successfulRequestElapsedTimeout;
+    }
+
+    private void setMaxOutstandingRequests(int maxOutstandingRequests) {
+        this.maxOutstandingRequests = maxOutstandingRequests;
+    }
+
+    private void setThroughputDegradationLimits(double throughputDegradationLimits) {
+        this.primaryAndCoordinatingThroughputDegradationLimits = throughputDegradationLimits;
+        this.replicaThroughputDegradationLimits = this.primaryAndCoordinatingThroughputDegradationLimits * 1.5;
+    }
+
+    private void setNodeSoftLimit(double nodeSoftLimit) {
+        this.nodeSoftLimit = nodeSoftLimit;
+    }
+}

--- a/server/src/main/java/org/opensearch/index/ShardIndexingPressureTracker.java
+++ b/server/src/main/java/org/opensearch/index/ShardIndexingPressureTracker.java
@@ -198,7 +198,7 @@ public class ShardIndexingPressureTracker {
      */
     public static class PerformanceTracker {
         private final AtomicLong latencyInMillis = new AtomicLong();
-        private final AtomicLong lastSuccessfulRequestTimestamp = new AtomicLong();
+        private volatile long lastSuccessfulRequestTimestamp = 0;
         private final AtomicLong totalOutstandingRequests = new AtomicLong();
         /**
          * Shard Window Throughput Tracker.
@@ -217,11 +217,11 @@ public class ShardIndexingPressureTracker {
         }
 
         public long getLastSuccessfulRequestTimestamp() {
-            return lastSuccessfulRequestTimestamp.get();
+            return lastSuccessfulRequestTimestamp;
         }
 
-        public long updateLastSuccessfulRequestTimestamp(long timeStamp) {
-            return lastSuccessfulRequestTimestamp.getAndSet(timeStamp);
+        public void updateLastSuccessfulRequestTimestamp(long timeStamp) {
+            lastSuccessfulRequestTimestamp = timeStamp;
         }
 
         public long getTotalOutstandingRequests() {

--- a/server/src/main/java/org/opensearch/index/ShardIndexingPressureTracker.java
+++ b/server/src/main/java/org/opensearch/index/ShardIndexingPressureTracker.java
@@ -57,8 +57,16 @@ public class ShardIndexingPressureTracker {
         return primaryAndCoordinatingLimits.get();
     }
 
+    public boolean compareAndSetPrimaryAndCoordinatingLimits(long expectedValue, long newValue) {
+        return primaryAndCoordinatingLimits.compareAndSet(expectedValue, newValue);
+    }
+
     public long getReplicaLimits() {
         return replicaLimits.get();
+    }
+
+    public boolean compareAndSetReplicaLimits(long expectedValue, long newValue) {
+        return replicaLimits.compareAndSet(expectedValue, newValue);
     }
 
     public OperationTracker getCoordinatingOperationTracker() {
@@ -116,8 +124,16 @@ public class ShardIndexingPressureTracker {
             return currentBytes.get();
         }
 
+        public long incrementCurrentBytes(long bytes) {
+            return currentBytes.addAndGet(bytes);
+        }
+
         public long getTotalBytes() {
             return totalBytes.get();
+        }
+
+        public long incrementTotalBytes(long bytes) {
+            return totalBytes.addAndGet(bytes);
         }
 
         public long getRequestCount() {
@@ -149,12 +165,24 @@ public class ShardIndexingPressureTracker {
             return nodeLimitsBreachedRejections.get();
         }
 
+        public long incrementNodeLimitsBreachedRejections() {
+            return nodeLimitsBreachedRejections.incrementAndGet();
+        }
+
         public long getLastSuccessfulRequestLimitsBreachedRejections() {
             return lastSuccessfulRequestLimitsBreachedRejections.get();
         }
 
+        public long incrementLastSuccessfulRequestLimitsBreachedRejections() {
+            return lastSuccessfulRequestLimitsBreachedRejections.incrementAndGet();
+        }
+
         public long getThroughputDegradationLimitsBreachedRejections() {
             return throughputDegradationLimitsBreachedRejections.get();
+        }
+
+        public long incrementThroughputDegradationLimitsBreachedRejections() {
+            return throughputDegradationLimitsBreachedRejections.incrementAndGet();
         }
     }
 
@@ -184,16 +212,32 @@ public class ShardIndexingPressureTracker {
             return latencyInMillis.get();
         }
 
+        public long addLatencyInMillis(long latency) {
+            return latencyInMillis.addAndGet(latency);
+        }
+
         public long getLastSuccessfulRequestTimestamp() {
             return lastSuccessfulRequestTimestamp.get();
+        }
+
+        public long updateLastSuccessfulRequestTimestamp(long timeStamp) {
+            return lastSuccessfulRequestTimestamp.getAndSet(timeStamp);
         }
 
         public long getTotalOutstandingRequests() {
             return totalOutstandingRequests.get();
         }
 
+        public long incrementTotalOutstandingRequests() {
+            return totalOutstandingRequests.incrementAndGet();
+        }
+
         public long getThroughputMovingAverage() {
             return throughputMovingAverage.get();
+        }
+
+        public long updateThroughputMovingAverage(long newAvg) {
+            return throughputMovingAverage.getAndSet(newAvg);
         }
 
         public boolean addNewThroughout(Double newThroughput) {
@@ -222,6 +266,10 @@ public class ShardIndexingPressureTracker {
 
         public long getCurrentCombinedCoordinatingAndPrimaryBytes() {
             return currentCombinedCoordinatingAndPrimaryBytes.get();
+        }
+
+        public long incrementCurrentCombinedCoordinatingAndPrimaryBytes(long bytes) {
+            return currentCombinedCoordinatingAndPrimaryBytes.addAndGet(bytes);
         }
 
         public long getTotalCombinedCoordinatingAndPrimaryBytes() {

--- a/server/src/test/java/org/opensearch/index/ShardIndexingPressureMemoryManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/ShardIndexingPressureMemoryManagerTests.java
@@ -1,0 +1,562 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index;
+
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase {
+
+    private final Settings settings = Settings.builder().put(IndexingPressure.MAX_INDEXING_BYTES.getKey(), "10KB")
+        .put(ShardIndexingPressureMemoryManager.MAX_OUTSTANDING_REQUESTS.getKey(), 1)
+        .put(ShardIndexingPressureMemoryManager.SUCCESSFUL_REQUEST_ELAPSED_TIMEOUT.getKey(), 20)
+        .put(ShardIndexingPressureSettings.REQUEST_SIZE_WINDOW.getKey(), 2)
+        .build();
+    private final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+    private final ShardIndexingPressureSettings shardIndexingPressureSettings =
+        new ShardIndexingPressureSettings(new ClusterService(settings, clusterSettings, null), settings,
+            IndexingPressure.MAX_INDEXING_BYTES.get(settings).getBytes());
+
+    private final Index index = new Index("IndexName", "UUID");
+    private final ShardId shardId1 = new ShardId(index, 0);
+    private final ShardId shardId2 = new ShardId(index, 1);
+
+    public void testCoordinatingPrimaryShardLimitsNotBreached() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker = memoryManager.getShardIndexingPressureTracker(shardId1);
+        tracker.getCommonOperationTracker().incrementCurrentCombinedCoordinatingAndPrimaryBytes(1);
+        long requestStartTime = System.currentTimeMillis();
+        Map<ShardId, ShardIndexingPressureTracker> hotStore = memoryManager.getShardIndexingPressureHotStore();
+
+        assertFalse(memoryManager.isCoordinatingShardLimitBreached(tracker, 1 * 1024, requestStartTime));
+        assertFalse(memoryManager.isPrimaryShardLimitBreached(tracker,  1 * 1024, requestStartTime));
+    }
+
+    public void testReplicaShardLimitsNotBreached() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker = memoryManager.getShardIndexingPressureTracker(shardId1);
+        tracker.getReplicaOperationTracker().getStatsTracker().incrementCurrentBytes(1);
+        long requestStartTime = System.currentTimeMillis();
+        Map<Long, ShardIndexingPressureTracker> hotStore = Collections.singletonMap((long) shardId1.hashCode(), tracker);
+
+        assertFalse(memoryManager.isReplicaShardLimitBreached(tracker, 1 * 1024, requestStartTime));
+    }
+
+    public void testCoordinatingPrimaryShardLimitsIncreasedAndSoftLimitNotBreached() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker = memoryManager.getShardIndexingPressureTracker(shardId1);
+        tracker.getCommonOperationTracker().incrementCurrentCombinedCoordinatingAndPrimaryBytes(10);
+        long baseLimit = tracker.getPrimaryAndCoordinatingLimits();
+        long requestStartTime = System.currentTimeMillis();
+        Map<ShardId, ShardIndexingPressureTracker> hotStore = memoryManager.getShardIndexingPressureHotStore();
+
+        assertFalse(memoryManager.isCoordinatingShardLimitBreached(tracker, 1 * 1024, requestStartTime));
+        assertFalse(memoryManager.isPrimaryShardLimitBreached(tracker, 1 * 1024, requestStartTime));
+
+        assertTrue(tracker.getPrimaryAndCoordinatingLimits() > baseLimit);
+        assertEquals(tracker.getPrimaryAndCoordinatingLimits(), (long)(baseLimit/0.85));
+    }
+
+    public void testReplicaShardLimitsIncreasedAndSoftLimitNotBreached() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker = memoryManager.getShardIndexingPressureTracker(shardId1);
+        tracker.getReplicaOperationTracker().getStatsTracker().incrementCurrentBytes(15);
+        long baseLimit = tracker.getReplicaLimits();
+        long requestStartTime = System.currentTimeMillis();
+        Map<ShardId, ShardIndexingPressureTracker> hotStore = memoryManager.getShardIndexingPressureHotStore();
+
+        assertFalse(memoryManager.isReplicaShardLimitBreached(tracker, 1 * 1024, requestStartTime));
+        assertTrue(tracker.getReplicaLimits() > baseLimit);
+        assertEquals(tracker.getReplicaLimits(), (long)(baseLimit/0.85));
+    }
+
+    public void testCoordinatingPrimarySoftLimitNotBreachedAndNodeLevelRejections() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker1 = memoryManager.getShardIndexingPressureTracker(shardId1);
+        ShardIndexingPressureTracker tracker2 = memoryManager.getShardIndexingPressureTracker(shardId2);
+        tracker1.getCommonOperationTracker().incrementCurrentCombinedCoordinatingAndPrimaryBytes(4 * 1024);
+        tracker2.compareAndSetPrimaryAndCoordinatingLimits(tracker2.getPrimaryAndCoordinatingLimits(), 6 * 1024);
+        long limit1 = tracker1.getPrimaryAndCoordinatingLimits();
+        long limit2 = tracker2.getPrimaryAndCoordinatingLimits();
+        long requestStartTime = System.currentTimeMillis();
+        Map<ShardId, ShardIndexingPressureTracker> hotStore = memoryManager.getShardIndexingPressureHotStore();
+
+        assertTrue(memoryManager.isCoordinatingShardLimitBreached(tracker1, 8 * 1024, requestStartTime));
+        assertEquals(1, tracker1.getCoordinatingOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+        assertEquals(0, tracker2.getCoordinatingOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+
+        assertTrue(memoryManager.isPrimaryShardLimitBreached(tracker1, 8 * 1024, requestStartTime));
+        assertEquals(1, tracker1.getPrimaryOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+        assertEquals(0, tracker2.getPrimaryOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+
+        assertEquals(limit1, tracker1.getPrimaryAndCoordinatingLimits());
+        assertEquals(limit2, tracker2.getPrimaryAndCoordinatingLimits());
+        assertEquals(2, memoryManager.totalNodeLimitsBreachedRejections.get());
+    }
+
+    public void testReplicaShardLimitsSoftLimitNotBreachedAndNodeLevelRejections() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker1 = memoryManager.getShardIndexingPressureTracker(shardId1);
+        ShardIndexingPressureTracker tracker2 = memoryManager.getShardIndexingPressureTracker(shardId2);
+        tracker1.getReplicaOperationTracker().getStatsTracker().incrementCurrentBytes(5 * 1024);
+        tracker2.compareAndSetReplicaLimits(tracker2.getReplicaLimits(), 10 * 1024);
+        long limit1 = tracker1.getReplicaLimits();
+        long limit2 = tracker2.getReplicaLimits();
+        long requestStartTime = System.currentTimeMillis();
+        Map<ShardId, ShardIndexingPressureTracker> hotStore = memoryManager.getShardIndexingPressureHotStore();
+
+        assertTrue(memoryManager.isReplicaShardLimitBreached(tracker1, 10 * 1024, requestStartTime));
+        assertEquals(limit1, tracker1.getReplicaLimits());
+        assertEquals(limit2, tracker2.getReplicaLimits());
+        assertEquals(1, tracker1.getReplicaOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+        assertEquals(0, tracker2.getReplicaOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+        assertEquals(1, memoryManager.totalNodeLimitsBreachedRejections.get());
+    }
+
+    public void testCoordinatingPrimarySoftLimitBreachedAndNodeLevelRejections() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker1 = memoryManager.getShardIndexingPressureTracker(shardId1);
+        ShardIndexingPressureTracker tracker2 = memoryManager.getShardIndexingPressureTracker(shardId2);
+        tracker1.getCommonOperationTracker().incrementCurrentCombinedCoordinatingAndPrimaryBytes(4 * 1024);
+        tracker2.compareAndSetPrimaryAndCoordinatingLimits(tracker2.getPrimaryAndCoordinatingLimits(), 6 * 1024);
+        long limit1 = tracker1.getPrimaryAndCoordinatingLimits();
+        long limit2 = tracker2.getPrimaryAndCoordinatingLimits();
+        long requestStartTime = System.currentTimeMillis();
+
+        assertTrue(memoryManager.isCoordinatingShardLimitBreached(tracker1, 8 * 1024, requestStartTime));
+        assertEquals(1, tracker1.getCoordinatingOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+        assertEquals(0, tracker2.getCoordinatingOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+
+        assertTrue(memoryManager.isPrimaryShardLimitBreached(tracker1,  8 * 1024, requestStartTime));
+        assertEquals(1, tracker1.getPrimaryOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+        assertEquals(0, tracker2.getPrimaryOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+
+        assertEquals(limit1, tracker1.getPrimaryAndCoordinatingLimits());
+        assertEquals(limit2, tracker2.getPrimaryAndCoordinatingLimits());
+        assertEquals(2, memoryManager.totalNodeLimitsBreachedRejections.get());
+    }
+
+    public void testReplicaShardLimitsSoftLimitBreachedAndNodeLevelRejections() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker1 = memoryManager.getShardIndexingPressureTracker(shardId1);
+        ShardIndexingPressureTracker tracker2 = memoryManager.getShardIndexingPressureTracker(shardId2);
+        tracker1.getReplicaOperationTracker().getStatsTracker().incrementCurrentBytes(5 * 1024);
+        tracker2.compareAndSetReplicaLimits(tracker2.getReplicaLimits(), 12 * 1024);
+        long limit1 = tracker1.getReplicaLimits();
+        long limit2 = tracker2.getReplicaLimits();
+        long requestStartTime = System.currentTimeMillis();
+        Map<ShardId, ShardIndexingPressureTracker> hotStore = memoryManager.getShardIndexingPressureHotStore();
+
+        assertTrue(memoryManager.isReplicaShardLimitBreached(tracker1,  12 * 1024, requestStartTime));
+        assertEquals(limit1, tracker1.getReplicaLimits());
+        assertEquals(limit2, tracker2.getReplicaLimits());
+        assertEquals(1, tracker1.getReplicaOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+        assertEquals(0, tracker2.getReplicaOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+        assertEquals(1, memoryManager.totalNodeLimitsBreachedRejections.get());
+    }
+
+    public void testCoordinatingPrimarySoftLimitBreachedAndLastSuccessfulRequestLimitRejections() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker1 = memoryManager.getShardIndexingPressureTracker(shardId1);
+        ShardIndexingPressureTracker tracker2 = memoryManager.getShardIndexingPressureTracker(shardId2);
+        tracker1.getCommonOperationTracker().incrementCurrentCombinedCoordinatingAndPrimaryBytes(4 * 1024);
+        tracker2.compareAndSetPrimaryAndCoordinatingLimits(tracker2.getPrimaryAndCoordinatingLimits(), 6 * 1024);
+        long limit1 = tracker1.getPrimaryAndCoordinatingLimits();
+        long limit2 = tracker2.getPrimaryAndCoordinatingLimits();
+        long requestStartTime = System.currentTimeMillis();
+        Map<ShardId, ShardIndexingPressureTracker> hotStore = memoryManager.getShardIndexingPressureHotStore();
+
+
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().updateLastSuccessfulRequestTimestamp(requestStartTime - 100);
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+
+        assertTrue(memoryManager.isCoordinatingShardLimitBreached(tracker1, 8 * 1024, requestStartTime));
+        assertEquals(1, tracker1.getCoordinatingOperationTracker().getRejectionTracker()
+            .getLastSuccessfulRequestLimitsBreachedRejections());
+        assertEquals(0, tracker2.getCoordinatingOperationTracker().getRejectionTracker()
+            .getLastSuccessfulRequestLimitsBreachedRejections());
+
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().updateLastSuccessfulRequestTimestamp(requestStartTime - 100);
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+
+        assertTrue(memoryManager.isPrimaryShardLimitBreached(tracker1,  8 * 1024, requestStartTime));
+        assertEquals(1, tracker1.getPrimaryOperationTracker().getRejectionTracker()
+            .getLastSuccessfulRequestLimitsBreachedRejections());
+        assertEquals(0, tracker2.getPrimaryOperationTracker().getRejectionTracker()
+            .getLastSuccessfulRequestLimitsBreachedRejections());
+
+        assertEquals(limit1, tracker1.getPrimaryAndCoordinatingLimits());
+        assertEquals(limit2, tracker2.getPrimaryAndCoordinatingLimits());
+        assertEquals(2, memoryManager.totalLastSuccessfulRequestLimitsBreachedRejections.get());
+    }
+
+    public void testReplicaShardLimitsSoftLimitBreachedAndLastSuccessfulRequestLimitRejections() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+
+        ShardIndexingPressureTracker tracker1 = memoryManager.getShardIndexingPressureTracker(shardId1);
+        ShardIndexingPressureTracker tracker2 = memoryManager.getShardIndexingPressureTracker(shardId2);
+        tracker1.getReplicaOperationTracker().getStatsTracker().incrementCurrentBytes(5 * 1024);
+        tracker2.compareAndSetReplicaLimits(tracker2.getReplicaLimits(), 12 * 1024);
+        long limit1 = tracker1.getReplicaLimits();
+        long limit2 = tracker2.getReplicaLimits();
+        long requestStartTime = System.currentTimeMillis();
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().updateLastSuccessfulRequestTimestamp(requestStartTime - 100);
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+
+        assertTrue(memoryManager.isReplicaShardLimitBreached(tracker1,  12 * 1024, requestStartTime));
+        assertEquals(limit1, tracker1.getReplicaLimits());
+        assertEquals(limit2, tracker2.getReplicaLimits());
+        assertEquals(1, tracker1.getReplicaOperationTracker().getRejectionTracker()
+            .getLastSuccessfulRequestLimitsBreachedRejections());
+        assertEquals(0, tracker2.getReplicaOperationTracker().getRejectionTracker()
+            .getLastSuccessfulRequestLimitsBreachedRejections());
+        assertEquals(1, memoryManager.totalLastSuccessfulRequestLimitsBreachedRejections.get());
+    }
+
+    public void testCoordinatingPrimarySoftLimitBreachedAndLessOutstandingRequestsAndNoLastSuccessfulRequestLimitRejections() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker1 = memoryManager.getShardIndexingPressureTracker(shardId1);
+        ShardIndexingPressureTracker tracker2 = memoryManager.getShardIndexingPressureTracker(shardId2);
+        tracker1.getCommonOperationTracker().incrementCurrentCombinedCoordinatingAndPrimaryBytes(1 * 1024);
+        tracker2.compareAndSetPrimaryAndCoordinatingLimits(tracker2.getPrimaryAndCoordinatingLimits(), 6 * 1024);
+        long limit1 = tracker1.getPrimaryAndCoordinatingLimits();
+        long limit2 = tracker2.getPrimaryAndCoordinatingLimits();
+        long requestStartTime = System.currentTimeMillis();
+        Map<ShardId, ShardIndexingPressureTracker> hotStore = memoryManager.getShardIndexingPressureHotStore();
+
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().updateLastSuccessfulRequestTimestamp(requestStartTime - 100);
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+
+        assertFalse(memoryManager.isCoordinatingShardLimitBreached(tracker1, 8 * 1024, requestStartTime));
+        assertEquals(0, tracker1.getCoordinatingOperationTracker().getRejectionTracker()
+            .getLastSuccessfulRequestLimitsBreachedRejections());
+        assertEquals(0, tracker2.getCoordinatingOperationTracker().getRejectionTracker()
+            .getLastSuccessfulRequestLimitsBreachedRejections());
+
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().updateLastSuccessfulRequestTimestamp(requestStartTime - 100);
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+
+        assertFalse(memoryManager.isPrimaryShardLimitBreached(tracker1,  8 * 1024, requestStartTime));
+        assertEquals(0, tracker1.getPrimaryOperationTracker().getRejectionTracker()
+            .getLastSuccessfulRequestLimitsBreachedRejections());
+        assertEquals(0, tracker2.getPrimaryOperationTracker().getRejectionTracker()
+            .getLastSuccessfulRequestLimitsBreachedRejections());
+
+        assertTrue(tracker1.getPrimaryAndCoordinatingLimits() > limit1);
+        assertEquals((long)(1 * 1024/0.85), tracker1.getPrimaryAndCoordinatingLimits());
+        assertEquals(limit2, tracker2.getPrimaryAndCoordinatingLimits());
+        assertEquals(0, memoryManager.totalLastSuccessfulRequestLimitsBreachedRejections.get());
+    }
+
+    public void testReplicaShardLimitsSoftLimitBreachedAndLessOutstandingRequestsAndNoLastSuccessfulRequestLimitRejections() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker1 = memoryManager.getShardIndexingPressureTracker(shardId1);
+        ShardIndexingPressureTracker tracker2 = memoryManager.getShardIndexingPressureTracker(shardId2);
+        tracker1.getReplicaOperationTracker().getStatsTracker().incrementCurrentBytes(2 * 1024);
+        tracker2.compareAndSetReplicaLimits(tracker2.getReplicaLimits(), 12 * 1024);
+        long limit1 = tracker1.getReplicaLimits();
+        long limit2 = tracker2.getReplicaLimits();
+        long requestStartTime = System.currentTimeMillis();
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().updateLastSuccessfulRequestTimestamp(requestStartTime - 100);
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+
+        assertFalse(memoryManager.isReplicaShardLimitBreached(tracker1,  12 * 1024, requestStartTime));
+        assertTrue(tracker1.getReplicaLimits() > limit1);
+        assertEquals((long)(2 * 1024/0.85), tracker1.getReplicaLimits());
+        assertEquals(limit2, tracker2.getReplicaLimits());
+        assertEquals(0, tracker1.getReplicaOperationTracker().getRejectionTracker()
+            .getLastSuccessfulRequestLimitsBreachedRejections());
+        assertEquals(0, tracker2.getReplicaOperationTracker().getRejectionTracker()
+            .getLastSuccessfulRequestLimitsBreachedRejections());
+        assertEquals(0, memoryManager.totalLastSuccessfulRequestLimitsBreachedRejections.get());
+    }
+
+    public void testCoordinatingPrimarySoftLimitBreachedAndThroughputDegradationLimitRejections() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker1 = memoryManager.getShardIndexingPressureTracker(shardId1);
+        ShardIndexingPressureTracker tracker2 = memoryManager.getShardIndexingPressureTracker(shardId2);
+        tracker1.getCommonOperationTracker().incrementCurrentCombinedCoordinatingAndPrimaryBytes(4 * 1024);
+        tracker2.compareAndSetPrimaryAndCoordinatingLimits(tracker2.getPrimaryAndCoordinatingLimits(), 6 * 1024);
+        long limit1 = tracker1.getPrimaryAndCoordinatingLimits();
+        long limit2 = tracker2.getPrimaryAndCoordinatingLimits();
+        long requestStartTime = System.currentTimeMillis();
+
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().updateThroughputMovingAverage(Double.doubleToLongBits(1d));
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+        tracker1.getCoordinatingOperationTracker().getStatsTracker().incrementTotalBytes(60);
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().addLatencyInMillis(10);
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().addNewThroughout(1d);
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().addNewThroughout(2d);
+
+        assertTrue(memoryManager.isCoordinatingShardLimitBreached(tracker1, 8 * 1024, requestStartTime));
+        assertEquals(1, tracker1.getCoordinatingOperationTracker().getRejectionTracker()
+            .getThroughputDegradationLimitsBreachedRejections());
+        assertEquals(0, tracker2.getCoordinatingOperationTracker().getRejectionTracker()
+            .getThroughputDegradationLimitsBreachedRejections());
+
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().updateThroughputMovingAverage(Double.doubleToLongBits(1d));
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+        tracker1.getPrimaryOperationTracker().getStatsTracker().incrementTotalBytes(60);
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().addLatencyInMillis(10);
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().addNewThroughout(1d);
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().addNewThroughout(2d);
+
+        assertTrue(memoryManager.isPrimaryShardLimitBreached(tracker1,  8 * 1024, requestStartTime));
+        assertEquals(1, tracker1.getPrimaryOperationTracker().getRejectionTracker()
+            .getThroughputDegradationLimitsBreachedRejections());
+        assertEquals(0, tracker2.getPrimaryOperationTracker().getRejectionTracker()
+            .getThroughputDegradationLimitsBreachedRejections());
+
+        assertEquals(limit1, tracker1.getPrimaryAndCoordinatingLimits());
+        assertEquals(limit2, tracker2.getPrimaryAndCoordinatingLimits());
+        assertEquals(2, memoryManager.totalThroughputDegradationLimitsBreachedRejections.get());
+    }
+
+    public void testReplicaShardLimitsSoftLimitBreachedAndThroughputDegradationLimitRejections() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker1 = memoryManager.getShardIndexingPressureTracker(shardId1);
+        ShardIndexingPressureTracker tracker2 = memoryManager.getShardIndexingPressureTracker(shardId2);
+        tracker1.getReplicaOperationTracker().getStatsTracker().incrementCurrentBytes(5 * 1024);
+        tracker2.compareAndSetReplicaLimits(tracker2.getReplicaLimits(), 12 * 1024);
+        long limit1 = tracker1.getReplicaLimits();
+        long limit2 = tracker2.getReplicaLimits();
+        long requestStartTime = System.currentTimeMillis();
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().updateThroughputMovingAverage(Double.doubleToLongBits(1d));
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+        tracker1.getReplicaOperationTracker().getStatsTracker().incrementTotalBytes(80);
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().addLatencyInMillis(10);
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().addNewThroughout(1d);
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().addNewThroughout(2d);
+
+        assertTrue(memoryManager.isReplicaShardLimitBreached(tracker1,  12 * 1024, requestStartTime));
+        assertEquals(limit1, tracker1.getReplicaLimits());
+        assertEquals(limit2, tracker2.getReplicaLimits());
+        assertEquals(1, tracker1.getReplicaOperationTracker().getRejectionTracker()
+            .getThroughputDegradationLimitsBreachedRejections());
+        assertEquals(0, tracker2.getReplicaOperationTracker().getRejectionTracker()
+            .getThroughputDegradationLimitsBreachedRejections());
+        assertEquals(1, memoryManager.totalThroughputDegradationLimitsBreachedRejections.get());
+    }
+
+    public void testCoordinatingPrimarySoftLimitBreachedAndMovingAverageQueueNotBuildUpAndNoThroughputDegradationLimitRejections() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+
+        ShardIndexingPressureTracker tracker1 = memoryManager.getShardIndexingPressureTracker(shardId1);
+        ShardIndexingPressureTracker tracker2 = memoryManager.getShardIndexingPressureTracker(shardId2);
+        tracker1.getCommonOperationTracker().incrementCurrentCombinedCoordinatingAndPrimaryBytes(1 * 1024);
+        tracker2.compareAndSetPrimaryAndCoordinatingLimits(tracker2.getPrimaryAndCoordinatingLimits(), 6 * 1024);
+        long limit1 = tracker1.getPrimaryAndCoordinatingLimits();
+        long limit2 = tracker2.getPrimaryAndCoordinatingLimits();
+        long requestStartTime = System.currentTimeMillis();
+
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().updateThroughputMovingAverage
+            (Double.doubleToLongBits(1d));
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+        tracker1.getCoordinatingOperationTracker().getStatsTracker().incrementTotalBytes(60);
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().addLatencyInMillis(10);
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().addNewThroughout(1d);
+
+        assertFalse(memoryManager.isCoordinatingShardLimitBreached(tracker1, 8 * 1024, requestStartTime));
+        assertEquals(0, tracker1.getCoordinatingOperationTracker().getRejectionTracker()
+            .getThroughputDegradationLimitsBreachedRejections());
+        assertEquals(0, tracker2.getCoordinatingOperationTracker().getRejectionTracker()
+            .getThroughputDegradationLimitsBreachedRejections());
+        assertEquals(0, tracker1.getCoordinatingOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+        assertEquals(0, tracker2.getCoordinatingOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().updateThroughputMovingAverage(Double.doubleToLongBits(1d));
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+        tracker1.getPrimaryOperationTracker().getStatsTracker().incrementTotalBytes(60);
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().addLatencyInMillis(10);
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().addNewThroughout(1d);
+
+        assertFalse(memoryManager.isPrimaryShardLimitBreached(tracker1,  8 * 1024, requestStartTime));
+        assertEquals(0, tracker1.getPrimaryOperationTracker().getRejectionTracker()
+            .getThroughputDegradationLimitsBreachedRejections());
+        assertEquals(0, tracker2.getPrimaryOperationTracker().getRejectionTracker()
+            .getThroughputDegradationLimitsBreachedRejections());
+        assertEquals(0, tracker1.getPrimaryOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+        assertEquals(0, tracker2.getPrimaryOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+
+        assertTrue(tracker1.getPrimaryAndCoordinatingLimits() > limit1);
+        assertEquals((long)(1 * 1024/0.85), tracker1.getPrimaryAndCoordinatingLimits());
+        assertEquals(limit2, tracker2.getPrimaryAndCoordinatingLimits());
+        assertEquals(0, memoryManager.totalThroughputDegradationLimitsBreachedRejections.get());
+    }
+
+    public void testReplicaShardLimitsSoftLimitBreachedAndMovingAverageQueueNotBuildUpAndNThroughputDegradationLimitRejections() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker1 = memoryManager.getShardIndexingPressureTracker(shardId1);
+        ShardIndexingPressureTracker tracker2 = memoryManager.getShardIndexingPressureTracker(shardId2);
+        tracker1.getReplicaOperationTracker().getStatsTracker().incrementCurrentBytes(2 * 1024);
+        tracker2.compareAndSetReplicaLimits(tracker2.getReplicaLimits(), 12 * 1024);
+        long limit1 = tracker1.getReplicaLimits();
+        long limit2 = tracker2.getReplicaLimits();
+        long requestStartTime = System.currentTimeMillis();
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().updateThroughputMovingAverage(Double.doubleToLongBits(1d));
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+        tracker1.getReplicaOperationTracker().getStatsTracker().incrementTotalBytes(80);
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().addLatencyInMillis(10);
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().addNewThroughout(1d);
+
+        assertFalse(memoryManager.isReplicaShardLimitBreached(tracker1,  12 * 1024, requestStartTime));
+        assertTrue(tracker1.getReplicaLimits() > limit1);
+        assertEquals((long)(2 * 1024/0.85), tracker1.getReplicaLimits());
+        assertEquals(limit2, tracker2.getReplicaLimits());
+        assertEquals(0, tracker1.getReplicaOperationTracker().getRejectionTracker()
+            .getThroughputDegradationLimitsBreachedRejections());
+        assertEquals(0, tracker2.getReplicaOperationTracker().getRejectionTracker()
+            .getThroughputDegradationLimitsBreachedRejections());
+        assertEquals(0, tracker1.getReplicaOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+        assertEquals(0, memoryManager.totalThroughputDegradationLimitsBreachedRejections.get());
+    }
+
+    public void testCoordinatingPrimarySoftLimitBreachedAndNoSecondaryParameterBreachedAndNodeLevelRejections() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker1 = memoryManager.getShardIndexingPressureTracker(shardId1);
+        ShardIndexingPressureTracker tracker2 = memoryManager.getShardIndexingPressureTracker(shardId2);
+        tracker1.getCommonOperationTracker().incrementCurrentCombinedCoordinatingAndPrimaryBytes(4 * 1024);
+        tracker2.compareAndSetPrimaryAndCoordinatingLimits(tracker2.getPrimaryAndCoordinatingLimits(), 6 * 1024);
+        long limit1 = tracker1.getPrimaryAndCoordinatingLimits();
+        long limit2 = tracker2.getPrimaryAndCoordinatingLimits();
+        long requestStartTime = System.currentTimeMillis();
+
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().updateThroughputMovingAverage(Double.doubleToLongBits(1d));
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+        tracker1.getCoordinatingOperationTracker().getStatsTracker().incrementTotalBytes(60);
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().addLatencyInMillis(10);
+        tracker1.getCoordinatingOperationTracker().getPerformanceTracker().addNewThroughout(1d);
+
+        assertTrue(memoryManager.isCoordinatingShardLimitBreached(tracker1, 8 * 1024, requestStartTime));
+        assertEquals(1, tracker1.getCoordinatingOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+        assertEquals(0, tracker2.getCoordinatingOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().updateThroughputMovingAverage(Double.doubleToLongBits(1d));
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+        tracker1.getPrimaryOperationTracker().getStatsTracker().incrementTotalBytes(60);
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().addLatencyInMillis(10);
+        tracker1.getPrimaryOperationTracker().getPerformanceTracker().addNewThroughout(1d);
+
+        assertTrue(memoryManager.isPrimaryShardLimitBreached(tracker1,  8 * 1024, requestStartTime));
+        assertEquals(1, tracker1.getPrimaryOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+        assertEquals(0, tracker2.getPrimaryOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+
+        assertEquals(limit1, tracker1.getPrimaryAndCoordinatingLimits());
+        assertEquals(limit2, tracker2.getPrimaryAndCoordinatingLimits());
+        assertEquals(2, memoryManager.totalNodeLimitsBreachedRejections.get());
+    }
+
+    public void testReplicaShardLimitsSoftLimitBreachedAndNoSecondaryParameterBreachedAndNodeLevelRejections() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+
+        ShardIndexingPressureTracker tracker1 = memoryManager.getShardIndexingPressureTracker(shardId1);
+        ShardIndexingPressureTracker tracker2 = memoryManager.getShardIndexingPressureTracker(shardId2);
+        tracker1.getReplicaOperationTracker().getStatsTracker().incrementCurrentBytes(5 * 1024);
+        tracker2.compareAndSetReplicaLimits(tracker2.getReplicaLimits(), 12 * 1024);
+        long limit1 = tracker1.getReplicaLimits();
+        long limit2 = tracker2.getReplicaLimits();
+        long requestStartTime = System.currentTimeMillis();
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().updateThroughputMovingAverage(Double.doubleToLongBits(1d));
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
+        tracker1.getReplicaOperationTracker().getStatsTracker().incrementTotalBytes(80);
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().addLatencyInMillis(10);
+        tracker1.getReplicaOperationTracker().getPerformanceTracker().addNewThroughout(1d);
+
+        assertTrue(memoryManager.isReplicaShardLimitBreached(tracker1,  12 * 1024, requestStartTime));
+        assertEquals(limit1, tracker1.getReplicaLimits());
+        assertEquals(limit2, tracker2.getReplicaLimits());
+        assertEquals(1, tracker1.getReplicaOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+        assertEquals(0, tracker2.getReplicaOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
+        assertEquals(1, memoryManager.totalNodeLimitsBreachedRejections.get());
+    }
+
+    public void testDecreaseShardPrimaryAndCoordinatingLimitsToBaseLimit() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker1 = memoryManager.getShardIndexingPressureTracker(shardId1);
+        tracker1.compareAndSetPrimaryAndCoordinatingLimits(tracker1.getPrimaryAndCoordinatingLimits(), 1 * 1024);
+        tracker1.getCommonOperationTracker().incrementCurrentCombinedCoordinatingAndPrimaryBytes(0);
+        long limit1 = tracker1.getPrimaryAndCoordinatingLimits();
+        memoryManager.decreaseShardPrimaryAndCoordinatingLimits(tracker1);
+
+        assertTrue(tracker1.getPrimaryAndCoordinatingLimits() < limit1);
+        assertEquals(10, tracker1.getPrimaryAndCoordinatingLimits());
+    }
+
+    public void testDecreaseShardReplicaLimitsToBaseLimit() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker1 = memoryManager.getShardIndexingPressureTracker(shardId1);
+
+        tracker1.compareAndSetReplicaLimits(tracker1.getReplicaLimits(), 1 * 1024);
+        tracker1.getReplicaOperationTracker().getStatsTracker().incrementCurrentBytes(0);
+        long limit1 = tracker1.getReplicaLimits();
+        memoryManager.decreaseShardReplicaLimits(tracker1);
+
+        assertTrue(tracker1.getReplicaLimits() < limit1);
+        assertEquals(15, tracker1.getReplicaLimits());
+    }
+
+    public void testDecreaseShardPrimaryAndCoordinatingLimits() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker1 = memoryManager.getShardIndexingPressureTracker(shardId1);
+        tracker1.compareAndSetPrimaryAndCoordinatingLimits(tracker1.getPrimaryAndCoordinatingLimits(), 1 * 1024);
+        tracker1.getCommonOperationTracker().incrementCurrentCombinedCoordinatingAndPrimaryBytes(512);
+        long limit1 = tracker1.getPrimaryAndCoordinatingLimits();
+        memoryManager.decreaseShardPrimaryAndCoordinatingLimits(tracker1);
+
+        assertTrue(tracker1.getPrimaryAndCoordinatingLimits() < limit1);
+        assertEquals((long)(512/0.85), tracker1.getPrimaryAndCoordinatingLimits());
+    }
+
+    public void testDecreaseShardReplicaLimits() {
+        ShardIndexingPressureMemoryManager memoryManager = new ShardIndexingPressureMemoryManager(shardIndexingPressureSettings,
+            clusterSettings, settings);
+        ShardIndexingPressureTracker tracker1 = memoryManager.getShardIndexingPressureTracker(shardId1);
+
+        tracker1.compareAndSetReplicaLimits(tracker1.getReplicaLimits(), 1 * 1024);
+        tracker1.getReplicaOperationTracker().getStatsTracker().incrementCurrentBytes(512);
+        long limit1 = tracker1.getReplicaLimits();
+        memoryManager.decreaseShardReplicaLimits(tracker1);
+
+        assertTrue(tracker1.getReplicaLimits() < limit1);
+        assertEquals((long)(512/0.85), tracker1.getReplicaLimits());
+    }
+}

--- a/server/src/test/java/org/opensearch/index/ShardIndexingPressureMemoryManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/ShardIndexingPressureMemoryManagerTests.java
@@ -57,7 +57,7 @@ public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase 
     public void testCoordinatingPrimaryShardLimitsNotBreached() {
         ShardIndexingPressureTracker tracker = memoryManager.getShardIndexingPressureTracker(shardId1);
         tracker.getCommonOperationTracker().incrementCurrentCombinedCoordinatingAndPrimaryBytes(1);
-        long requestStartTime = System.currentTimeMillis();
+        long requestStartTime = System.nanoTime();
 
         assertFalse(memoryManager.isCoordinatingShardLimitBreached(tracker, 1 * 1024, requestStartTime));
         assertFalse(memoryManager.isPrimaryShardLimitBreached(tracker,  1 * 1024, requestStartTime));
@@ -66,7 +66,7 @@ public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase 
     public void testReplicaShardLimitsNotBreached() {
         ShardIndexingPressureTracker tracker = memoryManager.getShardIndexingPressureTracker(shardId1);
         tracker.getReplicaOperationTracker().getStatsTracker().incrementCurrentBytes(1);
-        long requestStartTime = System.currentTimeMillis();
+        long requestStartTime = System.nanoTime();
 
         assertFalse(memoryManager.isReplicaShardLimitBreached(tracker, 1 * 1024, requestStartTime));
     }
@@ -75,7 +75,7 @@ public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase 
         ShardIndexingPressureTracker tracker = memoryManager.getShardIndexingPressureTracker(shardId1);
         tracker.getCommonOperationTracker().incrementCurrentCombinedCoordinatingAndPrimaryBytes(10);
         long baseLimit = tracker.getPrimaryAndCoordinatingLimits();
-        long requestStartTime = System.currentTimeMillis();
+        long requestStartTime = System.nanoTime();
 
         assertFalse(memoryManager.isCoordinatingShardLimitBreached(tracker, 1 * 1024, requestStartTime));
         assertFalse(memoryManager.isPrimaryShardLimitBreached(tracker, 1 * 1024, requestStartTime));
@@ -88,7 +88,7 @@ public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase 
         ShardIndexingPressureTracker tracker = memoryManager.getShardIndexingPressureTracker(shardId1);
         tracker.getReplicaOperationTracker().getStatsTracker().incrementCurrentBytes(15);
         long baseLimit = tracker.getReplicaLimits();
-        long requestStartTime = System.currentTimeMillis();
+        long requestStartTime = System.nanoTime();
 
         assertFalse(memoryManager.isReplicaShardLimitBreached(tracker, 1 * 1024, requestStartTime));
         assertTrue(tracker.getReplicaLimits() > baseLimit);
@@ -102,7 +102,7 @@ public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase 
         tracker2.compareAndSetPrimaryAndCoordinatingLimits(tracker2.getPrimaryAndCoordinatingLimits(), 6 * 1024);
         long limit1 = tracker1.getPrimaryAndCoordinatingLimits();
         long limit2 = tracker2.getPrimaryAndCoordinatingLimits();
-        long requestStartTime = System.currentTimeMillis();
+        long requestStartTime = System.nanoTime();
 
         assertTrue(memoryManager.isCoordinatingShardLimitBreached(tracker1, 8 * 1024, requestStartTime));
         assertEquals(1, tracker1.getCoordinatingOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
@@ -124,7 +124,7 @@ public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase 
         tracker2.compareAndSetReplicaLimits(tracker2.getReplicaLimits(), 10 * 1024);
         long limit1 = tracker1.getReplicaLimits();
         long limit2 = tracker2.getReplicaLimits();
-        long requestStartTime = System.currentTimeMillis();
+        long requestStartTime = System.nanoTime();
 
         assertTrue(memoryManager.isReplicaShardLimitBreached(tracker1, 10 * 1024, requestStartTime));
         assertEquals(limit1, tracker1.getReplicaLimits());
@@ -141,7 +141,7 @@ public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase 
         tracker2.compareAndSetPrimaryAndCoordinatingLimits(tracker2.getPrimaryAndCoordinatingLimits(), 6 * 1024);
         long limit1 = tracker1.getPrimaryAndCoordinatingLimits();
         long limit2 = tracker2.getPrimaryAndCoordinatingLimits();
-        long requestStartTime = System.currentTimeMillis();
+        long requestStartTime = System.nanoTime();
 
         assertTrue(memoryManager.isCoordinatingShardLimitBreached(tracker1, 8 * 1024, requestStartTime));
         assertEquals(1, tracker1.getCoordinatingOperationTracker().getRejectionTracker().getNodeLimitsBreachedRejections());
@@ -163,7 +163,7 @@ public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase 
         tracker2.compareAndSetReplicaLimits(tracker2.getReplicaLimits(), 12 * 1024);
         long limit1 = tracker1.getReplicaLimits();
         long limit2 = tracker2.getReplicaLimits();
-        long requestStartTime = System.currentTimeMillis();
+        long requestStartTime = System.nanoTime();
 
         assertTrue(memoryManager.isReplicaShardLimitBreached(tracker1,  12 * 1024, requestStartTime));
         assertEquals(limit1, tracker1.getReplicaLimits());
@@ -180,7 +180,7 @@ public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase 
         tracker2.compareAndSetPrimaryAndCoordinatingLimits(tracker2.getPrimaryAndCoordinatingLimits(), 6 * 1024);
         long limit1 = tracker1.getPrimaryAndCoordinatingLimits();
         long limit2 = tracker2.getPrimaryAndCoordinatingLimits();
-        long requestStartTime = System.currentTimeMillis();
+        long requestStartTime = System.nanoTime();
 
         tracker1.getCoordinatingOperationTracker().getPerformanceTracker().updateLastSuccessfulRequestTimestamp(requestStartTime - 100);
         tracker1.getCoordinatingOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
@@ -214,7 +214,7 @@ public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase 
         tracker2.compareAndSetReplicaLimits(tracker2.getReplicaLimits(), 12 * 1024);
         long limit1 = tracker1.getReplicaLimits();
         long limit2 = tracker2.getReplicaLimits();
-        long requestStartTime = System.currentTimeMillis();
+        long requestStartTime = System.nanoTime();
         tracker1.getReplicaOperationTracker().getPerformanceTracker().updateLastSuccessfulRequestTimestamp(requestStartTime - 100);
         tracker1.getReplicaOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
         tracker1.getReplicaOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
@@ -236,7 +236,7 @@ public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase 
         tracker2.compareAndSetPrimaryAndCoordinatingLimits(tracker2.getPrimaryAndCoordinatingLimits(), 6 * 1024);
         long limit1 = tracker1.getPrimaryAndCoordinatingLimits();
         long limit2 = tracker2.getPrimaryAndCoordinatingLimits();
-        long requestStartTime = System.currentTimeMillis();
+        long requestStartTime = System.nanoTime();
 
         tracker1.getCoordinatingOperationTracker().getPerformanceTracker().updateLastSuccessfulRequestTimestamp(requestStartTime - 100);
         tracker1.getCoordinatingOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
@@ -269,7 +269,7 @@ public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase 
         tracker2.compareAndSetReplicaLimits(tracker2.getReplicaLimits(), 12 * 1024);
         long limit1 = tracker1.getReplicaLimits();
         long limit2 = tracker2.getReplicaLimits();
-        long requestStartTime = System.currentTimeMillis();
+        long requestStartTime = System.nanoTime();
         tracker1.getReplicaOperationTracker().getPerformanceTracker().updateLastSuccessfulRequestTimestamp(requestStartTime - 100);
         tracker1.getReplicaOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
 
@@ -291,7 +291,7 @@ public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase 
         tracker2.compareAndSetPrimaryAndCoordinatingLimits(tracker2.getPrimaryAndCoordinatingLimits(), 6 * 1024);
         long limit1 = tracker1.getPrimaryAndCoordinatingLimits();
         long limit2 = tracker2.getPrimaryAndCoordinatingLimits();
-        long requestStartTime = System.currentTimeMillis();
+        long requestStartTime = System.nanoTime();
 
         tracker1.getCoordinatingOperationTracker().getPerformanceTracker().updateThroughputMovingAverage(Double.doubleToLongBits(1d));
         tracker1.getCoordinatingOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
@@ -333,7 +333,7 @@ public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase 
         tracker2.compareAndSetReplicaLimits(tracker2.getReplicaLimits(), 12 * 1024);
         long limit1 = tracker1.getReplicaLimits();
         long limit2 = tracker2.getReplicaLimits();
-        long requestStartTime = System.currentTimeMillis();
+        long requestStartTime = System.nanoTime();
         tracker1.getReplicaOperationTracker().getPerformanceTracker().updateThroughputMovingAverage(Double.doubleToLongBits(1d));
         tracker1.getReplicaOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
         tracker1.getReplicaOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
@@ -359,7 +359,7 @@ public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase 
         tracker2.compareAndSetPrimaryAndCoordinatingLimits(tracker2.getPrimaryAndCoordinatingLimits(), 6 * 1024);
         long limit1 = tracker1.getPrimaryAndCoordinatingLimits();
         long limit2 = tracker2.getPrimaryAndCoordinatingLimits();
-        long requestStartTime = System.currentTimeMillis();
+        long requestStartTime = System.nanoTime();
 
         tracker1.getCoordinatingOperationTracker().getPerformanceTracker().updateThroughputMovingAverage
             (Double.doubleToLongBits(1d));
@@ -403,7 +403,7 @@ public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase 
         tracker2.compareAndSetReplicaLimits(tracker2.getReplicaLimits(), 12 * 1024);
         long limit1 = tracker1.getReplicaLimits();
         long limit2 = tracker2.getReplicaLimits();
-        long requestStartTime = System.currentTimeMillis();
+        long requestStartTime = System.nanoTime();
         tracker1.getReplicaOperationTracker().getPerformanceTracker().updateThroughputMovingAverage(Double.doubleToLongBits(1d));
         tracker1.getReplicaOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
         tracker1.getReplicaOperationTracker().getStatsTracker().incrementTotalBytes(80);
@@ -429,7 +429,7 @@ public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase 
         tracker2.compareAndSetPrimaryAndCoordinatingLimits(tracker2.getPrimaryAndCoordinatingLimits(), 6 * 1024);
         long limit1 = tracker1.getPrimaryAndCoordinatingLimits();
         long limit2 = tracker2.getPrimaryAndCoordinatingLimits();
-        long requestStartTime = System.currentTimeMillis();
+        long requestStartTime = System.nanoTime();
 
         tracker1.getCoordinatingOperationTracker().getPerformanceTracker().updateThroughputMovingAverage(Double.doubleToLongBits(1d));
         tracker1.getCoordinatingOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
@@ -463,7 +463,7 @@ public class ShardIndexingPressureMemoryManagerTests extends OpenSearchTestCase 
         tracker2.compareAndSetReplicaLimits(tracker2.getReplicaLimits(), 12 * 1024);
         long limit1 = tracker1.getReplicaLimits();
         long limit2 = tracker2.getReplicaLimits();
-        long requestStartTime = System.currentTimeMillis();
+        long requestStartTime = System.nanoTime();
         tracker1.getReplicaOperationTracker().getPerformanceTracker().updateThroughputMovingAverage(Double.doubleToLongBits(1d));
         tracker1.getReplicaOperationTracker().getPerformanceTracker().incrementTotalOutstandingRequests();
         tracker1.getReplicaOperationTracker().getStatsTracker().incrementTotalBytes(80);


### PR DESCRIPTION
Signed-off-by: Saurabh Singh <sisurab@amazon.com>

### Description
This PR is 5th of the multiple planned PRs planned for Shard Indexing Pressure (#478). It introduces a Memory Manager for Shard Indexing Pressure. It is responsible for increasing and decreasing the allocated shard limit based on incoming requests, and validate the current values against the thresholds.
 
### Issues Resolved
Addresses Item 5 of #478 
 
### ToDo before we move from draft to complete
- [x] Condense the core logic for some of the shard limits increment, decrement and isLimitBreached operations for Primary, Replica and Coordinating into one.
- [x] Address some of the java comments related to settings and block comments.
- [x] Verify and add few more unit tests, to ensure full coverage.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
