### PR TITLE
Better JDK-18 EA (and beyond) support of SecurityManager

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -346,6 +346,15 @@ gradle.projectsEvaluated {
     if (tasks.findByPath('test') != null && tasks.findByPath('integTest') != null) {
       integTest.mustRunAfter test
     }
+
+    project.tasks.withType(Test) { task ->
+      if (task != null) {
+        if (BuildParams.runtimeJavaVersion > JavaVersion.VERSION_17) {
+          task.jvmArgs += ["-Djava.security.manager=allow"]
+        }
+      }
+    }
+
     configurations.matching { it.canBeResolved }.all { Configuration configuration ->
       dependencies.matching { it instanceof ProjectDependency }.all { ProjectDependency dep ->
         Project upstreamProject = dep.dependencyProject

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ systemProp.org.gradle.warning.mode=fail
 systemProp.jdk.tls.client.protocols=TLSv1.2
 
 # jvm args for faster test execution by default
-systemProp.tests.jvm.argline=-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m -Djava.security.manager=allow
+systemProp.tests.jvm.argline=-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Better support of  JDK-18 EA without breaking other JDK runtimes **(tests only)**.  Tested with

```
gradle :plugins:repository-azure:check -Druntime.java=11
gradle :plugins:repository-azure:check -Druntime.java=15
gradle :plugins:repository-azure:check -Druntime.java=16
gradle :plugins:repository-azure:check -Druntime.java=18
gradle :plugins:repository-azure:check
```
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
