### PR TITLE
Include sources and javadoc artifacts while publishing to a Maven repository

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/PublishPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/PublishPlugin.java
@@ -121,14 +121,15 @@ public class PublishPlugin implements Plugin<Project> {
             });
         });
 
-        // Add git origin info to generated POM files
         publishing.getPublications().withType(MavenPublication.class, publication -> {
+            // Add git origin info to generated POM files
             publication.getPom().withXml(PublishPlugin::addScmInfo);
 
             // have to defer this until archivesBaseName is set
             project.afterEvaluate(p -> publication.setArtifactId(getArchivesBaseName(project)));
 
-            if (project.getPlugins().hasPlugin("opensearch.java")) {
+            // publish sources and javadoc for Java projects.
+            if (project.getPluginManager().hasPlugin("opensearch.java")) {
                 publication.artifact(project.getTasks().getByName("sourcesJar"));
                 publication.artifact(project.getTasks().getByName("javadocJar"));
             }

--- a/buildSrc/src/main/java/org/opensearch/gradle/PublishPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/PublishPlugin.java
@@ -128,6 +128,11 @@ public class PublishPlugin implements Plugin<Project> {
             // have to defer this until archivesBaseName is set
             project.afterEvaluate(p -> publication.setArtifactId(getArchivesBaseName(project)));
 
+            if (project.getPlugins().hasPlugin("opensearch.java")) {
+                publication.artifact(project.getTasks().getByName("sourcesJar"));
+                publication.artifact(project.getTasks().getByName("javadocJar"));
+            }
+
             generatePomTask.configure(
                 t -> t.dependsOn(String.format("generatePomFileFor%sPublication", Util.capitalize(publication.getName())))
             );


### PR DESCRIPTION
### Description

This change fixes the issue where running publish commands, the sources and javadoc artifacts were not built and included with the publications.

### Issues Resolved
#1028 
 
### Check List
- [x] All tests pass
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>
