### PR TITLE
[Revert] Translog Pruning Setting Deprecation Removal

### DIFF
--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -267,7 +267,7 @@ public final class IndexSettings {
     @Deprecated
     public static final Setting<Boolean> INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING =
         Setting.boolSetting("index.plugins.replication.translog.retention_lease.pruning.enabled", false,
-            Property.IndexScope, Property.Dynamic);
+            Property.IndexScope, Property.Dynamic, Property.Deprecated);
 
     /**
      * Controls how many soft-deleted documents will be kept around before being merged away. Keeping more deleted

--- a/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
@@ -673,6 +673,9 @@ public class IndexSettingsTests extends OpenSearchTestCase {
             assertFalse(indexSettings.shouldPruneTranslogByRetentionLease());
             assertThat(indexSettings.getTranslogRetentionSize().getBytes(), equalTo(-1L));
         }
+        assertWarnings("[index.plugins.replication.translog.retention_lease.pruning.enabled] setting " +
+            "was deprecated in OpenSearch and will be removed in a future release! See the breaking changes documentation " +
+            "for the next major version.");
     }
 
     public void testTranslogPruningSettingsWithSoftDeletesDisabled() {
@@ -687,5 +690,8 @@ public class IndexSettingsTests extends OpenSearchTestCase {
         IndexSettings indexSettings = new IndexSettings(metadata, Settings.EMPTY);
         assertFalse(indexSettings.shouldPruneTranslogByRetentionLease());
         assertThat(indexSettings.getTranslogRetentionSize().getBytes(), equalTo(retentionSize.getBytes()));
+        assertWarnings("[index.plugins.replication.translog.retention_lease.pruning.enabled] setting " +
+            "was deprecated in OpenSearch and will be removed in a future release! See the breaking changes documentation " +
+            "for the next major version.");
     }
 }


### PR DESCRIPTION
INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING was
deprecated, then deprecation was removed. This adds deprecation back so that the
setting can be moved to the plugin in the next minor release.