### PR TITLE
Run spotless and exclude checkstyle on `rest-api-spec` module

### DIFF
--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -27,7 +27,9 @@
   <suppress files="libs" checks="." />
   <!-- Excludes checkstyle run on modules module -->
   <suppress files="modules" checks="." />
-
+  <!-- Excludes checkstyle run on rest-api-spec module -->
+  <suppress files="rest-api-spec" checks="." />
+  
   <!--
     Truly temporary suppressions suppression of snippets included in
     documentation that are so wide that they scroll.

--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -78,7 +78,6 @@ def projectPathsToExclude = [
   ':plugins:store-smb',
   ':plugins:transport-nio',
   ':qa:die-with-dignity',
-  ':rest-api-spec',
   ':test:fixtures:azure-fixture',
   ':test:fixtures:gcs-fixture',
   ':test:fixtures:hdfs-fixture',

--- a/rest-api-spec/src/yamlRestTest/java/org/opensearch/test/rest/ClientYamlTestSuiteIT.java
+++ b/rest-api-spec/src/yamlRestTest/java/org/opensearch/test/rest/ClientYamlTestSuiteIT.java
@@ -41,7 +41,7 @@ import org.opensearch.test.rest.yaml.OpenSearchClientYamlSuiteTestCase;
 
 /** Rest integration test. Runs against a cluster started by {@code gradle integTest} */
 
-//The default 20 minutes timeout isn't always enough, but Darwin CI hosts are incredibly slow...
+// The default 20 minutes timeout isn't always enough, but Darwin CI hosts are incredibly slow...
 @TimeoutSuite(millis = 40 * TimeUnits.MINUTE)
 public class ClientYamlTestSuiteIT extends OpenSearchClientYamlSuiteTestCase {
     public ClientYamlTestSuiteIT(ClientYamlTestCandidate testCandidate) {


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Applied Spotless to rest-api-spec module and excluded it from CheckStyle.
 
### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/1362 and https://github.com/opensearch-project/OpenSearch/issues/974
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
