### PR TITLE
Fixing support for a multi-node cluster via "gradle run"

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchCluster.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchCluster.java
@@ -103,10 +103,9 @@ public class OpenSearchCluster implements TestClusterConfiguration, Named {
         this.nodes = project.container(OpenSearchNode.class);
         this.bwcJdk = bwcJdk;
 
-        this.nodes.add(
-            new OpenSearchNode(path, clusterName + "-0", project, reaper, fileSystemOperations, archiveOperations, workingDirBase, bwcJdk)
-        );
-        // configure the cluster name eagerly so nodes know about it
+        // Always add the first node
+        addNode(clusterName + "-0");
+        // configure the cluster name eagerly so all nodes know about it
         this.nodes.all((node) -> node.defaultConfig.put("cluster.name", safeName(clusterName)));
 
         addWaitForClusterHealth();
@@ -126,19 +125,24 @@ public class OpenSearchCluster implements TestClusterConfiguration, Named {
         }
 
         for (int i = nodes.size(); i < numberOfNodes; i++) {
-            this.nodes.add(
-                new OpenSearchNode(
-                    path,
-                    clusterName + "-" + i,
-                    project,
-                    reaper,
-                    fileSystemOperations,
-                    archiveOperations,
-                    workingDirBase,
-                    bwcJdk
-                )
-            );
+            addNode(clusterName + "-" + i);
         }
+    }
+
+    private void addNode(String nodeName) {
+        OpenSearchNode newNode = new OpenSearchNode(
+            path,
+            nodeName,
+            project,
+            reaper,
+            fileSystemOperations,
+            archiveOperations,
+            workingDirBase,
+            bwcJdk
+        );
+        // configure the cluster name eagerly
+        newNode.defaultConfig.put("cluster.name", safeName(clusterName));
+        this.nodes.add(newNode);
     }
 
     @Internal

--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
@@ -116,11 +116,7 @@ public class OpenSearchNode implements TestClusterConfiguration {
     private static final TimeUnit NODE_UP_TIMEOUT_UNIT = TimeUnit.MINUTES;
     private static final int ADDITIONAL_CONFIG_TIMEOUT = 15;
     private static final TimeUnit ADDITIONAL_CONFIG_TIMEOUT_UNIT = TimeUnit.SECONDS;
-    private static final List<String> OVERRIDABLE_SETTINGS = Arrays.asList(
-        "path.repo",
-        "discovery.seed_providers"
-
-    );
+    private static final List<String> OVERRIDABLE_SETTINGS = Arrays.asList("path.repo", "discovery.seed_providers", "discovery.seed_hosts");
 
     private static final int TAIL_LOG_MESSAGES_COUNT = 40;
     private static final List<String> MESSAGES_WE_DONT_CARE_ABOUT = Arrays.asList(


### PR DESCRIPTION
### Description

This change updates the logic in RunTask to use deterministic port values for all nodes rather than just the first node in a cluster. The local address of the first node is also used as the seed_hosts value to allow the cluster to form correctly.

Signed-off-by: Kartik Ganesh <85275476+kartg@users.noreply.github.com>
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [x ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
