### PR TITLE
[Backport] [1.x] Gradle clean failing after a failed gradle check, folders created by Docker under 'root' user (#1726)

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -155,6 +155,10 @@ opensearch_distributions {
 
 tasks.named("preProcessFixture").configure {
   dependsOn opensearch_distributions.docker
+  // always run the task, otherwise the folders won't be created
+  outputs.upToDateWhen { 
+    false 
+  }
   doLast {
     // tests expect to have an empty repo
     project.delete(
@@ -261,4 +265,8 @@ subprojects { Project subProject ->
       dependsOn(exportTaskName)
     }
   }
+}
+
+tasks.named("composeUp").configure {
+  dependsOn preProcessFixture
 }

--- a/qa/remote-clusters/build.gradle
+++ b/qa/remote-clusters/build.gradle
@@ -51,8 +51,12 @@ opensearch_distributions {
   }
 }
 
-preProcessFixture {
+tasks.named("preProcessFixture").configure {
   dependsOn opensearch_distributions.docker
+  // always run the task, otherwise the folders won't be created
+  outputs.upToDateWhen { 
+    false 
+  }
   doLast {
     // tests expect to have an empty repo
     project.delete(
@@ -86,3 +90,7 @@ tasks.register("integTest", Test) {
 }
 
 tasks.named("check").configure { dependsOn "integTest" }
+
+tasks.named("composeUp").configure {
+  dependsOn preProcessFixture
+}


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Backport of https://github.com/opensearch-project/OpenSearch/pull/1726 to 1.x
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/1675
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
