### PR TITLE
Delay the request size calculation until required by the indexing pressure framework

### DIFF
--- a/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java
@@ -210,9 +210,8 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
 
     @Override
     protected void doExecute(Task task, BulkRequest bulkRequest, ActionListener<BulkResponse> listener) {
-        final long indexingBytes = bulkRequest.ramBytesUsed();
         final boolean isOnlySystem = isOnlySystem(bulkRequest, clusterService.state().metadata().getIndicesLookup(), systemIndices);
-        final Releasable releasable = indexingPressureService.markCoordinatingOperationStarted(indexingBytes, isOnlySystem);
+        final Releasable releasable = indexingPressureService.markCoordinatingOperationStarted(bulkRequest, isOnlySystem);
         final ActionListener<BulkResponse> releasingListener = ActionListener.runBefore(listener, releasable::close);
         final String executorName = isOnlySystem ? Names.SYSTEM_WRITE : Names.WRITE;
         try {
@@ -631,7 +630,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
                 final boolean isOnlySystem = isOnlySystem(bulkRequest, clusterService.state().metadata().getIndicesLookup(), systemIndices);
                 final Releasable releasable = indexingPressureService.markCoordinatingOperationStarted(
                     shardId,
-                    bulkShardRequest.ramBytesUsed(),
+                    bulkShardRequest,
                     isOnlySystem
                 );
                 shardBulkAction.execute(bulkShardRequest, ActionListener.runBefore(new ActionListener<BulkShardResponse>() {

--- a/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java
@@ -211,7 +211,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
     @Override
     protected void doExecute(Task task, BulkRequest bulkRequest, ActionListener<BulkResponse> listener) {
         final boolean isOnlySystem = isOnlySystem(bulkRequest, clusterService.state().metadata().getIndicesLookup(), systemIndices);
-        final Releasable releasable = indexingPressureService.markCoordinatingOperationStarted(bulkRequest, isOnlySystem);
+        final Releasable releasable = indexingPressureService.markCoordinatingOperationStarted(bulkRequest::ramBytesUsed, isOnlySystem);
         final ActionListener<BulkResponse> releasingListener = ActionListener.runBefore(listener, releasable::close);
         final String executorName = isOnlySystem ? Names.SYSTEM_WRITE : Names.WRITE;
         try {
@@ -630,7 +630,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
                 final boolean isOnlySystem = isOnlySystem(bulkRequest, clusterService.state().metadata().getIndicesLookup(), systemIndices);
                 final Releasable releasable = indexingPressureService.markCoordinatingOperationStarted(
                     shardId,
-                    bulkShardRequest,
+                    bulkShardRequest::ramBytesUsed,
                     isOnlySystem
                 );
                 shardBulkAction.execute(bulkShardRequest, ActionListener.runBefore(new ActionListener<BulkShardResponse>() {

--- a/server/src/main/java/org/opensearch/index/IndexingPressureService.java
+++ b/server/src/main/java/org/opensearch/index/IndexingPressureService.java
@@ -6,6 +6,8 @@
 package org.opensearch.index;
 
 import org.opensearch.action.admin.indices.stats.CommonStatsFlags;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkShardRequest;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.settings.Settings;
@@ -25,16 +27,18 @@ public class IndexingPressureService {
         shardIndexingPressure = new ShardIndexingPressure(settings, clusterService);
     }
 
-    public Releasable markCoordinatingOperationStarted(long bytes, boolean forceExecution) {
+    public Releasable markCoordinatingOperationStarted(BulkRequest bulkRequest, boolean forceExecution) {
         if (isShardIndexingPressureEnabled() == false) {
+            final long bytes = bulkRequest.ramBytesUsed();
             return shardIndexingPressure.markCoordinatingOperationStarted(bytes, forceExecution);
         } else {
             return () -> {};
         }
     }
 
-    public Releasable markCoordinatingOperationStarted(ShardId shardId, long bytes, boolean forceExecution) {
+    public Releasable markCoordinatingOperationStarted(ShardId shardId, BulkShardRequest bulkShardRequest, boolean forceExecution) {
         if (isShardIndexingPressureEnabled()) {
+            final long bytes = bulkShardRequest.ramBytesUsed();
             return shardIndexingPressure.markCoordinatingOperationStarted(shardId, bytes, forceExecution);
         } else {
             return () -> {};

--- a/server/src/main/java/org/opensearch/index/IndexingPressureService.java
+++ b/server/src/main/java/org/opensearch/index/IndexingPressureService.java
@@ -6,14 +6,14 @@
 package org.opensearch.index;
 
 import org.opensearch.action.admin.indices.stats.CommonStatsFlags;
-import org.opensearch.action.bulk.BulkRequest;
-import org.opensearch.action.bulk.BulkShardRequest;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.index.stats.IndexingPressureStats;
 import org.opensearch.index.stats.ShardIndexingPressureStats;
+
+import java.util.function.LongSupplier;
 
 /**
  * Sets up classes for node/shard level indexing pressure.
@@ -27,24 +27,48 @@ public class IndexingPressureService {
         shardIndexingPressure = new ShardIndexingPressure(settings, clusterService);
     }
 
-    public Releasable markCoordinatingOperationStarted(BulkRequest bulkRequest, boolean forceExecution) {
+    /**
+     * Marks the beginning of coordinating operation for an indexing request on the node. Rejects the operation if node's
+     * memory limit is breached.
+     * Performs the node level accounting only if shard indexing pressure is disabled. Else empty releasable is returned.
+     * @param bytes memory bytes to be tracked for the current operation
+     * @param forceExecution permits operation even if the node level memory limit is breached
+     * @return Releasable to mark the completion of operation and release the accounted bytes
+     */
+    public Releasable markCoordinatingOperationStarted(LongSupplier bytes, boolean forceExecution) {
         if (isShardIndexingPressureEnabled() == false) {
-            final long bytes = bulkRequest.ramBytesUsed();
-            return shardIndexingPressure.markCoordinatingOperationStarted(bytes, forceExecution);
+            return shardIndexingPressure.markCoordinatingOperationStarted(bytes.getAsLong(), forceExecution);
         } else {
             return () -> {};
         }
     }
 
-    public Releasable markCoordinatingOperationStarted(ShardId shardId, BulkShardRequest bulkShardRequest, boolean forceExecution) {
+    /**
+     * Marks the beginning of coordinating operation for an indexing request on the Shard. Rejects the operation if shard's
+     * memory limit is breached.
+     * Performs the shard level accounting only if shard indexing pressure is enabled. Else empty releasable is returned.
+     * @param shardId Shard ID for which the current indexing operation is targeted for
+     * @param bytes memory bytes to be tracked for the current operation
+     * @param forceExecution permits operation even if the node level memory limit is breached
+     * @return Releasable to mark the completion of operation and release the accounted bytes
+     */
+    public Releasable markCoordinatingOperationStarted(ShardId shardId, LongSupplier bytes, boolean forceExecution) {
         if (isShardIndexingPressureEnabled()) {
-            final long bytes = bulkShardRequest.ramBytesUsed();
-            return shardIndexingPressure.markCoordinatingOperationStarted(shardId, bytes, forceExecution);
+            return shardIndexingPressure.markCoordinatingOperationStarted(shardId, bytes.getAsLong(), forceExecution);
         } else {
             return () -> {};
         }
     }
 
+    /**
+     * Marks the beginning of primary operation for an indexing request. Rejects the operation if memory limit is breached.
+     * Performs the node level accounting only if shard indexing pressure is not disabled. Else shard level accounting
+     * is performed.
+     * @param shardId Shard ID for which the current indexing operation is targeted for
+     * @param bytes memory bytes to be tracked for the current operation
+     * @param forceExecution permits operation even if the memory limit is breached
+     * @return Releasable to mark the completion of operation and release the accounted bytes
+     */
     public Releasable markPrimaryOperationStarted(ShardId shardId, long bytes, boolean forceExecution) {
         if (isShardIndexingPressureEnabled()) {
             return shardIndexingPressure.markPrimaryOperationStarted(shardId, bytes, forceExecution);
@@ -53,6 +77,15 @@ public class IndexingPressureService {
         }
     }
 
+    /**
+     * Marks the beginning of primary operation for an indexing request, when primary shard is local to the coordinator node.
+     * Rejects the operation if memory limit is breached.
+     * Performs the node level accounting only if shard indexing pressure is not disabled. Else shard level accounting
+     * is performed.
+     * @param shardId Shard ID for which the current indexing operation is targeted for
+     * @param bytes memory bytes to be tracked for the current operation
+     * @return Releasable to mark the completion of operation and release the accounted bytes
+     */
     public Releasable markPrimaryOperationLocalToCoordinatingNodeStarted(ShardId shardId, long bytes) {
         if (isShardIndexingPressureEnabled()) {
             return shardIndexingPressure.markPrimaryOperationLocalToCoordinatingNodeStarted(shardId, bytes);
@@ -61,6 +94,15 @@ public class IndexingPressureService {
         }
     }
 
+    /**
+     * Marks the beginning of replication operation for an indexing request. Rejects the operation if memory limit is breached.
+     * Performs the node level accounting only if shard indexing pressure is not disabled. Else shard level accounting
+     * is performed.
+     * @param shardId Shard ID for which the current indexing operation is targeted for
+     * @param bytes memory bytes to be tracked for the current operation
+     * @param forceExecution permits operation even if the memory limit is breached
+     * @return Releasable to mark the completion of operation and release the accounted bytes
+     */
     public Releasable markReplicaOperationStarted(ShardId shardId, long bytes, boolean forceExecution) {
         if (isShardIndexingPressureEnabled()) {
             return shardIndexingPressure.markReplicaOperationStarted(shardId, bytes, forceExecution);

--- a/server/src/test/java/org/opensearch/index/IndexingPressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexingPressureServiceTests.java
@@ -9,7 +9,14 @@
 package org.opensearch.index;
 
 import org.junit.Before;
+import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.admin.indices.stats.CommonStatsFlags;
+import org.opensearch.action.bulk.BulkItemRequest;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkShardRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.client.Requests;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.settings.ClusterSettings;
@@ -43,11 +50,18 @@ public class IndexingPressureServiceTests extends OpenSearchTestCase {
         IndexingPressureService service = new IndexingPressureService(settings, clusterService);
         Index index = new Index("IndexName", "UUID");
         ShardId shardId = new ShardId(index, 0);
-
-        Releasable releasable = service.markCoordinatingOperationStarted(shardId, 1024, false);
+        BulkItemRequest[] items = new BulkItemRequest[1];
+        DocWriteRequest<IndexRequest> writeRequest = new IndexRequest("index", "_doc", "id").source(
+            Requests.INDEX_CONTENT_TYPE,
+            "foo",
+            "bar"
+        );
+        items[0] = new BulkItemRequest(0, writeRequest);
+        BulkShardRequest bulkShardRequest = new BulkShardRequest(shardId, WriteRequest.RefreshPolicy.NONE, items);
+        Releasable releasable = service.markCoordinatingOperationStarted(shardId, bulkShardRequest, false);
 
         IndexingPressurePerShardStats shardStats = service.shardStats(CommonStatsFlags.ALL).getIndexingPressureShardStats(shardId);
-        assertEquals(1024, shardStats.getCurrentCoordinatingBytes());
+        assertEquals(bulkShardRequest.ramBytesUsed(), shardStats.getCurrentCoordinatingBytes());
         releasable.close();
     }
 
@@ -64,11 +78,12 @@ public class IndexingPressureServiceTests extends OpenSearchTestCase {
         );
         clusterSettings.applySettings(updated.build());
 
-        Releasable releasable = service.markCoordinatingOperationStarted(1024, false);
+        BulkRequest bulkRequest = new BulkRequest();
+        Releasable releasable = service.markCoordinatingOperationStarted(bulkRequest, false);
         IndexingPressurePerShardStats shardStats = service.shardStats(CommonStatsFlags.ALL).getIndexingPressureShardStats(shardId);
         assertNull(shardStats);
         IndexingPressureStats nodeStats = service.nodeStats();
-        assertEquals(1024, nodeStats.getCurrentCoordinatingBytes());
+        assertEquals(bulkRequest.ramBytesUsed(), nodeStats.getCurrentCoordinatingBytes());
         releasable.close();
     }
 

--- a/server/src/test/java/org/opensearch/index/IndexingPressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexingPressureServiceTests.java
@@ -58,7 +58,7 @@ public class IndexingPressureServiceTests extends OpenSearchTestCase {
         );
         items[0] = new BulkItemRequest(0, writeRequest);
         BulkShardRequest bulkShardRequest = new BulkShardRequest(shardId, WriteRequest.RefreshPolicy.NONE, items);
-        Releasable releasable = service.markCoordinatingOperationStarted(shardId, bulkShardRequest, false);
+        Releasable releasable = service.markCoordinatingOperationStarted(shardId, bulkShardRequest::ramBytesUsed, false);
 
         IndexingPressurePerShardStats shardStats = service.shardStats(CommonStatsFlags.ALL).getIndexingPressureShardStats(shardId);
         assertEquals(bulkShardRequest.ramBytesUsed(), shardStats.getCurrentCoordinatingBytes());
@@ -79,7 +79,7 @@ public class IndexingPressureServiceTests extends OpenSearchTestCase {
         clusterSettings.applySettings(updated.build());
 
         BulkRequest bulkRequest = new BulkRequest();
-        Releasable releasable = service.markCoordinatingOperationStarted(bulkRequest, false);
+        Releasable releasable = service.markCoordinatingOperationStarted(bulkRequest::ramBytesUsed, false);
         IndexingPressurePerShardStats shardStats = service.shardStats(CommonStatsFlags.ALL).getIndexingPressureShardStats(shardId);
         assertNull(shardStats);
         IndexingPressureStats nodeStats = service.nodeStats();


### PR DESCRIPTION
### Description
Delay the ramBytesUsed computation for Indexing requests on the coordinator until reached a point, where absolutely necessary for IndexingPressure or ShardIndexingPressure.

### Issues Resolved
This optimises the additional request size calculation, which otherwise would have been no-op. See (#1560)

The ramBytesUsed computations are done repeatedly at multiple places (replica, primary and coordinator), and are present even in the older version of IndexingPressure. Here in OS1.2 for every request overhead would be the request size computations for the number of documents in the batch. Given that this call has neither showed up in any CPU profiling data and was neither was called out as regression when first added in the indexing path during 7.9 release, this might not be the smoking gun, however this definitely optimises it down further.

