### PR TITLE
[1.x] Add support to generate code coverage report with JaCoCo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ apply from: 'gradle/formatting.gradle'
 apply from: 'gradle/local-distribution.gradle'
 apply from: 'gradle/fips.gradle'
 apply from: 'gradle/run.gradle'
+apply from: 'gradle/code-coverage.gradle'
 
 // common maven publishing configuration
 allprojects {

--- a/buildSrc/src/main/groovy/org/opensearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/gradle/BuildPlugin.groovy
@@ -81,6 +81,7 @@ class BuildPlugin implements Plugin<Project> {
         configureLicenseAndNotice(project)
         project.pluginManager.apply('opensearch.publish')
         project.pluginManager.apply(DependenciesInfoPlugin)
+        project.pluginManager.apply('jacoco')
 
         PrecommitTasks.create(project, true)
     }

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+apply plugin: 'jacoco'
+
+repositories {
+  mavenCentral()
+}
+
+allprojects {
+  plugins.withId('jacoco') {
+    // The default JaCoCo version in Gradle 6.6.1 is 0.8.5, but at least version 0.8.6 officially supports Java 14
+    jacoco.toolVersion = '0.8.7'
+  }
+}
+
+def codeCoverageReportTask = tasks.register("codeCoverageReport", JacocoReport) {
+  description = 'Generates aggregate report from all subprojects.'
+  executionData.setFrom fileTree(dir: '.', include: '**/build/jacoco/*.exec')
+}
+
+tasks.register("codeCoverageReportForUnitTest", JacocoReport) {
+  description = 'Generates aggregate report from all subprojects for unit test.'
+  executionData.setFrom fileTree(dir: '.', include: '**/build/jacoco/test.exec')
+}
+
+tasks.register("codeCoverageReportForIntegrationTest", JacocoReport) {
+  description = 'Generates aggregate report from all subprojects for integration test.'
+  // These kinds of tests are integration test, and the tests can be ran by Gradle tasks with the same name
+  def integrationTestExecPathList = ['**/build/jacoco/integTest.exec',
+                                     '**/build/jacoco/internalClusterTest.exec',
+                                     '**/build/jacoco/javaRestTest.exec',
+                                     '**/build/jacoco/yamlRestTest.exec' ]
+  executionData.setFrom fileTree(dir: '.', include: integrationTestExecPathList)
+}
+
+tasks.withType(JacocoReport).configureEach {
+  group = JavaBasePlugin.VERIFICATION_GROUP
+
+  // Select projects with corresponding tests in order to run proper tests and select proper classes to generate the report
+  def projectsWithJavaPlugin = subprojects.findAll { it.pluginManager.hasPlugin('java') }
+  def projectsWithUnitTest = projectsWithJavaPlugin.findAll { it.tasks.findByName('test').enabled }
+  def projectsWithIntegTest = projectsWithJavaPlugin.findAll {it.tasks.findByName('integTest')}
+  def projectsWithInternalClusterTest = projectsWithJavaPlugin.findAll {it.tasks.findByName('internalClusterTest')}
+  def projectsWithJavaRestTest = projectsWithJavaPlugin.findAll {it.tasks.findByName('javaRestTest')}
+  def projectsWithYamlRestTest = projectsWithJavaPlugin.findAll {it.tasks.findByName('yamlRestTest')}
+  def projectsWithIntegrationTest = projectsWithIntegTest + projectsWithInternalClusterTest + projectsWithJavaRestTest + projectsWithYamlRestTest
+  def projectsWithTest = projectsWithUnitTest + projectsWithIntegrationTest
+
+  def selectedProjects
+  switch (name) {
+    case "codeCoverageReportForUnitTest":
+      dependsOn projectsWithUnitTest.test
+      selectedProjects = projectsWithUnitTest
+      break
+    case "codeCoverageReportForIntegrationTest":
+      dependsOn projectsWithIntegTest.integTest
+      dependsOn projectsWithInternalClusterTest.internalClusterTest
+      dependsOn projectsWithJavaRestTest.javaRestTest
+      dependsOn projectsWithYamlRestTest.yamlRestTest
+      selectedProjects = projectsWithIntegrationTest
+      break
+    default:
+      dependsOn projectsWithUnitTest.test
+      dependsOn projectsWithIntegTest.integTest
+      dependsOn projectsWithInternalClusterTest.internalClusterTest
+      dependsOn projectsWithJavaRestTest.javaRestTest
+      dependsOn projectsWithYamlRestTest.yamlRestTest
+      selectedProjects = projectsWithTest
+      break
+  }
+  sourceDirectories.setFrom files(selectedProjects.sourceSets.main.allSource.srcDirs)
+  classDirectories.setFrom files(selectedProjects.sourceSets.main.output)
+
+  reports {
+    // Code coverage report in HTML and CSV formats are on demand, in case they take extra disk space.
+    xml.enabled System.getProperty('tests.coverage.report.xml', 'true').toBoolean()
+    html.enabled System.getProperty('tests.coverage.report.html', 'false').toBoolean()
+    csv.enabled System.getProperty('tests.coverage.report.csv', 'false').toBoolean()
+  }
+}
+
+if (System.getProperty("tests.coverage")) {
+  // Attach code coverage report task to Gradle check task
+  project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME).configure {
+    dependsOn codeCoverageReportTask
+  }
+}

