### PR TITLE
Remove LegacyESVersion.V_6_4_x constants

### DIFF
--- a/modules/lang-painless/src/main/java/org/opensearch/painless/action/PainlessExecuteAction.java
+++ b/modules/lang-painless/src/main/java/org/opensearch/painless/action/PainlessExecuteAction.java
@@ -42,7 +42,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
-import org.opensearch.LegacyESVersion;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.opensearch.action.ActionRequestValidationException;
@@ -314,15 +313,8 @@ public class PainlessExecuteAction extends ActionType<PainlessExecuteAction.Resp
         Request(StreamInput in) throws IOException {
             super(in);
             script = new Script(in);
-            if (in.getVersion().before(LegacyESVersion.V_6_4_0)) {
-                byte scriptContextId = in.readByte();
-                assert scriptContextId == 0;
-                context = null;
-                contextSetup = null;
-            } else {
-                context = fromScriptContextName(in.readString());
-                contextSetup = in.readOptionalWriteable(ContextSetup::new);
-            }
+            context = fromScriptContextName(in.readString());
+            contextSetup = in.readOptionalWriteable(ContextSetup::new);
         }
 
         public Script getScript() {
@@ -358,12 +350,8 @@ public class PainlessExecuteAction extends ActionType<PainlessExecuteAction.Resp
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             script.writeTo(out);
-            if (out.getVersion().before(LegacyESVersion.V_6_4_0)) {
-                out.writeByte((byte) 0);
-            } else {
-                out.writeString(context.name);
-                out.writeOptionalWriteable(contextSetup);
-            }
+            out.writeString(context.name);
+            out.writeOptionalWriteable(contextSetup);
         }
 
         // For testing only:

--- a/qa/full-cluster-restart/src/test/java/org/opensearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/opensearch/upgrades/FullClusterRestartIT.java
@@ -351,7 +351,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
             client().performRequest(updateSettingsRequest);
 
             Request shrinkIndexRequest = new Request("PUT", "/" + index + "/_shrink/" + shrunkenIndex);
