### PR TITLE
Use try-with-resources with MockLogAppender

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/opensearch/transport/netty4/OpenSearchLoggingHandlerIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/opensearch/transport/netty4/OpenSearchLoggingHandlerIT.java
@@ -36,7 +36,6 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchNetty4IntegTestCase;
 import org.opensearch.action.admin.cluster.node.hotthreads.NodesHotThreadsRequest;
-import org.opensearch.common.logging.Loggers;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.MockLogAppender;
@@ -53,17 +52,15 @@ public class OpenSearchLoggingHandlerIT extends OpenSearchNetty4IntegTestCase {
 
     public void setUp() throws Exception {
         super.setUp();
-        appender = MockLogAppender.createStarted();
-        Loggers.addAppender(LogManager.getLogger(OpenSearchLoggingHandler.class), appender);
-        Loggers.addAppender(LogManager.getLogger(TransportLogger.class), appender);
-        Loggers.addAppender(LogManager.getLogger(TcpTransport.class), appender);
+        appender = MockLogAppender.createForLoggers(
+            LogManager.getLogger(OpenSearchLoggingHandler.class),
+            LogManager.getLogger(TransportLogger.class),
+            LogManager.getLogger(TcpTransport.class)
+        );
     }
 
     public void tearDown() throws Exception {
-        Loggers.removeAppender(LogManager.getLogger(OpenSearchLoggingHandler.class), appender);
-        Loggers.removeAppender(LogManager.getLogger(TransportLogger.class), appender);
-        Loggers.removeAppender(LogManager.getLogger(TcpTransport.class), appender);
-        appender.stop();
+        appender.close();
         super.tearDown();
     }
 

--- a/plugins/transport-nio/src/internalClusterTest/java/org/opensearch/transport/nio/NioTransportLoggingIT.java
+++ b/plugins/transport-nio/src/internalClusterTest/java/org/opensearch/transport/nio/NioTransportLoggingIT.java
@@ -37,7 +37,6 @@ import org.apache.logging.log4j.LogManager;
 
 import org.opensearch.NioIntegTestCase;
 import org.opensearch.action.admin.cluster.node.hotthreads.NodesHotThreadsRequest;
-import org.opensearch.common.logging.Loggers;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.MockLogAppender;
@@ -54,15 +53,11 @@ public class NioTransportLoggingIT extends NioIntegTestCase {
 
     public void setUp() throws Exception {
         super.setUp();
-        appender = MockLogAppender.createStarted();
-        Loggers.addAppender(LogManager.getLogger(TransportLogger.class), appender);
-        Loggers.addAppender(LogManager.getLogger(TcpTransport.class), appender);
+        appender = MockLogAppender.createForLoggers(LogManager.getLogger(TransportLogger.class), LogManager.getLogger(TcpTransport.class));
     }
 
     public void tearDown() throws Exception {
-        Loggers.removeAppender(LogManager.getLogger(TransportLogger.class), appender);
-        Loggers.removeAppender(LogManager.getLogger(TcpTransport.class), appender);
-        appender.stop();
+        appender.close();
         super.tearDown();
     }
 

--- a/server/src/test/java/org/opensearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/service/MasterServiceTests.java
@@ -34,7 +34,6 @@ package org.opensearch.cluster.service;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.cluster.AckedClusterStateUpdateTask;
@@ -54,7 +53,6 @@ import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.Priority;
 import org.opensearch.common.collect.Tuple;
-import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -327,168 +325,163 @@ public class MasterServiceTests extends OpenSearchTestCase {
 
     @TestLogging(value = "org.opensearch.cluster.service:TRACE", reason = "to ensure that we log cluster state events on TRACE level")
     public void testClusterStateUpdateLogging() throws Exception {
-        MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
-        mockAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "test1 start",
-                MasterService.class.getCanonicalName(),
-                Level.DEBUG,
-                "executing cluster state update for [test1]"
-            )
-        );
-        mockAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "test1 computation",
-                MasterService.class.getCanonicalName(),
-                Level.DEBUG,
-                "took [1s] to compute cluster state update for [test1]"
-            )
-        );
-        mockAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "test1 notification",
-                MasterService.class.getCanonicalName(),
-                Level.DEBUG,
-                "took [0s] to notify listeners on unchanged cluster state for [test1]"
-            )
-        );
+        try (MockLogAppender mockAppender = MockLogAppender.createForLoggers(LogManager.getLogger(MasterService.class))) {
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "test1 start",
+                    MasterService.class.getCanonicalName(),
+                    Level.DEBUG,
+                    "executing cluster state update for [test1]"
+                )
+            );
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "test1 computation",
+                    MasterService.class.getCanonicalName(),
+                    Level.DEBUG,
+                    "took [1s] to compute cluster state update for [test1]"
+                )
+            );
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "test1 notification",
+                    MasterService.class.getCanonicalName(),
+                    Level.DEBUG,
+                    "took [0s] to notify listeners on unchanged cluster state for [test1]"
+                )
+            );
 
