### PR TITLE
[plugin] repository-azure is not working properly hangs on basic operations

### DIFF
--- a/plugins/repository-azure/build.gradle
+++ b/plugins/repository-azure/build.gradle
@@ -283,4 +283,23 @@ task azureThirdPartyTest(type: Test) {
     nonInputProperties.systemProperty 'test.azure.endpoint_suffix', "${-> azureAddress.call() }"
   }
 }
-check.dependsOn(azureThirdPartyTest)
+
+task azureThirdPartyDefaultXmlTest(type: Test) {
+  SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+  SourceSet internalTestSourceSet = sourceSets.getByName(InternalClusterTestPlugin.SOURCE_SET_NAME)
+  setTestClassesDirs(internalTestSourceSet.getOutput().getClassesDirs())
+  setClasspath(internalTestSourceSet.getRuntimeClasspath())
+  dependsOn tasks.internalClusterTest
+  include '**/AzureStorageCleanupThirdPartyTests.class'
+  systemProperty 'javax.xml.stream.XMLInputFactory', "com.sun.xml.internal.stream.XMLInputFactoryImpl"
+  systemProperty 'test.azure.account', azureAccount ? azureAccount : ""
+  systemProperty 'test.azure.key', azureKey ? azureKey : ""
+  systemProperty 'test.azure.sas_token', azureSasToken ? azureSasToken : ""
+  systemProperty 'test.azure.container', azureContainer ? azureContainer : ""
+  systemProperty 'test.azure.base', (azureBasePath ? azureBasePath : "") + "_third_party_tests_" + BuildParams.testSeed
+  if (useFixture) {
+    nonInputProperties.systemProperty 'test.azure.endpoint_suffix', "${-> azureAddress.call() }"
+  }
+}
+
+check.dependsOn(azureThirdPartyTest, azureThirdPartyDefaultXmlTest)

