### PR TITLE
[1.x] Replace Elasticsearch docs links in scripts (#994)

### DIFF
--- a/distribution/src/bin/opensearch-env
+++ b/distribution/src/bin/opensearch-env
@@ -108,7 +108,7 @@ if [[ "$OPENSEARCH_DISTRIBUTION_TYPE" == "docker" ]]; then
   #
   # will cause OpenSearch to be invoked with -Ecluster.name=testcluster
   #
-  # see https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html#_setting_default_settings
+  # see https://opensearch.org/docs/opensearch/configuration/ 
 
   declare -a opensearch_arg_array
 

--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -11,7 +11,7 @@
 ## -Xms4g
 ## -Xmx4g
 ##
-## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## See https://opensearch.org/docs/opensearch/install/important-settings/
 ## for more information
 ##
 ################################################################


### PR DESCRIPTION
Replace the docs links In scripts bin/opensearch-env and config/jvm.options, with OpenSearch docs links.

Signed-off-by: Poojita-Raj <poojiraj@amazon.com>
(cherry picked from commit 6bc4ce017ad654cc2c8d7d37553c82d61c61b964)
Signed-off-by: Poojita-Raj <poojiraj@amazon.com>

### Description
Backported #994 into 1.x 
 
### Issues Resolved
Replaces elasticsearch documentation links with OpenSearch documentation links 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
