### PR TITLE
Reduce iterations to improve test run time for SearchServiceTests.testSearchWhileIndexDeleted

### DIFF
--- a/server/src/test/java/org/opensearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchServiceTests.java
@@ -269,7 +269,6 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
         assertEquals(activeRefs, indexShard.store().refCount());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/578")
     public void testSearchWhileIndexDeleted() throws InterruptedException {
         createIndex("index");
         client().prepareIndex("index", "type", "1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
@@ -315,7 +314,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
         thread.start();
         startGun.await();
         try {
-            final int rounds = scaledRandomIntBetween(100, 10000);
+            final int rounds = scaledRandomIntBetween(100, 1000);
             SearchRequest searchRequest = new SearchRequest().allowPartialSearchResults(true);
             SearchRequest scrollSearchRequest = new SearchRequest().allowPartialSearchResults(true)
                 .scroll(new Scroll(TimeValue.timeValueMinutes(1)));


### PR DESCRIPTION
Signed-off-by: Abbas Hussain <abbas_10690@yahoo.com>

### Description
Improves test run time for server/src/test/java/org/opensearch/search/SearchServiceTests.testSearchWhileIndexDeleted by reducing max iterations.

See details [here](https://github.com/opensearch-project/OpenSearch/issues/578#issuecomment-907990472)
 
### Issues Resolved
#578 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
