### PR TITLE
Move Gradle wrapper and precommit checks into OpenSearch repo.

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -1,0 +1,15 @@
+name: Gradle Precommit
+on: [pull_request]
+jobs:
+  precommit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: adopt
+      - name: Run Gradle
+        run: |
+          ./gradlew precommit --parallel

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -1,5 +1,6 @@
 name: Gradle Precommit
 on: [pull_request]
+
 jobs:
   precommit:
     runs-on: ubuntu-latest

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -1,0 +1,26 @@
+name: Validate Gradle Wrapper
+on: [pull_request]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: adopt
+      - name: Check Gradle Wrapper
+        run: |
+          cd gradle/wrapper
+
+          GRADLE_WRAPPER_VERSION=`basename $(cat gradle-wrapper.properties | grep distributionUrl) | sed 's/gradle-//g;s/-all.zip//g'`
+          GRADLE_WRAPPER_HASH_REMOTE="https://services.gradle.org/distributions/gradle-${GRADLE_WRAPPER_VERSION}-wrapper.jar.sha256"
+
+          curl --location --output gradle-wrapper.jar.sha256 $GRADLE_WRAPPER_HASH_REMOTE
+          echo "  gradle-wrapper.jar" >> gradle-wrapper.jar.sha256
+
+          echo $GRADLE_WRAPPER_VERSION
+          cat gradle-wrapper.jar.sha256
+
+          sha256sum --check gradle-wrapper.jar.sha256

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -1,23 +1,10 @@
 name: Validate Gradle Wrapper
-on: [pull_request]
-defaults:
-  run:
-    shell: bash
-    working-directory: gradle/wrapper
+on: [push, pull_request]
+
 jobs:
   validate:
+    name: Validate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Check Gradle Wrapper
-        run: |
-          GRADLE_WRAPPER_VERSION=`basename $(cat gradle-wrapper.properties | grep distributionUrl) | sed 's/gradle-//g;s/-all.zip//g'`
-          GRADLE_WRAPPER_HASH_REMOTE="https://services.gradle.org/distributions/gradle-${GRADLE_WRAPPER_VERSION}-wrapper.jar.sha256"
-
-          curl --location --output gradle-wrapper.jar.sha256 $GRADLE_WRAPPER_HASH_REMOTE
-          echo "  gradle-wrapper.jar" >> gradle-wrapper.jar.sha256
-
-          echo $GRADLE_WRAPPER_VERSION
-          cat gradle-wrapper.jar.sha256
-
-          sha256sum --check gradle-wrapper.jar.sha256
+      - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -1,19 +1,16 @@
 name: Validate Gradle Wrapper
 on: [pull_request]
+defaults:
+  run:
+    shell: bash
+    working-directory: gradle/wrapper
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
-        with:
-          java-version: 11
-          distribution: adopt
       - name: Check Gradle Wrapper
         run: |
-          cd gradle/wrapper
-
           GRADLE_WRAPPER_VERSION=`basename $(cat gradle-wrapper.properties | grep distributionUrl) | sed 's/gradle-//g;s/-all.zip//g'`
           GRADLE_WRAPPER_HASH_REMOTE="https://services.gradle.org/distributions/gradle-${GRADLE_WRAPPER_VERSION}-wrapper.jar.sha256"
 


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

As part of https://github.com/opensearch-project/opensearch-build/issues/982, move gradle wrapper and precommit checks into the OpenSearch GHA. These currently are implemented and running on a private Jenkins instance, which needs not to be.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
