### PR TITLE
Introduce replaceRoutes() method and 2 new constructors to RestHandler.java

### DIFF
--- a/server/src/main/java/org/opensearch/rest/RestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/RestHandler.java
@@ -174,17 +174,17 @@ public interface RestHandler {
     }
 
     /**
-     * Add customized prefix(_opendistro... and _plugins...)to API rest routes
+     * Replace deprecated route prefix with a new route prefix(_plugins)
      * @param routes routes
-     * @param newPrefix new prefix
-     * @param oldPrefix old prefix
-     * @return new list of API routes prefixed with the strings listed in prefixes
-     * Total number of routes will be expanded len(prefixes) as much comparing to the list passed in
+     * @param prefix new prefix
+     * @param deprecatedPrefix deprecated prefix
+     * @return new list of API routes prefixed with the prefix string
+     * Total number of routes will be the same as number of routes passed.
      */
-    static List<ReplacedRoute> addRoutesPrefix(List<Route> routes, final String newPrefix, final String oldPrefix){
+    static List<ReplacedRoute> replaceRoutes(List<Route> routes, final String prefix, final String deprecatedPrefix){
         return routes.stream()
-            .map(p -> new ReplacedRoute(p.getMethod(), newPrefix + p.getPath(),
-                p.getMethod(), oldPrefix + p.getPath()))
+            .map(r -> new ReplacedRoute(r.getMethod(), prefix + r.getPath(),
+                r.getMethod(), deprecatedPrefix + r.getPath()))
             .collect(Collectors.toList());
     }
 }

--- a/server/src/main/java/org/opensearch/rest/RestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/RestHandler.java
@@ -158,16 +158,36 @@ public interface RestHandler {
         private final String deprecatedPath;
         private final Method deprecatedMethod;
 
+        /**
+         * Construct replaced routes using new and deprocated methods and new and deprecated paths
+         * @param method route method
+         * @param path new route path
+         * @param deprecatedMethod deprecated method
+         * @param deprecatedPath deprecated path
+         */
         public ReplacedRoute(Method method, String path, Method deprecatedMethod, String deprecatedPath) {
             super(method, path);
             this.deprecatedMethod = deprecatedMethod;
             this.deprecatedPath = deprecatedPath;
         }
 
-        public ReplacedRoute(Method method, String path, String deprecatedPath){
+        /**
+         * Construct replaced routes using route method, new and deprecated paths
+         * This constructor can be used when both new and deprecated paths use the same method
+         * @param method route method
+         * @param path new route path
+         * @param deprecatedPath deprecated path
+         */
+        public ReplacedRoute(Method method, String path, String deprecatedPath) {
             this(method, path, method, deprecatedPath);
         }
 
+        /**
+         * Construct replaced routes using route, new and deprecated prefixes
+         * @param route route
+         * @param prefix new route prefix
+         * @param deprecatedPrefix deprecated prefix
+         */
         public ReplacedRoute(Route route, String prefix, String deprecatedPrefix) {
             this(route.getMethod(), prefix + route.getPath(), deprecatedPrefix + route.getPath());
         }

--- a/server/src/main/java/org/opensearch/rest/RestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/RestHandler.java
@@ -164,8 +164,12 @@ public interface RestHandler {
             this.deprecatedPath = deprecatedPath;
         }
 
+        public ReplacedRoute(Method method, String path, String deprecatedPath){
+            this(method, path, method, deprecatedPath);
+        }
+
         public ReplacedRoute(Route route, String prefix, String deprecatedPrefix) {
-            this(route.getMethod(), prefix + route.getPath(), route.getMethod(), deprecatedPrefix + route.getPath());
+            this(route.getMethod(), prefix + route.getPath(), deprecatedPrefix + route.getPath());
         }
 
         public String getDeprecatedPath() {

--- a/server/src/main/java/org/opensearch/rest/RestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/RestHandler.java
@@ -164,6 +164,10 @@ public interface RestHandler {
             this.deprecatedPath = deprecatedPath;
         }
 
+        public ReplacedRoute(Route route, String prefix, String deprecatedPrefix) {
+            this(route.getMethod(), prefix + route.getPath(), route.getMethod(), deprecatedPrefix + route.getPath());
+        }
+
         public String getDeprecatedPath() {
             return deprecatedPath;
         }
@@ -174,17 +178,15 @@ public interface RestHandler {
     }
 
     /**
-     * Replace deprecated route prefix with a new route prefix(_plugins)
+     * Construct replaced routes using routes template and prefixes for new and deprecated paths
      * @param routes routes
      * @param prefix new prefix
      * @param deprecatedPrefix deprecated prefix
      * @return new list of API routes prefixed with the prefix string
-     * Total number of routes will be the same as number of routes passed.
      */
     static List<ReplacedRoute> replaceRoutes(List<Route> routes, final String prefix, final String deprecatedPrefix){
         return routes.stream()
-            .map(r -> new ReplacedRoute(r.getMethod(), prefix + r.getPath(),
-                r.getMethod(), deprecatedPrefix + r.getPath()))
+            .map(route -> new ReplacedRoute(route, prefix, deprecatedPrefix))
             .collect(Collectors.toList());
     }
 }

--- a/server/src/main/java/org/opensearch/rest/RestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/RestHandler.java
@@ -38,6 +38,7 @@ import org.opensearch.rest.RestRequest.Method;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Handler for REST requests
@@ -170,5 +171,20 @@ public interface RestHandler {
         public Method getDeprecatedMethod() {
             return deprecatedMethod;
         }
+    }
+
+    /**
+     * Add customized prefix(_opendistro... and _plugins...)to API rest routes
+     * @param routes routes
+     * @param newPrefix new prefix
+     * @param oldPrefix old prefix
+     * @return new list of API routes prefixed with the strings listed in prefixes
+     * Total number of routes will be expanded len(prefixes) as much comparing to the list passed in
+     */
+    static List<ReplacedRoute> addRoutesPrefix(List<Route> routes, final String newPrefix, final String oldPrefix){
+        return routes.stream()
+            .map(p -> new ReplacedRoute(p.getMethod(), newPrefix + p.getPath(),
+                p.getMethod(), oldPrefix + p.getPath()))
+            .collect(Collectors.toList());
     }
 }

--- a/server/src/test/java/org/opensearch/rest/BaseRestHandlerTests.java
+++ b/server/src/test/java/org/opensearch/rest/BaseRestHandlerTests.java
@@ -45,10 +45,16 @@ import org.opensearch.test.rest.FakeRestChannel;
 import org.opensearch.test.rest.FakeRestRequest;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.rest.RestRequest.Method;
+import org.opensearch.rest.RestHandler.Route;
+import org.opensearch.rest.RestHandler.ReplacedRoute;
+import org.opensearch.rest.RestHandler;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -335,6 +341,14 @@ public class BaseRestHandlerTests extends OpenSearchTestCase {
             assertThat(e, hasToString(containsString("request [GET /] does not support having a body")));
             assertFalse(executed.get());
         }
+    }
+
+    public void testReplaceRoutesMethod() throws Exception {
+        List<Route> routes = Arrays.asList(new RestHandler.Route(Method.GET, "/path/test"));
+        List<ReplacedRoute> replacedRoutes = RestHandler.replaceRoutes(routes, "/prefix", "/deprecatedPrefix");
+        List<ReplacedRoute> expectedReplacedRoutes = Arrays.asList(new RestHandler.ReplacedRoute(Method.GET,
+            "/prefix/path/test", "/deprecatedPrefix/path/test"));
+        assertEquals(replacedRoutes, expectedReplacedRoutes);
     }
 
 }

