### PR TITLE
[Backport-1.x] Support for bwc tests for plugins (#1051)

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
@@ -409,6 +409,14 @@ public class OpenSearchNode implements TestClusterConfiguration {
     }
 
     @Override
+    public void upgradePlugin(List<Provider<RegularFile>> plugins) {
+        this.plugins.clear();
+        for (Provider<RegularFile> plugin : plugins) {
+            this.plugins.add(plugin.map(RegularFile::getAsFile));
+        }
+    }
+
+    @Override
     public void plugin(String pluginProjectPath) {
         plugin(maybeCreatePluginOrModuleDependency(pluginProjectPath));
     }

--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/TestClusterConfiguration.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/TestClusterConfiguration.java
@@ -59,6 +59,8 @@ public interface TestClusterConfiguration {
 
     void plugin(String pluginProjectPath);
 
+    void upgradePlugin(List<Provider<RegularFile>> plugins);
+
     void module(Provider<RegularFile> module);
 
     void module(String moduleProjectPath);


### PR DESCRIPTION
* Support for bwc tests for plugins

Signed-off-by: Vacha <vachshah@amazon.com>

* Adding support for restart upgrades for plugins bwc

Signed-off-by: Vacha <vachshah@amazon.com>

### Description
Backport #1051 in 1.x
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
