### PR TITLE
Fix gradle check fail due to artifact renaming with "-min"

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -239,10 +239,17 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
         DistributionProject(String name, String baseDir, Version version, String classifier, String extension, File checkoutDir) {
             this.name = name;
             this.projectPath = baseDir + "/" + name;
-            this.distFile = new File(
-                checkoutDir,
-                baseDir + "/" + name + "/build/distributions/opensearch-" + version + "-SNAPSHOT" + classifier + "." + extension
-            );
+            if (version.onOrAfter("1.1.0")) {
+                this.distFile = new File(
+                    checkoutDir,
+                    baseDir + "/" + name + "/build/distributions/opensearch-min-" + version + "-SNAPSHOT" + classifier + "." + extension
+                );
+            } else {
+                this.distFile = new File(
+                    checkoutDir,
+                    baseDir + "/" + name + "/build/distributions/opensearch-" + version + "-SNAPSHOT" + classifier + "." + extension
+                );
+            }
             // we only ported this down to the 7.x branch.
             if (version.onOrAfter("7.10.0") && (name.endsWith("zip") || name.endsWith("tar"))) {
                 this.expandedDistDir = new File(checkoutDir, baseDir + "/" + name + "/build/install");


### PR DESCRIPTION
Signed-off-by: Xue Zhou <xuezhou@amazon.com>

### Description
Fix gradle check failing due to artifact renaming in #1094.

### Issues Resolved
#1285 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
