### PR TITLE
Support Gradle 7. Fixing 'eclipse' plugin dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ import org.opensearch.gradle.VersionProperties
 import org.opensearch.gradle.info.BuildParams
 import org.opensearch.gradle.plugin.PluginBuildPlugin
 import org.gradle.plugins.ide.eclipse.model.AccessRule
+import org.gradle.plugins.ide.eclipse.model.EclipseJdt
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
 import org.gradle.util.DistributionLocator
 import org.gradle.util.GradleVersion
@@ -423,6 +424,12 @@ allprojects {
   tasks.named('cleanEclipse') { dependsOn 'wipeEclipseSettings' }
   // otherwise the eclipse merging is *super confusing*
   tasks.named('eclipse') { dependsOn 'cleanEclipse', 'copyEclipseSettings' }
+  
+  afterEvaluate {
+     tasks.findByName("eclipseJdt")?.configure {
+         dependsOn 'copyEclipseSettings'
+     } 
+  }
 }
 
 wrapper {


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
The `eclipse` plugin fails with:

```
...
> Task :test:fixtures:hdfs-fixture:eclipseJdt                                                                                                                                                
Execution optimizations have been disabled for task ':test:fixtures:hdfs-fixture:eclipseJdt' to ensure correctness due to the following reasons:                                             
  - Gradle detected a problem with the following location: '/home/andriy.redko/Workspaces/Experiments/OpenSearch/test/fixtures/hdfs-fixture/.settings/org.eclipse.jdt.core.prefs'. Reason: Ta
sk ':test:fixtures:hdfs-fixture:eclipseJdt' uses this output of task ':test:fixtures:hdfs-fixture:copyEclipseSettings' without declaring an explicit or implicit dependency. This can lead to
 incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.3/userguide/validation_problems.html#implicit_dependency for mor
e details about this problem.                                                                 
Gradle detected a problem with the following location: '/home/andriy.redko/Workspaces/Experiments/OpenSearch/test/fixtures/hdfs-fixture/.settings/org.eclipse.jdt.core.prefs'. Reason: Task '
:test:fixtures:hdfs-fixture:eclipseJdt' uses this output of task ':test:fixtures:hdfs-fixture:copyEclipseSettings' without declaring an explicit or implicit dependency. This can lead to inc
orrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.3/userguide/validation_problems.html#implicit_dependency for more de
tails about this problem. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. Execution optimizations are disabled to ensure correctness. See https://docs.gradl
e.org/7.3/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
...
```
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
