### PR TITLE
Remove LegacyESVersion.V_6_2_x constants

### DIFF
--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/CommonAnalysisPlugin.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/CommonAnalysisPlugin.java
@@ -498,12 +498,6 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin, Scri
                     "[delimited_payload_filter] is not supported for new indices, use [delimited_payload] instead"
                 );
             }
-            if (version.onOrAfter(LegacyESVersion.V_6_2_0)) {
-                deprecationLogger.deprecate(
-                    "analysis_delimited_payload_filter",
-                    "Deprecated [delimited_payload_filter] used, replaced by [delimited_payload]"
-                );
-            }
             return new DelimitedPayloadTokenFilter(
                 input,
                 DelimitedPayloadTokenFilterFactory.DEFAULT_DELIMITER,

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/LegacyDelimitedPayloadTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/LegacyDelimitedPayloadTokenFilterFactory.java
@@ -33,26 +33,17 @@
 package org.opensearch.analysis.common;
 
 import org.opensearch.LegacyESVersion;
-import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
 import org.opensearch.index.IndexSettings;
 
 public class LegacyDelimitedPayloadTokenFilterFactory extends DelimitedPayloadTokenFilterFactory {
 
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(LegacyDelimitedPayloadTokenFilterFactory.class);
-
     LegacyDelimitedPayloadTokenFilterFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
         super(indexSettings, env, name, settings);
         if (indexSettings.getIndexVersionCreated().onOrAfter(LegacyESVersion.V_7_0_0)) {
             throw new IllegalArgumentException(
                 "[delimited_payload_filter] is not supported for new indices, use [delimited_payload] instead"
-            );
-        }
-        if (indexSettings.getIndexVersionCreated().onOrAfter(LegacyESVersion.V_6_2_0)) {
-            deprecationLogger.deprecate(
-                "analysis_legacy_delimited_payload_filter",
-                "Deprecated [delimited_payload_filter] used, replaced by [delimited_payload]"
             );
         }
     }

--- a/server/src/main/java/org/opensearch/LegacyESVersion.java
+++ b/server/src/main/java/org/opensearch/LegacyESVersion.java
@@ -48,11 +48,6 @@ public class LegacyESVersion extends Version {
 
     // The below version is missing from the 7.3 JAR
     private static final org.apache.lucene.util.Version LUCENE_7_2_1 = org.apache.lucene.util.Version.fromBits(7, 2, 1);
-    public static final LegacyESVersion V_6_2_0 = new LegacyESVersion(6020099, LUCENE_7_2_1);
-    public static final LegacyESVersion V_6_2_1 = new LegacyESVersion(6020199, LUCENE_7_2_1);
-    public static final LegacyESVersion V_6_2_2 = new LegacyESVersion(6020299, LUCENE_7_2_1);
-    public static final LegacyESVersion V_6_2_3 = new LegacyESVersion(6020399, LUCENE_7_2_1);
-    public static final LegacyESVersion V_6_2_4 = new LegacyESVersion(6020499, LUCENE_7_2_1);
     public static final LegacyESVersion V_6_3_0 = new LegacyESVersion(6030099, org.apache.lucene.util.Version.LUCENE_7_3_1);
     public static final LegacyESVersion V_6_3_1 = new LegacyESVersion(6030199, org.apache.lucene.util.Version.LUCENE_7_3_1);
     public static final LegacyESVersion V_6_3_2 = new LegacyESVersion(6030299, org.apache.lucene.util.Version.LUCENE_7_3_1);

--- a/server/src/main/java/org/opensearch/OpenSearchException.java
+++ b/server/src/main/java/org/opensearch/OpenSearchException.java
@@ -1525,7 +1525,7 @@ public class OpenSearchException extends RuntimeException implements ToXContentF
             MultiBucketConsumerService.TooManyBucketsException.class,
             MultiBucketConsumerService.TooManyBucketsException::new,
             149,
-            LegacyESVersion.V_6_2_0
+            UNKNOWN_VERSION_ADDED
         ),
         COORDINATION_STATE_REJECTED_EXCEPTION(
             org.opensearch.cluster.coordination.CoordinationStateRejectedException.class,

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -84,9 +84,7 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
         if (in.readBoolean()) {
             waitForEvents = Priority.readFrom(in);
         }
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_2_0)) {
-            waitForNoInitializingShards = in.readBoolean();
-        }
+        waitForNoInitializingShards = in.readBoolean();
         if (in.getVersion().onOrAfter(LegacyESVersion.V_7_2_0)) {
             indicesOptions = IndicesOptions.readIndicesOptions(in);
         } else {
@@ -118,9 +116,7 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
             out.writeBoolean(true);
             Priority.writeTo(waitForEvents, out);
         }
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_2_0)) {
-            out.writeBoolean(waitForNoInitializingShards);
-        }
+        out.writeBoolean(waitForNoInitializingShards);
         if (out.getVersion().onOrAfter(LegacyESVersion.V_7_2_0)) {
             indicesOptions.writeIndicesOptions(out);
         }

