### PR TITLE
Moved Gradle check into OpenSearch repo

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,29 @@
+name: Gradle Check
+on: [pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: adopt
+      - name: Run Gradle
+        run: |
+          echo "./gradlew check --no-daemon --no-scan"
+          ./gradlew check --no-daemon --no-scan
+          GRADLE_CHECK_STATUS=$?
+
+          cd ../
+          REPORTS_DIR=`find ./search -name reports`
+          zip -9 -q -r gradle_check_${BUILD_NUMBER}_reports.zip ${REPORTS_DIR}
+          ls | grep "gradle_check_${BUILD_NUMBER}"
+
+          if [ "$GRADLE_CHECK_STATUS" != 0 ]
+          then
+            echo Gradle Check Failed!
+            exit 1
+          fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,26 +4,40 @@ on: [pull_request]
 jobs:
   check:
     runs-on: ubuntu-latest
+    env:
+      JAVA_HOME: /opt/hostedtoolcache/Java_Adopt_jdk/14.0.2-12/x64/
+      JAVA11_HOME: /opt/hostedtoolcache/Java_Adopt_jdk/11.0.11-9/x64/
+      JAVA8_HOME: /opt/hostedtoolcache/Java_Adopt_jdk/8.0.292-1/x64/
+      JAVA14_HOME: /opt/hostedtoolcache/Java_Adopt_jdk/14.0.2-12/x64/
+      JAVA17_HOME: /opt/hostedtoolcache/Java_Adopt_jdk/17.0.1-12/x64/
     steps:
+      - name: Checkout OpenSearch 
+        uses: actions/checkout@v2
+
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
+      - uses: actions/setup-java@v2
         with:
-          java-version: 11
-          distribution: adopt
+          distribution: 'adopt'
+          java-version: '8'
+          targets: 'JDK_8'
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+          targets: 'JDK_11'
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '17'
+          targets: 'JDK_17'
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '14'
+          targets: 'JDK_14'
+      - uses: actions/checkout@v2
       - name: Run Gradle
-        run: |
-          echo "./gradlew check --no-daemon --no-scan"
-          ./gradlew check --no-daemon --no-scan
-          GRADLE_CHECK_STATUS=$?
-
-          cd ../
-          REPORTS_DIR=`find ./search -name reports`
-          zip -9 -q -r gradle_check_${BUILD_NUMBER}_reports.zip ${REPORTS_DIR}
-          ls | grep "gradle_check_${BUILD_NUMBER}"
-
-          if [ "$GRADLE_CHECK_STATUS" != 0 ]
-          then
-            echo Gradle Check Failed!
-            exit 1
-          fi
+        run: ./gradlew check --parallel


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Moved gradle check from private jenkins instance to OpenSearch repo. 
Sample run: https://github.com/owaiskazi19/OpenSearch/runs/4705950671?check_suite_focus=true
 
### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/982
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
