### PR TITLE
[1.x] Clarify JDK requirement in the Developer Guide

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -57,9 +57,9 @@ sdk install java 14.0.2-open
 sdk use java 14.0.2-open
 ```
 
-By default, tests use the same runtime as `JAVA_HOME`. However, since OpenSearch supports JDK 8, the build supports compiling with JDK 14 and testing on a different version of JDK runtime. To do this, set `RUNTIME_JAVA_HOME` pointing to the Java home of another JDK installation, e.g. `RUNTIME_JAVA_HOME=/usr/lib/jvm/jdk-8`.
+By default, tests use the same runtime as `JAVA_HOME`. However, since OpenSearch also supports JDK 8 as the runtime, the build supports compiling with JDK 14 and testing on a different version of JDK runtime. To do this, set `RUNTIME_JAVA_HOME` pointing to the Java home of another JDK installation, e.g. `RUNTIME_JAVA_HOME=/usr/lib/jvm/jdk-8`.
 
-To run the full suite of tests you will also need `JAVA8_HOME`, `JAVA9_HOME`, `JAVA10_HOME`, `JAVA11_HOME`, and `JAVA12_HOME`.
+To run the full suite of tests you will also need `JAVA8_HOME` and `JAVA14_HOME`. They are required by the [backwards compatibility test](./TESTING.md#testing-backwards-compatibility).
 
 #### Docker
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -359,7 +359,13 @@ These test tasks can use the `--tests`, `--info`, and `--debug` parameters just 
 
 # Testing backwards compatibility
 
-Backwards compatibility tests exist to test upgrading from each supported version to the current version. To run them all use:
+Backwards compatibility tests exist to test upgrading from each supported version to the current version. 
+
+The test can be run for any versions which the current version will be compatible with. Tests are run for released versions download the distributions from the artifact repository, see [DistributionDownloadPlugin](./buildSrc/src/main/java/org/opensearch/gradle/DistributionDownloadPlugin.java) for the repository location. Tests are run for versions that are not yet released automatically check out the branch and build from source to get the distributions, see [BwcVersions](./buildSrc/src/main/java/org/opensearch/gradle/BwcVersions.java) and [distribution/bwc/build.gradle](./distribution/bwc/build.gradle) for more information.
+
+The minimum JDK versions for runtime and compiling need to be installed, and environment variables `JAVAx_HOME`, such as `JAVA8_HOME`, pointing to the JDK installations are required to run the tests against unreleased versions, since the distributions are created by building from source. The required JDK versions for each branch are located at [.ci/java-versions.properties](.ci/java-versions.properties), see [BwcSetupExtension](./buildSrc/src/main/java/org/opensearch/gradle/internal/BwcSetupExtension.java) for more information. 
+
+To run all the backwards compatibility tests use:
 
     ./gradlew bwcTest
 
@@ -372,8 +378,6 @@ Use -Dtest.class and -Dtests.method to run a specific bwcTest test. For example 
     ./gradlew :qa:rolling-upgrade:v7.7.0#bwcTest \
      -Dtests.class=org.opensearch.upgrades.RecoveryIT \
      -Dtests.method=testHistoryUUIDIsGenerated
-
-Tests are run for versions that are not yet released but with which the current version will be compatible with. These are automatically checked out and built from source. See [BwcVersions](./buildSrc/src/main/java/org/opensearch/gradle/BwcVersions.java) and [distribution/bwc/build.gradle](./distribution/bwc/build.gradle) for more information.
 
 When running `./gradlew check`, minimal bwc checks are also run against compatible versions that are not yet released.
 


### PR DESCRIPTION
### Description

Backport PR https://github.com/opensearch-project/OpenSearch/pull/1153 to `1.x` branch.

In DEVELOPER_GUIDE.md:
- Explicitly point out the JDK 8 requirement is for runtime, but not for compiling.
- Clarify the `JAVAx_HOME` env variables are for the "backwards compatibility test".
- Update the requirement for the `JAVAx_HOME` env variables. (Run BWC test for `1.0` or `1.x` branch requires JDK 8 and 14)

In TESTING.md:
- Add explanation on how the backwards compatibility tests get the OpenSearch distributions for a specific version.
- Clarify the requirement for `JAVAx_HOME` env variables.
 
### Issues Resolved
#1138 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
