### PR TITLE
Prevent /_cat/master from getting tripped by the CB

### DIFF
--- a/server/src/main/java/org/opensearch/rest/action/cat/RestMasterAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestMasterAction.java
@@ -80,6 +80,11 @@ public class RestMasterAction extends AbstractCatAction {
     }
 
     @Override
+    public boolean canTripCircuitBreaker() {
+        return false;
+    }
+
+    @Override
     protected Table getTableWithHeader(final RestRequest request) {
         Table table = new Table();
         table.startHeaders()


### PR DESCRIPTION
Signed-off-by: Bukhtawar Khan bukhtawa@amazon.com

### Description
`_cat/master` is a fundamental API to know the master instance in the cluster. Given `RestClusterState` is exempted from tripping already, doesn't make sense for `RestMasterAction` to trip

https://github.com/opensearch-project/OpenSearch/blob/b7cf1fae41869416ab206e5e8a36226e5d9c57ac/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterStateAction.java#L156-L159


```
[2021-08-02T02:46:28,857][DEBUG][r.suppressed             ] [7f929454300e3b3db558b8d2980127fd] path: /_cat/master, params: {v=}
org.elasticsearch.common.breaker.CircuitBreakingException: [parent] Data too large, data for [<http_request>] would be [8163010008/7.6gb], which is larger than the limit of [8127315968/7.5gb], real usage: [8163010008/7.6gb], new bytes reserved: [0/0b], usages [request=0/0b, fielddata=5989062/5.7mb, in_flight_requests=49864/48.6kb, accounting=112149712/106.9mb]
        at org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService.checkParentLimit(HierarchyCircuitBreakerService.java:346) ~[elasticsearch-7.10.2.jar:7.10.2]
        at org.elasticsearch.common.breaker.ChildMemoryCircuitBreaker.addEstimateBytesAndMaybeBreak(ChildMemoryCircuitBreaker.java:109) ~[elasticsearch-7.10.2.jar:7.10.2]
        at org.elasticsearch.rest.RestController.dispatchRequest(RestController.java:241) [elasticsearch-7.10.2.jar:7.10.2]
        at org.elasticsearch.rest.RestController.tryAllHandlers(RestController.java:340) [elasticsearch-7.10.2.jar:7.10.2]
        at org.elasticsearch.rest.RestController.dispatchRequest(RestController.java:191) [elasticsearch-7.10.2.jar:7.10.2]
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
