### PR TITLE
Avoid crashing on using the index.lifecycle.name in the API body

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1044,7 +1044,10 @@ public class MetadataCreateIndexService {
         for (final String key : settings.keySet()) {
             final Setting<?> setting = indexScopedSettings.get(key);
             if (setting == null) {
-                assert indexScopedSettings.isPrivateSetting(key) : "expected [" + key + "] to be private but it was not";
+                //https://github.com/opensearch-project/OpenSearch/issues/1019
+                if(!indexScopedSettings.isPrivateSetting(key)) {
+                    validationErrors.add("expected [" + key + "] to be private but it was not");
+                }
             } else if (setting.isPrivateIndex()) {
                 validationErrors.add("private index setting [" + key + "] can not be set explicitly");
             }

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1044,7 +1044,7 @@ public class MetadataCreateIndexService {
         for (final String key : settings.keySet()) {
             final Setting<?> setting = indexScopedSettings.get(key);
             if (setting == null) {
-                //https://github.com/opensearch-project/OpenSearch/issues/1019
+                // see: https://github.com/opensearch-project/OpenSearch/issues/1019
                 if(!indexScopedSettings.isPrivateSetting(key)) {
                     validationErrors.add("expected [" + key + "] to be private but it was not");
                 }

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -965,7 +965,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
     }
 
     public void testIndexLifecycleNameSetting() {
-        //https://github.com/opensearch-project/OpenSearch/issues/1019
+        // see: https://github.com/opensearch-project/OpenSearch/issues/1019
         final Settings ilnSetting = Settings.builder().put("index.lifecycle.name", "dummy").build();
         withTemporaryClusterService(((clusterService, threadPool) -> {
             MetadataCreateIndexService checkerService = new MetadataCreateIndexService(

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -66,6 +66,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.BigArrays;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.env.Environment;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.IndexSettings;
@@ -961,6 +962,31 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             Collections.emptySet());
         assertWarnings("Translog retention settings [index.translog.retention.age] "
             + "and [index.translog.retention.size] are deprecated and effectively ignored. They will be removed in a future version.");
+    }
+
+    public void testIndexLifecycleNameSetting() {
+        //https://github.com/opensearch-project/OpenSearch/issues/1019
+        final Settings ilnSetting = Settings.builder().put("index.lifecycle.name", "dummy").build();
+        withTemporaryClusterService(((clusterService, threadPool) -> {
+            MetadataCreateIndexService checkerService = new MetadataCreateIndexService(
+                Settings.EMPTY,
+                clusterService,
+                null,
+                null,
+                null,
+                createTestShardLimitService(randomIntBetween(1, 1000), clusterService),
+                new Environment(Settings.builder().put("path.home", "dummy").build(), null),
+                new IndexScopedSettings(ilnSetting, Collections.emptySet()),
+                threadPool,
+                null,
+                new SystemIndices(Collections.emptyMap()),
+                true
+            );
+
+            final List<String> validationErrors =  checkerService.getIndexSettingsValidationErrors(ilnSetting, true);
+            assertThat(validationErrors.size(), is(1));
+            assertThat(validationErrors.get(0), is("expected [index.lifecycle.name] to be private but it was not"));
+        }));
     }
 
     private IndexTemplateMetadata addMatchingTemplate(Consumer<IndexTemplateMetadata.Builder> configurator) {


### PR DESCRIPTION
Signed-off-by: frotsch <frotsch@mailbox.org>

### Description
Fix OpenSearch process crashing on using the index.lifecycle.name in the API body when asserts are enabled
 
### Issues Resolved
#1019
 
### Check List
- [ x] All tests pass
- [x ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
