### PR TITLE
Remove LegacyESVersion.V_6_1_x constants

### DIFF
--- a/modules/percolator/src/main/java/org/opensearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/opensearch/percolator/PercolatorFieldMapper.java
@@ -50,11 +50,9 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.LongValuesSource;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.common.ParsingException;
@@ -67,7 +65,6 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentLocation;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.mapper.BinaryFieldMapper;
 import org.opensearch.index.mapper.FieldMapper;
 import org.opensearch.index.mapper.KeywordFieldMapper;
@@ -108,8 +105,6 @@ import java.util.function.Supplier;
 import static org.opensearch.index.query.AbstractQueryBuilder.parseInnerQueryBuilder;
 
 public class PercolatorFieldMapper extends ParametrizedFieldMapper {
-
-    static final XContentType QUERY_BUILDER_CONTENT_TYPE = XContentType.SMILE;
 
     static final Setting<Boolean> INDEX_MAP_UNMAPPED_FIELDS_AS_TEXT_SETTING = Setting.boolSetting(
         "index.percolator.map_unmapped_fields_as_text",
@@ -303,18 +298,11 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
             }
 
             BooleanQuery.Builder candidateQuery = new BooleanQuery.Builder();
-            if (canUseMinimumShouldMatchField && indexVersion.onOrAfter(LegacyESVersion.V_6_1_0)) {
-                LongValuesSource valuesSource = LongValuesSource.fromIntField(minimumShouldMatchField.name());
-                for (BytesRef extractedTerm : extractedTerms) {
-                    subQueries.add(new TermQuery(new Term(queryTermsField.name(), extractedTerm)));
-                }
-                candidateQuery.add(new CoveringQuery(subQueries, valuesSource), BooleanClause.Occur.SHOULD);
-            } else {
-                candidateQuery.add(new TermInSetQuery(queryTermsField.name(), extractedTerms), BooleanClause.Occur.SHOULD);
-                for (Query subQuery : subQueries) {
-                    candidateQuery.add(subQuery, BooleanClause.Occur.SHOULD);
-                }
+            LongValuesSource valuesSource = LongValuesSource.fromIntField(minimumShouldMatchField.name());
+            for (BytesRef extractedTerm : extractedTerms) {
+                subQueries.add(new TermQuery(new Term(queryTermsField.name(), extractedTerm)));
             }
+            candidateQuery.add(new CoveringQuery(subQueries, valuesSource), BooleanClause.Occur.SHOULD);
             // include extractionResultField:failed, because docs with this term have no extractedTermsField
             // and otherwise we would fail to return these docs. Docs that failed query term extraction
             // always need to be verified by MemoryIndex:
@@ -458,7 +446,6 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
             }
         }
 
