### PR TITLE
[Upgrade] 1.2 BWC to Lucene 8.10.1

### DIFF
--- a/server/src/main/java/org/opensearch/Version.java
+++ b/server/src/main/java/org/opensearch/Version.java
@@ -73,7 +73,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_1_0_0 = new Version(1000099, org.apache.lucene.util.Version.LUCENE_8_8_2);
     public static final Version V_1_0_1 = new Version(1000199, org.apache.lucene.util.Version.LUCENE_8_8_2);
     public static final Version V_1_1_0 = new Version(1010099, org.apache.lucene.util.Version.LUCENE_8_9_0);
-    public static final Version V_1_2_0 = new Version(1020099, org.apache.lucene.util.Version.LUCENE_8_9_0);
+    public static final Version V_1_2_0 = new Version(1020099, org.apache.lucene.util.Version.LUCENE_8_10_1);
     public static final Version V_2_0_0 = new Version(2000099, org.apache.lucene.util.Version.LUCENE_8_10_1);
     public static final Version CURRENT = V_2_0_0;
 


### PR DESCRIPTION
This PR upgrades the BWC 1.2 lucene dependency to version 8.10.1

Signed-off-by: Nicholas Walter Knize <nknize@apache.org>