### PR TITLE
Close first engine instance before creating second

### DIFF
--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -3807,43 +3807,35 @@ public class InternalEngineTests extends EngineTestCase {
         }
         TranslogDeletionPolicyFactory translogDeletionPolicyFactory = CustomTranslogDeletionPolicy::new;
 
-        try (Store store = createStore()) {
-            EngineConfig config = engine.config();
-
-            EngineConfig configWithCustomTranslogDeletionPolicyFactory = new EngineConfig(
-                config.getShardId(),
-                config.getThreadPool(),
-                config.getIndexSettings(),
-                config.getWarmer(),
-                store,
-                config.getMergePolicy(),
-                config.getAnalyzer(),
-                config.getSimilarity(),
-                new CodecService(null, logger),
-                config.getEventListener(),
-                config.getQueryCache(),
-                config.getQueryCachingPolicy(),
-                new TranslogConfig(
-                    config.getTranslogConfig().getShardId(),
-                    createTempDir("other-translog"),
-                    config.getTranslogConfig().getIndexSettings(),
-                    config.getTranslogConfig().getBigArrays()
-                ),
-                translogDeletionPolicyFactory,
-                config.getFlushMergesAfter(),
-                config.getExternalRefreshListener(),
-                config.getInternalRefreshListener(),
-                config.getIndexSort(),
-                config.getCircuitBreakerService(),
-                config.getGlobalCheckpointSupplier(),
-                config.retentionLeasesSupplier(),
-                config.getPrimaryTermSupplier(),
-                config.getTombstoneDocSupplier()
-            );
-            try (InternalEngine engine = createEngine(configWithCustomTranslogDeletionPolicyFactory)) {
-                assertTrue(engine.getTranslog().getDeletionPolicy() instanceof CustomTranslogDeletionPolicy);
-            }
-        }
+        EngineConfig config = engine.config();
+        EngineConfig configWithCustomTranslogDeletionPolicyFactory = new EngineConfig(
+            config.getShardId(),
+            config.getThreadPool(),
+            config.getIndexSettings(),
+            config.getWarmer(),
+            config.getStore(),
+            config.getMergePolicy(),
+            config.getAnalyzer(),
+            config.getSimilarity(),
+            new CodecService(null, logger),
+            config.getEventListener(),
+            config.getQueryCache(),
+            config.getQueryCachingPolicy(),
+            config.getTranslogConfig(),
+            translogDeletionPolicyFactory,
+            config.getFlushMergesAfter(),
+            config.getExternalRefreshListener(),
+            config.getInternalRefreshListener(),
+            config.getIndexSort(),
+            config.getCircuitBreakerService(),
+            config.getGlobalCheckpointSupplier(),
+            config.retentionLeasesSupplier(),
+            config.getPrimaryTermSupplier(),
+            config.getTombstoneDocSupplier()
+        );
+        engine.close();
+        engine = createEngine(configWithCustomTranslogDeletionPolicyFactory);
+        assertTrue(engine.getTranslog().getDeletionPolicy() instanceof CustomTranslogDeletionPolicy);
     }
 
     public void testShardNotAvailableExceptionWhenEngineClosedConcurrently() throws IOException, InterruptedException {


### PR DESCRIPTION
### Description
This fixes a test that appears to fail for certain test seeds. The following is a test run that will fail without this fix:

```
  2> REPRODUCE WITH: ./gradlew ':server:test' --tests "org.opensearch.index.engine.InternalEngineTests.testEngineCreationWithCustomTranslogDeletePolicy" -Dtests.seed=E3E5AAD95ABD299B -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=vi -Dtests.timezone=Europe/Astrakhan -Druntime.java=11
  2> java.io.IOException: could not remove the following files (in the order of attempts):
       /home/ubuntu/OpenSearch/server/build/testrun/test/temp/org.opensearch.index.engine.InternalEngineTests_E3E5AAD95ABD299B-001/translog-primary-001/translog-2.tlog: java.io.IOException: access denied: /home/ubuntu/OpenSearch/server/build/testrun/test/temp/org.opensearch.index.engine.InternalEngineTests_E3E5AAD95ABD299B-001/translog-primary-001/translog-2.tlog
       /home/ubuntu/OpenSearch/server/build/testrun/test/temp/org.opensearch.index.engine.InternalEngineTests_E3E5AAD95ABD299B-001/translog-primary-001/translog.ckp: java.io.IOException: access denied: /home/ubuntu/OpenSearch/server/build/testrun/test/temp/org.opensearch.index.engine.InternalEngineTests_E3E5AAD95ABD299B-001/translog-primary-001/translog.ckp
       /home/ubuntu/OpenSearch/server/build/testrun/test/temp/org.opensearch.index.engine.InternalEngineTests_E3E5AAD95ABD299B-001/translog-primary-001/translog-1.tlog: java.io.IOException: access denied: /home/ubuntu/OpenSearch/server/build/testrun/test/temp/org.opensearch.index.engine.InternalEngineTests_E3E5AAD95ABD299B-001/translog-primary-001/translog-1.tlog
       /home/ubuntu/OpenSearch/server/build/testrun/test/temp/org.opensearch.index.engine.InternalEngineTests_E3E5AAD95ABD299B-001/translog-primary-001: java.nio.file.DirectoryNotEmptyException: /home/ubuntu/OpenSearch/server/build/testrun/test/temp/org.opensearch.index.engine.InternalEngineTests_E3E5AAD95ABD299B-001/translog-primary-001
        at __randomizedtesting.SeedInfo.seed([E3E5AAD95ABD299B:4F3E3027C1E8F03B]:0)
        at org.opensearch.core.internal.io.IOUtils.rm(IOUtils.java:220)
        at org.opensearch.index.translog.Translog.createEmptyTranslog(Translog.java:2027)
        at org.opensearch.index.translog.Translog.createEmptyTranslog(Translog.java:1999)
        at org.opensearch.index.translog.Translog.createEmptyTranslog(Translog.java:1989)
        at org.opensearch.index.engine.EngineTestCase.createEngine(EngineTestCase.java:538)
        at org.opensearch.index.engine.EngineTestCase.createEngine(EngineTestCase.java:527)
        at org.opensearch.index.engine.InternalEngineTests.testEngineCreationWithCustomTranslogDeletePolicy(InternalEngineTests.java:3838)
```
 
### Issues Resolved
None
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
