### PR TITLE
enables http.custom.headers option in opensearch.yml

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -291,6 +291,9 @@ public final class ClusterSettings extends AbstractScopedSettings {
             NetworkModule.TRANSPORT_DEFAULT_TYPE_SETTING,
             NetworkModule.HTTP_TYPE_SETTING,
             NetworkModule.TRANSPORT_TYPE_SETTING,
+            //start: added by asfoorial
+            HttpTransportSettings.SETTING_HTTP_CUSTOM_HEADERS, 
+            //end: added by asfoorial
             HttpTransportSettings.SETTING_CORS_ALLOW_CREDENTIALS,
             HttpTransportSettings.SETTING_CORS_ENABLED,
             HttpTransportSettings.SETTING_CORS_MAX_AGE,

--- a/server/src/main/java/org/opensearch/http/DefaultRestChannel.java
+++ b/server/src/main/java/org/opensearch/http/DefaultRestChannel.java
@@ -134,6 +134,24 @@ public class DefaultRestChannel extends AbstractRestChannel implements RestChann
                 setHeaderField(httpResponse, X_OPAQUE_ID, opaque);
             }
 
+            //start: added by asfoorial
+            List<String> headers = settings.getCustomHeaders();
+            
+            //System.out.println("Custom Headers are: "+ headers);
+            if(headers!=null)
+            {
+            	for(String header:headers)
+                {
+                	if(header.contains(":"))
+                	{
+                		String[] parts = header.split(":");
+                		setHeaderField(httpResponse, parts[0], parts[1], false);
+                		
+                	}
+                }
+            }
+            //end: added by asfoorial
+
             // Add all custom headers
             addCustomHeaders(httpResponse, restResponse.getHeaders());
             addCustomHeaders(httpResponse, threadContext.getResponseHeaders());

--- a/server/src/main/java/org/opensearch/http/HttpHandlingSettings.java
+++ b/server/src/main/java/org/opensearch/http/HttpHandlingSettings.java
@@ -114,7 +114,7 @@ public class HttpHandlingSettings {
                 SETTING_PIPELINING_MAX_EVENTS.get(settings),
                 SETTING_HTTP_READ_TIMEOUT.get(settings).getMillis(),
                 SETTING_CORS_ENABLED.get(settings));
-    	List<String> headers = org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_CUSTOM_HEADERS.get(settings);
+    	List<String> headers = org.opensearch.http.HttpTransportSettings.SETTING_HTTP_CUSTOM_HEADERS.get(settings);
     	handler.setCustomHeaders(headers);
         return handler;
     }

--- a/server/src/main/java/org/opensearch/http/HttpHandlingSettings.java
+++ b/server/src/main/java/org/opensearch/http/HttpHandlingSettings.java
@@ -60,6 +60,17 @@ public class HttpHandlingSettings {
     private final long readTimeoutMillis;
     private boolean corsEnabled;
 
+    //start: added by asfoorial
+    List<String> customHeaders;
+    public List<String> getCustomHeaders() {
+		return customHeaders;
+	}
+
+	public void setCustomHeaders(List<String> customHeaders) {
+		this.customHeaders = customHeaders;
+	}
+    //end: added by asfoorial
+
     public HttpHandlingSettings(int maxContentLength, int maxChunkSize, int maxHeaderSize, int maxInitialLineLength,
                                 boolean resetCookies, boolean compression, int compressionLevel, boolean detailedErrorsEnabled,
                                 int pipeliningMaxEvents, long readTimeoutMillis, boolean corsEnabled) {
@@ -76,6 +87,7 @@ public class HttpHandlingSettings {
         this.corsEnabled = corsEnabled;
     }
 
+    /*
     public static HttpHandlingSettings fromSettings(Settings settings) {
         return new HttpHandlingSettings(Math.toIntExact(SETTING_HTTP_MAX_CONTENT_LENGTH.get(settings).getBytes()),
             Math.toIntExact(SETTING_HTTP_MAX_CHUNK_SIZE.get(settings).getBytes()),
@@ -88,8 +100,26 @@ public class HttpHandlingSettings {
             SETTING_PIPELINING_MAX_EVENTS.get(settings),
             SETTING_HTTP_READ_TIMEOUT.get(settings).getMillis(),
             SETTING_CORS_ENABLED.get(settings));
+    }*/
+    //start: added by asfoorial
+    public static HttpHandlingSettings fromSettings(Settings settings) {
+    	HttpHandlingSettings handler = new HttpHandlingSettings(Math.toIntExact(SETTING_HTTP_MAX_CONTENT_LENGTH.get(settings).getBytes()),
+                Math.toIntExact(SETTING_HTTP_MAX_CHUNK_SIZE.get(settings).getBytes()),
+                Math.toIntExact(SETTING_HTTP_MAX_HEADER_SIZE.get(settings).getBytes()),
+                Math.toIntExact(SETTING_HTTP_MAX_INITIAL_LINE_LENGTH.get(settings).getBytes()),
+                SETTING_HTTP_RESET_COOKIES.get(settings),
+                SETTING_HTTP_COMPRESSION.get(settings),
+                SETTING_HTTP_COMPRESSION_LEVEL.get(settings),
+                SETTING_HTTP_DETAILED_ERRORS_ENABLED.get(settings),
+                SETTING_PIPELINING_MAX_EVENTS.get(settings),
+                SETTING_HTTP_READ_TIMEOUT.get(settings).getMillis(),
+                SETTING_CORS_ENABLED.get(settings));
+    	List<String> headers = org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_CUSTOM_HEADERS.get(settings);
+    	handler.setCustomHeaders(headers);
+        return handler;
     }
-
+    //end: added by asfoorial
+    
     public int getMaxContentLength() {
         return maxContentLength;
     }

--- a/server/src/main/java/org/opensearch/http/HttpTransportSettings.java
+++ b/server/src/main/java/org/opensearch/http/HttpTransportSettings.java
@@ -52,6 +52,11 @@ import static org.opensearch.common.settings.Setting.listSetting;
 
 public final class HttpTransportSettings {
 
+    //start: added by asfoorial
+    public static final Setting<List<String>> SETTING_HTTP_CUSTOM_HEADERS =
+            listSetting("http.custom.headers", emptyList(), Function.identity(), Property.NodeScope);
+    //end: added by asfoorial
+    
     public static final Setting<Boolean> SETTING_CORS_ENABLED =
         Setting.boolSetting("http.cors.enabled", false, Property.NodeScope);
     public static final Setting<String> SETTING_CORS_ALLOW_ORIGIN =


### PR DESCRIPTION
### Description
Added new configuration option to opensearch.yml to enable sending custom http response headers. The option can be defined as shown below:
http.custom.headers: ["Strict-Security-Transport:max-age=31536000; includeSubDomains;"]
 
### Issues Resolved
#1069 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
