### PR TITLE
Search Task Resource Tracking PoC

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/stats/TaskResourceTrackerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/stats/TaskResourceTrackerIT.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.stats;
+
+
+import org.opensearch.action.ActionFuture;
+import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
+import org.opensearch.action.admin.indices.stats.ShardStats;
+import org.opensearch.action.index.IndexRequestBuilder;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
+import static org.opensearch.search.aggregations.AggregationBuilders.count;
+import static org.opensearch.test.OpenSearchIntegTestCase.*;
+
+
+@ClusterScope(scope = Scope.SUITE, supportsDedicatedMasters = false, numDataNodes = 3, numClientNodes = 1)
+public class TaskResourceTrackerIT extends OpenSearchIntegTestCase {
+
+    private void addDocuments(String index, int start, int end) throws Exception {
+        List<IndexRequestBuilder> builders = new ArrayList<>();
+        for (int i = start; i < end; i++) {
+            builders.add(client().prepareIndex(index, "type", "" + i + 1).setSource(jsonBuilder()
+                .startObject()
+                .field("value", i + 1)
+                .field("tag", "tag" + i)
+                .endObject()));
+        }
+
+        indexRandom(true, builders);
+        ensureSearchable();
+    }
+
+    public void testAggregation() throws Exception {
+        String index = "idx";
+        createIndex(index, Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 3).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build());
+        addDocuments(index, 0, 50);
+
+        ActionFuture<SearchResponse> searchResponseActionFuture = client().prepareSearch(index)
+            .setQuery(matchAllQuery())
+            .addAggregation(count("count").field("value"))
+            .execute();
+
+        List<String> nodeIds = getNodeNames(index);
+
+//        Thread.sleep(6000);
+
+//        NodesStatsResponse nodesStats = client().admin().cluster().prepareNodesStats().addMetric("thread_pool/search").get();
+
+        searchResponseActionFuture.get();
+    }
+
+    private List<String> getNodeNames(String indexName) {
+        IndicesStatsResponse response = client().admin().indices().prepareStats(indexName).get();
+        return Stream.of(response.getShards())
+            .map(ShardStats::getShardRouting)
+            .filter(ShardRouting::primary)
+            .map(ShardRouting::currentNodeId)
+            .collect(Collectors.toList());
+    }
+
+}

--- a/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
@@ -32,9 +32,11 @@
 
 package org.opensearch.action.search;
 
+import com.sun.management.ThreadMXBean;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.util.SetOnce;
+import org.opensearch.tasks.TaskResourceTracker;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
@@ -56,8 +58,10 @@ import org.opensearch.search.internal.AliasFilter;
 import org.opensearch.search.internal.InternalSearchResponse;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.internal.ShardSearchRequest;
+import org.opensearch.tasks.TaskResourceTracker;
 import org.opensearch.transport.Transport;
 
+import java.lang.management.ManagementFactory;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -283,6 +287,10 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
                             } finally {
                                 executeNext(pendingExecutions, thread);
                             }
+                            ThreadMXBean threadMXBean = (ThreadMXBean) ManagementFactory.getThreadMXBean();
+                            long bytes = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+
+                            TaskResourceTracker.getInstance().transfer(task.getId(), result, bytes);
                         }
 
                         @Override

--- a/server/src/main/java/org/opensearch/common/util/concurrent/OpenSearchExecutors.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/OpenSearchExecutors.java
@@ -201,6 +201,16 @@ public class OpenSearchExecutors {
             ConcurrentCollections.<Runnable>newBlockingQueue(),
             initialQueueCapacity
         );
