### PR TITLE
Concurrent Searching (Experimental)

### DIFF
--- a/sandbox/plugins/concurrent-search/build.gradle
+++ b/sandbox/plugins/concurrent-search/build.gradle
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+apply plugin: 'opensearch.opensearchplugin'
+apply plugin: 'opensearch.yaml-rest-test'
+
+opensearchplugin {
+  name 'concurrent-search'
+  description 'The experimental plugin which implements concurrent search over Apache Lucene segments'
+  classname 'org.opensearch.search.ConcurrentSegmentSearchPlugin'
+  licenseFile rootProject.file('licenses/APACHE-LICENSE-2.0.txt')
+  noticeFile rootProject.file('NOTICE.txt')
+}
+
+yamlRestTest.enabled = false;
+testingConventions.enabled = false;

--- a/sandbox/plugins/concurrent-search/src/main/java/org/opensearch/search/ConcurrentSegmentSearchPlugin.java
+++ b/sandbox/plugins/concurrent-search/src/main/java/org/opensearch/search/ConcurrentSegmentSearchPlugin.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.SearchPlugin;
+import org.opensearch.search.query.ConcurrentQueryPhaseSearcher;
+import org.opensearch.search.query.QueryPhaseSearcher;
+import org.opensearch.threadpool.ExecutorBuilder;
+import org.opensearch.threadpool.FixedExecutorBuilder;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The experimental plugin which implements the concurrent search over Apache Lucene segments.
+ */
+public class ConcurrentSegmentSearchPlugin extends Plugin implements SearchPlugin {
+    private static final String INDEX_SEARCHER = "index_searcher";
+
+    /**
+     * Default constructor
+     */
+    public ConcurrentSegmentSearchPlugin() {}
+
+    @Override
+    public Optional<QueryPhaseSearcher> getQueryPhaseSearcher() {
+        return Optional.of(new ConcurrentQueryPhaseSearcher());
+    }
+
+    @Override
+    public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {
+        final int allocatedProcessors = OpenSearchExecutors.allocatedProcessors(settings);
+        return Collections.singletonList(
+            new FixedExecutorBuilder(settings, INDEX_SEARCHER, allocatedProcessors, 1000, "thread_pool." + INDEX_SEARCHER)
+        );
+    }
+
+    @Override
+    public Optional<ExecutorServiceProvider> getIndexSearcherExecutorProvider() {
+        return Optional.of((ThreadPool threadPool) -> threadPool.executor(INDEX_SEARCHER));
+    }
+}

--- a/sandbox/plugins/concurrent-search/src/main/java/org/opensearch/search/package-info.java
+++ b/sandbox/plugins/concurrent-search/src/main/java/org/opensearch/search/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * The implementation of the experimental plugin which implements the concurrent search over Apache Lucene segments.
+ */
+package org.opensearch.search;

--- a/sandbox/plugins/concurrent-search/src/main/java/org/opensearch/search/query/ConcurrentQueryPhaseSearcher.java
+++ b/sandbox/plugins/concurrent-search/src/main/java/org/opensearch/search/query/ConcurrentQueryPhaseSearcher.java
@@ -1,0 +1,124 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.query;
+
+import static org.opensearch.search.query.TopDocsCollectorContext.createTopDocsCollectorContext;
+
+import java.io.IOException;
+import java.util.LinkedList;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
+import org.apache.lucene.search.Query;
+import org.opensearch.search.internal.ContextIndexSearcher;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.profile.query.ProfileCollectorManager;
+import org.opensearch.search.query.QueryPhase.DefaultQueryPhaseSearcher;
+import org.opensearch.search.query.QueryPhase.TimeExceededException;
+
+/**
+ * The implementation of the {@link QueryPhaseSearcher} which attempts to use concurrent
+ * search of Apache Lucene segments if it has been enabled.
+ */
+public class ConcurrentQueryPhaseSearcher extends DefaultQueryPhaseSearcher {
+    private static final Logger LOGGER = LogManager.getLogger(ConcurrentQueryPhaseSearcher.class);
+
+    /**
+     * Default constructor
+     */
+    public ConcurrentQueryPhaseSearcher() {}
+
+    @Override
+    protected boolean searchWithCollector(
+        SearchContext searchContext,
+        ContextIndexSearcher searcher,
+        Query query,
+        LinkedList<QueryCollectorContext> collectors,
+        boolean hasFilterCollector,
+        boolean hasTimeout
+    ) throws IOException {
+        boolean couldUseConcurrentSegmentSearch = allowConcurrentSegmentSearch(searcher);
+
+        // TODO: support aggregations
+        if (searchContext.aggregations() != null) {
+            couldUseConcurrentSegmentSearch = false;
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Unable to use concurrent search over index segments (experimental): aggregations are present");
+            }
+        }
+
+        if (couldUseConcurrentSegmentSearch) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Using concurrent search over index segments (experimental)");
+            }
+
+            return searchWithCollectorManager(searchContext, searcher, query, collectors, hasFilterCollector, hasTimeout);
+        } else {
+            return super.searchWithCollector(searchContext, searcher, query, collectors, hasFilterCollector, hasTimeout);
+        }
+    }
+
+    private static boolean searchWithCollectorManager(
+        SearchContext searchContext,
+        ContextIndexSearcher searcher,
+        Query query,
+        LinkedList<QueryCollectorContext> collectorContexts,
+        boolean hasFilterCollector,
+        boolean timeoutSet
+    ) throws IOException {
+        // create the top docs collector last when the other collectors are known
+        final TopDocsCollectorContext topDocsFactory = createTopDocsCollectorContext(searchContext, hasFilterCollector);
+        // add the top docs collector, the first collector context in the chain
+        collectorContexts.addFirst(topDocsFactory);
+
+        final QuerySearchResult queryResult = searchContext.queryResult();
+        final CollectorManager<?, ReduceableSearchResult> collectorManager;
+
+        // TODO: support aggregations in concurrent segment search flow
+        if (searchContext.aggregations() != null) {
+            throw new UnsupportedOperationException("The concurrent segment search does not support aggregations yet");
+        }
+
+        if (searchContext.getProfilers() != null) {
+            final ProfileCollectorManager<? extends Collector, ReduceableSearchResult> profileCollectorManager =
+                QueryCollectorManagerContext.createQueryCollectorManagerWithProfiler(collectorContexts);
+            searchContext.getProfilers().getCurrentQueryProfiler().setCollector(profileCollectorManager);
+            collectorManager = profileCollectorManager;
+        } else {
+            // Create multi collector manager instance
+            collectorManager = QueryCollectorManagerContext.createMultiCollectorManager(collectorContexts);
+        }
+
+        try {
+            final ReduceableSearchResult result = searcher.search(query, collectorManager);
+            result.reduce(queryResult);
+        } catch (EarlyTerminatingCollector.EarlyTerminationException e) {
+            queryResult.terminatedEarly(true);
+        } catch (TimeExceededException e) {
+            assert timeoutSet : "TimeExceededException thrown even though timeout wasn't set";
+            if (searchContext.request().allowPartialSearchResults() == false) {
+                // Can't rethrow TimeExceededException because not serializable
+                throw new QueryPhaseExecutionException(searchContext.shardTarget(), "Time exceeded");
+            }
+            queryResult.searchTimedOut(true);
+        }
+        if (searchContext.terminateAfter() != SearchContext.DEFAULT_TERMINATE_AFTER && queryResult.terminatedEarly() == null) {
+            queryResult.terminatedEarly(false);
+        }
+
+        return topDocsFactory.shouldRescore();
+    }
+
+    private static boolean allowConcurrentSegmentSearch(final ContextIndexSearcher searcher) {
+        return (searcher.getExecutor() != null);
+    }
+
+}

--- a/sandbox/plugins/concurrent-search/src/main/java/org/opensearch/search/query/ConcurrentQueryPhaseSearcher.java
+++ b/sandbox/plugins/concurrent-search/src/main/java/org/opensearch/search/query/ConcurrentQueryPhaseSearcher.java
@@ -50,16 +50,11 @@ public class ConcurrentQueryPhaseSearcher extends DefaultQueryPhaseSearcher {
         // TODO: support aggregations
         if (searchContext.aggregations() != null) {
             couldUseConcurrentSegmentSearch = false;
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Unable to use concurrent search over index segments (experimental): aggregations are present");
-            }
+            LOGGER.debug("Unable to use concurrent search over index segments (experimental): aggregations are present");
         }
 
         if (couldUseConcurrentSegmentSearch) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Using concurrent search over index segments (experimental)");
