### PR TITLE
Added a test for #923.

### DIFF
--- a/server/src/main/java/org/opensearch/rest/action/RestActionListener.java
+++ b/server/src/main/java/org/opensearch/rest/action/RestActionListener.java
@@ -67,12 +67,16 @@ public abstract class RestActionListener<Response> implements ActionListener<Res
 
     protected abstract void processResponse(Response response) throws Exception;
 
+    protected BytesRestResponse getRestResponse(Exception e) throws IOException {
+        return new BytesRestResponse(channel, e);
+    }
+
     private BytesRestResponse from(Exception e) throws IOException {
         try {
-            return new BytesRestResponse(channel, e);
+            return getRestResponse(e);
         } catch (Exception inner) {
             try {
-                return new BytesRestResponse(channel, inner);
+                return getRestResponse(inner);
             } finally {
                 inner.addSuppressed(e);
                 logger.error("failed to construct failure response", inner);

--- a/server/src/test/java/org/opensearch/rest/action/RestActionListenerTests.java
+++ b/server/src/test/java/org/opensearch/rest/action/RestActionListenerTests.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.rest.action;
+
+import java.io.IOException;
+
+import org.opensearch.action.ActionResponse;
+import org.opensearch.rest.AbstractRestChannel;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.RestResponse;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+
+import static org.hamcrest.Matchers.instanceOf;
+
+public class RestActionListenerTests extends OpenSearchTestCase {
+    private static class SimpleExceptionRestChannel extends AbstractRestChannel {
+        private RestResponse lastResponse = null; 
+
+        public RestResponse getLastResponse() {
+            return lastResponse;
+        }
+
+        SimpleExceptionRestChannel(RestRequest request) {
+            super(request, false);
+        }
+
+        @Override
+        public void sendResponse(RestResponse response) {
+            this.lastResponse = response;
+        }
+    }
+
+    /**
+     * Ensure that first failure to construct a BytesRestResponse is handled.
+     * see https://github.com/opensearch-project/OpenSearch/pull/923
+     */
+    public void testWrapsException() {
+        RestRequest request = new FakeRestRequest();
+        SimpleExceptionRestChannel channel = new SimpleExceptionRestChannel(request);
+
+        class DummyActionListener extends RestActionListener<ActionResponse> {
+            protected DummyActionListener(RestChannel channel) {
+                super(channel);
+            }
+    
+            private int exceptionCount = 0;
+    
+            public int getExceptionCount() {
+                return exceptionCount;
+            }
+    
+            @Override
+            protected BytesRestResponse getRestResponse(Exception e) throws IOException {
+                if (exceptionCount++ == 1) {
+                    throw new IOException();
+                } else {
+                    return super.getRestResponse(e);
+                }
+            }
+    
+            @Override
+            protected void processResponse(ActionResponse response) throws Exception {
+    
+            }        
+        }
+
+        DummyActionListener listener = new DummyActionListener(channel);
+        listener.onFailure(new Exception());
+        assertThat(channel.getLastResponse(), instanceOf(BytesRestResponse.class));
+        assertEquals(1, listener.getExceptionCount());
+    }    
+}


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

This is a test for #923 and best I could come up with to simulate the fact that `BytesRestResponse` would raise an exception the first time.

@vrozov WDYT? Overkill? Silly? 🤔 ? Other better ideas? Rewrite everything in Ruby and just use `expect`? :)
 
### Issues Resolved

Closes #989.
  
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
