### PR TITLE
Support JDK 18 EA builds

### DIFF
--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -75,3 +75,6 @@ ${error.file}
 
 # JDK 9+ GC logging
 9-:-Xlog:gc*,gc+age=trace,safepoint:file=${loggc}:utctime,pid,tags:filecount=32,filesize=64m
+
+# Explicitly allow security manager (https://bugs.openjdk.java.net/browse/JDK-8270380)
+18-:-Djava.security.manager=allow

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ systemProp.org.gradle.warning.mode=fail
 systemProp.jdk.tls.client.protocols=TLSv1.2
 
 # jvm args for faster test execution by default
-systemProp.tests.jvm.argline=-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m
+systemProp.tests.jvm.argline=-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m -Djava.security.manager=allow


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Since the integration of [1] into JDK-18,  setting `SecurityManager` now requires JVM command line option to enable it explicitly. Running OpenSearch server or tests on latest JDK-18 EA builds fails with exception:

```
Exception in thread "main" java.lang.UnsupportedOperationException: The Security Manager is deprecated and will be removed in a future release
        at java.base/java.lang.System.setSecurityManager(System.java:416)
        at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:91)
```

[1] https://bugs.openjdk.java.net/browse/JDK-8270380

### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/1687
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
