### PR TITLE
Override default Distribution Download URL with customTestDistributionUrl for OpenSearch, which is passed as a parameter from a plugin.

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchCluster.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchCluster.java
@@ -36,6 +36,7 @@ import org.opensearch.gradle.Jdk;
 import org.opensearch.gradle.PropertyNormalization;
 import org.opensearch.gradle.ReaperService;
 import org.opensearch.gradle.http.WaitForHttpResource;
+import org.opensearch.gradle.DistributionDownloadPlugin;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
@@ -143,6 +144,11 @@ public class OpenSearchCluster implements TestClusterConfiguration, Named {
         // configure the cluster name eagerly
         newNode.defaultConfig.put("cluster.name", safeName(clusterName));
         this.nodes.add(newNode);
+    }
+
+    // This method is called by plugins to override default Url
+    public static void setCustomTestDistributionUrl(String customTestDistributionUrl) {
+        DistributionDownloadPlugin.setCustomTestDistributionUrl(customTestDistributionUrl);
     }
 
     @Internal


### PR DESCRIPTION
Override default Distribution Download URL with custom URL

Signed-off-by: Rishikesh1159 <rishireddy1159@gmail.com>

### Description
It Overrides Distribution Download URL with customTestDistributionUrl which is passed as a parameter from plugin. Along with changes made in this PR, plugins should make subsequent change to allow user to pass custom url from CLI.
 
### Issues Resolved
#1240  
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
