### PR TITLE
[Backport 1.x] Rename field_masking_span to span_field_masking (#1606)

### DIFF
--- a/server/src/main/java/org/opensearch/index/query/FieldMaskingSpanQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/FieldMaskingSpanQueryBuilder.java
@@ -48,7 +48,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMaskingSpanQueryBuilder> implements SpanQueryBuilder {
-    public static final String NAME = "field_masking_span";
+    public static final ParseField SPAN_FIELD_MASKING_FIELD = new ParseField("span_field_masking", "field_masking_span");
 
     private static final ParseField FIELD_FIELD = new ParseField("field");
     private static final ParseField QUERY_FIELD = new ParseField("query");
@@ -105,7 +105,7 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(NAME);
+        builder.startObject(SPAN_FIELD_MASKING_FIELD.getPreferredName());
         builder.field(QUERY_FIELD.getPreferredName());
         queryBuilder.toXContent(builder, params);
         builder.field(FIELD_FIELD.getPreferredName(), fieldName);
@@ -129,13 +129,16 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
                 if (QUERY_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     QueryBuilder query = parseInnerQueryBuilder(parser);
                     if (query instanceof SpanQueryBuilder == false) {
-                        throw new ParsingException(parser.getTokenLocation(), "[field_masking_span] query must be of type span query");
+                        throw new ParsingException(
+                            parser.getTokenLocation(),
+                            "[" + SPAN_FIELD_MASKING_FIELD.getPreferredName() + "] query must be of type span query"
+                        );
                     }
                     inner = (SpanQueryBuilder) query;
                 } else {
                     throw new ParsingException(
                         parser.getTokenLocation(),
-                        "[field_masking_span] query does not support [" + currentFieldName + "]"
+                        "[" + SPAN_FIELD_MASKING_FIELD.getPreferredName() + "] query does not support [" + currentFieldName + "]"
                     );
                 }
             } else {
@@ -148,16 +151,22 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
                 } else {
                     throw new ParsingException(
                         parser.getTokenLocation(),
-                        "[field_masking_span] query does not support [" + currentFieldName + "]"
+                        "[" + SPAN_FIELD_MASKING_FIELD.getPreferredName() + "] query does not support [" + currentFieldName + "]"
                     );
                 }
             }
         }
         if (inner == null) {
-            throw new ParsingException(parser.getTokenLocation(), "field_masking_span must have [query] span query clause");
+            throw new ParsingException(
+                parser.getTokenLocation(),
+                SPAN_FIELD_MASKING_FIELD.getPreferredName() + " must have [query] span query clause"
+            );
         }
         if (field == null) {
-            throw new ParsingException(parser.getTokenLocation(), "field_masking_span must have [field] set for it");
+            throw new ParsingException(
+                parser.getTokenLocation(),
+                SPAN_FIELD_MASKING_FIELD.getPreferredName() + " must have [field] set for it"
+            );
         }
 
         FieldMaskingSpanQueryBuilder queryBuilder = new FieldMaskingSpanQueryBuilder(inner, field);
@@ -190,6 +199,6 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
 
     @Override
     public String getWriteableName() {
-        return NAME;
+        return SPAN_FIELD_MASKING_FIELD.getPreferredName();
     }
 }

