### PR TITLE
Fixing the deprecation warning for system indices to be logged once

### DIFF
--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/70_throttle.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/70_throttle.yml
@@ -74,6 +74,8 @@
 
 ---
 "Rethrottle to -1 which turns off throttling":
+  - skip:
+      features: allowed_warnings
   # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
@@ -122,6 +124,8 @@
         task_id: $task
 
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       indices.refresh: {}
 
   - do:

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/70_throttle.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/70_throttle.yml
@@ -74,8 +74,6 @@
 
 ---
 "Rethrottle to -1 which turns off throttling":
-  - skip:
-      features: warnings
   # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
@@ -124,8 +122,6 @@
         task_id: $task
 
   - do:
-      warnings:
-        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       indices.refresh: {}
 
   - do:

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/80_slices.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/80_slices.yml
@@ -62,8 +62,6 @@
 
 ---
 "Multiple slices with wait_for_completion=false":
-  - skip:
-      features: warnings
   - do:
       index:
         index:   test
@@ -153,12 +151,8 @@
 
   # Only the "parent" reindex task wrote its status to the tasks index though
   - do:
-      warnings:
-        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       indices.refresh: {}
   - do:
-      warnings:
-        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       search:
         rest_total_hits_as_int: true
         index: .tasks
@@ -171,8 +165,6 @@
 
 ---
 "Multiple slices with rethrottle":
-  - skip:
-      features: warnings
   - do:
       index:
         index:   test
@@ -268,12 +260,8 @@
 
   # Only the "parent" reindex task wrote its status to the tasks index though
   - do:
-      warnings:
-        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       indices.refresh: {}
   - do:
-      warnings:
-        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       search:
         rest_total_hits_as_int: true
         index: .tasks

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/80_slices.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/80_slices.yml
@@ -62,6 +62,8 @@
 
 ---
 "Multiple slices with wait_for_completion=false":
+  - skip:
+      features: allowed_warnings
   - do:
       index:
         index:   test
@@ -151,8 +153,12 @@
 
   # Only the "parent" reindex task wrote its status to the tasks index though
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       indices.refresh: {}
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       search:
         rest_total_hits_as_int: true
         index: .tasks
@@ -165,6 +171,8 @@
 
 ---
 "Multiple slices with rethrottle":
+  - skip:
+      features: allowed_warnings
   - do:
       index:
         index:   test
@@ -260,8 +268,12 @@
 
   # Only the "parent" reindex task wrote its status to the tasks index though
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       indices.refresh: {}
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       search:
         rest_total_hits_as_int: true
         index: .tasks

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/80_slices.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/80_slices.yml
@@ -58,8 +58,6 @@
 
 ---
 "Multiple slices with wait_for_completion=false":
-  - skip:
-      features: warnings
   - do:
       index:
         index:   source
@@ -162,12 +160,8 @@
 
   # Only the "parent" reindex task wrote its status to the tasks index though
   - do:
-      warnings:
-        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       indices.refresh: {}
   - do:
-      warnings:
-        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       search:
         rest_total_hits_as_int: true
         index: .tasks
@@ -176,8 +170,6 @@
 
 ---
 "Multiple slices with rethrottle":
-  - skip:
-      features: warnings
   - do:
       index:
         index:   source
@@ -280,12 +272,8 @@
 
   # Only the "parent" reindex task wrote its status to the tasks index though
   - do:
-      warnings:
-        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       indices.refresh: {}
   - do:
-      warnings:
-        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       search:
         rest_total_hits_as_int: true
         index: .tasks

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/80_slices.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/80_slices.yml
@@ -58,6 +58,8 @@
 
 ---
 "Multiple slices with wait_for_completion=false":
+  - skip:
+      features: allowed_warnings
   - do:
       index:
         index:   source
@@ -160,8 +162,12 @@
 
   # Only the "parent" reindex task wrote its status to the tasks index though
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       indices.refresh: {}
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       search:
         rest_total_hits_as_int: true
         index: .tasks
@@ -170,6 +176,8 @@
 
 ---
 "Multiple slices with rethrottle":
+  - skip:
+      features: allowed_warnings
   - do:
       index:
         index:   source
@@ -272,8 +280,12 @@
 
   # Only the "parent" reindex task wrote its status to the tasks index though
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       indices.refresh: {}
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       search:
         rest_total_hits_as_int: true
         index: .tasks

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/70_slices.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/70_slices.yml
@@ -54,8 +54,6 @@
 
 ---
 "Multiple slices with wait_for_completion=false":
-  - skip:
-      features: warnings
   - do:
       index:
         index:   test