-        Version indexVersionCreated = context.mapperService().getIndexSettings().getIndexVersionCreated();
         if (result.matchAllDocs) {
             doc.add(new Field(extractionResultField.name(), EXTRACTION_FAILED, INDEXED_KEYWORD));
             if (result.verified) {
@@ -471,9 +458,7 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
         }
 
         createFieldNamesField(context);
-        if (indexVersionCreated.onOrAfter(LegacyESVersion.V_6_1_0)) {
-            doc.add(new NumericDocValuesField(minimumShouldMatchFieldMapper.name(), result.minimumShouldMatch));
-        }
+        doc.add(new NumericDocValuesField(minimumShouldMatchFieldMapper.name(), result.minimumShouldMatch));
     }
 
     static void configureContext(QueryShardContext context, boolean mapUnmappedFieldsAsString) {

--- a/modules/percolator/src/test/java/org/opensearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/opensearch/percolator/CandidateQueryTests.java
@@ -674,7 +674,6 @@ public class CandidateQueryTests extends OpenSearchSingleNodeTestCase {
         shardSearcher.setQueryCache(null);
 
         Version v = VersionUtils.randomIndexCompatibleVersion(random());
-        ;
         MemoryIndex memoryIndex = MemoryIndex.fromDocument(Collections.singleton(new IntPoint("int_field", 3)), new WhitespaceAnalyzer());
         IndexSearcher percolateSearcher = memoryIndex.createSearcher();
         Query query = fieldType.percolateQuery(

--- a/modules/percolator/src/test/java/org/opensearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/opensearch/percolator/CandidateQueryTests.java
@@ -90,7 +90,6 @@ import org.apache.lucene.search.spans.SpanTermQuery;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.CheckedFunction;
@@ -114,6 +113,7 @@ import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 import org.junit.After;
 import org.junit.Before;
+import org.opensearch.test.VersionUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -673,7 +673,8 @@ public class CandidateQueryTests extends OpenSearchSingleNodeTestCase {
         IndexSearcher shardSearcher = newSearcher(directoryReader);
         shardSearcher.setQueryCache(null);
 
-        Version v = LegacyESVersion.V_6_1_0;
+        Version v = VersionUtils.randomIndexCompatibleVersion(random());
+        ;
         MemoryIndex memoryIndex = MemoryIndex.fromDocument(Collections.singleton(new IntPoint("int_field", 3)), new WhitespaceAnalyzer());
         IndexSearcher percolateSearcher = memoryIndex.createSearcher();
         Query query = fieldType.percolateQuery(

--- a/qa/full-cluster-restart/src/test/java/org/opensearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/opensearch/upgrades/FullClusterRestartIT.java
@@ -1130,7 +1130,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
              * we will hit a warning exception because we put some deprecated settings in that test.
              */
             if (isRunningAgainstOldCluster() == false
-                && getOldClusterVersion().onOrAfter(LegacyESVersion.V_6_1_0) && getOldClusterVersion().before(LegacyESVersion.V_6_5_0)) {
+                && getOldClusterVersion().before(LegacyESVersion.V_6_5_0)) {
                 for (String warning : e.getResponse().getWarnings()) {
                     assertThat(warning, containsString(
                         "setting was deprecated and will be removed in a future release! "

--- a/qa/full-cluster-restart/src/test/java/org/opensearch/upgrades/FullClusterRestartSettingsUpgradeIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/opensearch/upgrades/FullClusterRestartSettingsUpgradeIT.java
@@ -58,7 +58,6 @@ import static org.hamcrest.Matchers.equalTo;
 public class FullClusterRestartSettingsUpgradeIT extends AbstractFullClusterRestartTestCase {
 
     public void testRemoteClusterSettingsUpgraded() throws IOException {
-        assumeTrue("skip_unavailable did not exist until 6.1.0", getOldClusterVersion().onOrAfter(LegacyESVersion.V_6_1_0));
         assumeTrue("settings automatically upgraded since 6.5.0", getOldClusterVersion().before(LegacyESVersion.V_6_5_0));
         if (isRunningAgainstOldCluster()) {
             final Request putSettingsRequest = new Request("PUT", "/_cluster/settings");
@@ -91,7 +90,7 @@ public class FullClusterRestartSettingsUpgradeIT extends AbstractFullClusterRest
                         SEARCH_REMOTE_CLUSTERS_SEEDS.getConcreteSettingForNamespace("foo").get(settings),
                         equalTo(Collections.singletonList("localhost:9200")));
                 assertTrue(SEARCH_REMOTE_CLUSTERS_PROXY.getConcreteSettingForNamespace("foo").exists(settings));
-                assertEquals(String.valueOf(SEARCH_REMOTE_CLUSTERS_PROXY.getConcreteSettingForNamespace("foo").get(settings)), 
+                assertEquals(String.valueOf(SEARCH_REMOTE_CLUSTERS_PROXY.getConcreteSettingForNamespace("foo").get(settings)),
                                 "localhost:9200");
             }
 
@@ -118,7 +117,7 @@ public class FullClusterRestartSettingsUpgradeIT extends AbstractFullClusterRest
                         equalTo(Collections.singletonList("localhost:9200")));
                 assertFalse(SEARCH_REMOTE_CLUSTERS_PROXY.getConcreteSettingForNamespace("foo").exists(settings));
                 assertTrue(REMOTE_CLUSTERS_PROXY.getConcreteSettingForNamespace("foo").exists(settings));
-                assertEquals(String.valueOf(REMOTE_CLUSTERS_PROXY.getConcreteSettingForNamespace("foo").get(settings)), 
+                assertEquals(String.valueOf(REMOTE_CLUSTERS_PROXY.getConcreteSettingForNamespace("foo").get(settings)),
                                 "localhost:9200");
             }
         }

--- a/server/src/main/java/org/opensearch/LegacyESVersion.java
+++ b/server/src/main/java/org/opensearch/LegacyESVersion.java
@@ -46,11 +46,6 @@ import java.lang.reflect.Field;
  */
 public class LegacyESVersion extends Version {
 
-    public static final LegacyESVersion V_6_1_0 = new LegacyESVersion(6010099, org.apache.lucene.util.Version.LUCENE_7_1_0);
-    public static final LegacyESVersion V_6_1_1 = new LegacyESVersion(6010199, org.apache.lucene.util.Version.LUCENE_7_1_0);
-    public static final LegacyESVersion V_6_1_2 = new LegacyESVersion(6010299, org.apache.lucene.util.Version.LUCENE_7_1_0);
-    public static final LegacyESVersion V_6_1_3 = new LegacyESVersion(6010399, org.apache.lucene.util.Version.LUCENE_7_1_0);
-    public static final LegacyESVersion V_6_1_4 = new LegacyESVersion(6010499, org.apache.lucene.util.Version.LUCENE_7_1_0);
     // The below version is missing from the 7.3 JAR
     private static final org.apache.lucene.util.Version LUCENE_7_2_1 = org.apache.lucene.util.Version.fromBits(7, 2, 1);
     public static final LegacyESVersion V_6_2_0 = new LegacyESVersion(6020099, LUCENE_7_2_1);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
@@ -134,11 +134,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         scriptStats = in.readOptionalWriteable(ScriptStats::new);
         discoveryStats = in.readOptionalWriteable(DiscoveryStats::new);
         ingestStats = in.readOptionalWriteable(IngestStats::new);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            adaptiveSelectionStats = in.readOptionalWriteable(AdaptiveSelectionStats::new);
-        } else {
-            adaptiveSelectionStats = null;
-        }
+        adaptiveSelectionStats = in.readOptionalWriteable(AdaptiveSelectionStats::new);
         scriptCacheStats = null;
         if (in.getVersion().onOrAfter(LegacyESVersion.V_7_8_0)) {
             if (in.getVersion().before(LegacyESVersion.V_7_9_0)) {
@@ -328,9 +324,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         out.writeOptionalWriteable(scriptStats);
         out.writeOptionalWriteable(discoveryStats);
         out.writeOptionalWriteable(ingestStats);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            out.writeOptionalWriteable(adaptiveSelectionStats);
-        }
+        out.writeOptionalWriteable(adaptiveSelectionStats);
         if (out.getVersion().onOrAfter(LegacyESVersion.V_7_8_0) && out.getVersion().before(LegacyESVersion.V_7_9_0)) {
             out.writeOptionalWriteable(scriptCacheStats);
         }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -74,9 +74,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
             optionallyAddMetric(in.readBoolean(), Metric.SCRIPT.metricName());
             optionallyAddMetric(in.readBoolean(), Metric.DISCOVERY.metricName());
             optionallyAddMetric(in.readBoolean(), Metric.INGEST.metricName());
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-                optionallyAddMetric(in.readBoolean(), Metric.ADAPTIVE_SELECTION.metricName());
-            }
+            optionallyAddMetric(in.readBoolean(), Metric.ADAPTIVE_SELECTION.metricName());
         } else {
             requestedMetrics.addAll(in.readStringList());
         }
@@ -212,9 +210,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
             out.writeBoolean(Metric.SCRIPT.containedIn(requestedMetrics));
             out.writeBoolean(Metric.DISCOVERY.containedIn(requestedMetrics));
             out.writeBoolean(Metric.INGEST.containedIn(requestedMetrics));
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-                out.writeBoolean(Metric.ADAPTIVE_SELECTION.containedIn(requestedMetrics));
-            }
+            out.writeBoolean(Metric.ADAPTIVE_SELECTION.containedIn(requestedMetrics));
         } else {
             out.writeStringArray(requestedMetrics.toArray(new String[0]));
         }

--- a/server/src/main/java/org/opensearch/action/admin/indices/open/OpenIndexRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/open/OpenIndexRequest.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.indices.open;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.IndicesRequest;
 import org.opensearch.action.support.ActiveShardCount;
@@ -59,9 +58,7 @@ public class OpenIndexRequest extends AcknowledgedRequest<OpenIndexRequest> impl
         super(in);
         indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            waitForActiveShards = ActiveShardCount.readFrom(in);
-        }
+        waitForActiveShards = ActiveShardCount.readFrom(in);
     }
 
     public OpenIndexRequest() {}
@@ -167,8 +164,6 @@ public class OpenIndexRequest extends AcknowledgedRequest<OpenIndexRequest> impl
         super.writeTo(out);
         out.writeStringArray(indices);
         indicesOptions.writeIndicesOptions(out);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            waitForActiveShards.writeTo(out);
-        }
+        waitForActiveShards.writeTo(out);
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/open/OpenIndexResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/open/OpenIndexResponse.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.indices.open;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.support.master.ShardsAcknowledgedResponse;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -57,7 +56,7 @@ public class OpenIndexResponse extends ShardsAcknowledgedResponse {
     }
 
     public OpenIndexResponse(StreamInput in) throws IOException {
-        super(in, in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0), true);
+        super(in, true, true);
     }
 
     public OpenIndexResponse(boolean acknowledged, boolean shardsAcknowledged) {
@@ -67,9 +66,7 @@ public class OpenIndexResponse extends ShardsAcknowledgedResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            writeShardsAcknowledged(out);
-        }
+        writeShardsAcknowledged(out);
     }
 
     public static OpenIndexResponse fromXContent(XContentParser parser) {

--- a/server/src/main/java/org/opensearch/action/admin/indices/rollover/MaxSizeCondition.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/rollover/MaxSizeCondition.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.action.admin.indices.rollover;
 
-import org.opensearch.LegacyESVersion;
-import org.opensearch.Version;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.unit.ByteSizeUnit;
@@ -63,11 +61,6 @@ public class MaxSizeCondition extends Condition<ByteSizeValue> {
     @Override
     public Result evaluate(Stats stats) {
         return new Result(this, stats.indexSize.getBytes() >= value.getBytes());
-    }
-
-    @Override
-    boolean includedInVersion(Version version) {
-        return version.onOrAfter(LegacyESVersion.V_6_1_0);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/indices/shrink/ResizeAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/shrink/ResizeAction.java
@@ -32,15 +32,12 @@
 
 package org.opensearch.action.admin.indices.shrink;
 
-import org.opensearch.LegacyESVersion;
-import org.opensearch.Version;
 import org.opensearch.action.ActionType;
 
 public class ResizeAction extends ActionType<ResizeResponse> {
 
     public static final ResizeAction INSTANCE = new ResizeAction();
     public static final String NAME = "indices:admin/resize";
-    public static final Version COMPATIBILITY_VERSION = LegacyESVersion.V_6_1_0; // TODO remove this once it's backported
 
     private ResizeAction() {
         super(NAME, ResizeResponse::new);

--- a/server/src/main/java/org/opensearch/action/admin/indices/shrink/ResizeRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/shrink/ResizeRequest.java
@@ -81,11 +81,7 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
         super(in);
         targetIndexRequest = new CreateIndexRequest(in);
         sourceIndex = in.readString();
-        if (in.getVersion().onOrAfter(ResizeAction.COMPATIBILITY_VERSION)) {
-            type = in.readEnum(ResizeType.class);
-        } else {
-            type = ResizeType.SHRINK; // BWC this used to be shrink only
-        }
+        type = in.readEnum(ResizeType.class);
         if (in.getVersion().before(LegacyESVersion.V_6_4_0)) {
             copySettings = null;
         } else {
@@ -128,12 +124,10 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
         super.writeTo(out);
         targetIndexRequest.writeTo(out);
         out.writeString(sourceIndex);
-        if (out.getVersion().onOrAfter(ResizeAction.COMPATIBILITY_VERSION)) {
-            if (type == ResizeType.CLONE && out.getVersion().before(LegacyESVersion.V_7_4_0)) {
-                throw new IllegalArgumentException("can't send clone request to a node that's older than " + LegacyESVersion.V_7_4_0);
-            }
-            out.writeEnum(type);
+        if (type == ResizeType.CLONE && out.getVersion().before(LegacyESVersion.V_7_4_0)) {
+            throw new IllegalArgumentException("can't send clone request to a node that's older than " + LegacyESVersion.V_7_4_0);
         }
+        out.writeEnum(type);
         // noinspection StatementWithEmptyBody
         if (out.getVersion().before(LegacyESVersion.V_6_4_0)) {
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/shrink/TransportResizeAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/shrink/TransportResizeAction.java
@@ -48,6 +48,7 @@ import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.MetadataCreateIndexService;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexNotFoundException;
@@ -69,6 +70,28 @@ import java.util.function.IntFunction;
 public class TransportResizeAction extends TransportMasterNodeAction<ResizeRequest, ResizeResponse> {
     private final MetadataCreateIndexService createIndexService;
     private final Client client;
+
+    @Inject
+    public TransportResizeAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        MetadataCreateIndexService createIndexService,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        Client client
+    ) {
+        this(
+            ResizeAction.NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            createIndexService,
+            actionFilters,
+            indexNameExpressionResolver,
+            client
+        );
+    }
 
     protected TransportResizeAction(
         String actionName,

--- a/server/src/main/java/org/opensearch/action/admin/indices/shrink/TransportResizeAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/shrink/TransportResizeAction.java
@@ -48,7 +48,6 @@ import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.MetadataCreateIndexService;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.inject.Inject;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexNotFoundException;
@@ -70,28 +69,6 @@ import java.util.function.IntFunction;
 public class TransportResizeAction extends TransportMasterNodeAction<ResizeRequest, ResizeResponse> {
     private final MetadataCreateIndexService createIndexService;
     private final Client client;
-
-    @Inject
-    public TransportResizeAction(
-        TransportService transportService,
-        ClusterService clusterService,
-        ThreadPool threadPool,
-        MetadataCreateIndexService createIndexService,
-        ActionFilters actionFilters,
-        IndexNameExpressionResolver indexNameExpressionResolver,
-        Client client
-    ) {
-        this(
-            ResizeAction.NAME,
-            transportService,
-            clusterService,
-            threadPool,
-            createIndexService,
-            actionFilters,
-            indexNameExpressionResolver,
-            client
-        );
-    }
 
     protected TransportResizeAction(
         String actionName,
@@ -250,12 +227,6 @@ public class TransportResizeAction extends TransportMasterNodeAction<ResizeReque
 
     @Override
     protected String getMasterActionName(DiscoveryNode node) {
-        if (node.getVersion().onOrAfter(ResizeAction.COMPATIBILITY_VERSION)) {
-            return super.getMasterActionName(node);
-        } else {
-            // this is for BWC - when we send this to version that doesn't have ResizeAction.NAME registered
-            // we have to send to shrink instead.
-            return ShrinkAction.NAME;
-        }
+        return super.getMasterActionName(node);
     }
 }

--- a/server/src/main/java/org/opensearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchResponse.java
@@ -103,11 +103,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
                 shardFailures[i] = ShardSearchFailure.readShardSearchFailure(in);
             }
         }
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            clusters = new Clusters(in);
-        } else {
-            clusters = Clusters.EMPTY;
-        }
+        clusters = new Clusters(in);
         scrollId = in.readOptionalString();
         tookInMillis = in.readVLong();
         skippedShards = in.readVInt();
@@ -460,9 +456,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
         for (ShardSearchFailure shardSearchFailure : shardFailures) {
             shardSearchFailure.writeTo(out);
         }
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            clusters.writeTo(out);
-        }
+        clusters.writeTo(out);
         out.writeOptionalString(scrollId);
         out.writeVLong(tookInMillis);
         out.writeVInt(skippedShards);

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/ResizeAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/ResizeAllocationDecider.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.cluster.routing.allocation.decider;
 
-import org.opensearch.action.admin.indices.shrink.ResizeAction;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.RecoverySource;
 import org.opensearch.cluster.routing.RoutingNode;
@@ -79,9 +78,6 @@ public class ResizeAllocationDecider extends AllocationDecider {
                 return allocation.decision(Decision.NO, NAME, "source primary shard [%s] is not active", shardId);
             }
             if (node != null) { // we might get called from the 2 param canAllocate method..
-                if (node.node().getVersion().before(ResizeAction.COMPATIBILITY_VERSION)) {
-                    return allocation.decision(Decision.NO, NAME, "node [%s] is too old to split a shard", node.nodeId());
-                }
                 if (sourceShardRouting.currentNodeId().equals(node.nodeId())) {
                     return allocation.decision(Decision.YES, NAME, "source primary is allocated on this node");
                 } else {

--- a/server/src/main/java/org/opensearch/common/lucene/search/Queries.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/Queries.java
@@ -43,7 +43,6 @@ import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.common.Nullable;
@@ -88,11 +87,7 @@ public class Queries {
      * @param indexVersionCreated the index version created since newer indices can identify a parent field more efficiently
      */
     public static Query newNonNestedFilter(Version indexVersionCreated) {
-        if (indexVersionCreated.onOrAfter(LegacyESVersion.V_6_1_0)) {
-            return new DocValuesFieldExistsQuery(SeqNoFieldMapper.PRIMARY_TERM_NAME);
-        } else {
-            return new BooleanQuery.Builder().add(new MatchAllDocsQuery(), Occur.FILTER).add(newNestedFilter(), Occur.MUST_NOT).build();
-        }
+        return new DocValuesFieldExistsQuery(SeqNoFieldMapper.PRIMARY_TERM_NAME);
     }
 
     public static BooleanQuery filtered(@Nullable Query query, @Nullable Query filter) {

--- a/server/src/main/java/org/opensearch/common/unit/Fuzziness.java
+++ b/server/src/main/java/org/opensearch/common/unit/Fuzziness.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.common.unit;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.io.stream.StreamInput;
@@ -95,7 +94,7 @@ public final class Fuzziness implements ToXContentFragment, Writeable {
      */
     public Fuzziness(StreamInput in) throws IOException {
         fuzziness = in.readString();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0) && in.readBoolean()) {
+        if (in.readBoolean()) {
             lowDistance = in.readVInt();
             highDistance = in.readVInt();
         }
@@ -104,17 +103,15 @@ public final class Fuzziness implements ToXContentFragment, Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(fuzziness);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            // we cannot serialize the low/high bounds since the other node does not know about them.
-            // This is a best-effort to not fail queries in case the cluster is being upgraded and users
-            // start using features that are not available on all nodes.
-            if (isAutoWithCustomValues()) {
-                out.writeBoolean(true);
-                out.writeVInt(lowDistance);
-                out.writeVInt(highDistance);
-            } else {
-                out.writeBoolean(false);
-            }
+        // we cannot serialize the low/high bounds since the other node does not know about them.
+        // This is a best-effort to not fail queries in case the cluster is being upgraded and users
+        // start using features that are not available on all nodes.
+        if (isAutoWithCustomValues()) {
+            out.writeBoolean(true);
+            out.writeVInt(lowDistance);
+            out.writeVInt(highDistance);
+        } else {
+            out.writeBoolean(false);
         }
     }
 

--- a/server/src/main/java/org/opensearch/discovery/DiscoveryStats.java
+++ b/server/src/main/java/org/opensearch/discovery/DiscoveryStats.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.discovery;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -55,21 +54,13 @@ public class DiscoveryStats implements Writeable, ToXContentFragment {
 
     public DiscoveryStats(StreamInput in) throws IOException {
         queueStats = in.readOptionalWriteable(PendingClusterStateStats::new);
-
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            publishStats = in.readOptionalWriteable(PublishClusterStateStats::new);
-        } else {
-            publishStats = null;
-        }
+        publishStats = in.readOptionalWriteable(PublishClusterStateStats::new);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalWriteable(queueStats);
-
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            out.writeOptionalWriteable(publishStats);
-        }
+        out.writeOptionalWriteable(publishStats);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/engine/Segment.java
+++ b/server/src/main/java/org/opensearch/index/engine/Segment.java
@@ -40,7 +40,6 @@ import org.apache.lucene.search.SortedSetSelector;
 import org.apache.lucene.search.SortedNumericSelector;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Accountables;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -89,10 +88,8 @@ public class Segment implements Writeable {
             ramTree = readRamTree(in);
         }
         segmentSort = readSegmentSort(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0) && in.readBoolean()) {
+        if (in.readBoolean()) {
             attributes = in.readMap(StreamInput::readString, StreamInput::readString);
-        } else {
-            attributes = null;
         }
     }
 
@@ -204,12 +201,10 @@ public class Segment implements Writeable {
             writeRamTree(out, ramTree);
         }
         writeSegmentSort(out, segmentSort);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            boolean hasAttributes = attributes != null;
-            out.writeBoolean(hasAttributes);
-            if (hasAttributes) {
-                out.writeMap(attributes, StreamOutput::writeString, StreamOutput::writeString);
-            }
+        boolean hasAttributes = attributes != null;
+        out.writeBoolean(hasAttributes);
+        if (hasAttributes) {
+            out.writeMap(attributes, StreamOutput::writeString, StreamOutput::writeString);
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/mapper/FieldNamesFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FieldNamesFieldMapper.java
@@ -32,20 +32,15 @@
 
 package org.opensearch.index.mapper;
 
-import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
-import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.Query;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.common.Explicit;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.search.lookup.SearchLookup;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -178,36 +173,6 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
     @Override
     public FieldNamesFieldType fieldType() {
         return (FieldNamesFieldType) super.fieldType();
-    }
-
-    @Override
-    public void postParse(ParseContext context) throws IOException {
-        if (context.indexSettings().getIndexVersionCreated().before(LegacyESVersion.V_6_1_0)) {
-            if (fieldType().isEnabled() == false) {
-                return;
-            }
-            for (ParseContext.Document document : context) {
-                final List<String> paths = new ArrayList<>(document.getFields().size());
-                String previousPath = ""; // used as a sentinel - field names can't be empty
-                for (IndexableField field : document.getFields()) {
-                    final String path = field.name();
-                    if (path.equals(previousPath)) {
-                        // Sometimes mappers create multiple Lucene fields, eg. one for indexing,
-                        // one for doc values and one for storing. Deduplicating is not required
-                        // for correctness but this simple check helps save utf-8 conversions and
-                        // gives Lucene fewer values to deal with.
-                        continue;
-                    }
-                    paths.add(path);
-                    previousPath = path;
-                }
-                for (String path : paths) {
-                    for (String fieldName : extractFieldNames(path)) {
-                        document.add(new Field(fieldType().name(), fieldName, Defaults.FIELD_TYPE));
-                    }
-                }
-            }
-        }
     }
 
     static Iterable<String> extractFieldNames(final String fullPath) {

--- a/server/src/main/java/org/opensearch/index/mapper/SeqNoFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/SeqNoFieldMapper.java
@@ -38,8 +38,6 @@ import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
-import org.opensearch.LegacyESVersion;
-import org.opensearch.Version;
 import org.opensearch.common.Nullable;
 import org.opensearch.index.fielddata.IndexFieldData;
 import org.opensearch.index.fielddata.IndexNumericFieldData.NumericType;
@@ -215,8 +213,7 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
         // we share the parent docs fields to ensure good compression
         SequenceIDFields seqID = context.seqID();
         assert seqID != null;
-        final Version versionCreated = context.mapperService().getIndexSettings().getIndexVersionCreated();
-        final boolean includePrimaryTerm = versionCreated.before(LegacyESVersion.V_6_1_0);
+        final boolean includePrimaryTerm = false;
         for (Document doc : context.nonRootDocuments()) {
             doc.add(seqID.seqNo);
             doc.add(seqID.seqNoDocValue);

--- a/server/src/main/java/org/opensearch/index/mapper/SeqNoFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/SeqNoFieldMapper.java
@@ -213,14 +213,9 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
         // we share the parent docs fields to ensure good compression
         SequenceIDFields seqID = context.seqID();
         assert seqID != null;
-        final boolean includePrimaryTerm = false;
         for (Document doc : context.nonRootDocuments()) {
             doc.add(seqID.seqNo);
             doc.add(seqID.seqNoDocValue);
-            if (includePrimaryTerm) {
-                // primary terms are used to distinguish between parent and nested docs since 6.1.0
-                doc.add(seqID.primaryTerm);
-            }
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/query/ExistsQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/ExistsQueryBuilder.java
@@ -40,7 +40,6 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.Strings;
@@ -172,10 +171,6 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
             }
         }
 
-        if (context.indexVersionCreated().before(LegacyESVersion.V_6_1_0)) {
-            return newLegacyExistsQuery(context, fields);
-        }
-
         if (fields.size() == 1) {
             String field = fields.iterator().next();
             return newFieldExistsQuery(context, field);
@@ -184,22 +179,6 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
         BooleanQuery.Builder boolFilterBuilder = new BooleanQuery.Builder();
         for (String field : fields) {
             boolFilterBuilder.add(newFieldExistsQuery(context, field), BooleanClause.Occur.SHOULD);
-        }
-        return new ConstantScoreQuery(boolFilterBuilder.build());
-    }
-
-    private static Query newLegacyExistsQuery(QueryShardContext context, Collection<String> fields) {
-        // We create TermsQuery directly here rather than using FieldNamesFieldType.termsQuery()
-        // so we don't end up with deprecation warnings
-        if (fields.size() == 1) {
-            Query filter = newLegacyExistsQuery(context, fields.iterator().next());
-            return new ConstantScoreQuery(filter);
-        }
-
-        BooleanQuery.Builder boolFilterBuilder = new BooleanQuery.Builder();
-        for (String field : fields) {
-            Query filter = newLegacyExistsQuery(context, field);
-            boolFilterBuilder.add(filter, BooleanClause.Occur.SHOULD);
         }
         return new ConstantScoreQuery(boolFilterBuilder.build());
     }

--- a/server/src/main/java/org/opensearch/index/query/MatchQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/MatchQueryBuilder.java
@@ -34,7 +34,6 @@ package org.opensearch.index.query;
 
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.Query;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.io.stream.StreamInput;
@@ -147,9 +146,7 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
         fuzzyRewrite = in.readOptionalString();
         fuzziness = in.readOptionalWriteable(Fuzziness::new);
         cutoffFrequency = in.readOptionalFloat();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            autoGenerateSynonymsPhraseQuery = in.readBoolean();
-        }
+        autoGenerateSynonymsPhraseQuery = in.readBoolean();
     }
 
     @Override
@@ -168,9 +165,7 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
         out.writeOptionalString(fuzzyRewrite);
         out.writeOptionalWriteable(fuzziness);
         out.writeOptionalFloat(cutoffFrequency);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            out.writeBoolean(autoGenerateSynonymsPhraseQuery);
-        }
+        out.writeBoolean(autoGenerateSynonymsPhraseQuery);
     }
 
     /** Returns the field name used in this query. */

--- a/server/src/main/java/org/opensearch/index/query/MultiMatchQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/MultiMatchQueryBuilder.java
@@ -251,17 +251,11 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
             in.readOptionalBoolean(); // unused use_dis_max flag
         }
         tieBreaker = in.readOptionalFloat();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            lenient = in.readOptionalBoolean();
-        } else {
-            lenient = in.readBoolean();
-        }
+        lenient = in.readOptionalBoolean();
         cutoffFrequency = in.readOptionalFloat();
         zeroTermsQuery = MatchQuery.ZeroTermsQuery.readFromStream(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            autoGenerateSynonymsPhraseQuery = in.readBoolean();
-            fuzzyTranspositions = in.readBoolean();
-        }
+        autoGenerateSynonymsPhraseQuery = in.readBoolean();
+        fuzzyTranspositions = in.readBoolean();
     }
 
     @Override
@@ -285,17 +279,11 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
             out.writeOptionalBoolean(null);
         }
         out.writeOptionalFloat(tieBreaker);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            out.writeOptionalBoolean(lenient);
-        } else {
-            out.writeBoolean(lenient == null ? MatchQuery.DEFAULT_LENIENCY : lenient);
-        }
+        out.writeOptionalBoolean(lenient);
         out.writeOptionalFloat(cutoffFrequency);
         zeroTermsQuery.writeTo(out);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            out.writeBoolean(autoGenerateSynonymsPhraseQuery);
-            out.writeBoolean(fuzzyTranspositions);
-        }
+        out.writeBoolean(autoGenerateSynonymsPhraseQuery);
+        out.writeBoolean(fuzzyTranspositions);
     }
 
     public Object value() {

--- a/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java
@@ -36,7 +36,6 @@ import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.automaton.Operations;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.io.stream.StreamInput;
@@ -208,10 +207,8 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
         timeZone = in.readOptionalZoneId();
         escape = in.readBoolean();
         maxDeterminizedStates = in.readVInt();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            autoGenerateSynonymsPhraseQuery = in.readBoolean();
-            fuzzyTranspositions = in.readBoolean();
-        }
+        autoGenerateSynonymsPhraseQuery = in.readBoolean();
+        fuzzyTranspositions = in.readBoolean();
     }
 
     @Override
