### PR TITLE
Support Gradle 7. Fixing publishing to Maven Local for plugins

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -263,6 +263,9 @@ if (project != rootProject) {
     tasks.named("validatePluginMavenPom").configure {
       dependsOn("generatePomFileForNebulaPublication")
     }
+    tasks.named("publishPluginMavenPublicationToMavenLocal").configure {
+      dependsOn("generatePomFileForNebulaPublication")
+    }
   }
 
   publishing.publications.named("nebula").configure {


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Fixing publishing to Maven Local for plugins

```
> Task :build-tools:publishPluginMavenPublicationToMavenLocal
Execution optimizations have been disabled for task ':build-tools:publishPluginMavenPublicationToMavenLocal' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/tmp/tmptny3_u2s/OpenSearch/buildSrc/build/distributions/build-tools-2.0.0-SNAPSHOT.pom'. Reason: Task ':build-tools:publishPluginMavenPublicationToMavenLocal' uses this output of task ':build-tools:generatePomFileForNebulaPublication' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.3/userguide/validation_problems.html#implicit_dependency for more details about this problem.
Gradle detected a problem with the following location: '/tmp/tmptny3_u2s/OpenSearch/buildSrc/build/distributions/build-tools-2.0.0-SNAPSHOT.pom'. Reason: Task ':build-tools:publishPluginMavenPublicationToMavenLocal' uses this output of task ':build-tools:generatePomFileForNebulaPublication' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.3/userguide/validation_problems.html#implicit_dependency for more details about this problem. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. Execution optimizations are disabled to ensure correctness. See https://docs.gradle.org/7.3/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
Multiple publications with coordinates 'org.opensearch.gradle:build-tools:2.0.0-SNAPSHOT' are published to repository 'mavenLocal'. The publications will overwrite each other!
```
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
