### PR TITLE
[Backport] [1.x] Adjust CodeCache size to eliminate JVM warnings (and crashes) (#1426)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ systemProp.org.gradle.warning.mode=fail
 systemProp.jdk.tls.client.protocols=TLSv1.2
 
 # jvm args for faster test execution by default
-systemProp.tests.jvm.argline=-XX:TieredStopAtLevel=1
+systemProp.tests.jvm.argline=-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Backport of https://github.com/opensearch-project/OpenSearch/pull/1426
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