@@ -243,10 +240,8 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
         out.writeOptionalZoneId(timeZone);
         out.writeBoolean(this.escape);
         out.writeVInt(this.maxDeterminizedStates);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            out.writeBoolean(autoGenerateSynonymsPhraseQuery);
-            out.writeBoolean(fuzzyTranspositions);
-        }
+        out.writeBoolean(autoGenerateSynonymsPhraseQuery);
+        out.writeBoolean(fuzzyTranspositions);
     }
 
     public String queryString() {

--- a/server/src/main/java/org/opensearch/index/query/SimpleQueryStringBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SimpleQueryStringBuilder.java
@@ -35,7 +35,6 @@ package org.opensearch.index.query;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.Query;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.Strings;
@@ -181,12 +180,10 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
         settings.analyzeWildcard(in.readBoolean());
         minimumShouldMatch = in.readOptionalString();
         settings.quoteFieldSuffix(in.readOptionalString());
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            settings.autoGenerateSynonymsPhraseQuery(in.readBoolean());
-            settings.fuzzyPrefixLength(in.readVInt());
-            settings.fuzzyMaxExpansions(in.readVInt());
-            settings.fuzzyTranspositions(in.readBoolean());
-        }
+        settings.autoGenerateSynonymsPhraseQuery(in.readBoolean());
+        settings.fuzzyPrefixLength(in.readVInt());
+        settings.fuzzyMaxExpansions(in.readVInt());
+        settings.fuzzyTranspositions(in.readBoolean());
     }
 
     @Override