-            if (getOldClusterVersion().onOrAfter(LegacyESVersion.V_6_4_0) && getOldClusterVersion().before(LegacyESVersion.V_7_0_0)) {
+            if (getOldClusterVersion().before(LegacyESVersion.V_7_0_0)) {
                 shrinkIndexRequest.addParameter("copy_settings", "true");
             }
             shrinkIndexRequest.setJsonEntity("{\"settings\": {\"index.number_of_shards\": 1}}");

--- a/server/src/main/java/org/opensearch/LegacyESVersion.java
+++ b/server/src/main/java/org/opensearch/LegacyESVersion.java
@@ -46,10 +46,6 @@ import java.lang.reflect.Field;
  */
 public class LegacyESVersion extends Version {
 
-    public static final LegacyESVersion V_6_4_0 = new LegacyESVersion(6040099, org.apache.lucene.util.Version.LUCENE_7_4_0);
-    public static final LegacyESVersion V_6_4_1 = new LegacyESVersion(6040199, org.apache.lucene.util.Version.LUCENE_7_4_0);
-    public static final LegacyESVersion V_6_4_2 = new LegacyESVersion(6040299, org.apache.lucene.util.Version.LUCENE_7_4_0);
-    public static final LegacyESVersion V_6_4_3 = new LegacyESVersion(6040399, org.apache.lucene.util.Version.LUCENE_7_4_0);
     public static final LegacyESVersion V_6_5_0 = new LegacyESVersion(6050099, org.apache.lucene.util.Version.LUCENE_7_5_0);
     public static final LegacyESVersion V_6_5_1 = new LegacyESVersion(6050199, org.apache.lucene.util.Version.LUCENE_7_5_0);
     public static final LegacyESVersion V_6_5_2 = new LegacyESVersion(6050299, org.apache.lucene.util.Version.LUCENE_7_5_0);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/reroute/ClusterRerouteResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/reroute/ClusterRerouteResponse.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.cluster.reroute;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.routing.allocation.RoutingExplanations;
@@ -53,15 +52,9 @@ public class ClusterRerouteResponse extends AcknowledgedResponse implements ToXC
     private final RoutingExplanations explanations;
 
     ClusterRerouteResponse(StreamInput in) throws IOException {
-        super(in, in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0));
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            state = ClusterState.readFrom(in, null);
-            explanations = RoutingExplanations.readFrom(in);
-        } else {
-            state = ClusterState.readFrom(in, null);
-            acknowledged = in.readBoolean();
-            explanations = RoutingExplanations.readFrom(in);
-        }
+        super(in);
+        state = ClusterState.readFrom(in, null);
+        explanations = RoutingExplanations.readFrom(in);
     }
 
     ClusterRerouteResponse(boolean acknowledged, ClusterState state, RoutingExplanations explanations) {
@@ -83,15 +76,9 @@ public class ClusterRerouteResponse extends AcknowledgedResponse implements ToXC
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            super.writeTo(out);
-            state.writeTo(out);
-            RoutingExplanations.writeTo(explanations, out);
-        } else {
-            state.writeTo(out);
-            out.writeBoolean(acknowledged);
-            RoutingExplanations.writeTo(explanations, out);
-        }
+        super.writeTo(out);
+        state.writeTo(out);
+        RoutingExplanations.writeTo(explanations, out);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/cluster/settings/ClusterUpdateSettingsResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/settings/ClusterUpdateSettingsResponse.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.cluster.settings;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.io.stream.StreamInput;
@@ -70,15 +69,9 @@ public class ClusterUpdateSettingsResponse extends AcknowledgedResponse {
     final Settings persistentSettings;
 
     ClusterUpdateSettingsResponse(StreamInput in) throws IOException {
-        super(in, in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0));
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            transientSettings = Settings.readSettingsFromStream(in);
-            persistentSettings = Settings.readSettingsFromStream(in);
-        } else {
-            transientSettings = Settings.readSettingsFromStream(in);
-            persistentSettings = Settings.readSettingsFromStream(in);
-            acknowledged = in.readBoolean();
-        }
+        super(in);
+        transientSettings = Settings.readSettingsFromStream(in);
+        persistentSettings = Settings.readSettingsFromStream(in);
     }
 
     ClusterUpdateSettingsResponse(boolean acknowledged, Settings transientSettings, Settings persistentSettings) {
@@ -97,15 +90,9 @@ public class ClusterUpdateSettingsResponse extends AcknowledgedResponse {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            super.writeTo(out);
-            Settings.writeSettingsToStream(transientSettings, out);
-            Settings.writeSettingsToStream(persistentSettings, out);
-        } else {
-            Settings.writeSettingsToStream(transientSettings, out);
-            Settings.writeSettingsToStream(persistentSettings, out);
-            out.writeBoolean(acknowledged);
-        }
+        super.writeTo(out);
+        Settings.writeSettingsToStream(transientSettings, out);
+        Settings.writeSettingsToStream(persistentSettings, out);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/SnapshotStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/SnapshotStats.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.cluster.snapshots.status;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -70,13 +69,8 @@ public class SnapshotStats implements Writeable, ToXContentObject {
         incrementalSize = in.readVLong();
         processedSize = in.readVLong();
 
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            totalFileCount = in.readVInt();
-            totalSize = in.readVLong();
-        } else {
-            totalFileCount = incrementalFileCount;
-            totalSize = incrementalSize;
-        }
+        totalFileCount = in.readVInt();
+        totalSize = in.readVLong();
     }
 
     SnapshotStats(
@@ -167,10 +161,8 @@ public class SnapshotStats implements Writeable, ToXContentObject {
         out.writeVLong(incrementalSize);
         out.writeVLong(processedSize);
 
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            out.writeVInt(totalFileCount);
-            out.writeVLong(totalSize);
-        }
+        out.writeVInt(totalFileCount);
+        out.writeVLong(totalSize);
     }
 
     static final class Fields {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/storedscripts/GetStoredScriptResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/storedscripts/GetStoredScriptResponse.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.cluster.storedscripts;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.io.stream.StreamInput;
@@ -91,9 +90,7 @@ public class GetStoredScriptResponse extends ActionResponse implements StatusToX
             source = null;
         }
 
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            id = in.readString();
-        }
+        id = in.readString();
     }
 
     GetStoredScriptResponse(String id, StoredScriptSource source) {
@@ -144,9 +141,7 @@ public class GetStoredScriptResponse extends ActionResponse implements StatusToX
             out.writeBoolean(true);
             source.writeTo(out);
         }
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            out.writeString(id);
-        }
+        out.writeString(id);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/indices/alias/Alias.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/alias/Alias.java
@@ -87,11 +87,7 @@ public class Alias implements Writeable, ToXContentFragment {
         filter = in.readOptionalString();
         indexRouting = in.readOptionalString();
         searchRouting = in.readOptionalString();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            writeIndex = in.readOptionalBoolean();
-        } else {
-            writeIndex = null;
-        }
+        writeIndex = in.readOptionalBoolean();
         if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
             isHidden = in.readOptionalBoolean();
         } else {
@@ -237,9 +233,7 @@ public class Alias implements Writeable, ToXContentFragment {
         out.writeOptionalString(filter);
         out.writeOptionalString(indexRouting);
         out.writeOptionalString(searchRouting);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            out.writeOptionalBoolean(writeIndex);
-        }
+        out.writeOptionalBoolean(writeIndex);
         if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
             out.writeOptionalBoolean(isHidden);
         }

--- a/server/src/main/java/org/opensearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -270,9 +270,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
             routing = in.readOptionalString();
             searchRouting = in.readOptionalString();
             indexRouting = in.readOptionalString();
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-                writeIndex = in.readOptionalBoolean();
-            }
+            writeIndex = in.readOptionalBoolean();
             // TODO fix for backport of https://github.com/elastic/elasticsearch/pull/52547
             if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
                 isHidden = in.readOptionalBoolean();
@@ -296,9 +294,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
             out.writeOptionalString(routing);
             out.writeOptionalString(searchRouting);
             out.writeOptionalString(indexRouting);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-                out.writeOptionalBoolean(writeIndex);
-            }
+            out.writeOptionalBoolean(writeIndex);
             // TODO fix for backport https://github.com/elastic/elasticsearch/pull/52547
             if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
                 out.writeOptionalBoolean(isHidden);

--- a/server/src/main/java/org/opensearch/action/admin/indices/alias/get/GetAliasesRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/alias/get/GetAliasesRequest.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.action.admin.indices.alias.get;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.AliasesRequest;
 import org.opensearch.action.support.IndicesOptions;
