### PR TITLE
Reset Elasticsearch 7.13 links in scripts

### DIFF
--- a/distribution/src/bin/opensearch-env
+++ b/distribution/src/bin/opensearch-env
@@ -108,7 +108,7 @@ if [[ "$OPENSEARCH_DISTRIBUTION_TYPE" == "docker" ]]; then
   #
   # will cause OpenSearch to be invoked with -Ecluster.name=testcluster
   #
-  # see https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html#_setting_default_settings
+  # see https://www.elastic.co/guide/en/elasticsearch/reference/7.12/settings.html#_setting_default_settings
 
   declare -a opensearch_arg_array
 

--- a/distribution/src/bin/opensearch-env
+++ b/distribution/src/bin/opensearch-env
@@ -108,7 +108,7 @@ if [[ "$OPENSEARCH_DISTRIBUTION_TYPE" == "docker" ]]; then
   #
   # will cause OpenSearch to be invoked with -Ecluster.name=testcluster
   #
-  # see https://www.elastic.co/guide/en/elasticsearch/reference/7.12/settings.html#_setting_default_settings
+  # see https://opensearch.org/docs/opensearch/configuration/ 
 
   declare -a opensearch_arg_array
 

--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -11,7 +11,7 @@
 ## -Xms4g
 ## -Xmx4g
 ##
-## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## See https://www.elastic.co/guide/en/elasticsearch/reference/7.12/heap-size.html#heap-size
 ## for more information
 ##
 ################################################################

--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -11,7 +11,7 @@
 ## -Xms4g
 ## -Xmx4g
 ##
-## See https://www.elastic.co/guide/en/elasticsearch/reference/7.12/heap-size.html#heap-size
+## See https://opensearch.org/docs/opensearch/install/important-settings/
 ## for more information
 ##
 ################################################################


### PR DESCRIPTION
### Description
In scripts bin/opensearch-env and config/jvm.options, the Elasticsearch 7.13 (current) version links have now been reset to Elasticsearch 7.12 version links. 
 
### Issues Resolved
#949 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