@@ -205,12 +202,10 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
         out.writeBoolean(settings.analyzeWildcard());
         out.writeOptionalString(minimumShouldMatch);
         out.writeOptionalString(settings.quoteFieldSuffix());
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            out.writeBoolean(settings.autoGenerateSynonymsPhraseQuery());
-            out.writeVInt(settings.fuzzyPrefixLength());
-            out.writeVInt(settings.fuzzyMaxExpansions());
-            out.writeBoolean(settings.fuzzyTranspositions());
-        }
+        out.writeBoolean(settings.autoGenerateSynonymsPhraseQuery());
+        out.writeVInt(settings.fuzzyPrefixLength());
+        out.writeVInt(settings.fuzzyMaxExpansions());
+        out.writeBoolean(settings.fuzzyTranspositions());
     }
 
     /** Returns the text to parse the query from. */

--- a/server/src/main/java/org/opensearch/index/reindex/AbstractBulkByScrollRequest.java
+++ b/server/src/main/java/org/opensearch/index/reindex/AbstractBulkByScrollRequest.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.index.reindex;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.search.SearchRequest;
@@ -491,18 +490,7 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
         out.writeTimeValue(retryBackoffInitialTime);
         out.writeVInt(maxRetries);
         out.writeFloat(requestsPerSecond);
