### PR TITLE
Replacing docs-beta links with /docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 * [Project Website](https://opensearch.org/)
 * [Downloads](https://opensearch.org/downloads.html).
-* [Documentation](https://docs-beta.opensearch.org/)
+* [Documentation](https://opensearch.org/docs/)
 * Need help? Try [Forums](https://discuss.opendistrocommunity.dev/)
 * [Project Principles](https://opensearch.org/#principles)
 * [Contributing to OpenSearch](CONTRIBUTING.md)

--- a/plugins/examples/rest-handler/src/yamlRestTest/resources/rest-api-spec/api/cat.example.json
+++ b/plugins/examples/rest-handler/src/yamlRestTest/resources/rest-api-spec/api/cat.example.json
@@ -1,7 +1,7 @@
 {
   "cat.example": {
     "documentation": {
-      "url": "https://docs-beta.opensearch.org/opensearch/install/plugins/",
+      "url": "https://opensearch.org/docs/opensearch/install/plugins/",
       "description": "Example"
     },
     "stability" : "stable",


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
The link checker is failing with the docs-beta links for example in PR #947. Updating the docs-beta link references to the /docs links. 
 
### Issues Resolved
#956 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
