### PR TITLE
Upgrading mockito version in OpenSearch

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -122,7 +122,7 @@ dependencies {
   testFixturesApi gradleApi()
   testFixturesApi gradleTestKit()
   testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone:2.23.2'
-  testImplementation 'org.mockito:mockito-core:1.9.5'
+  testImplementation 'org.mockito:mockito-core:3.11.2'
   integTestImplementation('org.spockframework:spock-core:1.3-groovy-2.5') {
     exclude module: "groovy"
   }


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Upgrading the `mockito-core` version in OpenSearch from 1.9.5 to 3.11.2.
 
### Issues Resolved
#1008 
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
