### PR TITLE
Improve test run time for SnapshotResiliencyTests.testSnapshotPrimaryRelocations

### DIFF
--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -873,16 +873,15 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
      * Simulates concurrent restarts of data and master nodes as well as relocating a primary shard, while starting and subsequently
      * deleting a snapshot.
      */
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/579")
     public void testSnapshotPrimaryRelocations() {
         final int masterNodeCount = randomFrom(1, 3, 5);
-        setupTestCluster(masterNodeCount, randomIntBetween(2, 10));
+        setupTestCluster(masterNodeCount, randomIntBetween(2, 5));
 
         String repoName = "repo";
         String snapshotName = "snapshot";
         final String index = "test";
 
-        final int shards = randomIntBetween(1, 10);
+        final int shards = randomIntBetween(1, 5);
 
         final TestClusterNodes.TestClusterNode masterNode =
             testClusterNodes.currentMaster(testClusterNodes.nodes.values().iterator().next().clusterService.state());


### PR DESCRIPTION
Signed-off-by: Abbas Hussain <abbas_10690@yahoo.com>

### Description
Improves test run time for `server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.testSnapshotPrimaryRelocations` by reducing max datanode count and max shard count in testcase.
 
### Issues Resolved
#579 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
