### PR TITLE
Remove LegacyESVersion.V_6_3_x constants

### DIFF
--- a/server/src/main/java/org/opensearch/Build.java
+++ b/server/src/main/java/org/opensearch/Build.java
@@ -215,15 +215,11 @@ public class Build {
         // (Integ test zip still write OSS as distribution)
         // See issue: https://github.com/opendistro-for-elasticsearch/search/issues/159
         // todo change to V_1_3_0 after backporting
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_3_0) && in.getVersion().before(Version.V_2_0_0)) {
+        if (in.getVersion().before(Version.V_2_0_0)) {
             String flavor = in.readString();
         }
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-            // be lenient when reading on the wire, the enumeration values from other versions might be different than what we know
-            type = Type.fromDisplayName(in.readString(), false);
-        } else {
-            type = Type.UNKNOWN;
-        }
+        // be lenient when reading on the wire, the enumeration values from other versions might be different than what we know
+        type = Type.fromDisplayName(in.readString(), false);
         String hash = in.readString();
         String date = in.readString();
         boolean snapshot = in.readBoolean();
@@ -247,18 +243,16 @@ public class Build {
         // TODO - clean up this code when we remove all v6 bwc tests.
         // TODO - clean this up when OSS flavor is removed in all of the code base
         // todo change to V_1_3_0 after backporting
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0) && out.getVersion().before(Version.V_2_0_0)) {
+        if (out.getVersion().before(Version.V_2_0_0)) {
             out.writeString("oss");
         }
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-            final Type buildType;
-            if (out.getVersion().before(LegacyESVersion.V_6_7_0) && build.type() == Type.DOCKER) {
-                buildType = Type.TAR;
-            } else {
-                buildType = build.type();
-            }
-            out.writeString(buildType.displayName());
+        final Type buildType;
+        if (out.getVersion().before(LegacyESVersion.V_6_7_0) && build.type() == Type.DOCKER) {
+            buildType = Type.TAR;
+        } else {
+            buildType = build.type();
         }
+        out.writeString(buildType.displayName());
         out.writeString(build.hash());
         out.writeString(build.date());
         out.writeBoolean(build.isSnapshot());

--- a/server/src/main/java/org/opensearch/LegacyESVersion.java
+++ b/server/src/main/java/org/opensearch/LegacyESVersion.java
@@ -46,9 +46,6 @@ import java.lang.reflect.Field;
  */
 public class LegacyESVersion extends Version {
 
-    public static final LegacyESVersion V_6_3_0 = new LegacyESVersion(6030099, org.apache.lucene.util.Version.LUCENE_7_3_1);
-    public static final LegacyESVersion V_6_3_1 = new LegacyESVersion(6030199, org.apache.lucene.util.Version.LUCENE_7_3_1);
-    public static final LegacyESVersion V_6_3_2 = new LegacyESVersion(6030299, org.apache.lucene.util.Version.LUCENE_7_3_1);
     public static final LegacyESVersion V_6_4_0 = new LegacyESVersion(6040099, org.apache.lucene.util.Version.LUCENE_7_4_0);
     public static final LegacyESVersion V_6_4_1 = new LegacyESVersion(6040199, org.apache.lucene.util.Version.LUCENE_7_4_0);
     public static final LegacyESVersion V_6_4_2 = new LegacyESVersion(6040299, org.apache.lucene.util.Version.LUCENE_7_4_0);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/reroute/ClusterRerouteResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/reroute/ClusterRerouteResponse.java
@@ -34,7 +34,6 @@ package org.opensearch.action.admin.cluster.reroute;
 
 import org.opensearch.LegacyESVersion;
 import org.opensearch.action.support.master.AcknowledgedResponse;
-import org.opensearch.cluster.ClusterModule;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.routing.allocation.RoutingExplanations;
 import org.opensearch.common.io.stream.StreamInput;
@@ -89,11 +88,7 @@ public class ClusterRerouteResponse extends AcknowledgedResponse implements ToXC
             state.writeTo(out);
             RoutingExplanations.writeTo(explanations, out);
         } else {
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-                state.writeTo(out);
-            } else {
-                ClusterModule.filterCustomsForPre63Clients(state).writeTo(out);
-            }
+            state.writeTo(out);
             out.writeBoolean(acknowledged);
             RoutingExplanations.writeTo(explanations, out);
         }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/ClusterStateResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/ClusterStateResponse.java