-        if (out.getVersion().before(LegacyESVersion.V_6_1_0) && slices == AUTO_SLICES) {
-            throw new IllegalArgumentException(
-                "Slices set as \"auto\" are not supported before version ["
-                    + LegacyESVersion.V_6_1_0
-                    + "]. "
-                    + "Found version ["
-                    + out.getVersion()
-                    + "]"
-            );
-        } else {
-            out.writeVInt(slices);
-        }
+        out.writeVInt(slices);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/shard/DocsStats.java
+++ b/server/src/main/java/org/opensearch/index/shard/DocsStats.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.index.shard;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -55,11 +54,7 @@ public class DocsStats implements Writeable, ToXContentFragment {
     public DocsStats(StreamInput in) throws IOException {
         count = in.readVLong();
         deleted = in.readVLong();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            totalSizeInBytes = in.readVLong();
-        } else {
-            totalSizeInBytes = -1;
-        }
+        totalSizeInBytes = in.readVLong();
     }
 
     public DocsStats(long count, long deleted, long totalSizeInBytes) {
@@ -109,9 +104,7 @@ public class DocsStats implements Writeable, ToXContentFragment {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(count);
         out.writeVLong(deleted);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            out.writeVLong(totalSizeInBytes);
-        }
+        out.writeVLong(totalSizeInBytes);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/monitor/os/OsStats.java
+++ b/server/src/main/java/org/opensearch/monitor/os/OsStats.java
@@ -34,7 +34,6 @@ package org.opensearch.monitor.os;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -468,15 +467,9 @@ public class OsStats implements Writeable, ToXContentFragment {
             cpuCfsPeriodMicros = in.readLong();
             cpuCfsQuotaMicros = in.readLong();
             cpuStat = new CpuStat(in);
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-                memoryControlGroup = in.readOptionalString();
-                memoryLimitInBytes = in.readOptionalString();
-                memoryUsageInBytes = in.readOptionalString();
-            } else {
-                memoryControlGroup = null;
-                memoryLimitInBytes = null;
-                memoryUsageInBytes = null;
-            }
+            memoryControlGroup = in.readOptionalString();
+            memoryLimitInBytes = in.readOptionalString();
+            memoryUsageInBytes = in.readOptionalString();
         }
 
         @Override
