### PR TITLE
Recommend Docker 3.6.0 on Windows

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -79,7 +79,7 @@ On Windows, set `_JAVA_OPTIONS: -Xmx4096M`. You may also need to set `LongPathsE
 
 Download and install [Docker](https://docs.docker.com/install/), required for building OpenSearch artifacts, and executing certain test suites.
 
-On Windows, uncheck support for Hyper-V during installation, run `"C:\Program Files\Docker\Docker\DockerCli.exe" -SwitchDaemon` to fix the ` In the default daemon configuration on Windows, the docker client must be run with elevated privileges to connect.` error, run Docker Desktop once, review and accept license agreement, and ensure that the Docker daemon is running.
+On Windows, [use Docker Desktop 3.6](https://docs.docker.com/desktop/windows/release-notes/3.x/). See [OpenSearch#1425](https://github.com/opensearch-project/OpenSearch/issues/1425) for workarounds and issues with Docker Desktop 4.1.1.
 
 ### Run Tests
 


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

On my Windows VM (Windows_Server-2019-English-Full-Base-2021.10.13 AMI) I cannot get Docker 3.6.0 nor 4.1.1 to work fully, but @reta reports Docker 3.6.0 to work properly [here](https://github.com/opensearch-project/OpenSearch/pull/1412#issuecomment-949692095), so let's recommend that. 
 
### Issues Resolved

Related to #1379.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
