### PR TITLE
[Backport] [1.x] Fixing allocation filters to persist existing state on settings updat…

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -1421,28 +1421,28 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             if (requireMap.isEmpty()) {
                 requireFilters = null;
             } else {
-                requireFilters = DiscoveryNodeFilters.buildFromKeyValue(AND, requireMap);
+                requireFilters = DiscoveryNodeFilters.buildOrUpdateFromKeyValue(null, AND, requireMap);
             }
             Map<String, String> includeMap = INDEX_ROUTING_INCLUDE_GROUP_SETTING.getAsMap(settings);
             final DiscoveryNodeFilters includeFilters;
             if (includeMap.isEmpty()) {
                 includeFilters = null;
             } else {
-                includeFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, includeMap);
+                includeFilters = DiscoveryNodeFilters.buildOrUpdateFromKeyValue(null, OR, includeMap);
             }
             Map<String, String> excludeMap = INDEX_ROUTING_EXCLUDE_GROUP_SETTING.getAsMap(settings);
             final DiscoveryNodeFilters excludeFilters;
             if (excludeMap.isEmpty()) {
                 excludeFilters = null;
             } else {
-                excludeFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, excludeMap);
+                excludeFilters = DiscoveryNodeFilters.buildOrUpdateFromKeyValue(null, OR, excludeMap);
             }
             Map<String, String> initialRecoveryMap = INDEX_ROUTING_INITIAL_RECOVERY_GROUP_SETTING.getAsMap(settings);
             final DiscoveryNodeFilters initialRecoveryFilters;
             if (initialRecoveryMap.isEmpty()) {
                 initialRecoveryFilters = null;
             } else {
-                initialRecoveryFilters = DiscoveryNodeFilters.buildFromKeyValue(OR, initialRecoveryMap);
+                initialRecoveryFilters = DiscoveryNodeFilters.buildOrUpdateFromKeyValue(null, OR, initialRecoveryMap);
             }
             Version indexCreatedVersion = Version.indexCreated(settings);
             Version indexUpgradedVersion = settings.getAsVersion(IndexMetadata.SETTING_VERSION_UPGRADED, indexCreatedVersion);

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeFilters.java
@@ -69,18 +69,31 @@ public class DiscoveryNodeFilters {
         }
     };
 
-    public static DiscoveryNodeFilters buildFromKeyValue(OpType opType, Map<String, String> filters) {
-        Map<String, String[]> bFilters = new HashMap<>();
+    /**
+     * Creates or updates filters returning a new {@link DiscoveryNodeFilters} object.
+     * If the new object has no filters, {@code null} is returned.
+     */
+    @Nullable
+    public static DiscoveryNodeFilters buildOrUpdateFromKeyValue(
+        final DiscoveryNodeFilters original,
+        final OpType opType,
+        final Map<String, String> filters
+    ) {
+        final DiscoveryNodeFilters updated;
+        if (original == null) {
+            updated = new DiscoveryNodeFilters(opType, new HashMap<>());
+        } else {
+            assert opType == original.opType : "operation type should match with node filter parameter";
+            updated = new DiscoveryNodeFilters(original.opType, original.filters);
+        }
         for (Map.Entry<String, String> entry : filters.entrySet()) {
             String[] values = Strings.tokenizeToStringArray(entry.getValue(), ",");
-            if (values.length > 0) {
-                bFilters.put(entry.getKey(), values);
-            }
+            updated.filters.compute(entry.getKey(), (k, v) -> values.length > 0 ? values : null);
         }
-        if (bFilters.isEmpty()) {
+        if (updated.filters.isEmpty()) {
             return null;
         }
-        return new DiscoveryNodeFilters(opType, bFilters);
+        return updated;
     }
 
     private final Map<String, String[]> filters;

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
@@ -255,14 +255,20 @@ public class FilterAllocationDecider extends AllocationDecider {
     }
 
     private void setClusterRequireFilters(Map<String, String> filters) {
-        clusterRequireFilters = DiscoveryNodeFilters.trimTier(DiscoveryNodeFilters.buildFromKeyValue(AND, filters));
+        clusterRequireFilters = DiscoveryNodeFilters.trimTier(
+            DiscoveryNodeFilters.buildOrUpdateFromKeyValue(clusterRequireFilters, AND, filters)
+        );
     }
 
     private void setClusterIncludeFilters(Map<String, String> filters) {
-        clusterIncludeFilters = DiscoveryNodeFilters.trimTier(DiscoveryNodeFilters.buildFromKeyValue(OR, filters));
+        clusterIncludeFilters = DiscoveryNodeFilters.trimTier(
+            DiscoveryNodeFilters.buildOrUpdateFromKeyValue(clusterIncludeFilters, OR, filters)
+        );
     }
 
     private void setClusterExcludeFilters(Map<String, String> filters) {
-        clusterExcludeFilters = DiscoveryNodeFilters.trimTier(DiscoveryNodeFilters.buildFromKeyValue(OR, filters));
+        clusterExcludeFilters = DiscoveryNodeFilters.trimTier(
+            DiscoveryNodeFilters.buildOrUpdateFromKeyValue(clusterExcludeFilters, OR, filters)
+        );
     }
 }


### PR DESCRIPTION
…e (#1718)

* Fixing allocation filters to persist existing state on settings update

Signed-off-by: Ankit Jain <jain.ankitk@gmail.com>

* Adding test for filter settings update

Signed-off-by: Ankit Jain <jain.ankitk@gmail.com>

* Adding more tests and review comments

Signed-off-by: Ankit Jain <jain.ankitk@gmail.com>

* Adding assertion and unit test for operation type mismatch

Signed-off-by: Ankit Jain <jain.ankitk@gmail.com>

* Updating test names

Signed-off-by: Ankit Jain <jain.ankitk@gmail.com>

### Description
Backport of #1718 to 1.x
 
### Issues Resolved
#1716
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