-        mockAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "test2 start",
-                MasterService.class.getCanonicalName(),
-                Level.DEBUG,
-                "executing cluster state update for [test2]"
-            )
-        );
-        mockAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "test2 failure",
-                MasterService.class.getCanonicalName(),
-                Level.TRACE,
-                "failed to execute cluster state update (on version: [*], uuid: [*]) for [test2]*"
-            )
-        );
-        mockAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "test2 computation",
-                MasterService.class.getCanonicalName(),
-                Level.DEBUG,
-                "took [2s] to compute cluster state update for [test2]"
-            )
-        );
-        mockAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "test2 notification",
-                MasterService.class.getCanonicalName(),
-                Level.DEBUG,
-                "took [0s] to notify listeners on unchanged cluster state for [test2]"
-            )
-        );
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "test2 start",
+                    MasterService.class.getCanonicalName(),
+                    Level.DEBUG,
+                    "executing cluster state update for [test2]"
+                )
+            );
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "test2 failure",
+                    MasterService.class.getCanonicalName(),
+                    Level.TRACE,
+                    "failed to execute cluster state update (on version: [*], uuid: [*]) for [test2]*"
+                )
+            );
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "test2 computation",
+                    MasterService.class.getCanonicalName(),
+                    Level.DEBUG,
+                    "took [2s] to compute cluster state update for [test2]"
+                )
+            );
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "test2 notification",
+                    MasterService.class.getCanonicalName(),
+                    Level.DEBUG,
+                    "took [0s] to notify listeners on unchanged cluster state for [test2]"
+                )
+            );
 
-        mockAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "test3 start",
-                MasterService.class.getCanonicalName(),
-                Level.DEBUG,
-                "executing cluster state update for [test3]"
-            )
-        );
-        mockAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "test3 computation",
-                MasterService.class.getCanonicalName(),
-                Level.DEBUG,
-                "took [3s] to compute cluster state update for [test3]"
-            )
-        );
-        mockAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "test3 notification",
-                MasterService.class.getCanonicalName(),
-                Level.DEBUG,
-                "took [4s] to notify listeners on successful publication of cluster state (version: *, uuid: *) for [test3]"
-            )
-        );
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "test3 start",
+                    MasterService.class.getCanonicalName(),
+                    Level.DEBUG,
+                    "executing cluster state update for [test3]"
+                )
+            );
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "test3 computation",
+                    MasterService.class.getCanonicalName(),
+                    Level.DEBUG,
+                    "took [3s] to compute cluster state update for [test3]"
+                )
+            );
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "test3 notification",
+                    MasterService.class.getCanonicalName(),
+                    Level.DEBUG,
+                    "took [4s] to notify listeners on successful publication of cluster state (version: *, uuid: *) for [test3]"
+                )
+            );
 
-        mockAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "test4",
-                MasterService.class.getCanonicalName(),
-                Level.DEBUG,
-                "executing cluster state update for [test4]"
-            )
-        );
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "test4",
+                    MasterService.class.getCanonicalName(),
+                    Level.DEBUG,
+                    "executing cluster state update for [test4]"
+                )
+            );
 
-        Logger clusterLogger = LogManager.getLogger(MasterService.class);
-        Loggers.addAppender(clusterLogger, mockAppender);
-        try (MasterService masterService = createMasterService(true)) {
-            masterService.submitStateUpdateTask("test1", new ClusterStateUpdateTask() {
-                @Override
-                public ClusterState execute(ClusterState currentState) {
-                    relativeTimeInMillis += TimeValue.timeValueSeconds(1).millis();
-                    return currentState;
-                }
+            try (MasterService masterService = createMasterService(true)) {
+                masterService.submitStateUpdateTask("test1", new ClusterStateUpdateTask() {
+                    @Override
+                    public ClusterState execute(ClusterState currentState) {
+                        relativeTimeInMillis += TimeValue.timeValueSeconds(1).millis();
+                        return currentState;
+                    }
 
-                @Override
-                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {}
+                    @Override
+                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {}
 
-                @Override
-                public void onFailure(String source, Exception e) {
-                    fail();
-                }
-            });
-            masterService.submitStateUpdateTask("test2", new ClusterStateUpdateTask() {
-                @Override
-                public ClusterState execute(ClusterState currentState) {
-                    relativeTimeInMillis += TimeValue.timeValueSeconds(2).millis();
-                    throw new IllegalArgumentException("Testing handling of exceptions in the cluster state task");
-                }
+                    @Override
+                    public void onFailure(String source, Exception e) {
+                        fail();
+                    }
+                });
+                masterService.submitStateUpdateTask("test2", new ClusterStateUpdateTask() {
+                    @Override
+                    public ClusterState execute(ClusterState currentState) {
+                        relativeTimeInMillis += TimeValue.timeValueSeconds(2).millis();
+                        throw new IllegalArgumentException("Testing handling of exceptions in the cluster state task");
+                    }
 
-                @Override
-                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                    fail();
-                }
+                    @Override
+                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                        fail();
+                    }
 
-                @Override
-                public void onFailure(String source, Exception e) {}
-            });
-            masterService.submitStateUpdateTask("test3", new ClusterStateUpdateTask() {
-                @Override
-                public ClusterState execute(ClusterState currentState) {
-                    relativeTimeInMillis += TimeValue.timeValueSeconds(3).millis();
-                    return ClusterState.builder(currentState).incrementVersion().build();
-                }
+                    @Override
+                    public void onFailure(String source, Exception e) {}
+                });
+                masterService.submitStateUpdateTask("test3", new ClusterStateUpdateTask() {
+                    @Override
+                    public ClusterState execute(ClusterState currentState) {
+                        relativeTimeInMillis += TimeValue.timeValueSeconds(3).millis();
+                        return ClusterState.builder(currentState).incrementVersion().build();
+                    }
 
-                @Override
-                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                    relativeTimeInMillis += TimeValue.timeValueSeconds(4).millis();
-                }
+                    @Override
+                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                        relativeTimeInMillis += TimeValue.timeValueSeconds(4).millis();
+                    }
 
-                @Override
-                public void onFailure(String source, Exception e) {
-                    fail();
-                }
-            });
-            masterService.submitStateUpdateTask("test4", new ClusterStateUpdateTask() {
-                @Override
-                public ClusterState execute(ClusterState currentState) {
-                    return currentState;
-                }
+                    @Override
+                    public void onFailure(String source, Exception e) {
+                        fail();
+                    }
+                });
+                masterService.submitStateUpdateTask("test4", new ClusterStateUpdateTask() {
+                    @Override
+                    public ClusterState execute(ClusterState currentState) {
+                        return currentState;
+                    }
 
-                @Override
-                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {}
+                    @Override
+                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {}
 
-                @Override
-                public void onFailure(String source, Exception e) {
-                    fail();
-                }
-            });
-            assertBusy(mockAppender::assertAllExpectationsMatched);
-        } finally {
-            Loggers.removeAppender(clusterLogger, mockAppender);
-            mockAppender.stop();
+                    @Override
+                    public void onFailure(String source, Exception e) {
+                        fail();
+                    }
+                });
+                assertBusy(mockAppender::assertAllExpectationsMatched);
+            }
         }
     }
 
