### PR TITLE
[Backport] [1.x] Fixing .gitattributes for binary content, removing *.class files (#1717)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,8 @@
 * text eol=lf
 *.bat text eol=crlf
+*.zip binary
+*.exe binary
+*.epub binary
+*.pdf binary
+*.vsdx binary
+*.doc binary


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Backport of https://github.com/opensearch-project/OpenSearch/pull/1717 to 1.x
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/1713
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
