### PR TITLE
Fix defects in code-coverage.gralde to generate code coverage report properly

### DIFF
--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -78,12 +78,10 @@ tasks.withType(JacocoReport).configureEach {
   classDirectories.setFrom files(selectedProjects.sourceSets.main.output)
 
   reports {
-    xml.enabled true
     // Code coverage report in HTML and CSV formats are on demand, in case they take extra disk space.
-    if (!System.getProperty('tests.coverage.report.html'))
-      html.enabled false
-    if (System.getProperty('tests.coverage.report.csv'))
-      csv.enabled true
+    xml.enabled System.getProperty('tests.coverage.report.xml', 'true').toBoolean()
+    html.enabled System.getProperty('tests.coverage.report.html', 'false').toBoolean()
+    csv.enabled System.getProperty('tests.coverage.report.csv', 'false').toBoolean()
   }
 }
 

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -80,8 +80,8 @@ tasks.withType(JacocoReport).configureEach {
   reports {
     xml.enabled true
     // Code coverage report in HTML format is on demand， since it takes up 100+MB of disk space.
-    if (System.getProperty('tests.coverage.html_report')) {
-      html.enabled true
+    if (!System.getProperty('tests.coverage.html_report')) {
+      html.enabled false
     }
   }
 }

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -79,10 +79,11 @@ tasks.withType(JacocoReport).configureEach {
 
   reports {
     xml.enabled true
-    // Code coverage report in HTML format is on demand， since it takes up 100+MB of disk space.
-    if (!System.getProperty('tests.coverage.html_report')) {
+    // Code coverage report in HTML and CSV formats are on demand, in case they take extra disk space.
+    if (!System.getProperty('tests.coverage.report.html'))
       html.enabled false
-    }
+    if (System.getProperty('tests.coverage.report.csv'))
+      csv.enabled true
   }
 }
 

--- a/test/framework/src/main/java/org/opensearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/opensearch/bootstrap/BootstrapForTesting.java
@@ -127,15 +127,6 @@ public class BootstrapForTesting {
                 if (Strings.hasLength(System.getProperty("tests.config"))) {
                     FilePermissionUtils.addSingleFilePath(perms, PathUtils.get(System.getProperty("tests.config")), "read,readlink");
                 }
-                // jacoco coverage output file
-                final boolean testsCoverage =
-                        Booleans.parseBoolean(System.getProperty("tests.coverage", "false"));
-                if (testsCoverage) {
-                    Path coverageDir = PathUtils.get(System.getProperty("tests.coverage.dir"));
-                    FilePermissionUtils.addSingleFilePath(perms, coverageDir.resolve("jacoco.exec"), "read,write");
-                    // in case we get fancy and use the -integration goals later:
-                    FilePermissionUtils.addSingleFilePath(perms, coverageDir.resolve("jacoco-it.exec"), "read,write");
-                }
                 // intellij hack: intellij test runner wants setIO and will
                 // screw up all test logging without it!
                 if (System.getProperty("tests.gradle") == null) {


### PR DESCRIPTION
### Description
- Fix the issue that code coverage in HTML format can't be disabled.
- Resolve the error when running `./gradlew check -Dtests.coverage=true`
 
Explanation:
1. Html format report is generated by default in [JaCoCo gradle plugin](https://github.com/gradle/gradle/blob/4fa9149b3148554bc84c2f6e12ec7b53c10e4e2f/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java#L159), so it needs to be disabled manually.
2. System property `tests.coverage` is introduced in https://github.com/elastic/elasticsearch/commit/2a129f186874689f7c16b8ab77eba508d9ae7250, then I used the same property for generating the code coverage report, and it caused the error (a past forum thread about the error https://discuss.elastic.co/t/estestcase-2-x-jacoco-not-working/45104).
- I think that part of code is out dated, as the build system was changed from at that time, and the jacoco file doesn't have permission issue now when Java security manager is enabled. And Java security manager is also [being deprecated](https://github.com/opensearch-project/OpenSearch/issues/528#issuecomment-824787677). [@rmuir Please correct me if I'm wrong. Thank you!]

Future plan:
Considering refactoring the groovy script `code-coverage.gradle` to Java code and put into `/buildSrc` (see [here](https://docs.gradle.org/6.6.1/userguide/organizing_gradle_projects.html#sec:build_sources) to learn more about "buildSrc" directory) , then unit test can be written to test the build script.

### Issues Resolved
Resolves #1213 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
