### PR TITLE
Fix failure in SearchCancellationIT.testMSearchChildReqCancellationWi…

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
@@ -509,7 +509,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
         client().admin().cluster().prepareUpdateSettings().setPersistentSettings(Settings.builder()
             .put(SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING_KEY, cancellationTimeout)
             .build()).get();
-        ActionFuture<MultiSearchResponse> mSearchResponse = client().prepareMultiSearch()
+        ActionFuture<MultiSearchResponse> mSearchResponse = client().prepareMultiSearch().setMaxConcurrentSearchRequests(2)
             .add(client().prepareSearch("test").setAllowPartialSearchResults(randomBoolean())
                 .setQuery(scriptQuery(new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.SCRIPT_NAME,
                     Collections.emptyMap()))))
@@ -541,7 +541,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
         client().admin().cluster().prepareUpdateSettings().setPersistentSettings(Settings.builder()
             .put(SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING_KEY, clusterCancellationTimeout)
             .build()).get();
-        ActionFuture<MultiSearchResponse> mSearchResponse = client().prepareMultiSearch()
+        ActionFuture<MultiSearchResponse> mSearchResponse = client().prepareMultiSearch().setMaxConcurrentSearchRequests(3)
             .add(client().prepareSearch("test").setAllowPartialSearchResults(randomBoolean())
                 .setCancelAfterTimeInterval(reqCancellationTimeout)
                 .setQuery(scriptQuery(new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.SCRIPT_NAME,


### PR DESCRIPTION
…thHybridTimeout

In some cases as one shared with issue #1099, the maxConcurrentSearchRequests was chosen as 0 which
will compute the final value during execution of the request based on processor counts. When this
computed value is less than number of search request in msearch request, it will execute all the
requests in multiple iterations causing the failure since test will only wait for one such
iteration. Hence setting the maxConcurrentSearchRequests explicitly to number of search requests
being added in the test to ensure correct behavior

Signed-off-by: Sorabh Hamirwasia <sohami.apache@gmail.com>

### Description
Port of https://github.com/opensearch-project/OpenSearch/pull/1103 to 1.1 branch
 
### Issues Resolved
Test failure
 
### Check List
- [N/A] New functionality includes testing.
  - [Y] All tests pass
- [N/A ] New functionality has been documented.
  - [N/A] New functionality has javadoc added
- [Y] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
