### PR TITLE
Introduce RestHandler.Wrapper to help with delegate implementations

### DIFF
--- a/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
@@ -50,6 +50,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -209,7 +210,7 @@ public abstract class BaseRestHandler implements RestHandler {
         protected final BaseRestHandler delegate;
 
         public Wrapper(BaseRestHandler delegate) {
-            this.delegate = delegate;
+            this.delegate = Objects.requireNonNull(delegate, "BaseRestHandler delegate can not be null");
         }
 
         @Override
@@ -255,6 +256,11 @@ public abstract class BaseRestHandler implements RestHandler {
         @Override
         public boolean allowsUnsafeBuffers() {
             return delegate.allowsUnsafeBuffers();
+        }
+
+        @Override
+        public boolean allowSystemIndexAccessByDefault() {
+            return delegate.allowSystemIndexAccessByDefault();
         }
     }
 }

--- a/server/src/main/java/org/opensearch/rest/RestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/RestHandler.java
@@ -38,6 +38,7 @@ import org.opensearch.rest.RestRequest.Method;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -111,6 +112,63 @@ public interface RestHandler {
      */
     default boolean allowSystemIndexAccessByDefault() {
         return false;
+    }
+
+    static RestHandler wrapper(RestHandler delegate) {
+        return new Wrapper(delegate);
+    }
+
+    class Wrapper implements RestHandler {
+        private final RestHandler delegate;
+
+        public Wrapper(RestHandler delegate) {
+            this.delegate = Objects.requireNonNull(delegate, "RestHandler delegate can not be null");
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
+
+        @Override
+        public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) throws Exception {
+            delegate.handleRequest(request, channel, client);
+        }
+
+        @Override
+        public boolean canTripCircuitBreaker() {
+            return delegate.canTripCircuitBreaker();
+        }
+
+        @Override
+        public boolean supportsContentStream() {
+            return delegate.supportsContentStream();
+        }
+
+        @Override
+        public boolean allowsUnsafeBuffers() {
+            return delegate.allowsUnsafeBuffers();
+        }
+
+        @Override
+        public List<Route> routes() {
+            return delegate.routes();
+        }
+
+        @Override
+        public List<DeprecatedRoute> deprecatedRoutes() {
+            return delegate.deprecatedRoutes();
+        }
+
+        @Override
+        public List<ReplacedRoute> replacedRoutes() {
+            return delegate.replacedRoutes();
+        }
+
+        @Override
+        public boolean allowSystemIndexAccessByDefault() {
+            return delegate.allowSystemIndexAccessByDefault();
+        }
     }
 
     class Route {


### PR DESCRIPTION
### Description
Wrapper class that implements delegate pattern for `RestHandler`
 
### Issues Resolved
None, this is java utility class that can be utilized by OpenSearch core and OpenSearch plugins
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
