### PR TITLE
[Backport -1.x]Fixed copyright to OpenSearch (#1175)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 OpenSearch (https://opensearch.org/)
-Copyright 2021 OpenSearch Contributors
+Copyright OpenSearch Contributors
 
 This product includes software developed by
 Elasticsearch (http://www.elastic.co).

--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ This project is licensed under the [Apache v2.0 License](LICENSE.txt).
 
 ## Copyright
 
-Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright OpenSearch Contributors. See [NOTICE](NOTICE.txt) for details.

--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/internal/InternalDistributionArchiveCheckPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/internal/InternalDistributionArchiveCheckPluginFuncTest.groovy
@@ -108,7 +108,7 @@ Copyright 2009-2018 Acme Coorp"""
         result.task(":darwin-tar:checkNotice").outcome == TaskOutcome.FAILED
         normalizedOutput(result.output).contains("> expected line [2] in " +
                 "[./darwin-tar/build/tar-extracted/opensearch-${VersionProperties.getOpenSearch()}/NOTICE.txt] " +
-                "to be [Copyright 2021 OpenSearch Contributors] but was [Copyright 2009-2018 Acme Coorp]")
+                "to be [Copyright OpenSearch Contributors] but was [Copyright 2009-2018 Acme Coorp]")
     }
 
     void license(File file = file("licenses/APACHE-LICENSE-2.0.txt")) {

--- a/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionArchiveCheckPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionArchiveCheckPlugin.java
@@ -105,7 +105,7 @@ public class InternalDistributionArchiveCheckPlugin implements Plugin<Project> {
                 public void execute(Task task) {
                     final List<String> noticeLines = Arrays.asList(
                         "OpenSearch (https://opensearch.org/)",
-                        "Copyright 2021 OpenSearch Contributors"
+                        "Copyright OpenSearch Contributors"
                     );
                     final Path noticePath = checkExtraction.get()
                         .getDestinationDir()

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -500,7 +500,7 @@ subprojects {
         (project.name.contains('deb') && dpkgExists.call(it)) || (project.name.contains('rpm') && rpmExists.call(it))
       }
       doLast {
-        final List<String> noticeLines = Arrays.asList("OpenSearch (https://opensearch.org/)", "Copyright 2021 OpenSearch Contributors")
+        final List<String> noticeLines = Arrays.asList("OpenSearch (https://opensearch.org/)", "Copyright OpenSearch Contributors")
         final Path noticePath = packageExtractionDir.toPath().resolve("usr/share/opensearch/NOTICE.txt")
         assertLinesInFile(noticePath, noticeLines)
       }


### PR DESCRIPTION
### Description
[Backport -1.x]Fixed copyright to OpenSearch 
 
### Issues Resolved
#1175 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
