### PR TITLE
Fix JavaDoc typo in XContentBuilder

### DIFF
--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentBuilder.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentBuilder.java
@@ -81,7 +81,7 @@ public final class XContentBuilder implements Closeable, Flushable {
      * The builder uses an internal {@link ByteArrayOutputStream} output stream to build the content. When both exclusive and
      * inclusive filters are provided, the underlying builder will first use exclusion filters to remove fields and then will check the
      * remaining fields against the inclusive filters.
-     * <p>
+     * </p>
      *
      * @param xContent the {@link XContent}
      * @param includes the inclusive filters: only fields and objects that match the inclusive filters will be written to the output.


### PR DESCRIPTION
### Description
Apologies for spamming. I was trying to compile a plugin and this typo was in the way.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