@@ -487,11 +480,9 @@ public class OsStats implements Writeable, ToXContentFragment {
             out.writeLong(cpuCfsPeriodMicros);
             out.writeLong(cpuCfsQuotaMicros);
             cpuStat.writeTo(out);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-                out.writeOptionalString(memoryControlGroup);
-                out.writeOptionalString(memoryLimitInBytes);
-                out.writeOptionalString(memoryUsageInBytes);
-            }
+            out.writeOptionalString(memoryControlGroup);
+            out.writeOptionalString(memoryLimitInBytes);
+            out.writeOptionalString(memoryUsageInBytes);
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/search/sort/FieldSortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/FieldSortBuilder.java
@@ -157,9 +157,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
         order = in.readOptionalWriteable(SortOrder::readFromStream);
         sortMode = in.readOptionalWriteable(SortMode::readFromStream);
         unmappedType = in.readOptionalString();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            nestedSort = in.readOptionalWriteable(NestedSortBuilder::new);
-        }
+        nestedSort = in.readOptionalWriteable(NestedSortBuilder::new);
         if (in.getVersion().onOrAfter(LegacyESVersion.V_7_2_0)) {
             numericType = in.readOptionalString();
         }
@@ -174,9 +172,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
         out.writeOptionalWriteable(order);
         out.writeOptionalWriteable(sortMode);
         out.writeOptionalString(unmappedType);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            out.writeOptionalWriteable(nestedSort);
-        }
+        out.writeOptionalWriteable(nestedSort);
         if (out.getVersion().onOrAfter(LegacyESVersion.V_7_2_0)) {
             out.writeOptionalString(numericType);
         }

--- a/server/src/main/java/org/opensearch/search/sort/GeoDistanceSortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/GeoDistanceSortBuilder.java
@@ -187,9 +187,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
         sortMode = in.readOptionalWriteable(SortMode::readFromStream);
         nestedFilter = in.readOptionalNamedWriteable(QueryBuilder.class);
         nestedPath = in.readOptionalString();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            nestedSort = in.readOptionalWriteable(NestedSortBuilder::new);