@@ -61,9 +60,7 @@ public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> 
         indices = in.readStringArray();
         aliases = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            originalAliases = in.readStringArray();
-        }
+        originalAliases = in.readStringArray();
     }
 
     @Override
@@ -72,9 +69,7 @@ public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> 
         out.writeStringArray(indices);
         out.writeStringArray(aliases);
         indicesOptions.writeIndicesOptions(out);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            out.writeStringArray(originalAliases);
-        }
+        out.writeStringArray(originalAliases);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/indices/close/CloseIndexResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/close/CloseIndexResponse.java
@@ -57,7 +57,7 @@ public class CloseIndexResponse extends ShardsAcknowledgedResponse {
     private final List<IndexResult> indices;
 
     CloseIndexResponse(StreamInput in) throws IOException {
-        super(in, in.getVersion().onOrAfter(LegacyESVersion.V_7_2_0), true);
+        super(in, in.getVersion().onOrAfter(LegacyESVersion.V_7_2_0));
         if (in.getVersion().onOrAfter(LegacyESVersion.V_7_3_0)) {
             indices = unmodifiableList(in.readList(IndexResult::new));
         } else {

--- a/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexResponse.java
@@ -71,7 +71,7 @@ public class CreateIndexResponse extends ShardsAcknowledgedResponse {
     private final String index;
 
     protected CreateIndexResponse(StreamInput in) throws IOException {
-        super(in, true, true);
+        super(in, true);
         index = in.readString();
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/get/GetIndexRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/get/GetIndexRequest.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.indices.get;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.support.master.info.ClusterInfoRequest;
 import org.opensearch.common.io.stream.StreamInput;
@@ -90,9 +89,7 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
         super(in);
         features = in.readArray(i -> Feature.fromId(i.readByte()), Feature[]::new);
         humanReadable = in.readBoolean();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            includeDefaults = in.readBoolean();
-        }
+        includeDefaults = in.readBoolean();
     }
 
     public GetIndexRequest features(Feature... features) {
@@ -156,9 +153,7 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
         super.writeTo(out);
         out.writeArray((o, f) -> o.writeByte(f.id), features);
         out.writeBoolean(humanReadable);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            out.writeBoolean(includeDefaults);
-        }
+        out.writeBoolean(includeDefaults);
     }
 
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/open/OpenIndexResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/open/OpenIndexResponse.java
@@ -56,7 +56,7 @@ public class OpenIndexResponse extends ShardsAcknowledgedResponse {
     }
 
     public OpenIndexResponse(StreamInput in) throws IOException {
-        super(in, true, true);
+        super(in, true);
     }
 
     public OpenIndexResponse(boolean acknowledged, boolean shardsAcknowledged) {

--- a/server/src/main/java/org/opensearch/action/admin/indices/readonly/AddIndexBlockResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/readonly/AddIndexBlockResponse.java
@@ -55,7 +55,7 @@ public class AddIndexBlockResponse extends ShardsAcknowledgedResponse {
     private final List<AddBlockResult> indices;
 
     AddIndexBlockResponse(StreamInput in) throws IOException {
-        super(in, true, true);
+        super(in, true);
         indices = unmodifiableList(in.readList(AddBlockResult::new));
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/rollover/RolloverResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/rollover/RolloverResponse.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.indices.rollover;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.support.master.ShardsAcknowledgedResponse;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.io.stream.StreamInput;
@@ -98,31 +97,17 @@ public final class RolloverResponse extends ShardsAcknowledgedResponse implement
     private final boolean shardsAcknowledged;
 
     RolloverResponse(StreamInput in) throws IOException {
-        super(in, false, in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0));
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            oldIndex = in.readString();
-            newIndex = in.readString();
-            int conditionSize = in.readVInt();
-            conditionStatus = new HashMap<>(conditionSize);
-            for (int i = 0; i < conditionSize; i++) {
-                conditionStatus.put(in.readString(), in.readBoolean());
-            }
-            dryRun = in.readBoolean();
-            rolledOver = in.readBoolean();
-            shardsAcknowledged = in.readBoolean();
-        } else {
-            oldIndex = in.readString();
-            newIndex = in.readString();
-            int conditionSize = in.readVInt();
-            conditionStatus = new HashMap<>(conditionSize);
-            for (int i = 0; i < conditionSize; i++) {
-                conditionStatus.put(in.readString(), in.readBoolean());
-            }
-            dryRun = in.readBoolean();
-            rolledOver = in.readBoolean();
-            acknowledged = in.readBoolean();
-            shardsAcknowledged = in.readBoolean();
+        super(in, false);
+        oldIndex = in.readString();
+        newIndex = in.readString();
+        int conditionSize = in.readVInt();
+        conditionStatus = new HashMap<>(conditionSize);
+        for (int i = 0; i < conditionSize; i++) {
+            conditionStatus.put(in.readString(), in.readBoolean());
         }
+        dryRun = in.readBoolean();
+        rolledOver = in.readBoolean();
+        shardsAcknowledged = in.readBoolean();
     }
 
     public RolloverResponse(
@@ -185,31 +170,17 @@ public final class RolloverResponse extends ShardsAcknowledgedResponse implement
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            super.writeTo(out);
-            out.writeString(oldIndex);
-            out.writeString(newIndex);
-            out.writeVInt(conditionStatus.size());
-            for (Map.Entry<String, Boolean> entry : conditionStatus.entrySet()) {
-                out.writeString(entry.getKey());
-                out.writeBoolean(entry.getValue());
-            }
-            out.writeBoolean(dryRun);
-            out.writeBoolean(rolledOver);
-            out.writeBoolean(shardsAcknowledged);
-        } else {
-            out.writeString(oldIndex);
-            out.writeString(newIndex);
-            out.writeVInt(conditionStatus.size());
-            for (Map.Entry<String, Boolean> entry : conditionStatus.entrySet()) {
-                out.writeString(entry.getKey());
-                out.writeBoolean(entry.getValue());
-            }
-            out.writeBoolean(dryRun);
-            out.writeBoolean(rolledOver);
-            out.writeBoolean(acknowledged);
-            writeShardsAcknowledged(out);
+        super.writeTo(out);
+        out.writeString(oldIndex);
+        out.writeString(newIndex);
+        out.writeVInt(conditionStatus.size());
+        for (Map.Entry<String, Boolean> entry : conditionStatus.entrySet()) {
+            out.writeString(entry.getKey());
+            out.writeBoolean(entry.getValue());
         }
+        out.writeBoolean(dryRun);
+        out.writeBoolean(rolledOver);
+        out.writeBoolean(shardsAcknowledged);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/indices/settings/get/GetSettingsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/settings/get/GetSettingsRequest.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.indices.settings.get;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.IndicesRequest;
 import org.opensearch.action.ValidateActions;
@@ -82,9 +81,7 @@ public class GetSettingsRequest extends MasterNodeReadRequest<GetSettingsRequest
         indicesOptions = IndicesOptions.readIndicesOptions(in);
         names = in.readStringArray();
         humanReadable = in.readBoolean();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            includeDefaults = in.readBoolean();
-        }
+        includeDefaults = in.readBoolean();
     }
 
     @Override
@@ -94,9 +91,7 @@ public class GetSettingsRequest extends MasterNodeReadRequest<GetSettingsRequest
         indicesOptions.writeIndicesOptions(out);
         out.writeStringArray(names);
         out.writeBoolean(humanReadable);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            out.writeBoolean(includeDefaults);
-        }
+        out.writeBoolean(includeDefaults);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/indices/shrink/ResizeRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/shrink/ResizeRequest.java
@@ -82,11 +82,7 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
         targetIndexRequest = new CreateIndexRequest(in);
         sourceIndex = in.readString();
         type = in.readEnum(ResizeType.class);
-        if (in.getVersion().before(LegacyESVersion.V_6_4_0)) {
-            copySettings = null;
-        } else {
-            copySettings = in.readOptionalBoolean();
-        }
+        copySettings = in.readOptionalBoolean();
     }
 
     ResizeRequest() {}
@@ -128,12 +124,7 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
             throw new IllegalArgumentException("can't send clone request to a node that's older than " + LegacyESVersion.V_7_4_0);
         }
         out.writeEnum(type);
