### PR TITLE
 [BUG] SymbolicLinkPreservingUntarTransform fails on Windows

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -16,6 +16,8 @@ import org.opensearch.gradle.VersionProperties
 import org.opensearch.gradle.docker.DockerBuildTask
 import org.opensearch.gradle.info.BuildParams
 import org.opensearch.gradle.testfixtures.TestFixturesPlugin
+import org.gradle.internal.os.OperatingSystem
+
 apply plugin: 'opensearch.standalone-rest-test'
 apply plugin: 'opensearch.test.fixtures'
 apply plugin: 'opensearch.internal-distribution-download'
@@ -183,7 +185,7 @@ void addBuildDockerImage(Architecture architecture, DockerBase base) {
 
   final TaskProvider<DockerBuildTask> buildDockerImageTask =
           tasks.register(taskName("build", architecture, base, "DockerImage"), DockerBuildTask) {
-    onlyIf { Architecture.current() == architecture }
+    onlyIf { Architecture.current() == architecture && !OperatingSystem.current().isWindows() }
     TaskProvider<Sync> copyContextTask = tasks.named(taskName("copy", architecture, base, "DockerContext"))
     dependsOn(copyContextTask)
     dockerContext.fileProvider(copyContextTask.map { it.destinationDir })
@@ -246,7 +248,7 @@ subprojects { Project subProject ->
         "opensearch:test"
 
       dependsOn(parent.path + ":" + buildTaskName)
-      onlyIf { Architecture.current() == architecture }
+      onlyIf { Architecture.current() == architecture && !OperatingSystem.current().isWindows()}
     }
 
     artifacts.add('default', file(tarFile)) {


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
When building distribution on Windows, the `./gradle assemble` task fails on attempt to build Linux/MacOS distributions. The cause was identified (see please https://github.com/opensearch-project/OpenSearch/issues/1430) and after discussion with @dblock , we have concluded that the best plan for action in this case is to build only Windows distributions on Windows platform. 

The Docker images building task is also impacted since it reuses the Linux-based distributions in order to prepare the images. Since those are not built anymore on Windows, its execution becomes conditional.

```
$  ./gradlew assemble
...

Skipping task linuxArm64Tar since it does not match current OS platform
Skipping task linuxTar since it does not match current OS platform
Skipping task darwinTar since it does not match current OS platform
Skipping task darwinTar since it does not match current OS platform
Skipping task freebsdTar since it does not match current OS platform
Skipping task freebsdTar since it does not match current OS platform
Skipping task linuxArm64Tar since it does not match current OS platform
Skipping task linuxTar since it does not match current OS platform
Skipping task noJdkDarwinTar since it does not match current OS platform
Skipping task noJdkDarwinTar since it does not match current OS platform
Skipping task noJdkFreebsdTar since it does not match current OS platform
Skipping task noJdkFreebsdTar since it does not match current OS platform
Skipping task noJdkLinuxTar since it does not match current OS platform
Skipping task noJdkLinuxTar since it does not match current OS platform

...

BUILD SUCCESSFUL in 2m 40s
782 actionable tasks: 781 executed, 1 up-to-date
```
 
### Issues Resolved
Fixes https://github.com/opensearch-project/OpenSearch/issues/1430
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
