### PR TITLE
Initial commit for IndexWrite

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/autorecover/IndexSettingUpdateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/autorecover/IndexSettingUpdateIT.java
@@ -1,0 +1,400 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.autorecover;
+
+import org.hamcrest.Matchers;
+import org.opensearch.action.ActionFuture;
+import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.cluster.SnapshotDeletionsInProgress;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.index.IndexService;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.snapshots.AbstractSnapshotIntegTestCase;
+import org.opensearch.snapshots.SnapshotInfo;
+import org.opensearch.snapshots.SnapshotState;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.disruption.BlockClusterStateProcessing;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class IndexSettingUpdateIT extends AbstractSnapshotIntegTestCase {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder().put(super.nodeSettings(nodeOrdinal))
+            .put(ThreadPool.ESTIMATED_TIME_INTERVAL_SETTING.getKey(), 0) // We have tests that check by-timestamp order
+            .build();
+    }
+
+    //Test case for Happy case scenario of index write with no replica
+    public void testIndexWrite() {
+        internalCluster().startMasterOnlyNode();
+        final String dataNode = internalCluster().startDataOnlyNode();
+        final String indexName = "index-test";
+        long beforeTime = client().threadPool().absoluteTimeInMillis();
+
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.persistentSettings(Settings.builder()
+            .put("snapshot.auto_restore_red_indices_enable", true));
+        assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+
+        ensureGreen();
+        createIndexWithContent(indexName);
+
+        IndexSettings indexSettings = getIndexSettings(indexName, dataNode);
+
+        // Validate auto_restore index setting is been updated
+        assertThat(indexSettings.getSettings().get("index.auto_restore.clean_to_restore_from_snapshot"), equalTo("false"));
+        assertThat(indexSettings.getSettings().getAsLong("index.auto_restore.setting_update_time", -1L), greaterThan(beforeTime));
+    }
+
+    //Test case for Happy case scenario of index write with no replica
+    public void testIndexWriteWithReplica() throws Exception {
+        internalCluster().startMasterOnlyNode();
+        final String dataNode = internalCluster().startDataOnlyNode();
+        final String dataNode1 = internalCluster().startDataOnlyNode();
+        final String repoName = "test-repo";
+        final String indexName = "index-test";
+        final String snapshot = "snap";
+        long beforeTime = client().threadPool().absoluteTimeInMillis();
+
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.persistentSettings(Settings.builder()
+            .put("snapshot.auto_restore_red_indices_enable", true)
+            .put("snapshot.auto_restore_red_indices_repository", repoName)
+        );
+        assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+
+        ensureGreen();
+        Settings setting = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build();
+        createIndexWithContent(indexName, setting);
+        IndexSettings indexSettings = getIndexSettings(indexName, dataNode);
+
+        assertThat(indexSettings.getSettings().get("index.auto_restore.clean_to_restore_from_snapshot"), equalTo("false"));
+        assertThat(indexSettings.getSettings().getAsLong("index.auto_restore.setting_update_time", -1L), greaterThan(beforeTime));
+    }
+
+    //Test index write fails when index setting update fails
+    public void testIndexWriteSettingUpdateFail() throws IOException {
+        final String masterNode =internalCluster().startMasterOnlyNode();
+        final String dataNode = internalCluster().startDataOnlyNode();
+        final String indexName = "index-test";
+
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.persistentSettings(Settings.builder()
+            .put("snapshot.auto_restore_red_indices_enable", true));
+        assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+        ensureGreen();
+        createIndex(indexName);
+
+        // Block cluster state processing on the master
+        BlockClusterStateProcessing disruption = new BlockClusterStateProcessing(masterNode, random());
+        internalCluster().setDisruptionScheme(disruption);
+        disruption.startDisrupting();
+
+        try {
+            IndexResponse response = index(indexName, "_doc", "9", "value", "expectedValue");
+            fail("Should have failed because index setting update disrupted ");
+        } catch (Exception e) {
+
+            assert(e.getMessage().contains("update-setting"));
+            IndexSettings indexSettings = getIndexSettings(indexName, dataNode);
+
+            // Validate auto_restore index setting is not updated
+            assertFalse(IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT.exists(indexSettings.getSettings()));
+            assertFalse(IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT_UPDATE_TIME.exists(indexSettings.getSettings()));
+        }
+    }
+
+
+    //Test no index setting update (related to autorecover red indices) happens if feature flag `snapshot.auto_restore_red_indices_enable`
+    //is disabled during index write
+    public void testIndexWriteAutoRestoreDisabled() {
+        internalCluster().startMasterOnlyNode();
+        final String dataNode = internalCluster().startDataOnlyNode();
+        final String indexName = "index-test";
+
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.persistentSettings(Settings.builder()
+            .put("snapshot.auto_restore_red_indices_enable", false));
+        assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+
+        ensureGreen();
+        createIndexWithContent(indexName);
+        IndexSettings indexSettings = getIndexSettings(indexName, dataNode);
+
+        // Ensure index settings is not updated if feature flag is disabled
+        assertFalse(IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT.exists(indexSettings.getSettings()));
+        assertFalse(IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT_UPDATE_TIME.exists(indexSettings.getSettings()));
+    }
+
+    //Test no index setting update (related to autorecover red indices) happens if feature flag `snapshot.auto_restore_red_indices_enable`
+    //is disabled during snapshot completion
+    public void testSnapshotAutoRestoreDisabled() throws Exception {
+        internalCluster().startMasterOnlyNode();
+        final String dataNode = internalCluster().startDataOnlyNode();
+        final String indexName = "index-test";
+        final String repoName = "test-repo";
+        createRepository(repoName, "mock");
+        final String snapshot = "snap";
+
+        ensureGreen();
+        createIndexWithContent(indexName);
+        final ActionFuture<CreateSnapshotResponse> createSnapshotFuture =
+            startFullSnapshot(repoName, snapshot);
+        assertSuccessful(createSnapshotFuture);
+        assertThat(createSnapshotFuture.isDone(), is(true));
+        IndexSettings indexSettings = getIndexSettings(indexName, dataNode);
+
+        // Ensure index settings is not updated during snapshot if feature flag is disabled
+        assertFalse(IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT.exists(indexSettings.getSettings()));
+        assertFalse(IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT_UPDATE_TIME.exists(indexSettings.getSettings()));
+    }
+
+    //Test index setting update when index write completes before snapshot start
+    public void testIndexWriteBeforeSnapshot() throws Exception {
+        internalCluster().startMasterOnlyNode();
+        final String dataNode = internalCluster().startDataOnlyNode();
+        final String repoName = "test-repo";
+        createRepository(repoName, "mock");
+        final String indexName = "index-test";
+        final String snapshot = "snap";
+        long beforeTime = client().threadPool().absoluteTimeInMillis();
+
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.persistentSettings(Settings.builder()
+            .put("snapshot.auto_restore_red_indices_enable", true)
+            .put("snapshot.auto_restore_red_indices_repository", repoName)
+        );
+        assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+
+        ensureGreen();
+        createIndexWithContent(indexName);
+        IndexSettings indexSettings = getIndexSettings(indexName, dataNode);
+
+        assertThat(indexSettings.getSettings().get("index.auto_restore.clean_to_restore_from_snapshot"), equalTo("false"));
+        assertThat(indexSettings.getSettings().getAsLong("index.auto_restore.setting_update_time", -1L), greaterThan(beforeTime));
+
+        final ActionFuture<CreateSnapshotResponse> createSnapshotFuture =
+            startFullSnapshot(repoName, snapshot);
+        assertSuccessful(createSnapshotFuture);
+        assertThat(createSnapshotFuture.isDone(), is(true));
+        indexSettings = getIndexSettings(indexName, dataNode);
+
+        assertThat(indexSettings.getSettings().get("index.auto_restore.clean_to_restore_from_snapshot"), equalTo("true"));
+        assertThat(indexSettings.getSettings().getAsLong("index.auto_restore.setting_update_time", -1L), greaterThan(beforeTime));
+    }
+
+    //Test index setting update when index write happens when snapshot is in_progress
+    public void testIndexWriteWithSnapshotInProgress() throws Exception {
+        final String masterNode = internalCluster().startMasterOnlyNode();
+        final String dataNode = internalCluster().startDataOnlyNode();
+
+        final String repoName = "test-repo";
+        createRepository(repoName, "mock");
+        final String indexName = "index-test";
+        final String firstSnapshot = "snap1";
+        final String secondSnapshot = "snap2";
+        String expectedValue = "expected";
+        // Write a document
+        String docId = Integer.toString(randomInt());
+        long beforeTime = client().threadPool().absoluteTimeInMillis();
+
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.persistentSettings(Settings.builder()
+            .put("snapshot.auto_restore_red_indices_enable", true)
+            .put("snapshot.auto_restore_red_indices_repository", repoName)
+        );
+        assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+
+        ensureGreen();
+        createIndexWithContent(indexName);
+        final ActionFuture<CreateSnapshotResponse> createSnapshotFuture =
+            startFullSnapshot(repoName, firstSnapshot);
+        assertSuccessful(createSnapshotFuture);
+
+        assertThat(createSnapshotFuture.isDone(), is(true));
+        IndexSettings indexSettings = getIndexSettings(indexName, dataNode);
+        assertThat(indexSettings.getSettings().get("index.auto_restore.clean_to_restore_from_snapshot"), equalTo("true"));
+        assertThat(indexSettings.getSettings().getAsLong("index.auto_restore.setting_update_time", -1L), greaterThan(beforeTime));
+
+        long beforeTime1 = client().threadPool().absoluteTimeInMillis();
+
+        // Will make snapshot in progress state
+        blockMasterOnWriteIndexFile(repoName);
+        final ActionFuture<CreateSnapshotResponse> createSnapshotFuture2 =
+            startFullSnapshot(repoName, secondSnapshot);
+        waitForBlock(masterNode, repoName, TimeValue.timeValueSeconds(30L));
+
+        assertThat(createSnapshotFuture2.isDone(), is(false));
+        IndexResponse response = index(indexName, "_doc", docId, "value", expectedValue);
+        unblockNode(repoName, masterNode);
+        assertSuccessful(createSnapshotFuture2);
+        indexSettings = getIndexSettings(indexName, dataNode);
+        assertThat(indexSettings.getSettings().get("index.auto_restore.clean_to_restore_from_snapshot"), equalTo("false"));
+        assertThat(indexSettings.getSettings().getAsLong("index.auto_restore.setting_update_time", -1L), greaterThan(beforeTime1));
+    }
+
+    //Test index setting update when index write happens after snapshot completion
+    public void testIndexWriteAfterSnapshotComplete() throws Exception {
+        final String masterNode = internalCluster().startMasterOnlyNode();
+        final String dataNode = internalCluster().startDataOnlyNode();
+
+        final String repoName = "test-repo";
+        createRepository(repoName, "mock");
+        final String indexName = "index-test";
+        final String firstSnapshot = "snap1";
+        String expectedValue = "expected";
+        // Write a document
+        String docId = Integer.toString(randomInt());
+        long beforeTime = client().threadPool().absoluteTimeInMillis();
+
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.persistentSettings(Settings.builder()
+            .put("snapshot.auto_restore_red_indices_enable", true)
+            .put("snapshot.auto_restore_red_indices_repository", repoName)
+        );
+        assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+
+        ensureGreen();
+        createIndexWithContent(indexName);
+        final ActionFuture<CreateSnapshotResponse> createSnapshotFuture =
+            startFullSnapshot(repoName, firstSnapshot);
+        assertSuccessful(createSnapshotFuture);
+
+        assertThat(createSnapshotFuture.isDone(), is(true));
+        IndexSettings indexSettings = getIndexSettings(indexName, dataNode);
+        assertThat(indexSettings.getSettings().get("index.auto_restore.clean_to_restore_from_snapshot"), equalTo("true"));
+        assertThat(indexSettings.getSettings().getAsLong("index.auto_restore.setting_update_time", -1L), greaterThan(beforeTime));
+
+        long beforeTime1 = client().threadPool().absoluteTimeInMillis();
+        // Write to index
+        IndexResponse response = index(indexName, "_doc", docId, "value", expectedValue);
+        indexSettings = getIndexSettings(indexName, dataNode);
+        assertThat(indexSettings.getSettings().get("index.auto_restore.clean_to_restore_from_snapshot"), equalTo("false"));
+        assertThat(indexSettings.getSettings().getAsLong("index.auto_restore.setting_update_time", -1L), greaterThan(beforeTime1));
+    }
+
+    //Test index setting update when snapshot of index ends in FAILED state
+    public void testSnapshotFailure() throws Exception {
+        internalCluster().startMasterOnlyNode();
+        final String dataNode = internalCluster().startDataOnlyNode();
+
+        final String repoName = "test-repo";
+        createRepository(repoName, "mock");
+        final String indexName = "index-test";
+        final String snapshot = "snap";
+        long beforeTime = client().threadPool().absoluteTimeInMillis();
+
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.persistentSettings(Settings.builder()
+            .put("snapshot.auto_restore_red_indices_enable", true)
+            .put("snapshot.auto_restore_red_indices_repository", repoName)
+        );
+        assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+
+        ensureGreen();
+        createIndexWithContent(indexName);
+        IndexSettings indexSettings = getIndexSettings(indexName, dataNode);
+
+        assertThat(indexSettings.getSettings().get("index.auto_restore.clean_to_restore_from_snapshot"), equalTo("false"));
+        assertThat(indexSettings.getSettings().getAsLong("index.auto_restore.setting_update_time", -1L), greaterThan(beforeTime));
+
+        final ActionFuture<CreateSnapshotResponse> createSnapshotFuture =
+            startFullSnapshotBlockedOnDataNode( snapshot, repoName, dataNode);
+
+        final ActionFuture<AcknowledgedResponse> deleteSnapshotsResponse = startDeleteSnapshot(repoName, snapshot);
+        awaitNDeletionsInProgress(1);
+
+        unblockNode(repoName, dataNode);
+        final SnapshotInfo firstSnapshotInfo = createSnapshotFuture.get().getSnapshotInfo();
+        assertThat(firstSnapshotInfo.state(), Matchers.is(SnapshotState.FAILED));
+        assertThat(firstSnapshotInfo.reason(), is("Snapshot was aborted by deletion"));
+
+        indexSettings = getIndexSettings(indexName, dataNode);
+        assertThat(indexSettings.getSettings().get("index.auto_restore.clean_to_restore_from_snapshot"), equalTo("false"));
+        assertThat(indexSettings.getSettings().getAsLong("index.auto_restore.setting_update_time", -1L), greaterThan(beforeTime));
+
+        awaitNDeletionsInProgress(0);
+    }
+
+    //Tests index setting update when snapshot in PARTIAL state,
+    //i.e for some index snapshot is successful and for some it failed.
+    public void testSnapshotPartial() throws Exception {
+        internalCluster().startMasterOnlyNode();
+        final String dataNode = internalCluster().startDataOnlyNode();
+
+        final String repoName = "test-repo";
+        createRepository(repoName, "mock");
+        final String indexName = "index-test";
+        final String snapshot = "snap";
+        long beforeTime = client().threadPool().absoluteTimeInMillis();
+
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.persistentSettings(Settings.builder()
+            .put("snapshot.auto_restore_red_indices_enable", true)
+            .put("snapshot.auto_restore_red_indices_repository", repoName)
+        );
+        assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+
+        createIndex(indexName, Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 1).build());
+        ensureYellow(indexName);
+        index(indexName, "_doc", "some_id", "foo", "bar");
+
+
+        IndexSettings indexSettings = getIndexSettings(indexName, dataNode);
+        assertThat(indexSettings.getSettings().get("index.auto_restore.clean_to_restore_from_snapshot"), equalTo("false"));
+        assertThat(indexSettings.getSettings().getAsLong("index.auto_restore.setting_update_time", -1L), greaterThan(beforeTime));
+
+        final ActionFuture<CreateSnapshotResponse> createSnapshotFuture =
+            startFullSnapshotBlockedOnDataNode( snapshot, repoName, dataNode);
+
+        final ActionFuture<AcknowledgedResponse> deleteSnapshotsResponse = startDeleteSnapshot(repoName, snapshot);
+        awaitNDeletionsInProgress(1);
+
+        unblockNode(repoName, dataNode);
+        final SnapshotInfo firstSnapshotInfo = createSnapshotFuture.get().getSnapshotInfo();
+        assertThat(firstSnapshotInfo.state(), is(SnapshotState.FAILED));
+        assertThat(firstSnapshotInfo.reason(), is("Snapshot was aborted by deletion"));
+
+        indexSettings = getIndexSettings(indexName, dataNode);
+        assertThat(indexSettings.getSettings().get("index.auto_restore.clean_to_restore_from_snapshot"), equalTo("false"));
+        assertThat(indexSettings.getSettings().getAsLong("index.auto_restore.setting_update_time", -1L), greaterThan(beforeTime));
+
+        awaitNDeletionsInProgress(0);
+    }
+
+    private IndexSettings getIndexSettings(String indexName, String nodeName) {
+        final IndicesService indicesService = internalCluster().getInstance(IndicesService.class, nodeName);
+        final IndexService indexService = indicesService.indexService(resolveIndex(indexName));
+        return indexService.getIndexSettings();
+    }
+
+    private void awaitNDeletionsInProgress(int count) throws Exception {
+        logger.info("--> wait for [{}] deletions to show up in the cluster state", count);
+        awaitClusterState(state ->
+            state.custom(SnapshotDeletionsInProgress.TYPE, SnapshotDeletionsInProgress.EMPTY).getEntries().size() == count);
+    }
+}