@@ -741,233 +734,228 @@ public class MasterServiceTests extends OpenSearchTestCase {
 
     @TestLogging(value = "org.opensearch.cluster.service:WARN", reason = "to ensure that we log cluster state events on WARN level")
     public void testLongClusterStateUpdateLogging() throws Exception {
-        MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
-        mockAppender.addExpectation(
-            new MockLogAppender.UnseenEventExpectation(
-                "test1 shouldn't log because it was fast enough",
-                MasterService.class.getCanonicalName(),
-                Level.WARN,
-                "*took*test1*"
-            )
-        );
-        mockAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "test2",
-                MasterService.class.getCanonicalName(),
-                Level.WARN,
-                "*took [*], which is over [10s], to compute cluster state update for [test2]"
-            )
-        );
-        mockAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "test3",
-                MasterService.class.getCanonicalName(),
-                Level.WARN,
-                "*took [*], which is over [10s], to compute cluster state update for [test3]"
-            )
-        );
-        mockAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "test4",
-                MasterService.class.getCanonicalName(),
-                Level.WARN,
-                "*took [*], which is over [10s], to compute cluster state update for [test4]"
-            )
-        );
-        mockAppender.addExpectation(
-            new MockLogAppender.UnseenEventExpectation(
-                "test5 should not log despite publishing slowly",
-                MasterService.class.getCanonicalName(),
-                Level.WARN,
-                "*took*test5*"
-            )
-        );
-        mockAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "test6 should log due to slow and failing publication",
-                MasterService.class.getCanonicalName(),
-                Level.WARN,
-                "took [*] and then failed to publish updated cluster state (version: *, uuid: *) for [test6]:*"
-            )
-        );
-
-        Logger clusterLogger = LogManager.getLogger(MasterService.class);
-        Loggers.addAppender(clusterLogger, mockAppender);
-        try (
-            MasterService masterService = new MasterService(
-                Settings.builder()
-                    .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), MasterServiceTests.class.getSimpleName())
-                    .put(Node.NODE_NAME_SETTING.getKey(), "test_node")
-                    .build(),
-                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
-                threadPool
-            )
-        ) {
-
-            final DiscoveryNode localNode = new DiscoveryNode(
-                "node1",
-                buildNewFakeTransportAddress(),
-                emptyMap(),
-                emptySet(),
-                Version.CURRENT
+        try (MockLogAppender mockAppender = MockLogAppender.createForLoggers(LogManager.getLogger(MasterService.class))) {
+            mockAppender.addExpectation(
+                new MockLogAppender.UnseenEventExpectation(
+                    "test1 shouldn't log because it was fast enough",
+                    MasterService.class.getCanonicalName(),
+                    Level.WARN,
+                    "*took*test1*"
+                )
             );
-            final ClusterState initialClusterState = ClusterState.builder(new ClusterName(MasterServiceTests.class.getSimpleName()))
-                .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()).masterNodeId(localNode.getId()))
-                .blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK)
-                .build();
-            final AtomicReference<ClusterState> clusterStateRef = new AtomicReference<>(initialClusterState);
-            masterService.setClusterStatePublisher((event, publishListener, ackListener) -> {
-                if (event.source().contains("test5")) {
-                    relativeTimeInMillis += MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING.get(Settings.EMPTY).millis()
-                        + randomLongBetween(1, 1000000);
-                }
-                if (event.source().contains("test6")) {
-                    relativeTimeInMillis += MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING.get(Settings.EMPTY).millis()
-                        + randomLongBetween(1, 1000000);
-                    throw new OpenSearchException("simulated error during slow publication which should trigger logging");
-                }
-                clusterStateRef.set(event.state());
-                publishListener.onResponse(null);
-            });
-            masterService.setClusterStateSupplier(clusterStateRef::get);
-            masterService.start();
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "test2",
+                    MasterService.class.getCanonicalName(),
+                    Level.WARN,
+                    "*took [*], which is over [10s], to compute cluster state update for [test2]"
+                )
+            );
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "test3",
+                    MasterService.class.getCanonicalName(),
+                    Level.WARN,
+                    "*took [*], which is over [10s], to compute cluster state update for [test3]"
+                )
+            );
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "test4",
+                    MasterService.class.getCanonicalName(),
+                    Level.WARN,
+                    "*took [*], which is over [10s], to compute cluster state update for [test4]"
+                )
+            );
+            mockAppender.addExpectation(
+                new MockLogAppender.UnseenEventExpectation(
+                    "test5 should not log despite publishing slowly",
+                    MasterService.class.getCanonicalName(),
+                    Level.WARN,
+                    "*took*test5*"
+                )
+            );
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "test6 should log due to slow and failing publication",
+                    MasterService.class.getCanonicalName(),
+                    Level.WARN,
+                    "took [*] and then failed to publish updated cluster state (version: *, uuid: *) for [test6]:*"
+                )
+            );
 
