### PR TITLE
[Remove] DynamicTemplate deprecations

### DIFF
--- a/server/src/main/java/org/opensearch/index/mapper/DynamicTemplate.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DynamicTemplate.java
@@ -32,9 +32,6 @@
 
 package org.opensearch.index.mapper;
 
-import org.opensearch.LegacyESVersion;
-import org.opensearch.Version;
-import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.regex.Regex;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -48,8 +45,6 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public class DynamicTemplate implements ToXContentObject {
-
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(DynamicTemplate.class);
 
     public enum MatchType {
         SIMPLE {
@@ -183,7 +178,7 @@ public class DynamicTemplate implements ToXContentObject {
         public abstract String defaultMappingType();
     }
 
-    public static DynamicTemplate parse(String name, Map<String, Object> conf, Version indexVersionCreated) throws MapperParsingException {
+    public static DynamicTemplate parse(String name, Map<String, Object> conf) throws MapperParsingException {
         String match = null;
         String pathMatch = null;
         String unmatch = null;
@@ -229,20 +224,18 @@ public class DynamicTemplate implements ToXContentObject {
 
         final MatchType matchType = MatchType.fromString(matchPattern);
 
-        if (indexVersionCreated.onOrAfter(LegacyESVersion.V_6_3_0)) {
-            // Validate that the pattern
-            for (String regex : new String[] { pathMatch, match, pathUnmatch, unmatch }) {
-                if (regex == null) {
-                    continue;
-                }
-                try {
-                    matchType.matches(regex, "");
-                } catch (IllegalArgumentException e) {
-                    throw new IllegalArgumentException(
-                        "Pattern [" + regex + "] of type [" + matchType + "] is invalid. Cannot create dynamic template [" + name + "].",
-                        e
-                    );
-                }
+        // Validate the pattern
+        for (String regex : new String[] { pathMatch, match, pathUnmatch, unmatch }) {
+            if (regex == null) {
+                continue;
+            }
+            try {
+                matchType.matches(regex, "");
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(
+                    "Pattern [" + regex + "] of type [" + matchType + "] is invalid. Cannot create dynamic template [" + name + "].",
+                    e
+                );
             }
         }
 

--- a/server/src/main/java/org/opensearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/RootObjectMapper.java
@@ -207,7 +207,7 @@ public class RootObjectMapper extends ObjectMapper {
                     Map.Entry<String, Object> entry = tmpl.entrySet().iterator().next();
                     String templateName = entry.getKey();
                     Map<String, Object> templateParams = (Map<String, Object>) entry.getValue();
-                    DynamicTemplate template = DynamicTemplate.parse(templateName, templateParams, parserContext.indexVersionCreated());
+                    DynamicTemplate template = DynamicTemplate.parse(templateName, templateParams);
                     if (template != null) {
                         validateDynamicTemplate(parserContext, template);
                         templates.add(template);

--- a/server/src/test/java/org/opensearch/index/mapper/DynamicTemplateTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DynamicTemplateTests.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.index.mapper;
 
-import org.opensearch.LegacyESVersion;
-import org.opensearch.Version;
 import org.opensearch.common.Strings;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -55,7 +53,7 @@ public class DynamicTemplateTests extends OpenSearchTestCase {
 
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> DynamicTemplate.parse("my_template", templateDef, Version.CURRENT.minimumIndexCompatibilityVersion())
+            () -> DynamicTemplate.parse("my_template", templateDef)
         );
         assertEquals("Illegal dynamic template parameter: [random_param]", e.getMessage());
     }
@@ -67,7 +65,7 @@ public class DynamicTemplateTests extends OpenSearchTestCase {
         // if a wrong match type is specified, we ignore the template
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> DynamicTemplate.parse("my_template", templateDef2, Version.CURRENT.minimumIndexCompatibilityVersion())
+            () -> DynamicTemplate.parse("my_template", templateDef2)
         );
         assertEquals(
             "No field type matched on [text], possible values are [object, string, long, double, boolean, date, binary]",
@@ -84,7 +82,7 @@ public class DynamicTemplateTests extends OpenSearchTestCase {
             templateDef.put("mapping", Collections.singletonMap("store", true));
             IllegalArgumentException e = expectThrows(
                 IllegalArgumentException.class,
-                () -> DynamicTemplate.parse("my_template", templateDef, LegacyESVersion.V_6_3_0)
+                () -> DynamicTemplate.parse("my_template", templateDef)
             );
             assertEquals("Pattern [*a] of type [regex] is invalid. Cannot create dynamic template [my_template].", e.getMessage());
         }
@@ -94,7 +92,7 @@ public class DynamicTemplateTests extends OpenSearchTestCase {
         Map<String, Object> templateDef = new HashMap<>();
         templateDef.put("match_mapping_type", "*");
         templateDef.put("mapping", Collections.singletonMap("store", true));
-        DynamicTemplate template = DynamicTemplate.parse("my_template", templateDef, Version.CURRENT.minimumIndexCompatibilityVersion());
+        DynamicTemplate template = DynamicTemplate.parse("my_template", templateDef);
         assertTrue(template.match("a.b", "b", randomFrom(XContentFieldType.values())));
     }
 
@@ -102,7 +100,7 @@ public class DynamicTemplateTests extends OpenSearchTestCase {
         Map<String, Object> templateDef = new HashMap<>();
         templateDef.put("match_mapping_type", "string");
         templateDef.put("mapping", Collections.singletonMap("store", true));
-        DynamicTemplate template = DynamicTemplate.parse("my_template", templateDef, Version.CURRENT.minimumIndexCompatibilityVersion());
+        DynamicTemplate template = DynamicTemplate.parse("my_template", templateDef);
         assertTrue(template.match("a.b", "b", XContentFieldType.STRING));
         assertFalse(template.match("a.b", "b", XContentFieldType.BOOLEAN));
     }
@@ -112,7 +110,7 @@ public class DynamicTemplateTests extends OpenSearchTestCase {
         Map<String, Object> templateDef = new HashMap<>();
         templateDef.put("match_mapping_type", "string");
         templateDef.put("mapping", Collections.singletonMap("store", true));
-        DynamicTemplate template = DynamicTemplate.parse("my_template", templateDef, Version.CURRENT.minimumIndexCompatibilityVersion());
+        DynamicTemplate template = DynamicTemplate.parse("my_template", templateDef);
         XContentBuilder builder = JsonXContent.contentBuilder();
         template.toXContent(builder, ToXContent.EMPTY_PARAMS);
         assertEquals("{\"match_mapping_type\":\"string\",\"mapping\":{\"store\":true}}", Strings.toString(builder));
@@ -122,7 +120,7 @@ public class DynamicTemplateTests extends OpenSearchTestCase {
         templateDef.put("match", "*name");
         templateDef.put("unmatch", "first_name");
         templateDef.put("mapping", Collections.singletonMap("store", true));
-        template = DynamicTemplate.parse("my_template", templateDef, Version.CURRENT.minimumIndexCompatibilityVersion());
+        template = DynamicTemplate.parse("my_template", templateDef);
         builder = JsonXContent.contentBuilder();
         template.toXContent(builder, ToXContent.EMPTY_PARAMS);
         assertEquals("{\"match\":\"*name\",\"unmatch\":\"first_name\",\"mapping\":{\"store\":true}}", Strings.toString(builder));
@@ -132,7 +130,7 @@ public class DynamicTemplateTests extends OpenSearchTestCase {
         templateDef.put("path_match", "*name");
         templateDef.put("path_unmatch", "first_name");
         templateDef.put("mapping", Collections.singletonMap("store", true));
-        template = DynamicTemplate.parse("my_template", templateDef, Version.CURRENT.minimumIndexCompatibilityVersion());
+        template = DynamicTemplate.parse("my_template", templateDef);
         builder = JsonXContent.contentBuilder();
         template.toXContent(builder, ToXContent.EMPTY_PARAMS);
         assertEquals("{\"path_match\":\"*name\",\"path_unmatch\":\"first_name\",\"mapping\":{\"store\":true}}", Strings.toString(builder));
@@ -142,7 +140,7 @@ public class DynamicTemplateTests extends OpenSearchTestCase {
         templateDef.put("match", "^a$");
         templateDef.put("match_pattern", "regex");
         templateDef.put("mapping", Collections.singletonMap("store", true));
-        template = DynamicTemplate.parse("my_template", templateDef, Version.CURRENT.minimumIndexCompatibilityVersion());
+        template = DynamicTemplate.parse("my_template", templateDef);
         builder = JsonXContent.contentBuilder();
         template.toXContent(builder, ToXContent.EMPTY_PARAMS);
         assertEquals("{\"match\":\"^a$\",\"match_pattern\":\"regex\",\"mapping\":{\"store\":true}}", Strings.toString(builder));

--- a/server/src/test/java/org/opensearch/index/mapper/DynamicTemplateTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DynamicTemplateTests.java
@@ -51,10 +51,7 @@ public class DynamicTemplateTests extends OpenSearchTestCase {
         templateDef.put("mapping", Collections.singletonMap("store", true));
         templateDef.put("random_param", "random_value");
 
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> DynamicTemplate.parse("my_template", templateDef)
-        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> DynamicTemplate.parse("my_template", templateDef));
         assertEquals("Illegal dynamic template parameter: [random_param]", e.getMessage());
     }
 
@@ -63,10 +60,7 @@ public class DynamicTemplateTests extends OpenSearchTestCase {
         templateDef2.put("match_mapping_type", "text");
         templateDef2.put("mapping", Collections.singletonMap("store", true));
         // if a wrong match type is specified, we ignore the template
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> DynamicTemplate.parse("my_template", templateDef2)
-        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> DynamicTemplate.parse("my_template", templateDef2));
         assertEquals(
             "No field type matched on [text], possible values are [object, string, long, double, boolean, date, binary]",
             e.getMessage()


### PR DESCRIPTION
This PR removes legacy version checks in DynamicTemplate parsing that are no longer valid in OpenSearch 2.0.0.