-        // noinspection StatementWithEmptyBody
-        if (out.getVersion().before(LegacyESVersion.V_6_4_0)) {
-
-        } else {
-            out.writeOptionalBoolean(copySettings);
-        }
+        out.writeOptionalBoolean(copySettings);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/indices/validate/query/QueryExplanation.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/validate/query/QueryExplanation.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.indices.validate.query;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -84,11 +83,7 @@ public class QueryExplanation implements Writeable, ToXContentFragment {
     private String error;
 
     public QueryExplanation(StreamInput in) throws IOException {
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            index = in.readOptionalString();
-        } else {
-            index = in.readString();
-        }
+        index = in.readOptionalString();
         shard = in.readInt();
         valid = in.readBoolean();
         explanation = in.readOptionalString();
@@ -125,11 +120,7 @@ public class QueryExplanation implements Writeable, ToXContentFragment {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            out.writeOptionalString(index);
-        } else {
-            out.writeString(index);
-        }
+        out.writeOptionalString(index);
         out.writeInt(shard);
         out.writeBoolean(valid);
         out.writeOptionalString(explanation);

--- a/server/src/main/java/org/opensearch/action/resync/ResyncReplicationRequest.java
+++ b/server/src/main/java/org/opensearch/action/resync/ResyncReplicationRequest.java
@@ -36,7 +36,6 @@ import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.support.replication.ReplicatedWriteRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
-import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.index.translog.Translog;
 
@@ -55,11 +54,7 @@ public final class ResyncReplicationRequest extends ReplicatedWriteRequest<Resyn
 
     ResyncReplicationRequest(StreamInput in) throws IOException {
         super(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            trimAboveSeqNo = in.readZLong();
-        } else {
-            trimAboveSeqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
-        }
+        trimAboveSeqNo = in.readZLong();
         if (in.getVersion().onOrAfter(LegacyESVersion.V_6_5_0)) {
             maxSeenAutoIdTimestampOnPrimary = in.readZLong();
         } else {
@@ -95,9 +90,7 @@ public final class ResyncReplicationRequest extends ReplicatedWriteRequest<Resyn
     @Override
     public void writeTo(final StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            out.writeZLong(trimAboveSeqNo);
-        }
+        out.writeZLong(trimAboveSeqNo);
         if (out.getVersion().onOrAfter(LegacyESVersion.V_6_5_0)) {
             out.writeZLong(maxSeenAutoIdTimestampOnPrimary);
         }

--- a/server/src/main/java/org/opensearch/action/support/master/ShardsAcknowledgedResponse.java
+++ b/server/src/main/java/org/opensearch/action/support/master/ShardsAcknowledgedResponse.java
@@ -62,8 +62,8 @@ public abstract class ShardsAcknowledgedResponse extends AcknowledgedResponse {
 
     private final boolean shardsAcknowledged;
 
-    protected ShardsAcknowledgedResponse(StreamInput in, boolean readShardsAcknowledged, boolean readAcknowledged) throws IOException {
-        super(in, readAcknowledged);
+    protected ShardsAcknowledgedResponse(StreamInput in, boolean readShardsAcknowledged) throws IOException {
+        super(in);
         if (readShardsAcknowledged) {
             this.shardsAcknowledged = in.readBoolean();
         } else {

--- a/server/src/main/java/org/opensearch/cluster/metadata/AliasMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AliasMetadata.java
@@ -221,9 +221,7 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
             out.writeBoolean(false);
         }
 
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            out.writeOptionalBoolean(writeIndex());
-        }
+        out.writeOptionalBoolean(writeIndex());
 
         if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
             out.writeOptionalBoolean(isHidden());
@@ -249,11 +247,7 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
             searchRouting = null;
             searchRoutingValues = emptySet();
         }
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            writeIndex = in.readOptionalBoolean();
-        } else {
-            writeIndex = null;
-        }
+        writeIndex = in.readOptionalBoolean();
 
         if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
             isHidden = in.readOptionalBoolean();

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -968,9 +968,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             aliases.writeTo(out);
             customData.writeTo(out);
             inSyncAllocationIds.writeTo(out);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-                rolloverInfos.writeTo(out);
-            }
+            rolloverInfos.writeTo(out);
             if (out.getVersion().onOrAfter(SYSTEM_INDEX_FLAG_ADDED)) {
                 out.writeBoolean(isSystem);
             }
@@ -1041,11 +1039,9 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             Set<String> allocationIds = DiffableUtils.StringSetValueSerializer.getInstance().read(in, key);
             builder.putInSyncAllocationIds(key, allocationIds);
         }
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            int rolloverAliasesSize = in.readVInt();
-            for (int i = 0; i < rolloverAliasesSize; i++) {
-                builder.putRolloverInfo(new RolloverInfo(in));
-            }
+        int rolloverAliasesSize = in.readVInt();
+        for (int i = 0; i < rolloverAliasesSize; i++) {
+            builder.putRolloverInfo(new RolloverInfo(in));
         }
         if (in.getVersion().onOrAfter(SYSTEM_INDEX_FLAG_ADDED)) {
             builder.system(in.readBoolean());
@@ -1092,11 +1088,9 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             out.writeVInt(cursor.key);
             DiffableUtils.StringSetValueSerializer.getInstance().write(cursor.value, out);
         }
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            out.writeVInt(rolloverInfos.size());
-            for (ObjectCursor<RolloverInfo> cursor : rolloverInfos.values()) {
-                cursor.value.writeTo(out);
-            }
+        out.writeVInt(rolloverInfos.size());
+        for (ObjectCursor<RolloverInfo> cursor : rolloverInfos.values()) {
+            cursor.value.writeTo(out);
         }
         if (out.getVersion().onOrAfter(SYSTEM_INDEX_FLAG_ADDED)) {
             out.writeBoolean(isSystem);

--- a/server/src/main/java/org/opensearch/index/query/AbstractGeometryQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/AbstractGeometryQueryBuilder.java
@@ -35,7 +35,6 @@ package org.opensearch.index.query;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.SetOnce;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
@@ -204,11 +203,7 @@ public abstract class AbstractGeometryQueryBuilder<QB extends AbstractGeometryQu
             indexedShapeType = in.readOptionalString();
             indexedShapeIndex = in.readOptionalString();
             indexedShapePath = in.readOptionalString();
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-                indexedShapeRouting = in.readOptionalString();
-            } else {
-                indexedShapeRouting = null;
-            }
+            indexedShapeRouting = in.readOptionalString();
         }
         relation = ShapeRelation.readFromStream(in);
         ignoreUnmapped = in.readBoolean();
