### PR TITLE
Renaming Slave terminology to Replica in 1.x branch (backporting)

### DIFF
--- a/modules/mapper-extras/src/test/resources/org/opensearch/index/mapper/metricbeat-6.0.template.json
+++ b/modules/mapper-extras/src/test/resources/org/opensearch/index/mapper/metricbeat-6.0.template.json
@@ -4598,7 +4598,7 @@
                         }
                       }
                     },
-                    "connected_slaves": {
+                    "connected_replicas": {
                       "type": "long"
                     },
                     "master_offset": {


### PR DESCRIPTION
Signed-off-by: Rishikesh Pasham <rishireddy1159@gmail.com>

### Description
Renaming Slave Terminology to Replica in 1.x branch. This is backporting to 1.x of PR https://github.com/opensearch-project/OpenSearch/pull/1569
 
### Issues Resolved
https://github.com/opensearch-project/opensearch/issues/1556
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
