### PR TITLE
Fixing bwc test for repository-multi-version

### DIFF
--- a/qa/repository-multi-version/build.gradle
+++ b/qa/repository-multi-version/build.gradle
@@ -76,16 +76,28 @@ for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
     systemProperty 'tests.rest.suite', 'step2'
   }
 
-  tasks.register("${baseName}#Step3OldClusterTest", StandaloneRestIntegTestTask) {
+  // Step 3 and Step 4 registered for versions for OpenSearch 
+  // since the ES cluster would not be able to read snapshots from OpenSearch cluster in Step 3.
+  if (bwcVersion.after('7.10.2')) {
+    tasks.register("${baseName}#Step3OldClusterTest", StandaloneRestIntegTestTask) {
     useCluster testClusters."${oldClusterName}"
     dependsOn "${baseName}#Step2NewClusterTest"
     systemProperty 'tests.rest.suite', 'step3'
   }
 
-  tasks.register("${baseName}#Step4NewClusterTest", StandaloneRestIntegTestTask) {
-    useCluster testClusters."${newClusterName}"
-    dependsOn "${baseName}#Step3OldClusterTest"
-    systemProperty 'tests.rest.suite', 'step4'
+    tasks.register("${baseName}#Step4NewClusterTest", StandaloneRestIntegTestTask) {
+      useCluster testClusters."${newClusterName}"
+      dependsOn "${baseName}#Step3OldClusterTest"
+      systemProperty 'tests.rest.suite', 'step4'
+    }
+
+    tasks.register(bwcTaskName(bwcVersion)) {
+      dependsOn tasks.named("${baseName}#Step4NewClusterTest")
+    }
+  } else {
+    tasks.register(bwcTaskName(bwcVersion)) {
+      dependsOn tasks.named("${baseName}#Step2NewClusterTest")
+    }
   }
 
   tasks.matching { it.name.startsWith(baseName) && it.name.endsWith("ClusterTest") }.configureEach {
@@ -94,10 +106,6 @@ for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
     def clusterName = it.name.contains("Step2") || it.name.contains("Step4") ? "${newClusterName}" : "${oldClusterName}"
     it.nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${clusterName}".allHttpSocketURI.join(",")}")
     it.nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${clusterName}".getName()}")
-  }
-
-  tasks.register(bwcTaskName(bwcVersion)) {
-    dependsOn tasks.named("${baseName}#Step4NewClusterTest")
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Vacha <vachshah@amazon.com>

### Description
The repository-multi-version tests for Elasticsearch version 7.10.2 fail at Step 3 where the old Elasticsearch cluster tries to read snapshots from the OpenSearch Cluster and fails for reading the version when trying to parse the repository metadata. Step 3 works fine between OpenSearch versions but would not work for ElasticSearch cluster. Modifying the `build.gradle` according to this.
 
### Issues Resolved
#919 
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
