### PR TITLE
Moved translog pruning warning to index creation time to avoid warnings for all the client calls

### DIFF
--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -267,7 +267,7 @@ public final class IndexSettings {
     @Deprecated
     public static final Setting<Boolean> INDEX_PLUGINS_REPLICATION_TRANSLOG_RETENTION_LEASE_PRUNING_ENABLED_SETTING =
         Setting.boolSetting("index.plugins.replication.translog.retention_lease.pruning.enabled", false,
-            Property.IndexScope, Property.Dynamic, Property.Deprecated);
+            Property.IndexScope, Property.Dynamic);
 
     /**
      * Controls how many soft-deleted documents will be kept around before being merged away. Keeping more deleted

--- a/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
@@ -673,9 +673,6 @@ public class IndexSettingsTests extends OpenSearchTestCase {
             assertFalse(indexSettings.shouldPruneTranslogByRetentionLease());
             assertThat(indexSettings.getTranslogRetentionSize().getBytes(), equalTo(-1L));
         }
-        assertWarnings("[index.plugins.replication.translog.retention_lease.pruning.enabled] setting " +
-            "was deprecated in OpenSearch and will be removed in a future release! See the breaking changes documentation " +
-            "for the next major version.");
     }
 
     public void testTranslogPruningSettingsWithSoftDeletesDisabled() {
@@ -690,8 +687,5 @@ public class IndexSettingsTests extends OpenSearchTestCase {
         IndexSettings indexSettings = new IndexSettings(metadata, Settings.EMPTY);
         assertFalse(indexSettings.shouldPruneTranslogByRetentionLease());
         assertThat(indexSettings.getTranslogRetentionSize().getBytes(), equalTo(retentionSize.getBytes()));
-        assertWarnings("[index.plugins.replication.translog.retention_lease.pruning.enabled] setting " +
-            "was deprecated in OpenSearch and will be removed in a future release! See the breaking changes documentation " +
-            "for the next major version.");
     }
 }


### PR DESCRIPTION
### Description
Moved warning to index creation time to avoid warnings for all the client calls
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
