### PR TITLE
Fix org.opensearch.index.reindex.ReindexRestClientSslTests#testClientSucceedsWithCertificateAuthorities - javax.net.ssl.SSLPeerUnverifiedException

### DIFF
--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/ReindexRestClientSslTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/ReindexRestClientSslTests.java
@@ -62,7 +62,6 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509ExtendedTrustManager;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.security.cert.Certificate;
@@ -90,7 +89,7 @@ public class ReindexRestClientSslTests extends OpenSearchTestCase {
 
     @BeforeClass
     public static void setupHttpServer() throws Exception {
-        InetSocketAddress address = new InetSocketAddress(InetAddress.getLoopbackAddress().getHostAddress(), 0);
+        InetSocketAddress address = new InetSocketAddress("localhost", 0);
         SSLContext sslContext = buildServerSslContext();
         server = MockHttpServer.createHttps(address, 0);
         server.setHttpsConfigurator(new ClientAuthHttpsConfigurator(sslContext));
@@ -213,7 +212,7 @@ public class ReindexRestClientSslTests extends OpenSearchTestCase {
     }
 
     private RemoteInfo getRemoteInfo() {
-        return new RemoteInfo("https", server.getAddress().getHostName(), server.getAddress().getPort(), "/",
+        return new RemoteInfo("https", "localhost", server.getAddress().getPort(), "/",
             new BytesArray("{\"match_all\":{}}"), "user", "password", Collections.emptyMap(), RemoteInfo.DEFAULT_SOCKET_TIMEOUT,
             RemoteInfo.DEFAULT_CONNECT_TIMEOUT);
     }


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
On Windows with Docker Desktop installed, some of the `org.opensearch.index.reindex.ReindexRestClientSslTests` are failling with `javax.net.ssl.SSLPeerUnverifiedException`. The problem in this particular case is related to the fact that all certificates have been generated for the `localhost` but the local hostname was resolved to `kubernetes.docker.internal`.

The solution is pretty simple and has no consequences: just use `localhost` as bind and connect address, otherwise the certificate validation is going to fail in any case (run into it while working on https://github.com/opensearch-project/OpenSearch/pull/1205, issue is gone after the fix)
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/710
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
