### PR TITLE
Giving informative error messages for double slashes in API call URLs

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -251,7 +251,6 @@ public class MetadataCreateIndexService {
             throw exceptionCtor.apply(index, "must not contain the following characters " + Strings.INVALID_FILENAME_CHARS);
         }
         if (index.isEmpty()) {
-            logger.info("Invalid Index Name [], must not be empty");
             throw exceptionCtor.apply(index, "must not be empty");
         }
         if (index.contains("#")) {

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -252,7 +252,10 @@ public class MetadataCreateIndexService {
         }
         if (index.isEmpty()) {
             logger.info(() -> new ParameterizedMessage("Empty Index, presence of double slash maybe?"));
-            throw exceptionCtor.apply(index, "reason: empty string is an invalid index name (do you have a double slash in the URL by accident?)");
+            throw exceptionCtor.apply(
+                index,
+                "reason: empty string is an invalid index name (do you have a double slash in the URL by accident?)"
+            );
         }
         if (index.contains("#")) {
             throw exceptionCtor.apply(index, "must not contain '#'");

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -250,6 +250,10 @@ public class MetadataCreateIndexService {
         if (!Strings.validFileName(index)) {
             throw exceptionCtor.apply(index, "must not contain the following characters " + Strings.INVALID_FILENAME_CHARS);
         }
+        if (index.isEmpty()) {
+            logger.info(() -> new ParameterizedMessage("Empty Index, presence of double slash maybe?"));
+            throw exceptionCtor.apply(index, "reason: empty string is an invalid index name (do you have a double slash in the URL by accident?)");
+        }
         if (index.contains("#")) {
             throw exceptionCtor.apply(index, "must not contain '#'");
         }

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -251,11 +251,8 @@ public class MetadataCreateIndexService {
             throw exceptionCtor.apply(index, "must not contain the following characters " + Strings.INVALID_FILENAME_CHARS);
         }
         if (index.isEmpty()) {
-            logger.info(() -> new ParameterizedMessage("Empty Index, presence of double slash maybe?"));
-            throw exceptionCtor.apply(
-                index,
-                "reason: empty string is an invalid index name (do you have a double slash in the URL by accident?)"
-            );
+            logger.info("Invalid Index Name [], must not be empty");
+            throw exceptionCtor.apply(index, "must not be empty");
         }
         if (index.contains("#")) {
             throw exceptionCtor.apply(index, "must not contain '#'");

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -614,7 +614,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
                 false
             );
             validateIndexName(checkerService, "index?name", "must not contain the following characters " + Strings.INVALID_FILENAME_CHARS);
-
+            
             validateIndexName(checkerService, "index#name", "must not contain '#'");
 
             validateIndexName(checkerService, "_indexname", "must not start with '_', '-', or '+'");
@@ -626,6 +626,8 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             validateIndexName(checkerService, "..", "must not be '.' or '..'");
 
             validateIndexName(checkerService, "foo:bar", "must not contain ':'");
+
+            validateIndexName(checkerService, "", "Invalid index name [], reason: empty string is an invalid index name (do you have a double slash in the URL by accident?)");
         }));
     }
 

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -614,7 +614,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
                 false
             );
             validateIndexName(checkerService, "index?name", "must not contain the following characters " + Strings.INVALID_FILENAME_CHARS);
-            
+
             validateIndexName(checkerService, "index#name", "must not contain '#'");
 
             validateIndexName(checkerService, "_indexname", "must not start with '_', '-', or '+'");
@@ -627,7 +627,11 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
 
             validateIndexName(checkerService, "foo:bar", "must not contain ':'");
 
-            validateIndexName(checkerService, "", "Invalid index name [], reason: empty string is an invalid index name (do you have a double slash in the URL by accident?)");
+            validateIndexName(
+                checkerService,
+                "",
+                "Invalid index name [], reason: empty string is an invalid index name (do you have a double slash in the URL by accident?)"
+            );
         }));
     }
 

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -627,11 +627,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
 
             validateIndexName(checkerService, "foo:bar", "must not contain ':'");
 
-            validateIndexName(
-                checkerService,
-                "",
-                "Invalid index name [], reason: empty string is an invalid index name (do you have a double slash in the URL by accident?)"
-            );
+            validateIndexName(checkerService, "", "Invalid index name [], must not be empty");
         }));
     }
 


### PR DESCRIPTION
Signed-off-by: Megha Sai Kavikondala <kavmegha@amazon.com>

Changes made for giving more informative error messages.

### Description
If a URL with an empty index name or having double slash is requested, a pretty random answer is given:
```
$ curl -X PUT -H 'Content-type: application/json' localhost:9200//_cluster/settings?pretty -d '{}'
{
  "error" : {
    "root_cause" : [
      {
        "type" : "string_index_out_of_bounds_exception",
        "reason" : "String index out of range: 0"
      }
    ],
    "type" : "string_index_out_of_bounds_exception",
    "reason" : "String index out of range: 0"
  },
  "status" : 500
}
```
Thus, rather than giving a random answer, an informative error message is given:
```
{
  "error" : {
    "root_cause" : [
      {
        "type" : "invalid_index_name_exception",
        "reason" : "Invalid index name [], reason: Invalid index name [], must not be empty",
        "index" : "",
        "index_uuid" : "_na_"
      }
    ],
    "type" : "invalid_index_name_exception",
    "reason" : "Invalid index name [], reason: Invalid index name [], must not be empty",
    "index" : "",
    "index_uuid" : "_na_"
  },
  "status" : 400
}
```
### Issues Resolved
[List any issues this PR will resolve]
 
https://github.com/opensearch-project/OpenSearch/issues/1499

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
