### PR TITLE
[1.x] Restoring alpha/beta/rc version semantics (#1112)

### DIFF
--- a/server/src/main/java/org/opensearch/LegacyESVersion.java
+++ b/server/src/main/java/org/opensearch/LegacyESVersion.java
@@ -288,4 +288,29 @@ public class LegacyESVersion extends Version {
     protected int maskId(final int id) {
         return id;
     }
+    
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(major).append('.').append(minor).append('.').append(revision);
+        if (isAlpha()) {
+            sb.append("-alpha");
+            sb.append(build);
+        } else if (isBeta()) {
+            if (major >= 2) {
+                sb.append("-beta");
+            } else {
+                sb.append(".Beta");
+            }
+            sb.append(major < 5 ? build : build-25);
+        } else if (build < 99) {
+            if (major >= 2) {
+                sb.append("-rc");
+            } else {
+                sb.append(".RC");
+            }
+            sb.append(build - 50);
+        }
+        return sb.toString();
+    }
 }

--- a/server/src/test/java/org/opensearch/VersionTests.java
+++ b/server/src/test/java/org/opensearch/VersionTests.java
@@ -265,12 +265,36 @@ public class VersionTests extends OpenSearchTestCase {
         assertEquals("5.0.0-alpha1", LegacyESVersion.fromString("5.0.0-alpha1").toString());
     }
 
+    public void testIsRc() {
+        assertTrue(LegacyESVersion.fromString("2.0.0-rc1").isRC());
+        assertTrue(LegacyESVersion.fromString("1.0.0.RC1").isRC());
+        assertTrue(Version.fromString("1.0.0-rc1").isRC());
+        assertTrue(Version.fromString("2.0.0.RC1").isRC());
+
+        for (int i = 0 ; i < 25; i++) {
+            assertEquals(LegacyESVersion.fromString("5.0.0-rc" + i).id, LegacyESVersion.fromId(5000000 + i + 50).id);
+            assertEquals("5.0.0-rc" + i, LegacyESVersion.fromId(5000000 + i + 50).toString());
+            
+            assertEquals(Version.fromString("1.0.0-rc" + i).id, Version.fromId(135217728 + i + 50).id);
+            assertEquals("1.0.0-rc" + i, Version.fromId(135217728 + i + 50).toString());
+        }
+    }
+    
     public void testIsBeta() {
         assertTrue(LegacyESVersion.fromString("2.0.0-beta1").isBeta());
         assertTrue(LegacyESVersion.fromString("1.0.0.Beta1").isBeta());
         assertTrue(LegacyESVersion.fromString("0.90.0.Beta1").isBeta());
-    }
+        assertTrue(Version.fromString("1.0.0.Beta1").isBeta());
+        assertTrue(Version.fromString("2.0.0.beta1").isBeta());
 
+        for (int i = 0 ; i < 25; i++) {
+            assertEquals(LegacyESVersion.fromString("5.0.0-beta" + i).id, LegacyESVersion.fromId(5000000 + i + 25).id);
+            assertEquals("5.0.0-beta" + i, LegacyESVersion.fromId(5000000 + i + 25).toString());
+            
+            assertEquals(Version.fromString("1.0.0-beta" + i).id, Version.fromId(135217728 + i + 25).id);
+            assertEquals("1.0.0-beta" + i, Version.fromId(135217728 + i + 25).toString());
+        }
+    }
 
     public void testIsAlpha() {
         assertTrue(new LegacyESVersion(5000001, org.apache.lucene.util.Version.LUCENE_7_0_0).isAlpha());
@@ -279,15 +303,16 @@ public class VersionTests extends OpenSearchTestCase {
         assertTrue(LegacyESVersion.fromString("5.0.0-alpha14").isAlpha());
         assertEquals(5000014, LegacyESVersion.fromString("5.0.0-alpha14").id);
         assertTrue(LegacyESVersion.fromId(5000015).isAlpha());
+        
+        assertEquals(135217742, Version.fromString("1.0.0-alpha14").id);
+        assertTrue(Version.fromString("1.0.0-alpha14").isAlpha());
 
         for (int i = 0 ; i < 25; i++) {
             assertEquals(LegacyESVersion.fromString("5.0.0-alpha" + i).id, LegacyESVersion.fromId(5000000 + i).id);
             assertEquals("5.0.0-alpha" + i, LegacyESVersion.fromId(5000000 + i).toString());
-        }
-
-        for (int i = 0 ; i < 25; i++) {
-            assertEquals(LegacyESVersion.fromString("5.0.0-beta" + i).id, LegacyESVersion.fromId(5000000 + i + 25).id);
-            assertEquals("5.0.0-beta" + i, LegacyESVersion.fromId(5000000 + i + 25).toString());
+            
+            assertEquals(Version.fromString("1.0.0-alpha" + i).id, Version.fromId(135217728 + i).id);
+            assertEquals("1.0.0-alpha" + i, Version.fromId(135217728 + i).toString());
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Cherry-picking https://github.com/opensearch-project/OpenSearch/pull/1112 to 1.x
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/622
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
