### PR TITLE
Clarify opensearch.version to not include -SNAPSHOT.

### DIFF
--- a/buildSrc/src/main/resources/plugin-descriptor.properties
+++ b/buildSrc/src/main/resources/plugin-descriptor.properties
@@ -36,7 +36,7 @@ version=${version}
 # 'name': the plugin name
 name=${name}
 #
-# 'classname': the name of the class to load, fully-qualified.
+# 'classname': the name of the class to load, fully-qualified
 classname=${classname}
 #
 # 'java.version': version of java the code is built against
@@ -45,14 +45,16 @@ classname=${classname}
 # separated by "."'s and may have leading zeros
 java.version=${javaVersion}
 #
-# 'opensearch.version': version of opensearch compiled against
+# 'opensearch.version': semantic version of opensearch the plugin is compatible with
+# does not include -SNAPSHOT if compiled against a snapshot build
 opensearch.version=${opensearchVersion}
+#
 ### optional elements for plugins:
 #
-# 'custom.foldername': the custom name of the folder in which the plugin is installed.
+# 'custom.foldername': the custom name of the folder in which the plugin is installed
 custom.foldername=${customFolderName}
 #
-#  'extended.plugins': other plugins this plugin extends through SPI
+# 'extended.plugins': other plugins this plugin extends through SPI
 extended.plugins=${extendedPlugins}
 #
 # 'has.native.controller': whether or not the plugin has a native controller


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Clarify the version number of OpenSearch that goes into plugin-descriptor.properties.
 
If you include `-SNAPSHOT`, then a plugin cannot be installed. See https://github.com/opensearch-project/opensearch-build/issues/359 for a discussion.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
