### PR TITLE
Delay the request size calculation until required by the indexing pre…

### DIFF
--- a/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java
@@ -210,9 +210,8 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
 
     @Override
     protected void doExecute(Task task, BulkRequest bulkRequest, ActionListener<BulkResponse> listener) {
-        final long indexingBytes = bulkRequest.ramBytesUsed();
         final boolean isOnlySystem = isOnlySystem(bulkRequest, clusterService.state().metadata().getIndicesLookup(), systemIndices);
-        final Releasable releasable = indexingPressureService.markCoordinatingOperationStarted(indexingBytes, isOnlySystem);
+        final Releasable releasable = indexingPressureService.markCoordinatingOperationStarted(bulkRequest, isOnlySystem);
         final ActionListener<BulkResponse> releasingListener = ActionListener.runBefore(listener, releasable::close);
         final String executorName = isOnlySystem ? Names.SYSTEM_WRITE : Names.WRITE;
         try {
@@ -631,7 +630,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
                 final boolean isOnlySystem = isOnlySystem(bulkRequest, clusterService.state().metadata().getIndicesLookup(), systemIndices);
                 final Releasable releasable = indexingPressureService.markCoordinatingOperationStarted(
                     shardId,
-                    bulkShardRequest.ramBytesUsed(),
+                    bulkShardRequest,
                     isOnlySystem
                 );
                 shardBulkAction.execute(bulkShardRequest, ActionListener.runBefore(new ActionListener<BulkShardResponse>() {

--- a/server/src/main/java/org/opensearch/index/IndexingPressureService.java
+++ b/server/src/main/java/org/opensearch/index/IndexingPressureService.java
@@ -6,6 +6,8 @@
 package org.opensearch.index;
 
 import org.opensearch.action.admin.indices.stats.CommonStatsFlags;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkShardRequest;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.settings.Settings;
@@ -25,16 +27,18 @@ public class IndexingPressureService {
         shardIndexingPressure = new ShardIndexingPressure(settings, clusterService);
     }
 
-    public Releasable markCoordinatingOperationStarted(long bytes, boolean forceExecution) {
+    public Releasable markCoordinatingOperationStarted(BulkRequest bulkRequest, boolean forceExecution) {
         if (isShardIndexingPressureEnabled() == false) {
-            return shardIndexingPressure.markCoordinatingOperationStarted(bytes, forceExecution);
+            final long indexingBytes = bulkRequest.ramBytesUsed();
+            return shardIndexingPressure.markCoordinatingOperationStarted(indexingBytes, forceExecution);
         } else {
             return () -> {};
         }
     }
 
-    public Releasable markCoordinatingOperationStarted(ShardId shardId, long bytes, boolean forceExecution) {
+    public Releasable markCoordinatingOperationStarted(ShardId shardId, BulkShardRequest bulkShardRequest, boolean forceExecution) {
         if (isShardIndexingPressureEnabled()) {
+            final long bytes = bulkShardRequest.ramBytesUsed();
             return shardIndexingPressure.markCoordinatingOperationStarted(shardId, bytes, forceExecution);
         } else {
             return () -> {};

--- a/server/src/test/java/org/opensearch/index/IndexingPressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexingPressureServiceTests.java
@@ -9,7 +9,14 @@
 package org.opensearch.index;
 
 import org.junit.Before;
+import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.admin.indices.stats.CommonStatsFlags;
+import org.opensearch.action.bulk.BulkItemRequest;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkShardRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.client.Requests;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.settings.ClusterSettings;
@@ -43,11 +50,18 @@ public class IndexingPressureServiceTests extends OpenSearchTestCase {
         IndexingPressureService service = new IndexingPressureService(settings, clusterService);
         Index index = new Index("IndexName", "UUID");
         ShardId shardId = new ShardId(index, 0);
-
-        Releasable releasable = service.markCoordinatingOperationStarted(shardId, 1024, false);
+        BulkItemRequest[] items = new BulkItemRequest[1];
+        DocWriteRequest<IndexRequest> writeRequest = new IndexRequest("index", "_doc", "id").source(
+            Requests.INDEX_CONTENT_TYPE,
+            "foo",
+            "bar"
+        );
+        items[0] = new BulkItemRequest(0, writeRequest);
+        BulkShardRequest bulkShardRequest = new BulkShardRequest(shardId, WriteRequest.RefreshPolicy.NONE, items);
+        Releasable releasable = service.markCoordinatingOperationStarted(shardId, bulkShardRequest, false);
 
         IndexingPressurePerShardStats shardStats = service.shardStats(CommonStatsFlags.ALL).getIndexingPressureShardStats(shardId);
-        assertEquals(1024, shardStats.getCurrentCoordinatingBytes());
+        assertEquals(bulkShardRequest.ramBytesUsed(), shardStats.getCurrentCoordinatingBytes());
         releasable.close();
     }
 
@@ -64,11 +78,12 @@ public class IndexingPressureServiceTests extends OpenSearchTestCase {
         );
         clusterSettings.applySettings(updated.build());
 
-        Releasable releasable = service.markCoordinatingOperationStarted(1024, false);
+        BulkRequest bulkRequest = new BulkRequest();
+        Releasable releasable = service.markCoordinatingOperationStarted(bulkRequest, false);
         IndexingPressurePerShardStats shardStats = service.shardStats(CommonStatsFlags.ALL).getIndexingPressureShardStats(shardId);
         assertNull(shardStats);
         IndexingPressureStats nodeStats = service.nodeStats();
-        assertEquals(1024, nodeStats.getCurrentCoordinatingBytes());
+        assertEquals(bulkRequest.ramBytesUsed(), nodeStats.getCurrentCoordinatingBytes());
         releasable.close();
     }
 


### PR DESCRIPTION
### Description
Delay the ``ramBytesUsed `` computation for Indexing requests on the coordinator until reached a point, where absolutely necessary for IndexingPressure or ShardIndexingPressure. 
 
### Issues Resolved
This optimises the additional request size calculation, which otherwise would have been no-op. See (#1560)

The ramBytesUsed computations are done repeatedly at multiple places (replica, primary and coordinator), and are present even in the older version of IndexingPressure. Here in OS1.2 for every request overhead would be the request size computations for the number of documents in the batch. Given that this call has neither showed up in any CPU profiling data and was neither was called out as regression when first added in the indexing path during 7.9 release, this might not be the smoking gun, however this definitely optimises it down further. 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
