### PR TITLE
Run link checker GitHub action on schedule.

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,10 +1,7 @@
 name: Link Checker
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-
+  schedule:
+    - cron:  '0 0 * * *'
 jobs:
   linkchecker:
 


### PR DESCRIPTION
### Description
Most PRs do not add/update links, however sites go down often. This change makes sure that we catch any broken links in the repository and fix it, but at the same time we do not block PRs because of some unrelated broken link.

This PR updates the workflow to run everyday at midnight UTC.

### Issues Resolved
N/A
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>