### PR TITLE
Enable RestHighLevel-Client to set parameter require_alias for bulk index and reindex requests

### DIFF
--- a/client/rest-high-level/src/main/java/org/opensearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/RequestConverters.java
@@ -363,6 +363,7 @@ final class RequestConverters {
         parameters.withPipeline(indexRequest.getPipeline());
         parameters.withRefreshPolicy(indexRequest.getRefreshPolicy());
         parameters.withWaitForActiveShards(indexRequest.waitForActiveShards());
+        parameters.withRequireAlias(indexRequest.isRequireAlias());
 
         BytesRef source = indexRequest.source().toBytesRef();
         ContentType contentType = createContentType(indexRequest.getContentType());
@@ -391,6 +392,7 @@ final class RequestConverters {
         parameters.withRetryOnConflict(updateRequest.retryOnConflict());
         parameters.withVersion(updateRequest.version());
         parameters.withVersionType(updateRequest.versionType());
+        parameters.withRequireAlias(updateRequest.isRequireAlias());
 
         // The Java API allows update requests with different content types
         // set for the partial document and the upsert document. This client
@@ -618,6 +620,7 @@ final class RequestConverters {
             .withTimeout(reindexRequest.getTimeout())
             .withWaitForActiveShards(reindexRequest.getWaitForActiveShards())
             .withRequestsPerSecond(reindexRequest.getRequestsPerSecond())
+            .withRequireAlias(reindexRequest.getDestination().isRequireAlias())
             .withSlices(reindexRequest.getSlices());
 
         if (reindexRequest.getScrollTime() != null) {
@@ -962,6 +965,13 @@ final class RequestConverters {
             } else {
                 return putParam(RethrottleRequest.REQUEST_PER_SECOND_PARAMETER, "-1");
             }
+        }
+
+        Params withRequireAlias(boolean requireAlias) {
+            if (requireAlias) {
+                return putParam("require_alias", Boolean.TRUE.toString());
+            }
+            return this;
         }
 
         Params withRetryOnConflict(int retryOnConflict) {


### PR DESCRIPTION
Signed-off-by: Jan Baudisch <jan.baudisch.libri@gmail.com>

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ x] New functionality includes testing.
  - [ ] All tests pass
- [x ] New functionality has been documented.
  - [ x] New functionality has javadoc added
- [x ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