-            final CountDownLatch latch = new CountDownLatch(6);
-            final CountDownLatch processedFirstTask = new CountDownLatch(1);
-            masterService.submitStateUpdateTask("test1", new ClusterStateUpdateTask() {
-                @Override
-                public ClusterState execute(ClusterState currentState) {
-                    relativeTimeInMillis += randomLongBetween(
-                        0L,
-                        MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING.get(Settings.EMPTY).millis()
-                    );
-                    return currentState;
-                }
+            try (
+                MasterService masterService = new MasterService(
+                    Settings.builder()
+                        .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), MasterServiceTests.class.getSimpleName())
+                        .put(Node.NODE_NAME_SETTING.getKey(), "test_node")
+                        .build(),
+                    new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+                    threadPool
+                )
+            ) {
 
-                @Override
-                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                    latch.countDown();
-                    processedFirstTask.countDown();
-                }
+                final DiscoveryNode localNode = new DiscoveryNode(
+                    "node1",
+                    buildNewFakeTransportAddress(),
+                    emptyMap(),
+                    emptySet(),
+                    Version.CURRENT
+                );
+                final ClusterState initialClusterState = ClusterState.builder(new ClusterName(MasterServiceTests.class.getSimpleName()))
+                    .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()).masterNodeId(localNode.getId()))
+                    .blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK)
+                    .build();
+                final AtomicReference<ClusterState> clusterStateRef = new AtomicReference<>(initialClusterState);
+                masterService.setClusterStatePublisher((event, publishListener, ackListener) -> {
+                    if (event.source().contains("test5")) {
+                        relativeTimeInMillis += MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING.get(Settings.EMPTY)
+                            .millis() + randomLongBetween(1, 1000000);
+                    }
+                    if (event.source().contains("test6")) {
+                        relativeTimeInMillis += MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING.get(Settings.EMPTY)
+                            .millis() + randomLongBetween(1, 1000000);
+                        throw new OpenSearchException("simulated error during slow publication which should trigger logging");
+                    }
+                    clusterStateRef.set(event.state());
+                    publishListener.onResponse(null);
+                });
+                masterService.setClusterStateSupplier(clusterStateRef::get);
+                masterService.start();
 
-                @Override
-                public void onFailure(String source, Exception e) {
-                    fail();
-                }
-            });
+                final CountDownLatch latch = new CountDownLatch(6);
+                final CountDownLatch processedFirstTask = new CountDownLatch(1);
+                masterService.submitStateUpdateTask("test1", new ClusterStateUpdateTask() {
+                    @Override
+                    public ClusterState execute(ClusterState currentState) {
+                        relativeTimeInMillis += randomLongBetween(
+                            0L,
+                            MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING.get(Settings.EMPTY).millis()
+                        );
+                        return currentState;
+                    }
 
-            processedFirstTask.await();
-            masterService.submitStateUpdateTask("test2", new ClusterStateUpdateTask() {
-                @Override
-                public ClusterState execute(ClusterState currentState) {
-                    relativeTimeInMillis += MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING.get(Settings.EMPTY).millis()
-                        + randomLongBetween(1, 1000000);
-                    throw new IllegalArgumentException("Testing handling of exceptions in the cluster state task");
-                }
+                    @Override
+                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                        latch.countDown();
+                        processedFirstTask.countDown();
+                    }
 
-                @Override
-                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                    fail();
-                }
+                    @Override
+                    public void onFailure(String source, Exception e) {
+                        fail();
+                    }
+                });
 
-                @Override
-                public void onFailure(String source, Exception e) {
-                    latch.countDown();
-                }
-            });
-            masterService.submitStateUpdateTask("test3", new ClusterStateUpdateTask() {
-                @Override
-                public ClusterState execute(ClusterState currentState) {
-                    relativeTimeInMillis += MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING.get(Settings.EMPTY).millis()
-                        + randomLongBetween(1, 1000000);
-                    return ClusterState.builder(currentState).incrementVersion().build();
-                }
+                processedFirstTask.await();
+                masterService.submitStateUpdateTask("test2", new ClusterStateUpdateTask() {
+                    @Override
+                    public ClusterState execute(ClusterState currentState) {
+                        relativeTimeInMillis += MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING.get(Settings.EMPTY)
+                            .millis() + randomLongBetween(1, 1000000);
+                        throw new IllegalArgumentException("Testing handling of exceptions in the cluster state task");
+                    }
 
-                @Override
-                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                    latch.countDown();
-                }
+                    @Override
+                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                        fail();
+                    }
 
-                @Override
-                public void onFailure(String source, Exception e) {
-                    fail();
-                }
-            });
-            masterService.submitStateUpdateTask("test4", new ClusterStateUpdateTask() {
-                @Override
-                public ClusterState execute(ClusterState currentState) {
-                    relativeTimeInMillis += MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING.get(Settings.EMPTY).millis()
-                        + randomLongBetween(1, 1000000);
-                    return currentState;
-                }
+                    @Override
+                    public void onFailure(String source, Exception e) {
+                        latch.countDown();
+                    }
+                });
+                masterService.submitStateUpdateTask("test3", new ClusterStateUpdateTask() {
+                    @Override
+                    public ClusterState execute(ClusterState currentState) {
+                        relativeTimeInMillis += MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING.get(Settings.EMPTY)
+                            .millis() + randomLongBetween(1, 1000000);
+                        return ClusterState.builder(currentState).incrementVersion().build();
+                    }
 
-                @Override
-                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                    latch.countDown();
-                }
+                    @Override
+                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                        latch.countDown();
+                    }
 
