### PR TITLE
Update node-attribute check to explicit version check (v1.2) for SIP

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
@@ -33,6 +33,7 @@
 package org.opensearch.action.admin.cluster.node.stats;
 
 import org.opensearch.LegacyESVersion;
+import org.opensearch.Version;
 import org.opensearch.action.support.nodes.BaseNodeResponse;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
@@ -43,7 +44,6 @@ import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.discovery.DiscoveryStats;
 import org.opensearch.http.HttpStats;
-import org.opensearch.index.ShardIndexingPressureSettings;
 import org.opensearch.index.stats.IndexingPressureStats;
 import org.opensearch.index.stats.ShardIndexingPressureStats;
 import org.opensearch.indices.NodeIndicesStats;
@@ -152,7 +152,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         } else {
             indexingPressureStats = null;
         }
-        if (ShardIndexingPressureSettings.isShardIndexingPressureAttributeEnabled()) {
+        if (in.getVersion().onOrAfter(Version.V_1_2_0)) {
             shardIndexingPressureStats = in.readOptionalWriteable(ShardIndexingPressureStats::new);
         } else {
             shardIndexingPressureStats = null;
@@ -327,7 +327,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         if (out.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
             out.writeOptionalWriteable(indexingPressureStats);
         }
-        if (ShardIndexingPressureSettings.isShardIndexingPressureAttributeEnabled()) {
+        if (out.getVersion().onOrAfter(Version.V_1_2_0)) {
             out.writeOptionalWriteable(shardIndexingPressureStats);
         }
     }

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -33,10 +33,10 @@
 package org.opensearch.action.admin.indices.stats;
 
 import org.opensearch.LegacyESVersion;
+import org.opensearch.Version;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
-import org.opensearch.index.ShardIndexingPressureSettings;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -83,7 +83,7 @@ public class CommonStatsFlags implements Writeable, Cloneable {
         if (in.getVersion().onOrAfter(LegacyESVersion.V_7_2_0)) {
             includeUnloadedSegments = in.readBoolean();
         }
-        if (ShardIndexingPressureSettings.isShardIndexingPressureAttributeEnabled()) {
+        if (in.getVersion().onOrAfter(Version.V_1_2_0)) {
             includeAllShardIndexingPressureTrackers = in.readBoolean();
             includeOnlyTopIndexingPressureMetrics = in.readBoolean();
         }
@@ -105,7 +105,7 @@ public class CommonStatsFlags implements Writeable, Cloneable {
         if (out.getVersion().onOrAfter(LegacyESVersion.V_7_2_0)) {
             out.writeBoolean(includeUnloadedSegments);
         }
-        if (ShardIndexingPressureSettings.isShardIndexingPressureAttributeEnabled()) {
+        if (out.getVersion().onOrAfter(Version.V_1_2_0)) {
             out.writeBoolean(includeAllShardIndexingPressureTrackers);
             out.writeBoolean(includeOnlyTopIndexingPressureMetrics);
         }

--- a/server/src/main/java/org/opensearch/index/ShardIndexingPressureSettings.java
+++ b/server/src/main/java/org/opensearch/index/ShardIndexingPressureSettings.java
@@ -5,14 +5,10 @@
 
 package org.opensearch.index;
 
-import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
-
-import java.util.Iterator;
-import java.util.Objects;
 
 /**
  * This class contains all the settings which are required and owned by {TODO link ShardIndexingPressure}. These will be
@@ -54,10 +50,8 @@ public final class ShardIndexingPressureSettings {
     private volatile int requestSizeWindow;
     private volatile double shardMinLimit;
     private final long primaryAndCoordinatingNodeLimits;
-    private static ClusterService clusterService;
 
     public ShardIndexingPressureSettings(ClusterService clusterService, Settings settings, long primaryAndCoordinatingLimits) {
-        ShardIndexingPressureSettings.clusterService = clusterService;
         ClusterSettings clusterSettings = clusterService.getClusterSettings();
 
         this.shardIndexingPressureEnabled = SHARD_INDEXING_PRESSURE_ENABLED.get(settings);
@@ -75,20 +69,6 @@ public final class ShardIndexingPressureSettings {
         this.shardPrimaryAndCoordinatingBaseLimits = (long) (primaryAndCoordinatingLimits * shardMinLimit);
         this.shardReplicaBaseLimits = (long) (shardPrimaryAndCoordinatingBaseLimits * 1.5);
         clusterSettings.addSettingsUpdateConsumer(SHARD_MIN_LIMIT, this::setShardMinLimit);
-    }
-
-    public static boolean isShardIndexingPressureAttributeEnabled() {
-        // Null check is required only for bwc tests which start node without initializing cluster service.
-        // In actual run time, clusterService will never be null.
-        if (Objects.nonNull(clusterService) && clusterService.getClusterApplierService().isInitialClusterStateSet()) {
-            Iterator<DiscoveryNode> nodes = clusterService.state().getNodes().getNodes().valuesIt();
-            while (nodes.hasNext()) {
-                if (Boolean.parseBoolean(nodes.next().getAttributes().get(SHARD_INDEXING_PRESSURE_ENABLED_ATTRIBUTE_KEY)) == false) {
-                    return false;
-                }
-            }
-        }
-        return true;
     }
 
     private void setShardIndexingPressureEnabled(Boolean shardIndexingPressureEnableValue) {


### PR DESCRIPTION
Current implementation for Shard Indexing Pressure relies on the node level attribute ``shard_indexing_pressure_enabled`` (introduced as part of the feature) for serializng and de-serializing transport requests/responses during node to node communication. The node level attribute serves instrumental during ser-der of responses in homogeneous (where all nodes understand indexing pressure) and heterogeneous setup (where only few nodes understand indexing pressure) of clusters, irrespective of the exact version version check. This strategy eases out the backporting effort, if required to older versions in future, without having to change versions at multiple places. 

However, this node-attribute check also demands that all Integration Tests always initialize the Cluster Service appropriately while extending the  ``OpenSearchIntegTestCase``. Not doing so will result into default behaviour, where the new attributes are always present in the response and few existing tests will fail if unhandled.

**Note** : This change is required only to fix existing plugin tests, and not to mandate these test to have the cluster service initialized while asserting node attributes. This change does not affect any current functionality or does not changes any existing behaviour with the cluster coordination.

Signed-off-by: Saurabh Singh <sisurab@amazon.com>

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/pull/1375/files#
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