--- a/server/src/main/java/org/opensearch/action/fieldcaps/FieldCapabilitiesIndexRequest.java
+++ b/server/src/main/java/org/opensearch/action/fieldcaps/FieldCapabilitiesIndexRequest.java
@@ -64,11 +64,7 @@ public class FieldCapabilitiesIndexRequest extends ActionRequest implements Indi
         shardId = in.readOptionalWriteable(ShardId::new);
         index = in.readOptionalString();
         fields = in.readStringArray();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_2_0)) {
-            originalIndices = OriginalIndices.readOriginalIndices(in);
-        } else {
-            originalIndices = OriginalIndices.NONE;
-        }
+        originalIndices = OriginalIndices.readOriginalIndices(in);
         indexFilter = in.getVersion().onOrAfter(LegacyESVersion.V_7_9_0) ? in.readOptionalNamedWriteable(QueryBuilder.class) : null;
         nowInMillis = in.getVersion().onOrAfter(LegacyESVersion.V_7_9_0) ? in.readLong() : 0L;
     }
@@ -131,9 +127,7 @@ public class FieldCapabilitiesIndexRequest extends ActionRequest implements Indi
         out.writeOptionalWriteable(shardId);
         out.writeOptionalString(index);
         out.writeStringArray(fields);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_2_0)) {
-            OriginalIndices.writeOriginalIndices(originalIndices, out);
-        }
+        OriginalIndices.writeOriginalIndices(originalIndices, out);
         if (out.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
             out.writeOptionalNamedWriteable(indexFilter);
             out.writeLong(nowInMillis);

--- a/server/src/main/java/org/opensearch/common/unit/ByteSizeValue.java
+++ b/server/src/main/java/org/opensearch/common/unit/ByteSizeValue.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.common.unit;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
@@ -65,23 +64,14 @@ public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue>, ToXC
     private final ByteSizeUnit unit;
 
     public ByteSizeValue(StreamInput in) throws IOException {
-        if (in.getVersion().before(LegacyESVersion.V_6_2_0)) {
-            size = in.readVLong();
-            unit = ByteSizeUnit.BYTES;
-        } else {
-            size = in.readZLong();
-            unit = ByteSizeUnit.readFrom(in);
-        }
+        size = in.readZLong();
+        unit = ByteSizeUnit.readFrom(in);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().before(LegacyESVersion.V_6_2_0)) {
-            out.writeVLong(getBytes());
-        } else {
-            out.writeZLong(size);
-            unit.writeTo(out);
-        }
+        out.writeZLong(size);
+        unit.writeTo(out);
     }
 
     public ByteSizeValue(long bytes) {

--- a/server/src/main/java/org/opensearch/indices/flush/SyncedFlushService.java
+++ b/server/src/main/java/org/opensearch/indices/flush/SyncedFlushService.java
@@ -699,11 +699,7 @@ public class SyncedFlushService implements IndexEventListener {
         PreSyncedFlushResponse(StreamInput in) throws IOException {
             super(in);
             commitId = new Engine.CommitId(in);
-            if (includeNumDocs(in.getVersion())) {
-                numDocs = in.readInt();
-            } else {
-                numDocs = UNKNOWN_NUM_DOCS;
-            }
+            numDocs = in.readInt();
             if (includeExistingSyncId(in.getVersion())) {
                 existingSyncId = in.readOptionalString();
             }
@@ -715,10 +711,6 @@ public class SyncedFlushService implements IndexEventListener {
             this.existingSyncId = existingSyncId;
         }
 
-        boolean includeNumDocs(Version version) {
-            return version.onOrAfter(LegacyESVersion.V_6_2_2);
-        }
-
         boolean includeExistingSyncId(Version version) {
             return version.onOrAfter(LegacyESVersion.V_6_3_0);
         }
@@ -726,12 +718,7 @@ public class SyncedFlushService implements IndexEventListener {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             commitId.writeTo(out);
-            if (includeNumDocs(out.getVersion())) {
-                out.writeInt(numDocs);
-            }
-            if (includeExistingSyncId(out.getVersion())) {
-                out.writeOptionalString(existingSyncId);
-            }
+            out.writeInt(numDocs);
         }
     }
 

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoveryPrepareForTranslogOperationsRequest.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoveryPrepareForTranslogOperationsRequest.java
@@ -57,7 +57,7 @@ class RecoveryPrepareForTranslogOperationsRequest extends RecoveryTransportReque
         recoveryId = in.readLong();
         shardId = new ShardId(in);
         totalTranslogOps = in.readVInt();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_2_0) && in.getVersion().before(LegacyESVersion.V_7_4_0)) {
+        if (in.getVersion().before(LegacyESVersion.V_7_4_0)) {
             in.readBoolean(); // was fileBasedRecovery
         }
     }