+        Function<Runnable, WrappedRunnable> runnableWrapper;
+        if (name.endsWith("search")) {
+            runnableWrapper = (r) -> {
+                ResourceRunnable rr = new ResourceRunnable(contextHolder, r, name);
+                return new TimedRunnable(rr);
+            };
+        } else {
+            runnableWrapper = TimedRunnable::new;
+        }
+
         return new QueueResizingOpenSearchThreadPoolExecutor(
             name,
             size,
@@ -210,7 +220,7 @@ public class OpenSearchExecutors {
             queue,
             minQueueSize,
             maxQueueSize,
-            TimedRunnable::new,
+            runnableWrapper,
             frameSize,
             targetedResponseTime,
             threadFactory,

--- a/server/src/main/java/org/opensearch/common/util/concurrent/ResourceRunnable.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/ResourceRunnable.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.util.concurrent;
+
+import java.lang.management.ManagementFactory;
+import java.util.Objects;
+
+import com.sun.management.ThreadMXBean;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.tasks.TaskResourceTracker;
+
+public class ResourceRunnable extends AbstractRunnable implements WrappedRunnable {
+
+    private Runnable original;
+    private ThreadContext threadContext;
+    ThreadMXBean threadMXBean;
+    private String taskId;
+    private String threadpoolName;
+
+    public ResourceRunnable(ThreadContext threadContext, final Runnable original, String name) {
+        this.original = original;
+        this.threadContext = threadContext;
+        this.threadMXBean = (ThreadMXBean) ManagementFactory.getThreadMXBean();
+        this.threadpoolName = name;
+    }
+
+    @Override
+    public void onFailure(Exception e) {
+        if (original instanceof AbstractRunnable) {
+            ((AbstractRunnable) original).onRejection(e);
+        } else {
+            ExceptionsHelper.reThrowIfNotNull(e);
+        }
+    }
+
+    @Override
+    protected void doRun() throws Exception {
+        if (Objects.nonNull(threadContext.getTransient("TASK_ID"))) {
+            String taskId = threadContext.getTransient("TASK_ID");
+            long threadId = Thread.currentThread().getId();
+            TaskResourceTracker.getInstance().registerWorkerForTask(Long.parseLong(taskId), threadId,
+                    threadMXBean.getCurrentThreadCpuTime(),
+                    threadMXBean.getThreadAllocatedBytes(threadId), threadpoolName);
+        }
+        try {
+            original.run();
+        } finally {
+            if (Objects.nonNull(threadContext.getTransient("TASK_ID"))) {
+                String taskId = threadContext.getTransient("TASK_ID");
+                long threadId = Thread.currentThread().getId();
+                TaskResourceTracker.getInstance().unregisterWorkerForTask(Long.parseLong(taskId), threadId,
+                        threadMXBean.getCurrentThreadCpuTime(), threadMXBean.getThreadAllocatedBytes(threadId));
+            }
+        }
+
+    }
+
+    @Override
+    public Runnable unwrap() {
+        return original;
+    }
+}

--- a/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
@@ -140,10 +140,12 @@ public final class ThreadContext implements Writeable {
                     .put(Task.X_OPAQUE_ID, context.requestHeaders.get(Task.X_OPAQUE_ID))
                     .immutableMap()
             );
-            threadLocal.set(threadContextStruct);
-        } else {
-            threadLocal.set(DEFAULT_CONTEXT);
         }
+        if (context.transientHeaders.containsKey("TASK_ID")) {
+            DEFAULT_CONTEXT.putTransient("TASK_ID", context.transientHeaders.get("TASK_ID"));
+        }
+        threadLocal.set(DEFAULT_CONTEXT);
+
         return () -> {
             // If the node and thus the threadLocal get closed while this task
             // is still executing, we don't want this runnable to fail with an

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.SetOnce;
+import org.opensearch.tasks.TaskResourceTracker;
 import org.opensearch.index.IndexingPressureService;
 import org.opensearch.watcher.ResourceWatcherService;
 import org.opensearch.Assertions;
@@ -431,6 +432,7 @@ public class Node implements Closeable {
             resourcesToClose.add(() -> ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS));
             final ResourceWatcherService resourceWatcherService = new ResourceWatcherService(settings, threadPool);
             resourcesToClose.add(resourceWatcherService);
+            resourceWatcherService.add(TaskResourceTracker.getInstance(), ResourceWatcherService.Frequency.HIGH);
             // adds the context to the DeprecationLogger so that it does not need to be injected everywhere
             HeaderWarning.setThreadContext(threadPool.getThreadContext());
             resourcesToClose.add(() -> HeaderWarning.removeThreadContext(threadPool.getThreadContext()));

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestThreadPoolAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestThreadPoolAction.java
@@ -156,6 +156,8 @@ public class RestThreadPoolAction extends AbstractCatAction {
         table.addCell("max", "alias:mx;default:false;text-align:right;desc:maximum number of threads in a scaling thread pool");
         table.addCell("size", "alias:sz;default:false;text-align:right;desc:number of threads in a fixed thread pool");
         table.addCell("keep_alive", "alias:ka;default:false;text-align:right;desc:thread keep alive time");
+        table.addCell("bytes", "alias:by;default:true;text-align:right;desc:Bytes consumed");
+        table.addCell("resposne_overhead", "alias:ro;default:true;text-align:right;desc:Response overhead");
         table.endHeaders();
         return table;
     }
@@ -260,6 +262,8 @@ public class RestThreadPoolAction extends AbstractCatAction {
                 table.addCell(max);
                 table.addCell(size);
                 table.addCell(keepAlive);
+                table.addCell(poolStats == null ? null : poolStats.getBytes());
+                table.addCell(poolStats == null ? null : poolStats.getRO());
 
                 table.endRow();
             }

--- a/server/src/main/java/org/opensearch/tasks/TaskInfoKey.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskInfoKey.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.tasks;
+
+import org.opensearch.index.shard.ShardId;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class TaskInfoKey {
+
+    private final long taskId;
+    private final List<String> indices;
+    private final ShardId shardId;
+    private final String action;
+
+    public TaskInfoKey(long taskId) {
+        this(taskId, new ArrayList<>(), null, null);
+    }
+
+    public TaskInfoKey(long taskId, List<String> indices, ShardId shardId, String action) {
+        this.taskId = taskId;
+        this.indices = indices;
+        this.shardId = shardId;
+        this.action = action;
+    }
+
+    public long getTaskId() {
+        return taskId;
+    }
+
+    public List<String> getIndices() {
+        return indices;
+    }
+
+    public ShardId getShardId() {
+        return shardId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TaskInfoKey that = (TaskInfoKey) o;
+        return Objects.equals(taskId, that.taskId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(taskId);
+    }
+
+}

--- a/server/src/main/java/org/opensearch/tasks/TaskResourceTracker.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResourceTracker.java
@@ -1,0 +1,153 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.tasks;
+
+import com.sun.management.ThreadMXBean;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.watcher.ResourceWatcher;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class TaskResourceTracker implements ResourceWatcher {
+
+    private static final Logger logger = LogManager.getLogger(TaskManager.class);
+
+    /**
+     * Single class instance
+     */
+    private static TaskResourceTracker instance = new TaskResourceTracker();
+
+    public final ConcurrentHashMap<TaskInfoKey, List<TaskWorkerResourceUtilInfo>> taskMap;
+    public final ConcurrentHashMap<Object, Long> overhead;
+    private ThreadMXBean threadMXBean;
+    private long searchBytes;
+    private long responseOverheadBytes;
+
+    /**
+     * Private constructor to keep class Singleton
+     */
+    private TaskResourceTracker() {
+        taskMap = new ConcurrentHashMap<>();
+        threadMXBean = (ThreadMXBean) ManagementFactory.getThreadMXBean();
+        searchBytes = 0;
+        responseOverheadBytes = 0;
+        overhead = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Method for returning static instance of class
+     *
+     * @return singleton instance for class
+     */
+    public static TaskResourceTracker getInstance() {
+        return instance;
+    }
+
+    public void registerTaskForTracking(long taskId, List<String> indices, ShardId shardId, String actionName) {
+        taskMap.put(new TaskInfoKey(taskId, indices, shardId, actionName), new ArrayList<>());
+    }
+
+    public void registerWorkerForTask(long taskId, long workerId, long cpuCurrent, long bytesCurrent, String threadpoolName) {
+        // TODO remove this after identifying cases where it can be true
+        if (taskMap.get(new TaskInfoKey(taskId)) == null) {
+            return;
+        }
+
+        TaskWorkerResourceUtilInfo taskWorkerResourceUtilInfo =
+            new TaskWorkerResourceUtilInfo(workerId, cpuCurrent, cpuCurrent, bytesCurrent, bytesCurrent,
+                true, threadpoolName);
+
+        taskMap.get(new TaskInfoKey(taskId)).add(taskWorkerResourceUtilInfo);
+    }
+
+    public void unregisterWorkerForTask(long taskId, long workerId, long cpuCurrent, long bytesCurrent) {
+        // This happens when task is unregistered first and then the runnable finishes
+        if (taskMap.get(new TaskInfoKey(taskId)) == null) {
+            return;
+        }
+        TaskWorkerResourceUtilInfo taskWorkerResourceUtilInfo = taskMap.get(new TaskInfoKey(taskId)).stream()
+            .filter(twrui -> twrui.getWorkerId() != null && twrui.getWorkerId() == workerId
+                && twrui.isActive()).findFirst().get();
+        taskWorkerResourceUtilInfo.setHeapNow(bytesCurrent);
+        taskWorkerResourceUtilInfo.setCpuNow(cpuCurrent);
+        taskWorkerResourceUtilInfo.setActive(false);
+    }
+
+    private void snapshot() {
+        final long[] search = {0};
+        final long[] response = {0};
+        taskMap.forEach((taskInfoKey, taskWorkerResourceUtilInfos) -> taskWorkerResourceUtilInfos.forEach(taskWorkerResourceUtilInfo -> {
+            if (taskWorkerResourceUtilInfo.isActive()) {
+                taskWorkerResourceUtilInfo.setHeapNow(threadMXBean.getThreadAllocatedBytes(taskWorkerResourceUtilInfo.getWorkerId()));
+            }
+            if ("tw".equals(taskWorkerResourceUtilInfo.getThreadPoolName())) {
+                response[0] += taskWorkerResourceUtilInfo.getOverheardBytes();
+            } else {
+                search[0] += taskWorkerResourceUtilInfo.getHeapNow() - taskWorkerResourceUtilInfo.getHeapStart();
+            }
+        }));
+
+        searchBytes = search[0];
+        responseOverheadBytes = response[0];
+    }
+
+    @Override
+    public void init() throws IOException {
+    }
+
+    @Override
+    public void checkAndNotify() throws IOException {
+        logger.trace("Taking Scheduled snapshot for System resources");
+        snapshot();
+    }
+
+    public void unregisterTaskForTracking(long id) {
+        logger.trace("Unregistering task");
+        // TODO if there's any active worker take snapshot of those and exit. (If accurate data required for a task)
+        taskMap.remove(new TaskInfoKey(id));
+    }
+
+    public void registerResponseOverhead(long taskId, long bytes) {
+        TaskWorkerResourceUtilInfo taskWorkerResourceUtilInfo =
+            new TaskWorkerResourceUtilInfo(bytes);
+
+        // TODO remove from overhead map as well
+
+        taskMap.get(new TaskInfoKey(taskId)).add(taskWorkerResourceUtilInfo);
+    }
+
+    public void registerResponseOverhead1(Object ob, long bytes) {
+        overhead.put(ob, bytes);
+    }
+
+    public void transfer(long taskId, Object ob, long bytes) {
+        TaskInfoKey key = new TaskInfoKey(taskId);
+        if (!overhead.containsKey(ob) || taskMap.get(key) == null) return;
+
+        long bytesStart = overhead.get(ob);
+
+        TaskWorkerResourceUtilInfo t = new TaskWorkerResourceUtilInfo(1L, 0L, 0L, bytesStart, bytes, false, "tw");
+        taskMap.get(key).add(t);
+        overhead.remove(ob);
+    }
+
+    public long getBytes() {
+        return searchBytes;
+    }
+
+    public long getResponseOverhead() {
+        return responseOverheadBytes;
+    }
+}

--- a/server/src/main/java/org/opensearch/tasks/TaskWorkerResourceUtilInfo.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskWorkerResourceUtilInfo.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.tasks;
+
+public class TaskWorkerResourceUtilInfo {
+
+    private Long workerId;
+    private Long cpuStart;
+    private Long cpuNow;
+    private Long heapStart;
+    private Long heapNow;
+    private boolean active;
+    private String threadPoolName;
+
+    public long getOverheardBytes() {
+        return overheardBytes;
+    }
+
+    private long overheardBytes;
+
+    public TaskWorkerResourceUtilInfo(Long workerId, Long cpuStart, Long cpuNow, Long heapStart, Long heapNow, boolean active, String threadPoolName) {
+        this.workerId = workerId;
+        this.cpuStart = cpuStart;
+        this.cpuNow = cpuNow;
+        this.heapStart = heapStart;
+        this.heapNow = heapNow;
+        this.active = active;
+        this.threadPoolName = threadPoolName;
+    }
+
+    public TaskWorkerResourceUtilInfo(Long overhead) {
+        overheardBytes = overhead;
+    }
+
+    public Long getWorkerId() {
+        return workerId;
+    }
+
+    public void setWorkerId(Long workerId) {
+        this.workerId = workerId;
+    }
+
+    public Long getCpuStart() {
+        return cpuStart;
+    }
+
+    public void setCpuStart(Long cpuStart) {
+        this.cpuStart = cpuStart;
+    }
+
+    public Long getCpuNow() {
+        return cpuNow;
+    }
+
+    public void setCpuNow(Long cpuNow) {
+        this.cpuNow = cpuNow;
+    }
+
+    public Long getHeapStart() {
+        return heapStart;
+    }
+
+    public void setHeapStart(Long heapStart) {
+        this.heapStart = heapStart;
+    }
+
+    public Long getHeapNow() {
+        return heapNow;
+    }
+
+    public void setHeapNow(Long heapNow) {
+        this.heapNow = heapNow;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    public String getThreadPoolName() {
+        return threadPoolName;
+    }
+
+    public void setThreadPoolName(String threadPoolName) {
+        this.threadPoolName = threadPoolName;
+    }
+}

--- a/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
@@ -53,6 +53,7 @@ import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.node.Node;
 import org.opensearch.node.ReportingService;
+import org.opensearch.tasks.TaskResourceTracker;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -318,6 +319,13 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
             long rejected = -1;
             int largest = -1;
             long completed = -1;
+            long jvmBytes = -1;
+            long responseOverhead = -1;
+
+            if (Names.SEARCH.equals(name)) {
+                jvmBytes = TaskResourceTracker.getInstance().getBytes();
+                responseOverhead = TaskResourceTracker.getInstance().getResponseOverhead();
+            }
             if (holder.executor() instanceof ThreadPoolExecutor) {
                 ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) holder.executor();
                 threads = threadPoolExecutor.getPoolSize();
@@ -330,7 +338,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
                     rejected = ((XRejectedExecutionHandler) rejectedExecutionHandler).rejected();
                 }
             }
-            stats.add(new ThreadPoolStats.Stats(name, threads, queue, active, rejected, largest, completed));
+            stats.add(new ThreadPoolStats.Stats(name, threads, queue, active, rejected, largest, completed, jvmBytes, responseOverhead));
         }
         return new ThreadPoolStats(stats);
     }

--- a/server/src/main/java/org/opensearch/threadpool/ThreadPoolStats.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPoolStats.java
@@ -55,6 +55,8 @@ public class ThreadPoolStats implements Writeable, ToXContentFragment, Iterable<
         private final long rejected;
         private final int largest;
         private final long completed;
+        private long ro;
+        private long bytes;
 
         public Stats(String name, int threads, int queue, int active, long rejected, int largest, long completed) {
             this.name = name;
@@ -66,6 +68,18 @@ public class ThreadPoolStats implements Writeable, ToXContentFragment, Iterable<
             this.completed = completed;
         }
 
+        public Stats(String name, int threads, int queue, int active, long rejected, int largest, long completed, long bytes, long ro) {
+            this.name = name;
+            this.threads = threads;
+            this.queue = queue;
+            this.active = active;
+            this.rejected = rejected;
+            this.largest = largest;
+            this.completed = completed;
+            this.bytes = bytes;
+            this.ro = ro;
+        }
+
         public Stats(StreamInput in) throws IOException {
             name = in.readString();
             threads = in.readInt();
@@ -74,6 +88,8 @@ public class ThreadPoolStats implements Writeable, ToXContentFragment, Iterable<
             rejected = in.readLong();
             largest = in.readInt();
             completed = in.readLong();
+            bytes = in.readLong();
+            ro = in.readLong();
         }
 
         @Override
@@ -85,6 +101,8 @@ public class ThreadPoolStats implements Writeable, ToXContentFragment, Iterable<
             out.writeLong(rejected);
             out.writeInt(largest);
             out.writeLong(completed);
+            out.writeLong(bytes);
+            out.writeLong(ro);
         }
 
         public String getName() {
@@ -105,6 +123,14 @@ public class ThreadPoolStats implements Writeable, ToXContentFragment, Iterable<
 
         public long getRejected() {
             return rejected;
+        }
+
+        public long getBytes() {
+            return bytes;
+        }
+
+        public long getRO() {
+            return ro;
         }
 
         public int getLargest() {
@@ -135,6 +161,12 @@ public class ThreadPoolStats implements Writeable, ToXContentFragment, Iterable<
             }
             if (completed != -1) {
                 builder.field(Fields.COMPLETED, completed);
+            }
+            if (bytes != -1) {
+                builder.field("bytes", bytes);
+            }
+            if (bytes != -1) {
+                builder.field("worker_count", ro);
             }
             builder.endObject();
             return builder;


### PR DESCRIPTION
### Description
This PoC is to capture the system resource overhead for Search requests either on data node or coordinator node. It captures all the heap allocations being done by the threads running on search threadpool. It also captures the heap overhead for the responses received on coordinator while it is waiting for other data nodes to respond back (this serialization of response is generally done on transport_worker and doesn't get accounted for search threadpool tracking).

This PoC just aims to validate correctness and performance impact. Post these validations I'll focus more on concrete design aspect of the changes

 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/1179


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
