### PR TITLE
Fix unit test testFailsHealthOnHungIOBeyondHealthyTimeout() by incresing the max waiting time before assertion

### DIFF
--- a/server/src/test/java/org/opensearch/monitor/fs/FsHealthServiceTests.java
+++ b/server/src/test/java/org/opensearch/monitor/fs/FsHealthServiceTests.java
@@ -222,12 +222,10 @@ public class FsHealthServiceTests extends OpenSearchTestCase {
             disruptFileSystemProvider.injectIODelay.set(true);
             final FsHealthService fsHealthSrvc = new FsHealthService(settings, clusterSettings, testThreadPool, env);
             fsHealthSrvc.doStart();
-            assertTrue(
-                waitUntil(
-                    () -> fsHealthSrvc.getHealth().getStatus() == UNHEALTHY,
-                    healthyTimeoutThreshold + (2 * refreshInterval),
-                    TimeUnit.MILLISECONDS
-                )
+            waitUntil(
+                () -> fsHealthSrvc.getHealth().getStatus() == UNHEALTHY,
+                healthyTimeoutThreshold + (2 * refreshInterval),
+                TimeUnit.MILLISECONDS
             );
             fsHealth = fsHealthSrvc.getHealth();
             assertEquals(UNHEALTHY, fsHealth.getStatus());
@@ -237,9 +235,9 @@ public class FsHealthServiceTests extends OpenSearchTestCase {
             logger.info("--> Fix file system disruption");
             disruptFileSystemProvider.injectIODelay.set(false);
             waitUntil(
-                    () -> fsHealthSrvc.getHealth().getStatus() == HEALTHY,
-                    delayBetweenChecks + (3 * refreshInterval),
-                    TimeUnit.MILLISECONDS
+                () -> fsHealthSrvc.getHealth().getStatus() == HEALTHY,
+                delayBetweenChecks + (3 * refreshInterval),
+                TimeUnit.MILLISECONDS
             );
             fsHealth = fsHealthSrvc.getHealth();
             assertEquals(HEALTHY, fsHealth.getStatus());

--- a/server/src/test/java/org/opensearch/monitor/fs/FsHealthServiceTests.java
+++ b/server/src/test/java/org/opensearch/monitor/fs/FsHealthServiceTests.java
@@ -236,12 +236,10 @@ public class FsHealthServiceTests extends OpenSearchTestCase {
             assertThat(disruptedPathCount, equalTo(1));
             logger.info("--> Fix file system disruption");
             disruptFileSystemProvider.injectIODelay.set(false);
-            assertTrue(
-                waitUntil(
+            waitUntil(
                     () -> fsHealthSrvc.getHealth().getStatus() == HEALTHY,
-                    delayBetweenChecks + (2 * refreshInterval),
+                    delayBetweenChecks + (3 * refreshInterval),
                     TimeUnit.MILLISECONDS
-                )
             );
             fsHealth = fsHealthSrvc.getHealth();
             assertEquals(HEALTHY, fsHealth.getStatus());


### PR DESCRIPTION
### Description
Try to fix the unit test `testFailsHealthOnHungIOBeyondHealthyTimeout()` in class `FsHealthServiceTests`, according to the idea in comment https://github.com/opensearch-project/OpenSearch/issues/1567#issuecomment-989021906

- Increase the max waiting time between cancelling the IO hanging and checking the File System health status. Increase the `2x` multiplier to `3x` that applied to `refreshInterval`.
- Remove the duplicate assertion statements for getting better error message.

Note:
**1**
The test failure can not be reproduced easily locally, and only sometime shows up in the CI workflow. I guess the reason of the test failure is there are dozens of file directories have to be restoring from the IO hanging status in the below step,
https://github.com/opensearch-project/OpenSearch/blob/538b40a0dc44aed9839b8b943b8bb438bf905ff7/server/src/test/java/org/opensearch/monitor/fs/FsHealthServiceTests.java#L237-L238
but the max waiting time in below code is not enough for all those file directories restored to a healthy state. https://github.com/opensearch-project/OpenSearch/blob/538b40a0dc44aed9839b8b943b8bb438bf905ff7/server/src/test/java/org/opensearch/monitor/fs/FsHealthServiceTests.java#L242
 
**2**
Before removing the duplicate assertion statement:
```
org.opensearch.monitor.fs.FsHealthServiceTests > testFailsHealthOnHungIOBeyondHealthyTimeout FAILED
    java.lang.AssertionError
        at __randomizedtesting.SeedInfo.seed([20C97377870AC21B:A2BD2D7EF3F6B453]:0)
        at org.junit.Assert.fail(Assert.java:86)
        at org.junit.Assert.assertTrue(Assert.java:41)
        at org.junit.Assert.assertTrue(Assert.java:52)
        at org.opensearch.monitor.fs.FsHealthServiceTests.testFailsHealthOnHungIOBeyondHealthyTimeout(FsHealthServiceTests.java:239)
```

After removing, the error message can be more intuitive:
```
org.opensearch.monitor.fs.FsHealthServiceTests > testFailsHealthOnHungIOBeyondHealthyTimeout FAILED
    java.lang.AssertionError: expected:<HEALTHY> but was:<UNHEALTHY>
        at __randomizedtesting.SeedInfo.seed([8E47558C149873A4:C330B85606405EC]:0)
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:834)
        at org.junit.Assert.assertEquals(Assert.java:118)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at org.opensearch.monitor.fs.FsHealthServiceTests.testFailsHealthOnHungIOBeyondHealthyTimeout(FsHealthServiceTests.java:243)
```

### Issues Resolved
#1567 - I wish it could be resolved after the PR.
#1307 and #1450 - These 2 issues reporting the same test failure as #1567.
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