-                @Override
-                public void onFailure(String source, Exception e) {
-                    fail();
-                }
-            });
-            masterService.submitStateUpdateTask("test5", new ClusterStateUpdateTask() {
-                @Override
-                public ClusterState execute(ClusterState currentState) {
-                    return ClusterState.builder(currentState).incrementVersion().build();
-                }
+                    @Override
+                    public void onFailure(String source, Exception e) {
+                        fail();
+                    }
+                });
+                masterService.submitStateUpdateTask("test4", new ClusterStateUpdateTask() {
+                    @Override
+                    public ClusterState execute(ClusterState currentState) {
+                        relativeTimeInMillis += MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING.get(Settings.EMPTY)
+                            .millis() + randomLongBetween(1, 1000000);
+                        return currentState;
+                    }
 
-                @Override
-                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                    latch.countDown();
-                }
+                    @Override
+                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                        latch.countDown();
+                    }
 
-                @Override
-                public void onFailure(String source, Exception e) {
-                    fail();
-                }
-            });
-            masterService.submitStateUpdateTask("test6", new ClusterStateUpdateTask() {
-                @Override
-                public ClusterState execute(ClusterState currentState) {
-                    return ClusterState.builder(currentState).incrementVersion().build();
-                }
+                    @Override
+                    public void onFailure(String source, Exception e) {
+                        fail();
+                    }
+                });
+                masterService.submitStateUpdateTask("test5", new ClusterStateUpdateTask() {
+                    @Override
+                    public ClusterState execute(ClusterState currentState) {
+                        return ClusterState.builder(currentState).incrementVersion().build();
+                    }
 
-                @Override
-                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                    fail();
-                }
+                    @Override
+                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                        latch.countDown();
+                    }
 
-                @Override
-                public void onFailure(String source, Exception e) {
-                    fail(); // maybe we should notify here?
-                }
-            });
-            // Additional update task to make sure all previous logging made it to the loggerName
-            // We don't check logging for this on since there is no guarantee that it will occur before our check
-            masterService.submitStateUpdateTask("test7", new ClusterStateUpdateTask() {
-                @Override
-                public ClusterState execute(ClusterState currentState) {
-                    return currentState;
-                }
+                    @Override
+                    public void onFailure(String source, Exception e) {
+                        fail();
+                    }
+                });
+                masterService.submitStateUpdateTask("test6", new ClusterStateUpdateTask() {
+                    @Override
+                    public ClusterState execute(ClusterState currentState) {
+                        return ClusterState.builder(currentState).incrementVersion().build();
+                    }
 
-                @Override
-                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                    latch.countDown();
-                }
+                    @Override
+                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                        fail();
+                    }
 
-                @Override
-                public void onFailure(String source, Exception e) {
-                    fail();
-                }
-            });
-            latch.await();
-        } finally {
-            Loggers.removeAppender(clusterLogger, mockAppender);
-            mockAppender.stop();
+                    @Override
+                    public void onFailure(String source, Exception e) {
+                        fail(); // maybe we should notify here?
+                    }
+                });
+                // Additional update task to make sure all previous logging made it to the loggerName
+                // We don't check logging for this on since there is no guarantee that it will occur before our check
+                masterService.submitStateUpdateTask("test7", new ClusterStateUpdateTask() {
+                    @Override
+                    public ClusterState execute(ClusterState currentState) {
+                        return currentState;
+                    }
+
+                    @Override
+                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onFailure(String source, Exception e) {
+                        fail();
+                    }
+                });
+                latch.await();
+            }
+            mockAppender.assertAllExpectationsMatched();
         }