--- a/test/framework/src/main/java/org/opensearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/opensearch/bootstrap/BootstrapForTesting.java
@@ -127,15 +127,6 @@ public class BootstrapForTesting {
                 if (Strings.hasLength(System.getProperty("tests.config"))) {
                     FilePermissionUtils.addSingleFilePath(perms, PathUtils.get(System.getProperty("tests.config")), "read,readlink");
                 }
-                // jacoco coverage output file
-                final boolean testsCoverage =
-                        Booleans.parseBoolean(System.getProperty("tests.coverage", "false"));
-                if (testsCoverage) {
-                    Path coverageDir = PathUtils.get(System.getProperty("tests.coverage.dir"));
-                    FilePermissionUtils.addSingleFilePath(perms, coverageDir.resolve("jacoco.exec"), "read,write");
-                    // in case we get fancy and use the -integration goals later:
-                    FilePermissionUtils.addSingleFilePath(perms, coverageDir.resolve("jacoco-it.exec"), "read,write");
-                }
                 // intellij hack: intellij test runner wants setIO and will
                 // screw up all test logging without it!
                 if (System.getProperty("tests.gradle") == null) {


### PR DESCRIPTION
### Description
Backport #971 and #1214 to `1.x` branch

- Apply JaCoCo Gradle plugin to the root project, and to all the sub-projects through `BuildPlugin`.
- Add 3 Gradle tasks: `codeCoverageReport`, `codeCoverageReportForUnitTest`, `codeCoverageReportForIntegrationTest` to generate code coverage report for all the tests, unit tests, and integration tests correspondingly.
- Attach Gradle `codeCoverageReport` task to `check` task.
- Remove outdated code of giving JaCoCo files permission when Java security manager enabled

Usage of the new Gradle tasks:
- Generate code coverage report after `check` task: run `./gradlew check -Dtests.coverage=true`
- Generate code coverage report
   for all the test: `./gradlew codeCoverageReport`, 
   for unit tests only: `./gradlew codeCoverageReportForUnitTest`,
   for integration tests only: `./gradlew codeCoverageReportForIntegrationTest`
- The report will be in `XML` format only by default, 
   to generate report in `HTML` format, add parameter `-Dtests.coverage.report.html=true`, for example `./gradlew codeCoverageReport -Dtests.coverage.report.html=true`, 
   to generate report in `CSV` format, add parameter `-Dtests.coverage.report.csv=true`, 
   not generate report in `XML` format, add parameter `-Dtests.coverage.report.xml=false`,

### Issues Resolved
#850
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
