### PR TITLE
Avoid crashing on using the index.lifecycle.name in the API body (#1060)

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1044,7 +1044,10 @@ public class MetadataCreateIndexService {
         for (final String key : settings.keySet()) {
             final Setting<?> setting = indexScopedSettings.get(key);
             if (setting == null) {
-                assert indexScopedSettings.isPrivateSetting(key) : "expected [" + key + "] to be private but it was not";
+                // see: https://github.com/opensearch-project/OpenSearch/issues/1019
+                if(!indexScopedSettings.isPrivateSetting(key)) {
+                    validationErrors.add("expected [" + key + "] to be private but it was not");
+                }
             } else if (setting.isPrivateIndex()) {
                 validationErrors.add("private index setting [" + key + "] can not be set explicitly");
             }


### PR DESCRIPTION
Signed-off-by: frotsch <frotsch@mailbox.org>

### Description
Backport of #1060 Avoid crashing on using the index.lifecycle.name in the API body
 
### Issues Resolved
#1019
 
### Check List
- [x] All tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
