### PR TITLE
[bwc] reenable bwc testing after syncing staged branches

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -192,9 +192,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
+boolean bwc_tests_enabled = true
 /* place an issue link here when committing bwc changes */
-final String bwc_tests_disabled_issue = "https://github.com/opensearch-project/OpenSearch/issues/1507"
+final String bwc_tests_disabled_issue = ""
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")


### PR DESCRIPTION
This PR reenables bwc testing after syncing proper staged versions on all development branches.

closes #1507 