-        }
+        nestedSort = in.readOptionalWriteable(NestedSortBuilder::new);
         validation = GeoValidationMethod.readFromStream(in);
         if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
             ignoreUnmapped = in.readBoolean();
@@ -206,9 +204,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
         out.writeOptionalWriteable(sortMode);
         out.writeOptionalNamedWriteable(nestedFilter);
         out.writeOptionalString(nestedPath);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            out.writeOptionalWriteable(nestedSort);
-        }
+        out.writeOptionalWriteable(nestedSort);
         validation.writeTo(out);
         if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
             out.writeBoolean(ignoreUnmapped);

--- a/server/src/main/java/org/opensearch/search/sort/ScriptSortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/ScriptSortBuilder.java
@@ -135,9 +135,7 @@ public class ScriptSortBuilder extends SortBuilder<ScriptSortBuilder> {
         sortMode = in.readOptionalWriteable(SortMode::readFromStream);
         nestedPath = in.readOptionalString();
         nestedFilter = in.readOptionalNamedWriteable(QueryBuilder.class);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            nestedSort = in.readOptionalWriteable(NestedSortBuilder::new);
-        }
+        nestedSort = in.readOptionalWriteable(NestedSortBuilder::new);
     }
 
     @Override
@@ -148,9 +146,7 @@ public class ScriptSortBuilder extends SortBuilder<ScriptSortBuilder> {
         out.writeOptionalWriteable(sortMode);
         out.writeOptionalString(nestedPath);
         out.writeOptionalNamedWriteable(nestedFilter);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            out.writeOptionalWriteable(nestedSort);
-        }
+        out.writeOptionalWriteable(nestedSort);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/suggest/completion/CompletionSuggestion.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/CompletionSuggestion.java
@@ -34,7 +34,6 @@ package org.opensearch.search.suggest.completion;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.util.PriorityQueue;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -98,9 +97,7 @@ public final class CompletionSuggestion extends Suggest.Suggestion<CompletionSug
 
     public CompletionSuggestion(StreamInput in) throws IOException {
         super(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            skipDuplicates = in.readBoolean();
-        }
+        skipDuplicates = in.readBoolean();
     }
 
     @Override
@@ -111,9 +108,7 @@ public final class CompletionSuggestion extends Suggest.Suggestion<CompletionSug
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            out.writeBoolean(skipDuplicates);
-        }
+        out.writeBoolean(skipDuplicates);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/suggest/completion/CompletionSuggestionBuilder.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/CompletionSuggestionBuilder.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.search.suggest.completion;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.bytes.BytesReference;
@@ -147,9 +146,7 @@ public class CompletionSuggestionBuilder extends SuggestionBuilder<CompletionSug
         fuzzyOptions = in.readOptionalWriteable(FuzzyOptions::new);
         regexOptions = in.readOptionalWriteable(RegexOptions::new);
         contextBytes = in.readOptionalBytesReference();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            skipDuplicates = in.readBoolean();
-        }
+        skipDuplicates = in.readBoolean();
     }
 
     @Override
