### PR TITLE
[Backport] [1.x] Support for Heap after GC stats (opensearch-project#1265)

### DIFF
--- a/server/src/main/java/org/opensearch/monitor/jvm/JvmStats.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/JvmStats.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.monitor.jvm;
 
+import org.opensearch.Version;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -85,6 +86,11 @@ public class JvmStats implements Writeable, ToXContentFragment {
             try {
                 MemoryUsage usage = memoryPoolMXBean.getUsage();
                 MemoryUsage peakUsage = memoryPoolMXBean.getPeakUsage();
+                MemoryUsage collectionUsage = memoryPoolMXBean.getCollectionUsage();
+                // For some pools, the collection usage may not be supported and the method returns null.
+                if (collectionUsage == null) {
+                    collectionUsage = new MemoryUsage(0, 0, 0, 0);
+                }
                 String name = GcNames.getByMemoryPoolName(memoryPoolMXBean.getName(), null);
                 if (name == null) { // if we can't resolve it, its not interesting.... (Per Gen, Code Cache)
                     continue;
@@ -93,8 +99,13 @@ public class JvmStats implements Writeable, ToXContentFragment {
                         usage.getUsed() < 0 ? 0 : usage.getUsed(),
                         usage.getMax() < 0 ? 0 : usage.getMax(),
                         peakUsage.getUsed() < 0 ? 0 : peakUsage.getUsed(),
-                        peakUsage.getMax() < 0 ? 0 : peakUsage.getMax()
-                ));
+                        peakUsage.getMax() < 0 ? 0 : peakUsage.getMax(),
+                        new MemoryPoolGcStats(
+                            collectionUsage.getUsed() < 0 ? 0 : collectionUsage.getUsed(),
+                            collectionUsage.getMax() < 0 ? 0 : collectionUsage.getMax()
+                        )
+                    ));
+                
             } catch (final Exception ignored) {
 
             }
@@ -223,6 +234,12 @@ public class JvmStats implements Writeable, ToXContentFragment {
             builder.humanReadableField(Fields.PEAK_USED_IN_BYTES, Fields.PEAK_USED, new ByteSizeValue(pool.peakUsed));
             builder.humanReadableField(Fields.PEAK_MAX_IN_BYTES, Fields.PEAK_MAX, new ByteSizeValue(pool.peakMax));
 
+            builder.startObject(Fields.LAST_GC_STATS);
+            builder.humanReadableField(Fields.USED_IN_BYTES, Fields.USED, new ByteSizeValue(pool.getLastGcStats().used));
+            builder.humanReadableField(Fields.MAX_IN_BYTES, Fields.MAX, new ByteSizeValue(pool.getLastGcStats().max));
+            builder.field(Fields.USAGE_PERCENT, pool.getLastGcStats().getUsagePercent());
+            builder.endObject();
+            
             builder.endObject();
         }
         builder.endObject();
@@ -299,7 +316,9 @@ public class JvmStats implements Writeable, ToXContentFragment {
         static final String PEAK_USED_IN_BYTES = "peak_used_in_bytes";
         static final String PEAK_MAX = "peak_max";
         static final String PEAK_MAX_IN_BYTES = "peak_max_in_bytes";
-
+        static final String USAGE_PERCENT = "usage_percent";
+        static final String LAST_GC_STATS = "last_gc_stats";
+        
         static final String THREADS = "threads";
         static final String COUNT = "count";
         static final String PEAK_COUNT = "peak_count";
@@ -414,6 +433,48 @@ public class JvmStats implements Writeable, ToXContentFragment {
             return peakCount;
         }
     }
+    
+    /**
+     * Stores the memory usage after the Java virtual machine
+     * most recently expended effort in recycling unused objects
+     * in particular memory pool.
+     */
+    public static class MemoryPoolGcStats implements Writeable {
+
+        private final long used;
+        private final long max;
+        
+        public MemoryPoolGcStats(long used, long max) {
+            this.used = used;
+            this.max = max;
+        }
+        
+        public MemoryPoolGcStats(StreamInput in) throws IOException {
+            used = in.readVLong();
+            max = in.readVLong();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVLong(used);
+            out.writeVLong(max);
+        }
+
+        public ByteSizeValue getUsed() {
+            return new ByteSizeValue(used);
+        }
+
+        public ByteSizeValue getMax() {
+            return new ByteSizeValue(max);
+        }
+        
+        public short getUsagePercent() {
+            if (max == 0) {
+                return -1;
+            }
+            return (short) (used * 100 / max);
+        }
+    }
 
     public static class MemoryPool implements Writeable {
 
@@ -422,13 +483,15 @@ public class JvmStats implements Writeable, ToXContentFragment {
         private final long max;
         private final long peakUsed;
         private final long peakMax;
+        private final MemoryPoolGcStats lastGcStats;
 
-        public MemoryPool(String name, long used, long max, long peakUsed, long peakMax) {
+        public MemoryPool(String name, long used, long max, long peakUsed, long peakMax, MemoryPoolGcStats lastGcStats) {
             this.name = name;
             this.used = used;
             this.max = max;
             this.peakUsed = peakUsed;
             this.peakMax = peakMax;
+            this.lastGcStats = lastGcStats;
         }
 
         public MemoryPool(StreamInput in) throws IOException {
@@ -437,6 +500,11 @@ public class JvmStats implements Writeable, ToXContentFragment {
             max = in.readVLong();
             peakUsed = in.readVLong();
             peakMax = in.readVLong();
+            if (in.getVersion().onOrAfter(Version.V_1_2_0)) {
+                lastGcStats = new MemoryPoolGcStats(in);
+            } else {
+                lastGcStats = new MemoryPoolGcStats(0, 0);
+            }
         }
 
         @Override
@@ -446,6 +514,9 @@ public class JvmStats implements Writeable, ToXContentFragment {
             out.writeVLong(max);
             out.writeVLong(peakUsed);
             out.writeVLong(peakMax);
+            if (out.getVersion().onOrAfter(Version.V_1_2_0)) {
+                lastGcStats.writeTo(out);
+            }
         }
 
         public String getName() {
@@ -466,6 +537,13 @@ public class JvmStats implements Writeable, ToXContentFragment {
 
         public ByteSizeValue getPeakMax() {
             return new ByteSizeValue(peakMax);
+        }
+        
+        /**
+         * Returns the heap usage after last garbage collection cycle
+         */
+        public MemoryPoolGcStats getLastGcStats() {
+            return lastGcStats;
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Backport of https://github.com/opensearch-project/OpenSearch/pull/1265 to 1.x
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/981
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