@@ -230,11 +225,7 @@ public abstract class AbstractGeometryQueryBuilder<QB extends AbstractGeometryQu
             out.writeOptionalString(indexedShapeType);
             out.writeOptionalString(indexedShapeIndex);
             out.writeOptionalString(indexedShapePath);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-                out.writeOptionalString(indexedShapeRouting);
-            } else if (indexedShapeRouting != null) {
-                throw new IllegalStateException("indexed shape routing cannot be serialized to older nodes");
-            }
+            out.writeOptionalString(indexedShapeRouting);
         }
         relation.writeTo(out);
         out.writeBoolean(ignoreUnmapped);

--- a/server/src/main/java/org/opensearch/index/query/InnerHitBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/InnerHitBuilder.java
@@ -61,7 +61,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.opensearch.common.xcontent.XContentParser.Token.END_OBJECT;
 
@@ -191,17 +190,7 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
         }
         trackScores = in.readBoolean();
         storedFieldsContext = in.readOptionalWriteable(StoredFieldsContext::new);
-        if (in.getVersion().before(LegacyESVersion.V_6_4_0)) {
-            @SuppressWarnings("unchecked")
-            List<String> fieldList = (List<String>) in.readGenericValue();
-            if (fieldList == null) {
-                docValueFields = null;
-            } else {
-                docValueFields = fieldList.stream().map(field -> new FieldAndFormat(field, null)).collect(Collectors.toList());
-            }
-        } else {
-            docValueFields = in.readBoolean() ? in.readList(FieldAndFormat::new) : null;
-        }
+        docValueFields = in.readBoolean() ? in.readList(FieldAndFormat::new) : null;
         if (in.readBoolean()) {
             int size = in.readVInt();
             scriptFields = new HashSet<>(size);
@@ -218,9 +207,7 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
             }
         }
         highlightBuilder = in.readOptionalWriteable(HighlightBuilder::new);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            this.innerCollapseBuilder = in.readOptionalWriteable(CollapseBuilder::new);
