### PR TITLE
[Backport 1.x]Remove codeQL warning about implicit narrowing conversion in compound assignment

### DIFF
--- a/libs/nio/src/test/java/org/opensearch/nio/InboundChannelBufferTests.java
+++ b/libs/nio/src/test/java/org/opensearch/nio/InboundChannelBufferTests.java
@@ -266,10 +266,10 @@ public class InboundChannelBufferTests extends OpenSearchTestCase {
             if (randomBoolean()) {
                 long bytesToRelease = Math.min(randomInt(50), channelBuffer.getIndex());
                 channelBuffer.release(bytesToRelease);
-                bytesReleased += bytesToRelease;
+                bytesReleased += (int) bytesToRelease;
             }
             channelBuffer.incrementIndex(amountToInc);
-            indexIncremented += amountToInc;
+            indexIncremented += (int) amountToInc;
         }
 
         assertEquals(0, channelBuffer.sliceBuffersFrom(channelBuffer.getIndex()).length);

--- a/plugins/examples/rescore/src/main/java/org/opensearch/example/rescore/ExampleRescoreBuilder.java
+++ b/plugins/examples/rescore/src/main/java/org/opensearch/example/rescore/ExampleRescoreBuilder.java
@@ -222,7 +222,7 @@ public class ExampleRescoreBuilder extends RescorerBuilder<ExampleRescoreBuilder
                                 + "]"
                         );
                     }
-                    topDocs.scoreDocs[i].score *= data.nextValue();
+                    topDocs.scoreDocs[i].score *= (float) data.nextValue();
                 }
             }
             // Sort by score descending, then docID ascending, just like lucene's QueryRescorer

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
@@ -195,7 +195,7 @@ public class BestBucketsDeferringCollector extends DeferringBucketCollector {
                 final PackedLongValues.Iterator buckets = entry.buckets.iterator();
                 int doc = 0;
                 for (long i = 0, end = entry.docDeltas.size(); i < end; ++i) {
-                    doc += docDeltaIterator.next();
+                    doc += (int) docDeltaIterator.next();
                     final long bucket = buckets.next();
                     final long rebasedBucket = this.selectedBuckets.find(bucket);
                     if (rebasedBucket != -1) {

--- a/server/src/test/java/org/opensearch/action/search/SearchPhaseControllerTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchPhaseControllerTests.java
@@ -396,7 +396,7 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
         for (SearchPhaseResult shardResult : results.asList()) {
             TopDocs topDocs = shardResult.queryResult().topDocs().topDocs;
             assert topDocs.totalHits.relation == Relation.EQUAL_TO;
-            resultCount += topDocs.totalHits.value;
+            resultCount += (int) topDocs.totalHits.value;
         }
         return resultCount;
     }

--- a/server/src/test/java/org/opensearch/index/shard/StoreRecoveryTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/StoreRecoveryTests.java
@@ -118,7 +118,7 @@ public class StoreRecoveryTests extends OpenSearchTestCase {
             && f.equals("write.lock") == false
             && f.startsWith("extra") == false;
         for (Directory d : dirs) {
-            numFiles += Arrays.asList(d.listAll()).stream().filter(filesFilter).count();
+            numFiles += (int) Arrays.asList(d.listAll()).stream().filter(filesFilter).count();
         }
         final long targetNumFiles = Arrays.asList(target.listAll()).stream().filter(filesFilter).count();
         assertEquals(numFiles, targetNumFiles);

--- a/server/src/test/java/org/opensearch/index/snapshots/blobstore/FileInfoTests.java
+++ b/server/src/test/java/org/opensearch/index/snapshots/blobstore/FileInfoTests.java
@@ -169,7 +169,7 @@ public class FileInfoTests extends OpenSearchTestCase {
         );
         int numBytes = 0;
         for (int i = 0; i < info.numberOfParts(); i++) {
-            numBytes += info.partBytes(i);
+            numBytes += (int) info.partBytes(i);
         }
         assertEquals(numBytes, 36);
 
@@ -180,7 +180,7 @@ public class FileInfoTests extends OpenSearchTestCase {
         );
         numBytes = 0;
         for (int i = 0; i < info.numberOfParts(); i++) {
-            numBytes += info.partBytes(i);
+            numBytes += (int) info.partBytes(i);
         }
         assertEquals(numBytes, 35);
         final int numIters = randomIntBetween(10, 100);
@@ -189,7 +189,7 @@ public class FileInfoTests extends OpenSearchTestCase {
             info = new BlobStoreIndexShardSnapshot.FileInfo("foo", metadata, new ByteSizeValue(randomIntBetween(1, 1000)));
             numBytes = 0;
             for (int i = 0; i < info.numberOfParts(); i++) {
-                numBytes += info.partBytes(i);
+                numBytes += (int) info.partBytes(i);
             }
             assertEquals(numBytes, metadata.length());
         }

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
@@ -114,7 +114,7 @@ public class InternalBinaryRangeTests extends InternalRangeTestCase<InternalBina
         for (Range.Bucket bucket : reduced.getBuckets()) {
             int expectedCount = 0;
             for (InternalBinaryRange input : inputs) {
-                expectedCount += input.getBuckets().get(pos).getDocCount();
+                expectedCount += (int) input.getBuckets().get(pos).getDocCount();
             }
             assertEquals(expectedCount, bucket.getDocCount());
             pos++;

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/SumAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/SumAggregatorTests.java
@@ -252,7 +252,7 @@ public class SumAggregatorTests extends AggregatorTestCase {
         int sum = 0;
         for (int i = 0; i < numDocs; i++) {
             final long value = randomLongBetween(0, 1000);
-            sum += value;
+            sum += (int) value;
             docs.add(singleton(new NumericDocValuesField(fieldType.name(), value)));
         }
 

--- a/test/framework/src/main/java/org/opensearch/common/bytes/AbstractBytesReferenceTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/common/bytes/AbstractBytesReferenceTestCase.java
@@ -659,7 +659,7 @@ public abstract class AbstractBytesReferenceTestCase extends OpenSearchTestCase 
             assertNotEquals(b1, differentLen);
 
             // test changed bytes
-            array1[offset1 + randomInt(len - 1)] += 13;
+            array1[offset1 + randomInt(len - 1)] += (byte) 13;
             assertNotEquals(b1, b2);
         }
     }


### PR DESCRIPTION

Signed-off-by: Xue Zhou <xuezhou@amazon.com>

### Description
Backport PR#[1403](https://github.com/opensearch-project/OpenSearch/pull/1403)
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
