### PR TITLE
Minor fix to disable shard indexing pressure when cluster service is not initialized

### DIFF
--- a/server/src/main/java/org/opensearch/index/ShardIndexingPressureSettings.java
+++ b/server/src/main/java/org/opensearch/index/ShardIndexingPressureSettings.java
@@ -78,9 +78,9 @@ public final class ShardIndexingPressureSettings {
     }
 
     public static boolean isShardIndexingPressureAttributeEnabled() {
-        // Null check is required only for bwc tests which start node without initializing cluster service.
-        // In actual run time, clusterService will never be null.
-        if (Objects.nonNull(clusterService) && clusterService.getClusterApplierService().isInitialClusterStateSet()) {
+        // Null check as some plugin tests appear to start node without initializing cluster service
+        if (Objects.isNull(clusterService)) return false;
+        if (clusterService.getClusterApplierService().isInitialClusterStateSet()) {
             Iterator<DiscoveryNode> nodes = clusterService.state().getNodes().getNodes().valuesIt();
             while (nodes.hasNext()) {
                 if (Boolean.parseBoolean(nodes.next().getAttributes().get(SHARD_INDEXING_PRESSURE_ENABLED_ATTRIBUTE_KEY)) == false) {


### PR DESCRIPTION
Signed-off-by: Robert Downs <downsrob@amazon.com>

This is a parallel change to https://github.com/opensearch-project/OpenSearch/pull/1375 on main to unblock Index Management, which currently consumes the OpenSearch 1.x branch.
### Description
[Some tests](https://github.com/opensearch-project/index-management/blob/main/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/MetadataRegressionIT.kt) for the [Index Management](https://github.com/opensearch-project/index-management) plugin were permanently failing due to changes introduced when adding shard level indexing pressure in [this PR](https://github.com/opensearch-project/OpenSearch/commit/11237da62fc8020b643d9f9d004a3e9de77a2f16). Plugins with integration tests extending from OpenSearchIntegTestCase seem to start a node without initializing the cluster service, the small change in this PR disables shard indexing pressure in that case, unblocking the Index Management tests. The Index Management test failures can be seen [here](https://github.com/opensearch-project/index-management/runs/3887582307?check_suite_focus=true).
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).