### PR TITLE
Gradle clean failing after a failed gradle check, folders created by Docker under 'root' user

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -155,6 +155,10 @@ opensearch_distributions {
 
 tasks.named("preProcessFixture").configure {
   dependsOn opensearch_distributions.docker
+  // always run the task, otherwise the folders won't be created
+  outputs.upToDateWhen { 
+    false 
+  }
   doLast {
     // tests expect to have an empty repo
     project.delete(
@@ -261,4 +265,8 @@ subprojects { Project subProject ->
       dependsOn(exportTaskName)
     }
   }
+}
+
+tasks.named("composeUp").configure {
+  dependsOn preProcessFixture
 }

--- a/qa/remote-clusters/build.gradle
+++ b/qa/remote-clusters/build.gradle
@@ -51,8 +51,12 @@ opensearch_distributions {
   }
 }
 
-preProcessFixture {
+tasks.named("preProcessFixture").configure {
   dependsOn opensearch_distributions.docker
+  // always run the task, otherwise the folders won't be created
+  outputs.upToDateWhen { 
+    false 
+  }
   doLast {
     // tests expect to have an empty repo
     project.delete(
@@ -86,3 +90,7 @@ tasks.register("integTest", Test) {
 }
 
 tasks.named("check").configure { dependsOn "integTest" }
+
+tasks.named("composeUp").configure {
+  dependsOn preProcessFixture
+}


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
the `composeUp` needs `preProcessFixture` to be executed before, otherwise the folders:

```
distribution/docker/build/logs/1
distribution/docker/build/logs/2
```

won't exists and will be created by `Docker` under `root` user:

```
drwxrwxr-x 3 user.user user.user 4.0K Nov 29 15:40 classes
drwxrwxr-x 4 user.user user.user 4.0K Nov 30 10:03 docker
drwxrwxr-x 3 user.user user.user 4.0K Nov 29 15:38 forbidden-apis-config
drwxrwxr-x 3 user.user user.user 4.0K Nov 29 15:40 generated
drwxrwxr-x 2 user.user user.user 4.0K Nov 29 15:45 heapdump
drwxr-xr-x 4 root         root         4.0K Dec 14 11:24 logs
drwxrwxr-x 2 user.user user.user 4.0K Nov 29 15:44 markers
drwxrwxrwx 2 user.user user.user 4.0K Dec 13 09:20 repo
drwxrwxr-x 4 user.user user.user 4.0K Nov 29 15:45 reports
```
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/1675
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
