### PR TITLE
[Backport-1.x]Avoid override of routes() in BaseRestHandler to respect the default behavior defined in RestHandler (#889)

### DIFF
--- a/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
@@ -95,12 +95,6 @@ public abstract class BaseRestHandler implements RestHandler {
      */
     public abstract String getName();
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public abstract List<Route> routes();
-
     @Override
     public final void handleRequest(RestRequest request, RestChannel channel, NodeClient client) throws Exception {
         // prepare the request for execution; has the side effect of touching the request parameters

--- a/server/src/test/java/org/opensearch/rest/BaseRestHandlerTests.java
+++ b/server/src/test/java/org/opensearch/rest/BaseRestHandlerTests.java
@@ -49,7 +49,6 @@ import org.opensearch.threadpool.ThreadPool;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -87,11 +86,6 @@ public class BaseRestHandlerTests extends OpenSearchTestCase {
             public String getName() {
                 return "test_one_unconsumed_response_action";
             }
-
-            @Override
-            public List<Route> routes() {
-                return Collections.emptyList();
-            }
         };
 
         final HashMap<String, String> params = new HashMap<>();
@@ -117,11 +111,6 @@ public class BaseRestHandlerTests extends OpenSearchTestCase {
             @Override
             public String getName() {
                 return "test_multiple_unconsumed_response_action";
-            }
-
-            @Override
-            public List<Route> routes() {
-                return Collections.emptyList();
             }
         };
 
@@ -158,11 +147,6 @@ public class BaseRestHandlerTests extends OpenSearchTestCase {
             @Override
             public String getName() {
                 return "test_unconsumed_did_you_mean_response_action";
-            }
-
-            @Override
-            public List<Route> routes() {
-                return Collections.emptyList();
             }
         };
 
@@ -207,11 +191,6 @@ public class BaseRestHandlerTests extends OpenSearchTestCase {
             public String getName() {
                 return "test_unconsumed_response_action";
             }
-
-            @Override
-            public List<Route> routes() {
-                return Collections.emptyList();
-            }
         };
 
         final HashMap<String, String> params = new HashMap<>();
@@ -234,11 +213,6 @@ public class BaseRestHandlerTests extends OpenSearchTestCase {
             @Override
             public String getName() {
                 return "test_default_response_action";
-            }
-
-            @Override
-            public List<Route> routes() {
-                return Collections.emptyList();
             }
         };
 
@@ -275,11 +249,6 @@ public class BaseRestHandlerTests extends OpenSearchTestCase {
             public String getName() {
                 return "test_cat_response_action";
             }
-
-            @Override
-            public List<Route> routes() {
-                return Collections.emptyList();
-            }
         };
 
         final HashMap<String, String> params = new HashMap<>();
@@ -310,11 +279,6 @@ public class BaseRestHandlerTests extends OpenSearchTestCase {
             public String getName() {
                 return "test_consumed_body";
             }
-
-            @Override
-            public List<Route> routes() {
-                return Collections.emptyList();
-            }
         };
 
         try (XContentBuilder builder = JsonXContent.contentBuilder().startObject().endObject()) {
@@ -339,11 +303,6 @@ public class BaseRestHandlerTests extends OpenSearchTestCase {
             public String getName() {
                 return "test_unconsumed_body";
             }
-
-            @Override
-            public List<Route> routes() {
-                return Collections.emptyList();
-            }
         };
 
         final RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).build();
@@ -363,11 +322,6 @@ public class BaseRestHandlerTests extends OpenSearchTestCase {
             @Override
             public String getName() {
                 return "test_unconsumed_body";
-            }
-
-            @Override
-            public List<Route> routes() {
-                return Collections.emptyList();
             }
         };
 

--- a/server/src/test/java/org/opensearch/usage/UsageServiceTests.java
+++ b/server/src/test/java/org/opensearch/usage/UsageServiceTests.java
@@ -40,8 +40,6 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.client.NoOpNodeClient;
 import org.opensearch.test.rest.FakeRestRequest;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -198,11 +196,6 @@ public class UsageServiceTests extends OpenSearchTestCase {
         @Override
         public String getName() {
             return name;
-        }
-
-        @Override
-        public List<Route> routes() {
-            return Collections.emptyList();
         }
 
         @Override


### PR DESCRIPTION
### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
