### PR TITLE
Fixing allocation filters to persist existing state on settings update

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -1421,28 +1421,28 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             if (requireMap.isEmpty()) {
                 requireFilters = null;
             } else {
-                requireFilters = DiscoveryNodeFilters.buildFromKeyValue(AND, requireMap);
+                requireFilters = DiscoveryNodeFilters.buildOrUpdateFromKeyValue(null, AND, requireMap);
             }
             Map<String, String> includeMap = INDEX_ROUTING_INCLUDE_GROUP_SETTING.getAsMap(settings);
             final DiscoveryNodeFilters includeFilters;
             if (includeMap.isEmpty()) {
                 includeFilters = null;
             } else {
-                includeFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, includeMap);
+                includeFilters = DiscoveryNodeFilters.buildOrUpdateFromKeyValue(null, OR, includeMap);
             }
             Map<String, String> excludeMap = INDEX_ROUTING_EXCLUDE_GROUP_SETTING.getAsMap(settings);
             final DiscoveryNodeFilters excludeFilters;
             if (excludeMap.isEmpty()) {
                 excludeFilters = null;
             } else {
-                excludeFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, excludeMap);
+                excludeFilters = DiscoveryNodeFilters.buildOrUpdateFromKeyValue(null, OR, excludeMap);
             }
             Map<String, String> initialRecoveryMap = INDEX_ROUTING_INITIAL_RECOVERY_GROUP_SETTING.getAsMap(settings);
             final DiscoveryNodeFilters initialRecoveryFilters;
             if (initialRecoveryMap.isEmpty()) {
                 initialRecoveryFilters = null;
             } else {
-                initialRecoveryFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, initialRecoveryMap);
+                initialRecoveryFilters = DiscoveryNodeFilters.buildOrUpdateFromKeyValue(null, OR, initialRecoveryMap);
             }
             Version indexCreatedVersion = Version.indexCreated(settings);
             Version indexUpgradedVersion = settings.getAsVersion(IndexMetadata.SETTING_VERSION_UPGRADED, indexCreatedVersion);

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeFilters.java
@@ -83,6 +83,7 @@ public class DiscoveryNodeFilters {
         if (original == null) {
             updated = new DiscoveryNodeFilters(opType, new HashMap<>());
         } else {
+            assert opType == original.opType : "operation type should match with node filter parameter";
             updated = new DiscoveryNodeFilters(original.opType, original.filters);
         }
         for (Map.Entry<String, String> entry : filters.entrySet()) {

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeFilters.java
@@ -129,6 +129,25 @@ public class DiscoveryNodeFilters {
         }
     }
 
+    /**
+     * Updates filters returning a new {@link DiscoveryNodeFilters} object.
+     * If the new object has no filters, {@code null} is returned.
+     */
+    @Nullable
+    public static DiscoveryNodeFilters updateFromKeyValue(final DiscoveryNodeFilters original, final Map<String, String> updatedFilters) {
+        final DiscoveryNodeFilters existing = new DiscoveryNodeFilters(original.opType, original.filters);
+        for (final Map.Entry<String, String> entry : updatedFilters.entrySet()) {
+            final String[] values = Strings.tokenizeToStringArray(entry.getValue(), ",");
+            existing.filters.compute(entry.getKey(), (k,v) -> values.length > 0 ? values : null);
+        }
+
+        if (existing.filters.size() == 0) {
+            return null;
+        } else {
+            return existing;
+        }
+    }
+
     public boolean match(DiscoveryNode node) {
         for (Map.Entry<String, String[]> entry : filters.entrySet()) {
             String attr = entry.getKey();

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeFilters.java
@@ -69,18 +69,30 @@ public class DiscoveryNodeFilters {
         }
     };
 
-    public static DiscoveryNodeFilters buildFromKeyValue(OpType opType, Map<String, String> filters) {
-        Map<String, String[]> bFilters = new HashMap<>();
+    /**
+     * Creates or updates filters returning a new {@link DiscoveryNodeFilters} object.
+     * If the new object has no filters, {@code null} is returned.
+     */
+    @Nullable
+    public static DiscoveryNodeFilters buildOrUpdateFromKeyValue(
+        final DiscoveryNodeFilters original,
+        final OpType opType,
+        final Map<String, String> filters
+    ) {
+        final DiscoveryNodeFilters updated;
+        if (original == null) {
+            updated = new DiscoveryNodeFilters(opType, new HashMap<>());
+        } else {
+            updated = new DiscoveryNodeFilters(original.opType, original.filters);
+        }
         for (Map.Entry<String, String> entry : filters.entrySet()) {
             String[] values = Strings.tokenizeToStringArray(entry.getValue(), ",");
-            if (values.length > 0) {
-                bFilters.put(entry.getKey(), values);
-            }
+            updated.filters.compute(entry.getKey(), (k, v) -> values.length > 0 ? values : null);
         }
-        if (bFilters.isEmpty()) {
+        if (updated.filters.isEmpty()) {
             return null;
         }
-        return new DiscoveryNodeFilters(opType, bFilters);
+        return updated;
     }
 
     private final Map<String, String[]> filters;
@@ -126,25 +138,6 @@ public class DiscoveryNodeFilters {
             return null;
         } else {
             return new DiscoveryNodeFilters(original.opType, newFilters);
-        }
-    }
-
-    /**
-     * Updates filters returning a new {@link DiscoveryNodeFilters} object.
-     * If the new object has no filters, {@code null} is returned.
-     */
-    @Nullable
-    public static DiscoveryNodeFilters updateFromKeyValue(final DiscoveryNodeFilters original, final Map<String, String> updatedFilters) {
-        final DiscoveryNodeFilters existing = new DiscoveryNodeFilters(original.opType, original.filters);
-        for (final Map.Entry<String, String> entry : updatedFilters.entrySet()) {
-            final String[] values = Strings.tokenizeToStringArray(entry.getValue(), ",");
-            existing.filters.compute(entry.getKey(), (k,v) -> values.length > 0 ? values : null);
-        }
-
-        if (existing.filters.size() == 0) {
-            return null;
-        } else {
-            return existing;
         }
     }
 

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
@@ -255,32 +255,20 @@ public class FilterAllocationDecider extends AllocationDecider {
     }
 
     private void setClusterRequireFilters(Map<String, String> filters) {
-        final DiscoveryNodeFilters updated;
-        if (clusterRequireFilters == null) {
-            updated = DiscoveryNodeFilters.buildFromKeyValue(AND, filters);
-        } else {
-            updated = DiscoveryNodeFilters.updateFromKeyValue(clusterRequireFilters, filters);
-        }
-        clusterRequireFilters = DiscoveryNodeFilters.trimTier(updated);
+        clusterRequireFilters = DiscoveryNodeFilters.trimTier(
+            DiscoveryNodeFilters.buildOrUpdateFromKeyValue(clusterRequireFilters, AND, filters)
+        );
     }
 
     private void setClusterIncludeFilters(Map<String, String> filters) {
-        final DiscoveryNodeFilters updated;
-        if (clusterIncludeFilters == null) {
-            updated = DiscoveryNodeFilters.buildFromKeyValue(OR, filters);
-        } else {
-            updated = DiscoveryNodeFilters.updateFromKeyValue(clusterIncludeFilters, filters);
-        }
-        clusterIncludeFilters = DiscoveryNodeFilters.trimTier(updated);
+        clusterIncludeFilters = DiscoveryNodeFilters.trimTier(
+            DiscoveryNodeFilters.buildOrUpdateFromKeyValue(clusterIncludeFilters, OR, filters)
+        );
     }
 
     private void setClusterExcludeFilters(Map<String, String> filters) {
-        final DiscoveryNodeFilters updated;
-        if (clusterExcludeFilters == null) {
-            updated = DiscoveryNodeFilters.buildFromKeyValue(OR, filters);
-        } else {
-            updated = DiscoveryNodeFilters.updateFromKeyValue(clusterExcludeFilters, filters);
-        }
-        clusterExcludeFilters = DiscoveryNodeFilters.trimTier(updated);
+        clusterExcludeFilters = DiscoveryNodeFilters.trimTier(
+            DiscoveryNodeFilters.buildOrUpdateFromKeyValue(clusterExcludeFilters, OR, filters)
+        );
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
@@ -255,14 +255,32 @@ public class FilterAllocationDecider extends AllocationDecider {
     }
 
     private void setClusterRequireFilters(Map<String, String> filters) {
-        clusterRequireFilters = DiscoveryNodeFilters.trimTier(DiscoveryNodeFilters.buildFromKeyValue(AND, filters));
+        final DiscoveryNodeFilters updated;
+        if (clusterRequireFilters == null) {
+            updated = DiscoveryNodeFilters.buildFromKeyValue(AND, filters);
+        } else {
+            updated = DiscoveryNodeFilters.updateFromKeyValue(clusterRequireFilters, filters);
+        }
+        clusterRequireFilters = DiscoveryNodeFilters.trimTier(updated);
     }
 
     private void setClusterIncludeFilters(Map<String, String> filters) {
-        clusterIncludeFilters = DiscoveryNodeFilters.trimTier(DiscoveryNodeFilters.buildFromKeyValue(OR, filters));
+        final DiscoveryNodeFilters updated;
+        if (clusterIncludeFilters == null) {
+            updated = DiscoveryNodeFilters.buildFromKeyValue(OR, filters);
+        } else {
+            updated = DiscoveryNodeFilters.updateFromKeyValue(clusterIncludeFilters, filters);
+        }
+        clusterIncludeFilters = DiscoveryNodeFilters.trimTier(updated);
     }
 
     private void setClusterExcludeFilters(Map<String, String> filters) {
-        clusterExcludeFilters = DiscoveryNodeFilters.trimTier(DiscoveryNodeFilters.buildFromKeyValue(OR, filters));
+        final DiscoveryNodeFilters updated;
+        if (clusterExcludeFilters == null) {
+            updated = DiscoveryNodeFilters.buildFromKeyValue(OR, filters);
+        } else {
+            updated = DiscoveryNodeFilters.updateFromKeyValue(clusterExcludeFilters, filters);
+        }
+        clusterExcludeFilters = DiscoveryNodeFilters.trimTier(updated);
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeFiltersTests.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeFiltersTests.java
@@ -344,6 +344,16 @@ public class DiscoveryNodeFiltersTests extends OpenSearchTestCase {
         assertThat(filters.match(node2), equalTo(true));
     }
 
+    public void testOpTypeMismatch() {
+        Settings settings = Settings.builder().put("xxx._id", "id1").build();
+        DiscoveryNodeFilters filters = buildFromSettings(OR, "xxx.", settings);
+        try {
+            buildOrUpdateFromSettings(filters, AND, "xxx.", Settings.builder().put("xxx.name", "name2").build());
+        } catch (AssertionError error) {
+            assertEquals("operation type should match with node filter parameter", error.getMessage());
+        }
+    }
+
     private Settings shuffleSettings(Settings source) {
         Settings.Builder settings = Settings.builder();
         List<String> keys = new ArrayList<>(source.keySet());

--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeFiltersTests.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeFiltersTests.java
@@ -262,6 +262,88 @@ public class DiscoveryNodeFiltersTests extends OpenSearchTestCase {
         assertTrue(filters.match(node));
     }
 
+    public void testAndNodeFiltersUpdate() {
+        Settings settings = Settings.builder().put("xxx._id", "id1").build();
+        DiscoveryNodeFilters filters = buildFromSettings(AND, "xxx.", settings);
+
+        final DiscoveryNode node1 = new DiscoveryNode(
+            "name1",
+            "id1",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            emptySet(),
+            Version.CURRENT
+        );
+        assertThat(filters.match(node1), equalTo(true));
+
+        final DiscoveryNode node2 = new DiscoveryNode(
+            "name2",
+            "id2",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            emptySet(),
+            Version.CURRENT
+        );
+        assertThat(filters.match(node2), equalTo(false));
+
+        filters = buildOrUpdateFromSettings(filters, AND, "xxx.", Settings.builder().put("xxx.name", "name2").build());
+        assertThat(filters.match(node1), equalTo(false));
+        assertThat(filters.match(node2), equalTo(false));
+
+        filters = buildOrUpdateFromSettings(filters, AND, "xxx.", Settings.builder().put("xxx._id", "").build());
+        assertThat(filters.match(node1), equalTo(false));
+        assertThat(filters.match(node2), equalTo(true));
+
+        filters = buildOrUpdateFromSettings(filters, AND, "xxx.", Settings.builder().put("xxx.name", "name1").build());
+        assertThat(filters.match(node1), equalTo(true));
+        assertThat(filters.match(node2), equalTo(false));
+
+        filters = buildOrUpdateFromSettings(filters, AND, "xxx.", Settings.builder().put("xxx.name", "").put("xxx._id", "id2").build());
+        assertThat(filters.match(node1), equalTo(false));
+        assertThat(filters.match(node2), equalTo(true));
+    }
+
+    public void testOrNodeFiltersUpdate() {
+        Settings settings = Settings.builder().put("xxx._id", "id1").build();
+        DiscoveryNodeFilters filters = buildFromSettings(OR, "xxx.", settings);
+
+        final DiscoveryNode node1 = new DiscoveryNode(
+            "name1",
+            "id1",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            emptySet(),
+            Version.CURRENT
+        );
+        assertThat(filters.match(node1), equalTo(true));
+
+        final DiscoveryNode node2 = new DiscoveryNode(
+            "name2",
+            "id2",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            emptySet(),
+            Version.CURRENT
+        );
+        assertThat(filters.match(node2), equalTo(false));
+
+        filters = buildOrUpdateFromSettings(filters, OR, "xxx.", Settings.builder().put("xxx.name", "name2").build());
+        assertThat(filters.match(node1), equalTo(true));
+        assertThat(filters.match(node2), equalTo(true));
+
+        filters = buildOrUpdateFromSettings(filters, OR, "xxx.", Settings.builder().put("xxx._id", "").build());
+        assertThat(filters.match(node1), equalTo(false));
+        assertThat(filters.match(node2), equalTo(true));
+
+        filters = buildOrUpdateFromSettings(filters, OR, "xxx.", Settings.builder().put("xxx.name", "name1").build());
+        assertThat(filters.match(node1), equalTo(true));
+        assertThat(filters.match(node2), equalTo(false));
+
+        filters = buildOrUpdateFromSettings(filters, OR, "xxx.", Settings.builder().put("xxx.name", "name1,name2").build());
+        assertThat(filters.match(node1), equalTo(true));
+        assertThat(filters.match(node2), equalTo(true));
+    }
+
     private Settings shuffleSettings(Settings source) {
         Settings.Builder settings = Settings.builder();
         List<String> keys = new ArrayList<>(source.keySet());
@@ -273,7 +355,16 @@ public class DiscoveryNodeFiltersTests extends OpenSearchTestCase {
     }
 
     public static DiscoveryNodeFilters buildFromSettings(DiscoveryNodeFilters.OpType opType, String prefix, Settings settings) {
+        return buildOrUpdateFromSettings(null, opType, prefix, settings);
+    }
+
+    public static DiscoveryNodeFilters buildOrUpdateFromSettings(
+        DiscoveryNodeFilters filters,
+        DiscoveryNodeFilters.OpType opType,
+        String prefix,
+        Settings settings
+    ) {
         Setting.AffixSetting<String> setting = Setting.prefixKeySetting(prefix, key -> Setting.simpleString(key));
-        return DiscoveryNodeFilters.buildFromKeyValue(opType, setting.getAsMap(settings));
+        return DiscoveryNodeFilters.buildOrUpdateFromKeyValue(filters, opType, setting.getAsMap(settings));
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
@@ -224,8 +224,14 @@ public class FilterAllocationDeciderTests extends OpenSearchAllocationTestCase {
         assertEquals("node passes include/exclude/require filters", decision.getExplanation());
     }
 
-    private void filterSettingsUpdateHelper(final Settings initialSettings, final Type type1, final String explanation1,
-                                            final Settings updatedSettings, final Type type2, final String explanation2) {
+    private void filterSettingsUpdateHelper(
+        final Settings initialSettings,
+        final Type type1,
+        final String explanation1,
+        final Settings updatedSettings,
+        final Type type2,
+        final String explanation2
+    ) {
         ClusterSettings clusterSettings = new ClusterSettings(initialSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         FilterAllocationDecider filterAllocationDecider = new FilterAllocationDecider(initialSettings, clusterSettings);
         AllocationDeciders allocationDeciders = new AllocationDeciders(
@@ -242,11 +248,7 @@ public class FilterAllocationDeciderTests extends OpenSearchAllocationTestCase {
             EmptyClusterInfoService.INSTANCE,
             EmptySnapshotsInfoService.INSTANCE
         );
-        ClusterState state = createInitialClusterState(
-            service,
-            Settings.EMPTY,
-            Settings.EMPTY
-        );
+        ClusterState state = createInitialClusterState(service, Settings.EMPTY, Settings.EMPTY);
         RoutingTable routingTable = state.routingTable();
         RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state, null, null, 0);
         allocation.debugDecision(true);
@@ -267,6 +269,7 @@ public class FilterAllocationDeciderTests extends OpenSearchAllocationTestCase {
         assertEquals(decision.toString(), type2, decision.type());
         assertEquals(explanation2, decision.getExplanation());
     }
+
     public void testFilterUpdate1() {
         filterSettingsUpdateHelper(
             Settings.builder().put("cluster.routing.allocation.require.attr", "attr1").build(),
@@ -275,15 +278,15 @@ public class FilterAllocationDeciderTests extends OpenSearchAllocationTestCase {
             Settings.builder().put("cluster.routing.allocation.require.zone", "zone1").build(),
             Type.NO,
             "node does not match cluster setting [cluster.routing.allocation.require] filters [zone:\"zone1\",attr:\"attr1\"]"
-            );
+        );
     }
 
     public void testFilterUpdate2() {
         filterSettingsUpdateHelper(
             Settings.builder()
-            .put("cluster.routing.allocation.require.attr", "attr1")
-            .put("cluster.routing.allocation.require.zone", "zone1")
-            .build(),
+                .put("cluster.routing.allocation.require.attr", "attr1")
+                .put("cluster.routing.allocation.require.zone", "zone1")
+                .build(),
             Type.NO,
             "node does not match cluster setting [cluster.routing.allocation.require] filters [zone:\"zone1\",attr:\"attr1\"]",
             Settings.builder()
@@ -292,7 +295,7 @@ public class FilterAllocationDeciderTests extends OpenSearchAllocationTestCase {
                 .build(),
             Type.NO,
             "node does not match cluster setting [cluster.routing.allocation.require] filters [zone:\"zone1\"]"
-            );
+        );
     }
 
     public void testFilterUpdate3() {

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
@@ -224,6 +224,94 @@ public class FilterAllocationDeciderTests extends OpenSearchAllocationTestCase {
         assertEquals("node passes include/exclude/require filters", decision.getExplanation());
     }
 
+    private void filterSettingsUpdateHelper(final Settings initialSettings, final Type type1, final String explanation1,
+                                            final Settings updatedSettings, final Type type2, final String explanation2) {
+        ClusterSettings clusterSettings = new ClusterSettings(initialSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        FilterAllocationDecider filterAllocationDecider = new FilterAllocationDecider(initialSettings, clusterSettings);
+        AllocationDeciders allocationDeciders = new AllocationDeciders(
+            Arrays.asList(
+                filterAllocationDecider,
+                new SameShardAllocationDecider(Settings.EMPTY, clusterSettings),
+                new ReplicaAfterPrimaryActiveAllocationDecider()
+            )
+        );
+        AllocationService service = new AllocationService(
+            allocationDeciders,
+            new TestGatewayAllocator(),
+            new BalancedShardsAllocator(Settings.EMPTY),
+            EmptyClusterInfoService.INSTANCE,
+            EmptySnapshotsInfoService.INSTANCE
+        );
+        ClusterState state = createInitialClusterState(
+            service,
+            Settings.EMPTY,
+            Settings.EMPTY
+        );
+        RoutingTable routingTable = state.routingTable();
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state.getRoutingNodes(), state, null, null, 0);
+        allocation.debugDecision(true);
+        Decision.Single decision = (Decision.Single) filterAllocationDecider.canAllocate(
+            routingTable.index("idx").shard(0).shards().get(0),
+            state.getRoutingNodes().node("node2"),
+            allocation
+        );
+        assertEquals(decision.toString(), type1, decision.type());
+        assertEquals(explanation1, decision.getExplanation());
+
+        clusterSettings.applySettings(updatedSettings);
+        decision = (Decision.Single) filterAllocationDecider.canAllocate(
+            routingTable.index("idx").shard(0).shards().get(0),
+            state.getRoutingNodes().node("node2"),
+            allocation
+        );
+        assertEquals(decision.toString(), type2, decision.type());
+        assertEquals(explanation2, decision.getExplanation());
+    }
+    public void testFilterUpdate1() {
+        filterSettingsUpdateHelper(
+            Settings.builder().put("cluster.routing.allocation.require.attr", "attr1").build(),
+            Type.NO,
+            "node does not match cluster setting [cluster.routing.allocation.require] filters [attr:\"attr1\"]",
+            Settings.builder().put("cluster.routing.allocation.require.zone", "zone1").build(),
+            Type.NO,
+            "node does not match cluster setting [cluster.routing.allocation.require] filters [zone:\"zone1\",attr:\"attr1\"]"
+            );
+    }
+
+    public void testFilterUpdate2() {
+        filterSettingsUpdateHelper(
+            Settings.builder()
+            .put("cluster.routing.allocation.require.attr", "attr1")
+            .put("cluster.routing.allocation.require.zone", "zone1")
+            .build(),
+            Type.NO,
+            "node does not match cluster setting [cluster.routing.allocation.require] filters [zone:\"zone1\",attr:\"attr1\"]",
+            Settings.builder()
+                .put("cluster.routing.allocation.require.attr", "")
+                .put("cluster.routing.allocation.require._tier_preference", "hot")
+                .build(),
+            Type.NO,
+            "node does not match cluster setting [cluster.routing.allocation.require] filters [zone:\"zone1\"]"
+            );
+    }
+
+    public void testFilterUpdate3() {
+        filterSettingsUpdateHelper(
+            Settings.builder()
+                .put("cluster.routing.allocation.require.flag", "flag1")
+                .put("cluster.routing.allocation.require.zone", "zone1")
+                .build(),
+            Type.NO,
+            "node does not match cluster setting [cluster.routing.allocation.require] filters [flag:\"flag1\",zone:\"zone1\"]",
+            Settings.builder()
+                .put("cluster.routing.allocation.require.flag", "")
+                .put("cluster.routing.allocation.require.zone", "")
+                .build(),
+            Type.YES,
+            "node passes include/exclude/require filters"
+        );
+    }
+
     private ClusterState createInitialClusterState(AllocationService service, Settings indexSettings) {
         return createInitialClusterState(service, indexSettings, Settings.EMPTY);
     }

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
@@ -270,7 +270,7 @@ public class FilterAllocationDeciderTests extends OpenSearchAllocationTestCase {
         assertEquals(explanation2, decision.getExplanation());
     }
 
-    public void testFilterUpdate1() {
+    public void testFilterUpdateAddNew() {
         filterSettingsUpdateHelper(
             Settings.builder().put("cluster.routing.allocation.require.attr", "attr1").build(),
             Type.NO,
@@ -281,7 +281,7 @@ public class FilterAllocationDeciderTests extends OpenSearchAllocationTestCase {
         );
     }
 
-    public void testFilterUpdate2() {
+    public void testFilterUpdateRemovePartial() {
         filterSettingsUpdateHelper(
             Settings.builder()
                 .put("cluster.routing.allocation.require.attr", "attr1")
@@ -298,7 +298,7 @@ public class FilterAllocationDeciderTests extends OpenSearchAllocationTestCase {
         );
     }
 
-    public void testFilterUpdate3() {
+    public void testFilterUpdateRemoveAll() {
         filterSettingsUpdateHelper(
             Settings.builder()
                 .put("cluster.routing.allocation.require.flag", "flag1")


### PR DESCRIPTION
Signed-off-by: Ankit Jain <jain.ankitk@gmail.com>

### Description
Instead of recreating the filters from the difference passed to settings update consumer, existing filters are updated to preserve original settings as well
 
### Issues Resolved
#1716
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
