### PR TITLE
alt bash path support

### DIFF
--- a/buildSrc/src/main/resources/deb/postinst.ftl
+++ b/buildSrc/src/main/resources/deb/postinst.ftl
@@ -1,2 +1,2 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 <% commands.each {command -> %><%= command %><% } %>

--- a/buildSrc/src/main/resources/deb/preinst.ftl
+++ b/buildSrc/src/main/resources/deb/preinst.ftl
@@ -1,2 +1,2 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 <% commands.each {command -> %><%= command %><% } %>

--- a/client/sniffer/src/test/resources/create_test_nodes_info.bash
+++ b/client/sniffer/src/test/resources/create_test_nodes_info.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Recreates the v_nodes_http.json files in this directory. This is
 # meant to be an "every once in a while" thing that we do only when

--- a/distribution/docker/docker-test-entrypoint.sh
+++ b/distribution/docker/docker-test-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd /usr/share/opensearch/bin/
 
 /usr/local/bin/docker-entrypoint.sh | tee > /usr/share/opensearch/logs/console.log

--- a/distribution/docker/src/docker/bin/docker-entrypoint.sh
+++ b/distribution/docker/src/docker/bin/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Files created by Elasticsearch should always be group writable too

--- a/distribution/packages/src/common/scripts/preinst
+++ b/distribution/packages/src/common/scripts/preinst
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script is executed in the pre-installation phase
 #

--- a/distribution/packages/src/deb/init.d/opensearch
+++ b/distribution/packages/src/deb/init.d/opensearch
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # /etc/init.d/opensearch -- startup script for OpenSearch
 #

--- a/distribution/packages/src/rpm/init.d/opensearch
+++ b/distribution/packages/src/rpm/init.d/opensearch
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # opensearch <summary>
 #

--- a/libs/ssl-config/src/test/resources/certs/README.txt
+++ b/libs/ssl-config/src/test/resources/certs/README.txt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This is README describes how the certificates in this directory were created.
 # This file can also be executed as a script

--- a/plugins/examples/custom-settings/src/main/bin/test
+++ b/plugins/examples/custom-settings/src/main/bin/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Plugin can contain executable files that are copied by the plugin manager
 # to a <plugin-name>/bin folder.

--- a/qa/remote-clusters/docker-test-entrypoint.sh
+++ b/qa/remote-clusters/docker-test-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd /usr/share/opensearch/bin/
 ./opensearch-users useradd rest_user -p test-password -r superuser || true
 echo "testnode" > /tmp/password

--- a/test/fixtures/krb5kdc-fixture/src/main/resources/provision/addprinc.sh
+++ b/test/fixtures/krb5kdc-fixture/src/main/resources/provision/addprinc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed to Elasticsearch under one or more contributor
 # license agreements. See the NOTICE file distributed with

--- a/test/fixtures/krb5kdc-fixture/src/main/resources/provision/hdfs.sh
+++ b/test/fixtures/krb5kdc-fixture/src/main/resources/provision/hdfs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/test/fixtures/krb5kdc-fixture/src/main/resources/provision/installkdc.sh
+++ b/test/fixtures/krb5kdc-fixture/src/main/resources/provision/installkdc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/test/fixtures/krb5kdc-fixture/src/main/resources/provision/peppa.sh
+++ b/test/fixtures/krb5kdc-fixture/src/main/resources/provision/peppa.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Signed-off-by: hackacad <admin@hackacad.net>

### Description
Using portable shebangs as mentioned in #1013.

Not using env for /bin/sh as this should be present on every Linux/Unix.
 

### Issues Resolved
#1013
 
mention https://github.com/opensearch-project/opensearch-build/issues/101

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
