### PR TITLE
Add extension point for custom TranslogDeletionPolicy in EnginePlugin.

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
@@ -52,14 +52,13 @@ import org.opensearch.index.seqno.RetentionLeases;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.translog.TranslogConfig;
-import org.opensearch.index.translog.TranslogDeletionPolicy;
+import org.opensearch.index.translog.TranslogDeletionPolicyFactory;
 import org.opensearch.indices.IndexingMemoryController;
 import org.opensearch.indices.breaker.CircuitBreakerService;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.function.BiFunction;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
@@ -72,7 +71,7 @@ public final class EngineConfig {
     private final ShardId shardId;
     private final IndexSettings indexSettings;
     private final ByteSizeValue indexingBufferSize;
-    private final BiFunction<IndexSettings, Supplier<RetentionLeases>, TranslogDeletionPolicy> customTranslogDeletionPolicyFn;
+    private final TranslogDeletionPolicyFactory translogDeletionPolicyFactory;
     private volatile boolean enableGcDeletes = true;
     private final TimeValue flushMergesAfter;
     private final String codecName;
@@ -216,7 +215,7 @@ public final class EngineConfig {
         QueryCache queryCache,
         QueryCachingPolicy queryCachingPolicy,
         TranslogConfig translogConfig,
-        BiFunction<IndexSettings, Supplier<RetentionLeases>, TranslogDeletionPolicy> customTranslogDeletionPolicyFn,
+        TranslogDeletionPolicyFactory translogDeletionPolicyFactory,
         TimeValue flushMergesAfter,
         List<ReferenceManager.RefreshListener> externalRefreshListener,
         List<ReferenceManager.RefreshListener> internalRefreshListener,
@@ -255,7 +254,7 @@ public final class EngineConfig {
         this.queryCache = queryCache;
         this.queryCachingPolicy = queryCachingPolicy;
         this.translogConfig = translogConfig;
-        this.customTranslogDeletionPolicyFn = customTranslogDeletionPolicyFn;
+        this.translogDeletionPolicyFactory = translogDeletionPolicyFactory;
         this.flushMergesAfter = flushMergesAfter;
         this.externalRefreshListener = externalRefreshListener;
         this.internalRefreshListener = internalRefreshListener;
@@ -480,7 +479,7 @@ public final class EngineConfig {
         return tombstoneDocSupplier;
     }
 
-    public BiFunction<IndexSettings, Supplier<RetentionLeases>, TranslogDeletionPolicy> getCustomTranslogDeletionPolicyFn() {
-        return customTranslogDeletionPolicyFn;
+    public TranslogDeletionPolicyFactory getCustomTranslogDeletionPolicyFactory() {
+        return translogDeletionPolicyFactory;
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -226,9 +226,9 @@ public class InternalEngine extends Engine {
         }
         final TranslogDeletionPolicy translogDeletionPolicy;
         TranslogDeletionPolicy customTranslogDeletionPolicy = null;
-        if (engineConfig.getCustomTranslogDeletionPolicyFn() != null) {
-            customTranslogDeletionPolicy = engineConfig.getCustomTranslogDeletionPolicyFn()
-                .apply(engineConfig.getIndexSettings(), engineConfig.retentionLeasesSupplier());
+        if (engineConfig.getCustomTranslogDeletionPolicyFactory() != null) {
+            customTranslogDeletionPolicy = engineConfig.getCustomTranslogDeletionPolicyFactory()
+                .create(engineConfig.getIndexSettings(), engineConfig.retentionLeasesSupplier());
         }
         if (customTranslogDeletionPolicy != null) {
             translogDeletionPolicy = customTranslogDeletionPolicy;

--- a/server/src/main/java/org/opensearch/index/translog/TranslogDeletionPolicyFactory.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogDeletionPolicyFactory.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.translog;
+
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.seqno.RetentionLeases;
+
+import java.util.function.Supplier;
+
+@FunctionalInterface
+public interface TranslogDeletionPolicyFactory {
+    TranslogDeletionPolicy create(IndexSettings settings, Supplier<RetentionLeases> supplier);
+}

--- a/server/src/main/java/org/opensearch/plugins/EnginePlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/EnginePlugin.java
@@ -37,9 +37,9 @@ import org.opensearch.index.codec.CodecService;
 import org.opensearch.index.engine.EngineFactory;
 import org.opensearch.index.seqno.RetentionLeases;
 import org.opensearch.index.translog.TranslogDeletionPolicy;
+import org.opensearch.index.translog.TranslogDeletionPolicyFactory;
 
 import java.util.Optional;
-import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 /**
@@ -77,9 +77,7 @@ public interface EnginePlugin {
      *
      * @return a function that returns an instance of {@link TranslogDeletionPolicy}
      */
-    default
-        Optional<BiFunction<IndexSettings, Supplier<RetentionLeases>, TranslogDeletionPolicy>>
-        getCustomTranslogDeletionPolicyFunction() {
+    default Optional<TranslogDeletionPolicyFactory> getCustomTranslogDeletionPolicyFactory() {
         return Optional.empty();
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/EngineConfigFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/EngineConfigFactoryTests.java
@@ -16,6 +16,7 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.codec.CodecService;
 import org.opensearch.index.seqno.RetentionLeases;
 import org.opensearch.index.translog.TranslogDeletionPolicy;
+import org.opensearch.index.translog.TranslogDeletionPolicyFactory;
 import org.opensearch.plugins.EnginePlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.IndexSettingsModule;
@@ -25,7 +26,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 public class EngineConfigFactoryTests extends OpenSearchTestCase {
@@ -65,8 +65,8 @@ public class EngineConfigFactoryTests extends OpenSearchTestCase {
         );
 
         assertNotNull(config.getCodec());
-        assertNotNull(config.getCustomTranslogDeletionPolicyFn());
-        assertTrue(config.getCustomTranslogDeletionPolicyFn().apply(indexSettings, null) instanceof CustomTranslogDeletionPolicy);
+        assertNotNull(config.getCustomTranslogDeletionPolicyFactory());
+        assertTrue(config.getCustomTranslogDeletionPolicyFactory().create(indexSettings, null) instanceof CustomTranslogDeletionPolicy);
     }
 
     public void testCreateEngineConfigFromFactoryMultipleCodecServiceIllegalStateException() {
@@ -81,7 +81,7 @@ public class EngineConfigFactoryTests extends OpenSearchTestCase {
         expectThrows(IllegalStateException.class, () -> new EngineConfigFactory(plugins, indexSettings));
     }
 
-    public void testCreateEngineConfigFromFactoryMultipleCustomTranslogDeletionPolicyFnIllegalStateException() {
+    public void testCreateEngineConfigFromFactoryMultipleCustomTranslogDeletionPolicyFactoryIllegalStateException() {
         IndexMetadata meta = IndexMetadata.builder("test")
             .settings(settings(Version.CURRENT))
             .numberOfShards(1)
@@ -105,12 +105,8 @@ public class EngineConfigFactoryTests extends OpenSearchTestCase {
         }
 
         @Override
-        public
-            Optional<BiFunction<IndexSettings, Supplier<RetentionLeases>, TranslogDeletionPolicy>>
-            getCustomTranslogDeletionPolicyFunction() {
-            BiFunction<IndexSettings, Supplier<RetentionLeases>, TranslogDeletionPolicy> customTranslogDeletionPolicyFn =
-                CustomTranslogDeletionPolicy::new;
-            return Optional.of(customTranslogDeletionPolicyFn);
+        public Optional<TranslogDeletionPolicyFactory> getCustomTranslogDeletionPolicyFactory() {
+            return Optional.of(CustomTranslogDeletionPolicy::new);
         }
     }
 
@@ -133,12 +129,8 @@ public class EngineConfigFactoryTests extends OpenSearchTestCase {
         }
 
         @Override
-        public
-            Optional<BiFunction<IndexSettings, Supplier<RetentionLeases>, TranslogDeletionPolicy>>
-            getCustomTranslogDeletionPolicyFunction() {
-            BiFunction<IndexSettings, Supplier<RetentionLeases>, TranslogDeletionPolicy> customTranslogDeletionPolicyFn =
-                CustomTranslogDeletionPolicy::new;
-            return Optional.of(customTranslogDeletionPolicyFn);
+        public Optional<TranslogDeletionPolicyFactory> getCustomTranslogDeletionPolicyFactory() {
+            return Optional.of(CustomTranslogDeletionPolicy::new);
         }
     }
 

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -149,6 +149,7 @@ import org.opensearch.index.translog.TestTranslog;
 import org.opensearch.index.translog.Translog;
 import org.opensearch.index.translog.TranslogConfig;
 import org.opensearch.index.translog.TranslogDeletionPolicy;
+import org.opensearch.index.translog.TranslogDeletionPolicyFactory;
 import org.opensearch.indices.breaker.NoneCircuitBreakerService;
 import org.opensearch.test.IndexSettingsModule;
 import org.opensearch.test.VersionUtils;
@@ -3804,13 +3805,12 @@ public class InternalEngineTests extends EngineTestCase {
                 );
             }
         }
-        BiFunction<IndexSettings, Supplier<RetentionLeases>, TranslogDeletionPolicy> customTranslogDeletionPolicyFn =
-            CustomTranslogDeletionPolicy::new;
+        TranslogDeletionPolicyFactory translogDeletionPolicyFactory = CustomTranslogDeletionPolicy::new;
 
         try (Store store = createStore()) {
             EngineConfig config = engine.config();
 
-            EngineConfig configWithCustomTranslogDeletionPolicyFn = new EngineConfig(
+            EngineConfig configWithCustomTranslogDeletionPolicyFactory = new EngineConfig(
                 config.getShardId(),
                 config.getThreadPool(),
                 config.getIndexSettings(),
@@ -3824,7 +3824,7 @@ public class InternalEngineTests extends EngineTestCase {
                 config.getQueryCache(),
                 config.getQueryCachingPolicy(),
                 config.getTranslogConfig(),
-                customTranslogDeletionPolicyFn,
+                translogDeletionPolicyFactory,
                 config.getFlushMergesAfter(),
                 config.getExternalRefreshListener(),
                 config.getInternalRefreshListener(),
@@ -3835,7 +3835,7 @@ public class InternalEngineTests extends EngineTestCase {
                 config.getPrimaryTermSupplier(),
                 config.getTombstoneDocSupplier()
             );
-            try (InternalEngine engine = createEngine(configWithCustomTranslogDeletionPolicyFn)) {
+            try (InternalEngine engine = createEngine(configWithCustomTranslogDeletionPolicyFactory)) {
                 assertTrue(engine.getTranslog().getDeletionPolicy() instanceof CustomTranslogDeletionPolicy);
             }
         }


### PR DESCRIPTION
### Description
This change adds a method that can be used to provide a custom TranslogDeletionPolicy. ~~It also removes the deprecated settings for translog pruning based on retention leases.~~ The removal of deprecated settings and CCR specific logic will be done as part of a separate PR.
 
### Issues Resolved

Resolves #1260 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>