@@ -34,7 +34,6 @@ package org.opensearch.action.admin.cluster.state;
 
 import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionResponse;
-import org.opensearch.cluster.ClusterModule;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.node.DiscoveryNodes;
@@ -105,11 +104,7 @@ public class ClusterStateResponse extends ActionResponse {
         if (out.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
             out.writeOptionalWriteable(clusterState);
         } else {
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-                clusterState.writeTo(out);
-            } else {
-                ClusterModule.filterCustomsForPre63Clients(clusterState).writeTo(out);
-            }
+            clusterState.writeTo(out);
         }
         if (out.getVersion().before(LegacyESVersion.V_7_0_0)) {
             ByteSizeValue.ZERO.writeTo(out);

--- a/server/src/main/java/org/opensearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequest.java
@@ -235,9 +235,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         } else {
             preFilterShardSize = in.readVInt();
         }
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-            allowPartialSearchResults = in.readOptionalBoolean();
-        }
+        allowPartialSearchResults = in.readOptionalBoolean();
         if (in.getVersion().onOrAfter(LegacyESVersion.V_6_7_0)) {
             localClusterAlias = in.readOptionalString();
             if (localClusterAlias != null) {
@@ -280,9 +278,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         } else {
             out.writeVInt(preFilterShardSize == null ? DEFAULT_BATCHED_REDUCE_SIZE : preFilterShardSize);
         }
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-            out.writeOptionalBoolean(allowPartialSearchResults);
-        }
+        out.writeOptionalBoolean(allowPartialSearchResults);
         if (out.getVersion().onOrAfter(LegacyESVersion.V_6_7_0)) {
             out.writeOptionalString(localClusterAlias);
             if (localClusterAlias != null) {

--- a/server/src/main/java/org/opensearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/opensearch/cluster/action/shard/ShardStateAction.java
@@ -566,11 +566,7 @@ public class ShardStateAction {
             primaryTerm = in.readVLong();
             message = in.readString();
             failure = in.readException();
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-                markAsStale = in.readBoolean();
-            } else {
-                markAsStale = true;
-            }
+            markAsStale = in.readBoolean();
         }
 
         public FailedShardEntry(
@@ -605,9 +601,7 @@ public class ShardStateAction {
             out.writeVLong(primaryTerm);
             out.writeString(message);
             out.writeException(failure);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-                out.writeBoolean(markAsStale);
-            }
+            out.writeBoolean(markAsStale);
         }
 
         @Override
@@ -825,19 +819,12 @@ public class ShardStateAction {
             super(in);
             shardId = new ShardId(in);
             allocationId = in.readString();
-            if (in.getVersion().before(LegacyESVersion.V_6_3_0)) {
-                primaryTerm = in.readVLong();
-                assert primaryTerm == UNASSIGNED_PRIMARY_TERM : "shard is only started by itself: primary term [" + primaryTerm + "]";
-            } else if (in.getVersion().onOrAfter(LegacyESVersion.V_6_7_0)) {
+            if (in.getVersion().onOrAfter(LegacyESVersion.V_6_7_0)) {
                 primaryTerm = in.readVLong();
             } else {
                 primaryTerm = UNASSIGNED_PRIMARY_TERM;
             }
             this.message = in.readString();
-            if (in.getVersion().before(LegacyESVersion.V_6_3_0)) {
-                final Exception ex = in.readException();
-                assert ex == null : "started shard must not have failure [" + ex + "]";
-            }
         }
 
         public StartedShardEntry(final ShardId shardId, final String allocationId, final long primaryTerm, final String message) {
@@ -852,15 +839,10 @@ public class ShardStateAction {
             super.writeTo(out);
             shardId.writeTo(out);
             out.writeString(allocationId);
-            if (out.getVersion().before(LegacyESVersion.V_6_3_0)) {
-                out.writeVLong(0L);
-            } else if (out.getVersion().onOrAfter(LegacyESVersion.V_6_7_0)) {
+            if (out.getVersion().onOrAfter(LegacyESVersion.V_6_7_0)) {
                 out.writeVLong(primaryTerm);
             }
             out.writeString(message);
-            if (out.getVersion().before(LegacyESVersion.V_6_3_0)) {
-                out.writeException(null);
-            }
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/index/flush/FlushStats.java
+++ b/server/src/main/java/org/opensearch/index/flush/FlushStats.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.index.flush;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -55,9 +54,7 @@ public class FlushStats implements Writeable, ToXContentFragment {
     public FlushStats(StreamInput in) throws IOException {
         total = in.readVLong();
         totalTimeInMillis = in.readVLong();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-            periodic = in.readVLong();
-        }
+        periodic = in.readVLong();
     }
 
     public FlushStats(long total, long periodic, long totalTimeInMillis) {
@@ -135,8 +132,6 @@ public class FlushStats implements Writeable, ToXContentFragment {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(total);
         out.writeVLong(totalTimeInMillis);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-            out.writeVLong(periodic);
-        }
+        out.writeVLong(periodic);
     }
 }

--- a/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
@@ -693,16 +693,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
             this.localCheckpoint = in.readZLong();
             this.globalCheckpoint = in.readZLong();
             this.inSync = in.readBoolean();
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-                this.tracked = in.readBoolean();
-            } else {
-                // Every in-sync shard copy is also tracked (see invariant). This was the case even in earlier OpenSearch versions.
-                // Non in-sync shard copies might be tracked or not. As this information here is only serialized during relocation hand-off,
-                // after which replica recoveries cannot complete anymore (i.e. they cannot move from in-sync == false to in-sync == true),
-                // we can treat non in-sync replica shard copies as untracked. They will go through a fresh recovery against the new
-                // primary and will become tracked again under this primary before they are marked as in-sync.
-                this.tracked = inSync;
-            }
+            this.tracked = in.readBoolean();
         }
 
         @Override
@@ -710,9 +701,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
             out.writeZLong(localCheckpoint);
             out.writeZLong(globalCheckpoint);
             out.writeBoolean(inSync);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-                out.writeBoolean(tracked);
-            }
+            out.writeBoolean(tracked);
         }
 
         /**

--- a/server/src/main/java/org/opensearch/index/translog/TranslogStats.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogStats.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.index.translog;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -57,9 +56,7 @@ public class TranslogStats implements Writeable, ToXContentFragment {
         translogSizeInBytes = in.readVLong();
         uncommittedOperations = in.readVInt();
         uncommittedSizeInBytes = in.readVLong();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-            earliestLastModifiedAge = in.readVLong();
-        }
+        earliestLastModifiedAge = in.readVLong();
     }
 
     public TranslogStats(
@@ -152,8 +149,6 @@ public class TranslogStats implements Writeable, ToXContentFragment {
         out.writeVLong(translogSizeInBytes);
         out.writeVInt(uncommittedOperations);
         out.writeVLong(uncommittedSizeInBytes);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-            out.writeVLong(earliestLastModifiedAge);
-        }
+        out.writeVLong(earliestLastModifiedAge);
     }
 }

--- a/server/src/main/java/org/opensearch/indices/flush/SyncedFlushService.java
+++ b/server/src/main/java/org/opensearch/indices/flush/SyncedFlushService.java
@@ -36,7 +36,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchException;
-import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.StepListener;
 import org.opensearch.action.admin.indices.flush.FlushRequest;
@@ -700,9 +699,7 @@ public class SyncedFlushService implements IndexEventListener {
             super(in);
             commitId = new Engine.CommitId(in);
             numDocs = in.readInt();
-            if (includeExistingSyncId(in.getVersion())) {
-                existingSyncId = in.readOptionalString();
-            }
+            existingSyncId = in.readOptionalString();
         }
 
         PreSyncedFlushResponse(Engine.CommitId commitId, int numDocs, String existingSyncId) {
@@ -711,17 +708,11 @@ public class SyncedFlushService implements IndexEventListener {
             this.existingSyncId = existingSyncId;
         }
 
-        boolean includeExistingSyncId(Version version) {
-            return version.onOrAfter(LegacyESVersion.V_6_3_0);
-        }
-
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             commitId.writeTo(out);
             out.writeInt(numDocs);
-            if (includeExistingSyncId(out.getVersion())) {
-                out.writeOptionalString(existingSyncId);
-            }
+            out.writeOptionalString(existingSyncId);
         }
     }
 

--- a/server/src/main/java/org/opensearch/persistent/PersistentTasksCustomMetadata.java
+++ b/server/src/main/java/org/opensearch/persistent/PersistentTasksCustomMetadata.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.persistent;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.ResourceNotFoundException;
 import org.opensearch.Version;
@@ -382,11 +381,7 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
             id = in.readString();
             allocationId = in.readLong();
             taskName = in.readString();
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-                params = (P) in.readNamedWriteable(PersistentTaskParams.class);
-            } else {
-                params = (P) in.readOptionalNamedWriteable(PersistentTaskParams.class);
-            }
+            params = (P) in.readNamedWriteable(PersistentTaskParams.class);
             state = in.readOptionalNamedWriteable(PersistentTaskState.class);
             assignment = new Assignment(in.readOptionalString(), in.readString());
             allocationIdOnLastStatusUpdate = in.readOptionalLong();
@@ -397,11 +392,7 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
             out.writeString(id);
             out.writeLong(allocationId);
             out.writeString(taskName);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-                out.writeNamedWriteable(params);
-            } else {
-                out.writeOptionalNamedWriteable(params);
-            }
+            out.writeNamedWriteable(params);
             out.writeOptionalNamedWriteable(state);
             out.writeOptionalString(assignment.executorNode);
             out.writeString(assignment.explanation);

--- a/server/src/main/java/org/opensearch/persistent/StartPersistentTaskAction.java
+++ b/server/src/main/java/org/opensearch/persistent/StartPersistentTaskAction.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.persistent;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.ActionType;
@@ -83,11 +82,7 @@ public class StartPersistentTaskAction extends ActionType<PersistentTaskResponse
             super(in);
             taskId = in.readString();
             taskName = in.readString();
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-                params = in.readNamedWriteable(PersistentTaskParams.class);
-            } else {
-                params = in.readOptionalNamedWriteable(PersistentTaskParams.class);
-            }
+            params = in.readNamedWriteable(PersistentTaskParams.class);
         }
 
         public Request(String taskId, String taskName, PersistentTaskParams params) {
@@ -101,11 +96,7 @@ public class StartPersistentTaskAction extends ActionType<PersistentTaskResponse
             super.writeTo(out);
             out.writeString(taskId);
             out.writeString(taskName);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-                out.writeNamedWriteable(params);
-            } else {
-                out.writeOptionalNamedWriteable(params);
-            }
+            out.writeNamedWriteable(params);
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -117,6 +117,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         if (afterKey != null) {
             afterKey.writeTo(out);
         }
+
         if (out.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
             out.writeBoolean(earlyTerminated);
         }

--- a/server/src/main/java/org/opensearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/opensearch/search/internal/ShardSearchRequest.java
@@ -252,8 +252,6 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
         clusterAlias = in.readOptionalString();
         if (in.getVersion().onOrAfter(LegacyESVersion.V_7_0_0)) {
             allowPartialSearchResults = in.readBoolean();
-        } else if (in.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-            allowPartialSearchResults = in.readOptionalBoolean();
         } else {
             allowPartialSearchResults = false;
         }
@@ -335,8 +333,6 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
         out.writeOptionalString(clusterAlias);
         if (out.getVersion().onOrAfter(LegacyESVersion.V_7_0_0)) {
             out.writeBoolean(allowPartialSearchResults);
-        } else if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-            out.writeOptionalBoolean(allowPartialSearchResults);
         }
         if (asKey == false) {
             if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {

--- a/server/src/main/java/org/opensearch/search/slice/SliceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/slice/SliceBuilder.java
@@ -117,23 +117,14 @@ public class SliceBuilder implements Writeable, ToXContentObject {
     }
 
     public SliceBuilder(StreamInput in) throws IOException {
-        String field = in.readString();
-        if ("_uid".equals(field) && in.getVersion().before(LegacyESVersion.V_6_3_0)) {
-            // This is safe because _id and _uid are handled the same way in #toFilter
-            field = IdFieldMapper.NAME;
-        }
-        this.field = field;
+        this.field = in.readString();
         this.id = in.readVInt();
         this.max = in.readVInt();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (IdFieldMapper.NAME.equals(field) && out.getVersion().before(LegacyESVersion.V_6_3_0)) {
-            out.writeString("_uid");
-        } else {
-            out.writeString(field);
-        }
+        out.writeString(field);
         out.writeVInt(id);
         out.writeVInt(max);
     }

--- a/server/src/main/java/org/opensearch/transport/Header.java
+++ b/server/src/main/java/org/opensearch/transport/Header.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.transport;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.io.stream.StreamInput;
@@ -121,15 +120,11 @@ public class Header {
         this.headers = ThreadContext.readHeadersFromStream(input);
 
         if (isRequest()) {
-            if (version.onOrAfter(LegacyESVersion.V_6_3_0)) {
-                final String[] featuresFound = input.readStringArray();
-                if (featuresFound.length == 0) {
-                    features = Collections.emptySet();
-                } else {
-                    features = Collections.unmodifiableSet(new TreeSet<>(Arrays.asList(featuresFound)));
-                }
-            } else {
+            final String[] featuresFound = input.readStringArray();
+            if (featuresFound.length == 0) {
                 features = Collections.emptySet();
+            } else {
+                features = Collections.unmodifiableSet(new TreeSet<>(Arrays.asList(featuresFound)));
             }
             this.actionName = input.readString();
         } else {

--- a/server/src/main/java/org/opensearch/transport/OutboundMessage.java
+++ b/server/src/main/java/org/opensearch/transport/OutboundMessage.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.transport;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.bytes.BytesReference;
@@ -136,9 +135,7 @@ abstract class OutboundMessage extends NetworkMessage {
         @Override
         protected void writeVariableHeader(StreamOutput stream) throws IOException {
             super.writeVariableHeader(stream);
-            if (version.onOrAfter(LegacyESVersion.V_6_3_0)) {
-                stream.writeStringArray(features);
-            }
+            stream.writeStringArray(features);
             stream.writeString(action);
         }
 

--- a/server/src/main/java/org/opensearch/transport/TransportLogger.java
+++ b/server/src/main/java/org/opensearch/transport/TransportLogger.java
@@ -33,7 +33,6 @@ package org.opensearch.transport;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.compress.CompressorFactory;
@@ -120,10 +119,8 @@ public final class TransportLogger {
                 ThreadContext.readHeadersFromStream(streamInput);
 
                 if (isRequest) {
-                    if (streamInput.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-                        // discard features
-                        streamInput.readStringArray();
-                    }
+                    // discard features
+                    streamInput.readStringArray();
                     sb.append(", action: ").append(streamInput.readString());
                 }
                 sb.append(']');

--- a/server/src/test/java/org/opensearch/BuildTests.java
+++ b/server/src/test/java/org/opensearch/BuildTests.java
@@ -301,9 +301,7 @@ public class BuildTests extends OpenSearchTestCase {
 
         final List<Version> versions = Version.getDeclaredVersions(LegacyESVersion.class);
         final Version post63Pre67Version = randomFrom(
-            versions.stream()
-                .filter(v -> v.onOrAfter(LegacyESVersion.V_6_3_0) && v.before(LegacyESVersion.V_6_7_0))
-                .collect(Collectors.toList())
+            versions.stream().filter(v -> v.before(LegacyESVersion.V_6_7_0)).collect(Collectors.toList())
         );
         final Version post67Pre70Version = randomFrom(
             versions.stream()

--- a/server/src/test/java/org/opensearch/LegacyESVersionTests.java
+++ b/server/src/test/java/org/opensearch/LegacyESVersionTests.java
@@ -64,8 +64,8 @@ public class LegacyESVersionTests extends OpenSearchTestCase {
 
         // compare opensearch version to LegacyESVersion
         assertThat(Version.V_1_0_0.compareMajor(LegacyESVersion.V_7_0_0), is(0));
-        assertThat(Version.V_1_0_0.compareMajor(LegacyESVersion.V_6_3_0), is(1));
-        assertThat(LegacyESVersion.V_6_3_0.compareMajor(Version.V_1_0_0), is(-1));
+        assertThat(Version.V_1_0_0.compareMajor(LegacyESVersion.fromString("6.3.0")), is(1));
+        assertThat(LegacyESVersion.fromString("6.3.0").compareMajor(Version.V_1_0_0), is(-1));
     }
 
     public void testMin() {
@@ -143,7 +143,7 @@ public class LegacyESVersionTests extends OpenSearchTestCase {
 
         Version major56x = LegacyESVersion.fromString("5.6.0");
         assertThat(LegacyESVersion.V_6_5_0.minimumCompatibilityVersion(), equalTo(major56x));
-        assertThat(LegacyESVersion.V_6_3_1.minimumCompatibilityVersion(), equalTo(major56x));
+        assertThat(LegacyESVersion.fromString("6.3.1").minimumCompatibilityVersion(), equalTo(major56x));
 
         // from 7.0 on we are supporting the latest minor of the previous major... this might fail once we add a new version ie. 5.x is
         // released since we need to bump the supported minor in Version#minimumCompatibilityVersion()

--- a/server/src/test/java/org/opensearch/action/admin/cluster/health/ClusterHealthRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/health/ClusterHealthRequestTests.java
@@ -40,6 +40,7 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.VersionUtils;
 
 import java.util.Locale;
 
@@ -77,7 +78,7 @@ public class ClusterHealthRequestTests extends OpenSearchTestCase {
         for (int runs = 0; runs < randomIntBetween(5, 20); runs++) {
             // Generate a random cluster health request in version < 7.2.0 and serializes it
             final BytesStreamOutput out = new BytesStreamOutput();
-            out.setVersion(randomVersionBetween(random(), LegacyESVersion.V_6_3_0, getPreviousVersion(LegacyESVersion.V_7_2_0)));
+            out.setVersion(randomVersionBetween(random(), VersionUtils.getFirstVersion(), getPreviousVersion(LegacyESVersion.V_7_2_0)));
 
             final ClusterHealthRequest expected = randomRequest();
             {
@@ -132,7 +133,7 @@ public class ClusterHealthRequestTests extends OpenSearchTestCase {
 
             // Serialize to node in version < 7.2.0
             final BytesStreamOutput out = new BytesStreamOutput();
-            out.setVersion(randomVersionBetween(random(), LegacyESVersion.V_6_3_0, getPreviousVersion(LegacyESVersion.V_7_2_0)));
+            out.setVersion(randomVersionBetween(random(), VersionUtils.getFirstVersion(), getPreviousVersion(LegacyESVersion.V_7_2_0)));
             expected.writeTo(out);
 
             // Deserialize and check the cluster health request

--- a/server/src/test/java/org/opensearch/search/slice/SliceBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/slice/SliceBuilderTests.java
@@ -42,7 +42,6 @@ import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.OriginalIndices;
 import org.opensearch.action.search.SearchRequest;
@@ -358,21 +357,6 @@ public class SliceBuilderTests extends OpenSearchTestCase {
                 () -> builder.toFilter(null, createRequest(0), context, Version.CURRENT)
             );
             assertThat(exc.getMessage(), containsString("cannot load numeric doc values"));
-        }
-    }
-
-    public void testToFilterDeprecationMessage() throws IOException {
-        Directory dir = new ByteBuffersDirectory();
-        try (IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())))) {
-            writer.commit();
-        }
-        try (IndexReader reader = DirectoryReader.open(dir)) {
-            QueryShardContext context = createShardContext(LegacyESVersion.V_6_3_0, reader, "_uid", null, 1, 0);
-            SliceBuilder builder = new SliceBuilder("_uid", 5, 10);
-            Query query = builder.toFilter(null, createRequest(0), context, Version.CURRENT);
-            assertThat(query, instanceOf(TermsSliceQuery.class));
-            assertThat(builder.toFilter(null, createRequest(0), context, Version.CURRENT), equalTo(query));
-            assertWarnings("Computing slices on the [_uid] field is deprecated for 6.x indices, use [_id] instead");
         }
     }
 

--- a/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/SetupSectionTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/SetupSectionTests.java
@@ -136,7 +136,7 @@ public class SetupSectionTests extends AbstractClientYamlTestFragmentParserTestC
         assertThat(setupSection.getSkipSection().isEmpty(), equalTo(false));
         assertThat(setupSection.getSkipSection(), notNullValue());
         assertThat(setupSection.getSkipSection().getLowerVersion(), equalTo(LegacyESVersion.fromString("6.0.0")));
-        assertThat(setupSection.getSkipSection().getUpperVersion(), equalTo(LegacyESVersion.V_6_3_0));
+        assertThat(setupSection.getSkipSection().getUpperVersion(), equalTo(LegacyESVersion.fromString("6.3.0")));
         assertThat(setupSection.getSkipSection().getReason(), equalTo("Update doesn't return metadata fields, waiting for #3259"));
         assertThat(setupSection.getExecutableSections().size(), equalTo(2));
         assertThat(setupSection.getExecutableSections().get(0), instanceOf(DoSection.class));


### PR DESCRIPTION
This PR removes `LegacyESVersion.V_6_3_x` constants including all
pre-release versions and bug fixes.

closes #1688