### PR TITLE
[Tests] Translog Pruning tests to MetadataCreateIndexServiceTests

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1258,11 +1258,19 @@ public class MetadataCreateIndexService {
     }
 
     public static void validateTranslogRetentionSettings(Settings indexSettings) {
-        if (IndexSettings.INDEX_SOFT_DELETES_SETTING.get(indexSettings) &&
-            (IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.exists(indexSettings)
-                || IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.exists(indexSettings))) {
-            DEPRECATION_LOGGER.deprecate("translog_retention", "Translog retention settings [index.translog.retention.age] "
-                + "and [index.translog.retention.size] are deprecated and effectively ignored. They will be removed in a future version.");
+        if (IndexSettings.INDEX_SOFT_DELETES_SETTING.get(indexSettings)) {
+            if(IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.exists(indexSettings)
+                || IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.exists(indexSettings)) {
+                DEPRECATION_LOGGER.deprecate("translog_retention", "Translog retention settings " +
+                    "[index.translog.retention.age] "
+                    + "and [index.translog.retention.size] are deprecated and effectively ignored. " +
+                    "They will be removed in a future version.");
+            } else if(IndexSettings.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.exists(indexSettings)) {
+                DEPRECATION_LOGGER.deprecate("translog_pruning_retention_lease",
+                    "[index.plugins.replication.translog.retention_lease.pruning.enabled] " +
+                        "setting was deprecated in OpenSearch and will be removed in a future release! " +
+                        "See the breaking changes documentation for the next major version.");
+            }
         }
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -1001,6 +1001,19 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             "or better performance, or other file systems instead.");
     }
 
+    public void testTranslogPruningBasedOnRetentionLeaseDeprecation() {
+        request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
+        request.settings(Settings.builder()
+            .put(INDEX_SOFT_DELETES_SETTING.getKey(), true)
+            .put(IndexSettings.INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING.getKey(), true).build());
+        aggregateIndexSettings(ClusterState.EMPTY_STATE, request, Settings.EMPTY,
+            null, Settings.EMPTY, IndexScopedSettings.DEFAULT_SCOPED_SETTINGS, randomShardLimitService(),
+            Collections.emptySet());
+        assertWarnings("[index.plugins.replication.translog.retention_lease.pruning.enabled] setting " +
+            "was deprecated in OpenSearch and will be removed in a future release! " +
+            "See the breaking changes documentation for the next major version.");
+    }
+
     private IndexTemplateMetadata addMatchingTemplate(Consumer<IndexTemplateMetadata.Builder> configurator) {
         IndexTemplateMetadata.Builder builder = templateMetadataBuilder("template1", "te*");
         configurator.accept(builder);


### PR DESCRIPTION
This commit adds test coverage for translog pruning setting to
MetadataCreateIndexServiceTests