### PR TITLE
[Remove] Remaining Flavor Serialization

### DIFF
--- a/server/src/main/java/org/opensearch/Build.java
+++ b/server/src/main/java/org/opensearch/Build.java
@@ -245,7 +245,7 @@ public class Build {
         // The following block is kept for existing BWS tests to pass.
         // TODO - clean up this code when we remove all v6 bwc tests.
         // TODO - clean this up when OSS flavor is removed in all of the code base
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0) && out.getVersion().before(Version.V_1_3_0) ) {
+        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0) && out.getVersion().before(Version.V_1_3_0)) {
             out.writeString("oss");
         }
         if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {

--- a/server/src/main/java/org/opensearch/Build.java
+++ b/server/src/main/java/org/opensearch/Build.java
@@ -214,7 +214,8 @@ public class Build {
         // TODO - clean this up when OSS flavor is removed in all of the code base
         // (Integ test zip still write OSS as distribution)
         // See issue: https://github.com/opendistro-for-elasticsearch/search/issues/159
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_3_0) && in.getVersion().before(Version.V_1_3_0)) {
+        // todo change to V_1_3_0 after backporting
+        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_3_0) && in.getVersion().before(Version.V_2_0_0)) {
             String flavor = in.readString();
         }
         if (in.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
@@ -245,7 +246,8 @@ public class Build {
         // The following block is kept for existing BWS tests to pass.
         // TODO - clean up this code when we remove all v6 bwc tests.
         // TODO - clean this up when OSS flavor is removed in all of the code base
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0) && out.getVersion().before(Version.V_1_3_0)) {
+        // todo change to V_1_3_0 after backporting
+        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0) && out.getVersion().before(Version.V_2_0_0)) {
             out.writeString("oss");
         }
         if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {

--- a/server/src/main/java/org/opensearch/Build.java
+++ b/server/src/main/java/org/opensearch/Build.java
@@ -201,7 +201,6 @@ public class Build {
 
     public static Build readBuild(StreamInput in) throws IOException {
         final String distribution;
-        final String flavor;
         final Type type;
         // the following is new for opensearch: we write the distribution to support any "forks"
         if (in.getVersion().onOrAfter(Version.V_1_0_0)) {
@@ -215,8 +214,8 @@ public class Build {
         // TODO - clean this up when OSS flavor is removed in all of the code base
         // (Integ test zip still write OSS as distribution)
         // See issue: https://github.com/opendistro-for-elasticsearch/search/issues/159
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
-            flavor = in.readString();
+        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_3_0) && in.getVersion().before(Version.V_1_3_0)) {
+            String flavor = in.readString();
         }
         if (in.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
             // be lenient when reading on the wire, the enumeration values from other versions might be different than what we know
@@ -246,8 +245,7 @@ public class Build {
         // The following block is kept for existing BWS tests to pass.
         // TODO - clean up this code when we remove all v6 bwc tests.
         // TODO - clean this up when OSS flavor is removed in all of the code base
-        // See issue: https://github.com/opendistro-for-elasticsearch/search/issues/159
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
+        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0) && out.getVersion().before(Version.V_1_3_0) ) {
             out.writeString("oss");
         }
         if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {


### PR DESCRIPTION
This PR removes unnecessary serialization of unused flavor variable in build
metadata from V_1_3_0+. This will need to be backported to ensure bwc tests do not fail.