### PR TITLE
Added all icu-project.org websites to the link checker exclusions.

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Load Excludes
         run: |
-          LYCHEE_EXCLUDE=$(sed -e :a  -e 'N;s/\n/ --exclude /;ta' .lycheeexclude)
+          LYCHEE_EXCLUDE=$(sed -e :a  -e 'N;s/\n/ /;ta' .lycheeexclude)
           echo "LYCHEE_EXCLUDE=$LYCHEE_EXCLUDE" >> $GITHUB_ENV
 
       - name: lychee Link Checker

--- a/.lycheeexclude
+++ b/.lycheeexclude
@@ -2,7 +2,9 @@ http://bitbucket.org/jpbarrette/moman/overview/
 http://eid-applet.googlecode.com/
 http://opensource.adobe.com/wiki/display/cmap/Downloads
 http://project.carrot2.org/license.html
+http://source.icu-project.org/
 http://site.icu-project.org/
+http://www.icu-project.org/
 http://snapshot/ 
 http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 http://www.eclipse.org/jetty/downloads.php


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Fixes https://github.com/opensearch-project/OpenSearch/issues/1199.

Lychee also reads `--exclude [list]`, so specifying multiple `--exclude` is unnecessary.

If you read this far, you might be interested in https://github.com/lycheeverse/lychee/pull/306.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