-            }
-
+            LOGGER.debug("Using concurrent search over index segments (experimental)");
             return searchWithCollectorManager(searchContext, searcher, query, collectors, hasFilterCollector, hasTimeout);
         } else {
             return super.searchWithCollector(searchContext, searcher, query, collectors, hasFilterCollector, hasTimeout);

--- a/sandbox/plugins/concurrent-search/src/main/java/org/opensearch/search/query/package-info.java
+++ b/sandbox/plugins/concurrent-search/src/main/java/org/opensearch/search/query/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * {@link org.opensearch.search.query.QueryPhaseSearcher} implementation for concurrent search
+ */
+package org.opensearch.search.query;

--- a/sandbox/plugins/concurrent-search/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
+++ b/sandbox/plugins/concurrent-search/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
@@ -1,0 +1,1182 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.query;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queries.spans.SpanNearQuery;
+import org.apache.lucene.queries.spans.SpanTermQuery;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.grouping.CollapseTopFieldDocs;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.FilterCollector;
+import org.apache.lucene.search.FilterLeafCollector;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.store.Directory;
+import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.index.mapper.NumberFieldMapper.NumberFieldType;
+import org.opensearch.index.mapper.NumberFieldMapper.NumberType;
+import org.opensearch.index.query.ParsedQuery;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.IndexShardTestCase;
+import org.opensearch.lucene.queries.MinDocQuery;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.collapse.CollapseBuilder;
+import org.opensearch.search.internal.ContextIndexSearcher;
+import org.opensearch.search.internal.ScrollContext;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.profile.ProfileResult;
+import org.opensearch.search.profile.ProfileShardResult;
+import org.opensearch.search.profile.SearchProfileShardResults;
+import org.opensearch.search.profile.query.CollectorResult;
+import org.opensearch.search.profile.query.QueryProfileShardResult;
+import org.opensearch.search.sort.SortAndFormats;
+import org.opensearch.test.TestSearchContext;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.hamcrest.Matchers.hasSize;
+
+public class QueryProfilePhaseTests extends IndexShardTestCase {
+
+    private IndexShard indexShard;
+    private final ExecutorService executor;
+    private final QueryPhaseSearcher queryPhaseSearcher;
+
+    @ParametersFactory
+    public static Collection<Object[]> concurrency() {
+        return Arrays.asList(
+            new Object[] { 0, QueryPhase.DEFAULT_QUERY_PHASE_SEARCHER },
+            new Object[] { 5, new ConcurrentQueryPhaseSearcher() }
+        );
+    }
+
+    public QueryProfilePhaseTests(int concurrency, QueryPhaseSearcher queryPhaseSearcher) {
+        this.executor = (concurrency > 0) ? Executors.newFixedThreadPool(concurrency) : null;
+        this.queryPhaseSearcher = queryPhaseSearcher;
+    }
+
+    @Override
+    public Settings threadPoolSettings() {
+        return Settings.builder().put(super.threadPoolSettings()).put("thread_pool.search.min_queue_size", 10).build();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        indexShard = newShard(true);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        closeShards(indexShard);
+
+        if (executor != null) {
+            ThreadPool.terminate(executor, 10, TimeUnit.SECONDS);
+        }
+    }
+
+    public void testPostFilterDisablesCountOptimization() throws Exception {
+        Directory dir = newDirectory();
+        final Sort sort = new Sort(new SortField("rank", SortField.Type.INT));
+        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        Document doc = new Document();
+        w.addDocument(doc);
+        w.close();
+
+        IndexReader reader = DirectoryReader.open(dir);
+
+        TestSearchContext context = new TestSearchContext(null, indexShard, newEarlyTerminationContextSearcher(reader, 0, executor));
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
+
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+        assertEquals(1, context.queryResult().topDocs().topDocs.totalHits.value);
+        assertProfileData(context, "MatchAllDocsQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_count"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        context.setSearcher(newContextSearcher(reader, executor));
+        context.parsedPostFilter(new ParsedQuery(new MatchNoDocsQuery()));
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+        assertEquals(0, context.queryResult().topDocs().topDocs.totalHits.value);
+        assertProfileData(context, collector -> {
+            assertThat(collector.getReason(), equalTo("search_post_filter"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), hasSize(1));
+            assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_count"));
+            assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+        }, (query) -> {
+            assertThat(query.getQueryName(), equalTo("MatchNoDocsQuery"));
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, (query) -> {
+            assertThat(query.getQueryName(), equalTo("MatchAllDocsQuery"));
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        });
+
+        reader.close();
+        dir.close();
+    }
+
+    public void testTerminateAfterWithFilter() throws Exception {
+        Directory dir = newDirectory();
+        final Sort sort = new Sort(new SortField("rank", SortField.Type.INT));
+        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        Document doc = new Document();
+        for (int i = 0; i < 10; i++) {
+            doc.add(new StringField("foo", Integer.toString(i), Store.NO));
+        }
+        w.addDocument(doc);
+        w.close();
+
+        IndexReader reader = DirectoryReader.open(dir);
+
+        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader, executor));
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+
+        context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
+        context.terminateAfter(1);
+        context.setSize(10);
+        for (int i = 0; i < 10; i++) {
+            context.parsedPostFilter(new ParsedQuery(new TermQuery(new Term("foo", Integer.toString(i)))));
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+            assertEquals(1, context.queryResult().topDocs().topDocs.totalHits.value);
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+            assertProfileData(context, collector -> {
+                assertThat(collector.getReason(), equalTo("search_post_filter"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), hasSize(1));
+                assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_terminate_after_count"));
+                assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren().get(0).getProfiledChildren(), hasSize(1));
+                assertThat(collector.getProfiledChildren().get(0).getProfiledChildren().get(0).getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getProfiledChildren().get(0).getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            }, (query) -> {
+                assertThat(query.getQueryName(), equalTo("TermQuery"));
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, (query) -> {
+                assertThat(query.getQueryName(), equalTo("MatchAllDocsQuery"));
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(1L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            });
+        }
+        reader.close();
+        dir.close();
+    }
+
+    public void testMinScoreDisablesCountOptimization() throws Exception {
+        Directory dir = newDirectory();
+        final Sort sort = new Sort(new SortField("rank", SortField.Type.INT));
+        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        Document doc = new Document();
+        w.addDocument(doc);
+        w.close();
+
+        IndexReader reader = DirectoryReader.open(dir);
+        TestSearchContext context = new TestSearchContext(null, indexShard, newEarlyTerminationContextSearcher(reader, 0, executor));
+        context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
+        context.setSize(0);
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+        assertEquals(1, context.queryResult().topDocs().topDocs.totalHits.value);
+        assertProfileData(context, "MatchAllDocsQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_count"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        context.minimumScore(100);
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+        assertEquals(0, context.queryResult().topDocs().topDocs.totalHits.value);
+        assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
+        assertProfileData(context, "MatchAllDocsQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThanOrEqualTo(100L));
+            assertThat(query.getTimeBreakdown().get("score_count"), equalTo(1L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_min_score"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), hasSize(1));
+            assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_count"));
+            assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+        });
+
+        reader.close();
+        dir.close();
+    }
+
+    public void testInOrderScrollOptimization() throws Exception {
+        Directory dir = newDirectory();
+        final Sort sort = new Sort(new SortField("rank", SortField.Type.INT));
+        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        final int numDocs = scaledRandomIntBetween(600, 900);
+        for (int i = 0; i < numDocs; ++i) {
+            w.addDocument(new Document());
+        }
+        w.close();
+        IndexReader reader = DirectoryReader.open(dir);
+        ScrollContext scrollContext = new ScrollContext();
+        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader, executor), scrollContext);
+        context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
+        scrollContext.lastEmittedDoc = null;
+        scrollContext.maxScore = Float.NaN;
+        scrollContext.totalHits = null;
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        int size = randomIntBetween(2, 5);
+        context.setSize(size);
+
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+        assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+        assertNull(context.queryResult().terminatedEarly());
+        assertThat(context.terminateAfter(), equalTo(0));
+        assertThat(context.queryResult().getTotalHits().value, equalTo((long) numDocs));
+        assertProfileData(context, "MatchAllDocsQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        context.setSearcher(newEarlyTerminationContextSearcher(reader, size, executor));
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+        assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+        assertThat(context.terminateAfter(), equalTo(size));
+        assertThat(context.queryResult().getTotalHits().value, equalTo((long) numDocs));
+        assertThat(context.queryResult().topDocs().topDocs.scoreDocs[0].doc, greaterThanOrEqualTo(size));
+        assertProfileData(context, "ConstantScoreQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score"), equalTo(0L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score_count"), equalTo(0L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_terminate_after_count"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), hasSize(1));
+            assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+        });
+
+        reader.close();
+        dir.close();
+    }
+
+    public void testTerminateAfterEarlyTermination() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = newIndexWriterConfig();
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        final int numDocs = scaledRandomIntBetween(600, 900);
+        for (int i = 0; i < numDocs; ++i) {
+            Document doc = new Document();
+            if (randomBoolean()) {
+                doc.add(new StringField("foo", "bar", Store.NO));
+            }
+            if (randomBoolean()) {
+                doc.add(new StringField("foo", "baz", Store.NO));
+            }
+            doc.add(new NumericDocValuesField("rank", numDocs - i));
+            w.addDocument(doc);
+        }
+        w.close();
+        final IndexReader reader = DirectoryReader.open(dir);
+        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader, executor));
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
+
+        context.terminateAfter(1);
+        {
+            context.setSize(1);
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(1L));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+            assertProfileData(context, "MatchAllDocsQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_terminate_after_count"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), hasSize(1));
+                assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            });
+
+            context.setSize(0);
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(1L));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
+            assertProfileData(context, "MatchAllDocsQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_terminate_after_count"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), hasSize(1));
+                assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_count"));
+                assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            });
+        }
+
+        {
+            context.setSize(1);
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(1L));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+            assertProfileData(context, "MatchAllDocsQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_terminate_after_count"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), hasSize(1));
+                assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            });
+        }
+        {
+            context.setSize(1);
+            BooleanQuery bq = new BooleanQuery.Builder().add(new TermQuery(new Term("foo", "bar")), Occur.SHOULD)
+                .add(new TermQuery(new Term("foo", "baz")), Occur.SHOULD)
+                .build();
+            context.parsedQuery(new ParsedQuery(bq));
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(1L));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+            assertProfileData(context, "BooleanQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+                assertThat(query.getProfiledChildren(), hasSize(2));
+                assertThat(query.getProfiledChildren().get(0).getQueryName(), equalTo("TermQuery"));
+                assertThat(query.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+                assertThat(query.getProfiledChildren().get(1).getQueryName(), equalTo("TermQuery"));
+                assertThat(query.getProfiledChildren().get(1).getTime(), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_terminate_after_count"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), hasSize(1));
+                assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            });
+            context.setSize(0);
+            context.parsedQuery(new ParsedQuery(bq));
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(1L));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
+
+            assertProfileData(context, "BooleanQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+                assertThat(query.getProfiledChildren(), hasSize(2));
+                assertThat(query.getProfiledChildren().get(0).getQueryName(), equalTo("TermQuery"));
+                assertThat(query.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score_count"), equalTo(0L));
+
+                assertThat(query.getProfiledChildren().get(1).getQueryName(), equalTo("TermQuery"));
+                assertThat(query.getProfiledChildren().get(1).getTime(), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score_count"), equalTo(0L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_terminate_after_count"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), hasSize(1));
+                assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_count"));
+                assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            });
+        }
+
+        context.terminateAfter(7);
+        context.setSize(10);
+        for (int trackTotalHits : new int[] { -1, 3, 75, 100 }) {
+            context.trackTotalHitsUpTo(trackTotalHits);
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+            assertTrue(context.queryResult().terminatedEarly());
+            if (trackTotalHits == -1) {
+                assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(0L));
+            } else {
+                assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(7L));
+            }
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(7));
+            assertProfileData(context, "BooleanQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(7L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+                assertThat(query.getProfiledChildren(), hasSize(2));
+                assertThat(query.getProfiledChildren().get(0).getQueryName(), equalTo("TermQuery"));
+                assertThat(query.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score_count"), greaterThan(0L));
+
+                assertThat(query.getProfiledChildren().get(1).getQueryName(), equalTo("TermQuery"));
+                assertThat(query.getProfiledChildren().get(1).getTime(), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score_count"), greaterThan(0L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_terminate_after_count"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), hasSize(1));
+                assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            });
+        }
+
+        reader.close();
+        dir.close();
+    }
+
+    public void testIndexSortingEarlyTermination() throws Exception {
+        Directory dir = newDirectory();
+        final Sort sort = new Sort(new SortField("rank", SortField.Type.INT));
+        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        final int numDocs = scaledRandomIntBetween(600, 900);
+        for (int i = 0; i < numDocs; ++i) {
+            Document doc = new Document();
+            if (randomBoolean()) {
+                doc.add(new StringField("foo", "bar", Store.NO));
+            }
+            if (randomBoolean()) {
+                doc.add(new StringField("foo", "baz", Store.NO));
+            }
+            doc.add(new NumericDocValuesField("rank", numDocs - i));
+            w.addDocument(doc);
+        }
+        w.close();
+
+        final IndexReader reader = DirectoryReader.open(dir);
+        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader, executor));
+        context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
+        context.setSize(1);
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        context.sort(new SortAndFormats(sort, new DocValueFormat[] { DocValueFormat.RAW }));
+
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+        assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+        assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+        assertThat(context.queryResult().topDocs().topDocs.scoreDocs[0], instanceOf(FieldDoc.class));
+        FieldDoc fieldDoc = (FieldDoc) context.queryResult().topDocs().topDocs.scoreDocs[0];
+        assertThat(fieldDoc.fields[0], equalTo(1));
+        assertProfileData(context, "MatchAllDocsQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        {
+            context.parsedPostFilter(new ParsedQuery(new MinDocQuery(1)));
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+            assertNull(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(numDocs - 1L));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs[0], instanceOf(FieldDoc.class));
+            assertThat(fieldDoc.fields[0], anyOf(equalTo(1), equalTo(2)));
+            assertProfileData(context, collector -> {
+                assertThat(collector.getReason(), equalTo("search_post_filter"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), hasSize(1));
+                assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            }, (query) -> {
+                assertThat(query.getQueryName(), equalTo("MinDocQuery"));
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, (query) -> {
+                assertThat(query.getQueryName(), equalTo("MatchAllDocsQuery"));
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            });
+            context.parsedPostFilter(null);
+        }
+
+        {
+            context.setSearcher(newEarlyTerminationContextSearcher(reader, 1, executor));
+            context.trackTotalHitsUpTo(SearchContext.TRACK_TOTAL_HITS_DISABLED);
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+            assertNull(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs[0], instanceOf(FieldDoc.class));
+            assertThat(fieldDoc.fields[0], anyOf(equalTo(1), equalTo(2)));
+            assertProfileData(context, "MatchAllDocsQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), empty());
+            });
+
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+            assertNull(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs[0], instanceOf(FieldDoc.class));
+            assertThat(fieldDoc.fields[0], anyOf(equalTo(1), equalTo(2)));
+            assertProfileData(context, "MatchAllDocsQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), empty());
+            });
+        }
+
+        reader.close();
+        dir.close();
+    }
+
+    public void testIndexSortScrollOptimization() throws Exception {
+        Directory dir = newDirectory();
+        final Sort indexSort = new Sort(new SortField("rank", SortField.Type.INT), new SortField("tiebreaker", SortField.Type.INT));
+        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(indexSort);
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        final int numDocs = scaledRandomIntBetween(600, 900);
+        for (int i = 0; i < numDocs; ++i) {
+            Document doc = new Document();
+            doc.add(new NumericDocValuesField("rank", random().nextInt()));
+            doc.add(new NumericDocValuesField("tiebreaker", i));
+            w.addDocument(doc);
+        }
+        if (randomBoolean()) {
+            w.forceMerge(randomIntBetween(1, 10));
+        }
+        w.close();
+
+        final IndexReader reader = DirectoryReader.open(dir);
+        List<SortAndFormats> searchSortAndFormats = new ArrayList<>();
+        searchSortAndFormats.add(new SortAndFormats(indexSort, new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }));
+        // search sort is a prefix of the index sort
+        searchSortAndFormats.add(new SortAndFormats(new Sort(indexSort.getSort()[0]), new DocValueFormat[] { DocValueFormat.RAW }));
+        for (SortAndFormats searchSortAndFormat : searchSortAndFormats) {
+            ScrollContext scrollContext = new ScrollContext();
+            TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader, executor), scrollContext);
+            context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
+            scrollContext.lastEmittedDoc = null;
+            scrollContext.maxScore = Float.NaN;
+            scrollContext.totalHits = null;
+            context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+            context.setSize(10);
+            context.sort(searchSortAndFormat);
+
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+            assertNull(context.queryResult().terminatedEarly());
+            assertThat(context.terminateAfter(), equalTo(0));
+            assertThat(context.queryResult().getTotalHits().value, equalTo((long) numDocs));
+            assertProfileData(context, "MatchAllDocsQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), empty());
+            });
+
+            int sizeMinus1 = context.queryResult().topDocs().topDocs.scoreDocs.length - 1;
+            FieldDoc lastDoc = (FieldDoc) context.queryResult().topDocs().topDocs.scoreDocs[sizeMinus1];
+
+            context.setSearcher(newEarlyTerminationContextSearcher(reader, 10, executor));
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+            assertNull(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+            assertThat(context.terminateAfter(), equalTo(0));
+            assertThat(context.queryResult().getTotalHits().value, equalTo((long) numDocs));
+            assertProfileData(context, "ConstantScoreQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+                assertThat(query.getProfiledChildren(), hasSize(1));
+                assertThat(query.getProfiledChildren().get(0).getQueryName(), equalTo("SearchAfterSortedDocQuery"));
+                assertThat(query.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), empty());
+            });
+            FieldDoc firstDoc = (FieldDoc) context.queryResult().topDocs().topDocs.scoreDocs[0];
+            for (int i = 0; i < searchSortAndFormat.sort.getSort().length; i++) {
+                @SuppressWarnings("unchecked")
+                FieldComparator<Object> comparator = (FieldComparator<Object>) searchSortAndFormat.sort.getSort()[i].getComparator(i, true);
+                int cmp = comparator.compareValues(firstDoc.fields[i], lastDoc.fields[i]);
+                if (cmp == 0) {
+                    continue;
+                }
+                assertThat(cmp, equalTo(1));
+                break;
+            }
+        }
+        reader.close();
+        dir.close();
+    }
+
+    public void testDisableTopScoreCollection() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = newIndexWriterConfig(new StandardAnalyzer());
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        Document doc = new Document();
+        final int numDocs = 2 * scaledRandomIntBetween(50, 450);
+        for (int i = 0; i < numDocs; i++) {
+            doc.clear();
+            if (i % 2 == 0) {
+                doc.add(new TextField("title", "foo bar", Store.NO));
+            } else {
+                doc.add(new TextField("title", "foo", Store.NO));
+            }
+            w.addDocument(doc);
+        }
+        w.close();
+
+        IndexReader reader = DirectoryReader.open(dir);
+        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader, executor));
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        Query q = new SpanNearQuery.Builder("title", true).addClause(new SpanTermQuery(new Term("title", "foo")))
+            .addClause(new SpanTermQuery(new Term("title", "bar")))
+            .build();
+
+        context.parsedQuery(new ParsedQuery(q));
+        context.setSize(3);
+        context.trackTotalHitsUpTo(3);
+        TopDocsCollectorContext topDocsContext = TopDocsCollectorContext.createTopDocsCollectorContext(context, false);
+        assertEquals(topDocsContext.create(null).scoreMode(), org.apache.lucene.search.ScoreMode.COMPLETE);
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+        assertEquals(numDocs / 2, context.queryResult().topDocs().topDocs.totalHits.value);
+        assertEquals(context.queryResult().topDocs().topDocs.totalHits.relation, TotalHits.Relation.EQUAL_TO);
+        assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(3));
+        assertProfileData(context, "SpanNearQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        context.sort(new SortAndFormats(new Sort(new SortField("other", SortField.Type.INT)), new DocValueFormat[] { DocValueFormat.RAW }));
+        topDocsContext = TopDocsCollectorContext.createTopDocsCollectorContext(context, false);
+        assertEquals(topDocsContext.create(null).scoreMode(), org.apache.lucene.search.ScoreMode.TOP_DOCS);
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+        assertEquals(numDocs / 2, context.queryResult().topDocs().topDocs.totalHits.value);
+        assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(3));
+        assertEquals(context.queryResult().topDocs().topDocs.totalHits.relation, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
+        assertProfileData(context, "SpanNearQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        reader.close();
+        dir.close();
+    }
+
+    public void testMinScore() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = newIndexWriterConfig();
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        for (int i = 0; i < 10; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("foo", "bar", Store.NO));
+            doc.add(new StringField("filter", "f1", Store.NO));
+            w.addDocument(doc);
+        }
+        w.close();
+
+        IndexReader reader = DirectoryReader.open(dir);
+        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader, executor));
+        context.parsedQuery(
+            new ParsedQuery(
+                new BooleanQuery.Builder().add(new TermQuery(new Term("foo", "bar")), Occur.MUST)
+                    .add(new TermQuery(new Term("filter", "f1")), Occur.SHOULD)
+                    .build()
+            )
+        );
+        context.minimumScore(0.01f);
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        context.setSize(1);
+        context.trackTotalHitsUpTo(5);
+
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+        assertEquals(10, context.queryResult().topDocs().topDocs.totalHits.value);
+        assertProfileData(context, "BooleanQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), equalTo(10L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+            assertThat(query.getProfiledChildren(), hasSize(2));
+            assertThat(query.getProfiledChildren().get(0).getQueryName(), equalTo("TermQuery"));
+            assertThat(query.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+            assertThat(query.getProfiledChildren().get(1).getQueryName(), equalTo("TermQuery"));
+            assertThat(query.getProfiledChildren().get(1).getTime(), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_min_score"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), hasSize(1));
+            assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+        });
+
+        reader.close();
+        dir.close();
+    }
+
+    public void testMaxScore() throws Exception {
+        Directory dir = newDirectory();
+        final Sort sort = new Sort(new SortField("filter", SortField.Type.STRING));
+        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+
+        final int numDocs = scaledRandomIntBetween(600, 900);
+        for (int i = 0; i < numDocs; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("foo", "bar", Store.NO));
+            doc.add(new StringField("filter", "f1" + ((i > 0) ? " " + Integer.toString(i) : ""), Store.NO));
+            doc.add(new SortedDocValuesField("filter", newBytesRef("f1" + ((i > 0) ? " " + Integer.toString(i) : ""))));
+            w.addDocument(doc);
+        }
+        w.close();
+
+        IndexReader reader = DirectoryReader.open(dir);
+        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader, executor));
+        context.trackScores(true);
+        context.parsedQuery(
+            new ParsedQuery(
+                new BooleanQuery.Builder().add(new TermQuery(new Term("foo", "bar")), Occur.MUST)
+                    .add(new TermQuery(new Term("filter", "f1")), Occur.SHOULD)
+                    .build()
+            )
+        );
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        context.setSize(1);
+        context.trackTotalHitsUpTo(5);
+
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+        assertFalse(Float.isNaN(context.queryResult().getMaxScore()));
+        assertEquals(1, context.queryResult().topDocs().topDocs.scoreDocs.length);
+        assertThat(context.queryResult().topDocs().topDocs.totalHits.value, greaterThanOrEqualTo(6L));
+        assertProfileData(context, "BooleanQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+            assertThat(query.getProfiledChildren(), hasSize(2));
+            assertThat(query.getProfiledChildren().get(0).getQueryName(), equalTo("TermQuery"));
+            assertThat(query.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+            assertThat(query.getProfiledChildren().get(1).getQueryName(), equalTo("TermQuery"));
+            assertThat(query.getProfiledChildren().get(1).getTime(), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        context.sort(new SortAndFormats(sort, new DocValueFormat[] { DocValueFormat.RAW }));
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+        assertFalse(Float.isNaN(context.queryResult().getMaxScore()));
+        assertEquals(1, context.queryResult().topDocs().topDocs.scoreDocs.length);
+        assertThat(context.queryResult().topDocs().topDocs.totalHits.value, greaterThanOrEqualTo(6L));
+        assertProfileData(context, "BooleanQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+            assertThat(query.getProfiledChildren(), hasSize(2));
+            assertThat(query.getProfiledChildren().get(0).getQueryName(), equalTo("TermQuery"));
+            assertThat(query.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+            assertThat(query.getProfiledChildren().get(1).getQueryName(), equalTo("TermQuery"));
+            assertThat(query.getProfiledChildren().get(1).getTime(), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        reader.close();
+        dir.close();
+    }
+
+    public void testCollapseQuerySearchResults() throws Exception {
+        Directory dir = newDirectory();
+        final Sort sort = new Sort(new SortField("user", SortField.Type.INT));
+        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+
+        // Always end up with uneven buckets so collapsing is predictable
+        final int numDocs = 2 * scaledRandomIntBetween(600, 900) - 1;
+        for (int i = 0; i < numDocs; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("foo", "bar", Store.NO));
+            doc.add(new NumericDocValuesField("user", i & 1));
+            w.addDocument(doc);
+        }
+        w.close();
+
+        IndexReader reader = DirectoryReader.open(dir);
+        QueryShardContext queryShardContext = mock(QueryShardContext.class);
+        when(queryShardContext.fieldMapper("user")).thenReturn(
+            new NumberFieldType("user", NumberType.INTEGER, true, false, true, false, null, Collections.emptyMap())
+        );
+
+        TestSearchContext context = new TestSearchContext(queryShardContext, indexShard, newContextSearcher(reader, executor));
+        context.collapse(new CollapseBuilder("user").build(context.getQueryShardContext()));
+        context.trackScores(true);
+        context.parsedQuery(new ParsedQuery(new TermQuery(new Term("foo", "bar"))));
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        context.setSize(2);
+        context.trackTotalHitsUpTo(5);
+
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+        assertFalse(Float.isNaN(context.queryResult().getMaxScore()));
+        assertEquals(2, context.queryResult().topDocs().topDocs.scoreDocs.length);
+        assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+        assertThat(context.queryResult().topDocs().topDocs, instanceOf(CollapseTopFieldDocs.class));
+
+        assertProfileData(context, "TermQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            assertThat(query.getProfiledChildren(), empty());
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        context.sort(new SortAndFormats(sort, new DocValueFormat[] { DocValueFormat.RAW }));
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers(), queryPhaseSearcher);
+        assertFalse(Float.isNaN(context.queryResult().getMaxScore()));
+        assertEquals(2, context.queryResult().topDocs().topDocs.scoreDocs.length);
+        assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+        assertThat(context.queryResult().topDocs().topDocs, instanceOf(CollapseTopFieldDocs.class));
+
+        assertProfileData(context, "TermQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            assertThat(query.getProfiledChildren(), empty());
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        reader.close();
+        dir.close();
+    }
+
+    private void assertProfileData(SearchContext context, String type, Consumer<ProfileResult> query, Consumer<CollectorResult> collector)
+        throws IOException {
+        assertProfileData(context, collector, (profileResult) -> {
+            assertThat(profileResult.getQueryName(), equalTo(type));
+            assertThat(profileResult.getTime(), greaterThan(0L));
+            query.accept(profileResult);
+        });
+    }
+
+    private void assertProfileData(SearchContext context, Consumer<CollectorResult> collector, Consumer<ProfileResult> query1)
+        throws IOException {
+        assertProfileData(context, Arrays.asList(query1), collector, false);
+    }
+
+    private void assertProfileData(
+        SearchContext context,
+        Consumer<CollectorResult> collector,
+        Consumer<ProfileResult> query1,
+        Consumer<ProfileResult> query2
+    ) throws IOException {
+        assertProfileData(context, Arrays.asList(query1, query2), collector, false);
+    }
+
+    private final void assertProfileData(
+        SearchContext context,
+        List<Consumer<ProfileResult>> queries,
+        Consumer<CollectorResult> collector,
+        boolean debug
+    ) throws IOException {
+        assertThat(context.getProfilers(), not(nullValue()));
+
+        final ProfileShardResult result = SearchProfileShardResults.buildShardResults(context.getProfilers(), null);
+        if (debug) {
+            final SearchProfileShardResults results = new SearchProfileShardResults(
+                Collections.singletonMap(indexShard.shardId().toString(), result)
+            );
+
+            try (final XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint()) {
+                builder.startObject();
+                results.toXContent(builder, ToXContent.EMPTY_PARAMS);
+                builder.endObject();
+                builder.flush();
+
+                final OutputStream out = builder.getOutputStream();
+                assertThat(out, instanceOf(ByteArrayOutputStream.class));
+
+                logger.info(new String(((ByteArrayOutputStream) out).toByteArray(), StandardCharsets.UTF_8));
+            }
+        }
+
+        assertThat(result.getQueryProfileResults(), hasSize(1));
+
+        final QueryProfileShardResult queryProfileShardResult = result.getQueryProfileResults().get(0);
+        assertThat(queryProfileShardResult.getQueryResults(), hasSize(queries.size()));
+
+        for (int i = 0; i < queries.size(); ++i) {
+            queries.get(i).accept(queryProfileShardResult.getQueryResults().get(i));
+        }
+
+        collector.accept(queryProfileShardResult.getCollectorResult());
+    }
+
+    private static ContextIndexSearcher newContextSearcher(IndexReader reader, ExecutorService executor) throws IOException {
+        return new ContextIndexSearcher(
+            reader,
+            IndexSearcher.getDefaultSimilarity(),
+            IndexSearcher.getDefaultQueryCache(),
+            IndexSearcher.getDefaultQueryCachingPolicy(),
+            true,
+            executor
+        );
+    }
+
+    private static ContextIndexSearcher newEarlyTerminationContextSearcher(IndexReader reader, int size, ExecutorService executor)
+        throws IOException {
+        return new ContextIndexSearcher(
+            reader,
+            IndexSearcher.getDefaultSimilarity(),
+            IndexSearcher.getDefaultQueryCache(),
+            IndexSearcher.getDefaultQueryCachingPolicy(),
+            true,
+            executor
+        ) {
+
+            @Override
+            public void search(List<LeafReaderContext> leaves, Weight weight, Collector collector) throws IOException {
+                final Collector in = new AssertingEarlyTerminationFilterCollector(collector, size);
+                super.search(leaves, weight, in);
+            }
+        };
+    }
+
+    private static class AssertingEarlyTerminationFilterCollector extends FilterCollector {
+        private final int size;
+
+        AssertingEarlyTerminationFilterCollector(Collector in, int size) {
+            super(in);
+            this.size = size;
+        }
+
+        @Override
+        public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+            final LeafCollector in = super.getLeafCollector(context);
+            return new FilterLeafCollector(in) {
+                int collected;
+
+                @Override
+                public void collect(int doc) throws IOException {
+                    assert collected <= size : "should not collect more than " + size + " doc per segment, got " + collected;
+                    ++collected;
+                    super.collect(doc);
+                }
+            };
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/common/lucene/MinimumScoreCollector.java
+++ b/server/src/main/java/org/opensearch/common/lucene/MinimumScoreCollector.java
@@ -55,6 +55,10 @@ public class MinimumScoreCollector extends SimpleCollector {
         this.minimumScore = minimumScore;
     }
 
+    public Collector getCollector() {
+        return collector;
+    }
+
     @Override
     public void setScorer(Scorable scorer) throws IOException {
         if (!(scorer instanceof ScoreCachingWrappingScorer)) {

--- a/server/src/main/java/org/opensearch/common/lucene/search/FilteredCollector.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/FilteredCollector.java
@@ -53,6 +53,10 @@ public class FilteredCollector implements Collector {
         this.filter = filter;
     }
 
+    public Collector getCollector() {
+        return collector;
+    }
+
     @Override
     public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
         final ScorerSupplier filterScorerSupplier = filter.scorerSupplier(context);

--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -36,6 +36,7 @@ import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
@@ -82,6 +83,7 @@ import org.opensearch.search.internal.ShardSearchRequest;
 import org.opensearch.search.profile.Profilers;
 import org.opensearch.search.query.QueryPhaseExecutionException;
 import org.opensearch.search.query.QuerySearchResult;
+import org.opensearch.search.query.ReduceableSearchResult;
 import org.opensearch.search.rescore.RescoreContext;
 import org.opensearch.search.slice.SliceBuilder;
 import org.opensearch.search.sort.SortAndFormats;
@@ -163,7 +165,7 @@ final class DefaultSearchContext extends SearchContext {
     private Profilers profilers;
 
     private final Map<String, SearchExtBuilder> searchExtBuilders = new HashMap<>();
-    private final Map<Class<?>, Collector> queryCollectors = new HashMap<>();
+    private final Map<Class<?>, CollectorManager<? extends Collector, ReduceableSearchResult>> queryCollectorManagers = new HashMap<>();
     private final QueryShardContext queryShardContext;
     private final FetchPhase fetchPhase;
 
@@ -823,8 +825,8 @@ final class DefaultSearchContext extends SearchContext {
     }
 
     @Override
-    public Map<Class<?>, Collector> queryCollectors() {
-        return queryCollectors;
+    public Map<Class<?>, CollectorManager<? extends Collector, ReduceableSearchResult>> queryCollectorManagers() {
+        return queryCollectorManagers;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/internal/FilteredSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/FilteredSearchContext.java
@@ -33,6 +33,7 @@
 package org.opensearch.search.internal;
 
 import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.Query;
 import org.opensearch.action.search.SearchShardTask;
@@ -61,6 +62,7 @@ import org.opensearch.search.fetch.subphase.ScriptFieldsContext;
 import org.opensearch.search.fetch.subphase.highlight.SearchHighlightContext;
 import org.opensearch.search.profile.Profilers;
 import org.opensearch.search.query.QuerySearchResult;
+import org.opensearch.search.query.ReduceableSearchResult;
 import org.opensearch.search.rescore.RescoreContext;
 import org.opensearch.search.sort.SortAndFormats;
 import org.opensearch.search.suggest.SuggestionSearchContext;
@@ -492,8 +494,8 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
-    public Map<Class<?>, Collector> queryCollectors() {
-        return in.queryCollectors();
+    public Map<Class<?>, CollectorManager<? extends Collector, ReduceableSearchResult>> queryCollectorManagers() {
+        return in.queryCollectorManagers();
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/SearchContext.java
@@ -32,6 +32,7 @@
 package org.opensearch.search.internal;
 
 import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.Query;
 import org.opensearch.action.search.SearchShardTask;
@@ -66,6 +67,7 @@ import org.opensearch.search.fetch.subphase.ScriptFieldsContext;
 import org.opensearch.search.fetch.subphase.highlight.SearchHighlightContext;
 import org.opensearch.search.profile.Profilers;
 import org.opensearch.search.query.QuerySearchResult;
+import org.opensearch.search.query.ReduceableSearchResult;
 import org.opensearch.search.rescore.RescoreContext;
 import org.opensearch.search.sort.SortAndFormats;
 import org.opensearch.search.suggest.SuggestionSearchContext;
@@ -388,8 +390,8 @@ public abstract class SearchContext implements Releasable {
      */
     public abstract long getRelativeTimeInMillis();
 
-    /** Return a view of the additional query collectors that should be run for this context. */
-    public abstract Map<Class<?>, Collector> queryCollectors();
+    /** Return a view of the additional query collector managers that should be run for this context. */
+    public abstract Map<Class<?>, CollectorManager<? extends Collector, ReduceableSearchResult>> queryCollectorManagers();
 
     public abstract QueryShardContext getQueryShardContext();
 

--- a/server/src/main/java/org/opensearch/search/profile/Profilers.java
+++ b/server/src/main/java/org/opensearch/search/profile/Profilers.java
@@ -57,7 +57,7 @@ public final class Profilers {
 
     /** Switch to a new profile. */
     public QueryProfiler addQueryProfiler() {
-        QueryProfiler profiler = new QueryProfiler(searcher.allowConcurrentSegmentSearch());
+        QueryProfiler profiler = new QueryProfiler(searcher.getExecutor() != null);
         searcher.setProfiler(profiler);
         queryProfilers.add(profiler);
         return profiler;

--- a/server/src/main/java/org/opensearch/search/profile/query/InternalProfileCollectorManager.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/InternalProfileCollectorManager.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.profile.query;
+
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
+import org.opensearch.search.query.EarlyTerminatingListener;
+import org.opensearch.search.query.ReduceableSearchResult;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class InternalProfileCollectorManager
+    implements
+        ProfileCollectorManager<InternalProfileCollector, ReduceableSearchResult>,
+        EarlyTerminatingListener {
+    private final CollectorManager<? extends Collector, ReduceableSearchResult> manager;
+    private final String reason;
+    private final List<InternalProfileCollectorManager> children;
+    private long time = 0;
+
+    public InternalProfileCollectorManager(
+        CollectorManager<? extends Collector, ReduceableSearchResult> manager,
+        String reason,
+        List<InternalProfileCollectorManager> children
+    ) {
+        this.manager = manager;
+        this.reason = reason;
+        this.children = children;
+    }
+
+    @Override
+    public InternalProfileCollector newCollector() throws IOException {
+        return new InternalProfileCollector(manager.newCollector(), reason, children);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ReduceableSearchResult reduce(Collection<InternalProfileCollector> collectors) throws IOException {
+        final Collection<Collector> subs = new ArrayList<>();
+
+        for (final InternalProfileCollector collector : collectors) {
+            subs.add(collector.getCollector());
+            time += collector.getTime();
+        }
+
+        return ((CollectorManager<Collector, ReduceableSearchResult>) manager).reduce(subs);
+    }
+
+    @Override
+    public String getReason() {
+        return reason;
+    }
+
+    @Override
+    public long getTime() {
+        return time;
+    }
+
+    @Override
+    public Collection<? extends InternalProfileComponent> children() {
+        return children;
+    }
+
+    @Override
+    public String getName() {
+        return manager.getClass().getSimpleName();
+    }
+
+    @Override
+    public CollectorResult getCollectorTree() {
+        return InternalProfileCollector.doGetCollectorTree(this);
+    }
+
+    @Override
+    public void onEarlyTemination(int maxCountHits, boolean forcedTermination) {
+        if (manager instanceof EarlyTerminatingListener) {
+            ((EarlyTerminatingListener) manager).onEarlyTemination(maxCountHits, forcedTermination);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/profile/query/InternalProfileCollectorManager.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/InternalProfileCollectorManager.java
@@ -81,9 +81,9 @@ public class InternalProfileCollectorManager
     }
 
     @Override
-    public void onEarlyTemination(int maxCountHits, boolean forcedTermination) {
+    public void onEarlyTermination(int maxCountHits, boolean forcedTermination) {
         if (manager instanceof EarlyTerminatingListener) {
-            ((EarlyTerminatingListener) manager).onEarlyTemination(maxCountHits, forcedTermination);
+            ((EarlyTerminatingListener) manager).onEarlyTermination(maxCountHits, forcedTermination);
         }
     }
 }

--- a/server/src/main/java/org/opensearch/search/profile/query/ProfileCollectorManager.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ProfileCollectorManager.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.profile.query;
+
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
+
+/**
+ * Collector manager which supports profiling
+ */
+public interface ProfileCollectorManager<C extends Collector, T> extends CollectorManager<C, T>, InternalProfileComponent {}

--- a/server/src/main/java/org/opensearch/search/query/EarlyTerminatingCollector.java
+++ b/server/src/main/java/org/opensearch/search/query/EarlyTerminatingCollector.java
@@ -95,6 +95,10 @@ public class EarlyTerminatingCollector extends FilterCollector {
         };
     }
 
+    Collector getCollector() {
+        return in;
+    }
+
     /**
      * Returns true if this collector has early terminated.
      */

--- a/server/src/main/java/org/opensearch/search/query/EarlyTerminatingCollectorManager.java
+++ b/server/src/main/java/org/opensearch/search/query/EarlyTerminatingCollectorManager.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.query;
+
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class EarlyTerminatingCollectorManager<C extends Collector>
+    implements
+        CollectorManager<EarlyTerminatingCollector, ReduceableSearchResult>,
+        EarlyTerminatingListener {
+
+    private final CollectorManager<C, ReduceableSearchResult> manager;
+    private final int maxCountHits;
+    private boolean forceTermination;
+
+    EarlyTerminatingCollectorManager(CollectorManager<C, ReduceableSearchResult> manager, int maxCountHits, boolean forceTermination) {
+        this.manager = manager;
+        this.maxCountHits = maxCountHits;
+        this.forceTermination = forceTermination;
+    }
+
+    @Override
+    public EarlyTerminatingCollector newCollector() throws IOException {
+        return new EarlyTerminatingCollector(manager.newCollector(), maxCountHits, false /* forced termination is not supported */);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ReduceableSearchResult reduce(Collection<EarlyTerminatingCollector> collectors) throws IOException {
+        final List<C> innerCollectors = new ArrayList<>(collectors.size());
+
+        boolean didTerminateEarly = false;
+        for (EarlyTerminatingCollector collector : collectors) {
+            innerCollectors.add((C) collector.getCollector());
+            if (collector.hasEarlyTerminated()) {
+                didTerminateEarly = true;
+            }
+        }
+
+        if (didTerminateEarly) {
+            onEarlyTemination(maxCountHits, forceTermination);
+
+            final ReduceableSearchResult result = manager.reduce(innerCollectors);
+            return new ReduceableSearchResult() {
+                @Override
+                public void reduce(QuerySearchResult r) throws IOException {
+                    result.reduce(r);
+                    r.terminatedEarly(true);
+                }
+            };
+        }
+
+        return manager.reduce(innerCollectors);
+    }
+
+    @Override
+    public void onEarlyTemination(int maxCountHits, boolean forcedTermination) {
+        if (manager instanceof EarlyTerminatingListener) {
+            ((EarlyTerminatingListener) manager).onEarlyTemination(maxCountHits, forcedTermination);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/query/EarlyTerminatingCollectorManager.java
+++ b/server/src/main/java/org/opensearch/search/query/EarlyTerminatingCollectorManager.java
@@ -50,7 +50,7 @@ public class EarlyTerminatingCollectorManager<C extends Collector>
         }
 
         if (didTerminateEarly) {
-            onEarlyTemination(maxCountHits, forceTermination);
+            onEarlyTermination(maxCountHits, forceTermination);
 
             final ReduceableSearchResult result = manager.reduce(innerCollectors);
             return new ReduceableSearchResult() {
@@ -66,9 +66,9 @@ public class EarlyTerminatingCollectorManager<C extends Collector>
     }
 
     @Override
-    public void onEarlyTemination(int maxCountHits, boolean forcedTermination) {
+    public void onEarlyTermination(int maxCountHits, boolean forcedTermination) {
         if (manager instanceof EarlyTerminatingListener) {
-            ((EarlyTerminatingListener) manager).onEarlyTemination(maxCountHits, forcedTermination);
+            ((EarlyTerminatingListener) manager).onEarlyTermination(maxCountHits, forcedTermination);
         }
     }
 }

--- a/server/src/main/java/org/opensearch/search/query/EarlyTerminatingListener.java
+++ b/server/src/main/java/org/opensearch/search/query/EarlyTerminatingListener.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.query;
+
+/**
+ * Early termination event listener. It is used during concurrent segment search
+ * to propagate the early termination intent.
+ */
+public interface EarlyTerminatingListener {
+    /**
+     * Early termination event notification
+     * @param maxCountHits desired maximum number of hits
+     * @param forcedTermination :true" if forced termination has been requested, "false" otherwise
+     */
+    void onEarlyTemination(int maxCountHits, boolean forcedTermination);
+}

--- a/server/src/main/java/org/opensearch/search/query/EarlyTerminatingListener.java
+++ b/server/src/main/java/org/opensearch/search/query/EarlyTerminatingListener.java
@@ -18,5 +18,5 @@ public interface EarlyTerminatingListener {
      * @param maxCountHits desired maximum number of hits
      * @param forcedTermination :true" if forced termination has been requested, "false" otherwise
      */
-    void onEarlyTemination(int maxCountHits, boolean forcedTermination);
+    void onEarlyTermination(int maxCountHits, boolean forcedTermination);
 }

--- a/server/src/main/java/org/opensearch/search/query/FilteredCollectorManager.java
+++ b/server/src/main/java/org/opensearch/search/query/FilteredCollectorManager.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.query;
+
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
+import org.apache.lucene.search.Weight;
+import org.opensearch.common.lucene.search.FilteredCollector;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+class FilteredCollectorManager implements CollectorManager<FilteredCollector, ReduceableSearchResult> {
+    private final CollectorManager<? extends Collector, ReduceableSearchResult> manager;
+    private final Weight filter;
+
+    FilteredCollectorManager(CollectorManager<? extends Collector, ReduceableSearchResult> manager, Weight filter) {
+        this.manager = manager;
+        this.filter = filter;
+    }
+
+    @Override
+    public FilteredCollector newCollector() throws IOException {
+        return new FilteredCollector(manager.newCollector(), filter);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public ReduceableSearchResult reduce(Collection<FilteredCollector> collectors) throws IOException {
+        final Collection<Collector> subCollectors = new ArrayList<>();
+
+        for (final FilteredCollector collector : collectors) {
+            subCollectors.add(collector.getCollector());
+        }
+
+        return ((CollectorManager<Collector, ReduceableSearchResult>) manager).reduce(subCollectors);
+    }
+}

--- a/server/src/main/java/org/opensearch/search/query/MinimumCollectorManager.java
+++ b/server/src/main/java/org/opensearch/search/query/MinimumCollectorManager.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.query;
+
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
+import org.opensearch.common.lucene.MinimumScoreCollector;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+class MinimumCollectorManager implements CollectorManager<MinimumScoreCollector, ReduceableSearchResult> {
+    private final CollectorManager<? extends Collector, ReduceableSearchResult> manager;
+    private final float minimumScore;
+
+    MinimumCollectorManager(CollectorManager<? extends Collector, ReduceableSearchResult> manager, float minimumScore) {
+        this.manager = manager;
+        this.minimumScore = minimumScore;
+    }
+
+    @Override
+    public MinimumScoreCollector newCollector() throws IOException {
+        return new MinimumScoreCollector(manager.newCollector(), minimumScore);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public ReduceableSearchResult reduce(Collection<MinimumScoreCollector> collectors) throws IOException {
+        final Collection<Collector> subCollectors = new ArrayList<>();
+
+        for (final MinimumScoreCollector collector : collectors) {
+            subCollectors.add(collector.getCollector());
+        }
+
+        return ((CollectorManager<Collector, ReduceableSearchResult>) manager).reduce(subCollectors);
+    }
+}

--- a/server/src/main/java/org/opensearch/search/query/MultiCollectorWrapper.java
+++ b/server/src/main/java/org/opensearch/search/query/MultiCollectorWrapper.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.query;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.MultiCollector;
+import org.apache.lucene.search.ScoreMode;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Wraps MultiCollector and provide access to underlying collectors.
+ * Please check out https://github.com/apache/lucene/pull/455.
+ */
+public class MultiCollectorWrapper implements Collector {
+    private final MultiCollector delegate;
+    private final Collection<Collector> collectors;
+
+    MultiCollectorWrapper(MultiCollector delegate, Collection<Collector> collectors) {
+        this.delegate = delegate;
+        this.collectors = collectors;
+    }
+
+    @Override
+    public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+        return delegate.getLeafCollector(context);
+    }
+
+    @Override
+    public ScoreMode scoreMode() {
+        return delegate.scoreMode();
+    }
+
+    public Collection<Collector> getCollectors() {
+        return collectors;
+    }
+
+    public static Collector wrap(Collector... collectors) {
+        final List<Collector> collectorsList = Arrays.asList(collectors);
+        final Collector collector = MultiCollector.wrap(collectorsList);
+        if (collector instanceof MultiCollector) {
+            return new MultiCollectorWrapper((MultiCollector) collector, collectorsList);
+        } else {
+            return collector;
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/query/QueryCollectorManagerContext.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryCollectorManagerContext.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.query;
+
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
+import org.apache.lucene.search.MultiCollectorManager;
+import org.opensearch.search.profile.query.InternalProfileCollectorManager;
+import org.opensearch.search.profile.query.ProfileCollectorManager;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public abstract class QueryCollectorManagerContext {
+    private static class QueryCollectorManager implements CollectorManager<Collector, ReduceableSearchResult> {
+        private final MultiCollectorManager manager;
+
+        private QueryCollectorManager(Collection<CollectorManager<? extends Collector, ReduceableSearchResult>> managers) {
+            this.manager = new MultiCollectorManager(managers.toArray(new CollectorManager<?, ?>[0]));
+        }
+
+        @Override
+        public Collector newCollector() throws IOException {
+            return manager.newCollector();
+        }
+
+        @Override
+        public ReduceableSearchResult reduce(Collection<Collector> collectors) throws IOException {
+            final Object[] results = manager.reduce(collectors);
+
+            final ReduceableSearchResult[] transformed = new ReduceableSearchResult[results.length];
+            for (int i = 0; i < results.length; ++i) {
+                assert results[i] instanceof ReduceableSearchResult;
+                transformed[i] = (ReduceableSearchResult) results[i];
+            }
+
+            return reduceWith(transformed);
+        }
+
+        protected ReduceableSearchResult reduceWith(final ReduceableSearchResult[] results) {
+            return (QuerySearchResult result) -> {
+                for (final ReduceableSearchResult r : results) {
+                    r.reduce(result);
+                }
+            };
+        }
+    }
+
+    private static class OpaqueQueryCollectorManager extends QueryCollectorManager {
+        private OpaqueQueryCollectorManager(Collection<CollectorManager<? extends Collector, ReduceableSearchResult>> managers) {
+            super(managers);
+        }
+
+        @Override
+        protected ReduceableSearchResult reduceWith(final ReduceableSearchResult[] results) {
+            return (QuerySearchResult result) -> {};
+        }
+    }
+
+    public static CollectorManager<? extends Collector, ReduceableSearchResult> createOpaqueCollectorManager(
+        List<CollectorManager<? extends Collector, ReduceableSearchResult>> managers
+    ) throws IOException {
+        return new OpaqueQueryCollectorManager(managers);
+    }
+
+    public static CollectorManager<? extends Collector, ReduceableSearchResult> createMultiCollectorManager(
+        List<QueryCollectorContext> collectors
+    ) throws IOException {
+        final Collection<CollectorManager<? extends Collector, ReduceableSearchResult>> managers = new ArrayList<>();
+
+        CollectorManager<?, ReduceableSearchResult> manager = null;
+        for (QueryCollectorContext ctx : collectors) {
+            manager = ctx.createManager(manager);
+            managers.add(manager);
+        }
+
+        return new QueryCollectorManager(managers);
+    }
+
+    public static ProfileCollectorManager<? extends Collector, ReduceableSearchResult> createQueryCollectorManagerWithProfiler(
+        List<QueryCollectorContext> collectors
+    ) throws IOException {
+        InternalProfileCollectorManager manager = null;
+
+        for (QueryCollectorContext ctx : collectors) {
+            manager = ctx.createWithProfiler(manager);
+        }
+
+        return manager;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryPhase.java
@@ -238,9 +238,9 @@ public class QueryPhase {
                 // this collector can filter documents during the collection
                 hasFilterCollector = true;
             }
-            if (searchContext.queryCollectors().isEmpty() == false) {
+            if (searchContext.queryCollectorManagers().isEmpty() == false) {
                 // plug in additional collectors, like aggregations
-                collectors.add(createMultiCollectorContext(searchContext.queryCollectors().values()));
+                collectors.add(createMultiCollectorContext(searchContext.queryCollectorManagers().values()));
             }
             if (searchContext.minimumScore() != null) {
                 // apply the minimum score after multi collector so we filter aggs as well

--- a/server/src/main/java/org/opensearch/search/query/ReduceableSearchResult.java
+++ b/server/src/main/java/org/opensearch/search/query/ReduceableSearchResult.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.query;
+
+import java.io.IOException;
+
+/**
+ * The search result callback returned by reduce phase of the collector manager.
+ */
+public interface ReduceableSearchResult {
+    /**
+     * Apply the reduce operation to the query search results
+     * @param result query search results
+     * @throws IOException exception if reduce operation failed
+     */
+    void reduce(QuerySearchResult result) throws IOException;
+}

--- a/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
@@ -486,7 +486,7 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext {
             }
 
             @Override
-            public void onEarlyTemination(int maxCountHits, boolean forcedTermination) {
+            public void onEarlyTermination(int maxCountHits, boolean forcedTermination) {
                 terminatedAfter = maxCountHits;
             }
 

--- a/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
@@ -44,6 +44,7 @@ import org.apache.lucene.queries.spans.SpanQuery;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.FieldDoc;
@@ -80,6 +81,9 @@ import org.opensearch.search.rescore.RescoreContext;
 import org.opensearch.search.sort.SortAndFormats;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -89,7 +93,7 @@ import static org.opensearch.search.profile.query.CollectorResult.REASON_SEARCH_
 /**
  * A {@link QueryCollectorContext} that creates top docs collector
  */
-abstract class TopDocsCollectorContext extends QueryCollectorContext {
+public abstract class TopDocsCollectorContext extends QueryCollectorContext {
     protected final int numHits;
 
     TopDocsCollectorContext(String profilerName, int numHits) {
@@ -107,7 +111,7 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
     /**
      * Returns true if the top docs should be re-scored after initial search
      */
-    boolean shouldRescore() {
+    public boolean shouldRescore() {
         return false;
     }
 
@@ -115,6 +119,8 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
         private final Sort sort;
         private final Collector collector;
         private final Supplier<TotalHits> hitCountSupplier;
+        private final int trackTotalHitsUpTo;
+        private final int hitCount;
 
         /**
          * Ctr
@@ -132,16 +138,18 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
         ) throws IOException {
             super(REASON_SEARCH_COUNT, 0);
             this.sort = sortAndFormats == null ? null : sortAndFormats.sort;
-            if (trackTotalHitsUpTo == SearchContext.TRACK_TOTAL_HITS_DISABLED) {
+            this.trackTotalHitsUpTo = trackTotalHitsUpTo;
+            if (this.trackTotalHitsUpTo == SearchContext.TRACK_TOTAL_HITS_DISABLED) {
                 this.collector = new EarlyTerminatingCollector(new TotalHitCountCollector(), 0, false);
                 // for bwc hit count is set to 0, it will be converted to -1 by the coordinating node
                 this.hitCountSupplier = () -> new TotalHits(0, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
+                this.hitCount = Integer.MIN_VALUE;
             } else {
                 TotalHitCountCollector hitCountCollector = new TotalHitCountCollector();
                 // implicit total hit counts are valid only when there is no filter collector in the chain
-                int hitCount = hasFilterCollector ? -1 : shortcutTotalHitCount(reader, query);
-                if (hitCount == -1) {
-                    if (trackTotalHitsUpTo == SearchContext.TRACK_TOTAL_HITS_ACCURATE) {
+                this.hitCount = hasFilterCollector ? -1 : shortcutTotalHitCount(reader, query);
+                if (this.hitCount == -1) {
+                    if (this.trackTotalHitsUpTo == SearchContext.TRACK_TOTAL_HITS_ACCURATE) {
                         this.collector = hitCountCollector;
                         this.hitCountSupplier = () -> new TotalHits(hitCountCollector.getTotalHits(), TotalHits.Relation.EQUAL_TO);
                     } else {
@@ -157,6 +165,39 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
                     this.hitCountSupplier = () -> new TotalHits(hitCount, TotalHits.Relation.EQUAL_TO);
                 }
             }
+        }
+
+        @Override
+        CollectorManager<?, ReduceableSearchResult> createManager(CollectorManager<?, ReduceableSearchResult> in) throws IOException {
+            assert in == null;
+
+            CollectorManager<?, ReduceableSearchResult> manager = null;
+
+            if (trackTotalHitsUpTo == SearchContext.TRACK_TOTAL_HITS_DISABLED) {
+                manager = new EarlyTerminatingCollectorManager<>(
+                    new TotalHitCountCollectorManager.Empty(new TotalHits(0, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO), sort),
+                    0,
+                    false
+                );
+            } else {
+                if (hitCount == -1) {
+                    if (trackTotalHitsUpTo != SearchContext.TRACK_TOTAL_HITS_ACCURATE) {
+                        manager = new EarlyTerminatingCollectorManager<>(
+                            new TotalHitCountCollectorManager(sort),
+                            trackTotalHitsUpTo,
+                            false
+                        );
+                    }
+                } else {
+                    manager = new EarlyTerminatingCollectorManager<>(
+                        new TotalHitCountCollectorManager.Empty(new TotalHits(hitCount, TotalHits.Relation.EQUAL_TO), sort),
+                        0,
+                        false
+                    );
+                }
+            }
+
+            return manager;
         }
 
         @Override
@@ -181,7 +222,11 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
     static class CollapsingTopDocsCollectorContext extends TopDocsCollectorContext {
         private final DocValueFormat[] sortFmt;
         private final CollapsingTopDocsCollector<?> topDocsCollector;
+        private final Collector collector;
         private final Supplier<Float> maxScoreSupplier;
+        private final CollapseContext collapseContext;
+        private final boolean trackMaxScore;
+        private final Sort sort;
 
         /**
          * Ctr
@@ -199,29 +244,93 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
             super(REASON_SEARCH_TOP_HITS, numHits);
             assert numHits > 0;
             assert collapseContext != null;
-            Sort sort = sortAndFormats == null ? Sort.RELEVANCE : sortAndFormats.sort;
+            this.sort = sortAndFormats == null ? Sort.RELEVANCE : sortAndFormats.sort;
             this.sortFmt = sortAndFormats == null ? new DocValueFormat[] { DocValueFormat.RAW } : sortAndFormats.formats;
+            this.collapseContext = collapseContext;
             this.topDocsCollector = collapseContext.createTopDocs(sort, numHits);
+            this.trackMaxScore = trackMaxScore;
 
-            MaxScoreCollector maxScoreCollector;
+            MaxScoreCollector maxScoreCollector = null;
             if (trackMaxScore) {
                 maxScoreCollector = new MaxScoreCollector();
                 maxScoreSupplier = maxScoreCollector::getMaxScore;
             } else {
+                maxScoreCollector = null;
                 maxScoreSupplier = () -> Float.NaN;
             }
+
+            this.collector = MultiCollector.wrap(topDocsCollector, maxScoreCollector);
         }
 
         @Override
         Collector create(Collector in) throws IOException {
             assert in == null;
-            return topDocsCollector;
+            return collector;
         }
 
         @Override
         void postProcess(QuerySearchResult result) throws IOException {
-            CollapseTopFieldDocs topDocs = topDocsCollector.getTopDocs();
+            final CollapseTopFieldDocs topDocs = topDocsCollector.getTopDocs();
             result.topDocs(new TopDocsAndMaxScore(topDocs, maxScoreSupplier.get()), sortFmt);
+        }
+
+        @Override
+        CollectorManager<?, ReduceableSearchResult> createManager(CollectorManager<?, ReduceableSearchResult> in) throws IOException {
+            return new CollectorManager<Collector, ReduceableSearchResult>() {
+                @Override
+                public Collector newCollector() throws IOException {
+                    MaxScoreCollector maxScoreCollector = null;
+
+                    if (trackMaxScore) {
+                        maxScoreCollector = new MaxScoreCollector();
+                    }
+
+                    return MultiCollectorWrapper.wrap(collapseContext.createTopDocs(sort, numHits), maxScoreCollector);
+                }
+
+                @Override
+                public ReduceableSearchResult reduce(Collection<Collector> collectors) throws IOException {
+                    final Collection<Collector> subs = new ArrayList<>();
+                    for (final Collector collector : collectors) {
+                        if (collector instanceof MultiCollectorWrapper) {
+                            subs.addAll(((MultiCollectorWrapper) collector).getCollectors());
+                        } else {
+                            subs.add(collector);
+                        }
+                    }
+
+                    final Collection<CollapseTopFieldDocs> topFieldDocs = new ArrayList<CollapseTopFieldDocs>();
+                    float maxScore = Float.NaN;
+
+                    for (final Collector collector : subs) {
+                        if (collector instanceof CollapsingTopDocsCollector<?>) {
+                            topFieldDocs.add(((CollapsingTopDocsCollector<?>) collector).getTopDocs());
+                        } else if (collector instanceof MaxScoreCollector) {
+                            float score = ((MaxScoreCollector) collector).getMaxScore();
+                            if (Float.isNaN(maxScore)) {
+                                maxScore = score;
+                            } else {
+                                maxScore = Math.max(maxScore, score);
+                            }
+                        }
+                    }
+
+                    return reduceWith(topFieldDocs, maxScore);
+                }
+            };
+        }
+
+        protected ReduceableSearchResult reduceWith(final Collection<CollapseTopFieldDocs> topFieldDocs, float maxScore) {
+            return (QuerySearchResult result) -> {
+                final CollapseTopFieldDocs topDocs = CollapseTopFieldDocs.merge(
+                    sort,
+                    0,
+                    numHits,
+                    topFieldDocs.toArray(new CollapseTopFieldDocs[0]),
+                    true
+                );
+                result.topDocs(new TopDocsAndMaxScore(topDocs, maxScore), sortFmt);
+            };
         }
     }
 
@@ -240,11 +349,38 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
             }
         }
 
+        private static CollectorManager<? extends TopDocsCollector<?>, ? extends TopDocs> createCollectorManager(
+            @Nullable SortAndFormats sortAndFormats,
+            int numHits,
+            @Nullable ScoreDoc searchAfter,
+            int hitCountThreshold
+        ) {
+            if (sortAndFormats == null) {
+                // See please https://github.com/apache/lucene/pull/450, should be fixed in 9.x
+                if (searchAfter != null) {
+                    return TopScoreDocCollector.createSharedManager(
+                        numHits,
+                        new FieldDoc(searchAfter.doc, searchAfter.score),
+                        hitCountThreshold
+                    );
+                } else {
+                    return TopScoreDocCollector.createSharedManager(numHits, null, hitCountThreshold);
+                }
+            } else {
+                return TopFieldCollector.createSharedManager(sortAndFormats.sort, numHits, (FieldDoc) searchAfter, hitCountThreshold);
+            }
+        }
+
         protected final @Nullable SortAndFormats sortAndFormats;
         private final Collector collector;
         private final Supplier<TotalHits> totalHitsSupplier;
         private final Supplier<TopDocs> topDocsSupplier;
         private final Supplier<Float> maxScoreSupplier;
+        private final ScoreDoc searchAfter;
+        private final int trackTotalHitsUpTo;
+        private final boolean trackMaxScore;
+        private final boolean hasInfMaxScore;
+        private final int hitCount;
 
         /**
          * Ctr
@@ -269,24 +405,30 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
         ) throws IOException {
             super(REASON_SEARCH_TOP_HITS, numHits);
             this.sortAndFormats = sortAndFormats;
+            this.searchAfter = searchAfter;
+            this.trackTotalHitsUpTo = trackTotalHitsUpTo;
+            this.trackMaxScore = trackMaxScore;
+            this.hasInfMaxScore = hasInfMaxScore(query);
 
             final TopDocsCollector<?> topDocsCollector;
 
-            if ((sortAndFormats == null || SortField.FIELD_SCORE.equals(sortAndFormats.sort.getSort()[0])) && hasInfMaxScore(query)) {
+            if ((sortAndFormats == null || SortField.FIELD_SCORE.equals(sortAndFormats.sort.getSort()[0])) && hasInfMaxScore) {
                 // disable max score optimization since we have a mandatory clause
                 // that doesn't track the maximum score
                 topDocsCollector = createCollector(sortAndFormats, numHits, searchAfter, Integer.MAX_VALUE);
                 topDocsSupplier = new CachedSupplier<>(topDocsCollector::topDocs);
                 totalHitsSupplier = () -> topDocsSupplier.get().totalHits;
+                hitCount = Integer.MIN_VALUE;
             } else if (trackTotalHitsUpTo == SearchContext.TRACK_TOTAL_HITS_DISABLED) {
                 // don't compute hit counts via the collector
                 topDocsCollector = createCollector(sortAndFormats, numHits, searchAfter, 1);
                 topDocsSupplier = new CachedSupplier<>(topDocsCollector::topDocs);
                 totalHitsSupplier = () -> new TotalHits(0, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
+                hitCount = -1;
             } else {
                 // implicit total hit counts are valid only when there is no filter collector in the chain
-                final int hitCount = hasFilterCollector ? -1 : shortcutTotalHitCount(reader, query);
-                if (hitCount == -1) {
+                this.hitCount = hasFilterCollector ? -1 : shortcutTotalHitCount(reader, query);
+                if (this.hitCount == -1) {
                     topDocsCollector = createCollector(sortAndFormats, numHits, searchAfter, trackTotalHitsUpTo);
                     topDocsSupplier = new CachedSupplier<>(topDocsCollector::topDocs);
                     totalHitsSupplier = () -> topDocsSupplier.get().totalHits;
@@ -294,7 +436,7 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
                     // don't compute hit counts via the collector
                     topDocsCollector = createCollector(sortAndFormats, numHits, searchAfter, 1);
                     topDocsSupplier = new CachedSupplier<>(topDocsCollector::topDocs);
-                    totalHitsSupplier = () -> new TotalHits(hitCount, TotalHits.Relation.EQUAL_TO);
+                    totalHitsSupplier = () -> new TotalHits(this.hitCount, TotalHits.Relation.EQUAL_TO);
                 }
             }
             MaxScoreCollector maxScoreCollector = null;
@@ -315,13 +457,148 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
             }
 
             this.collector = MultiCollector.wrap(topDocsCollector, maxScoreCollector);
+        }
 
+        private class SimpleTopDocsCollectorManager
+            implements
+                CollectorManager<Collector, ReduceableSearchResult>,
+                EarlyTerminatingListener {
+            private Integer terminatedAfter;
+            private final CollectorManager<? extends TopDocsCollector<?>, ? extends TopDocs> manager;
+
+            private SimpleTopDocsCollectorManager() {
+                if ((sortAndFormats == null || SortField.FIELD_SCORE.equals(sortAndFormats.sort.getSort()[0])) && hasInfMaxScore) {
+                    // disable max score optimization since we have a mandatory clause
+                    // that doesn't track the maximum score
+                    manager = createCollectorManager(sortAndFormats, numHits, searchAfter, Integer.MAX_VALUE);
+                } else if (trackTotalHitsUpTo == SearchContext.TRACK_TOTAL_HITS_DISABLED) {
+                    // don't compute hit counts via the collector
+                    manager = createCollectorManager(sortAndFormats, numHits, searchAfter, 1);
+                } else {
+                    // implicit total hit counts are valid only when there is no filter collector in the chain
+                    if (hitCount == -1) {
+                        manager = createCollectorManager(sortAndFormats, numHits, searchAfter, trackTotalHitsUpTo);
+                    } else {
+                        // don't compute hit counts via the collector
+                        manager = createCollectorManager(sortAndFormats, numHits, searchAfter, 1);
+                    }
+                }
+            }
+
+            @Override
+            public void onEarlyTemination(int maxCountHits, boolean forcedTermination) {
+                terminatedAfter = maxCountHits;
+            }
+
+            @Override
+            public Collector newCollector() throws IOException {
+                MaxScoreCollector maxScoreCollector = null;
+
+                if (sortAndFormats != null && trackMaxScore) {
+                    maxScoreCollector = new MaxScoreCollector();
+                }
+
+                return MultiCollectorWrapper.wrap(manager.newCollector(), maxScoreCollector);
+            }
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public ReduceableSearchResult reduce(Collection<Collector> collectors) throws IOException {
+                final Collection<TopDocsCollector<?>> topDocsCollectors = new ArrayList<>();
+                final Collection<MaxScoreCollector> maxScoreCollectors = new ArrayList<>();
+
+                for (final Collector collector : collectors) {
+                    if (collector instanceof MultiCollectorWrapper) {
+                        for (final Collector sub : (((MultiCollectorWrapper) collector).getCollectors())) {
+                            if (sub instanceof TopDocsCollector<?>) {
+                                topDocsCollectors.add((TopDocsCollector<?>) sub);
+                            } else if (sub instanceof MaxScoreCollector) {
+                                maxScoreCollectors.add((MaxScoreCollector) sub);
+                            }
+                        }
+                    } else if (collector instanceof TopDocsCollector<?>) {
+                        topDocsCollectors.add((TopDocsCollector<?>) collector);
+                    } else if (collector instanceof MaxScoreCollector) {
+                        maxScoreCollectors.add((MaxScoreCollector) collector);
+                    }
+                }
+
+                float maxScore = Float.NaN;
+                for (final MaxScoreCollector collector : maxScoreCollectors) {
+                    float score = collector.getMaxScore();
+                    if (Float.isNaN(maxScore)) {
+                        maxScore = score;
+                    } else {
+                        maxScore = Math.max(maxScore, score);
+                    }
+                }
+
+                final TopDocs topDocs = ((CollectorManager<TopDocsCollector<?>, ? extends TopDocs>) manager).reduce(topDocsCollectors);
+                return reduceWith(topDocs, maxScore, terminatedAfter);
+            }
+        }
+
+        @Override
+        CollectorManager<?, ReduceableSearchResult> createManager(CollectorManager<?, ReduceableSearchResult> in) throws IOException {
+            assert in == null;
+            return new SimpleTopDocsCollectorManager();
+        }
+
+        protected ReduceableSearchResult reduceWith(final TopDocs topDocs, final float maxScore, final Integer terminatedAfter) {
+            return (QuerySearchResult result) -> {
+                final TopDocsAndMaxScore topDocsAndMaxScore = newTopDocs(topDocs, maxScore, terminatedAfter);
+                result.topDocs(topDocsAndMaxScore, sortAndFormats == null ? null : sortAndFormats.formats);
+            };
         }
 
         @Override
         Collector create(Collector in) {
             assert in == null;
             return collector;
+        }
+
+        TopDocsAndMaxScore newTopDocs(final TopDocs topDocs, final float maxScore, final Integer terminatedAfter) {
+            TotalHits totalHits = null;
+
+            if ((sortAndFormats == null || SortField.FIELD_SCORE.equals(sortAndFormats.sort.getSort()[0])) && hasInfMaxScore) {
+                totalHits = topDocs.totalHits;
+            } else if (trackTotalHitsUpTo == SearchContext.TRACK_TOTAL_HITS_DISABLED) {
+                // don't compute hit counts via the collector
+                totalHits = new TotalHits(0, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
+            } else {
+                if (hitCount == -1) {
+                    totalHits = topDocs.totalHits;
+                } else {
+                    totalHits = new TotalHits(hitCount, TotalHits.Relation.EQUAL_TO);
+                }
+            }
+
+            // Since we cannot support early forced termination, we have to simulate it by
+            // artificially reducing the number of total hits and doc scores.
+            ScoreDoc[] scoreDocs = topDocs.scoreDocs;
+            if (terminatedAfter != null) {
+                if (totalHits.value > terminatedAfter) {
+                    totalHits = new TotalHits(terminatedAfter, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
+                }
+
+                if (scoreDocs != null && scoreDocs.length > terminatedAfter) {
+                    scoreDocs = Arrays.copyOf(scoreDocs, terminatedAfter);
+                }
+            }
+
+            final TopDocs newTopDocs;
+            if (topDocs instanceof TopFieldDocs) {
+                TopFieldDocs fieldDocs = (TopFieldDocs) topDocs;
+                newTopDocs = new TopFieldDocs(totalHits, scoreDocs, fieldDocs.fields);
+            } else {
+                newTopDocs = new TopDocs(totalHits, scoreDocs);
+            }
+
+            if (Float.isNaN(maxScore) && newTopDocs.scoreDocs.length > 0 && sortAndFormats == null) {
+                return new TopDocsAndMaxScore(newTopDocs, newTopDocs.scoreDocs[0].score);
+            } else {
+                return new TopDocsAndMaxScore(newTopDocs, maxScore);
+            }
         }
 
         TopDocsAndMaxScore newTopDocs() {
@@ -371,6 +648,35 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
             );
             this.scrollContext = Objects.requireNonNull(scrollContext);
             this.numberOfShards = numberOfShards;
+        }
+
+        @Override
+        protected ReduceableSearchResult reduceWith(final TopDocs topDocs, final float maxScore, final Integer terminatedAfter) {
+            return (QuerySearchResult result) -> {
+                final TopDocsAndMaxScore topDocsAndMaxScore = newTopDocs(topDocs, maxScore, terminatedAfter);
+
+                if (scrollContext.totalHits == null) {
+                    // first round
+                    scrollContext.totalHits = topDocsAndMaxScore.topDocs.totalHits;
+                    scrollContext.maxScore = topDocsAndMaxScore.maxScore;
+                } else {
+                    // subsequent round: the total number of hits and
+                    // the maximum score were computed on the first round
+                    topDocsAndMaxScore.topDocs.totalHits = scrollContext.totalHits;
+                    topDocsAndMaxScore.maxScore = scrollContext.maxScore;
+                }
+
+                if (numberOfShards == 1) {
+                    // if we fetch the document in the same roundtrip, we already know the last emitted doc
+                    if (topDocsAndMaxScore.topDocs.scoreDocs.length > 0) {
+                        // set the last emitted doc
+                        scrollContext.lastEmittedDoc = topDocsAndMaxScore.topDocs.scoreDocs[topDocsAndMaxScore.topDocs.scoreDocs.length
+                            - 1];
+                    }
+                }
+
+                result.topDocs(topDocsAndMaxScore, sortAndFormats == null ? null : sortAndFormats.formats);
+            };
         }
 
         @Override
@@ -457,7 +763,7 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
      * Creates a {@link TopDocsCollectorContext} from the provided <code>searchContext</code>.
      * @param hasFilterCollector True if the collector chain contains at least one collector that can filters document.
      */
-    static TopDocsCollectorContext createTopDocsCollectorContext(SearchContext searchContext, boolean hasFilterCollector)
+    public static TopDocsCollectorContext createTopDocsCollectorContext(SearchContext searchContext, boolean hasFilterCollector)
         throws IOException {
         final IndexReader reader = searchContext.searcher().getIndexReader();
         final Query query = searchContext.query();
@@ -515,7 +821,7 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
                 hasFilterCollector
             ) {
                 @Override
-                boolean shouldRescore() {
+                public boolean shouldRescore() {
                     return rescore;
                 }
             };

--- a/server/src/main/java/org/opensearch/search/query/TotalHitCountCollectorManager.java
+++ b/server/src/main/java/org/opensearch/search/query/TotalHitCountCollectorManager.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.query;
+
+import org.apache.lucene.search.CollectorManager;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopFieldDocs;
+import org.apache.lucene.search.TotalHitCountCollector;
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.common.lucene.Lucene;
+import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
+
+import java.io.IOException;
+import java.util.Collection;
+
+public class TotalHitCountCollectorManager
+    implements
+        CollectorManager<TotalHitCountCollector, ReduceableSearchResult>,
+        EarlyTerminatingListener {
+
+    private static final TotalHitCountCollector EMPTY_COLLECTOR = new TotalHitCountCollector() {
+        @Override
+        public void collect(int doc) {}
+
+        @Override
+        public ScoreMode scoreMode() {
+            return ScoreMode.COMPLETE_NO_SCORES;
+        }
+    };
+
+    private final Sort sort;
+    private Integer terminatedAfter;
+
+    public TotalHitCountCollectorManager(final Sort sort) {
+        this.sort = sort;
+    }
+
+    @Override
+    public void onEarlyTemination(int maxCountHits, boolean forcedTermination) {
+        terminatedAfter = maxCountHits;
+    }
+
+    @Override
+    public TotalHitCountCollector newCollector() throws IOException {
+        return new TotalHitCountCollector();
+    }
+
+    @Override
+    public ReduceableSearchResult reduce(Collection<TotalHitCountCollector> collectors) throws IOException {
+        return (QuerySearchResult result) -> {
+            final TotalHits.Relation relation = (terminatedAfter != null)
+                ? TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO
+                : TotalHits.Relation.EQUAL_TO;
+
+            int totalHits = collectors.stream().mapToInt(TotalHitCountCollector::getTotalHits).sum();
+            if (terminatedAfter != null && totalHits > terminatedAfter) {
+                totalHits = terminatedAfter;
+            }
+
+            final TotalHits totalHitCount = new TotalHits(totalHits, relation);
+            final TopDocs topDocs = (sort != null)
+                ? new TopFieldDocs(totalHitCount, Lucene.EMPTY_SCORE_DOCS, sort.getSort())
+                : new TopDocs(totalHitCount, Lucene.EMPTY_SCORE_DOCS);
+
+            result.topDocs(new TopDocsAndMaxScore(topDocs, Float.NaN), null);
+        };
+    }
+
+    static class Empty implements CollectorManager<TotalHitCountCollector, ReduceableSearchResult> {
+        private final TotalHits totalHits;
+        private final Sort sort;
+
+        Empty(final TotalHits totalHits, final Sort sort) {
+            this.totalHits = totalHits;
+            this.sort = sort;
+        }
+
+        @Override
+        public TotalHitCountCollector newCollector() throws IOException {
+            return EMPTY_COLLECTOR;
+        }
+
+        @Override
+        public ReduceableSearchResult reduce(Collection<TotalHitCountCollector> collectors) throws IOException {
+            return (QuerySearchResult result) -> {
+                final TopDocs topDocs;
+
+                if (sort != null) {
+                    topDocs = new TopFieldDocs(totalHits, Lucene.EMPTY_SCORE_DOCS, sort.getSort());
+                } else {
+                    topDocs = new TopDocs(totalHits, Lucene.EMPTY_SCORE_DOCS);
+                }
+
+                result.topDocs(new TopDocsAndMaxScore(topDocs, Float.NaN), null);
+            };
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/query/TotalHitCountCollectorManager.java
+++ b/server/src/main/java/org/opensearch/search/query/TotalHitCountCollectorManager.java
@@ -44,7 +44,7 @@ public class TotalHitCountCollectorManager
     }
 
     @Override
-    public void onEarlyTemination(int maxCountHits, boolean forcedTermination) {
+    public void onEarlyTermination(int maxCountHits, boolean forcedTermination) {
         terminatedAfter = maxCountHits;
     }
 

--- a/server/src/test/java/org/opensearch/search/SearchCancellationTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchCancellationTests.java
@@ -108,7 +108,8 @@ public class SearchCancellationTests extends OpenSearchTestCase {
             IndexSearcher.getDefaultSimilarity(),
             IndexSearcher.getDefaultQueryCache(),
             IndexSearcher.getDefaultQueryCachingPolicy(),
-            true
+            true,
+            null
         );
         NullPointerException npe = expectThrows(NullPointerException.class, () -> searcher.addQueryCancellation(null));
         assertEquals("cancellation runnable should not be null", npe.getMessage());
@@ -127,7 +128,8 @@ public class SearchCancellationTests extends OpenSearchTestCase {
             IndexSearcher.getDefaultSimilarity(),
             IndexSearcher.getDefaultQueryCache(),
             IndexSearcher.getDefaultQueryCachingPolicy(),
-            true
+            true,
+            null
         );
 
         searcher.search(new MatchAllDocsQuery(), collector1);
@@ -154,7 +156,8 @@ public class SearchCancellationTests extends OpenSearchTestCase {
             IndexSearcher.getDefaultSimilarity(),
             IndexSearcher.getDefaultQueryCache(),
             IndexSearcher.getDefaultQueryCachingPolicy(),
-            true
+            true,
+            null
         );
         searcher.addQueryCancellation(cancellation);
         CompiledAutomaton automaton = new CompiledAutomaton(new RegExp("a.*").toAutomaton());

--- a/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
@@ -258,7 +258,8 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
             IndexSearcher.getDefaultSimilarity(),
             IndexSearcher.getDefaultQueryCache(),
             IndexSearcher.getDefaultQueryCachingPolicy(),
-            true
+            true,
+            null
         );
 
         for (LeafReaderContext context : searcher.getIndexReader().leaves()) {

--- a/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryProfilePhaseTests.java
@@ -1,0 +1,1158 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.query;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queries.spans.SpanNearQuery;
+import org.apache.lucene.queries.spans.SpanTermQuery;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.grouping.CollapseTopFieldDocs;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.FilterCollector;
+import org.apache.lucene.search.FilterLeafCollector;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.index.mapper.NumberFieldMapper.NumberFieldType;
+import org.opensearch.index.mapper.NumberFieldMapper.NumberType;
+import org.opensearch.index.query.ParsedQuery;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.IndexShardTestCase;
+import org.opensearch.lucene.queries.MinDocQuery;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.collapse.CollapseBuilder;
+import org.opensearch.search.internal.ContextIndexSearcher;
+import org.opensearch.search.internal.ScrollContext;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.profile.ProfileResult;
+import org.opensearch.search.profile.ProfileShardResult;
+import org.opensearch.search.profile.SearchProfileShardResults;
+import org.opensearch.search.profile.query.CollectorResult;
+import org.opensearch.search.profile.query.QueryProfileShardResult;
+import org.opensearch.search.sort.SortAndFormats;
+import org.opensearch.test.TestSearchContext;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.hamcrest.Matchers.hasSize;
+
+public class QueryProfilePhaseTests extends IndexShardTestCase {
+
+    private IndexShard indexShard;
+
+    @Override
+    public Settings threadPoolSettings() {
+        return Settings.builder().put(super.threadPoolSettings()).put("thread_pool.search.min_queue_size", 10).build();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        indexShard = newShard(true);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        closeShards(indexShard);
+    }
+
+    public void testPostFilterDisablesCountOptimization() throws Exception {
+        Directory dir = newDirectory();
+        final Sort sort = new Sort(new SortField("rank", SortField.Type.INT));
+        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        Document doc = new Document();
+        w.addDocument(doc);
+        w.close();
+
+        IndexReader reader = DirectoryReader.open(dir);
+
+        TestSearchContext context = new TestSearchContext(null, indexShard, newEarlyTerminationContextSearcher(reader, 0));
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
+
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+        assertEquals(1, context.queryResult().topDocs().topDocs.totalHits.value);
+        assertProfileData(context, "MatchAllDocsQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_count"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        context.setSearcher(newContextSearcher(reader));
+        context.parsedPostFilter(new ParsedQuery(new MatchNoDocsQuery()));
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+        assertEquals(0, context.queryResult().topDocs().topDocs.totalHits.value);
+        assertProfileData(context, collector -> {
+            assertThat(collector.getReason(), equalTo("search_post_filter"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), hasSize(1));
+            assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_count"));
+            assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+        }, (query) -> {
+            assertThat(query.getQueryName(), equalTo("MatchNoDocsQuery"));
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, (query) -> {
+            assertThat(query.getQueryName(), equalTo("MatchAllDocsQuery"));
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        });
+
+        reader.close();
+        dir.close();
+    }
+
+    public void testTerminateAfterWithFilter() throws Exception {
+        Directory dir = newDirectory();
+        final Sort sort = new Sort(new SortField("rank", SortField.Type.INT));
+        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        Document doc = new Document();
+        for (int i = 0; i < 10; i++) {
+            doc.add(new StringField("foo", Integer.toString(i), Store.NO));
+        }
+        w.addDocument(doc);
+        w.close();
+
+        IndexReader reader = DirectoryReader.open(dir);
+
+        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader));
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+
+        context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
+        context.terminateAfter(1);
+        context.setSize(10);
+        for (int i = 0; i < 10; i++) {
+            context.parsedPostFilter(new ParsedQuery(new TermQuery(new Term("foo", Integer.toString(i)))));
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+            assertEquals(1, context.queryResult().topDocs().topDocs.totalHits.value);
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+            assertProfileData(context, collector -> {
+                assertThat(collector.getReason(), equalTo("search_post_filter"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), hasSize(1));
+                assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_terminate_after_count"));
+                assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren().get(0).getProfiledChildren(), hasSize(1));
+                assertThat(collector.getProfiledChildren().get(0).getProfiledChildren().get(0).getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getProfiledChildren().get(0).getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            }, (query) -> {
+                assertThat(query.getQueryName(), equalTo("TermQuery"));
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, (query) -> {
+                assertThat(query.getQueryName(), equalTo("MatchAllDocsQuery"));
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(1L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            });
+        }
+        reader.close();
+        dir.close();
+    }
+
+    public void testMinScoreDisablesCountOptimization() throws Exception {
+        Directory dir = newDirectory();
+        final Sort sort = new Sort(new SortField("rank", SortField.Type.INT));
+        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        Document doc = new Document();
+        w.addDocument(doc);
+        w.close();
+
+        IndexReader reader = DirectoryReader.open(dir);
+        TestSearchContext context = new TestSearchContext(null, indexShard, newEarlyTerminationContextSearcher(reader, 0));
+        context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
+        context.setSize(0);
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+        assertEquals(1, context.queryResult().topDocs().topDocs.totalHits.value);
+        assertProfileData(context, "MatchAllDocsQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_count"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        context.minimumScore(100);
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+        assertEquals(0, context.queryResult().topDocs().topDocs.totalHits.value);
+        assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
+        assertProfileData(context, "MatchAllDocsQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThanOrEqualTo(100L));
+            assertThat(query.getTimeBreakdown().get("score_count"), equalTo(1L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_min_score"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), hasSize(1));
+            assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_count"));
+            assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+        });
+
+        reader.close();
+        dir.close();
+    }
+
+    public void testInOrderScrollOptimization() throws Exception {
+        Directory dir = newDirectory();
+        final Sort sort = new Sort(new SortField("rank", SortField.Type.INT));
+        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        final int numDocs = scaledRandomIntBetween(600, 900);
+        for (int i = 0; i < numDocs; ++i) {
+            w.addDocument(new Document());
+        }
+        w.close();
+        IndexReader reader = DirectoryReader.open(dir);
+        ScrollContext scrollContext = new ScrollContext();
+        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader), scrollContext);
+        context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
+        scrollContext.lastEmittedDoc = null;
+        scrollContext.maxScore = Float.NaN;
+        scrollContext.totalHits = null;
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        int size = randomIntBetween(2, 5);
+        context.setSize(size);
+
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+        assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+        assertNull(context.queryResult().terminatedEarly());
+        assertThat(context.terminateAfter(), equalTo(0));
+        assertThat(context.queryResult().getTotalHits().value, equalTo((long) numDocs));
+        assertProfileData(context, "MatchAllDocsQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        context.setSearcher(newEarlyTerminationContextSearcher(reader, size));
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+        assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+        assertThat(context.terminateAfter(), equalTo(size));
+        assertThat(context.queryResult().getTotalHits().value, equalTo((long) numDocs));
+        assertThat(context.queryResult().topDocs().topDocs.scoreDocs[0].doc, greaterThanOrEqualTo(size));
+        assertProfileData(context, "ConstantScoreQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score"), equalTo(0L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score_count"), equalTo(0L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_terminate_after_count"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), hasSize(1));
+            assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+        });
+
+        reader.close();
+        dir.close();
+    }
+
+    public void testTerminateAfterEarlyTermination() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = newIndexWriterConfig();
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        final int numDocs = scaledRandomIntBetween(600, 900);
+        for (int i = 0; i < numDocs; ++i) {
+            Document doc = new Document();
+            if (randomBoolean()) {
+                doc.add(new StringField("foo", "bar", Store.NO));
+            }
+            if (randomBoolean()) {
+                doc.add(new StringField("foo", "baz", Store.NO));
+            }
+            doc.add(new NumericDocValuesField("rank", numDocs - i));
+            w.addDocument(doc);
+        }
+        w.close();
+        final IndexReader reader = DirectoryReader.open(dir);
+        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader));
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
+
+        context.terminateAfter(1);
+        {
+            context.setSize(1);
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(1L));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+            assertProfileData(context, "MatchAllDocsQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_terminate_after_count"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), hasSize(1));
+                assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            });
+
+            context.setSize(0);
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(1L));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
+            assertProfileData(context, "MatchAllDocsQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_terminate_after_count"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), hasSize(1));
+                assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_count"));
+                assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            });
+        }
+
+        {
+            context.setSize(1);
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(1L));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+            assertProfileData(context, "MatchAllDocsQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_terminate_after_count"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), hasSize(1));
+                assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            });
+        }
+        {
+            context.setSize(1);
+            BooleanQuery bq = new BooleanQuery.Builder().add(new TermQuery(new Term("foo", "bar")), Occur.SHOULD)
+                .add(new TermQuery(new Term("foo", "baz")), Occur.SHOULD)
+                .build();
+            context.parsedQuery(new ParsedQuery(bq));
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(1L));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+            assertProfileData(context, "BooleanQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+                assertThat(query.getProfiledChildren(), hasSize(2));
+                assertThat(query.getProfiledChildren().get(0).getQueryName(), equalTo("TermQuery"));
+                assertThat(query.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+                assertThat(query.getProfiledChildren().get(1).getQueryName(), equalTo("TermQuery"));
+                assertThat(query.getProfiledChildren().get(1).getTime(), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_terminate_after_count"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), hasSize(1));
+                assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            });
+            context.setSize(0);
+            context.parsedQuery(new ParsedQuery(bq));
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(1L));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
+
+            assertProfileData(context, "BooleanQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+                assertThat(query.getProfiledChildren(), hasSize(2));
+                assertThat(query.getProfiledChildren().get(0).getQueryName(), equalTo("TermQuery"));
+                assertThat(query.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score_count"), equalTo(0L));
+
+                assertThat(query.getProfiledChildren().get(1).getQueryName(), equalTo("TermQuery"));
+                assertThat(query.getProfiledChildren().get(1).getTime(), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score_count"), equalTo(0L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_terminate_after_count"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), hasSize(1));
+                assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_count"));
+                assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            });
+        }
+
+        context.terminateAfter(7);
+        context.setSize(10);
+        for (int trackTotalHits : new int[] { -1, 3, 75, 100 }) {
+            context.trackTotalHitsUpTo(trackTotalHits);
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+            assertTrue(context.queryResult().terminatedEarly());
+            if (trackTotalHits == -1) {
+                assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(0L));
+            } else {
+                assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(7L));
+            }
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(7));
+            assertProfileData(context, "BooleanQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(7L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+                assertThat(query.getProfiledChildren(), hasSize(2));
+                assertThat(query.getProfiledChildren().get(0).getQueryName(), equalTo("TermQuery"));
+                assertThat(query.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score_count"), greaterThan(0L));
+
+                assertThat(query.getProfiledChildren().get(1).getQueryName(), equalTo("TermQuery"));
+                assertThat(query.getProfiledChildren().get(1).getTime(), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("score_count"), greaterThan(0L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_terminate_after_count"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), hasSize(1));
+                assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            });
+        }
+
+        reader.close();
+        dir.close();
+    }
+
+    public void testIndexSortingEarlyTermination() throws Exception {
+        Directory dir = newDirectory();
+        final Sort sort = new Sort(new SortField("rank", SortField.Type.INT));
+        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        final int numDocs = scaledRandomIntBetween(600, 900);
+        for (int i = 0; i < numDocs; ++i) {
+            Document doc = new Document();
+            if (randomBoolean()) {
+                doc.add(new StringField("foo", "bar", Store.NO));
+            }
+            if (randomBoolean()) {
+                doc.add(new StringField("foo", "baz", Store.NO));
+            }
+            doc.add(new NumericDocValuesField("rank", numDocs - i));
+            w.addDocument(doc);
+        }
+        w.close();
+
+        final IndexReader reader = DirectoryReader.open(dir);
+        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader));
+        context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
+        context.setSize(1);
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        context.sort(new SortAndFormats(sort, new DocValueFormat[] { DocValueFormat.RAW }));
+
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+        assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+        assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+        assertThat(context.queryResult().topDocs().topDocs.scoreDocs[0], instanceOf(FieldDoc.class));
+        FieldDoc fieldDoc = (FieldDoc) context.queryResult().topDocs().topDocs.scoreDocs[0];
+        assertThat(fieldDoc.fields[0], equalTo(1));
+        assertProfileData(context, "MatchAllDocsQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        {
+            context.parsedPostFilter(new ParsedQuery(new MinDocQuery(1)));
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+            assertNull(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(numDocs - 1L));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs[0], instanceOf(FieldDoc.class));
+            assertThat(fieldDoc.fields[0], anyOf(equalTo(1), equalTo(2)));
+            assertProfileData(context, collector -> {
+                assertThat(collector.getReason(), equalTo("search_post_filter"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), hasSize(1));
+                assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            }, (query) -> {
+                assertThat(query.getQueryName(), equalTo("MinDocQuery"));
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, (query) -> {
+                assertThat(query.getQueryName(), equalTo("MatchAllDocsQuery"));
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            });
+            context.parsedPostFilter(null);
+        }
+
+        {
+            context.setSearcher(newEarlyTerminationContextSearcher(reader, 1));
+            context.trackTotalHitsUpTo(SearchContext.TRACK_TOTAL_HITS_DISABLED);
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+            assertNull(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs[0], instanceOf(FieldDoc.class));
+            assertThat(fieldDoc.fields[0], anyOf(equalTo(1), equalTo(2)));
+            assertProfileData(context, "MatchAllDocsQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), empty());
+            });
+
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+            assertNull(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs[0], instanceOf(FieldDoc.class));
+            assertThat(fieldDoc.fields[0], anyOf(equalTo(1), equalTo(2)));
+            assertProfileData(context, "MatchAllDocsQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), empty());
+            });
+        }
+
+        reader.close();
+        dir.close();
+    }
+
+    public void testIndexSortScrollOptimization() throws Exception {
+        Directory dir = newDirectory();
+        final Sort indexSort = new Sort(new SortField("rank", SortField.Type.INT), new SortField("tiebreaker", SortField.Type.INT));
+        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(indexSort);
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        final int numDocs = scaledRandomIntBetween(600, 900);
+        for (int i = 0; i < numDocs; ++i) {
+            Document doc = new Document();
+            doc.add(new NumericDocValuesField("rank", random().nextInt()));
+            doc.add(new NumericDocValuesField("tiebreaker", i));
+            w.addDocument(doc);
+        }
+        if (randomBoolean()) {
+            w.forceMerge(randomIntBetween(1, 10));
+        }
+        w.close();
+
+        final IndexReader reader = DirectoryReader.open(dir);
+        List<SortAndFormats> searchSortAndFormats = new ArrayList<>();
+        searchSortAndFormats.add(new SortAndFormats(indexSort, new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }));
+        // search sort is a prefix of the index sort
+        searchSortAndFormats.add(new SortAndFormats(new Sort(indexSort.getSort()[0]), new DocValueFormat[] { DocValueFormat.RAW }));
+        for (SortAndFormats searchSortAndFormat : searchSortAndFormats) {
+            ScrollContext scrollContext = new ScrollContext();
+            TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader), scrollContext);
+            context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
+            scrollContext.lastEmittedDoc = null;
+            scrollContext.maxScore = Float.NaN;
+            scrollContext.totalHits = null;
+            context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+            context.setSize(10);
+            context.sort(searchSortAndFormat);
+
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+            assertNull(context.queryResult().terminatedEarly());
+            assertThat(context.terminateAfter(), equalTo(0));
+            assertThat(context.queryResult().getTotalHits().value, equalTo((long) numDocs));
+            assertProfileData(context, "MatchAllDocsQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), empty());
+            });
+
+            int sizeMinus1 = context.queryResult().topDocs().topDocs.scoreDocs.length - 1;
+            FieldDoc lastDoc = (FieldDoc) context.queryResult().topDocs().topDocs.scoreDocs[sizeMinus1];
+
+            context.setSearcher(newEarlyTerminationContextSearcher(reader, 10));
+            QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+            assertNull(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+            assertThat(context.terminateAfter(), equalTo(0));
+            assertThat(context.queryResult().getTotalHits().value, equalTo((long) numDocs));
+            assertProfileData(context, "ConstantScoreQuery", query -> {
+                assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+                assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+                assertThat(query.getProfiledChildren(), hasSize(1));
+                assertThat(query.getProfiledChildren().get(0).getQueryName(), equalTo("SearchAfterSortedDocQuery"));
+                assertThat(query.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score"), equalTo(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("score_count"), equalTo(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+                assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            }, collector -> {
+                assertThat(collector.getReason(), equalTo("search_top_hits"));
+                assertThat(collector.getTime(), greaterThan(0L));
+                assertThat(collector.getProfiledChildren(), empty());
+            });
+            FieldDoc firstDoc = (FieldDoc) context.queryResult().topDocs().topDocs.scoreDocs[0];
+            for (int i = 0; i < searchSortAndFormat.sort.getSort().length; i++) {
+                @SuppressWarnings("unchecked")
+                FieldComparator<Object> comparator = (FieldComparator<Object>) searchSortAndFormat.sort.getSort()[i].getComparator(
+                    i,
+                    false
+                );
+                int cmp = comparator.compareValues(firstDoc.fields[i], lastDoc.fields[i]);
+                if (cmp == 0) {
+                    continue;
+                }
+                assertThat(cmp, equalTo(1));
+                break;
+            }
+        }
+        reader.close();
+        dir.close();
+    }
+
+    public void testDisableTopScoreCollection() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = newIndexWriterConfig(new StandardAnalyzer());
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        Document doc = new Document();
+        final int numDocs = 2 * scaledRandomIntBetween(50, 450);
+        for (int i = 0; i < numDocs; i++) {
+            doc.clear();
+            if (i % 2 == 0) {
+                doc.add(new TextField("title", "foo bar", Store.NO));
+            } else {
+                doc.add(new TextField("title", "foo", Store.NO));
+            }
+            w.addDocument(doc);
+        }
+        w.close();
+
+        IndexReader reader = DirectoryReader.open(dir);
+        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader));
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        Query q = new SpanNearQuery.Builder("title", true).addClause(new SpanTermQuery(new Term("title", "foo")))
+            .addClause(new SpanTermQuery(new Term("title", "bar")))
+            .build();
+
+        context.parsedQuery(new ParsedQuery(q));
+        context.setSize(3);
+        context.trackTotalHitsUpTo(3);
+        TopDocsCollectorContext topDocsContext = TopDocsCollectorContext.createTopDocsCollectorContext(context, false);
+        assertEquals(topDocsContext.create(null).scoreMode(), org.apache.lucene.search.ScoreMode.COMPLETE);
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+        assertEquals(numDocs / 2, context.queryResult().topDocs().topDocs.totalHits.value);
+        assertEquals(context.queryResult().topDocs().topDocs.totalHits.relation, TotalHits.Relation.EQUAL_TO);
+        assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(3));
+        assertProfileData(context, "SpanNearQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        context.sort(new SortAndFormats(new Sort(new SortField("other", SortField.Type.INT)), new DocValueFormat[] { DocValueFormat.RAW }));
+        topDocsContext = TopDocsCollectorContext.createTopDocsCollectorContext(context, false);
+        assertEquals(topDocsContext.create(null).scoreMode(), org.apache.lucene.search.ScoreMode.TOP_DOCS);
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+        assertEquals(numDocs / 2, context.queryResult().topDocs().topDocs.totalHits.value);
+        assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(3));
+        assertEquals(context.queryResult().topDocs().topDocs.totalHits.relation, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
+        assertProfileData(context, "SpanNearQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), equalTo(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        reader.close();
+        dir.close();
+    }
+
+    public void testMinScore() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriterConfig iwc = newIndexWriterConfig();
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+        for (int i = 0; i < 10; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("foo", "bar", Store.NO));
+            doc.add(new StringField("filter", "f1", Store.NO));
+            w.addDocument(doc);
+        }
+        w.close();
+
+        IndexReader reader = DirectoryReader.open(dir);
+        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader));
+        context.parsedQuery(
+            new ParsedQuery(
+                new BooleanQuery.Builder().add(new TermQuery(new Term("foo", "bar")), Occur.MUST)
+                    .add(new TermQuery(new Term("filter", "f1")), Occur.SHOULD)
+                    .build()
+            )
+        );
+        context.minimumScore(0.01f);
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        context.setSize(1);
+        context.trackTotalHitsUpTo(5);
+
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+        assertEquals(10, context.queryResult().topDocs().topDocs.totalHits.value);
+        assertProfileData(context, "BooleanQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), equalTo(10L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+            assertThat(query.getProfiledChildren(), hasSize(2));
+            assertThat(query.getProfiledChildren().get(0).getQueryName(), equalTo("TermQuery"));
+            assertThat(query.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+            assertThat(query.getProfiledChildren().get(1).getQueryName(), equalTo("TermQuery"));
+            assertThat(query.getProfiledChildren().get(1).getTime(), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_min_score"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), hasSize(1));
+            assertThat(collector.getProfiledChildren().get(0).getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+        });
+
+        reader.close();
+        dir.close();
+    }
+
+    public void testMaxScore() throws Exception {
+        Directory dir = newDirectory();
+        final Sort sort = new Sort(new SortField("filter", SortField.Type.STRING));
+        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+
+        final int numDocs = scaledRandomIntBetween(600, 900);
+        for (int i = 0; i < numDocs; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("foo", "bar", Store.NO));
+            doc.add(new StringField("filter", "f1" + ((i > 0) ? " " + Integer.toString(i) : ""), Store.NO));
+            doc.add(new SortedDocValuesField("filter", newBytesRef("f1" + ((i > 0) ? " " + Integer.toString(i) : ""))));
+            w.addDocument(doc);
+        }
+        w.close();
+
+        IndexReader reader = DirectoryReader.open(dir);
+        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader));
+        context.trackScores(true);
+        context.parsedQuery(
+            new ParsedQuery(
+                new BooleanQuery.Builder().add(new TermQuery(new Term("foo", "bar")), Occur.MUST)
+                    .add(new TermQuery(new Term("filter", "f1")), Occur.SHOULD)
+                    .build()
+            )
+        );
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        context.setSize(1);
+        context.trackTotalHitsUpTo(5);
+
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+        assertFalse(Float.isNaN(context.queryResult().getMaxScore()));
+        assertEquals(1, context.queryResult().topDocs().topDocs.scoreDocs.length);
+        assertThat(context.queryResult().topDocs().topDocs.totalHits.value, greaterThanOrEqualTo(6L));
+        assertProfileData(context, "BooleanQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+            assertThat(query.getProfiledChildren(), hasSize(2));
+            assertThat(query.getProfiledChildren().get(0).getQueryName(), equalTo("TermQuery"));
+            assertThat(query.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+            assertThat(query.getProfiledChildren().get(1).getQueryName(), equalTo("TermQuery"));
+            assertThat(query.getProfiledChildren().get(1).getTime(), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        context.sort(new SortAndFormats(sort, new DocValueFormat[] { DocValueFormat.RAW }));
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+        assertFalse(Float.isNaN(context.queryResult().getMaxScore()));
+        assertEquals(1, context.queryResult().topDocs().topDocs.scoreDocs.length);
+        assertThat(context.queryResult().topDocs().topDocs.totalHits.value, greaterThanOrEqualTo(6L));
+        assertProfileData(context, "BooleanQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+            assertThat(query.getProfiledChildren(), hasSize(2));
+            assertThat(query.getProfiledChildren().get(0).getQueryName(), equalTo("TermQuery"));
+            assertThat(query.getProfiledChildren().get(0).getTime(), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(0).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+
+            assertThat(query.getProfiledChildren().get(1).getQueryName(), equalTo("TermQuery"));
+            assertThat(query.getProfiledChildren().get(1).getTime(), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getProfiledChildren().get(1).getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        reader.close();
+        dir.close();
+    }
+
+    public void testCollapseQuerySearchResults() throws Exception {
+        Directory dir = newDirectory();
+        final Sort sort = new Sort(new SortField("user", SortField.Type.INT));
+        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
+
+        // Always end up with uneven buckets so collapsing is predictable
+        final int numDocs = 2 * scaledRandomIntBetween(600, 900) - 1;
+        for (int i = 0; i < numDocs; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("foo", "bar", Store.NO));
+            doc.add(new NumericDocValuesField("user", i & 1));
+            w.addDocument(doc);
+        }
+        w.close();
+
+        IndexReader reader = DirectoryReader.open(dir);
+        QueryShardContext queryShardContext = mock(QueryShardContext.class);
+        when(queryShardContext.fieldMapper("user")).thenReturn(
+            new NumberFieldType("user", NumberType.INTEGER, true, false, true, false, null, Collections.emptyMap())
+        );
+
+        TestSearchContext context = new TestSearchContext(queryShardContext, indexShard, newContextSearcher(reader));
+        context.collapse(new CollapseBuilder("user").build(context.getQueryShardContext()));
+        context.trackScores(true);
+        context.parsedQuery(new ParsedQuery(new TermQuery(new Term("foo", "bar"))));
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        context.setSize(2);
+        context.trackTotalHitsUpTo(5);
+
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+        assertFalse(Float.isNaN(context.queryResult().getMaxScore()));
+        assertEquals(2, context.queryResult().topDocs().topDocs.scoreDocs.length);
+        assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+        assertThat(context.queryResult().topDocs().topDocs, instanceOf(CollapseTopFieldDocs.class));
+
+        assertProfileData(context, "TermQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            assertThat(query.getProfiledChildren(), empty());
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        context.sort(new SortAndFormats(sort, new DocValueFormat[] { DocValueFormat.RAW }));
+        QueryPhase.executeInternal(context.withCleanQueryResult().withProfilers());
+        assertFalse(Float.isNaN(context.queryResult().getMaxScore()));
+        assertEquals(2, context.queryResult().topDocs().topDocs.scoreDocs.length);
+        assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+        assertThat(context.queryResult().topDocs().topDocs, instanceOf(CollapseTopFieldDocs.class));
+
+        assertProfileData(context, "TermQuery", query -> {
+            assertThat(query.getTimeBreakdown().keySet(), not(empty()));
+            assertThat(query.getTimeBreakdown().get("score"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("score_count"), greaterThanOrEqualTo(6L));
+            assertThat(query.getTimeBreakdown().get("create_weight"), greaterThan(0L));
+            assertThat(query.getTimeBreakdown().get("create_weight_count"), equalTo(1L));
+            assertThat(query.getProfiledChildren(), empty());
+        }, collector -> {
+            assertThat(collector.getReason(), equalTo("search_top_hits"));
+            assertThat(collector.getTime(), greaterThan(0L));
+            assertThat(collector.getProfiledChildren(), empty());
+        });
+
+        reader.close();
+        dir.close();
+    }
+
+    private void assertProfileData(SearchContext context, String type, Consumer<ProfileResult> query, Consumer<CollectorResult> collector)
+        throws IOException {
+        assertProfileData(context, collector, (profileResult) -> {
+            assertThat(profileResult.getQueryName(), equalTo(type));
+            assertThat(profileResult.getTime(), greaterThan(0L));
+            query.accept(profileResult);
+        });
+    }
+
+    private void assertProfileData(SearchContext context, Consumer<CollectorResult> collector, Consumer<ProfileResult> query1)
+        throws IOException {
+        assertProfileData(context, Arrays.asList(query1), collector, false);
+    }
+
+    private void assertProfileData(
+        SearchContext context,
+        Consumer<CollectorResult> collector,
+        Consumer<ProfileResult> query1,
+        Consumer<ProfileResult> query2
+    ) throws IOException {
+        assertProfileData(context, Arrays.asList(query1, query2), collector, false);
+    }
+
+    private final void assertProfileData(
+        SearchContext context,
+        List<Consumer<ProfileResult>> queries,
+        Consumer<CollectorResult> collector,
+        boolean debug
+    ) throws IOException {
+        assertThat(context.getProfilers(), not(nullValue()));
+
+        final ProfileShardResult result = SearchProfileShardResults.buildShardResults(context.getProfilers(), null);
+        if (debug) {
+            final SearchProfileShardResults results = new SearchProfileShardResults(
+                Collections.singletonMap(indexShard.shardId().toString(), result)
+            );
+
+            try (final XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint()) {
+                builder.startObject();
+                results.toXContent(builder, ToXContent.EMPTY_PARAMS);
+                builder.endObject();
+                builder.flush();
+
+                final OutputStream out = builder.getOutputStream();
+                assertThat(out, instanceOf(ByteArrayOutputStream.class));
+
+                logger.info(new String(((ByteArrayOutputStream) out).toByteArray(), StandardCharsets.UTF_8));
+            }
+        }
+
+        assertThat(result.getQueryProfileResults(), hasSize(1));
+
+        final QueryProfileShardResult queryProfileShardResult = result.getQueryProfileResults().get(0);
+        assertThat(queryProfileShardResult.getQueryResults(), hasSize(queries.size()));
+
+        for (int i = 0; i < queries.size(); ++i) {
+            queries.get(i).accept(queryProfileShardResult.getQueryResults().get(i));
+        }
+
+        collector.accept(queryProfileShardResult.getCollectorResult());
+    }
+
+    private static ContextIndexSearcher newContextSearcher(IndexReader reader) throws IOException {
+        return new ContextIndexSearcher(
+            reader,
+            IndexSearcher.getDefaultSimilarity(),
+            IndexSearcher.getDefaultQueryCache(),
+            IndexSearcher.getDefaultQueryCachingPolicy(),
+            true,
+            null
+        );
+    }
+
+    private static ContextIndexSearcher newEarlyTerminationContextSearcher(IndexReader reader, int size) throws IOException {
+        return new ContextIndexSearcher(
+            reader,
+            IndexSearcher.getDefaultSimilarity(),
+            IndexSearcher.getDefaultQueryCache(),
+            IndexSearcher.getDefaultQueryCachingPolicy(),
+            true,
+            null
+        ) {
+
+            @Override
+            public void search(List<LeafReaderContext> leaves, Weight weight, Collector collector) throws IOException {
+                final Collector in = new AssertingEarlyTerminationFilterCollector(collector, size);
+                super.search(leaves, weight, in);
+            }
+        };
+    }
+
+    private static class AssertingEarlyTerminationFilterCollector extends FilterCollector {
+        private final int size;
+
+        AssertingEarlyTerminationFilterCollector(Collector in, int size) {
+            super(in);
+            this.size = size;
+        }
+
+        @Override
+        public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+            final LeafCollector in = super.getLeafCollector(context);
+            return new FilterLeafCollector(in) {
+                int collected;
+
+                @Override
+                public void collect(int doc) throws IOException {
+                    assert collected <= size : "should not collect more than " + size + " doc per segment, got " + collected;
+                    ++collected;
+                    super.collect(doc);
+                }
+            };
+        }
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/search/aggregations/AggregatorTestCase.java
@@ -334,7 +334,8 @@ public abstract class AggregatorTestCase extends OpenSearchTestCase {
             indexSearcher.getSimilarity(),
             queryCache,
             queryCachingPolicy,
-            false
+            false,
+            null
         );
 
         SearchContext searchContext = mock(SearchContext.class);


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Allows to use experimental Apache Lucene low-level API which allows to parallelize execution of the search across segment.

 - [x] Implement multi-collectors query context (possibly, needs API change to use `CollectorManager`s instead)
 - [X] Implement profilers support
   
    The query profiling is supported but it has some limitations and differences with respect to naming. The profilers capture the time each collection type has taken and return it as the cumulative summary. The fact that **segments may have been searched concurrently is not reflected** (it requires significant overhauling of the profiling implementation), so the "real" perceived time may be smaller then profilers will report. The collector names are replaced with collector manager names (fe `MinimumScoreCollector` vs `MinimumCollectorManager`).
   
    To compare, here is the usual search profile 

   ```
   "collector" : [
      {
        "name" : "MinimumScoreCollector",
        "reason" : "search_min_score",
        "time_in_nanos" : 4702942,
        "children" : [
          {
            "name" : "SimpleTopScoreDocCollector",
            "reason" : "search_top_hits",
            "time_in_nanos" : 3450252
          }
        ]
      }
    ]
    ```

    vs the one where concurrent segment search is enabled

    ```
    "collector" : [
      {
        "name" : "MinimumCollectorManager",
        "reason" : "search_min_score",
        "time_in_nanos" : 74827,
        "children" : [
          {
            "name" : "SimpleTopDocsCollectorManager",
            "reason" : "search_top_hits",
            "time_in_nanos" : 98044
          }
        ]
      }
    ]
    ```

    Additionally, since TopDocs are merged, the query's **shardIndex** field is also populated, usual search profile has it set to `-1`, for example:

    ``` 
    "query" : [
      {
        "type" : "ConstantScoreQuery",
        "description" : "ConstantScore(SearchAfterSortedDocQuery(sort=<int: \"rank\">, afterDoc=doc=287 score=NaN shardIndex=-1 fields=[-2062713761]))",
        "time_in_nanos" : 1009712,
        ...
      }
   ]
    ```

    vs the one where concurrent segment search is enabled

    ```
    "query" : [
      {
        "type" : "ConstantScoreQuery",
        "description" : "ConstantScore(SearchAfterSortedDocQuery(sort=<int: \"rank\">, afterDoc=doc=287 score=NaN shardIndex=1 fields=[-2062713761]))",
        "time_in_nanos" : 35667,
          ....
      }
   ]
   ```
  
 - [X] Implement early termination and timeout support
   
    The forced early termination is simulated (without abrupt search termination) using Apache Lucene normal collection termination mechanism. The number of results is reduced to the desired one (if necessary) at the post search step. Essentially, to summarize, when early termination is requested and concurrent segment search is enabled, be the engine is going to do more work and (very likely) come up with more search hits than have been asked.

   If query finished by timeout, no results are being returned, even if returning partial results is acceptable. The reason for that exception propagation mechanism does not leave a chance for reducers to execute. 
 
 - [x] Add benchmarks suite

Splitting into subtasks:
 - [x] Extract changes related to profiler support (https://github.com/opensearch-project/OpenSearch/pull/1673)
 - [ ] Extract changes related to query context support
 - [ ] Move the concurrent search implementation to sandbox

Future Enhancements: 
 - [ ] Implement aggregations support

### Issues Resolved
Fixes https://github.com/opensearch-project/OpenSearch/issues/1286
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
