### PR TITLE
Updating .gitattributes for additional file types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,12 @@
 * text eol=lf
-*.bat text eol=crlf
+*.bat binary
 *.zip binary
 *.exe binary
 *.epub binary
 *.pdf binary
 *.vsdx binary
 *.doc binary
+*.bcfks binary
+*.crt binary
+*.p12 binary
+*.txt text=auto

--- a/release-notes/opensearch.release-notes-1.2.1.md
+++ b/release-notes/opensearch.release-notes-1.2.1.md
@@ -1,0 +1,27 @@
+* __Upgrade to log4j 2.15.0 (#1704)__
+
+    [Andrew Ross](mailto:andrross@amazon.com) - Fri, 10 Dec 2021 18:05:14 -0500
+    
+    Signed-off-by: Andrew Ross &lt;andrross@amazon.com&gt;
+
+* __Increment version to 1.2.1 (#1700)__
+
+    [Daniel Doubrovkine (dB.)](mailto:dblock@dblock.org) - Fri, 10 Dec 2021 14:06:17 -0500
+    
+    
+    * Increment version to 1.2.1.
+     Signed-off-by: dblock &lt;dblock@dblock.org&gt;
+    
+    * Move Gradle wrapper and precommit checks into OpenSearch repo. (#1664)
+    
+    * Move Gradle checks into OpenSearch repo.
+     Signed-off-by: dblock &lt;dblock@amazon.com&gt;
+    
+    * Use working-directory for gradle wrapper validation.
+     Signed-off-by: dblock &lt;dblock@amazon.com&gt;
+    
+    * Use https://github.com/gradle/wrapper-validation-action.
+     Signed-off-by: dblock &lt;dblock@amazon.com&gt;
+    
+    * Use Java 14.
+     Signed-off-by: dblock &lt;dblock@dblock.org&gt;


### PR DESCRIPTION
### Description
Updating `.gitattributes` for additional file types.

With exiting `.gitattributes`, Linux is seeing unexpected changes:
```
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   buildSrc/src/main/resources/cacerts.bcfks
	modified:   client/rest/src/test/resources/test.crt
	modified:   gradlew.bat
	modified:   libs/ssl-config/src/test/resources/certs/ca-all/ca.p12
	modified:   plugins/ingest-attachment/licenses/commons-collections4-LICENSE.txt
	modified:   plugins/ingest-attachment/licenses/commons-collections4-NOTICE.txt
	modified:   plugins/ingest-attachment/licenses/slf4j-api-LICENSE.txt
	modified:   plugins/ingest-attachment/licenses/xz-LICENSE.txt
	modified:   plugins/ingest-attachment/licenses/xz-NOTICE.txt
	modified:   plugins/repository-hdfs/licenses/commons-codec-LICENSE.txt
	modified:   plugins/repository-hdfs/licenses/commons-codec-NOTICE.txt
	modified:   server/licenses/joda-time-LICENSE.txt
```

Tested on Linux, and MacOS.
 
### Issues Resolved
#1713 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
