### PR TITLE
Part 1: Support for cancel_after_time_interval parameter in search and…

### DIFF
--- a/server/src/main/java/org/opensearch/action/search/MultiSearchRequest.java
+++ b/server/src/main/java/org/opensearch/action/search/MultiSearchRequest.java
@@ -66,6 +66,7 @@ import static org.opensearch.action.ValidateActions.addValidationError;
 import static org.opensearch.common.xcontent.support.XContentMapValues.nodeBooleanValue;
 import static org.opensearch.common.xcontent.support.XContentMapValues.nodeStringArrayValue;
 import static org.opensearch.common.xcontent.support.XContentMapValues.nodeStringValue;
+import static org.opensearch.common.xcontent.support.XContentMapValues.nodeTimeValue;
 
 /**
  * A multi search API request.
@@ -272,6 +273,9 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
                             allowNoIndices = value;
                         } else if ("ignore_throttled".equals(entry.getKey()) || "ignoreThrottled".equals(entry.getKey())) {
                             ignoreThrottled = value;
+                        } else if ("cancel_after_time_interval".equals(entry.getKey()) ||
+                            "cancelAfterTimeInterval".equals(entry.getKey())) {
+                            searchRequest.setCancelAfterTimeInterval(nodeTimeValue(value, null));
                         } else {
                             throw new IllegalArgumentException("key [" + entry.getKey() + "] is not supported in the metadata section");
                         }
@@ -361,6 +365,9 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
         }
         if (request.allowPartialSearchResults() != null) {
             xContentBuilder.field("allow_partial_search_results", request.allowPartialSearchResults());
+        }
+        if (request.getCancelAfterTimeInterval() != null) {
+            xContentBuilder.field("cancel_after_time_interval", request.getCancelAfterTimeInterval().getStringRep());
         }
         xContentBuilder.endObject();
     }

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestBuilder.java
@@ -626,4 +626,12 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
         this.request.setPreFilterShardSize(preFilterShardSize);
         return this;
     }
+
+    /**
+     * Request level time interval to control how long search is allowed to execute after which it is cancelled.
+     */
+    public SearchRequestBuilder setCancelAfterTimeInterval(TimeValue cancelAfterTimeInterval) {
+        this.request.setCancelAfterTimeInterval(cancelAfterTimeInterval);
+        return this;
+    }
 }

--- a/server/src/main/java/org/opensearch/action/search/SearchTask.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchTask.java
@@ -32,11 +32,14 @@
 
 package org.opensearch.action.search;
 
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.tasks.CancellableTask;
 import org.opensearch.tasks.TaskId;
 
 import java.util.Map;
 import java.util.function.Supplier;
