### PR TITLE
Run spotless and exclude checkstyle on `plugins/examples` module

### DIFF
--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -21,6 +21,8 @@
   <suppress files="server" checks="." />
   <!-- Excludes checkstyle run on client module -->
   <suppress files="client" checks="." />
+  <!-- Excludes checkstyle run on plugins/examples -->
+  <suppress files="plugins[/\\]examples" checks="." />
 
   <!--
     Truly temporary suppressions suppression of snippets included in

--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -57,13 +57,6 @@ import org.opensearch.gradle.BuildPlugin
 
 // Do not add new sub-projects here!
 def projectPathsToExclude = [
-  ':example-plugins:custom-settings',
-  ':example-plugins:custom-significance-heuristic',
-  ':example-plugins:custom-suggester',
-  ':example-plugins:painless-whitelist',
-  ':example-plugins:rescore',
-  ':example-plugins:rest-handler',
-  ':example-plugins:script-expert-scoring',
   ':libs:opensearch-cli',
   ':libs:opensearch-core',
   ':libs:opensearch-dissect',

--- a/plugins/examples/custom-settings/src/main/java/org/opensearch/example/customsettings/ExampleCustomSettingsConfig.java
+++ b/plugins/examples/custom-settings/src/main/java/org/opensearch/example/customsettings/ExampleCustomSettingsConfig.java
@@ -81,9 +81,12 @@ public class ExampleCustomSettingsConfig {
     /**
      * A setting that consists of a list of integers
      */
-    static final Setting<List<Integer>> LIST_SETTING =
-        Setting.listSetting("custom.list", Collections.emptyList(), Integer::valueOf, Property.NodeScope);
-
+    static final Setting<List<Integer>> LIST_SETTING = Setting.listSetting(
+        "custom.list",
+        Collections.emptyList(),
+        Integer::valueOf,
+        Property.NodeScope
+    );
 
     private final String simple;
     private final String validated;

--- a/plugins/examples/custom-settings/src/main/java/org/opensearch/example/customsettings/ExampleCustomSettingsPlugin.java
+++ b/plugins/examples/custom-settings/src/main/java/org/opensearch/example/customsettings/ExampleCustomSettingsPlugin.java
@@ -58,12 +58,14 @@ public class ExampleCustomSettingsPlugin extends Plugin {
      */
     @Override
     public List<Setting<?>> getSettings() {
-        return Arrays.asList(ExampleCustomSettingsConfig.SIMPLE_SETTING,
-                             ExampleCustomSettingsConfig.BOOLEAN_SETTING,
-                             ExampleCustomSettingsConfig.VALIDATED_SETTING,
-                             ExampleCustomSettingsConfig.FILTERED_SETTING,
-                             ExampleCustomSettingsConfig.SECURED_SETTING,
-                             ExampleCustomSettingsConfig.LIST_SETTING);
+        return Arrays.asList(
+            ExampleCustomSettingsConfig.SIMPLE_SETTING,
+            ExampleCustomSettingsConfig.BOOLEAN_SETTING,
+            ExampleCustomSettingsConfig.VALIDATED_SETTING,
+            ExampleCustomSettingsConfig.FILTERED_SETTING,
+            ExampleCustomSettingsConfig.SECURED_SETTING,
+            ExampleCustomSettingsConfig.LIST_SETTING
+        );
     }
 
     @Override

--- a/plugins/examples/custom-settings/src/test/java/org/opensearch/example/customsettings/ExampleCustomSettingsConfigTests.java
+++ b/plugins/examples/custom-settings/src/test/java/org/opensearch/example/customsettings/ExampleCustomSettingsConfigTests.java
@@ -50,8 +50,10 @@ public class ExampleCustomSettingsConfigTests extends OpenSearchTestCase {
         final String actual = VALIDATED_SETTING.get(Settings.builder().put(VALIDATED_SETTING.getKey(), expected).build());
         assertEquals(expected, actual);
 
-        final IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () ->
-            VALIDATED_SETTING.get(Settings.builder().put("custom.validated", "it's forbidden").build()));
+        final IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> VALIDATED_SETTING.get(Settings.builder().put("custom.validated", "it's forbidden").build())
+        );
         assertEquals("Setting must not contain [forbidden]", exception.getMessage());
     }
 }

