### PR TITLE
[Backport] Added logic to allow {dot} files on startup (#1437)

### DIFF
--- a/qa/no-bootstrap-tests/src/test/java/org/opensearch/bootstrap/SpawnerNoBootstrapTests.java
+++ b/qa/no-bootstrap-tests/src/test/java/org/opensearch/bootstrap/SpawnerNoBootstrapTests.java
@@ -215,33 +215,6 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
                 equalTo("module [test_plugin] does not have permission to fork native controller"));
     }
 
-    public void testSpawnerHandlingOfDesktopServicesStoreFiles() throws IOException {
-        final Path esHome = createTempDir().resolve("home");
-        final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), esHome.toString()).build();
-
-        final Environment environment = TestEnvironment.newEnvironment(settings);
-
-        Files.createDirectories(environment.modulesFile());
-        Files.createDirectories(environment.pluginsFile());
-
-        final Path desktopServicesStore = environment.modulesFile().resolve(".DS_Store");
-        Files.createFile(desktopServicesStore);
-
-        final Spawner spawner = new Spawner();
-        if (Constants.MAC_OS_X) {
-            // if the spawner were not skipping the Desktop Services Store files on macOS this would explode
-            spawner.spawnNativeControllers(environment, false);
-        } else {
-            // we do not ignore these files on non-macOS systems
-            final FileSystemException e = expectThrows(FileSystemException.class, () -> spawner.spawnNativeControllers(environment, false));
-            if (Constants.WINDOWS) {
-                assertThat(e, instanceOf(NoSuchFileException.class));
-            } else {
-                assertThat(e, hasToString(containsString("Not a directory")));
-            }
-        }
-    }
-
     private void createControllerProgram(final Path outputFile) throws IOException {
         final Path outputDir = outputFile.getParent();
         Files.createDirectories(outputDir);

--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -50,7 +50,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.component.LifecycleComponent;
 import org.opensearch.common.inject.Module;
-import org.opensearch.common.io.FileSystemUtils;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
@@ -365,7 +364,10 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         if (Files.exists(rootPath)) {
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(rootPath)) {
                 for (Path plugin : stream) {
-                    if (FileSystemUtils.isDesktopServicesStore(plugin) || plugin.getFileName().toString().startsWith(".removing-")) {
+                    if (plugin.getFileName().toString().startsWith(".") && !Files.isDirectory(plugin)) {
+                        logger.warn(
+                            "Non-plugin file located in the plugins folder with the following name: [" + plugin.getFileName() + "]"
+                        );
                         continue;
                     }
                     if (seen.add(plugin.getFileName().toString()) == false) {


### PR DESCRIPTION
* Added logic to allow {dot} files on startup

Signed-off-by: Ryan Bogan <rbogan@amazon.com>

* Ensures that only plugin directories are returned by findPluginDirs()

Signed-off-by: Ryan Bogan <rbogan@amazon.com>

* Prevents . files from being returned as plugins

Signed-off-by: Ryan Bogan <rbogan@amazon.com>

### Description
Backport of #1437 
 
### Issues Resolved
#626 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
