### PR TITLE
Adjust CodeCache size to eliminate JVM warnings (and crashes)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ systemProp.org.gradle.warning.mode=fail
 systemProp.jdk.tls.client.protocols=TLSv1.2
 
 # jvm args for faster test execution by default
-systemProp.tests.jvm.argline=-XX:TieredStopAtLevel=1
+systemProp.tests.jvm.argline=-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
During the build, there are JVM warnings popping up from time to time:

```
[24.554s][warning][codecache] CodeCache is full. Compiler has been disabled.
OpenJDK 64-Bit Server VM warning: Try increasing the code cache size using -XX:ReservedCodeCacheSize=
[24.554s][warning][codecache] Try increasing the code cache size using -XX:ReservedCodeCacheSize=
CodeCache: size=49152Kb used=49151Kb max_used=49151Kb free=0K
```

Also, a very rare crashes are observed (first seen in https://github.com/opensearch-project/OpenSearch/pull/1408, related to https://bugs.openjdk.java.net/browse/JDK-8248519):

```
Caused by:
                    java.lang.VirtualMachineError: Out of space in CodeCache for method handle intrinsic
                        at java.base/java.lang.invoke.MethodHandleNatives.resolve(Native Method)
                        ... 28 more
```

The suggested fix is to increase CodeCache size a bit (from 48m to 64m). 
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
