### PR TITLE
Exclude failing links from plugins/modules in link checker

### DIFF
--- a/.lycheeexclude
+++ b/.lycheeexclude
@@ -10,3 +10,4 @@ http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
 http://www.eclipse.org/jetty/downloads.php
 http://www.ecma-international.org/publications/files/ECMA-ST/Ecma%20PATENT/Patent%20statements%20ok/ECMA-376%20*
 http://www.unicode.org/Public/PROGRAMS/CVTUTF
+http://sgjp.pl/morfeusz/


### PR DESCRIPTION
Signed-off-by: Sai Kumar <karanas@amazon.com>

### Description
Exclude failing links from plugins/modules in link checker
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