+
+import static org.opensearch.search.SearchService.NO_TIMEOUT;
 
 /**
  * Task storing information about a currently running {@link SearchRequest}.
@@ -46,9 +49,14 @@ public class SearchTask extends CancellableTask {
     private final Supplier<String> descriptionSupplier;
     private SearchProgressListener progressListener = SearchProgressListener.NOOP;
 
-    public SearchTask(long id, String type, String action, Supplier<String> descriptionSupplier,
-                      TaskId parentTaskId, Map<String, String> headers) {
-        super(id, type, action, null, parentTaskId, headers);
+    public SearchTask(long id, String type, String action, Supplier<String> descriptionSupplier, TaskId parentTaskId,
+        Map<String, String> headers) {
+        this(id, type, action, descriptionSupplier, parentTaskId, headers, NO_TIMEOUT);
+    }
+
+    public SearchTask(long id, String type, String action, Supplier<String> descriptionSupplier, TaskId parentTaskId,
+        Map<String, String> headers, TimeValue cancelAfterTimeInterval) {
+        super(id, type, action, null, parentTaskId, headers, cancelAfterTimeInterval);
         this.descriptionSupplier = descriptionSupplier;
     }
 

--- a/server/src/main/java/org/opensearch/action/support/TimeoutTaskCancellationUtility.java
+++ b/server/src/main/java/org/opensearch/action/support/TimeoutTaskCancellationUtility.java
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.support;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
+import org.opensearch.client.OriginSettingClient;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.search.SearchService;
+import org.opensearch.tasks.CancellableTask;
+import org.opensearch.tasks.TaskId;
+import org.opensearch.threadpool.Scheduler;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.opensearch.action.admin.cluster.node.tasks.get.GetTaskAction.TASKS_ORIGIN;
+import static org.opensearch.action.search.TransportSearchAction.SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING;
+
+public class TimeoutTaskCancellationUtility {
+
+    private static final Logger logger = LogManager.getLogger(TimeoutTaskCancellationUtility.class);
+
+    /**
+     * Wraps a listener with a timeout listener {@link TimeoutRunnableListener} to schedule the task cancellation for provided tasks on
+     * generic thread pool
+     * @param client - {@link NodeClient}
+     * @param taskToCancel - task to schedule cancellation for
+     * @param clusterSettings - {@link ClusterSettings}
+     * @param listener - original listener associated with the task
+     * @return wrapped listener
+     */
+    public static <Response> ActionListener<Response>  wrapWithCancellationListener(NodeClient client, CancellableTask taskToCancel,
+        ClusterSettings clusterSettings, ActionListener<Response> listener) {
+        final TimeValue globalTimeout = clusterSettings.get(SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING);
+        final TimeValue timeoutInterval = (taskToCancel.getCancellationTimeout() == null) ? globalTimeout
+            : taskToCancel.getCancellationTimeout();
+        // Note: -1 (or no timeout) will help to turn off cancellation. The combinations will be request level set at -1 or request level
+        // set to null and cluster level set to -1.
+        ActionListener<Response> listenerToReturn = listener;
+        if (timeoutInterval.equals(SearchService.NO_TIMEOUT)) {
+            return listenerToReturn;
+        }
+
+        try {
+            final TimeoutRunnableListener<Response> wrappedListener = new TimeoutRunnableListener<>(timeoutInterval, listener, () -> {
+                final CancelTasksRequest cancelTasksRequest = new CancelTasksRequest();
+                cancelTasksRequest.setTaskId(new TaskId(client.getLocalNodeId(), taskToCancel.getId()));
+                cancelTasksRequest.setReason("Cancellation timeout of " + timeoutInterval + " is expired");
+                // force the origin to execute the cancellation as a system user
+                new OriginSettingClient(client, TASKS_ORIGIN).admin().cluster()
+                    .cancelTasks(cancelTasksRequest, ActionListener.wrap(r -> logger.debug(
+                        "Scheduled cancel task with timeout: {} for original task: {} is successfully completed", timeoutInterval,
+                        cancelTasksRequest.getTaskId()),
+                        e -> logger.error(new ParameterizedMessage("Scheduled cancel task with timeout: {} for original task: {} is failed",
+                            timeoutInterval, cancelTasksRequest.getTaskId()), e))
+                    );
+            });
+            wrappedListener.cancellable = client.threadPool().schedule(wrappedListener, timeoutInterval, ThreadPool.Names.GENERIC);
+            listenerToReturn = wrappedListener;
+        } catch (Exception ex) {
+            // if there is any exception in scheduling the cancellation task then continue without it
+            logger.warn("Failed to schedule the cancellation task for original task: {}, will continue without it", taskToCancel.getId());
+        }
+        return listenerToReturn;
+    }
+
+    /**
+     * Timeout listener which executes the provided runnable after timeout is expired and if a response/failure is not yet received.
+     * If either a response/failure is received before timeout then the scheduled task is cancelled and response/failure is sent back to
+     * the original listener.
+     */
+    private static class TimeoutRunnableListener<Response> implements ActionListener<Response>, Runnable {
+
+        private static final Logger logger = LogManager.getLogger(TimeoutRunnableListener.class);
+
+        // Runnable to execute after timeout
+        private final TimeValue timeout;
+        private final ActionListener<Response> originalListener;
+        private final Runnable timeoutRunnable;
+        private final AtomicBoolean executeRunnable = new AtomicBoolean(true);
+        private volatile Scheduler.ScheduledCancellable cancellable;
+        private final long creationTime;
+
+        TimeoutRunnableListener(TimeValue timeout, ActionListener<Response> listener, Runnable runAfterTimeout) {
+            this.timeout = timeout;
+            this.originalListener = listener;
+            this.timeoutRunnable = runAfterTimeout;
+            this.creationTime = System.nanoTime();
+        }
+
+        @Override public void onResponse(Response response) {
+            checkAndCancel();
+            originalListener.onResponse(response);
+        }
+
+        @Override public void onFailure(Exception e) {
+            checkAndCancel();
+            originalListener.onFailure(e);
+        }
+
+        @Override public void run() {
+            try {
+                if (executeRunnable.compareAndSet(true, false)) {
+                    timeoutRunnable.run();
+                } // else do nothing since either response/failure is already sent to client
+            } catch (Exception ex) {
+                // ignore the exception
+                logger.error(new ParameterizedMessage("Ignoring the failure to run the provided runnable after timeout of {} with " +
+                    "exception", timeout), ex);
+            }
+        }
+
+        private void checkAndCancel() {
+            if (executeRunnable.compareAndSet(true, false)) {
+                logger.debug("Aborting the scheduled cancel task after {}",
+                    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - creationTime));
+                // timer has not yet expired so cancel it
+                cancellable.cancel();
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -345,6 +345,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
             SearchService.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS,
             ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING,
             TransportSearchAction.SHARD_COUNT_LIMIT_SETTING,
+            TransportSearchAction.SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING,
             RemoteClusterService.REMOTE_CLUSTER_SKIP_UNAVAILABLE,
             RemoteClusterService.SEARCH_REMOTE_CLUSTER_SKIP_UNAVAILABLE,
             SniffConnectionStrategy.REMOTE_CONNECTIONS_PER_CLUSTER,

--- a/server/src/main/java/org/opensearch/rest/action/search/RestMultiSearchAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/search/RestMultiSearchAction.java
@@ -44,6 +44,7 @@ import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContent;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
@@ -158,6 +159,7 @@ public class RestMultiSearchAction extends BaseRestHandler {
             multiRequest.add(searchRequest);
         });
         List<SearchRequest> requests = multiRequest.requests();
+        final TimeValue cancelAfterTimeInterval = restRequest.paramAsTime("cancel_after_time_interval", null);
         for (SearchRequest request : requests) {
             // preserve if it's set on the request
             if (preFilterShardSize != null && request.getPreFilterShardSize() == null) {
@@ -165,6 +167,11 @@ public class RestMultiSearchAction extends BaseRestHandler {
             }
             if (maxConcurrentShardRequests != null) {
                 request.setMaxConcurrentShardRequests(maxConcurrentShardRequests);
+            }
+            // if cancel_after_time_interval parameter is set at per search request level than that is used otherwise one set at
+            // multi search request level will be used
+            if (request.getCancelAfterTimeInterval() == null) {
+                request.setCancelAfterTimeInterval(cancelAfterTimeInterval);
             }
         }
         return multiRequest;

--- a/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java
@@ -208,6 +208,8 @@ public class RestSearchAction extends BaseRestHandler {
             searchRequest.setCcsMinimizeRoundtrips(
                 request.paramAsBoolean("ccs_minimize_roundtrips", searchRequest.isCcsMinimizeRoundtrips()));
         }
+
+        searchRequest.setCancelAfterTimeInterval(request.paramAsTime("cancel_after_time_interval", null));
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/dfs/DfsPhase.java
+++ b/server/src/main/java/org/opensearch/search/dfs/DfsPhase.java
@@ -62,7 +62,7 @@ public class DfsPhase {
                 @Override
                 public TermStatistics termStatistics(Term term, int docFreq, long totalTermFreq) throws IOException {
                     if (context.isCancelled()) {
-                        throw new TaskCancelledException("cancelled");
+                        throw new TaskCancelledException("cancelled task with reason: " + context.getTask().getReasonCancelled());
                     }
                     TermStatistics ts = super.termStatistics(term, docFreq, totalTermFreq);
                     if (ts != null) {
@@ -74,7 +74,7 @@ public class DfsPhase {
                 @Override
                 public CollectionStatistics collectionStatistics(String field) throws IOException {
                     if (context.isCancelled()) {
-                        throw new TaskCancelledException("cancelled");
+                        throw new TaskCancelledException("cancelled task with reason: " + context.getTask().getReasonCancelled());
                     }
                     CollectionStatistics cs = super.collectionStatistics(field);
                     if (cs != null) {

--- a/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
@@ -108,7 +108,7 @@ public class FetchPhase {
         }
 
         if (context.isCancelled()) {
-            throw new TaskCancelledException("cancelled");
+            throw new TaskCancelledException("cancelled task with reason: " + context.getTask().getReasonCancelled());
         }
 
         if (context.docIdsToLoadSize() == 0) {
@@ -140,7 +140,7 @@ public class FetchPhase {
         boolean hasSequentialDocs = hasSequentialDocs(docs);
         for (int index = 0; index < context.docIdsToLoadSize(); index++) {
             if (context.isCancelled()) {
-                throw new TaskCancelledException("cancelled");
+                throw new TaskCancelledException("cancelled task with reason: " + context.getTask().getReasonCancelled());
             }
             int docId = docs[index].docId;
             try {
@@ -181,7 +181,7 @@ public class FetchPhase {
             }
         }
         if (context.isCancelled()) {
-            throw new TaskCancelledException("cancelled");
+            throw new TaskCancelledException("cancelled task with reason: " + context.getTask().getReasonCancelled());
         }
 
         TotalHits totalHits = context.queryResult().getTotalHits();

--- a/server/src/main/java/org/opensearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryPhase.java
@@ -126,7 +126,7 @@ public class QueryPhase {
             cancellation = context.searcher().addQueryCancellation(() -> {
                 SearchShardTask task = context.getTask();
                 if (task != null && task.isCancelled()) {
-                    throw new TaskCancelledException("cancelled");
+                    throw new TaskCancelledException("cancelled task with reason: " + task.getReasonCancelled());
                 }
             });
         } else {
@@ -295,7 +295,7 @@ public class QueryPhase {
                 searcher.addQueryCancellation(() -> {
                     SearchShardTask task = searchContext.getTask();
                     if (task != null && task.isCancelled()) {
-                        throw new TaskCancelledException("cancelled");
+                        throw new TaskCancelledException("cancelled task with reason: " + task.getReasonCancelled());
                     }
                 });
             }

--- a/server/src/main/java/org/opensearch/tasks/CancellableTask.java
+++ b/server/src/main/java/org/opensearch/tasks/CancellableTask.java
@@ -33,9 +33,12 @@
 package org.opensearch.tasks;
 
 import org.opensearch.common.Nullable;
+import org.opensearch.common.unit.TimeValue;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.opensearch.search.SearchService.NO_TIMEOUT;
 
 /**
  * A task that can be canceled
@@ -44,9 +47,16 @@ public abstract class CancellableTask extends Task {
 
     private volatile String reason;
     private final AtomicBoolean cancelled = new AtomicBoolean(false);
+    private final TimeValue cancelAfterTimeInterval;
 
     public CancellableTask(long id, String type, String action, String description, TaskId parentTaskId, Map<String, String> headers) {
+        this(id, type, action, description, parentTaskId, headers, NO_TIMEOUT);
+    }
+
+    public CancellableTask(long id, String type, String action, String description, TaskId parentTaskId, Map<String, String> headers,
+        TimeValue cancelAfterTimeInterval) {
         super(id, type, action, description, parentTaskId, headers);
+        this.cancelAfterTimeInterval = cancelAfterTimeInterval;
     }
 
     /**
@@ -75,6 +85,10 @@ public abstract class CancellableTask extends Task {
 
     public boolean isCancelled() {
         return cancelled.get();
+    }
+
+    public TimeValue getCancellationTimeout() {
+        return cancelAfterTimeInterval;
     }
 
     /**

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestTests.java
@@ -115,6 +115,12 @@ public class SearchRequestTests extends AbstractSearchTestCase {
             assertEquals(searchRequest.getAbsoluteStartMillis(), deserializedRequest.getAbsoluteStartMillis());
             assertEquals(searchRequest.isFinalReduce(), deserializedRequest.isFinalReduce());
         }
+
+        if (version.onOrAfter(Version.V_1_1_0)) {
+            assertEquals(searchRequest.getCancelAfterTimeInterval(), deserializedRequest.getCancelAfterTimeInterval());
+        } else {
+            assertNull(deserializedRequest.getCancelAfterTimeInterval());
+        }
     }
 
     public void testReadFromPre6_7_0() throws IOException {
@@ -261,6 +267,8 @@ public class SearchRequestTests extends AbstractSearchTestCase {
             () -> randomFrom(SearchType.DFS_QUERY_THEN_FETCH, SearchType.QUERY_THEN_FETCH))));
         mutators.add(() -> mutation.source(randomValueOtherThan(searchRequest.source(), this::createSearchSourceBuilder)));
         mutators.add(() -> mutation.setCcsMinimizeRoundtrips(searchRequest.isCcsMinimizeRoundtrips() == false));
+        mutators.add(() -> mutation.setCancelAfterTimeInterval(searchRequest.getCancelAfterTimeInterval() != null
+            ? null : TimeValue.parseTimeValue(randomTimeValue(), null, "cancel_after_time_interval")));
         randomFrom(mutators).run();
         return mutation;
     }

--- a/test/framework/src/main/java/org/opensearch/search/RandomSearchRequestGenerator.java
+++ b/test/framework/src/main/java/org/opensearch/search/RandomSearchRequestGenerator.java
@@ -130,6 +130,10 @@ public class RandomSearchRequestGenerator {
         if (randomBoolean()) {
             searchRequest.source(randomSearchSourceBuilder.get());
         }
+        if (randomBoolean()) {
+            searchRequest.setCancelAfterTimeInterval(
+                TimeValue.parseTimeValue(randomTimeValue(), null, "cancel_after_time_interval"));
+        }
         return searchRequest;
     }
 


### PR DESCRIPTION
… msearch request (#986)

* Part 1: Support for cancel_after_timeinterval parameter in search and msearch request

This commit introduces the new request level parameter to configure the timeout interval after which
a search request will be cancelled. For msearch request the parameter is supported both at parent
request and at sub child search requests. If it is provided at parent level and child search request
doesn't have it then the parent level value is set at such child request. The parent level msearch
is not used to cancel the parent request as it may be tricky to come up with correct value in cases
when child search request can have different runtimes

TEST: Added test for ser/de with new parameter

Signed-off-by: Sorabh Hamirwasia <sohami.apache@gmail.com>

* Part 2: Support for cancel_after_timeinterval parameter in search and msearch request

This commit adds the handling of the new request level parameter and schedule cancellation task. It
also adds a cluster setting to set a global cancellation timeout for search request which will be
used in absence of request level timeout.

TEST: Added new tests in SearchCancellationIT
Signed-off-by: Sorabh Hamirwasia <sohami.apache@gmail.com>

* Address Review feedback for Part 1

Signed-off-by: Sorabh Hamirwasia <sohami.apache@gmail.com>

* Address review feedback for Part 2

Signed-off-by: Sorabh Hamirwasia <sohami.apache@gmail.com>

* Update CancellableTask to remove the cancelOnTimeout boolean flag

Signed-off-by: Sorabh Hamirwasia <sohami.apache@gmail.com>

* Replace search.cancellation.timeout cluster setting with search.enforce_server.timeout.cancellation to control if cluster level cancel_after_time_interval should take precedence over request level cancel_after_time_interval value

Signed-off-by: Sorabh Hamirwasia <sohami.apache@gmail.com>

* Removing the search.enforce_server.timeout.cancellation cluster setting and just keeping search.cancel_after_time_interval setting with request level parameter taking the precedence.

Signed-off-by: Sorabh Hamirwasia <sohami.apache@gmail.com>

Co-authored-by: Sorabh Hamirwasia <hsorabh@amazon.com>

### Description
This is cherry-pick of [this commit](9b6e62145245218e620d48ee4cc37acdb6024231) from main branch
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/817
 
### Check List
- [Y] New functionality includes testing.
  - [Y] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [Y] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
