### PR TITLE
[1.x] Max scroll limit breach to throw a OpenSearchRejectedExecutionException (#1054)

### DIFF
--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -65,6 +65,7 @@ import org.opensearch.common.util.BigArrays;
 import org.opensearch.common.util.CollectionUtils;
 import org.opensearch.common.util.concurrent.ConcurrentCollections;
 import org.opensearch.common.util.concurrent.ConcurrentMapLong;
+import org.opensearch.common.util.concurrent.OpenSearchRejectedExecutionException;
 import org.opensearch.core.internal.io.IOUtils;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexNotFoundException;
@@ -656,7 +657,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             if (request.scroll() != null) {
                 decreaseScrollContexts = openScrollContexts::decrementAndGet;
                 if (openScrollContexts.incrementAndGet() > maxOpenScrollContext) {
-                    throw new OpenSearchException(
+                    throw new OpenSearchRejectedExecutionException(
                         "Trying to create too many scroll contexts. Must be less than or equal to: [" +
                             maxOpenScrollContext + "]. " + "This limit can be set by changing the ["
                             + MAX_OPEN_SCROLL_CONTEXT.getKey() + "] setting.");

--- a/server/src/test/java/org/opensearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchServiceTests.java
@@ -37,7 +37,6 @@ import org.apache.lucene.index.FilterDirectoryReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.AlreadyClosedException;
-import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.OriginalIndices;
 import org.opensearch.action.index.IndexResponse;
@@ -56,6 +55,7 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.OpenSearchRejectedExecutionException;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexModule;
@@ -574,7 +574,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
         }
 
         final ShardScrollRequestTest request = new ShardScrollRequestTest(indexShard.shardId());
-        OpenSearchException ex = expectThrows(OpenSearchException.class,
+        OpenSearchRejectedExecutionException ex = expectThrows(OpenSearchRejectedExecutionException.class,
             () -> service.createAndPutReaderContext(
                 request, indexService, indexShard, indexShard.acquireSearcherSupplier(), randomBoolean()));
         assertEquals(
@@ -606,7 +606,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
                         try {
                             searchService.createAndPutReaderContext(
                                 new ShardScrollRequestTest(indexShard.shardId()), indexService, indexShard, reader, true);
-                        } catch (OpenSearchException e) {
+                        } catch (OpenSearchRejectedExecutionException e) {
                             assertThat(e.getMessage(), equalTo(
                                 "Trying to create too many scroll contexts. Must be less than or equal to: " +
                                     "[" + maxScrollContexts + "]. " +


### PR DESCRIPTION
Backport PR #1054 to 1.x

### Description

Changes the Exception to throw a OpenSearchRejectedExecutionException on max scroll limit breach
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Bukhtawar Khan bukhtawa@amazon.com