### PR TITLE
Ignore file order in test assertion

### DIFF
--- a/buildSrc/src/test/java/org/opensearch/gradle/precommit/UpdateShasTaskTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/precommit/UpdateShasTaskTests.java
@@ -91,9 +91,10 @@ public class UpdateShasTaskTests extends GradleUnitTestCase {
         getLicensesDir(project).mkdir();
         task.updateShas();
 
-        Path groovySha = Files.list(getLicensesDir(project).toPath()).findFirst().get();
-
-        assertTrue(groovySha.toFile().getName().startsWith("groovy-"));
+        assertTrue(
+            "Expected a sha file to exist with a name prefix of 'groovy-",
+            Files.list(getLicensesDir(project).toPath()).anyMatch(sha -> sha.toFile().getName().startsWith("groovy-"))
+        );
     }
 
     @Test


### PR DESCRIPTION
### Description

This unit test asserts that a SHA file for a groovy dependency gets
created. However, a SHA file for javaparser-core also gets created in
the same directory. For some reason, builds were failing on my machine
because `Files::list` was returning the javaparser-core file first. I
don't believe there are any ordering guarantees with that API, so I
relaxed the assertion to not depend on ordering.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
