### PR TITLE
Rank feature - unknown field linear (#983)

### DIFF
--- a/client/rest-high-level/src/test/java/org/opensearch/client/documentation/QueryDSLDocumentationTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/documentation/QueryDSLDocumentationTests.java
@@ -493,4 +493,10 @@ public class QueryDSLDocumentationTests extends OpenSearchTestCase {
             0.6f
         );
     }
+
+    public void testRankFeatureLinear() {
+        RankFeatureQueryBuilders.linear(
+            "pagerank"
+        );
+    }
 }

--- a/modules/mapper-extras/src/main/java/org/opensearch/index/query/RankFeatureQueryBuilders.java
+++ b/modules/mapper-extras/src/main/java/org/opensearch/index/query/RankFeatureQueryBuilders.java
@@ -77,4 +77,13 @@ public final class RankFeatureQueryBuilders {
         return new RankFeatureQueryBuilder(fieldName, new RankFeatureQueryBuilder.ScoreFunction.Sigmoid(pivot, exp));
     }
 
+    /**
+     * Return a new {@link RankFeatureQueryBuilder} that will score documents as
+     * {@code S)} where S is the indexed value of the static feature.
+     * @param fieldName     field that stores features
+     */
+    public static RankFeatureQueryBuilder linear(String fieldName) {
+        return new RankFeatureQueryBuilder(fieldName, new RankFeatureQueryBuilder.ScoreFunction.Linear());
+    }
+
 }

--- a/modules/mapper-extras/src/test/java/org/opensearch/index/query/RankFeatureQueryBuilderTests.java
+++ b/modules/mapper-extras/src/test/java/org/opensearch/index/query/RankFeatureQueryBuilderTests.java
@@ -73,7 +73,7 @@ public class RankFeatureQueryBuilderTests extends AbstractQueryTestCase<RankFeat
     protected RankFeatureQueryBuilder doCreateTestQueryBuilder() {
         ScoreFunction function;
         boolean mayUseNegativeField = true;
-        switch (random().nextInt(3)) {
+        switch (random().nextInt(4)) {
         case 0:
             mayUseNegativeField = false;
             function = new ScoreFunction.Log(1 + randomFloat());
@@ -87,6 +87,9 @@ public class RankFeatureQueryBuilderTests extends AbstractQueryTestCase<RankFeat
             break;
         case 2:
             function = new ScoreFunction.Sigmoid(randomFloat(), randomFloat());
+            break;
+        case 3:
+            function = new ScoreFunction.Linear();
             break;
         default:
             throw new AssertionError();


### PR DESCRIPTION
### Description
Add support for rank feature query linear

( backport as requested here https://github.com/opensearch-project/OpenSearch/pull/983#issuecomment-889366050 )
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/977
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
