### PR TITLE
Adding Github action for auto backport PR creation

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,16 @@
+name: Backport
+on:
+  pull_request:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: ubuntu-latest
+    name: Backport
+    steps:
+      - name: Backport
+        uses: tibdex/backport@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -3,7 +3,7 @@
     - [Git Clone OpenSearch Repo](#git-clone-opensearch-repo)
     - [Install Prerequisites](#install-prerequisites)
       - [JDK 11](#jdk-11)
-      - [JDK 8 and 17](#jdk-8-and-17)
+      - [JDK 8 and 14](#jdk-8-and-14)
       - [Runtime JDK](#runtime-jdk)
       - [Windows](#windows)
       - [Docker](#docker)
@@ -44,6 +44,7 @@
     - [Aggregations](#aggregations)
     - [Distributed Framework](#distributed-framework)
   - [Submitting Changes](#submitting-changes)
+  - [Backports](#backports)
 
 # Developer Guide
 
@@ -408,3 +409,7 @@ Includes:
 ## Submitting Changes
 
 See [CONTRIBUTING](CONTRIBUTING.md).
+
+## Backports
+
+The Github workflow in [`backport.yml`](.github/workflows/backport.yml) creates backport PRs automatically when the original PR with an appropriate label `backport <backport-branch-name>` is merged to main. For example, if a PR on main needs to be backported to `1.x` branch, add a label `backport 1.x` to the PR. Once this PR is merged to main, the workflow will create a backport PR to the `1.x` branch.


### PR DESCRIPTION
Signed-off-by: Vacha <vachshah@amazon.com>

### Description
This Github action creates backport PR automatically when appropriate labels are added to the PR on main. Once the original PR gets merged to main, this Github action will open backport PR. For example, if we want to backport a PR to 1.x, add label `backport 1.x` to the original PR, once this PR is merged, the Github action will open a backport to 1.x PR from the original PR.

Reference: https://github.com/marketplace/actions/backporting
I tried this on my own repo and was able to create appropriate backport PRs. Example: https://github.com/VachaShah/TestGithubActions/pull/7
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
