### PR TITLE
Restricting logs permissions

### DIFF
--- a/distribution/src/config/log4j2.properties
+++ b/distribution/src/config/log4j2.properties
@@ -20,6 +20,7 @@ appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%ma
 appender.rolling.type = RollingFile
 appender.rolling.name = rolling
 appender.rolling.fileName = ${sys:opensearch.logs.base_path}${sys:file.separator}${sys:opensearch.logs.cluster_name}_server.json
+appender.rolling.filePermissions = rw-r-----
 appender.rolling.layout.type = OpenSearchJsonLayout
 appender.rolling.layout.type_name = server
 
@@ -43,6 +44,7 @@ appender.rolling.strategy.action.condition.nested_condition.exceeds = 2GB
 appender.rolling_old.type = RollingFile
 appender.rolling_old.name = rolling_old
 appender.rolling_old.fileName = ${sys:opensearch.logs.base_path}${sys:file.separator}${sys:opensearch.logs.cluster_name}.log
+appender.rolling_old.filePermissions = rw-r-----
 appender.rolling_old.layout.type = PatternLayout
 appender.rolling_old.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
 
@@ -72,6 +74,7 @@ rootLogger.appenderRef.rolling_old.ref = rolling_old
 appender.deprecation_rolling.type = RollingFile
 appender.deprecation_rolling.name = deprecation_rolling
 appender.deprecation_rolling.fileName = ${sys:opensearch.logs.base_path}${sys:file.separator}${sys:opensearch.logs.cluster_name}_deprecation.json
+appender.deprecation_rolling.filePermissions = rw-r-----
 appender.deprecation_rolling.layout.type = OpenSearchJsonLayout
 appender.deprecation_rolling.layout.type_name = deprecation
 appender.deprecation_rolling.layout.opensearchmessagefields=x-opaque-id
@@ -91,6 +94,7 @@ appender.header_warning.name = header_warning
 appender.deprecation_rolling_old.type = RollingFile
 appender.deprecation_rolling_old.name = deprecation_rolling_old
 appender.deprecation_rolling_old.fileName = ${sys:opensearch.logs.base_path}${sys:file.separator}${sys:opensearch.logs.cluster_name}_deprecation.log
+appender.deprecation_rolling_old.filePermissions = rw-r-----
 appender.deprecation_rolling_old.layout.type = PatternLayout
 appender.deprecation_rolling_old.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
 
@@ -114,6 +118,7 @@ appender.index_search_slowlog_rolling.type = RollingFile
 appender.index_search_slowlog_rolling.name = index_search_slowlog_rolling
 appender.index_search_slowlog_rolling.fileName = ${sys:opensearch.logs.base_path}${sys:file.separator}${sys:opensearch.logs\
   .cluster_name}_index_search_slowlog.json
+appender.index_search_slowlog_rolling.filePermissions = rw-r-----
 appender.index_search_slowlog_rolling.layout.type = OpenSearchJsonLayout
 appender.index_search_slowlog_rolling.layout.type_name = index_search_slowlog
 appender.index_search_slowlog_rolling.layout.opensearchmessagefields=message,took,took_millis,total_hits,types,stats,search_type,total_shards,source,id
@@ -131,6 +136,7 @@ appender.index_search_slowlog_rolling_old.type = RollingFile
 appender.index_search_slowlog_rolling_old.name = index_search_slowlog_rolling_old
 appender.index_search_slowlog_rolling_old.fileName = ${sys:opensearch.logs.base_path}${sys:file.separator}${sys:opensearch.logs.cluster_name}\
   _index_search_slowlog.log
+appender.index_search_slowlog_rolling_old.filePermissions = rw-r-----
 appender.index_search_slowlog_rolling_old.layout.type = PatternLayout
 appender.index_search_slowlog_rolling_old.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
 
@@ -153,6 +159,7 @@ appender.index_indexing_slowlog_rolling.type = RollingFile
 appender.index_indexing_slowlog_rolling.name = index_indexing_slowlog_rolling
 appender.index_indexing_slowlog_rolling.fileName = ${sys:opensearch.logs.base_path}${sys:file.separator}${sys:opensearch.logs.cluster_name}\
   _index_indexing_slowlog.json
+appender.index_indexing_slowlog_rolling.filePermissions = rw-r-----
 appender.index_indexing_slowlog_rolling.layout.type = OpenSearchJsonLayout
 appender.index_indexing_slowlog_rolling.layout.type_name = index_indexing_slowlog
 appender.index_indexing_slowlog_rolling.layout.opensearchmessagefields=message,took,took_millis,doc_type,id,routing,source
@@ -170,6 +177,7 @@ appender.index_indexing_slowlog_rolling_old.type = RollingFile
 appender.index_indexing_slowlog_rolling_old.name = index_indexing_slowlog_rolling_old
 appender.index_indexing_slowlog_rolling_old.fileName = ${sys:opensearch.logs.base_path}${sys:file.separator}${sys:opensearch.logs.cluster_name}\
   _index_indexing_slowlog.log
+appender.index_indexing_slowlog_rolling_old.filePermissions = rw-r-----
 appender.index_indexing_slowlog_rolling_old.layout.type = PatternLayout
 appender.index_indexing_slowlog_rolling_old.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
 


### PR DESCRIPTION
### Description
Currently, the permissions for opensearch logs are -rw-r-r-, which gives read access to anyone. This weak permission structure can lead to leakage of any sensitive information (if published) in the logs. This commit restricts read access for logs with -rw-r--- permission.
 
New permission structure (verified w/ linux and darwin distros)
```
-rw-r----- 1 ubuntu ubuntu  7016 Jul 14 19:23 opensearch.log
-rw-r----- 1 ubuntu ubuntu     0 Jul 14 19:23 opensearch_deprecation.json
-rw-r----- 1 ubuntu ubuntu     0 Jul 14 19:23 opensearch_deprecation.log
-rw-r----- 1 ubuntu ubuntu     0 Jul 14 19:23 opensearch_index_indexing_slowlog.json
-rw-r----- 1 ubuntu ubuntu     0 Jul 14 19:23 opensearch_index_indexing_slowlog.log
-rw-r----- 1 ubuntu ubuntu     0 Jul 14 19:23 opensearch_index_search_slowlog.json
-rw-r----- 1 ubuntu ubuntu     0 Jul 14 19:23 opensearch_index_search_slowlog.log
-rw-r----- 1 ubuntu ubuntu 11779 Jul 14 19:23 opensearch_server.json
```
### Issues Resolved
#958 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Himanshu Setia <setiah@amazon.com>