### PR TITLE
Rename build artifact to include -min

### DIFF
--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/internal/InternalDistributionArchiveSetupPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/internal/InternalDistributionArchiveSetupPluginFuncTest.groovy
@@ -70,7 +70,7 @@ class InternalDistributionArchiveSetupPluginFuncTest extends AbstractGradleFuncT
 
         where:
         buildTaskName       | expectedOutputArchivePath
-        "buildDarwinTar" | "darwin-tar/build/distributions/opensearch.tar.gz"
+        "buildDarwinTar" | "darwin-tar/build/distributions/opensearch-min.tar.gz"
     }
 
     def "applies defaults to zip tasks"() {
@@ -91,7 +91,7 @@ class InternalDistributionArchiveSetupPluginFuncTest extends AbstractGradleFuncT
 
         where:
         buildTaskName       | expectedOutputArchivePath
-        "buildDarwinZip" | "darwin-zip/build/distributions/opensearch.zip"
+        "buildDarwinZip" | "darwin-zip/build/distributions/opensearch-min.zip"
     }
 
     def "registered distribution provides archives and directory variant"() {
@@ -148,8 +148,8 @@ class InternalDistributionArchiveSetupPluginFuncTest extends AbstractGradleFuncT
         then: "tar task executed and target folder contains plain tar"
         result.task(':buildProducerTar').outcome == TaskOutcome.SUCCESS
         result.task(':consumer:copyArchive').outcome == TaskOutcome.SUCCESS
-        file("producer-tar/build/distributions/opensearch.tar.gz").exists()
-        file("consumer/build/archives/opensearch.tar.gz").exists()
+        file("producer-tar/build/distributions/opensearch-min.tar.gz").exists()
+        file("consumer/build/archives/opensearch-min.tar.gz").exists()
 
         when:
         result = gradleRunner("copyDir", "-Pversion=1.0").build()

--- a/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionArchiveSetupPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionArchiveSetupPlugin.java
@@ -121,7 +121,7 @@ public class InternalDistributionArchiveSetupPlugin implements Plugin<Project> {
         project.getTasks().withType(AbstractArchiveTask.class).configureEach(t -> {
             String subdir = archiveTaskToSubprojectName(t.getName());
             t.getDestinationDirectory().set(project.file(subdir + "/build/distributions"));
-            t.getArchiveBaseName().set("opensearch");
+            t.getArchiveBaseName().set("opensearch-min");
         });
     }
 

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -50,7 +50,7 @@ ext.expansions = { Architecture architecture, DockerBase base, boolean local ->
     classifier = "linux-\$(arch)"
   }
 
-  final String opensearch = "opensearch-${VersionProperties.getOpenSearch()}-${classifier}.tar.gz"
+  final String opensearch = "opensearch-min-${VersionProperties.getOpenSearch()}-${classifier}.tar.gz"
 
   /* Both the following Dockerfile commands put the resulting artifact at
    * the same location, regardless of classifier, so that the commands that

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -136,9 +136,9 @@ Closure commonPackageConfig(String type, boolean jdk, String architecture) {
     // SystemPackagingTask overrides default archive task convention mappings, but doesn't provide a setter so we have to override the convention mapping itself
     // Deb convention uses a '_' for final separator before architecture, rpm uses a '.'
     if (type == 'deb') {
-      conventionMapping.archiveFile = { objects.fileProperty().fileValue(file("${destinationDirectory.get()}/${packageName}_${project.version}${jdkString}_${archString}.${type}")) }
+      conventionMapping.archiveFile = { objects.fileProperty().fileValue(file("${destinationDirectory.get()}/${packageName}-min_${project.version}${jdkString}_${archString}.${type}")) }
     } else {
-      conventionMapping.archiveFile = { objects.fileProperty().fileValue(file("${destinationDirectory.get()}/${packageName}-${project.version}${jdkString}.${archString}.${type}")) }
+      conventionMapping.archiveFile = { objects.fileProperty().fileValue(file("${destinationDirectory.get()}/${packageName}-min-${project.version}${jdkString}.${archString}.${type}")) }
     }
 
     String packagingFiles = "build/packaging/${jdk ? '' : 'no-jdk-'}${type}"


### PR DESCRIPTION
Signed-off-by: Xue Zhou <xuezhou@amazon.com>

### Description
Rename build artifact to include -min. Distinguish minimal distribution from bundle(with plugins from other repos in opensearch-project).
 
### Issues Resolved
#1094
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