@@ -157,9 +154,7 @@ public class CompletionSuggestionBuilder extends SuggestionBuilder<CompletionSug
         out.writeOptionalWriteable(fuzzyOptions);
         out.writeOptionalWriteable(regexOptions);
         out.writeOptionalBytesReference(contextBytes);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_1_0)) {
-            out.writeBoolean(skipDuplicates);
-        }
+        out.writeBoolean(skipDuplicates);
     }
 
     /**

--- a/server/src/test/java/org/opensearch/common/lucene/search/QueriesTests.java
+++ b/server/src/test/java/org/opensearch/common/lucene/search/QueriesTests.java
@@ -33,13 +33,11 @@
 package org.opensearch.common.lucene.search;
 
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.TermQuery;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.index.mapper.SeqNoFieldMapper;
 import org.opensearch.test.OpenSearchTestCase;
@@ -52,16 +50,7 @@ public class QueriesTests extends OpenSearchTestCase {
             // This is a custom query that extends AutomatonQuery and want to make sure the equals method works
             assertEquals(Queries.newNonNestedFilter(version), Queries.newNonNestedFilter(version));
             assertEquals(Queries.newNonNestedFilter(version).hashCode(), Queries.newNonNestedFilter(version).hashCode());
-            if (version.onOrAfter(LegacyESVersion.V_6_1_0)) {
-                assertEquals(Queries.newNonNestedFilter(version), new DocValuesFieldExistsQuery(SeqNoFieldMapper.PRIMARY_TERM_NAME));
-            } else {
-                assertEquals(
-                    Queries.newNonNestedFilter(version),
-                    new BooleanQuery.Builder().add(new MatchAllDocsQuery(), BooleanClause.Occur.FILTER)
-                        .add(Queries.newNestedFilter(), BooleanClause.Occur.MUST_NOT)
-                        .build()
-                );
-            }
+            assertEquals(Queries.newNonNestedFilter(version), new DocValuesFieldExistsQuery(SeqNoFieldMapper.PRIMARY_TERM_NAME));
         }
     }
 

--- a/server/src/test/java/org/opensearch/common/settings/SettingsTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/SettingsTests.java
@@ -634,7 +634,7 @@ public class SettingsTests extends OpenSearchTestCase {
 
     public void testReadWriteArray() throws IOException {
         BytesStreamOutput output = new BytesStreamOutput();
-        output.setVersion(randomFrom(Version.CURRENT, LegacyESVersion.V_6_1_0));
+        output.setVersion(randomFrom(Version.CURRENT, LegacyESVersion.V_7_0_0));
         Settings settings = Settings.builder().putList("foo.bar", "0", "1", "2", "3").put("foo.bar.baz", "baz").build();
         Settings.writeSettingsToStream(settings, output);
         StreamInput in = StreamInput.wrap(BytesReference.toBytes(output.bytes()));

--- a/server/src/test/java/org/opensearch/index/query/ExistsQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/ExistsQueryBuilderTests.java
@@ -40,7 +40,6 @@ import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.NormsFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
@@ -81,26 +80,7 @@ public class ExistsQueryBuilderTests extends AbstractQueryTestCase<ExistsQueryBu
             assertThat(query, instanceOf(MatchNoDocsQuery.class));
             return;
         }
-        if (context.getIndexSettings().getIndexVersionCreated().before(LegacyESVersion.V_6_1_0)) {
-            if (fields.size() == 1) {
-                assertThat(query, instanceOf(ConstantScoreQuery.class));
-                ConstantScoreQuery constantScoreQuery = (ConstantScoreQuery) query;
-                String field = expectedFieldName(fields.iterator().next());
-                assertThat(constantScoreQuery.getQuery(), instanceOf(TermQuery.class));
-                TermQuery termQuery = (TermQuery) constantScoreQuery.getQuery();
-                assertEquals(field, termQuery.getTerm().text());
-            } else {
-                assertThat(query, instanceOf(ConstantScoreQuery.class));
-                ConstantScoreQuery constantScoreQuery = (ConstantScoreQuery) query;
-                assertThat(constantScoreQuery.getQuery(), instanceOf(BooleanQuery.class));
-                BooleanQuery booleanQuery = (BooleanQuery) constantScoreQuery.getQuery();
-                assertThat(booleanQuery.clauses().size(), equalTo(mappedFields.size()));
-                for (int i = 0; i < mappedFields.size(); i++) {
-                    BooleanClause booleanClause = booleanQuery.clauses().get(i);
-                    assertThat(booleanClause.getOccur(), equalTo(BooleanClause.Occur.SHOULD));
-                }
-            }
-        } else if (fields.size() == 1) {
+        if (fields.size() == 1) {
             assertThat(query, instanceOf(ConstantScoreQuery.class));
             ConstantScoreQuery constantScoreQuery = (ConstantScoreQuery) query;
             String field = expectedFieldName(fields.iterator().next());

--- a/server/src/test/java/org/opensearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/QueryStringQueryBuilderTests.java
@@ -66,7 +66,6 @@ import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.Strings;
@@ -1039,8 +1038,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         QueryShardContext context = createShardContext();
         QueryStringQueryBuilder queryBuilder = new QueryStringQueryBuilder(TEXT_FIELD_NAME + ":*");
         Query query = queryBuilder.toQuery(context);
-        if (context.getIndexSettings().getIndexVersionCreated().onOrAfter(LegacyESVersion.V_6_1_0)
-            && (context.getMapperService().fieldType(TEXT_FIELD_NAME).getTextSearchInfo().hasNorms())) {
+        if ((context.getMapperService().fieldType(TEXT_FIELD_NAME).getTextSearchInfo().hasNorms())) {
             assertThat(query, equalTo(new ConstantScoreQuery(new NormsFieldExistsQuery(TEXT_FIELD_NAME))));
         } else {
             assertThat(query, equalTo(new ConstantScoreQuery(new TermQuery(new Term("_field_names", TEXT_FIELD_NAME)))));
@@ -1050,8 +1048,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             String value = (quoted ? "\"" : "") + TEXT_FIELD_NAME + (quoted ? "\"" : "");
             queryBuilder = new QueryStringQueryBuilder("_exists_:" + value);
             query = queryBuilder.toQuery(context);
-            if (context.getIndexSettings().getIndexVersionCreated().onOrAfter(LegacyESVersion.V_6_1_0)
-                && (context.getMapperService().fieldType(TEXT_FIELD_NAME).getTextSearchInfo().hasNorms())) {
+            if ((context.getMapperService().fieldType(TEXT_FIELD_NAME).getTextSearchInfo().hasNorms())) {
                 assertThat(query, equalTo(new ConstantScoreQuery(new NormsFieldExistsQuery(TEXT_FIELD_NAME))));
             } else {
                 assertThat(query, equalTo(new ConstantScoreQuery(new TermQuery(new Term("_field_names", TEXT_FIELD_NAME)))));

--- a/server/src/test/java/org/opensearch/index/query/RangeQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/RangeQueryBuilderTests.java
@@ -44,7 +44,6 @@ import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermRangeQuery;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.geo.ShapeRelation;
@@ -164,15 +163,13 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         String expectedFieldName = expectedFieldName(queryBuilder.fieldName());
         if (queryBuilder.from() == null && queryBuilder.to() == null) {
             final Query expectedQuery;
-            if (context.getIndexSettings().getIndexVersionCreated().onOrAfter(LegacyESVersion.V_6_1_0)
-                && context.getMapperService().fieldType(queryBuilder.fieldName()).hasDocValues()) {
+            if (context.getMapperService().fieldType(queryBuilder.fieldName()).hasDocValues()) {
                 expectedQuery = new ConstantScoreQuery(new DocValuesFieldExistsQuery(expectedFieldName));
-            } else if (context.getIndexSettings().getIndexVersionCreated().onOrAfter(LegacyESVersion.V_6_1_0)
-                && context.getMapperService().fieldType(queryBuilder.fieldName()).getTextSearchInfo().hasNorms()) {
-                    expectedQuery = new ConstantScoreQuery(new NormsFieldExistsQuery(expectedFieldName));
-                } else {
-                    expectedQuery = new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.NAME, expectedFieldName)));
-                }
+            } else if (context.getMapperService().fieldType(queryBuilder.fieldName()).getTextSearchInfo().hasNorms()) {
+                expectedQuery = new ConstantScoreQuery(new NormsFieldExistsQuery(expectedFieldName));
+            } else {
+                expectedQuery = new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.NAME, expectedFieldName)));
+            }
             assertThat(query, equalTo(expectedQuery));
         } else if (expectedFieldName.equals(DATE_FIELD_NAME) == false
             && expectedFieldName.equals(INT_FIELD_NAME) == false
@@ -472,8 +469,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         // Range query with open bounds rewrite to an exists query
         Query luceneQuery = rewrittenRange.toQuery(queryShardContext);
         final Query expectedQuery;
-        if (queryShardContext.getIndexSettings().getIndexVersionCreated().onOrAfter(LegacyESVersion.V_6_1_0)
-            && queryShardContext.fieldMapper(query.fieldName()).hasDocValues()) {
+        if (queryShardContext.fieldMapper(query.fieldName()).hasDocValues()) {
             expectedQuery = new ConstantScoreQuery(new DocValuesFieldExistsQuery(query.fieldName()));
         } else {
             expectedQuery = new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.NAME, query.fieldName())));

--- a/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/SkipSectionTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/SkipSectionTests.java
@@ -87,12 +87,16 @@ public class SkipSectionTests extends AbstractClientYamlTestFragmentParserTestCa
     }
 
     public void testParseSkipSectionVersionNoFeature() throws Exception {
-        parser = createParser(YamlXContent.yamlXContent, "version:     \" - 6.1.1\"\n" + "reason:      Delete ignores the parent param");
+        Version version = VersionUtils.randomVersion(random());
+        parser = createParser(
+            YamlXContent.yamlXContent,
+            "version:     \" - " + version + "\"\n" + "reason:      Delete ignores the parent param"
+        );
 
         SkipSection skipSection = SkipSection.parse(parser);
         assertThat(skipSection, notNullValue());
         assertThat(skipSection.getLowerVersion(), equalTo(VersionUtils.getFirstVersion()));
-        assertThat(skipSection.getUpperVersion(), equalTo(LegacyESVersion.V_6_1_1));
+        assertThat(skipSection.getUpperVersion(), equalTo(version));
         assertThat(skipSection.getFeatures().size(), equalTo(0));
         assertThat(skipSection.getReason(), equalTo("Delete ignores the parent param"));
     }


### PR DESCRIPTION
This PR removes `LegacyESVersion.V_6_1_x` constants including all
pre-release versions and bug fixes.

closes #1679 