### PR TITLE
Support for Heap after GC stats (correction after backport to 1.2.0)

### DIFF
--- a/server/src/main/java/org/opensearch/monitor/jvm/JvmStats.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/JvmStats.java
@@ -500,7 +500,7 @@ public class JvmStats implements Writeable, ToXContentFragment {
             max = in.readVLong();
             peakUsed = in.readVLong();
             peakMax = in.readVLong();
-            if (in.getVersion().onOrAfter(Version.V_2_0_0)) {
+            if (in.getVersion().onOrAfter(Version.V_1_2_0)) {
                 lastGcStats = new MemoryPoolGcStats(in);
             } else {
                 lastGcStats = new MemoryPoolGcStats(0, 0);
@@ -514,7 +514,7 @@ public class JvmStats implements Writeable, ToXContentFragment {
             out.writeVLong(max);
             out.writeVLong(peakUsed);
             out.writeVLong(peakMax);
-            if (out.getVersion().onOrAfter(Version.V_2_0_0)) {
+            if (out.getVersion().onOrAfter(Version.V_1_2_0)) {
                 lastGcStats.writeTo(out);
             }
         }


### PR DESCRIPTION
Signed-off-by: Andriy Redko andriy.redko@aiven.io

### Description
Correction after https://github.com/opensearch-project/OpenSearch/pull/1309 backport, lowering version requirements to `1.2.0`.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/981
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
