### PR TITLE
Minor fix for the flaky test to reduce concurrency (#1361)

### DIFF
--- a/server/src/test/java/org/opensearch/index/ShardIndexingPressureConcurrentExecutionTests.java
+++ b/server/src/test/java/org/opensearch/index/ShardIndexingPressureConcurrentExecutionTests.java
@@ -484,7 +484,7 @@ public class ShardIndexingPressureConcurrentExecutionTests extends OpenSearchTes
             .put(ShardIndexingPressureMemoryManager.THROUGHPUT_DEGRADATION_LIMITS.getKey(), 1)
             .put(ShardIndexingPressureSettings.REQUEST_SIZE_WINDOW.getKey(), 100)
             .build();
-        final int NUM_THREADS = scaledRandomIntBetween(100, 120);
+        final int NUM_THREADS = scaledRandomIntBetween(80, 100);
         ShardIndexingPressure shardIndexingPressure = new ShardIndexingPressure(settings, clusterService);
         Index index = new Index("IndexName", "UUID");
         ShardId shardId1 = new ShardId(index, 0);


### PR DESCRIPTION
Signed-off-by: Saurabh Singh <sisurab@amazon.com>

### Description
Fixes flakiness for test ``testReplicaThreadedThroughputDegradationAndRejection`` 
Reduced the number of threads concurrently executing from the initial range between (100-120) to a new range between (80-100), as the previous range was breaking the node limits set as 10kb, for every execution where number of threads were greater than 110. 
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/pull/1361
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