@@ -145,12 +143,8 @@
 
   # Only the "parent" reindex task wrote its status to the tasks index though
   - do:
-      warnings:
-        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       indices.refresh: {}
   - do:
-      warnings:
-        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       search:
         rest_total_hits_as_int: true
         index: .tasks
@@ -158,8 +152,6 @@
 
 ---
 "Multiple slices with rethrottle":
-  - skip:
-      features: warnings
   - do:
       index:
         index:   test
@@ -254,12 +246,8 @@
 
   # Only the "parent" reindex task wrote its status to the tasks index though
   - do:
-      warnings:
-        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       indices.refresh: {}
   - do:
-      warnings:
-        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       search:
         rest_total_hits_as_int: true
         index: .tasks

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/70_slices.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/70_slices.yml
@@ -54,6 +54,8 @@
 
 ---
 "Multiple slices with wait_for_completion=false":
+  - skip:
+      features: allowed_warnings
   - do:
       index:
         index:   test
@@ -143,8 +145,12 @@
 
   # Only the "parent" reindex task wrote its status to the tasks index though
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       indices.refresh: {}
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       search:
         rest_total_hits_as_int: true
         index: .tasks
@@ -152,6 +158,8 @@
 
 ---
 "Multiple slices with rethrottle":
+  - skip:
+      features: allowed_warnings
   - do:
       index:
         index:   test
@@ -246,8 +254,12 @@
 
   # Only the "parent" reindex task wrote its status to the tasks index though
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       indices.refresh: {}
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"
       search:
         rest_total_hits_as_int: true
         index: .tasks

--- a/qa/smoke-test-http/src/test/java/org/opensearch/http/SystemIndexRestIT.java
+++ b/qa/smoke-test-http/src/test/java/org/opensearch/http/SystemIndexRestIT.java
@@ -104,16 +104,10 @@ public class SystemIndexRestIT extends HttpSmokeTestCase {
         // And with a partial wildcard
         assertDeprecationWarningOnAccess(".test-*", SystemIndexTestPlugin.SYSTEM_INDEX_NAME);
 
-        // And with a total wildcard
-        assertDeprecationWarningOnAccess(randomFrom("*", "_all"), SystemIndexTestPlugin.SYSTEM_INDEX_NAME);
-
         // Try to index a doc directly
         {
-            String expectedWarning = "this request accesses system indices: [" + SystemIndexTestPlugin.SYSTEM_INDEX_NAME + "], but in a " +
-                "future major version, direct access to system indices will be prevented by default";
             Request putDocDirectlyRequest = new Request("PUT", "/" + SystemIndexTestPlugin.SYSTEM_INDEX_NAME + "/_doc/43");
             putDocDirectlyRequest.setJsonEntity("{\"some_field\":  \"some_other_value\"}");
-            putDocDirectlyRequest.setOptions(expectWarnings(expectedWarning));
             Response response = getRestClient().performRequest(putDocDirectlyRequest);
             assertThat(response.getStatusLine().getStatusCode(), equalTo(201));
         }

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -83,6 +83,8 @@ public class IndexNameExpressionResolver {
     public static final String SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY = "_system_index_access_allowed";
     public static final Version SYSTEM_INDEX_ENFORCEMENT_VERSION = LegacyESVersion.V_7_10_0;
 
+    private boolean isDeprecationWarningAlreadyLogged;
+
     private final DateMathExpressionResolver dateMathExpressionResolver = new DateMathExpressionResolver();
     private final WildcardExpressionResolver wildcardExpressionResolver = new WildcardExpressionResolver();
     private final List<ExpressionResolver> expressionResolvers = org.opensearch.common.collect.List.of(
@@ -364,13 +366,14 @@ public class IndexNameExpressionResolver {
                 .map(i -> i.getIndex().getName())
                 .sorted() // reliable order for testing
                 .collect(Collectors.toList());
-            if (resolvedSystemIndices.isEmpty() == false) {
+            if (resolvedSystemIndices.isEmpty() == false && !isDeprecationWarningAlreadyLogged) {
                 deprecationLogger.deprecate(
                     "open_system_index_access",
                     "this request accesses system indices: {}, but in a future major version, direct access to system "
                         + "indices will be prevented by default",
                     resolvedSystemIndices
                 );
+                isDeprecationWarningAlreadyLogged = true;
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Vacha <vachshah@amazon.com>

### Description
The deprecation warnings for system indices to be logged once instead of spamming the user with multiple logs. 
 
### Issues Resolved
Closes #1108 
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
