### PR TITLE
FreeBSD Java support

### DIFF
--- a/distribution/src/bin/opensearch-env
+++ b/distribution/src/bin/opensearch-env
@@ -1,10 +1,19 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -o pipefail
 
 CDPATH=""
 
 SCRIPT="$0"
+
+UNAME=$(uname -s)
+if [ $UNAME = "FreeBSD" ]; then
+  OS="freebsd"
+elif [ $UNAME = "Darwin" ]; then
+  OS="darwin"
+else
+  OS="other"
+fi
 
 # SCRIPT might be an arbitrarily deep series of symbolic links; loop until we
 # have the concrete path
@@ -40,9 +49,12 @@ if [ ! -z "$JAVA_HOME" ]; then
   JAVA="$JAVA_HOME/bin/java"
   JAVA_TYPE="JAVA_HOME"
 else
-  if [ "$(uname -s)" = "Darwin" ]; then
-    # macOS has a different structure
+  if [ $OS = "darwin" ]; then
+    # macOS bundled Java
     JAVA="$OPENSEARCH_HOME/jdk.app/Contents/Home/bin/java"
+  elif [ $OS = "freebsd" ]; then
+    # using FreeBSD default java from ports if JAVA_HOME is not set
+    JAVA="/usr/local/bin/java"
   else
     JAVA="$OPENSEARCH_HOME/jdk/bin/java"
   fi


### PR DESCRIPTION
Signed-off-by: hackacad <admin@hackacad.net>

### Description
Adding support for FreeBSD userland Java (installe via port/pkg)
 
### Issues Resolved
Adding reusable OS check ($OS) and location of Java on Darwin and FreeBSD
 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