-        }
+        this.innerCollapseBuilder = in.readOptionalWriteable(CollapseBuilder::new);
 
         if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
             if (in.readBoolean()) {
@@ -242,13 +229,10 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
         }
         out.writeBoolean(trackScores);
         out.writeOptionalWriteable(storedFieldsContext);
-        if (out.getVersion().before(LegacyESVersion.V_6_4_0)) {
-            out.writeGenericValue(docValueFields == null ? null : docValueFields.stream().map(ff -> ff.field).collect(Collectors.toList()));
-        } else {
-            out.writeBoolean(docValueFields != null);
-            if (docValueFields != null) {
-                out.writeList(docValueFields);
-            }
+
+        out.writeBoolean(docValueFields != null);
+        if (docValueFields != null) {
+            out.writeList(docValueFields);
         }
         boolean hasScriptFields = scriptFields != null;
         out.writeBoolean(hasScriptFields);
@@ -269,9 +253,7 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
             }
         }
         out.writeOptionalWriteable(highlightBuilder);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            out.writeOptionalWriteable(innerCollapseBuilder);
-        }
+        out.writeOptionalWriteable(innerCollapseBuilder);
 
         if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
             out.writeBoolean(fetchFields != null);

--- a/server/src/main/java/org/opensearch/index/reindex/RemoteInfo.java
+++ b/server/src/main/java/org/opensearch/index/reindex/RemoteInfo.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.index.reindex;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.io.stream.StreamInput;
@@ -130,11 +129,7 @@ public class RemoteInfo implements Writeable, ToXContentObject {
         this.headers = unmodifiableMap(headers);
         socketTimeout = in.readTimeValue();
         connectTimeout = in.readTimeValue();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            pathPrefix = in.readOptionalString();
-        } else {
-            pathPrefix = null;
-        }
+        pathPrefix = in.readOptionalString();
     }
 
     @Override
@@ -152,9 +147,7 @@ public class RemoteInfo implements Writeable, ToXContentObject {
         }
         out.writeTimeValue(socketTimeout);
         out.writeTimeValue(connectTimeout);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            out.writeOptionalString(pathPrefix);
-        }
+        out.writeOptionalString(pathPrefix);
     }
 
     public String getScheme() {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/range/InternalBinaryRange.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/range/InternalBinaryRange.java
@@ -33,7 +33,6 @@
 package org.opensearch.search.aggregations.bucket.range;
 
 import org.apache.lucene.util.BytesRef;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -93,7 +92,7 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
         }
 
         private static Bucket createFromStream(StreamInput in, DocValueFormat format, boolean keyed) throws IOException {
-            String key = in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0) ? in.readString() : in.readOptionalString();
+            String key = in.readString();
 
             BytesRef from = in.readBoolean() ? in.readBytesRef() : null;
             BytesRef to = in.readBoolean() ? in.readBytesRef() : null;
@@ -105,11 +104,7 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-                out.writeString(key);
-            } else {
-                out.writeOptionalString(key);
-            }
+            out.writeString(key);
             out.writeBoolean(from != null);
             if (from != null) {
                 out.writeBytesRef(from);

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/range/InternalRange.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/range/InternalRange.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.search.aggregations.bucket.range;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -178,11 +177,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-                out.writeString(key);
-            } else {
-                out.writeOptionalString(key);
-            }
+            out.writeString(key);
             out.writeDouble(from);
             out.writeDouble(to);
             out.writeVLong(docCount);
@@ -278,7 +273,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
         int size = in.readVInt();
         List<B> ranges = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            String key = in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0) ? in.readString() : in.readOptionalString();
