### PR TITLE
Drop mocksocket & securemock dependencies from sniffer and rest client (no needed)

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -38,6 +38,8 @@ commonscodec      = 1.13
 hamcrest          = 2.1
 securemock        = 1.2
 mocksocket        = 1.2
+mockito           = 1.9.5
+objenesis         = 1.0
 
 # benchmark dependencies
 jmh               = 1.19

--- a/client/rest/.gitignore
+++ b/client/rest/.gitignore
@@ -1,0 +1,1 @@
+/build-eclipse-default/

--- a/client/rest/.gitignore
+++ b/client/rest/.gitignore
@@ -1,1 +1,0 @@
-/build-eclipse-default/

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -51,8 +51,8 @@ dependencies {
   testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testImplementation "junit:junit:${versions.junit}"
   testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
-  testImplementation "org.elasticsearch:securemock:${versions.securemock}"
-  testImplementation "org.elasticsearch:mocksocket:${versions.mocksocket}"
+  testImplementation "org.mockito:mockito-core:${versions.mockito}"
+  testImplementation "org.objenesis:objenesis:${versions.objenesis}"
 }
 
 tasks.withType(CheckForbiddenApis).configureEach {

--- a/client/rest/src/test/java/org/opensearch/client/RestClientBuilderIntegTests.java
+++ b/client/rest/src/test/java/org/opensearch/client/RestClientBuilderIntegTests.java
@@ -37,7 +37,6 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
 import org.apache.http.HttpHost;
-import org.elasticsearch.mocksocket.MockHttpServer;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -73,7 +72,7 @@ public class RestClientBuilderIntegTests extends RestClientTestCase {
 
     @BeforeClass
     public static void startHttpServer() throws Exception {
-        httpsServer = MockHttpServer.createHttps(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        httpsServer = HttpsServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
         httpsServer.setHttpsConfigurator(new HttpsConfigurator(getSslContext()));
         httpsServer.createContext("/", new ResponseHandler());
         httpsServer.start();

--- a/client/rest/src/test/java/org/opensearch/client/RestClientGzipCompressionTests.java
+++ b/client/rest/src/test/java/org/opensearch/client/RestClientGzipCompressionTests.java
@@ -39,7 +39,6 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.elasticsearch.mocksocket.MockHttpServer;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -61,7 +60,7 @@ public class RestClientGzipCompressionTests extends RestClientTestCase {
 
     @BeforeClass
     public static void startHttpServer() throws Exception {
-        httpServer = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        httpServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
         httpServer.createContext("/", new GzipResponseHandler());
         httpServer.start();
     }

--- a/client/rest/src/test/java/org/opensearch/client/RestClientMultipleHostsIntegTests.java
+++ b/client/rest/src/test/java/org/opensearch/client/RestClientMultipleHostsIntegTests.java
@@ -36,7 +36,6 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import org.apache.http.HttpHost;
-import org.elasticsearch.mocksocket.MockHttpServer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -107,7 +106,7 @@ public class RestClientMultipleHostsIntegTests extends RestClientTestCase {
     }
 
     private static HttpServer createHttpServer() throws Exception {
-        HttpServer httpServer = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
         httpServer.start();
         //returns a different status code depending on the path
         for (int statusCode : getAllStatusCodes()) {

--- a/client/rest/src/test/java/org/opensearch/client/RestClientSingleHostIntegTests.java
+++ b/client/rest/src/test/java/org/opensearch/client/RestClientSingleHostIntegTests.java
@@ -52,7 +52,6 @@ import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.nio.entity.NStringEntity;
 import org.apache.http.util.EntityUtils;
-import org.elasticsearch.mocksocket.MockHttpServer;
 import org.junit.After;
 import org.junit.Before;
 
@@ -107,7 +106,7 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
     }
 
     private HttpServer createHttpServer() throws Exception {
-        HttpServer httpServer = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
         httpServer.start();
         //returns a different status code depending on the path
         for (int statusCode : getAllStatusCodes()) {

--- a/client/sniffer/build.gradle
+++ b/client/sniffer/build.gradle
@@ -47,8 +47,8 @@ dependencies {
   testImplementation project(":client:test")
   testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testImplementation "junit:junit:${versions.junit}"
-  testImplementation "org.elasticsearch:securemock:${versions.securemock}"
-  testImplementation "org.elasticsearch:mocksocket:${versions.mocksocket}"
+  testImplementation "org.mockito:mockito-core:${versions.mockito}"
+  testImplementation "org.objenesis:objenesis:${versions.objenesis}"
 }
 
 tasks.named('forbiddenApisMain').configure {

--- a/client/sniffer/src/test/java/org/opensearch/client/sniff/OpenSearchNodesSnifferTests.java
+++ b/client/sniffer/src/test/java/org/opensearch/client/sniff/OpenSearchNodesSnifferTests.java
@@ -48,7 +48,6 @@ import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestClientTestCase;
-import org.elasticsearch.mocksocket.MockHttpServer;
 import org.junit.After;
 import org.junit.Before;
 
@@ -153,7 +152,7 @@ public class OpenSearchNodesSnifferTests extends RestClientTestCase {
     }
 
     private static HttpServer createHttpServer(final SniffResponse sniffResponse, final int sniffTimeoutMillis) throws IOException {
-        HttpServer httpServer = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
         httpServer.createContext("/_nodes/http", new ResponseHandler(sniffTimeoutMillis, sniffResponse));
         return httpServer;
     }


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
In scope of https://github.com/opensearch-project/OpenSearch/issues/114, it turned out the `:client:sniffer` and `:client:rest` test cases are never run under `SecurityManager`. As such, the usage of `SecureMock` and `MockSocket` is not needed and regular `Mockito` dependency could be used without any consequences.
 
### Issues Resolved
Part of: https://github.com/opensearch-project/OpenSearch/issues/114
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