-        mockAppender.assertAllExpectationsMatched();
     }
 
     public void testAcking() throws InterruptedException {

--- a/server/src/test/java/org/opensearch/common/settings/SettingsFilterTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/SettingsFilterTests.java
@@ -35,7 +35,6 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.Strings;
-import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.json.JsonXContent;
@@ -143,14 +142,10 @@ public class SettingsFilterTests extends OpenSearchTestCase {
     private void assertExpectedLogMessages(Consumer<Logger> consumer, MockLogAppender.LoggingExpectation... expectations)
         throws IllegalAccessException {
         Logger testLogger = LogManager.getLogger("org.opensearch.test");
-        MockLogAppender appender = MockLogAppender.createStarted();
-        Loggers.addAppender(testLogger, appender);
-        try {
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(testLogger)) {
             Arrays.stream(expectations).forEach(appender::addExpectation);
             consumer.accept(testLogger);
             appender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(testLogger, appender);
         }
     }
 

--- a/server/src/test/java/org/opensearch/gateway/IncrementalClusterStateWriterTests.java
+++ b/server/src/test/java/org/opensearch/gateway/IncrementalClusterStateWriterTests.java
@@ -51,7 +51,6 @@ import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.cluster.routing.allocation.AllocationService;
 import org.opensearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
 import org.opensearch.common.collect.Tuple;
-import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
@@ -568,18 +567,11 @@ public class IncrementalClusterStateWriterTests extends OpenSearchAllocationTest
         IncrementalClusterStateWriter incrementalClusterStateWriter,
         MockLogAppender.LoggingExpectation expectation
     ) throws IllegalAccessException, WriteStateException {
-        MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
-        mockAppender.addExpectation(expectation);
         Logger classLogger = LogManager.getLogger(IncrementalClusterStateWriter.class);
-        Loggers.addAppender(classLogger, mockAppender);
-
-        try {
+        try (MockLogAppender mockAppender = MockLogAppender.createForLoggers(classLogger)) {
+            mockAppender.addExpectation(expectation);
             incrementalClusterStateWriter.updateClusterState(clusterState);
-        } finally {
-            Loggers.removeAppender(classLogger, mockAppender);
-            mockAppender.stop();
+            mockAppender.assertAllExpectationsMatched();
         }
-        mockAppender.assertAllExpectationsMatched();
     }
 }

--- a/server/src/test/java/org/opensearch/http/AbstractHttpServerTransportTests.java
+++ b/server/src/test/java/org/opensearch/http/AbstractHttpServerTransportTests.java
@@ -37,7 +37,6 @@ import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.bytes.BytesReference;
-import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.network.NetworkService;
 import org.opensearch.common.network.NetworkUtils;
 import org.opensearch.common.settings.ClusterSettings;
@@ -268,12 +267,8 @@ public class AbstractHttpServerTransportTests extends OpenSearchTestCase {
                     .put(HttpTransportSettings.SETTING_HTTP_TRACE_LOG_EXCLUDE.getKey(), excludeSettings)
                     .build()
             );
-            MockLogAppender appender = new MockLogAppender();
             final String traceLoggerName = "org.opensearch.http.HttpTracer";
-            try {
-                appender.start();
-                Loggers.addAppender(LogManager.getLogger(traceLoggerName), appender);
-
+            try (MockLogAppender appender = MockLogAppender.createForLoggers(LogManager.getLogger(traceLoggerName))) {
                 final String opaqueId = UUIDs.randomBase64UUID(random());
                 appender.addExpectation(
                     new MockLogAppender.PatternSeenEventExpectation(
@@ -342,9 +337,6 @@ public class AbstractHttpServerTransportTests extends OpenSearchTestCase {
 
                 transport.incomingRequest(fakeRestRequestExcludedPath.getHttpRequest(), fakeRestRequestExcludedPath.getHttpChannel());
                 appender.assertAllExpectationsMatched();
-            } finally {
-                Loggers.removeAppender(LogManager.getLogger(traceLoggerName), appender);
-                appender.stop();
             }
         }
     }

--- a/server/src/test/java/org/opensearch/transport/TcpTransportTests.java
+++ b/server/src/test/java/org/opensearch/transport/TcpTransportTests.java
@@ -40,7 +40,6 @@ import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.component.Lifecycle;
 import org.opensearch.common.io.stream.BytesStreamOutput;
-import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.network.NetworkService;
 import org.opensearch.common.network.NetworkUtils;
 import org.opensearch.common.settings.Settings;
@@ -524,12 +523,7 @@ public class TcpTransportTests extends OpenSearchTestCase {
         MockLogAppender.LoggingExpectation... expectations
     ) throws IllegalAccessException {
         final TestThreadPool testThreadPool = new TestThreadPool("test");
-        MockLogAppender appender = new MockLogAppender();
-
-        try {
-            appender.start();
-
-            Loggers.addAppender(LogManager.getLogger(TcpTransport.class), appender);
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(LogManager.getLogger(TcpTransport.class))) {
             for (MockLogAppender.LoggingExpectation expectation : expectations) {
                 appender.addExpectation(expectation);
             }
@@ -568,8 +562,6 @@ public class TcpTransportTests extends OpenSearchTestCase {
             appender.assertAllExpectationsMatched();
 
         } finally {
-            Loggers.removeAppender(LogManager.getLogger(TcpTransport.class), appender);
-            appender.stop();
             ThreadPool.terminate(testThreadPool, 30, TimeUnit.SECONDS);
         }
     }

--- a/test/framework/src/main/java/org/opensearch/test/MockLogAppender.java
+++ b/test/framework/src/main/java/org/opensearch/test/MockLogAppender.java
@@ -32,11 +32,15 @@
 package org.opensearch.test;
 
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.filter.RegexFilter;
+import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.regex.Regex;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.regex.Pattern;
@@ -47,32 +51,43 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Test appender that can be used to verify that certain events were logged correctly
  */
-public class MockLogAppender extends AbstractAppender {
+public class MockLogAppender extends AbstractAppender implements AutoCloseable {
 
     private static final String COMMON_PREFIX = System.getProperty("opensearch.logger.prefix", "org.opensearch.");
 
     private final List<LoggingExpectation> expectations;
+    private final List<Logger> loggers;
 
     /**
-     * Creates and starts a MockLogAppender. Generally preferred over using the constructor
-     * directly because adding an unstarted appender to the static logging context can cause
-     * difficult-to-identify errors in the tests and this method makes it impossible to do
-     * that.
+     * Creates an instance and adds it as an appender to the given Loggers. Upon
+     * closure, this instance will then remove itself from the Loggers it was added
+     * to. It is strongly recommended to use this class in a try-with-resources block
+     * to guarantee that it is properly removed from all Loggers. Since the logging
+     * state is static and therefore global within a JVM, it can cause unrelated
+     * tests to fail if, for example, they trigger a logging statement that tried to
+     * write to a closed MockLogAppender instance.
      */
-    public static MockLogAppender createStarted() throws IllegalAccessException {
-        final MockLogAppender appender = new MockLogAppender();
+    public static MockLogAppender createForLoggers(Logger... loggers) throws IllegalAccessException {
+        final MockLogAppender appender = new MockLogAppender(
+            RegexFilter.createFilter(".*(\n.*)*", new String[0], false, null, null),
+            Collections.unmodifiableList(Arrays.asList(loggers))
+        );
         appender.start();
+        for (Logger logger : loggers) {
+            Loggers.addAppender(logger, appender);
+        }
         return appender;
     }
 
-    public MockLogAppender() throws IllegalAccessException {
-        super("mock", RegexFilter.createFilter(".*(\n.*)*", new String[0], false, null, null), null);
+    private MockLogAppender(RegexFilter filter, List<Logger> loggers) {
+        super("mock", filter, null);
         /*
          * We use a copy-on-write array list since log messages could be appended while we are setting up expectations. When that occurs,
          * we would run into a concurrent modification exception from the iteration over the expectations in #append, concurrent with a
          * modification from #addExpectation.
          */
-        expectations = new CopyOnWriteArrayList<>();
+        this.expectations = new CopyOnWriteArrayList<>();
+        this.loggers = loggers;
     }
 
     public void addExpectation(LoggingExpectation expectation) {
@@ -90,6 +105,14 @@ public class MockLogAppender extends AbstractAppender {
         for (LoggingExpectation expectation : expectations) {
             expectation.assertMatched();
         }
+    }
+
+    @Override
+    public void close() {
+        for (Logger logger : loggers) {
+            Loggers.removeAppender(logger, this);
+        }
+        this.stop();
     }
 
     public interface LoggingExpectation {

--- a/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
@@ -34,6 +34,7 @@ package org.opensearch.transport;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
 import org.apache.lucene.util.CollectionUtil;
@@ -51,7 +52,6 @@ import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
-import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.network.CloseableChannel;
 import org.opensearch.common.network.NetworkAddress;
 import org.opensearch.common.network.NetworkUtils;
@@ -1202,10 +1202,8 @@ public abstract class AbstractSimpleTransportTestCase extends OpenSearchTestCase
                 .build()
         );
 
-        MockLogAppender appender = new MockLogAppender();
-        try {
-            appender.start();
-            Loggers.addAppender(LogManager.getLogger("org.opensearch.transport.TransportService.tracer"), appender);
+        final Logger logger = LogManager.getLogger("org.opensearch.transport.TransportService.tracer");
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(logger)) {
             final String requestSent = ".*\\[internal:test].*sent to.*\\{TS_B}.*";
             final MockLogAppender.LoggingExpectation requestSentExpectation = new MockLogAppender.PatternSeenEventExpectation(
                 "sent request",
@@ -1291,9 +1289,6 @@ public abstract class AbstractSimpleTransportTestCase extends OpenSearchTestCase
             future.txGet();
 
             assertBusy(appender::assertAllExpectationsMatched);
-        } finally {
-            Loggers.removeAppender(LogManager.getLogger("org.opensearch.transport.TransportService.tracer"), appender);
-            appender.stop();
         }
     }
 

--- a/test/framework/src/test/java/org/opensearch/transport/nio/TestEventHandlerTests.java
+++ b/test/framework/src/test/java/org/opensearch/transport/nio/TestEventHandlerTests.java
@@ -35,7 +35,6 @@ package org.opensearch.transport.nio;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.CheckedRunnable;
-import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.nio.ServerChannelContext;
 import org.opensearch.nio.SocketChannelContext;
@@ -54,73 +53,60 @@ import static org.mockito.Mockito.mock;
 
 public class TestEventHandlerTests extends OpenSearchTestCase {
 
-    private MockLogAppender appender;
-
-    public void setUp() throws Exception {
-        super.setUp();
-        appender = new MockLogAppender();
-        Loggers.addAppender(LogManager.getLogger(MockNioTransport.class), appender);
-        appender.start();
-    }
-
-    public void tearDown() throws Exception {
-        Loggers.removeAppender(LogManager.getLogger(MockNioTransport.class), appender);
-        appender.stop();
-        super.tearDown();
-    }
-
     public void testLogOnElapsedTime() throws Exception {
-        long start = System.nanoTime();
-        long end = start + TimeUnit.MILLISECONDS.toNanos(400);
-        AtomicBoolean isStart = new AtomicBoolean(true);
-        LongSupplier timeSupplier = () -> {
-            if (isStart.compareAndSet(true, false)) {
-                return start;
-            } else if (isStart.compareAndSet(false, true)) {
-                return end;
-            }
-            throw new IllegalStateException("Cannot update isStart");
-        };
-        final ThreadPool threadPool = mock(ThreadPool.class);
-        doAnswer(i -> timeSupplier.getAsLong()).when(threadPool).relativeTimeInNanos();
-        TestEventHandler eventHandler = new TestEventHandler(
-            e -> {},
-            () -> null,
-            new MockNioTransport.TransportThreadWatchdog(threadPool, Settings.EMPTY)
-        );
-
-        ServerChannelContext serverChannelContext = mock(ServerChannelContext.class);
-        SocketChannelContext socketChannelContext = mock(SocketChannelContext.class);
-        RuntimeException exception = new RuntimeException("boom");
-
-        Map<String, CheckedRunnable<Exception>> tests = new HashMap<>();
-
-        tests.put("acceptChannel", () -> eventHandler.acceptChannel(serverChannelContext));
-        tests.put("acceptException", () -> eventHandler.acceptException(serverChannelContext, exception));
-        tests.put("registrationException", () -> eventHandler.registrationException(socketChannelContext, exception));
-        tests.put("handleConnect", () -> eventHandler.handleConnect(socketChannelContext));
-        tests.put("connectException", () -> eventHandler.connectException(socketChannelContext, exception));
-        tests.put("handleRead", () -> eventHandler.handleRead(socketChannelContext));
-        tests.put("readException", () -> eventHandler.readException(socketChannelContext, exception));
-        tests.put("handleWrite", () -> eventHandler.handleWrite(socketChannelContext));
-        tests.put("writeException", () -> eventHandler.writeException(socketChannelContext, exception));
-        tests.put("handleTask", () -> eventHandler.handleTask(mock(Runnable.class)));
-        tests.put("taskException", () -> eventHandler.taskException(exception));
-        tests.put("handleClose", () -> eventHandler.handleClose(socketChannelContext));
-        tests.put("closeException", () -> eventHandler.closeException(socketChannelContext, exception));
-        tests.put("genericChannelException", () -> eventHandler.genericChannelException(socketChannelContext, exception));
-
-        for (Map.Entry<String, CheckedRunnable<Exception>> entry : tests.entrySet()) {
-            String message = "*Slow execution on network thread*";
-            MockLogAppender.LoggingExpectation slowExpectation = new MockLogAppender.SeenEventExpectation(
-                entry.getKey(),
-                MockNioTransport.class.getCanonicalName(),
-                Level.WARN,
-                message
+        try (MockLogAppender appender = MockLogAppender.createForLoggers(LogManager.getLogger(MockNioTransport.class))) {
+            long start = System.nanoTime();
+            long end = start + TimeUnit.MILLISECONDS.toNanos(400);
+            AtomicBoolean isStart = new AtomicBoolean(true);
+            LongSupplier timeSupplier = () -> {
+                if (isStart.compareAndSet(true, false)) {
+                    return start;
+                } else if (isStart.compareAndSet(false, true)) {
+                    return end;
+                }
+                throw new IllegalStateException("Cannot update isStart");
+            };
+            final ThreadPool threadPool = mock(ThreadPool.class);
+            doAnswer(i -> timeSupplier.getAsLong()).when(threadPool).relativeTimeInNanos();
+            TestEventHandler eventHandler = new TestEventHandler(
+                e -> {},
+                () -> null,
+                new MockNioTransport.TransportThreadWatchdog(threadPool, Settings.EMPTY)
             );
-            appender.addExpectation(slowExpectation);
-            entry.getValue().run();
-            appender.assertAllExpectationsMatched();
+
+            ServerChannelContext serverChannelContext = mock(ServerChannelContext.class);
+            SocketChannelContext socketChannelContext = mock(SocketChannelContext.class);
+            RuntimeException exception = new RuntimeException("boom");
+
+            Map<String, CheckedRunnable<Exception>> tests = new HashMap<>();
+
+            tests.put("acceptChannel", () -> eventHandler.acceptChannel(serverChannelContext));
+            tests.put("acceptException", () -> eventHandler.acceptException(serverChannelContext, exception));
+            tests.put("registrationException", () -> eventHandler.registrationException(socketChannelContext, exception));
+            tests.put("handleConnect", () -> eventHandler.handleConnect(socketChannelContext));
+            tests.put("connectException", () -> eventHandler.connectException(socketChannelContext, exception));
+            tests.put("handleRead", () -> eventHandler.handleRead(socketChannelContext));
+            tests.put("readException", () -> eventHandler.readException(socketChannelContext, exception));
+            tests.put("handleWrite", () -> eventHandler.handleWrite(socketChannelContext));
+            tests.put("writeException", () -> eventHandler.writeException(socketChannelContext, exception));
+            tests.put("handleTask", () -> eventHandler.handleTask(mock(Runnable.class)));
+            tests.put("taskException", () -> eventHandler.taskException(exception));
+            tests.put("handleClose", () -> eventHandler.handleClose(socketChannelContext));
+            tests.put("closeException", () -> eventHandler.closeException(socketChannelContext, exception));
+            tests.put("genericChannelException", () -> eventHandler.genericChannelException(socketChannelContext, exception));
+
+            for (Map.Entry<String, CheckedRunnable<Exception>> entry : tests.entrySet()) {
+                String message = "*Slow execution on network thread*";
+                MockLogAppender.LoggingExpectation slowExpectation = new MockLogAppender.SeenEventExpectation(
+                    entry.getKey(),
+                    MockNioTransport.class.getCanonicalName(),
+                    Level.WARN,
+                    message
+                );
+                appender.addExpectation(slowExpectation);
+                entry.getValue().run();
+                appender.assertAllExpectationsMatched();
+            }
         }
     }
 }


### PR DESCRIPTION
The context of this change is that some unit and integration tests make assertions about
the logging behavior of the code under test by adding a MockLogAppender to the
static (i.e. global) logging system to collect logging events. On top of this, the base
test class `OpenSearchTestCase` has an `@After` method that asserts that the logging
system itself did not emit any errors indicating a problem with the logging setup. A
problem occurs if a MockLogAppender is added to a logger before it is started or is
stopped before it is removed. A non-started appender can cause the logger to emit and
fail therefore fail a test. The specific error I've observed is "Attempted to append to non-started
appender mock". When running a single test in isolation, there will not be a problem
regardless of the start/add/remove/stop order of the appender, because there is nothing
else going on inside the JVM to trigger a logging event. However, if tests are being run
concurrently inside a JVM, then if a non-started appender is added to a logger then there
exists a race condition that if a particular logging event were to fire then it could cause an
error before the mock appender was started. These errors are quite difficult to chase down
as the tests that interfere with each other are otherwise entirely unrelated. The change here
is to handle the lifecycle management of MockLogAppender via try-with-resources so it
is handled correctly be default and it is not so easy to introduce a potential race condition.

Concretely, this is what the code looked like before:

```
final MockLogAppender appender = new MockLogAppender();
appender.start();
Loggers.addAppender(logger, appender); // <- Must be done after start()

.. test logic ...

Loggers.removeAppender(logger, appender); // <- Must be done before stop()
appender.stop();
```

 and this is what it looks like after the change in this PR:

```
try (MockLogAppender appender = MockLogAppender.createForLoggers(logger)) {
... test logic ...
}
```

The try-with-resources construct does the start/add/remove/stop logic in the correct order
and the developer doesn't need to think about it.

---

I previously added a helper that started a MockLogAppender to ensure it
was never added to a Logger before it was started. I subsequently found
the opposite case in RolloverIT.java where the appender was stopped
before it was closed, therefore creating a race where a concurrently
running test in the same JVM could cause a logging failure. This seems
like a really easy mistake to make when writing a test or introduce when
refactoring a test. I've made a change to use try-with-resources to
ensure that proper setup and teardown is done. This should make it much
harder to introduce this particular test bug in the future.
Unfortunately, it did involve touching a lot of files. The changes here
are purely structural to leverage try-with-resources; no testing logic
has been changed.

### Description
Fixes a potential race conditions in tests that lead to intermittent failures
 
### Issues Resolved
None
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
