### PR TITLE
[BUG] OpenSearchLoggerUsageChecker checks not updated to reflect log4j functionality

### DIFF
--- a/test/logger-usage/src/test/java/org/opensearch/test/loggerusage/OpenSearchLoggerUsageTests.java
+++ b/test/logger-usage/src/test/java/org/opensearch/test/loggerusage/OpenSearchLoggerUsageTests.java
@@ -208,15 +208,15 @@ public class OpenSearchLoggerUsageTests extends OpenSearchTestCase {
         logger.info((Supplier<?>) () -> new ParameterizedMessage("Hello {}", "world"), new Exception());
     }
 
-    public void checkFailOrderOfExceptionArgument1() {
+    public void checkOrderOfExceptionArgument2() {
         logger.info("Hello {}", "world", new Exception());
     }
 
-    public void checkOrderOfExceptionArgument2() {
+    public void checkOrderOfExceptionArgument3() {
         logger.info((Supplier<?>) () -> new ParameterizedMessage("Hello {}, {}", "world", 42), new Exception());
     }
 
-    public void checkFailOrderOfExceptionArgument2() {
+    public void checkOrderOfExceptionArgument4() {
         logger.info("Hello {}, {}", "world", 42, new Exception());
     }
 


### PR DESCRIPTION
Signed-off-by: Poojita Raj <poojiraj@amazon.com>

### Description
Updating OpenSearchLoggerUsageChecker checks to reflect the current support for exception parameterization (#1585 has full description)
 
### Issues Resolved
Resolves #1585 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