--- a/server/src/main/java/org/opensearch/search/SearchModule.java
+++ b/server/src/main/java/org/opensearch/search/SearchModule.java
@@ -1172,7 +1172,7 @@ public class SearchModule {
         );
         registerQuery(
             new QuerySpec<>(
-                FieldMaskingSpanQueryBuilder.NAME,
+                FieldMaskingSpanQueryBuilder.SPAN_FIELD_MASKING_FIELD,
                 FieldMaskingSpanQueryBuilder::new,
                 FieldMaskingSpanQueryBuilder::fromXContent
             )

--- a/server/src/test/java/org/opensearch/index/query/FieldMaskingSpanQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/FieldMaskingSpanQueryBuilderTests.java
@@ -38,6 +38,7 @@ import org.opensearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
 
+import static org.opensearch.index.query.FieldMaskingSpanQueryBuilder.SPAN_FIELD_MASKING_FIELD;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
@@ -73,7 +74,9 @@ public class FieldMaskingSpanQueryBuilderTests extends AbstractQueryTestCase<Fie
 
     public void testFromJson() throws IOException {
         String json = "{\n"
-            + "  \"field_masking_span\" : {\n"
+            + "  \""
+            + SPAN_FIELD_MASKING_FIELD.getPreferredName()
+            + "\" : {\n"
             + "    \"query\" : {\n"
             + "      \"span_term\" : {\n"
             + "        \"value\" : {\n"
@@ -91,5 +94,26 @@ public class FieldMaskingSpanQueryBuilderTests extends AbstractQueryTestCase<Fie
         checkGeneratedJson(json, parsed);
         assertEquals(json, 42.0, parsed.boost(), 0.00001);
         assertEquals(json, 0.23, parsed.innerQuery().boost(), 0.00001);
+    }
+
+    public void testDeprecatedName() throws IOException {
+        String json = "{\n"
+            + "  \"field_masking_span\" : {\n"
+            + "    \"query\" : {\n"
+            + "      \"span_term\" : {\n"
+            + "        \"value\" : {\n"
+            + "          \"value\" : \"foo\"\n"
+            + "        }\n"
+            + "      }\n"
+            + "    },\n"
+            + "    \"field\" : \"mapped_geo_shape\",\n"
+            + "    \"boost\" : 42.0,\n"
+            + "    \"_name\" : \"KPI\"\n"
+            + "  }\n"
+            + "}";
+        FieldMaskingSpanQueryBuilder parsed = (FieldMaskingSpanQueryBuilder) parseQuery(json);
+        assertWarnings(
+            "Deprecated field [field_masking_span] used, expected [" + SPAN_FIELD_MASKING_FIELD.getPreferredName() + "] instead"
+        );
     }
 }

--- a/server/src/test/java/org/opensearch/search/SearchModuleTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchModuleTests.java
@@ -337,7 +337,7 @@ public class SearchModuleTests extends OpenSearchTestCase {
         Set<String> registeredNonDeprecated = module.getNamedXContents()
             .stream()
             .filter(e -> e.categoryClass.equals(QueryBuilder.class))
-            .filter(e -> e.name.getDeprecatedNames().length == 0)
+            .filter(e -> e.name.getAllReplacedWith() == null)
             .map(e -> e.name.getPreferredName())
             .collect(toSet());
         Set<String> registeredAll = module.getNamedXContents()
@@ -422,7 +422,6 @@ public class SearchModuleTests extends OpenSearchTestCase {
         "constant_score",
         "dis_max",
         "exists",
-        "field_masking_span",
         "function_score",
         "fuzzy",
         "geo_bounding_box",
@@ -448,6 +447,7 @@ public class SearchModuleTests extends OpenSearchTestCase {
         "script_score",
         "simple_query_string",
         "span_containing",
+        "span_field_masking",
         "span_first",
         "span_gap",
         "span_multi",
@@ -465,7 +465,7 @@ public class SearchModuleTests extends OpenSearchTestCase {
         "distance_feature" };
 
     // add here deprecated queries to make sure we log a deprecation warnings when they are used
-    private static final String[] DEPRECATED_QUERIES = new String[] { "common" };
+    private static final String[] DEPRECATED_QUERIES = new String[] { "common", "field_masking_span" };
 
     /**
      * Dummy test {@link AggregationBuilder} used to test registering aggregation builders.


### PR DESCRIPTION

Signed-off-by: Xue Zhou <xuezhou@amazon.com>

### Description
Backport PR[#1606](https://github.com/opensearch-project/OpenSearch/pull/1606)
 
### Issues Resolved
Rename field_masking_span to span_field_masking as well as maintain backwards compatibility.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
