### PR TITLE
Use a non-default port for upgrade-cli unit tests

### DIFF
--- a/distribution/tools/upgrade-cli/src/test/java/org/opensearch/upgrade/DetectEsInstallationTaskTests.java
+++ b/distribution/tools/upgrade-cli/src/test/java/org/opensearch/upgrade/DetectEsInstallationTaskTests.java
@@ -49,7 +49,7 @@ public class DetectEsInstallationTaskTests extends OpenSearchTestCase {
         task.accept(input);
 
         assertThat(taskInput.getEsConfig(), is(esConfig));
-        assertThat(taskInput.getBaseUrl(), is("http://localhost:9200"));
+        assertThat(taskInput.getBaseUrl(), is("http://localhost:42123"));
         assertThat(taskInput.getPlugins(), hasSize(0));
         assertThat(taskInput.getNode(), is("node-x"));
         assertThat(taskInput.getCluster(), is("my-cluster"));

--- a/distribution/tools/upgrade-cli/src/test/java/org/opensearch/upgrade/ImportYmlConfigTaskTests.java
+++ b/distribution/tools/upgrade-cli/src/test/java/org/opensearch/upgrade/ImportYmlConfigTaskTests.java
@@ -59,8 +59,9 @@ public class ImportYmlConfigTaskTests extends OpenSearchTestCase {
         taskInput.setEsConfig(esConfig);
         task.accept(new Tuple<>(taskInput, terminal));
         Settings settings = Settings.builder().loadFromPath(taskInput.getOpenSearchConfig().resolve("opensearch.yml")).build();
-        assertThat(settings.keySet(), contains("cluster.name", "node.name", "path.data", "path.logs"));
+        assertThat(settings.keySet(), contains("cluster.name", "http.port", "node.name", "path.data", "path.logs"));
         assertThat(settings.get("cluster.name"), is("my-cluster"));
+        assertThat(settings.get("http.port"), is("42123"));
         assertThat(settings.get("node.name"), is("node-x"));
         assertThat(settings.get("path.data"), is("[/mnt/data_1, /mnt/data_2]"));
         assertThat(settings.get("path.logs"), is("/var/log/eslogs"));

--- a/distribution/tools/upgrade-cli/src/test/java/org/opensearch/upgrade/UpgradeCliTests.java
+++ b/distribution/tools/upgrade-cli/src/test/java/org/opensearch/upgrade/UpgradeCliTests.java
@@ -113,6 +113,7 @@ public class UpgradeCliTests extends CommandTestCase {
             Arrays.asList(
                 "---",
                 "cluster.name: \"my-cluster\"",
+                "http.port: \"42123\"",
                 "node.name: \"node-x\"",
                 "path.data:",
                 "- \"/mnt/data_1\"",

--- a/distribution/tools/upgrade-cli/src/test/resources/config/elasticsearch.yml
+++ b/distribution/tools/upgrade-cli/src/test/resources/config/elasticsearch.yml
@@ -5,3 +5,4 @@ path:
     - /mnt/data_1
     - /mnt/data_2
   logs: /var/log/eslogs
+http.port: 42123


### PR DESCRIPTION
I observed a [test failure][1] that I believe was caused by the fact
that an OpenSearch server happened to be running at localhost:9200 when
these unit tests were executed. The code under test has logic to try to
connect to localhost:9200 and then fall back to defaults if that port is
not open. The tests expect these defaults and will fail if different
data is returned. The change here is to use a non-default port to make
it very unlikely that a real instance will be running at the non-default
port. I don't know why an OpenSearch service happened to be running
during the linked test failure, but I think making these unit tests more
independent and isolated is helpful no matter the underlying cause in
this case.

[1]: https://fork-jenkins.searchservices.aws.dev/job/OpenSearch_CI/job/PR_Checks/job/Gradle_Check/975/artifact/gradle_check_975.log/*view*/


### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