--- a/plugins/examples/custom-significance-heuristic/src/main/java/org/opensearch/example/customsigheuristic/SimpleHeuristic.java
+++ b/plugins/examples/custom-significance-heuristic/src/main/java/org/opensearch/example/customsigheuristic/SimpleHeuristic.java
@@ -47,8 +47,7 @@ public class SimpleHeuristic extends SignificanceHeuristic {
     public static final String NAME = "simple";
     public static final ObjectParser<SimpleHeuristic, Void> PARSER = new ObjectParser<>(NAME, SimpleHeuristic::new);
 
-    public SimpleHeuristic() {
-    }
+    public SimpleHeuristic() {}
 
     /**
      * Read from a stream.

--- a/plugins/examples/custom-suggester/src/main/java/org/opensearch/example/customsuggester/CustomSuggester.java
+++ b/plugins/examples/custom-suggester/src/main/java/org/opensearch/example/customsuggester/CustomSuggester.java
@@ -49,20 +49,26 @@ public class CustomSuggester extends Suggester<CustomSuggestionContext> {
         String name,
         CustomSuggestionContext suggestion,
         IndexSearcher searcher,
-        CharsRefBuilder spare) throws IOException {
+        CharsRefBuilder spare
+    ) throws IOException {
 
         // create two suggestions with 12 and 123 appended
         CustomSuggestion response = emptySuggestion(name, suggestion, spare);
         CustomSuggestion.Entry entry = response.getEntries().get(0);
         String text = entry.getText().string();
 
-        String firstOption =
-            String.format(Locale.ROOT, "%s-%s-%s-%s", text, suggestion.getField(), suggestion.options.get("suffix"), "12");
+        String firstOption = String.format(Locale.ROOT, "%s-%s-%s-%s", text, suggestion.getField(), suggestion.options.get("suffix"), "12");
         CustomSuggestion.Entry.Option option12 = new CustomSuggestion.Entry.Option(new Text(firstOption), 0.9f, "option-dummy-value-1");
         entry.addOption(option12);
 
-        String secondOption =
-            String.format(Locale.ROOT, "%s-%s-%s-%s", text, suggestion.getField(), suggestion.options.get("suffix"), "123");
+        String secondOption = String.format(
+            Locale.ROOT,
+            "%s-%s-%s-%s",
+            text,
+            suggestion.getField(),
+            suggestion.options.get("suffix"),
+            "123"
+        );
         CustomSuggestion.Entry.Option option123 = new CustomSuggestion.Entry.Option(new Text(secondOption), 0.8f, "option-dummy-value-2");
         entry.addOption(option123);
 
@@ -70,8 +76,7 @@ public class CustomSuggester extends Suggester<CustomSuggestionContext> {
     }
 
     @Override
-    protected CustomSuggestion emptySuggestion(String name, CustomSuggestionContext suggestion,
-            CharsRefBuilder spare) throws IOException {
+    protected CustomSuggestion emptySuggestion(String name, CustomSuggestionContext suggestion, CharsRefBuilder spare) throws IOException {
         String text = suggestion.getText().utf8ToString();
         CustomSuggestion response = new CustomSuggestion(name, suggestion.getSize(), "suggestion-dummy-value");
         CustomSuggestion.Entry entry = new CustomSuggestion.Entry(new Text(text), 0, text.length(), "entry-dummy-value");

--- a/plugins/examples/custom-suggester/src/main/java/org/opensearch/example/customsuggester/CustomSuggestion.java
+++ b/plugins/examples/custom-suggester/src/main/java/org/opensearch/example/customsuggester/CustomSuggestion.java
@@ -169,13 +169,15 @@ public class CustomSuggestion extends Suggest.Suggestion<CustomSuggestion.Entry>
         public static class Option extends Suggest.Suggestion.Entry.Option {
 
             private static final ConstructingObjectParser<Option, Void> PARSER = new ConstructingObjectParser<>(
-                "CustomSuggestionObjectParser", true,
+                "CustomSuggestionObjectParser",
+                true,
                 args -> {
                     Text text = new Text((String) args[0]);
                     float score = (float) args[1];
                     String dummy = (String) args[2];
                     return new Option(text, score, dummy);
-                });
+                }
+            );
 
             static {
                 PARSER.declareString(constructorArg(), TEXT);

--- a/plugins/examples/custom-suggester/src/main/java/org/opensearch/example/customsuggester/CustomSuggestionBuilder.java
+++ b/plugins/examples/custom-suggester/src/main/java/org/opensearch/example/customsuggester/CustomSuggestionBuilder.java
@@ -119,8 +119,7 @@ public class CustomSuggestionBuilder extends SuggestionBuilder<CustomSuggestionB
                     suffix = parser.text();
                 }
             } else {
-                throw new ParsingException(parser.getTokenLocation(),
-                    "suggester[custom] doesn't support field [" + currentFieldName + "]");
+                throw new ParsingException(parser.getTokenLocation(), "suggester[custom] doesn't support field [" + currentFieldName + "]");
             }
         }
 

--- a/plugins/examples/painless-whitelist/src/main/java/org/opensearch/example/painlesswhitelist/ExampleWhitelistExtension.java
+++ b/plugins/examples/painless-whitelist/src/main/java/org/opensearch/example/painlesswhitelist/ExampleWhitelistExtension.java
@@ -53,16 +53,32 @@ public class ExampleWhitelistExtension implements PainlessExtension {
     public Map<ScriptContext<?>, List<Whitelist>> getContextWhitelists() {
         Map<String, WhitelistAnnotationParser> parsers = new HashMap<>(WhitelistAnnotationParser.BASE_ANNOTATION_PARSERS);
         parsers.put(ExamplePainlessAnnotation.NAME, ExampleWhitelistAnnotationParser.INSTANCE);
-        Whitelist classWhitelist =
-                WhitelistLoader.loadFromResourceFiles(ExampleWhitelistExtension.class, parsers, "example_whitelist.txt");
+        Whitelist classWhitelist = WhitelistLoader.loadFromResourceFiles(ExampleWhitelistExtension.class, parsers, "example_whitelist.txt");
 
         ExampleWhitelistedInstance ewi = new ExampleWhitelistedInstance(1);
-        WhitelistInstanceBinding addValue = new WhitelistInstanceBinding("example addValue", ewi,
-            "addValue", "int", Collections.singletonList("int"), Collections.emptyList());
-        WhitelistInstanceBinding getValue = new WhitelistInstanceBinding("example getValue", ewi,
-            "getValue", "int", Collections.emptyList(), Collections.emptyList());
-        Whitelist instanceWhitelist = new Whitelist(ewi.getClass().getClassLoader(), Collections.emptyList(),
-            Collections.emptyList(), Collections.emptyList(), Arrays.asList(addValue, getValue));
+        WhitelistInstanceBinding addValue = new WhitelistInstanceBinding(
+            "example addValue",
+            ewi,
+            "addValue",
+            "int",
+            Collections.singletonList("int"),
+            Collections.emptyList()
+        );
+        WhitelistInstanceBinding getValue = new WhitelistInstanceBinding(
+            "example getValue",
+            ewi,
+            "getValue",
+            "int",
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+        Whitelist instanceWhitelist = new Whitelist(
+            ewi.getClass().getClassLoader(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Arrays.asList(addValue, getValue)
+        );
 
         return Collections.singletonMap(FieldScript.CONTEXT, Arrays.asList(classWhitelist, instanceWhitelist));
     }

--- a/plugins/examples/painless-whitelist/src/yamlRestTest/java/org/opensearch/example/painlesswhitelist/PainlessWhitelistClientYamlTestSuiteIT.java
+++ b/plugins/examples/painless-whitelist/src/yamlRestTest/java/org/opensearch/example/painlesswhitelist/PainlessWhitelistClientYamlTestSuiteIT.java
@@ -48,4 +48,3 @@ public class PainlessWhitelistClientYamlTestSuiteIT extends OpenSearchClientYaml
         return OpenSearchClientYamlSuiteTestCase.createParameters();
     }
 }
-

--- a/plugins/examples/rescore/src/main/java/org/opensearch/example/rescore/ExampleRescoreBuilder.java
+++ b/plugins/examples/rescore/src/main/java/org/opensearch/example/rescore/ExampleRescoreBuilder.java
@@ -101,6 +101,7 @@ public class ExampleRescoreBuilder extends RescorerBuilder<ExampleRescoreBuilder
 
     private static final ParseField FACTOR = new ParseField("factor");
     private static final ParseField FACTOR_FIELD = new ParseField("factor_field");
+
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.field(FACTOR.getPreferredName(), factor);
@@ -109,20 +110,22 @@ public class ExampleRescoreBuilder extends RescorerBuilder<ExampleRescoreBuilder
         }
     }
 
-    private static final ConstructingObjectParser<ExampleRescoreBuilder, Void> PARSER = new ConstructingObjectParser<>(NAME,
-            args -> new ExampleRescoreBuilder((float) args[0], (String) args[1]));
+    private static final ConstructingObjectParser<ExampleRescoreBuilder, Void> PARSER = new ConstructingObjectParser<>(
+        NAME,
+        args -> new ExampleRescoreBuilder((float) args[0], (String) args[1])
+    );
     static {
         PARSER.declareFloat(constructorArg(), FACTOR);
         PARSER.declareString(optionalConstructorArg(), FACTOR_FIELD);
     }
+
     public static ExampleRescoreBuilder fromXContent(XContentParser parser) {
         return PARSER.apply(parser, null);
     }
 
     @Override
     public RescoreContext innerBuildContext(int windowSize, QueryShardContext context) throws IOException {
-        IndexFieldData<?> factorField =
-                this.factorField == null ? null : context.getForField(context.fieldMapper(this.factorField));
+        IndexFieldData<?> factorField = this.factorField == null ? null : context.getForField(context.fieldMapper(this.factorField));
         return new ExampleRescoreContext(windowSize, factor, factorField);
     }
 
@@ -132,8 +135,7 @@ public class ExampleRescoreBuilder extends RescorerBuilder<ExampleRescoreBuilder
             return false;
         }
         ExampleRescoreBuilder other = (ExampleRescoreBuilder) obj;
-        return factor == other.factor
-                && Objects.equals(factorField, other.factorField);
+        return factor == other.factor && Objects.equals(factorField, other.factorField);
     }
 
     @Override
@@ -203,12 +205,22 @@ public class ExampleRescoreBuilder extends RescorerBuilder<ExampleRescoreBuilder
                         data = ((LeafNumericFieldData) fd).getDoubleValues();
                     }
                     if (false == data.advanceExact(topDocs.scoreDocs[i].doc - leaf.docBase)) {
-                        throw new IllegalArgumentException("document [" + topDocs.scoreDocs[i].doc
-                                + "] does not have the field [" + context.factorField.getFieldName() + "]");
+                        throw new IllegalArgumentException(
+                            "document ["
+                                + topDocs.scoreDocs[i].doc
+                                + "] does not have the field ["
+                                + context.factorField.getFieldName()
+                                + "]"
+                        );
                     }
                     if (data.docValueCount() > 1) {
-                        throw new IllegalArgumentException("document [" + topDocs.scoreDocs[i].doc
-                                + "] has more than one value for [" + context.factorField.getFieldName() + "]");
+                        throw new IllegalArgumentException(
+                            "document ["
+                                + topDocs.scoreDocs[i].doc
+                                + "] has more than one value for ["
+                                + context.factorField.getFieldName()
+                                + "]"
+                        );
                     }
                     topDocs.scoreDocs[i].score *= data.nextValue();
                 }
@@ -228,8 +240,8 @@ public class ExampleRescoreBuilder extends RescorerBuilder<ExampleRescoreBuilder
         }
 
         @Override
-        public Explanation explain(int topLevelDocId, IndexSearcher searcher, RescoreContext rescoreContext,
-                Explanation sourceExplanation) throws IOException {
+        public Explanation explain(int topLevelDocId, IndexSearcher searcher, RescoreContext rescoreContext, Explanation sourceExplanation)
+            throws IOException {
             ExampleRescoreContext context = (ExampleRescoreContext) rescoreContext;
             // Note that this is inaccurate because it ignores factor field
             return Explanation.match(context.factor, "test", singletonList(sourceExplanation));

--- a/plugins/examples/rescore/src/main/java/org/opensearch/example/rescore/ExampleRescorePlugin.java
+++ b/plugins/examples/rescore/src/main/java/org/opensearch/example/rescore/ExampleRescorePlugin.java
@@ -43,6 +43,7 @@ public class ExampleRescorePlugin extends Plugin implements SearchPlugin {
     @Override
     public List<RescorerSpec<?>> getRescorers() {
         return singletonList(
-                new RescorerSpec<>(ExampleRescoreBuilder.NAME, ExampleRescoreBuilder::new, ExampleRescoreBuilder::fromXContent));
+            new RescorerSpec<>(ExampleRescoreBuilder.NAME, ExampleRescoreBuilder::new, ExampleRescoreBuilder::fromXContent)
+        );
     }
 }

--- a/plugins/examples/rescore/src/test/java/org/opensearch/example/rescore/ExampleRescoreBuilderTests.java
+++ b/plugins/examples/rescore/src/test/java/org/opensearch/example/rescore/ExampleRescoreBuilderTests.java
@@ -59,14 +59,16 @@ public class ExampleRescoreBuilderTests extends AbstractWireSerializingTestCase<
     protected ExampleRescoreBuilder mutateInstance(ExampleRescoreBuilder instance) throws IOException {
         @SuppressWarnings("unchecked")
         Supplier<ExampleRescoreBuilder> supplier = randomFrom(
-                () -> new ExampleRescoreBuilder(instance.factor(), instance.factorField())
-                        .windowSize(randomValueOtherThan(instance.windowSize(), () -> between(0, Integer.MAX_VALUE))),
-                () -> new ExampleRescoreBuilder(
-                    randomValueOtherThan(instance.factor(), OpenSearchTestCase::randomFloat), instance.factorField())
-                        .windowSize(instance.windowSize()),
-                () -> new ExampleRescoreBuilder(
-                            instance.factor(), randomValueOtherThan(instance.factorField(), () -> randomAlphaOfLength(5)))
-                        .windowSize(instance.windowSize()));
+            () -> new ExampleRescoreBuilder(instance.factor(), instance.factorField()).windowSize(
+                randomValueOtherThan(instance.windowSize(), () -> between(0, Integer.MAX_VALUE))
+            ),
+            () -> new ExampleRescoreBuilder(
+                randomValueOtherThan(instance.factor(), OpenSearchTestCase::randomFloat),
+                instance.factorField()
+            ).windowSize(instance.windowSize()),
+            () -> new ExampleRescoreBuilder(instance.factor(), randomValueOtherThan(instance.factorField(), () -> randomAlphaOfLength(5)))
+                .windowSize(instance.windowSize())
+        );
 
         return supplier.get();
     }

--- a/plugins/examples/rescore/src/yamlRestTest/java/org/opensearch/example/rescore/ExampleRescoreClientYamlTestSuiteIT.java
+++ b/plugins/examples/rescore/src/yamlRestTest/java/org/opensearch/example/rescore/ExampleRescoreClientYamlTestSuiteIT.java
@@ -48,4 +48,3 @@ public class ExampleRescoreClientYamlTestSuiteIT extends OpenSearchClientYamlSui
         return OpenSearchClientYamlSuiteTestCase.createParameters();
     }
 }
-

--- a/plugins/examples/rest-handler/src/main/java/org/opensearch/example/resthandler/ExampleCatAction.java
+++ b/plugins/examples/rest-handler/src/main/java/org/opensearch/example/resthandler/ExampleCatAction.java
@@ -52,9 +52,7 @@ public class ExampleCatAction extends AbstractCatAction {
 
     @Override
     public List<Route> routes() {
-        return unmodifiableList(asList(
-            new Route(GET, "/_cat/example"),
-            new Route(POST, "/_cat/example")));
+        return unmodifiableList(asList(new Route(GET, "/_cat/example"), new Route(POST, "/_cat/example")));
     }
 
     @Override

--- a/plugins/examples/rest-handler/src/main/java/org/opensearch/example/resthandler/ExampleRestHandlerPlugin.java
+++ b/plugins/examples/rest-handler/src/main/java/org/opensearch/example/resthandler/ExampleRestHandlerPlugin.java
@@ -51,13 +51,15 @@ import static java.util.Collections.singletonList;
 public class ExampleRestHandlerPlugin extends Plugin implements ActionPlugin {
 
     @Override
-    public List<RestHandler> getRestHandlers(final Settings settings,
-                                             final RestController restController,
-                                             final ClusterSettings clusterSettings,
-                                             final IndexScopedSettings indexScopedSettings,
-                                             final SettingsFilter settingsFilter,
-                                             final IndexNameExpressionResolver indexNameExpressionResolver,
-                                             final Supplier<DiscoveryNodes> nodesInCluster) {
+    public List<RestHandler> getRestHandlers(
+        final Settings settings,
+        final RestController restController,
+        final ClusterSettings clusterSettings,
+        final IndexScopedSettings indexScopedSettings,
+        final SettingsFilter settingsFilter,
+        final IndexNameExpressionResolver indexNameExpressionResolver,
+        final Supplier<DiscoveryNodes> nodesInCluster
+    ) {
 
         return singletonList(new ExampleCatAction());
     }

--- a/plugins/examples/script-expert-scoring/src/main/java/org/opensearch/example/expertscript/ExpertScriptPlugin.java
+++ b/plugins/examples/script-expert-scoring/src/main/java/org/opensearch/example/expertscript/ExpertScriptPlugin.java
@@ -59,10 +59,7 @@ import java.util.Set;
 public class ExpertScriptPlugin extends Plugin implements ScriptPlugin {
 
     @Override
-    public ScriptEngine getScriptEngine(
-        Settings settings,
-        Collection<ScriptContext<?>> contexts
-    ) {
+    public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
         return new MyExpertScriptEngine();
     }
 

--- a/plugins/examples/script-expert-scoring/src/yamlRestTest/java/org/opensearch/example/expertscript/ExpertScriptClientYamlTestSuiteIT.java
+++ b/plugins/examples/script-expert-scoring/src/yamlRestTest/java/org/opensearch/example/expertscript/ExpertScriptClientYamlTestSuiteIT.java
@@ -48,4 +48,3 @@ public class ExpertScriptClientYamlTestSuiteIT extends OpenSearchClientYamlSuite
         return OpenSearchClientYamlSuiteTestCase.createParameters();
     }
 }
-


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Applied Spotless to plugins/examples module and excluded it from CheckStyle.
 
### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/1362 and https://github.com/opensearch-project/OpenSearch/issues/974
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
