### PR TITLE
Added logic to allow {dot} files on startup

### DIFF
--- a/qa/no-bootstrap-tests/src/test/java/org/opensearch/bootstrap/SpawnerNoBootstrapTests.java
+++ b/qa/no-bootstrap-tests/src/test/java/org/opensearch/bootstrap/SpawnerNoBootstrapTests.java
@@ -215,33 +215,6 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
                 equalTo("module [test_plugin] does not have permission to fork native controller"));
     }
 
-    public void testSpawnerHandlingOfDesktopServicesStoreFiles() throws IOException {
-        final Path esHome = createTempDir().resolve("home");
-        final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), esHome.toString()).build();
-
-        final Environment environment = TestEnvironment.newEnvironment(settings);
-
-        Files.createDirectories(environment.modulesFile());
-        Files.createDirectories(environment.pluginsFile());
-
-        final Path desktopServicesStore = environment.modulesFile().resolve(".DS_Store");
-        Files.createFile(desktopServicesStore);
-
-        final Spawner spawner = new Spawner();
-        if (Constants.MAC_OS_X) {
-            // if the spawner were not skipping the Desktop Services Store files on macOS this would explode
-            spawner.spawnNativeControllers(environment, false);
-        } else {
-            // we do not ignore these files on non-macOS systems
-            final FileSystemException e = expectThrows(FileSystemException.class, () -> spawner.spawnNativeControllers(environment, false));
-            if (Constants.WINDOWS) {
-                assertThat(e, instanceOf(NoSuchFileException.class));
-            } else {
-                assertThat(e, hasToString(containsString("Not a directory")));
-            }
-        }
-    }
-
     private void createControllerProgram(final Path outputFile) throws IOException {
         final Path outputDir = outputFile.getParent();
         Files.createDirectories(outputDir);

--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -50,7 +50,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.component.LifecycleComponent;
 import org.opensearch.common.inject.Module;
-import org.opensearch.common.io.FileSystemUtils;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
@@ -365,13 +364,9 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         if (Files.exists(rootPath)) {
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(rootPath)) {
                 for (Path plugin : stream) {
-                    if (FileSystemUtils.isDesktopServicesStore(plugin)
-                        || plugin.getFileName().toString().startsWith(".removing-")
-                        || plugin.getFileName().toString().startsWith(".")
-                            && !Files.isDirectory(plugin)
-                            && !plugin.getFileName().toString().equals(".DS_Store")) {
+                    if (plugin.getFileName().toString().startsWith(".") && !Files.isDirectory(plugin)) {
                         logger.warn(
-                            "WARNING: Non-plugin file located in the plugins folder with the following name: " + plugin.getFileName()
+                            "Non-plugin file located in the plugins folder with the following name: [" + plugin.getFileName() + "]"
                         );
                         continue;
                     }

--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -365,7 +365,14 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         if (Files.exists(rootPath)) {
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(rootPath)) {
                 for (Path plugin : stream) {
-                    if (FileSystemUtils.isDesktopServicesStore(plugin) || plugin.getFileName().toString().startsWith(".removing-")) {
+                    if (FileSystemUtils.isDesktopServicesStore(plugin)
+                        || plugin.getFileName().toString().startsWith(".removing-")
+                        || plugin.getFileName().toString().startsWith(".")
+                            && !Files.isDirectory(plugin)
+                            && !plugin.getFileName().toString().equals(".DS_Store")) {
+                        logger.warn(
+                            "WARNING: Non-plugin file located in the plugins folder with the following name: " + plugin.getFileName()
+                        );
                         continue;
                     }
                     if (seen.add(plugin.getFileName().toString()) == false) {
@@ -432,15 +439,8 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
     private static Set<Bundle> findBundles(final Path directory, String type) throws IOException {
         final Set<Bundle> bundles = new HashSet<>();
         for (final Path plugin : findPluginDirs(directory)) {
-            final String pluginFileName = plugin.getFileName().toString();
-            final boolean isHiddenFile = !pluginFileName.isEmpty()
-                && pluginFileName.charAt(0) == '.'
-                && !pluginFileName.equals(".DS_Store")
-                && !Files.isDirectory(plugin);
-            if (!isHiddenFile) {
-                final Bundle bundle = readPluginBundle(bundles, plugin, type);
-                bundles.add(bundle);
-            }
+            final Bundle bundle = readPluginBundle(bundles, plugin, type);
+            bundles.add(bundle);
         }
 
         return bundles;

--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -432,8 +432,15 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
     private static Set<Bundle> findBundles(final Path directory, String type) throws IOException {
         final Set<Bundle> bundles = new HashSet<>();
         for (final Path plugin : findPluginDirs(directory)) {
-            final Bundle bundle = readPluginBundle(bundles, plugin, type);
-            bundles.add(bundle);
+            final String pluginFileName = plugin.getFileName().toString();
+            final boolean isHiddenFile = !pluginFileName.isEmpty()
+                && pluginFileName.charAt(0) == '.'
+                && !pluginFileName.equals(".DS_Store")
+                && !Files.isDirectory(plugin);
+            if (!isHiddenFile) {
+                final Bundle bundle = readPluginBundle(bundles, plugin, type);
+                bundles.add(bundle);
+            }
         }
 
         return bundles;

--- a/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
@@ -32,7 +32,10 @@
 
 package org.opensearch.plugins;
 
+import org.opensearch.common.logging.Loggers;
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.LuceneTestCase;
 import org.opensearch.LegacyESVersion;
@@ -44,6 +47,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
 import org.opensearch.env.TestEnvironment;
 import org.opensearch.index.IndexModule;
+import org.opensearch.test.MockLogAppender;
 import org.opensearch.test.OpenSearchTestCase;
 import org.hamcrest.Matchers;
 
@@ -51,9 +55,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
-import java.nio.file.FileSystemException;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
@@ -163,38 +165,6 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         final IllegalStateException e = expectThrows(IllegalStateException.class, () -> newPluginsService(settings));
         final String expected = "Could not load plugin descriptor for plugin directory [.hidden]";
         assertThat(e, hasToString(containsString(expected)));
-    }
-
-    public void testDesktopServicesStoreFiles() throws IOException {
-        final Path home = createTempDir();
-        final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), home).build();
-        final Path plugins = home.resolve("plugins");
-        Files.createDirectories(plugins);
-        final Path desktopServicesStore = plugins.resolve(".DS_Store");
-        Files.createFile(desktopServicesStore);
-        if (Constants.MAC_OS_X) {
-            @SuppressWarnings("unchecked")
-            final PluginsService pluginsService = newPluginsService(settings);
-            assertNotNull(pluginsService);
-        } else {
-            final IllegalStateException e = expectThrows(IllegalStateException.class, () -> newPluginsService(settings));
-            assertThat(e.getMessage(), containsString("Could not load plugin descriptor for plugin directory [.DS_Store]"));
-            assertNotNull(e.getCause());
-            assertThat(e.getCause(), instanceOf(FileSystemException.class));
-            if (Constants.WINDOWS) {
-                assertThat(e.getCause(), instanceOf(NoSuchFileException.class));
-            } else {
-                // force a "Not a directory" exception to be thrown so that we can extract the locale-dependent message
-                final String expected;
-                try (InputStream ignored = Files.newInputStream(desktopServicesStore.resolve("not-a-directory"))) {
-                    throw new AssertionError();
-                } catch (final FileSystemException inner) {
-                    // locale-dependent translation of "Not a directory"
-                    expected = inner.getReason();
-                }
-                assertThat(e.getCause(), hasToString(containsString(expected)));
-            }
-        }
     }
 
     public void testStartupWithRemovingMarker() throws IOException {
@@ -764,11 +734,24 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         assertThat(e.getMessage(), containsString("my_plugin requires Java"));
     }
 
-    public void testFindPluginDirs() throws IOException {
+    public void testFindPluginDirs() throws Exception {
         final Path plugins = createTempDir();
 
+        final MockLogAppender mockLogAppender = new MockLogAppender();
+        mockLogAppender.start();
+        mockLogAppender.addExpectation(
+            new MockLogAppender.SeenEventExpectation(
+                "[.test] warning",
+                "org.opensearch.plugins.PluginsService",
+                Level.WARN,
+                "Non-plugin file located in the plugins folder with the following name: [.DS_Store]"
+            )
+        );
+        final Logger testLogger = LogManager.getLogger(PluginsService.class);
+        Loggers.addAppender(testLogger, mockLogAppender);
+
         final Path fake = plugins.resolve("fake");
-        Path testFile = plugins.resolve(".test");
+        Path testFile = plugins.resolve(".DS_Store");
         Files.createFile(testFile);
 
         PluginTestUtil.writePluginProperties(
@@ -792,6 +775,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         }
 
         assertThat(PluginsService.findPluginDirs(plugins), containsInAnyOrder(fake));
+        mockLogAppender.assertAllExpectationsMatched();
     }
 
     public void testExistingMandatoryClasspathPlugin() {

--- a/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
@@ -768,6 +768,8 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         final Path plugins = createTempDir();
 
         final Path fake = plugins.resolve("fake");
+        Path testFile = plugins.resolve(".test");
+        Files.createFile(testFile);
 
         PluginTestUtil.writePluginProperties(
             fake,

--- a/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
@@ -154,14 +154,13 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         assertEquals(FilterablePlugin.class, scriptPlugins.get(0).getClass());
     }
 
-    public void testHiddenFiles() throws IOException {
+    public void testHiddenDirectories() throws IOException {
         final Path home = createTempDir();
         final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), home).build();
         final Path hidden = home.resolve("plugins").resolve(".hidden");
         Files.createDirectories(hidden);
         @SuppressWarnings("unchecked")
         final IllegalStateException e = expectThrows(IllegalStateException.class, () -> newPluginsService(settings));
-
         final String expected = "Could not load plugin descriptor for plugin directory [.hidden]";
         assertThat(e, hasToString(containsString(expected)));
     }


### PR DESCRIPTION
Signed-off-by: Ryan Bogan <rbogan@amazon.com>

### Description
Fixes a bug that would not allow OpenSearch to run when a {dot} file (i.e. ".test") was present in the plugins folder.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/626
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