--- a/server/src/main/java/org/opensearch/autorecover/IndexWriteShardAction.java
+++ b/server/src/main/java/org/opensearch/autorecover/IndexWriteShardAction.java
@@ -1,0 +1,150 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.autorecover;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
+import org.opensearch.client.Client;
+import org.opensearch.client.Requests;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.SnapshotsInProgress;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.engine.Engine;
+import org.opensearch.index.shard.IndexingOperationListener;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportRequestDeduplicator;
+
+import java.io.IOException;
+
+public class IndexWriteShardAction implements IndexingOperationListener {
+    private static final Logger logger = LogManager.getLogger(IndexWriteShardAction.class);
+
+    private final ClusterService clusterService;
+    private final Client client;
+    private final ThreadPool threadPool;
+
+
+    /**
+     * Setting that specifies if auto recover of red indices from past snapshots is enabled or not
+     */
+    public static final Setting<Boolean> AUTO_RESTORE_RED_INDICES_ENABLE =
+        Setting.boolSetting("snapshot.auto_restore_red_indices_enable",false,
+            Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+    /**
+     * Setting that specifies if auto recover of red indices on data loss or not
+     */
+    public static final Setting<Boolean> AUTO_RESTORE_RED_INDICES_IF_NO_DATA_LOSS =
+        Setting.boolSetting("snapshot.auto_restore_red_indices_if_no_data_loss",true,
+            Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+    /**
+     * Setting that specifies from which repository to restore red indices
+     */
+    public static final Setting<String> AUTO_RESTORE_RED_INDICES_REPOSITORY =
+        Setting.simpleString("snapshot.auto_restore_red_indices_repository",
+            Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+    private final TransportRequestDeduplicator<UpdateIndexCleanStatusRequest> remoteFailedRequestDeduplicator =
+        new TransportRequestDeduplicator<>();
+
+    public IndexWriteShardAction(ClusterService clusterService, Client client, ThreadPool threadPool) {
+        this.clusterService = clusterService;
+        this.client = client;
+        this.threadPool = threadPool;
+    }
+
+    @Override
+    public void postIndex(ShardId shardId, Engine.Index index, Engine.IndexResult result) throws IOException{
+        boolean autoRestoreRedIndexEnabled = clusterService.getClusterSettings().get(AUTO_RESTORE_RED_INDICES_ENABLE);
+        if (!autoRestoreRedIndexEnabled) {
+            // No Action Needed
+            return;
+        }
+
+        ClusterStateRequest clusterStateRequest = Requests.clusterStateRequest().local(true);
+        ClusterState state = client.admin().cluster().state(clusterStateRequest).actionGet().getState();
+        if (!state.routingTable().shardRoutingTable(shardId).primaryShard().currentNodeId().equals(clusterService.localNode().getId())) {
+            // No Action Needed, Index setting update happens only on primary shard
+            return;
+        }
+
+        SnapshotsInProgress snapshotsInProgress = clusterService.state().custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
+
+        if (snapshotsInProgress.equals(SnapshotsInProgress.EMPTY)) {
+            logger.trace("No Snapshot in progress during index write");
+            updateIndexSetting(shardId);
+
+        } else {
+            logger.trace(" Snapshot in progress during index write:[{}]", snapshotsInProgress);
+            updateIndexSettingWithSnapshotInProgress(shardId, snapshotsInProgress);
+        }
+    }
+
+    public void updateIndexSetting(ShardId shardId) {
+        Settings indexSettings = client.admin().cluster().prepareState().get().getState().metadata().index(
+            shardId.getIndex().getName()).getSettings();
+        boolean index_clean_to_restore_from_snapshot = indexSettings.getAsBoolean(
+            IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT.getKey(), Boolean.FALSE);
+        long index_clean_to_restore_from_snapshot_update_time = indexSettings.getAsLong(
+            IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT_UPDATE_TIME.getKey(), -1L);
+
+        if(index_clean_to_restore_from_snapshot || index_clean_to_restore_from_snapshot_update_time == -1L) {
+            // TODO: Implement Batching
+            client.admin().indices().prepareUpdateSettings(shardId.getIndexName())
+                .setSettings(Settings.builder()
+                    .put(IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT.getKey(), false)
+                    .put(IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT_UPDATE_TIME.getKey(), threadPool.absoluteTimeInMillis())
+                ).get();
+            logger.info("[{}] updated index_clean_to_restore_from_snapshot to [{}] & index_clean_to_restore_from_snapshot_update_time" +
+                    " to [{}]", shardId, index_clean_to_restore_from_snapshot, index_clean_to_restore_from_snapshot_update_time);
+        }
+    }
+
+
+    public void updateIndexSettingWithSnapshotInProgress(ShardId shardId, SnapshotsInProgress snapshotsInProgress) {
+        Settings indexSettings = client.admin().cluster().prepareState().get().getState().metadata().index(
+            shardId.getIndex().getName()).getSettings();
+        boolean index_clean_to_restore_from_snapshot = indexSettings.getAsBoolean(
+            IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT.getKey(), Boolean.FALSE);
+        long index_clean_to_restore_from_snapshot_update_time = indexSettings.getAsLong(
+            IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT_UPDATE_TIME.getKey(), -1L);
+        String autoRestoreRedIndexRepositoryName = clusterService.getClusterSettings().get(AUTO_RESTORE_RED_INDICES_REPOSITORY);
+
+        if(index_clean_to_restore_from_snapshot || (index_clean_to_restore_from_snapshot_update_time != -1 &&
+            index_clean_to_restore_from_snapshot_update_time < getLatestSnapshotStartTime(snapshotsInProgress,
+                autoRestoreRedIndexRepositoryName))) {
+            // TODO: Implement Batching
+            client.admin().indices().prepareUpdateSettings(shardId.getIndexName())
+                .setSettings(Settings.builder()
+                    .put(IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT.getKey(), false)
+                    .put(IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT_UPDATE_TIME.getKey(), threadPool.absoluteTimeInMillis())
+                ).get();
+            logger.info("[{}] Found [{}], updated index_clean_to_restore_from_snapshot to [{}] & " +
+                    "index_clean_to_restore_from_snapshot_update_time to [{}]", shardId, snapshotsInProgress,
+                index_clean_to_restore_from_snapshot, index_clean_to_restore_from_snapshot_update_time);
+        }
+    }
+
+    private long getLatestSnapshotStartTime(SnapshotsInProgress snapshotsInProgress, String repositoryName) {
+        long latestSnapshotStartTime = -1;
+
+        for (SnapshotsInProgress.Entry entry : snapshotsInProgress.entries()) {
+            if (entry.repository().equals(repositoryName) && entry.startTime() > latestSnapshotStartTime) {
+                latestSnapshotStartTime = entry.startTime();
+            }
+        }
+        return  latestSnapshotStartTime;
+    }
+}

--- a/server/src/main/java/org/opensearch/autorecover/RecoverRedIndexService.java
+++ b/server/src/main/java/org/opensearch/autorecover/RecoverRedIndexService.java
@@ -1,0 +1,210 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.autorecover;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.master.TransportMasterNodeAction;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.ClusterStateUpdateTask;
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.component.AbstractLifecycleComponent;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.Index;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class RecoverRedIndexService extends AbstractLifecycleComponent {
+
+    private static final Logger logger = LogManager.getLogger(RecoverRedIndexService.class);
+
+    public static final String UPDATE_INDEX_STATUS_ACTION_NAME = "internal:cluster/recoverredindex/update_index_status";
+
+    public final UpdateIndexStatusAction updateIndexStatusHandler;
+
+    private final TransportService transportService;
+
+    private final ClusterService clusterService;
+
+    private final ThreadPool threadPool;
+
+    private final Client client;
+
+    public RecoverRedIndexService( TransportService transportService, ClusterService clusterService, ActionFilters actionFilters,
+                                   IndexNameExpressionResolver indexNameExpressionResolver, Client client) {
+        this.transportService = transportService;
+        this.clusterService = clusterService;
+        this.threadPool = transportService.getThreadPool();
+        this.client = client;
+
+        // The constructor of UpdateSnapshotStatusAction will register itself to the TransportService.
+        this.updateIndexStatusHandler =
+            new UpdateIndexStatusAction(transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver);
+
+    }
+
+
+    @Override
+    protected void doStart() {
+        assert this.updateIndexStatusHandler != null;
+        assert transportService.getRequestHandler(UPDATE_INDEX_STATUS_ACTION_NAME) != null;
+    }
+
+    @Override
+    protected void doStop() {
+
+    }
+
+    @Override
+    protected void doClose() throws IOException {
+    }
+
+    public void updateIndicesStatus(List<UpdateIndexCleanStatusRequest> requestList,
+                                    ActionListener<UpdateIndexCleanStatusResponse> listener) {
+
+        clusterService.submitStateUpdateTask("update_indices_clean_to_restore_status", new ClusterStateUpdateTask() {
+
+            @Override
+            public ClusterState execute(ClusterState currentState) {
+                Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata());
+
+                for (UpdateIndexCleanStatusRequest request : requestList) {
+                    IndexMetadata indexMetadata = currentState.metadata().index(request.getIndexName());
+                    Settings.Builder indexSettings = Settings.builder().put(indexMetadata.getSettings());
+
+                    indexSettings.put(IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT.getKey(),
+                        request.isIndexCleanToRestoreFromSnapshot())
+                        .put(IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT_UPDATE_TIME.getKey(),
+                            request.getIndexCleanToRestoreFromSnapshotUpdateTime());
+
+                    final IndexMetadata.Builder builder = IndexMetadata.builder(indexMetadata);
+                    builder.settings(indexSettings);
+                    builder.settingsVersion(1 + builder.settingsVersion());
+                    metadataBuilder.put(builder);
+                }
+
+                ClusterState updatedState = ClusterState.builder(currentState).metadata(metadataBuilder).build();
+                return updatedState;
+            }
+
+            @Override
+            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                listener.onResponse(UpdateIndexCleanStatusResponse.INSTANCE);
+            }
+
+            @Override
+            public void onFailure(String source, Exception e) {
+                logger.warn("Failed to update cluster state [{}]", source);
+                listener.onFailure(e);
+            }
+        });
+    }
+
+    /**
+     * Updates following settings from index list after snapshot process
+     * 1. INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT
+     * 2. INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT_UPDATE_TIME
+     */
+    public void updateSnapshotIndicesStatus(Map<Index, Boolean> indicesSucessfullySnapshottedStatusMap, long snapshotStartTime,
+                                            ActionListener<Void> listener) {
+        List<UpdateIndexCleanStatusRequest> requestList = new ArrayList<>();
+        for (Map.Entry<Index,Boolean> indexEntry : indicesSucessfullySnapshottedStatusMap.entrySet()) {
+
+            // Update Setting only for indices for which snapshot was successful
+            if (indexEntry.getValue()) {
+                Settings indexSettings = clusterService.state().metadata().index(indexEntry.getKey().getName()).getSettings();
+
+                if (IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT.exists(indexSettings)){
+                    Boolean indexCleanToRestoreFromSnapshot  = IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT.get(indexSettings);
+                    long indexCleanToRestoreFromSnapshotTime  = IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT_UPDATE_TIME.get(
+                        indexSettings);
+
+                    if (!indexCleanToRestoreFromSnapshot) {
+                        if(indexCleanToRestoreFromSnapshotTime < snapshotStartTime) {
+
+                            // Index write happened before snapshot was started for the index, hence updating setting
+                            UpdateIndexCleanStatusRequest updateIndexCleanStatusRequest = new UpdateIndexCleanStatusRequest(
+                                indexEntry.getValue(), threadPool.absoluteTimeInMillis(), indexEntry.getKey().getName());
+                            requestList.add(updateIndexCleanStatusRequest);
+                        }
+                    }
+                }
+            } else {
+                UpdateIndexCleanStatusRequest updateIndexCleanStatusRequest = new UpdateIndexCleanStatusRequest(indexEntry.getValue(),
+                    threadPool.absoluteTimeInMillis(), indexEntry.getKey().getName());
+                requestList.add(updateIndexCleanStatusRequest);
+            }
+        }
+        updateIndicesStatus(requestList,
+            new ActionListener<UpdateIndexCleanStatusResponse>() {
+                @Override
+                public void onResponse(UpdateIndexCleanStatusResponse updateIndexCleanStatusResponse) {
+                    logger.info("snapshot updated index setting [{}] for indices with status [{}]",
+                        IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT.getKey(), requestList);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    logger.warn(() -> new ParameterizedMessage("failed to update index setting [{}] for indices with status [{}]",
+                        IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT.getKey(), requestList), e);
+                    listener.onFailure(e);
+                }
+            });
+    }
+
+    public class UpdateIndexStatusAction
+        extends TransportMasterNodeAction<UpdateIndexCleanStatusRequest, UpdateIndexCleanStatusResponse> {
+        UpdateIndexStatusAction(TransportService transportService, ClusterService clusterService,
+                                ThreadPool threadPool, ActionFilters actionFilters,
+                                IndexNameExpressionResolver indexNameExpressionResolver) {
+            super(UPDATE_INDEX_STATUS_ACTION_NAME, false, transportService, clusterService, threadPool,
+                actionFilters, UpdateIndexCleanStatusRequest::new, indexNameExpressionResolver
+            );
+        }
+
+        @Override
+        protected String executor() {
+            return ThreadPool.Names.SAME;
+        }
+
+        @Override
+        protected UpdateIndexCleanStatusResponse read(StreamInput in) throws IOException {
+            return UpdateIndexCleanStatusResponse.INSTANCE;
+        }
+
+        @Override
+        protected void masterOperation(UpdateIndexCleanStatusRequest request, ClusterState state,
+                                       ActionListener<UpdateIndexCleanStatusResponse> listener) throws Exception {
+            List<UpdateIndexCleanStatusRequest> requestList = new ArrayList<UpdateIndexCleanStatusRequest>();
+            requestList.add(request);
+            updateIndicesStatus(requestList, listener);
+        }
+
+        @Override
+        protected ClusterBlockException checkBlock(UpdateIndexCleanStatusRequest request, ClusterState state) {
+            return null;
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/autorecover/UpdateIndexCleanStatusRequest.java
+++ b/server/src/main/java/org/opensearch/autorecover/UpdateIndexCleanStatusRequest.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.autorecover;
+
+
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.support.master.MasterNodeRequest;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.unit.TimeValue;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Internal request that is used to send changes in index clean to restore from past snapshot status to master
+ */
+public class UpdateIndexCleanStatusRequest extends MasterNodeRequest<UpdateIndexCleanStatusRequest> {
+    private final String indexName;
+    private final boolean indexCleanToRestoreFromSnapshot;
+    private final long indexCleanToRestoreFromSnapshotUpdateTime;
+
+    public UpdateIndexCleanStatusRequest(StreamInput in) throws IOException {
+        super(in);
+        indexCleanToRestoreFromSnapshot = in.readBoolean();
+        indexCleanToRestoreFromSnapshotUpdateTime = in.readLong();
+        indexName = in.readString();
+    }
+
+    public UpdateIndexCleanStatusRequest(boolean indexCleanToRestoreFromSnapshot, long indexCleanToRestoreFromSnapshotUpdateTime,
+                                         String indexName) {
+        this.indexCleanToRestoreFromSnapshot = indexCleanToRestoreFromSnapshot;
+        this.indexCleanToRestoreFromSnapshotUpdateTime = indexCleanToRestoreFromSnapshotUpdateTime;
+        this.indexName = indexName;
+        // By default, we keep trying to post index clean status getting stuck.
+        this.masterNodeTimeout = TimeValue.timeValueNanos(Long.MAX_VALUE);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeBoolean(indexCleanToRestoreFromSnapshot);
+        out.writeLong(indexCleanToRestoreFromSnapshotUpdateTime);
+        out.writeString(indexName);
+    }
+
+    @Override
+    public String toString() {
+        return "Index [" + indexName + "], indexCleanToRestoreFromSnapshot [" + indexCleanToRestoreFromSnapshot + "], " +
+            "indexCleanToRestoreFromSnapshotUpdateTime [" + indexCleanToRestoreFromSnapshotUpdateTime + "]";
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final UpdateIndexCleanStatusRequest that = (UpdateIndexCleanStatusRequest) o;
+        return indexCleanToRestoreFromSnapshot == (that.indexCleanToRestoreFromSnapshot) &&
+            indexCleanToRestoreFromSnapshotUpdateTime == (that.indexCleanToRestoreFromSnapshotUpdateTime);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(indexName, indexCleanToRestoreFromSnapshot, indexCleanToRestoreFromSnapshotUpdateTime);
+    }
+
+    public String getIndexName() {
+        return indexName;
+    }
+
+    public boolean isIndexCleanToRestoreFromSnapshot() {
+        return indexCleanToRestoreFromSnapshot;
+    }
+
+    public long getIndexCleanToRestoreFromSnapshotUpdateTime() {
+        return indexCleanToRestoreFromSnapshotUpdateTime;
+    }
+}

--- a/server/src/main/java/org/opensearch/autorecover/UpdateIndexCleanStatusResponse.java
+++ b/server/src/main/java/org/opensearch/autorecover/UpdateIndexCleanStatusResponse.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.autorecover;
+
+import org.opensearch.action.ActionResponse;
+import org.opensearch.common.io.stream.StreamOutput;
+import java.io.IOException;
+
+class UpdateIndexCleanStatusResponse extends ActionResponse {
+
+    public static final UpdateIndexCleanStatusResponse INSTANCE = new UpdateIndexCleanStatusResponse();
+
+    UpdateIndexCleanStatusResponse() {}
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {}
+}

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -33,6 +33,7 @@ package org.opensearch.common.settings;
 
 import org.apache.logging.log4j.LogManager;
 import org.opensearch.action.main.TransportMainAction;
+import org.opensearch.autorecover.IndexWriteShardAction;
 import org.opensearch.cluster.routing.allocation.decider.NodeLoadAwareAllocationDecider;
 import org.opensearch.watcher.ResourceWatcherService;
 import org.opensearch.action.admin.cluster.configuration.TransportAddVotingConfigExclusionsAction;
@@ -577,6 +578,9 @@ public final class ClusterSettings extends AbstractScopedSettings {
             DiscoveryUpgradeService.BWC_PING_TIMEOUT_SETTING,
             DiscoveryUpgradeService.ENABLE_UNSAFE_BOOTSTRAPPING_ON_UPGRADE_SETTING,
             SnapshotsService.MAX_CONCURRENT_SNAPSHOT_OPERATIONS_SETTING,
+            IndexWriteShardAction.AUTO_RESTORE_RED_INDICES_ENABLE,
+            IndexWriteShardAction.AUTO_RESTORE_RED_INDICES_IF_NO_DATA_LOSS,
+            IndexWriteShardAction.AUTO_RESTORE_RED_INDICES_REPOSITORY,
             FsHealthService.ENABLED_SETTING,
             FsHealthService.REFRESH_INTERVAL_SETTING,
             FsHealthService.SLOW_PATH_LOGGING_THRESHOLD_SETTING,

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -163,6 +163,8 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING,
         IndexSettings.INDEX_SEARCH_IDLE_AFTER,
         IndexSettings.INDEX_SEARCH_THROTTLED,
+        IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT,
+        IndexSettings.INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT_UPDATE_TIME,
         IndexFieldDataService.INDEX_FIELDDATA_CACHE_KEY,
         FieldMapper.IGNORE_MALFORMED_SETTING,
         FieldMapper.COERCE_SETTING,

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -361,6 +361,29 @@ public final class IndexSettings {
         Property.IndexScope, Property.PrivateIndex, Property.Dynamic);
 
     /**
+     * Marks an index is clean to be restored from past snapshots without any data loss
+     * This setting is realtime updateable
+     */
+    public static final Setting<Boolean> INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT =
+        Setting.boolSetting(
+            "index.auto_restore.clean_to_restore_from_snapshot",
+            false,
+            Property.IndexScope,
+            Property.Dynamic);
+
+    /**
+     * Index setting to track whenever setting INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT is updated
+     * This setting is realtime updateable
+     */
+    public static final Setting<Long> INDEX_CLEAN_TO_RESTORE_FROM_SNAPSHOT_UPDATE_TIME =
+        Setting.longSetting(
+            "index.auto_restore.setting_update_time",
+            -1L,
+            -1L,
+            Property.Dynamic,
+            Property.IndexScope);
+
+    /**
      * Determines a balance between file-based and operations-based peer recoveries. The number of operations that will be used in an
      * operations-based peer recovery is limited to this proportion of the total number of documents in the shard (including deleted
      * documents) on the grounds that a file-based peer recovery may copy all of the documents in the shard over to the new peer, but is

--- a/server/src/main/java/org/opensearch/index/shard/IndexingOperationListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexingOperationListener.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.index.engine.Engine;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -55,7 +56,7 @@ public interface IndexingOperationListener {
      * related failures. See {@link #postIndex(ShardId, Engine.Index, Exception)}
      * for engine level failures
      */
-    default void postIndex(ShardId shardId, Engine.Index index, Engine.IndexResult result) {}
+    default void postIndex(ShardId shardId, Engine.Index index, Engine.IndexResult result) throws IOException {}
 
     /**
      * Called after the indexing operation occurred with engine level exception.
@@ -113,13 +114,14 @@ public interface IndexingOperationListener {
         }
 
         @Override
-        public void postIndex(ShardId shardId, Engine.Index index, Engine.IndexResult result) {
+        public void postIndex(ShardId shardId, Engine.Index index, Engine.IndexResult result) throws IOException {
             assert index != null;
             for (IndexingOperationListener listener : listeners) {
                 try {
                     listener.postIndex(shardId, index, result);
                 } catch (Exception e) {
                     logger.warn(() -> new ParameterizedMessage("postIndex listener [{}] failed", listener), e);
+                    throw e;
                 }
             }
         }

--- a/server/src/test/java/org/opensearch/index/shard/IndexingOperationListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexingOperationListenerTests.java
@@ -40,6 +40,7 @@ import org.opensearch.index.mapper.Uid;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -51,7 +52,8 @@ import static org.hamcrest.Matchers.is;
 public class IndexingOperationListenerTests extends OpenSearchTestCase {
 
     // this test also tests if calls are correct if one or more listeners throw exceptions
-    public void testListenersAreExecuted() {
+    // Excepts for postIndex() as exception is thrown if postIndex() fails
+    public void testListenersAreExecuted() throws Exception{
         AtomicInteger preIndex = new AtomicInteger();
         AtomicInteger postIndex = new AtomicInteger();
         AtomicInteger postIndexException = new AtomicInteger();
@@ -120,11 +122,6 @@ public class IndexingOperationListenerTests extends OpenSearchTestCase {
         IndexingOperationListener throwingListener = new IndexingOperationListener() {
             @Override
             public Engine.Index preIndex(ShardId shardId, Engine.Index operation) {
-                throw new RuntimeException();
-            }
-
-            @Override
-            public void postIndex(ShardId shardId, Engine.Index index, Engine.IndexResult result) {
                 throw new RuntimeException();
             }
 

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -102,6 +102,7 @@ import org.opensearch.action.support.TransportAction;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.action.update.UpdateHelper;
+import org.opensearch.autorecover.RecoverRedIndexService;
 import org.opensearch.client.AdminClient;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.ClusterChangedEvent;
@@ -1502,12 +1503,14 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     Collections.singletonMap(FsRepository.TYPE, getRepoFactory(environment)), emptyMap(), threadPool
                 );
                 final ActionFilters actionFilters = new ActionFilters(emptySet());
+                client = new NodeClient(settings, threadPool);
+                RecoverRedIndexService recoverRedIndexService = new RecoverRedIndexService(transportService, clusterService, actionFilters,
+                    indexNameExpressionResolver, client);
                 snapshotsService = new SnapshotsService(settings, clusterService, indexNameExpressionResolver, repositoriesService,
-                        transportService, actionFilters);
+                        transportService, actionFilters, recoverRedIndexService);
                 nodeEnv = new NodeEnvironment(settings, environment);
                 final NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(Collections.emptyList());
                 final ScriptService scriptService = new ScriptService(settings, emptyMap(), emptyMap());
-                client = new NodeClient(settings, threadPool);
                 final SetOnce<RerouteService> rerouteServiceSetOnce = new SetOnce<>();
                 final SnapshotsInfoService snapshotsInfoService = new InternalSnapshotsInfoService(settings, clusterService,
                     () -> repositoriesService, rerouteServiceSetOnce::get);


### PR DESCRIPTION
Initial commit for IndexWrite
Signed-off-by: Piyush Daftary <piyush.besu@gmail.com>

### Description
This is first PR for Auto Recover RED Indices. Complete details of the feature can be found at : https://github.com/opensearch-project/OpenSearch/issues/1098

In this PR I am introducing following index level and cluster level settings : 

**Index Level Settings:** 

1. `index.auto_restore.clean_to_restore_from_snapshot` : Setting indicates if an index is clean to be restored from past snapshots without any data loss
2. `index.auto_restore.setting_update_time` : Setting to track when was setting `index.auto_restore.clean_to_restore_from_snapshot` last updated.

**Cluster Level Settings:**
1. `snapshot.auto_restore_red_indices_enable` : Setting that specifies if auto recover of red indices from past snapshots is enabled or not
2. `snapshot.auto_restore_red_indices_if_no_data_loss` : Setting that specifies if auto recover of red indices on data loss or not
3. `snapshot.auto_restore_red_indices_repository` : Setting that specifies from which repository to auto restore red indices


In this PR I am covering index setting update of above settings when 
1. Index write happens for the first time in index. 
2. Index write happens after successful snapshot.
3.  Snapshot of index is complete successfully.
 
Algorithm followed for the index setting update is as follows : 

# Index Write :

1. Whenever there is index write to an index in Data Node
    1. Check if snapshot is in progress
    2. If Snapshot for index is in progress
        1. If clean_to_restore_from_snapshot  is TRUE
            1. Update clean_to_restore_from_snapshot to FALSE  in index setting
            2. Update Index_Update_Time_Stamp with current time stamp  in index setting
        2. Else If clean_to_restore_from_snapshot  is FALSE and Index_Update_Time_Stamp  is *less* than snapshot_start_time, then
            1. Update Index_Update_Time_Stamp with current time stamp  in index setting
        3. Else
            1. NO ACTION
    3. Else
        1. if clean_to_restore_from_snapshot for index is  TRUE
            1. Update clean_to_restore_from_snapshot to FALSE in index setting
            2. Update Index_Update_Time_Stamp with current time stamp  in index setting
        2. Else
            1. NO ACTION

<br />
<br />

![Index_Write_Approach3](https://user-images.githubusercontent.com/9053059/129607855-028ad4ac-1a48-4cf6-84f2-16d750648ca6.jpg)

<br />

# Snapshot :

1. When Snapshot creation completes for an index  
    1. If snapshot for the index was sucessful
        1. If clean_to_restore_from_snapshot is FALSE
            1.  If Index_Update_Time_Stamp > SNAPSHOT_START_TIME for the index, 
                1. DO NOTHING , as there was index write after snapshot was started for the index.
            2. Else update clean_to_restore_from_snapshot to TRUE
    2. Else if Snapshot was failure for the index 
        1. NO ACTION

<br />
<br />

![snapshot_approach3](https://user-images.githubusercontent.com/9053059/129607899-68de0dd1-3096-4a42-be22-0bc2cc5dfaea.jpg)

<br />


**Added tests to cover various scenarios.**

### Issues Related
https://github.com/opensearch-project/OpenSearch/issues/1098 
 
### Check List
- [ Y] New functionality includes testing.
  - [Y] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ Y] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