@@ -80,7 +80,7 @@ class RecoveryPrepareForTranslogOperationsRequest extends RecoveryTransportReque
         out.writeLong(recoveryId);
         shardId.writeTo(out);
         out.writeVInt(totalTranslogOps);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_2_0) && out.getVersion().before(LegacyESVersion.V_7_4_0)) {
+        if (out.getVersion().before(LegacyESVersion.V_7_4_0)) {
             out.writeBoolean(true); // was fileBasedRecovery
         }
     }

--- a/server/src/main/java/org/opensearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginInfo.java
@@ -168,11 +168,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
         } else {
             customFolderName = this.name;
         }
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_2_0)) {
-            extendedPlugins = in.readStringList();
-        } else {
-            extendedPlugins = Collections.emptyList();
-        }
+        extendedPlugins = in.readStringList();
         hasNativeController = in.readBoolean();
         if (in.getVersion().onOrAfter(LegacyESVersion.fromId(6000027)) && in.getVersion().before(LegacyESVersion.V_6_3_0)) {
             /*
@@ -200,11 +196,9 @@ public class PluginInfo implements Writeable, ToXContentObject {
                 out.writeString(name);
             }
         }
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_2_0)) {
-            out.writeStringCollection(extendedPlugins);
-        }
+        out.writeStringCollection(extendedPlugins);
         out.writeBoolean(hasNativeController);
-        if (out.getVersion().onOrAfter(LegacyESVersion.fromId(6000027)) && out.getVersion().before(LegacyESVersion.V_6_3_0)) {
+        if (out.getVersion().before(LegacyESVersion.V_6_3_0)) {
             /*
              * Elasticsearch versions in [6.0.0-beta2, 6.3.0) allowed plugins to specify that they require the keystore and this was
              * serialized into the plugin info. Therefore, we have to write out a value for this boolean.

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java
@@ -98,8 +98,6 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
     private static final String INCLUDE_GLOBAL_STATE = "include_global_state";
     private static final String USER_METADATA = "metadata";
 
-    private static final Version INCLUDE_GLOBAL_STATE_INTRODUCED = LegacyESVersion.V_6_2_0;
-
     private static final Comparator<SnapshotInfo> COMPARATOR = Comparator.comparing(SnapshotInfo::startTime)
         .thenComparing(SnapshotInfo::snapshotId);
 
@@ -395,9 +393,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         successfulShards = in.readVInt();
         shardFailures = Collections.unmodifiableList(in.readList(SnapshotShardFailure::new));
         version = in.readBoolean() ? Version.readVersion(in) : null;
-        if (in.getVersion().onOrAfter(INCLUDE_GLOBAL_STATE_INTRODUCED)) {
-            includeGlobalState = in.readOptionalBoolean();
-        }
+        includeGlobalState = in.readOptionalBoolean();
         if (in.getVersion().onOrAfter(METADATA_FIELD_INTRODUCED)) {
             userMetadata = in.readMap();
         } else {
@@ -836,9 +832,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         } else {
             out.writeBoolean(false);
         }
-        if (out.getVersion().onOrAfter(INCLUDE_GLOBAL_STATE_INTRODUCED)) {
-            out.writeOptionalBoolean(includeGlobalState);
-        }
+        out.writeOptionalBoolean(includeGlobalState);
         if (out.getVersion().onOrAfter(METADATA_FIELD_INTRODUCED)) {
             out.writeMap(userMetadata);
             if (out.getVersion().onOrAfter(DATA_STREAMS_IN_SNAPSHOT)) {

--- a/server/src/main/java/org/opensearch/tasks/TaskInfo.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskInfo.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.tasks;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.Strings;
 import org.opensearch.common.bytes.BytesReference;
@@ -121,11 +120,7 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
         runningTimeNanos = in.readLong();
         cancellable = in.readBoolean();
         parentTaskId = TaskId.readFromStream(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_2_0)) {
-            headers = in.readMap(StreamInput::readString, StreamInput::readString);
-        } else {
-            headers = Collections.emptyMap();
-        }
+        headers = in.readMap(StreamInput::readString, StreamInput::readString);
     }
 
     @Override
@@ -139,9 +134,7 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
         out.writeLong(runningTimeNanos);
         out.writeBoolean(cancellable);
         parentTaskId.writeTo(out);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_2_0)) {
-            out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
-        }
+        out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
     }
 
     public TaskId getTaskId() {

--- a/server/src/test/java/org/opensearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/opensearch/ExceptionSerializationTests.java
@@ -393,7 +393,7 @@ public class ExceptionSerializationTests extends OpenSearchTestCase {
     }
 
     public void testTooManyBucketsException() throws IOException {
-        Version version = VersionUtils.randomVersionBetween(random(), LegacyESVersion.V_6_2_0, Version.CURRENT);
+        Version version = VersionUtils.randomCompatibleVersion(random(), Version.CURRENT);
         MultiBucketConsumerService.TooManyBucketsException ex = serialize(
             new MultiBucketConsumerService.TooManyBucketsException("Too many buckets", 100),
             version

--- a/server/src/test/java/org/opensearch/common/lucene/uid/VersionsTests.java
+++ b/server/src/test/java/org/opensearch/common/lucene/uid/VersionsTests.java
@@ -227,7 +227,7 @@ public class VersionsTests extends OpenSearchTestCase {
 
         // between two known versions, should use the lucene version of the previous version
         version = LegacyESVersion.fromString("6.2.50");
-        assertEquals(VersionUtils.getPreviousVersion(LegacyESVersion.V_6_2_4).luceneVersion, version.luceneVersion);
+        assertEquals(VersionUtils.getPreviousVersion(LegacyESVersion.fromString("6.2.4")).luceneVersion, version.luceneVersion);
 
         // too old version, major should be the oldest supported lucene version minus 1
         version = LegacyESVersion.fromString("5.2.1");

--- a/server/src/test/java/org/opensearch/search/slice/SliceBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/slice/SliceBuilderTests.java
@@ -64,7 +64,6 @@ import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.fielddata.IndexNumericFieldData;
-import org.opensearch.index.mapper.IdFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.TextSearchInfo;
@@ -74,6 +73,7 @@ import org.opensearch.index.shard.ShardId;
 import org.opensearch.search.internal.ShardSearchRequest;
 import org.opensearch.search.lookup.SearchLookup;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.VersionUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -376,27 +376,6 @@ public class SliceBuilderTests extends OpenSearchTestCase {
         }
     }
 
-    public void testSerializationBackcompat() throws IOException {
-        SliceBuilder sliceBuilder = new SliceBuilder(1, 5);
-        assertEquals(IdFieldMapper.NAME, sliceBuilder.getField());
-
-        SliceBuilder copy62 = copyWriteable(
-            sliceBuilder,
-            new NamedWriteableRegistry(Collections.emptyList()),
-            SliceBuilder::new,
-            LegacyESVersion.V_6_2_0
-        );
-        assertEquals(sliceBuilder, copy62);
-
-        SliceBuilder copy63 = copyWriteable(
-            copy62,
-            new NamedWriteableRegistry(Collections.emptyList()),
-            SliceBuilder::new,
-            LegacyESVersion.V_6_3_0
-        );
-        assertEquals(sliceBuilder, copy63);
-    }
-
     public void testToFilterWithRouting() throws IOException {
         Directory dir = new ByteBuffersDirectory();
         try (IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())))) {
@@ -414,15 +393,13 @@ public class SliceBuilderTests extends OpenSearchTestCase {
         when(clusterService.operationRouting()).thenReturn(routing);
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
         try (IndexReader reader = DirectoryReader.open(dir)) {
-            QueryShardContext context = createShardContext(Version.CURRENT, reader, "field", DocValuesType.SORTED, 5, 0);
-            SliceBuilder builder = new SliceBuilder("field", 6, 10);
+            Version version = VersionUtils.randomCompatibleVersion(random(), Version.CURRENT);
+            QueryShardContext context = createShardContext(version, reader, "field", DocValuesType.SORTED, 5, 0);            SliceBuilder builder = new SliceBuilder("field", 6, 10);
             String[] routings = new String[] { "foo" };
-            Query query = builder.toFilter(clusterService, createRequest(1, routings, null), context, Version.CURRENT);
+            Query query = builder.toFilter(clusterService, createRequest(1, routings, null), context, version);
             assertEquals(new DocValuesSliceQuery("field", 6, 10), query);
-            query = builder.toFilter(clusterService, createRequest(1, Strings.EMPTY_ARRAY, "foo"), context, Version.CURRENT);
+            query = builder.toFilter(clusterService, createRequest(1, Strings.EMPTY_ARRAY, "foo"), context, version);
             assertEquals(new DocValuesSliceQuery("field", 6, 10), query);
-            query = builder.toFilter(clusterService, createRequest(1, Strings.EMPTY_ARRAY, "foo"), context, LegacyESVersion.V_6_2_0);
-            assertEquals(new DocValuesSliceQuery("field", 1, 2), query);
         }
     }
 }

--- a/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
@@ -333,10 +333,7 @@ public abstract class OpenSearchRestTestCase extends OpenSearchTestCase {
     @After
     public final void cleanUpCluster() throws Exception {
         if (preserveClusterUponCompletion() == false) {
-            if (nodeVersions.stream().noneMatch(version -> version.before(LegacyESVersion.V_6_2_0))) {
-                // wait_for_no_initializing_shards added in 6.2
-                ensureNoInitializingShards();
-            }
+            ensureNoInitializingShards();
             wipeCluster();
             waitForClusterStateUpdatesToFinish();
             logIfThereAreRunningTasks();

--- a/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/ClientYamlTestSectionTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/ClientYamlTestSectionTests.java
@@ -131,7 +131,7 @@ public class ClientYamlTestSectionTests extends AbstractClientYamlTestFragmentPa
         assertThat(testSection.getName(), equalTo("First test section"));
         assertThat(testSection.getSkipSection(), notNullValue());
         assertThat(testSection.getSkipSection().getLowerVersion(), equalTo(LegacyESVersion.fromString("6.0.0")));
-        assertThat(testSection.getSkipSection().getUpperVersion(), equalTo(LegacyESVersion.V_6_2_0));
+        assertThat(testSection.getSkipSection().getUpperVersion(), equalTo(LegacyESVersion.fromString("6.2.0");
         assertThat(testSection.getSkipSection().getReason(), equalTo("Update doesn't return metadata fields, waiting for #3259"));
         assertThat(testSection.getExecutableSections().size(), equalTo(2));
         DoSection doSection = (DoSection) testSection.getExecutableSections().get(0);


### PR DESCRIPTION
This PR removes LegacyESVersion.V_6_2_x constants including all
pre-release versions and bug fixes.

closes #1680 