### PR TITLE
Increment version on main to 2.0 to avoid confusion with 1.1.

### DIFF
--- a/buildSrc/src/test/java/org/opensearch/gradle/BwcOpenSearchVersionsTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/BwcOpenSearchVersionsTests.java
@@ -37,6 +37,7 @@ public class BwcOpenSearchVersionsTests extends GradleUnitTestCase {
     static {
         sampleVersions.put("1.0.0", asList("5_6_13", "6_6_1", "6_8_15", "7_0_0", "7_9_1", "7_10_0", "7_10_1", "7_10_2", "1_0_0"));
         sampleVersions.put("1.1.0", asList("5_6_13", "6_6_1", "6_8_15", "7_0_0", "7_9_1", "7_10_0", "7_10_1", "7_10_2", "1_0_0", "1_1_0"));
+        sampleVersions.put("2.0.0", asList("5_6_13", "6_6_1", "6_8_15", "7_0_0", "7_9_1", "7_10_0", "7_10_1", "7_10_2", "1_0_0", "1_1_0", "2_0_0"));
     }
 
     public void testWireCompatible() {

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -1,4 +1,4 @@
-opensearch        = 1.1.0
+opensearch        = 2.0.0
 lucene            = 8.8.2
 
 bundled_jdk_vendor = adoptopenjdk

--- a/server/src/main/java/org/opensearch/Version.java
+++ b/server/src/main/java/org/opensearch/Version.java
@@ -72,7 +72,8 @@ public class Version implements Comparable<Version>, ToXContentFragment {
 
     public static final Version V_1_0_0 = new Version(1000099, org.apache.lucene.util.Version.LUCENE_8_8_2);
     public static final Version V_1_1_0 = new Version(1010099, org.apache.lucene.util.Version.LUCENE_8_8_2);
-    public static final Version CURRENT = V_1_1_0;
+    public static final Version V_2_0_0 = new Version(2000099, org.apache.lucene.util.Version.LUCENE_8_8_2);
+    public static final Version CURRENT = V_2_0_0;
 
     public static Version readVersion(StreamInput in) throws IOException {
         return fromId(in.readVInt());


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

We've been selectively backporting changes to 1.x for 1.1 version, but main is gathering lots of other changes. Plugins keep building against `main` as if it's 1.1. Increment version to 2.0 on main to avoid confusion.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
