### PR TITLE
[Backport] [1.x] [BUG] Fix org.opensearch.action.admin.cluster.node.stats.NodeStatsTests.testSerialization

### DIFF
--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -69,8 +69,7 @@ import java.util.stream.StreamSupport;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 public class NodeStatsTests extends OpenSearchTestCase {
     public void testSerialization() throws IOException {
@@ -180,8 +179,9 @@ public class NodeStatsTests extends OpenSearchTestCase {
                     final Map<String, JvmStats.MemoryPool> deserializedPools = StreamSupport.stream(deserializedMem.spliterator(), false)
                         .collect(Collectors.toMap(JvmStats.MemoryPool::getName, Function.identity()));
 
-                    assertThat(pools.keySet(), not(empty()));
-                    assertThat(deserializedPools.keySet(), not(empty()));
+                    final int poolsCount = (int) StreamSupport.stream(nodeStats.getJvm().getMem().spliterator(), false).count();
+                    assertThat(pools.keySet(), hasSize(poolsCount));
+                    assertThat(deserializedPools.keySet(), hasSize(poolsCount));
 
                     for (final Map.Entry<String, JvmStats.MemoryPool> entry : pools.entrySet()) {
                         assertThat(deserializedPools.containsKey(entry.getKey()), is(true));


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Backport of https://github.com/opensearch-project/OpenSearch/pull/1390 to 1.x
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/1389
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
