### PR TITLE
Bridging the gap in network overhead measurement in the profiler

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/profile/ProfilerSingleNodeNetworkTest.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/profile/ProfilerSingleNodeNetworkTest.java
@@ -58,12 +58,12 @@ public class ProfilerSingleNodeNetworkTest extends OpenSearchSingleNodeTestCase 
             for (Map.Entry<String, ProfileShardResult> shard : resp.getProfileResults().entrySet()) {
                 assertThat(
                     "Profile response inbound network time should be 0 in single node clusters",
-                    shard.getValue().getInboundNetworkTime(),
+                    shard.getValue().getNetworkTime().getInboundNetworkTime(),
                     is(0L)
                 );
                 assertThat(
                     "Profile response outbound network time should be 0 in single node clusters",
-                    shard.getValue().getOutboundNetworkTime(),
+                    shard.getValue().getNetworkTime().getOutboundNetworkTime(),
                     is(0L)
                 );
             }

--- a/server/src/internalClusterTest/java/org/opensearch/search/profile/ProfilerSingleNodeNetworkTest.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/profile/ProfilerSingleNodeNetworkTest.java
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.profile;
+
+import org.apache.lucene.util.English;
+import org.opensearch.action.index.IndexRequestBuilder;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchType;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.test.OpenSearchSingleNodeTestCase;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.opensearch.search.profile.query.RandomQueryGenerator.randomQueryBuilder;
+
+public class ProfilerSingleNodeNetworkTest extends OpenSearchSingleNodeTestCase {
+
+    /**
+     * This test checks to make sure in a single node cluster, the network time
+     * is 0 as expected in the profiler for inbound an doutbound network time.
+     */
+    public void testProfilerNetworkTime() throws Exception {
+        createIndex("test");
+        ensureGreen();
+
+        int numDocs = randomIntBetween(100, 150);
+        IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
+        for (int i = 0; i < numDocs; i++) {
+            docs[i] = client().prepareIndex("test", "type1", String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
+        }
+
+        List<String> stringFields = Arrays.asList("field1");
+        List<String> numericFields = Arrays.asList("field2");
+
+        int iters = between(20, 100);
+        for (int i = 0; i < iters; i++) {
+            QueryBuilder q = randomQueryBuilder(stringFields, numericFields, numDocs, 3);
+            logger.info("Query: {}", q);
+
+            SearchResponse resp = client().prepareSearch()
+                .setQuery(q)
+                .setTrackTotalHits(true)
+                .setProfile(true)
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .get();
+
+            assertNotNull("Profile response element should not be null", resp.getProfileResults());
+            assertThat("Profile response should not be an empty array", resp.getProfileResults().size(), not(0));
+            for (Map.Entry<String, ProfileShardResult> shard : resp.getProfileResults().entrySet()) {
+                assertThat(
+                    "Profile response inbound network time should be 0 in single node clusters",
+                    shard.getValue().getInboundNetworkTime(),
+                    is(0L)
+                );
+                assertThat(
+                    "Profile response outbound network time should be 0 in single node clusters",
+                    shard.getValue().getOutboundNetworkTime(),
+                    is(0L)
+                );
+            }
+        }
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/search/profile/query/QueryProfilerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/profile/query/QueryProfilerIT.java
@@ -46,7 +46,12 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.util.*;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.opensearch.search.profile.query.RandomQueryGenerator.randomQueryBuilder;
 
 public class QueryProfilerIT extends OpenSearchIntegTestCase {
@@ -86,8 +91,8 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
             assertNotNull("Profile response element should not be null", resp.getProfileResults());
             assertThat("Profile response should not be an empty array", resp.getProfileResults().size(), not(0));
             for (Map.Entry<String, ProfileShardResult> shard : resp.getProfileResults().entrySet()) {
-                assertThat(shard.getValue().getInboundNetworkTime(), greaterThanOrEqualTo(0L));
-                assertThat(shard.getValue().getOutboundNetworkTime(), greaterThanOrEqualTo(0L));
+                assertThat(shard.getValue().getNetworkTime().getInboundNetworkTime(), greaterThanOrEqualTo(0L));
+                assertThat(shard.getValue().getNetworkTime().getOutboundNetworkTime(), greaterThanOrEqualTo(0L));
                 for (QueryProfileShardResult searchProfiles : shard.getValue().getQueryProfileResults()) {
                     for (ProfileResult result : searchProfiles.getQueryResults()) {
                         assertNotNull(result.getQueryName());

--- a/server/src/internalClusterTest/java/org/opensearch/search/profile/query/QueryProfilerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/profile/query/QueryProfilerIT.java
@@ -34,11 +34,7 @@ package org.opensearch.search.profile.query;
 
 import org.apache.lucene.util.English;
 import org.opensearch.action.index.IndexRequestBuilder;
-import org.opensearch.action.search.MultiSearchResponse;
-import org.opensearch.action.search.SearchRequestBuilder;
-import org.opensearch.action.search.SearchResponse;
-import org.opensearch.action.search.SearchType;
-import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.action.search.*;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
@@ -48,18 +44,10 @@ import org.opensearch.search.profile.ProfileShardResult;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
+import static org.hamcrest.Matchers.*;
 import static org.opensearch.search.profile.query.RandomQueryGenerator.randomQueryBuilder;
-import static org.hamcrest.Matchers.emptyOrNullString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 
 public class QueryProfilerIT extends OpenSearchIntegTestCase {
 
@@ -98,6 +86,8 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
             assertNotNull("Profile response element should not be null", resp.getProfileResults());
             assertThat("Profile response should not be an empty array", resp.getProfileResults().size(), not(0));
             for (Map.Entry<String, ProfileShardResult> shard : resp.getProfileResults().entrySet()) {
+                assertThat(shard.getValue().getInboundNetworkTime(), greaterThanOrEqualTo(0L));
+                assertThat(shard.getValue().getOutboundNetworkTime(), greaterThanOrEqualTo(0L));
                 for (QueryProfileShardResult searchProfiles : shard.getValue().getQueryProfileResults()) {
                     for (ProfileResult result : searchProfiles.getQueryResults()) {
                         assertNotNull(result.getQueryName());

--- a/server/src/main/java/org/opensearch/action/search/SearchExecutionStatsCollector.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchExecutionStatsCollector.java
@@ -35,6 +35,7 @@ package org.opensearch.action.search;
 import org.opensearch.action.ActionListener;
 import org.opensearch.node.ResponseCollectorService;
 import org.opensearch.search.SearchPhaseResult;
+import org.opensearch.search.fetch.QueryFetchSearchResult;
 import org.opensearch.search.query.QuerySearchResult;
 import org.opensearch.transport.Transport;
 
@@ -66,6 +67,10 @@ public final class SearchExecutionStatsCollector implements ActionListener<Searc
 
     @Override
     public void onResponse(SearchPhaseResult response) {
+        if (response instanceof QueryFetchSearchResult) {
+            response.queryResult().getShardSearchRequest().setOutboundNetworkTime(0);
+            response.queryResult().getShardSearchRequest().setInboundNetworkTime(0);
+        }
         QuerySearchResult queryResult = response.queryResult();
         if (response.getShardSearchRequest() != null) {
             if (response.remoteAddress() != null) {

--- a/server/src/main/java/org/opensearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -121,6 +121,10 @@ class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<SearchPh
         final SearchActionListener<SearchPhaseResult> listener
     ) {
         ShardSearchRequest request = rewriteShardSearchRequest(super.buildShardSearchRequest(shardIt));
+        // update inbound network time with current time before sending request over n/w to data node
+        if (request != null) {
+            request.setInboundNetworkTime(System.currentTimeMillis());
+        }
         getSearchTransport().sendExecuteQuery(getConnection(shard.getClusterAlias(), shard.getNodeId()), request, getTask(), listener);
     }
 

--- a/server/src/main/java/org/opensearch/search/profile/NetworkTime.java
+++ b/server/src/main/java/org/opensearch/search/profile/NetworkTime.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.profile;
+
+import org.opensearch.Version;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+
+import java.io.IOException;
+
+public class NetworkTime implements Writeable {
+    private long inboundNetworkTime;
+    private long outboundNetworkTime;
+
+    public NetworkTime(long inboundTime, long outboundTime) {
+        this.inboundNetworkTime = inboundTime;
+        this.outboundNetworkTime = outboundTime;
+    }
+
+    public NetworkTime(StreamInput in) throws IOException {
+        if (in.getVersion().onOrAfter(Version.V_2_0_0)) {
+            this.inboundNetworkTime = in.readVLong();
+            this.outboundNetworkTime = in.readVLong();
+        }
+    }
+
+    public void writeTo(StreamOutput out) throws IOException {
+        if (out.getVersion().onOrAfter(Version.V_2_0_0)) {
+            out.writeVLong(inboundNetworkTime);
+            out.writeVLong(outboundNetworkTime);
+        }
+    }
+
+    public long getInboundNetworkTime() {
+        return this.inboundNetworkTime;
+    }
+
+    public long getOutboundNetworkTime() {
+        return this.outboundNetworkTime;
+    }
+
+    public void setInboundNetworkTime(long newTime) {
+        this.inboundNetworkTime = newTime;
+    }
+
+    public void setOutboundNetworkTime(long newTime) {
+        this.outboundNetworkTime = newTime;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/profile/ProfileShardResult.java
+++ b/server/src/main/java/org/opensearch/search/profile/ProfileShardResult.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.search.profile;
 
-import org.opensearch.Version;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -50,20 +49,16 @@ public class ProfileShardResult implements Writeable {
 
     private final AggregationProfileShardResult aggProfileShardResult;
 
-    private long inboundNetworkTime;
-
-    private long outboundNetworkTime;
+    private NetworkTime networkTime;
 
     public ProfileShardResult(
         List<QueryProfileShardResult> queryProfileResults,
         AggregationProfileShardResult aggProfileShardResult,
-        long inboundNetworkTime,
-        long outboundNetworkTime
+        NetworkTime networkTime
     ) {
         this.aggProfileShardResult = aggProfileShardResult;
         this.queryProfileResults = Collections.unmodifiableList(queryProfileResults);
-        this.inboundNetworkTime = inboundNetworkTime;
-        this.outboundNetworkTime = outboundNetworkTime;
+        this.networkTime = networkTime;
     }
 
     public ProfileShardResult(StreamInput in) throws IOException {
@@ -75,10 +70,7 @@ public class ProfileShardResult implements Writeable {
         }
         this.queryProfileResults = Collections.unmodifiableList(queryProfileResults);
         this.aggProfileShardResult = new AggregationProfileShardResult(in);
-        if (in.getVersion().onOrAfter(Version.V_2_0_0)) {
-            this.inboundNetworkTime = in.readVLong();
-            this.outboundNetworkTime = in.readVLong();
-        }
+        this.networkTime = new NetworkTime(in);
     }
 
     @Override
@@ -88,10 +80,7 @@ public class ProfileShardResult implements Writeable {
             queryShardResult.writeTo(out);
         }
         aggProfileShardResult.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_2_0_0)) {
-            out.writeVLong(inboundNetworkTime);
-            out.writeVLong(outboundNetworkTime);
-        }
+        networkTime.writeTo(out);
     }
 
     public List<QueryProfileShardResult> getQueryProfileResults() {
@@ -102,20 +91,13 @@ public class ProfileShardResult implements Writeable {
         return aggProfileShardResult;
     }
 
-    public long getInboundNetworkTime() {
-        return inboundNetworkTime;
+    public NetworkTime getNetworkTime() {
+        return networkTime;
     }
 
-    public void setInboundNetworkTime(long newTime) {
-        this.inboundNetworkTime = newTime;
-    }
-
-    public long getOutboundNetworkTime() {
-        return outboundNetworkTime;
-    }
-
-    public void setOutboundNetworkTime(long newTime) {
-        this.outboundNetworkTime = newTime;
+    public void setNetworkTime(NetworkTime newTime) {
+        networkTime.setInboundNetworkTime(newTime.getInboundNetworkTime());
+        networkTime.setOutboundNetworkTime(newTime.getOutboundNetworkTime());
     }
 
 }

--- a/server/src/main/java/org/opensearch/search/profile/ProfileShardResult.java
+++ b/server/src/main/java/org/opensearch/search/profile/ProfileShardResult.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.search.profile;
 
+import org.opensearch.Version;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -49,9 +50,20 @@ public class ProfileShardResult implements Writeable {
 
     private final AggregationProfileShardResult aggProfileShardResult;
 
-    public ProfileShardResult(List<QueryProfileShardResult> queryProfileResults, AggregationProfileShardResult aggProfileShardResult) {
+    private long inboundNetworkTime;
+
+    private long outboundNetworkTime;
+
+    public ProfileShardResult(
+        List<QueryProfileShardResult> queryProfileResults,
+        AggregationProfileShardResult aggProfileShardResult,
+        long inboundNetworkTime,
+        long outboundNetworkTime
+    ) {
         this.aggProfileShardResult = aggProfileShardResult;
         this.queryProfileResults = Collections.unmodifiableList(queryProfileResults);
+        this.inboundNetworkTime = inboundNetworkTime;
+        this.outboundNetworkTime = outboundNetworkTime;
     }
 
     public ProfileShardResult(StreamInput in) throws IOException {
@@ -63,6 +75,10 @@ public class ProfileShardResult implements Writeable {
         }
         this.queryProfileResults = Collections.unmodifiableList(queryProfileResults);
         this.aggProfileShardResult = new AggregationProfileShardResult(in);
+        if (in.getVersion().onOrAfter(Version.V_2_0_0)) {
+            this.inboundNetworkTime = in.readVLong();
+            this.outboundNetworkTime = in.readVLong();
+        }
     }
 
     @Override
@@ -72,6 +88,10 @@ public class ProfileShardResult implements Writeable {
             queryShardResult.writeTo(out);
         }
         aggProfileShardResult.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_2_0_0)) {
+            out.writeVLong(inboundNetworkTime);
+            out.writeVLong(outboundNetworkTime);
+        }
     }
 
     public List<QueryProfileShardResult> getQueryProfileResults() {
@@ -81,4 +101,21 @@ public class ProfileShardResult implements Writeable {
     public AggregationProfileShardResult getAggregationProfileResults() {
         return aggProfileShardResult;
     }
+
+    public long getInboundNetworkTime() {
+        return inboundNetworkTime;
+    }
+
+    public void setInboundNetworkTime(long newTime) {
+        this.inboundNetworkTime = newTime;
+    }
+
+    public long getOutboundNetworkTime() {
+        return outboundNetworkTime;
+    }
+
+    public void setOutboundNetworkTime(long newTime) {
+        this.outboundNetworkTime = newTime;
+    }
+
 }

--- a/server/src/main/java/org/opensearch/search/profile/SearchProfileShardResults.java
+++ b/server/src/main/java/org/opensearch/search/profile/SearchProfileShardResults.java
@@ -106,8 +106,8 @@ public final class SearchProfileShardResults implements Writeable, ToXContentFra
         for (String key : sortedKeys) {
             builder.startObject();
             builder.field(ID_FIELD, key);
-            builder.field(INBOUND_NETWORK_FIELD, shardResults.get(key).getInboundNetworkTime());
-            builder.field(OUTBOUND_NETWORK_FIELD, shardResults.get(key).getOutboundNetworkTime());
+            builder.field(INBOUND_NETWORK_FIELD, shardResults.get(key).getNetworkTime().getInboundNetworkTime());
+            builder.field(OUTBOUND_NETWORK_FIELD, shardResults.get(key).getNetworkTime().getOutboundNetworkTime());
             builder.startArray(SEARCHES_FIELD);
             ProfileShardResult profileShardResult = shardResults.get(key);
             for (QueryProfileShardResult result : profileShardResult.getQueryProfileResults()) {
@@ -178,10 +178,8 @@ public final class SearchProfileShardResults implements Writeable, ToXContentFra
                 parser.skipChildren();
             }
         }
-        searchProfileResults.put(
-            id,
-            new ProfileShardResult(queryProfileResults, aggProfileShardResult, inboundNetworkTime, outboundNetworkTime)
-        );
+        NetworkTime networkTime = new NetworkTime(inboundNetworkTime, outboundNetworkTime);
+        searchProfileResults.put(id, new ProfileShardResult(queryProfileResults, aggProfileShardResult, networkTime));
     }
 
     /**
@@ -206,9 +204,11 @@ public final class SearchProfileShardResults implements Writeable, ToXContentFra
             queryResults.add(result);
         }
         AggregationProfileShardResult aggResults = new AggregationProfileShardResult(aggProfiler.getTree());
+        NetworkTime networkTime = new NetworkTime(0, 0);
         if (request != null) {
-            return new ProfileShardResult(queryResults, aggResults, request.getInboundNetworkTime(), request.getOutboundNetworkTime());
+            networkTime.setInboundNetworkTime(request.getInboundNetworkTime());
+            networkTime.setOutboundNetworkTime(request.getOutboundNetworkTime());
         }
-        return new ProfileShardResult(queryResults, aggResults, 0, 0);
+        return new ProfileShardResult(queryResults, aggResults, networkTime);
     }
 }

--- a/server/src/main/java/org/opensearch/search/profile/SearchProfileShardResults.java
+++ b/server/src/main/java/org/opensearch/search/profile/SearchProfileShardResults.java
@@ -65,7 +65,6 @@ public final class SearchProfileShardResults implements Writeable, ToXContentFra
     public static final String PROFILE_FIELD = "profile";
     public static final String INBOUND_NETWORK_FIELD = "inbound_network_time_in_millis";
     public static final String OUTBOUND_NETWORK_FIELD = "outbound_network_time_in_millis";
-    public static final String ROUND_TRIP_NETWORK_FIELD = "round_trip_network_time_in_millis";
 
     private Map<String, ProfileShardResult> shardResults;
 
@@ -109,10 +108,6 @@ public final class SearchProfileShardResults implements Writeable, ToXContentFra
             builder.field(ID_FIELD, key);
             builder.field(INBOUND_NETWORK_FIELD, shardResults.get(key).getInboundNetworkTime());
             builder.field(OUTBOUND_NETWORK_FIELD, shardResults.get(key).getOutboundNetworkTime());
-            builder.field(
-                ROUND_TRIP_NETWORK_FIELD,
-                shardResults.get(key).getInboundNetworkTime() + shardResults.get(key).getOutboundNetworkTime()
-            );
             builder.startArray(SEARCHES_FIELD);
             ProfileShardResult profileShardResult = shardResults.get(key);
             for (QueryProfileShardResult result : profileShardResult.getQueryProfileResults()) {

--- a/server/src/main/java/org/opensearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryPhase.java
@@ -168,7 +168,10 @@ public class QueryPhase {
         aggregationPhase.execute(searchContext);
 
         if (searchContext.getProfilers() != null) {
-            ProfileShardResult shardResults = SearchProfileShardResults.buildShardResults(searchContext.getProfilers());
+            ProfileShardResult shardResults = SearchProfileShardResults.buildShardResults(
+                searchContext.getProfilers(),
+                searchContext.request()
+            );
             searchContext.queryResult().profileResults(shardResults);
         }
     }

--- a/server/src/main/java/org/opensearch/search/query/QuerySearchResult.java
+++ b/server/src/main/java/org/opensearch/search/query/QuerySearchResult.java
@@ -245,6 +245,8 @@ public final class QuerySearchResult extends SearchPhaseResult {
             throw new IllegalStateException("profile results already consumed");
         }
         ProfileShardResult result = profileShardResults;
+        result.setInboundNetworkTime(this.getShardSearchRequest().getInboundNetworkTime());
+        result.setOutboundNetworkTime(this.getShardSearchRequest().getOutboundNetworkTime());
         profileShardResults = null;
         return result;
     }

--- a/server/src/main/java/org/opensearch/search/query/QuerySearchResult.java
+++ b/server/src/main/java/org/opensearch/search/query/QuerySearchResult.java
@@ -32,12 +32,6 @@
 
 package org.opensearch.search.query;
 
-import static java.util.Collections.emptyList;
-import static org.opensearch.common.lucene.Lucene.readTopDocs;
-import static org.opensearch.common.lucene.Lucene.writeTopDocs;
-
-import java.io.IOException;
-
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.TotalHits;
 import org.opensearch.LegacyESVersion;
@@ -54,8 +48,15 @@ import org.opensearch.search.aggregations.InternalAggregations;
 import org.opensearch.search.aggregations.pipeline.PipelineAggregator;
 import org.opensearch.search.internal.ShardSearchContextId;
 import org.opensearch.search.internal.ShardSearchRequest;
+import org.opensearch.search.profile.NetworkTime;
 import org.opensearch.search.profile.ProfileShardResult;
 import org.opensearch.search.suggest.Suggest;
+
+import java.io.IOException;
+
+import static java.util.Collections.emptyList;
+import static org.opensearch.common.lucene.Lucene.readTopDocs;
+import static org.opensearch.common.lucene.Lucene.writeTopDocs;
 
 public final class QuerySearchResult extends SearchPhaseResult {
 
@@ -245,8 +246,11 @@ public final class QuerySearchResult extends SearchPhaseResult {
             throw new IllegalStateException("profile results already consumed");
         }
         ProfileShardResult result = profileShardResults;
-        result.setInboundNetworkTime(this.getShardSearchRequest().getInboundNetworkTime());
-        result.setOutboundNetworkTime(this.getShardSearchRequest().getOutboundNetworkTime());
+        NetworkTime newNetworkTime = new NetworkTime(
+            this.getShardSearchRequest().getInboundNetworkTime(),
+            this.getShardSearchRequest().getOutboundNetworkTime()
+        );
+        result.setNetworkTime(newNetworkTime);
         profileShardResults = null;
         return result;
     }

--- a/server/src/main/java/org/opensearch/transport/RequestHandlerRegistry.java
+++ b/server/src/main/java/org/opensearch/transport/RequestHandlerRegistry.java
@@ -36,6 +36,7 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lease.Releasables;
+import org.opensearch.search.internal.ShardSearchRequest;
 import org.opensearch.tasks.CancellableTask;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
@@ -83,6 +84,12 @@ public class RequestHandlerRegistry<Request extends TransportRequest> {
         Releasable unregisterTask = () -> taskManager.unregister(task);
         try {
             if (channel instanceof TcpTransportChannel && task instanceof CancellableTask) {
+                if (request instanceof ShardSearchRequest) {
+                    // on receiving request, update the inbound network time to reflect time spent in transit over the network
+                    ((ShardSearchRequest) request).setInboundNetworkTime(
+                        Math.max(0, System.currentTimeMillis() - ((ShardSearchRequest) request).getInboundNetworkTime())
+                    );
+                }
                 final TcpChannel tcpChannel = ((TcpTransportChannel) channel).getChannel();
                 final Releasable stopTracking = taskManager.startTrackingCancellableChannelTask(tcpChannel, (CancellableTask) task);
                 unregisterTask = Releasables.wrap(unregisterTask, stopTracking);

--- a/server/src/main/java/org/opensearch/transport/TcpTransportChannel.java
+++ b/server/src/main/java/org/opensearch/transport/TcpTransportChannel.java
@@ -34,6 +34,7 @@ package org.opensearch.transport;
 
 import org.opensearch.Version;
 import org.opensearch.common.lease.Releasable;
+import org.opensearch.search.query.QuerySearchResult;
 
 import java.io.IOException;
 import java.util.Set;
@@ -82,6 +83,10 @@ public final class TcpTransportChannel implements TransportChannel {
     @Override
     public void sendResponse(TransportResponse response) throws IOException {
         try {
+            if (response instanceof QuerySearchResult && ((QuerySearchResult) response).getShardSearchRequest() != null) {
+                // update outbound network time with current time before sending response over network
+                ((QuerySearchResult) response).getShardSearchRequest().setOutboundNetworkTime(System.currentTimeMillis());
+            }
             outboundHandler.sendResponse(version, features, channel, requestId, action, response, compressResponse, isHandshake);
         } finally {
             release(false);

--- a/server/src/test/java/org/opensearch/search/profile/SearchProfileShardResultsTests.java
+++ b/server/src/test/java/org/opensearch/search/profile/SearchProfileShardResultsTests.java
@@ -59,6 +59,8 @@ public class SearchProfileShardResultsTests extends OpenSearchTestCase {
 
     public static SearchProfileShardResults createTestItem() {
         int size = rarely() ? 0 : randomIntBetween(1, 2);
+        long inboundTime = 0;
+        long outboundTime = 0;
         Map<String, ProfileShardResult> searchProfileResults = new HashMap<>(size);
         for (int i = 0; i < size; i++) {
             List<QueryProfileShardResult> queryProfileResults = new ArrayList<>();
@@ -67,7 +69,10 @@ public class SearchProfileShardResultsTests extends OpenSearchTestCase {
                 queryProfileResults.add(QueryProfileShardResultTests.createTestItem());
             }
             AggregationProfileShardResult aggProfileShardResult = AggregationProfileShardResultTests.createTestItem(1);
-            searchProfileResults.put(randomAlphaOfLengthBetween(5, 10), new ProfileShardResult(queryProfileResults, aggProfileShardResult));
+            searchProfileResults.put(
+                randomAlphaOfLengthBetween(5, 10),
+                new ProfileShardResult(queryProfileResults, aggProfileShardResult, inboundTime, outboundTime)
+            );
         }
         return new SearchProfileShardResults(searchProfileResults);
     }

--- a/server/src/test/java/org/opensearch/search/profile/SearchProfileShardResultsTests.java
+++ b/server/src/test/java/org/opensearch/search/profile/SearchProfileShardResultsTests.java
@@ -69,9 +69,10 @@ public class SearchProfileShardResultsTests extends OpenSearchTestCase {
                 queryProfileResults.add(QueryProfileShardResultTests.createTestItem());
             }
             AggregationProfileShardResult aggProfileShardResult = AggregationProfileShardResultTests.createTestItem(1);
+            NetworkTime networkTime = new NetworkTime(inboundTime, outboundTime);
             searchProfileResults.put(
                 randomAlphaOfLengthBetween(5, 10),
-                new ProfileShardResult(queryProfileResults, aggProfileShardResult, inboundTime, outboundTime)
+                new ProfileShardResult(queryProfileResults, aggProfileShardResult, networkTime)
             );
         }
         return new SearchProfileShardResults(searchProfileResults);


### PR DESCRIPTION
Signed-off-by: Raj <poojiraj@a07817a9866b.ant.amazon.com>

### Description
For profiler queries on multi-node clusters, we get a timing breakdown on a shard-by-shard basis regarding time spent in various sub parts of the query. However, this neglects the time spent on each shard query in transit over the network in the case of multi node clusters.

This PR resolves this by adding additional fields for each shard to get the time spent in transit over the network (in milliseconds).
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
