### PR TITLE
[Backport-1.x]Introduce replaceRoutes() method and 2 new constructors to RestHandler.java (#947)

### DIFF
--- a/server/src/main/java/org/opensearch/rest/RestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/RestHandler.java
@@ -38,6 +38,7 @@ import org.opensearch.rest.RestRequest.Method;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Handler for REST requests
@@ -157,10 +158,38 @@ public interface RestHandler {
         private final String deprecatedPath;
         private final Method deprecatedMethod;
 
+        /**
+         * Construct replaced routes using new and deprocated methods and new and deprecated paths
+         * @param method route method
+         * @param path new route path
+         * @param deprecatedMethod deprecated method
+         * @param deprecatedPath deprecated path
+         */
         public ReplacedRoute(Method method, String path, Method deprecatedMethod, String deprecatedPath) {
             super(method, path);
             this.deprecatedMethod = deprecatedMethod;
             this.deprecatedPath = deprecatedPath;
+        }
+
+        /**
+         * Construct replaced routes using route method, new and deprecated paths
+         * This constructor can be used when both new and deprecated paths use the same method
+         * @param method route method
+         * @param path new route path
+         * @param deprecatedPath deprecated path
+         */
+        public ReplacedRoute(Method method, String path, String deprecatedPath) {
+            this(method, path, method, deprecatedPath);
+        }
+
+        /**
+         * Construct replaced routes using route, new and deprecated prefixes
+         * @param route route
+         * @param prefix new route prefix
+         * @param deprecatedPrefix deprecated prefix
+         */
+        public ReplacedRoute(Route route, String prefix, String deprecatedPrefix) {
+            this(route.getMethod(), prefix + route.getPath(), deprecatedPrefix + route.getPath());
         }
 
         public String getDeprecatedPath() {
@@ -170,5 +199,18 @@ public interface RestHandler {
         public Method getDeprecatedMethod() {
             return deprecatedMethod;
         }
+    }
+
+    /**
+     * Construct replaced routes using routes template and prefixes for new and deprecated paths
+     * @param routes routes
+     * @param prefix new prefix
+     * @param deprecatedPrefix deprecated prefix
+     * @return new list of API routes prefixed with the prefix string
+     */
+    static List<ReplacedRoute> replaceRoutes(List<Route> routes, final String prefix, final String deprecatedPrefix){
+        return routes.stream()
+            .map(route -> new ReplacedRoute(route, prefix, deprecatedPrefix))
+            .collect(Collectors.toList());
     }
 }

--- a/server/src/test/java/org/opensearch/rest/BaseRestHandlerTests.java
+++ b/server/src/test/java/org/opensearch/rest/BaseRestHandlerTests.java
@@ -45,10 +45,16 @@ import org.opensearch.test.rest.FakeRestChannel;
 import org.opensearch.test.rest.FakeRestRequest;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.rest.RestRequest.Method;
+import org.opensearch.rest.RestHandler.Route;
+import org.opensearch.rest.RestHandler.ReplacedRoute;
+import org.opensearch.rest.RestHandler;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -334,6 +340,17 @@ public class BaseRestHandlerTests extends OpenSearchTestCase {
                     expectThrows(IllegalArgumentException.class, () -> handler.handleRequest(request, channel, mockClient));
             assertThat(e, hasToString(containsString("request [GET /] does not support having a body")));
             assertFalse(executed.get());
+        }
+    }
+
+    public void testReplaceRoutesMethod() throws Exception {
+        List<Route> routes = Arrays.asList(new Route(Method.GET, "/path/test"), new Route(Method.PUT, "/path2/test"));
+        List<ReplacedRoute> replacedRoutes = RestHandler.replaceRoutes(routes, "/prefix", "/deprecatedPrefix");
+
+        for(int i = 0; i < routes.size(); i++) {
+            assertEquals("/prefix" + routes.get(i).getPath(), replacedRoutes.get(i).getPath());
+            assertEquals(routes.get(i).getMethod(), replacedRoutes.get(i).getMethod());
+            assertEquals("/deprecatedPrefix" + routes.get(i).getPath(), replacedRoutes.get(i).getDeprecatedPath());
         }
     }
 


### PR DESCRIPTION
* Add addRoutesPrefix() method to RestHandler.java

Signed-off-by: Azar Fazel <azar.fazel@gmail.com>
Signed-off-by: cliu123 <lc12251109@gmail.com>

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