--- a/plugins/repository-azure/src/main/java/org/opensearch/repositories/azure/AzureBlobStore.java
+++ b/plugins/repository-azure/src/main/java/org/opensearch/repositories/azure/AzureBlobStore.java
@@ -224,6 +224,8 @@ public class AzureBlobStore implements BlobStore {
 
             do {
                 // Fetch one page at a time, others are going to be fetched by continuation token
+                // TODO: reconsider reverting to simplified approach once https://github.com/Azure/azure-sdk-for-java/issues/26064
+                // gets addressed.
                 final Optional<PagedResponse<BlobItem>> pageOpt = blobContainer.listBlobs(listBlobsOptions, timeout())
                     .streamByPage(continuationToken)
                     .findFirst();
@@ -327,6 +329,8 @@ public class AzureBlobStore implements BlobStore {
 
             do {
                 // Fetch one page at a time, others are going to be fetched by continuation token
+                // TODO: reconsider reverting to simplified approach once https://github.com/Azure/azure-sdk-for-java/issues/26064
+                // gets addressed
                 final Optional<PagedResponse<BlobItem>> pageOpt = blobContainer.listBlobsByHierarchy("/", listBlobsOptions, timeout())
                     .streamByPage(continuationToken)
                     .findFirst();
@@ -372,6 +376,9 @@ public class AzureBlobStore implements BlobStore {
             String continuationToken = null;
 
             do {
+                // Fetch one page at a time, others are going to be fetched by continuation token
+                // TODO: reconsider reverting to simplified approach once https://github.com/Azure/azure-sdk-for-java/issues/26064
+                // gets addressed
                 final Optional<PagedResponse<BlobItem>> pageOpt = blobContainer.listBlobsByHierarchy("/", listBlobsOptions, timeout())
                     .streamByPage(continuationToken)
                     .findFirst();

--- a/plugins/repository-azure/src/main/java/org/opensearch/repositories/azure/AzureBlobStore.java
+++ b/plugins/repository-azure/src/main/java/org/opensearch/repositories/azure/AzureBlobStore.java
@@ -35,6 +35,7 @@ package org.opensearch.repositories.azure;
 import com.azure.core.http.HttpMethod;
 import com.azure.core.http.HttpRequest;
 import com.azure.core.http.HttpResponse;
+import com.azure.core.http.rest.PagedResponse;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.Context;
 import com.azure.storage.blob.BlobClient;
@@ -51,6 +52,7 @@ import com.azure.storage.blob.models.ListBlobsOptions;
 import com.azure.storage.blob.options.BlobParallelUploadOptions;
 import com.azure.storage.common.implementation.Constants;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.util.Throwables;
@@ -82,6 +84,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
@@ -217,50 +220,69 @@ public class AzureBlobStore implements BlobStore {
         final ListBlobsOptions listBlobsOptions = new ListBlobsOptions().setPrefix(path);
 
         SocketAccess.doPrivilegedVoidException(() -> {
-            for (final BlobItem blobItem : blobContainer.listBlobs(listBlobsOptions, timeout())) {
-                // Skipping prefixes as those are not deletable and should not be there
-                assert (blobItem.isPrefix() == null || !blobItem.isPrefix()) : "Only blobs (not prefixes) are expected";
+            String continuationToken = null;
 
-                outstanding.incrementAndGet();
-                executor.execute(new AbstractRunnable() {
-                    @Override
-                    protected void doRun() throws Exception {
-                        final long len = blobItem.getProperties().getContentLength();
+            do {
+                // Fetch one page at a time, others are going to be fetched by continuation token
+                final Optional<PagedResponse<BlobItem>> pageOpt = blobContainer.listBlobs(listBlobsOptions, timeout())
+                    .streamByPage(continuationToken)
+                    .findFirst();
 
-                        final BlobClient azureBlob = blobContainer.getBlobClient(blobItem.getName());
-                        logger.trace(
-                            () -> new ParameterizedMessage("container [{}]: blob [{}] found. removing.", container, blobItem.getName())
-                        );
-                        final Response<Void> response = azureBlob.deleteWithResponse(null, null, timeout(), client.v2().get());
-                        logger.trace(
-                            () -> new ParameterizedMessage(
-                                "container [{}]: blob [{}] deleted status [{}].",
-                                container,
-                                blobItem.getName(),
-                                response.getStatusCode()
-                            )
-                        );
+                if (!pageOpt.isPresent()) {
+                    // No more pages, should never happen
+                    break;
+                }
 
-                        blobsDeleted.incrementAndGet();
-                        if (len >= 0) {
-                            bytesDeleted.addAndGet(len);
+                final PagedResponse<BlobItem> page = pageOpt.get();
+                for (final BlobItem blobItem : page.getValue()) {
+                    // Skipping prefixes as those are not deletable and should not be there
+                    assert (blobItem.isPrefix() == null || !blobItem.isPrefix()) : "Only blobs (not prefixes) are expected";
+
+                    outstanding.incrementAndGet();
+                    executor.execute(new AbstractRunnable() {
+                        @Override
+                        protected void doRun() throws Exception {
+                            final long len = blobItem.getProperties().getContentLength();
+
+                            final BlobClient azureBlob = blobContainer.getBlobClient(blobItem.getName());
+                            logger.trace(
+                                () -> new ParameterizedMessage("container [{}]: blob [{}] found. removing.", container, blobItem.getName())
+                            );
+                            final Response<Void> response = azureBlob.deleteWithResponse(null, null, timeout(), client.v2().get());
+                            logger.trace(
+                                () -> new ParameterizedMessage(
+                                    "container [{}]: blob [{}] deleted status [{}].",
+                                    container,
+                                    blobItem.getName(),
+                                    response.getStatusCode()
+                                )
+                            );
+
+                            blobsDeleted.incrementAndGet();
+                            if (len >= 0) {
+                                bytesDeleted.addAndGet(len);
+                            }
                         }
-                    }
 
-                    @Override
-                    public void onFailure(Exception e) {
-                        exceptions.add(e);
-                    }
-
-                    @Override
-                    public void onAfter() {
-                        if (outstanding.decrementAndGet() == 0) {
-                            result.onResponse(null);
+                        @Override
+                        public void onFailure(Exception e) {
+                            exceptions.add(e);
                         }
-                    }
-                });
-            }
+
+                        @Override
+                        public void onAfter() {
+                            if (outstanding.decrementAndGet() == 0) {
+                                result.onResponse(null);
+                            }
+                        }
+                    });
+                }
+
+                // Fetch next continuation token
+                continuationToken = page.getContinuationToken();
+            } while (StringUtils.isNotBlank(continuationToken));
         });
+
         if (outstanding.decrementAndGet() == 0) {
             result.onResponse(null);
         }
@@ -301,20 +323,37 @@ public class AzureBlobStore implements BlobStore {
             .setPrefix(keyPath + (prefix == null ? "" : prefix));
 
         SocketAccess.doPrivilegedVoidException(() -> {
-            for (final BlobItem blobItem : blobContainer.listBlobsByHierarchy("/", listBlobsOptions, timeout())) {
-                // Skipping over the prefixes, only look for the blobs
-                if (blobItem.isPrefix() != null && blobItem.isPrefix()) {
-                    continue;
+            String continuationToken = null;
+
+            do {
+                // Fetch one page at a time, others are going to be fetched by continuation token
+                final Optional<PagedResponse<BlobItem>> pageOpt = blobContainer.listBlobsByHierarchy("/", listBlobsOptions, timeout())
+                    .streamByPage(continuationToken)
+                    .findFirst();
+
+                if (!pageOpt.isPresent()) {
+                    // No more pages, should never happen
+                    break;
                 }
 
-                final String name = getBlobName(blobItem.getName(), container, keyPath);
-                logger.trace(() -> new ParameterizedMessage("blob name [{}]", name));
+                final PagedResponse<BlobItem> page = pageOpt.get();
+                for (final BlobItem blobItem : page.getValue()) {
+                    // Skipping over the prefixes, only look for the blobs
+                    if (blobItem.isPrefix() != null && blobItem.isPrefix()) {
+                        continue;
+                    }
 
-                final BlobItemProperties properties = blobItem.getProperties();
-                logger.trace(() -> new ParameterizedMessage("blob name [{}], size [{}]", name, properties.getContentLength()));
-                blobsBuilder.put(name, new PlainBlobMetadata(name, properties.getContentLength()));
-            }
+                    final String name = getBlobName(blobItem.getName(), container, keyPath);
+                    logger.trace(() -> new ParameterizedMessage("blob name [{}]", name));
 
+                    final BlobItemProperties properties = blobItem.getProperties();
+                    logger.trace(() -> new ParameterizedMessage("blob name [{}], size [{}]", name, properties.getContentLength()));
+                    blobsBuilder.put(name, new PlainBlobMetadata(name, properties.getContentLength()));
+                }
+
+                // Fetch next continuation token
+                continuationToken = page.getContinuationToken();
+            } while (StringUtils.isNotBlank(continuationToken));
         });
 
         return MapBuilder.newMapBuilder(blobsBuilder).immutableMap();
@@ -330,18 +369,33 @@ public class AzureBlobStore implements BlobStore {
             .setPrefix(keyPath);
 
         SocketAccess.doPrivilegedVoidException(() -> {
-            for (final BlobItem blobItem : blobContainer.listBlobsByHierarchy("/", listBlobsOptions, timeout())) {
-                // Skipping over the blobs, only look for prefixes
-                if (blobItem.isPrefix() != null && blobItem.isPrefix()) {
-                    // Expecting name in the form /container/keyPath.* and we want to strip off the /container/
-                    // this requires 1 + container.length() + 1, with each 1 corresponding to one of the /.
-                    // Lastly, we add the length of keyPath to the offset to strip this container's path.
-                    final String name = getBlobName(blobItem.getName(), container, keyPath).replaceAll("/$", "");
-                    logger.trace(() -> new ParameterizedMessage("blob name [{}]", name));
-                    blobsBuilder.add(name);
+            String continuationToken = null;
+
+            do {
+                final Optional<PagedResponse<BlobItem>> pageOpt = blobContainer.listBlobsByHierarchy("/", listBlobsOptions, timeout())
+                    .streamByPage(continuationToken)
+                    .findFirst();
+
+                if (!pageOpt.isPresent()) {
+                    // No more pages, should never happen
+                    break;
                 }
-            }
-            ;
+
+                final PagedResponse<BlobItem> page = pageOpt.get();
+                for (final BlobItem blobItem : page.getValue()) {
+                    // Skipping over the blobs, only look for prefixes
+                    if (blobItem.isPrefix() != null && blobItem.isPrefix()) {
+                        // Expecting name in the form /container/keyPath.* and we want to strip off the /container/
+                        // this requires 1 + container.length() + 1, with each 1 corresponding to one of the /.
+                        // Lastly, we add the length of keyPath to the offset to strip this container's path.
+                        final String name = getBlobName(blobItem.getName(), container, keyPath).replaceAll("/$", "");
+                        logger.trace(() -> new ParameterizedMessage("blob name [{}]", name));
+                        blobsBuilder.add(name);
+                    }
+                }
+                // Fetch next continuation token
+                continuationToken = page.getContinuationToken();
+            } while (StringUtils.isNotBlank(continuationToken));
         });
 
         return Collections.unmodifiableMap(

--- a/test/fixtures/azure-fixture/src/main/java/fixture/azure/AzureHttpHandler.java
+++ b/test/fixtures/azure-fixture/src/main/java/fixture/azure/AzureHttpHandler.java
@@ -208,6 +208,7 @@ public class AzureHttpHandler implements HttpHandler {
 
                 }
                 list.append("</Blobs>");
+                list.append("<NextMarker />");
                 list.append("</EnumerationResults>");
 
                 byte[] response = list.toString().getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
The issue is closely related to FasterXML/jackson-databind#3322 and in the nutshell, Azure Blob APIs V12 heavily relies on the fact that empty XML elements / attributes are going to be nullified.

However, sadly, it highly depends on `XMLInputReader` instance being picked up at runtime: the `Woodstox` does that, whereas the default one from JDK `com.sun.org.apache.xerces.internal.impl.XMLStreamReaderImpl` does not. It leads to infinite loop within `listBlobsByHierarchy` or `listBlobs` - the page iterator only understands `null` as termination condition.

The fastest option to get it fixed is to fallback to manual iteration. The bug report to upstream is also submitted https://github.com/Azure/azure-sdk-for-java/issues/26064
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/1734
 
### Check List
- [X] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