+            String key = in.readString();
             ranges.add(
                 getFactory().createBucket(
                     key,

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -78,7 +78,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static org.opensearch.index.query.AbstractQueryBuilder.parseInnerQueryBuilder;
 import static org.opensearch.search.internal.SearchContext.TRACK_TOTAL_HITS_ACCURATE;
@@ -219,19 +218,10 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         aggregations = in.readOptionalWriteable(AggregatorFactories.Builder::new);
         explain = in.readOptionalBoolean();
         fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::new);
-        if (in.getVersion().before(LegacyESVersion.V_6_4_0)) {
-            List<String> dvFields = (List<String>) in.readGenericValue();
-            if (dvFields == null) {
-                docValueFields = null;
-            } else {
-                docValueFields = dvFields.stream().map(field -> new FieldAndFormat(field, null)).collect(Collectors.toList());
-            }
+        if (in.readBoolean()) {
+            docValueFields = in.readList(FieldAndFormat::new);
         } else {
-            if (in.readBoolean()) {
-                docValueFields = in.readList(FieldAndFormat::new);
-            } else {
-                docValueFields = null;
-            }
+            docValueFields = null;
         }
         storedFieldsContext = in.readOptionalWriteable(StoredFieldsContext::new);
         from = in.readVInt();
@@ -292,13 +282,9 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         out.writeOptionalWriteable(aggregations);
         out.writeOptionalBoolean(explain);
         out.writeOptionalWriteable(fetchSourceContext);
-        if (out.getVersion().before(LegacyESVersion.V_6_4_0)) {
-            out.writeGenericValue(docValueFields == null ? null : docValueFields.stream().map(ff -> ff.field).collect(Collectors.toList()));
-        } else {
-            out.writeBoolean(docValueFields != null);
-            if (docValueFields != null) {
-                out.writeList(docValueFields);
-            }
+        out.writeBoolean(docValueFields != null);
+        if (docValueFields != null) {
+            out.writeList(docValueFields);
         }
         out.writeOptionalWriteable(storedFieldsContext);
         out.writeVInt(from);

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/FieldAndFormat.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/FieldAndFormat.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.search.fetch.subphase;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.io.stream.StreamInput;
@@ -91,19 +90,13 @@ public final class FieldAndFormat implements Writeable, ToXContentObject {
     /** Serialization constructor. */
     public FieldAndFormat(StreamInput in) throws IOException {
         this.field = in.readString();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            format = in.readOptionalString();
-        } else {
-            format = null;
-        }
+        format = in.readOptionalString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(field);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            out.writeOptionalString(format);
-        }
+        out.writeOptionalString(format);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/opensearch/search/internal/ShardSearchRequest.java
@@ -255,13 +255,8 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
         } else {
             allowPartialSearchResults = false;
         }
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            indexRoutings = in.readStringArray();
-            preference = in.readOptionalString();
-        } else {
-            indexRoutings = Strings.EMPTY_ARRAY;
-            preference = null;
-        }
+        indexRoutings = in.readStringArray();
+        preference = in.readOptionalString();
         if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
             canReturnNullResponseIfMatchNoDocs = in.readBoolean();
             bottomSortValues = in.readOptionalWriteable(SearchSortValuesAndFormats::new);
@@ -335,10 +330,8 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
             out.writeBoolean(allowPartialSearchResults);
         }
         if (asKey == false) {
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-                out.writeStringArray(indexRoutings);
-                out.writeOptionalString(preference);
-            }
+            out.writeStringArray(indexRoutings);
+            out.writeOptionalString(preference);
         }
         if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0) && asKey == false) {
             out.writeBoolean(canReturnNullResponseIfMatchNoDocs);

--- a/server/src/main/java/org/opensearch/search/slice/SliceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/slice/SliceBuilder.java
@@ -227,20 +227,17 @@ public class SliceBuilder implements Writeable, ToXContentObject {
 
         int shardId = request.shardId().id();
         int numShards = context.getIndexSettings().getNumberOfShards();
-        if (minNodeVersion.onOrAfter(LegacyESVersion.V_6_4_0) && (request.preference() != null || request.indexRoutings().length > 0)) {
+        if ((request.preference() != null || request.indexRoutings().length > 0)) {
             GroupShardsIterator<ShardIterator> group = buildShardIterator(clusterService, request);
             assert group.size() <= numShards : "index routing shards: "
                 + group.size()
                 + " cannot be greater than total number of shards: "
                 + numShards;
             if (group.size() < numShards) {
-                /**
+                /*
                  * The routing of this request targets a subset of the shards of this index so we need to we retrieve
                  * the original {@link GroupShardsIterator} and compute the request shard id and number of
                  * shards from it.
-                 * This behavior has been added in {@link LegacyESVersion#V_6_4_0} so if there is another node in the cluster
-                 * with an older version we use the original shard id and number of shards in order to ensure that all
-                 * slices use the same numbers.
                  */
                 numShards = group.size();
                 int ord = 0;

--- a/server/src/main/java/org/opensearch/search/sort/GeoDistanceSortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/GeoDistanceSortBuilder.java
@@ -189,9 +189,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
         nestedPath = in.readOptionalString();
         nestedSort = in.readOptionalWriteable(NestedSortBuilder::new);
         validation = GeoValidationMethod.readFromStream(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            ignoreUnmapped = in.readBoolean();
-        }
+        ignoreUnmapped = in.readBoolean();
     }
 
     @Override
@@ -206,9 +204,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
         out.writeOptionalString(nestedPath);
         out.writeOptionalWriteable(nestedSort);
         validation.writeTo(out);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_4_0)) {
-            out.writeBoolean(ignoreUnmapped);
-        }
+        out.writeBoolean(ignoreUnmapped);
     }
 
     /**

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestTests.java
@@ -37,7 +37,6 @@ import org.opensearch.Version;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.common.Strings;
-import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.ArrayUtils;
 import org.opensearch.index.query.QueryBuilders;
@@ -52,7 +51,6 @@ import org.opensearch.test.VersionUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 
 import static java.util.Collections.emptyMap;
@@ -131,25 +129,6 @@ public class SearchRequestTests extends AbstractSearchTestCase {
             assertEquals(searchRequest.getCancelAfterTimeInterval(), deserializedRequest.getCancelAfterTimeInterval());
         } else {
             assertNull(deserializedRequest.getCancelAfterTimeInterval());
-        }
-    }
-
-    public void testReadFromPre6_7_0() throws IOException {
-        String msg = "AAEBBWluZGV4AAAAAQACAAAA/////w8AAAAAAAAA/////w8AAAAAAAACAAAAAAABAAMCBAUBAAKABACAAQIAAA==";
-        try (StreamInput in = StreamInput.wrap(Base64.getDecoder().decode(msg))) {
-            in.setVersion(
-                VersionUtils.randomVersionBetween(
-                    random(),
-                    LegacyESVersion.V_6_4_0,
-                    VersionUtils.getPreviousVersion(LegacyESVersion.V_6_7_0)
-                )
-            );
-            SearchRequest searchRequest = new SearchRequest(in);
-            assertArrayEquals(new String[] { "index" }, searchRequest.indices());
-            assertNull(searchRequest.getLocalClusterAlias());
-            assertAbsoluteStartMillisIsCurrentTime(searchRequest);
-            assertTrue(searchRequest.isCcsMinimizeRoundtrips());
-            assertTrue(searchRequest.isFinalReduce());
         }
     }
 

--- a/server/src/test/java/org/opensearch/action/support/master/ShardsAcknowledgedResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/support/master/ShardsAcknowledgedResponseTests.java
@@ -50,26 +50,17 @@ public class ShardsAcknowledgedResponseTests extends OpenSearchTestCase {
         ShardsAcknowledgedResponse result = copyWriteable(
             testInstance,
             new NamedWriteableRegistry(Collections.emptyList()),
-            in -> new TestImpl(in, true, true),
+            in -> new TestImpl(in, true),
             Version.CURRENT
         );
         assertThat(result.isAcknowledged(), is(true));
         assertThat(result.isShardsAcknowledged(), is(true));
-
-        result = copyWriteable(
-            testInstance,
-            new NamedWriteableRegistry(Collections.emptyList()),
-            in -> new TestImpl(in, false, false),
-            Version.CURRENT
-        );
-        assertThat(result.isAcknowledged(), is(false));
-        assertThat(result.isShardsAcknowledged(), is(false));
     }
 
     private static class TestImpl extends ShardsAcknowledgedResponse {
 
-        private TestImpl(StreamInput in, boolean readShardsAcknowledged, boolean readAcknowledged) throws IOException {
-            super(in, readShardsAcknowledged, readAcknowledged);
+        private TestImpl(StreamInput in, boolean readShardsAcknowledged) throws IOException {
+            super(in, readShardsAcknowledged);
         }
 
         private TestImpl(boolean acknowledged, boolean shardsAcknowledged) {

--- a/server/src/test/java/org/opensearch/cluster/coordination/JoinTaskExecutorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/JoinTaskExecutorTests.java
@@ -119,7 +119,7 @@ public class JoinTaskExecutorTests extends OpenSearchTestCase {
         }
 
         if (minNodeVersion.onOrAfter(LegacyESVersion.V_7_0_0)) {
-            Version oldMajor = LegacyESVersion.V_6_4_0.minimumCompatibilityVersion();
+            Version oldMajor = minNodeVersion.minimumCompatibilityVersion();
             expectThrows(IllegalStateException.class, () -> JoinTaskExecutor.ensureMajorVersionBarrier(oldMajor, minNodeVersion));
         }
 

--- a/server/src/test/java/org/opensearch/ingest/IngestStatsTests.java
+++ b/server/src/test/java/org/opensearch/ingest/IngestStatsTests.java
@@ -58,27 +58,6 @@ public class IngestStatsTests extends OpenSearchTestCase {
         assertIngestStats(ingestStats, serializedStats, true, true);
     }
 
-    public void testReadLegacyStream() throws IOException {
-        IngestStats.Stats totalStats = new IngestStats.Stats(50, 100, 200, 300);
-        List<IngestStats.PipelineStat> pipelineStats = createPipelineStats();
-
-        // legacy output logic
-        BytesStreamOutput out = new BytesStreamOutput();
-        out.setVersion(VersionUtils.getPreviousVersion(LegacyESVersion.V_6_5_0));
-        totalStats.writeTo(out);
-        out.writeVInt(pipelineStats.size());
-        for (IngestStats.PipelineStat pipelineStat : pipelineStats) {
-            out.writeString(pipelineStat.getPipelineId());
-            pipelineStat.getStats().writeTo(out);
-        }
-
-        StreamInput in = out.bytes().streamInput();
-        in.setVersion(VersionUtils.getPreviousVersion(LegacyESVersion.V_6_5_0));
-        IngestStats serializedStats = new IngestStats(in);
-        IngestStats expectedStats = new IngestStats(totalStats, pipelineStats, Collections.emptyMap());
-        assertIngestStats(expectedStats, serializedStats, false, true);
-    }
-
     public void testBWCIngestProcessorTypeStats() throws IOException {
         IngestStats.Stats totalStats = new IngestStats.Stats(50, 100, 200, 300);
         List<IngestStats.PipelineStat> pipelineStats = createPipelineStats();


### PR DESCRIPTION
### Description
This PR removes LegacyESVersion.V_6_4_x constants. 

### Issues Resolved
Part of the meta issue #1674 
 
### Check List
- [x] All tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>