### PR TITLE
[Bug] Change 1.0.0 version check in PluginInfo

### DIFF
--- a/server/src/main/java/org/opensearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginInfo.java
@@ -119,7 +119,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
             javaVersion = "1.8";
         }
         this.classname = in.readString();
-        if (in.getVersion().after(Version.V_1_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_1_1_0)) {
             customFolderName = in.readString();
         } else {
             customFolderName = this.name;
@@ -149,7 +149,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
             out.writeString(javaVersion);
         }
         out.writeString(classname);
-        if (out.getVersion().after(Version.V_1_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_1_1_0)) {
             if (customFolderName != null) {
                 out.writeString(customFolderName);
             } else {
@@ -204,12 +204,12 @@ public class PluginInfo implements Writeable, ToXContentObject {
                     "property [version] is missing for plugin [" + name + "]");
         }
 
-        final String esVersionString = propsMap.remove("opensearch.version");
-        if (esVersionString == null) {
+        final String opensearchVersionString = propsMap.remove("opensearch.version");
+        if (opensearchVersionString == null) {
             throw new IllegalArgumentException(
                     "property [opensearch.version] is missing for plugin [" + name + "]");
         }
-        final Version esVersion = Version.fromString(esVersionString);
+        final Version opensearchVersion = Version.fromString(opensearchVersionString);
         final String javaVersionString = propsMap.remove("java.version");
         if (javaVersionString == null) {
             throw new IllegalArgumentException(
@@ -224,7 +224,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
 
         final String customFolderNameValue = propsMap.remove("custom.foldername");
         final String customFolderName;
-        if (esVersion.after(Version.V_1_0_0)) {
+        if (opensearchVersion.onOrAfter(Version.V_1_1_0)) {
             customFolderName = customFolderNameValue;
         } else {
             customFolderName = name;
@@ -262,7 +262,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
             }
         }
 
-        if (esVersion.before(LegacyESVersion.V_6_3_0) && esVersion.onOrAfter(LegacyESVersion.V_6_0_0_beta2)) {
+        if (opensearchVersion.before(LegacyESVersion.V_6_3_0) && opensearchVersion.onOrAfter(LegacyESVersion.V_6_0_0_beta2)) {
             propsMap.remove("requires.keystore");
         }
 
@@ -270,7 +270,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
             throw new IllegalArgumentException("Unknown properties in plugin descriptor: " + propsMap.keySet());
         }
 
-        return new PluginInfo(name, description, version, esVersion, javaVersionString,
+        return new PluginInfo(name, description, version, opensearchVersion, javaVersionString,
                               classname, customFolderName, extendedPlugins, hasNativeController);
     }
 


### PR DESCRIPTION
PluginInfo should use .onOrAfter(Version.V_1_1_0) instead of .after(Version.V_1_0_0) for the new custom folder name for plugin feature.