### PR TITLE
Added .gitattributes to manage end-of-line checks for Windows/*nix systems

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text eol=lf
+*.bat text eol=crlf


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
There is a difference between end of line CRLF vs LF between Windows/*nix systems which causes `spotless` checks to fail. The suggested solution is to use `.gitattributes` , see please https://github.com/diffplug/spotless/issues/23

Linux:

```
$ ./gradlew spotlessJavaCheck
...
> Configure project :qa:os
Cannot add task 'destructiveDistroTest.docker' as a task with that name already exists.
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 7.3
  OS Info               : Linux 5.13.0-22-generic (amd64)
  JDK Version           : 11 (Ubuntu JDK)
  JAVA_HOME             : /usr/lib/jvm/java-11-openjdk-amd64
  Random Testing Seed   : 2A834AAD373C92B6
  In FIPS 140 mode      : false
=======================================

BUILD SUCCESSFUL in 2s
169 actionable tasks: 169 up-to-date
```

Windows:
```
$ ./gradlew.bat spotlessJavaCheck

> Configure project :plugins:repository-hdfs
hdfsFixture unsupported, please set HADOOP_HOME and put HADOOP_HOME\bin in PATH

> Configure project :qa:os
Cannot add task 'destructiveDistroTest.docker' as a task with that name already exists.
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 7.3
  OS Info               : Windows 10 10.0 (amd64)
  JDK Version           : 11 (Amazon Corretto JDK)
  JAVA_HOME             : C:\Program Files\Amazon Corretto\jdk11.0.11_9
  Random Testing Seed   : EA3DA7454331063
  In FIPS 140 mode      : false
=======================================

BUILD SUCCESSFUL in 7s
169 actionable tasks: 169 up-to-date
```
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/1637
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