--- a/server/src/test/java/org/opensearch/rest/BaseRestHandlerTests.java
+++ b/server/src/test/java/org/opensearch/rest/BaseRestHandlerTests.java
@@ -344,11 +344,13 @@ public class BaseRestHandlerTests extends OpenSearchTestCase {
     }
 
     public void testReplaceRoutesMethod() throws Exception {
-        List<Route> routes = Arrays.asList(new RestHandler.Route(Method.GET, "/path/test"));
+        List<Route> routes = Arrays.asList(new RestHandler.Route(Method.GET, "/path/test"),
+            new RestHandler.Route(Method.GET, "/path2/test"));
         List<ReplacedRoute> replacedRoutes = RestHandler.replaceRoutes(routes, "/prefix", "/deprecatedPrefix");
-        List<ReplacedRoute> expectedReplacedRoutes = Arrays.asList(new RestHandler.ReplacedRoute(Method.GET,
-            "/prefix/path/test", "/deprecatedPrefix/path/test"));
-        assertEquals(replacedRoutes, expectedReplacedRoutes);
+
+        for(int i = 0; i < routes.size(); i++) {
+            assertEquals(replacedRoutes.get(i).getPath(), "/prefix" + routes.get(i).getPath());
+        }
     }
 
 }

--- a/server/src/test/java/org/opensearch/rest/BaseRestHandlerTests.java
+++ b/server/src/test/java/org/opensearch/rest/BaseRestHandlerTests.java
@@ -344,12 +344,13 @@ public class BaseRestHandlerTests extends OpenSearchTestCase {
     }
 
     public void testReplaceRoutesMethod() throws Exception {
-        List<Route> routes = Arrays.asList(new RestHandler.Route(Method.GET, "/path/test"),
-            new RestHandler.Route(Method.GET, "/path2/test"));
+        List<Route> routes = Arrays.asList(new Route(Method.GET, "/path/test"), new Route(Method.PUT, "/path2/test"));
         List<ReplacedRoute> replacedRoutes = RestHandler.replaceRoutes(routes, "/prefix", "/deprecatedPrefix");
 
         for(int i = 0; i < routes.size(); i++) {
-            assertEquals(replacedRoutes.get(i).getPath(), "/prefix" + routes.get(i).getPath());
+            assertEquals("/prefix" + routes.get(i).getPath(), replacedRoutes.get(i).getPath());
+            assertEquals(routes.get(i).getMethod(), replacedRoutes.get(i).getMethod());
+            assertEquals("/deprecatedPrefix" + routes.get(i).getPath(), replacedRoutes.get(i).getDeprecatedPath());
         }
     }
 


### PR DESCRIPTION
### Description
The purpose of this PR is to add a method to `RestHandler` interface so it can add prefixes to both old and new routes for REST APIs.
 
### Issues Resolved
The PR will address the request from @vrozov in PR #1256: https://github.com/opensearch-project/security/pull/1256
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ Done] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ Done] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
