### PR TITLE
Remove LegacyESVersion.V_6_6_x constants

### DIFF
--- a/server/src/main/java/org/opensearch/LegacyESVersion.java
+++ b/server/src/main/java/org/opensearch/LegacyESVersion.java
@@ -46,9 +46,6 @@ import java.lang.reflect.Field;
  */
 public class LegacyESVersion extends Version {
 
-    public static final LegacyESVersion V_6_6_0 = new LegacyESVersion(6060099, org.apache.lucene.util.Version.LUCENE_7_6_0);
-    public static final LegacyESVersion V_6_6_1 = new LegacyESVersion(6060199, org.apache.lucene.util.Version.LUCENE_7_6_0);
-    public static final LegacyESVersion V_6_6_2 = new LegacyESVersion(6060299, org.apache.lucene.util.Version.LUCENE_7_6_0);
     public static final LegacyESVersion V_6_7_0 = new LegacyESVersion(6070099, org.apache.lucene.util.Version.LUCENE_7_7_0);
     public static final LegacyESVersion V_6_7_1 = new LegacyESVersion(6070199, org.apache.lucene.util.Version.LUCENE_7_7_0);
     public static final LegacyESVersion V_6_7_2 = new LegacyESVersion(6070299, org.apache.lucene.util.Version.LUCENE_7_7_0);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/ClusterStateRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/ClusterStateRequest.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.cluster.state;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.IndicesRequest;
 import org.opensearch.action.support.IndicesOptions;
@@ -69,10 +68,8 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
         customs = in.readBoolean();
         indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-            waitForTimeout = in.readTimeValue();
-            waitForMetadataVersion = in.readOptionalLong();
-        }
+        waitForTimeout = in.readTimeValue();
+        waitForMetadataVersion = in.readOptionalLong();
     }
 
     @Override
@@ -85,10 +82,8 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
         out.writeBoolean(customs);
         out.writeStringArray(indices);
         indicesOptions.writeIndicesOptions(out);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-            out.writeTimeValue(waitForTimeout);
-            out.writeOptionalLong(waitForMetadataVersion);
-        }
+        out.writeTimeValue(waitForTimeout);
+        out.writeOptionalLong(waitForMetadataVersion);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/ClusterStateResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/ClusterStateResponse.java
@@ -56,17 +56,11 @@ public class ClusterStateResponse extends ActionResponse {
     public ClusterStateResponse(StreamInput in) throws IOException {
         super(in);
         clusterName = new ClusterName(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-            clusterState = in.readOptionalWriteable(innerIn -> ClusterState.readFrom(innerIn, null));
-        } else {
-            clusterState = ClusterState.readFrom(in, null);
-        }
+        clusterState = in.readOptionalWriteable(innerIn -> ClusterState.readFrom(innerIn, null));
         if (in.getVersion().before(LegacyESVersion.V_7_0_0)) {
             new ByteSizeValue(in);
         }
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-            waitForTimedOut = in.readBoolean();
-        }
+        waitForTimedOut = in.readBoolean();
     }
 
     public ClusterStateResponse(ClusterName clusterName, ClusterState clusterState, boolean waitForTimedOut) {
@@ -101,17 +95,11 @@ public class ClusterStateResponse extends ActionResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         clusterName.writeTo(out);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-            out.writeOptionalWriteable(clusterState);
-        } else {
-            clusterState.writeTo(out);
-        }
+        out.writeOptionalWriteable(clusterState);
         if (out.getVersion().before(LegacyESVersion.V_7_0_0)) {
             ByteSizeValue.ZERO.writeTo(out);
         }
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-            out.writeBoolean(waitForTimedOut);
-        }
+        out.writeBoolean(waitForTimedOut);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/delete/DeleteRequest.java
+++ b/server/src/main/java/org/opensearch/action/delete/DeleteRequest.java
@@ -97,13 +97,8 @@ public class DeleteRequest extends ReplicatedWriteRequest<DeleteRequest>
         }
         version = in.readLong();
         versionType = VersionType.fromValue(in.readByte());
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-            ifSeqNo = in.readZLong();
-            ifPrimaryTerm = in.readVLong();
-        } else {
-            ifSeqNo = UNASSIGNED_SEQ_NO;
-            ifPrimaryTerm = UNASSIGNED_PRIMARY_TERM;
-        }
+        ifSeqNo = in.readZLong();
+        ifPrimaryTerm = in.readVLong();
     }
 
     public DeleteRequest() {
@@ -348,18 +343,8 @@ public class DeleteRequest extends ReplicatedWriteRequest<DeleteRequest>
         }
         out.writeLong(version);
         out.writeByte(versionType.getValue());
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-            out.writeZLong(ifSeqNo);
-            out.writeVLong(ifPrimaryTerm);
-        } else if (ifSeqNo != UNASSIGNED_SEQ_NO || ifPrimaryTerm != UNASSIGNED_PRIMARY_TERM) {
-            assert false : "setIfMatch [" + ifSeqNo + "], currentDocTem [" + ifPrimaryTerm + "]";
-            throw new IllegalStateException(
-                "sequence number based compare and write is not supported until all nodes are on version 7.0 or higher. "
-                    + "Stream version ["
-                    + out.getVersion()
-                    + "]"
-            );
-        }
+        out.writeZLong(ifSeqNo);
+        out.writeVLong(ifPrimaryTerm);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/index/IndexRequest.java
+++ b/server/src/main/java/org/opensearch/action/index/IndexRequest.java
@@ -167,13 +167,8 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
         } else {
             contentType = null;
         }
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-            ifSeqNo = in.readZLong();
-            ifPrimaryTerm = in.readVLong();
-        } else {
-            ifSeqNo = UNASSIGNED_SEQ_NO;
-            ifPrimaryTerm = UNASSIGNED_PRIMARY_TERM;
-        }
+        ifSeqNo = in.readZLong();
+        ifPrimaryTerm = in.readVLong();
         if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
             requireAlias = in.readBoolean();
         } else {
@@ -765,18 +760,8 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
         } else {
             out.writeBoolean(false);
         }
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-            out.writeZLong(ifSeqNo);
-            out.writeVLong(ifPrimaryTerm);
-        } else if (ifSeqNo != UNASSIGNED_SEQ_NO || ifPrimaryTerm != UNASSIGNED_PRIMARY_TERM) {
-            assert false : "setIfMatch [" + ifSeqNo + "], currentDocTem [" + ifPrimaryTerm + "]";
-            throw new IllegalStateException(
-                "sequence number based compare and write is not supported until all nodes are on version 7.0 or higher. "
-                    + "Stream version ["
-                    + out.getVersion()
-                    + "]"
-            );
-        }
+        out.writeZLong(ifSeqNo);
+        out.writeVLong(ifPrimaryTerm);
         if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
             out.writeBoolean(requireAlias);
         }

--- a/server/src/main/java/org/opensearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/opensearch/action/support/IndicesOptions.java
@@ -263,11 +263,6 @@ public class IndicesOptions implements ToXContentFragment {
 
     public void writeIndicesOptions(StreamOutput out) throws IOException {
         EnumSet<Option> options = this.options;
-        // never write this out to a pre 6.6 version
-        if (out.getVersion().before(LegacyESVersion.V_6_6_0) && options.contains(Option.IGNORE_THROTTLED)) {
-            options = EnumSet.copyOf(options);
-            options.remove(Option.IGNORE_THROTTLED);
-        }
         out.writeEnumSet(options);
         if (out.getVersion().before(LegacyESVersion.V_7_7_0) && expandWildcards.contains(WildcardStates.HIDDEN)) {
             final EnumSet<WildcardStates> states = EnumSet.copyOf(expandWildcards);

--- a/server/src/main/java/org/opensearch/cluster/RestoreInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/RestoreInProgress.java
@@ -34,7 +34,6 @@ package org.opensearch.cluster;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.cluster.ClusterState.Custom;
 import org.opensearch.common.collect.ImmutableOpenMap;
@@ -451,11 +450,7 @@ public class RestoreInProgress extends AbstractNamedDiffable<Custom> implements 
         final ImmutableOpenMap.Builder<String, Entry> entriesBuilder = ImmutableOpenMap.builder(count);
         for (int i = 0; i < count; i++) {
             final String uuid;
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-                uuid = in.readString();
-            } else {
-                uuid = BWC_UUID;
-            }
+            uuid = in.readString();
             Snapshot snapshot = new Snapshot(in);
             State state = State.fromValue(in.readByte());
             List<String> indexBuilder = in.readStringList();
@@ -478,9 +473,7 @@ public class RestoreInProgress extends AbstractNamedDiffable<Custom> implements 
         out.writeVInt(entries.size());
         for (ObjectCursor<Entry> v : entries.values()) {
             Entry entry = v.value;
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-                out.writeString(entry.uuid);
-            }
+            out.writeString(entry.uuid);
             entry.snapshot().writeTo(out);
             out.writeByte(entry.state().value());
             out.writeStringCollection(entry.indices);

--- a/server/src/main/java/org/opensearch/cluster/coordination/ClusterFormationFailureHelper.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/ClusterFormationFailureHelper.java
@@ -33,7 +33,6 @@ package org.opensearch.cluster.coordination;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.coordination.CoordinationMetadata.VotingConfiguration;
 import org.opensearch.cluster.coordination.CoordinationState.VoteCollection;
@@ -197,9 +196,6 @@ public class ClusterFormationFailureHelper {
             }
 
             if (clusterState.getLastAcceptedConfiguration().isEmpty()) {
-
-                // TODO handle the case that there is a 6.x node around here, when rolling upgrades are supported
-
                 final String bootstrappingDescription;
 
                 if (INITIAL_MASTER_NODES_SETTING.get(Settings.EMPTY).equals(INITIAL_MASTER_NODES_SETTING.get(settings))) {
@@ -214,8 +210,7 @@ public class ClusterFormationFailureHelper {
 
                 return String.format(
                     Locale.ROOT,
-                    "master not discovered yet, this node has not previously joined a bootstrapped (v%d+) cluster, and %s: %s",
-                    LegacyESVersion.V_6_6_0.major + 1,
+                    "master not discovered yet, this node has not previously joined a bootstrapped cluster, and %s: %s",
                     bootstrappingDescription,
                     discoveryStateIgnoringQuorum
                 );

--- a/server/src/main/java/org/opensearch/cluster/routing/RecoverySource.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RecoverySource.java
@@ -34,7 +34,6 @@ package org.opensearch.cluster.routing;
 
 import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
-import org.opensearch.cluster.RestoreInProgress;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -249,11 +248,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
         }
 
         SnapshotRecoverySource(StreamInput in) throws IOException {
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-                restoreUUID = in.readString();
-            } else {
-                restoreUUID = RestoreInProgress.BWC_UUID;
-            }
+            restoreUUID = in.readString();
             snapshot = new Snapshot(in);
             version = Version.readVersion(in);
             if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
@@ -287,9 +282,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
 
         @Override
         protected void writeAdditionalFields(StreamOutput out) throws IOException {
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-                out.writeString(restoreUUID);
-            }
+            out.writeString(restoreUUID);
             snapshot.writeTo(out);
             Version.writeVersion(version, out);
             if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {

--- a/server/src/main/java/org/opensearch/index/get/GetResult.java
+++ b/server/src/main/java/org/opensearch/index/get/GetResult.java
@@ -90,13 +90,8 @@ public class GetResult implements Writeable, Iterable<DocumentField>, ToXContent
         index = in.readString();
         type = in.readOptionalString();
         id = in.readString();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-            seqNo = in.readZLong();
-            primaryTerm = in.readVLong();
-        } else {
-            seqNo = UNASSIGNED_SEQ_NO;
-            primaryTerm = UNASSIGNED_PRIMARY_TERM;
-        }
+        seqNo = in.readZLong();
+        primaryTerm = in.readVLong();
         version = in.readLong();
         exists = in.readBoolean();
         if (exists) {
@@ -449,10 +444,8 @@ public class GetResult implements Writeable, Iterable<DocumentField>, ToXContent
         out.writeString(index);
         out.writeOptionalString(type);
         out.writeString(id);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-            out.writeZLong(seqNo);
-            out.writeVLong(primaryTerm);
-        }
+        out.writeZLong(seqNo);
+        out.writeVLong(primaryTerm);
         out.writeLong(version);
         out.writeBoolean(exists);
         if (exists) {

--- a/server/src/main/java/org/opensearch/index/mapper/AbstractShapeGeometryFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/AbstractShapeGeometryFieldMapper.java
@@ -32,7 +32,6 @@
 package org.opensearch.index.mapper;
 
 import org.apache.lucene.document.FieldType;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.Explicit;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.geo.builders.ShapeBuilder;
@@ -161,7 +160,7 @@ public abstract class AbstractShapeGeometryFieldMapper<Parsed, Processed> extend
                     iterator.remove();
                 }
             }
-            if (parserContext.indexVersionCreated().onOrAfter(LegacyESVersion.V_6_6_0) && parsedDeprecatedParameters == false) {
+            if (parsedDeprecatedParameters == false) {
                 params.remove(DEPRECATED_PARAMETERS_KEY);
             }
 

--- a/server/src/main/java/org/opensearch/index/mapper/LegacyGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/LegacyGeoShapeFieldMapper.java
@@ -220,8 +220,6 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
             }
             if (deprecatedParameters.tree != null) {
                 ft.setTree(deprecatedParameters.tree);
-            } else if (context.indexCreatedVersion().before(LegacyESVersion.V_6_6_0)) {
-                ft.setTree(DeprecatedParameters.PrefixTrees.GEOHASH);
             }
             if (deprecatedParameters.treeLevels != null) {
                 ft.setTreeLevels(deprecatedParameters.treeLevels);
@@ -517,13 +515,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
     public void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
 
-        if (includeDefaults
-            || (fieldType().tree()
-                .equals(
-                    indexCreatedVersion.onOrAfter(LegacyESVersion.V_6_6_0)
-                        ? DeprecatedParameters.Defaults.TREE
-                        : DeprecatedParameters.PrefixTrees.GEOHASH
-                )) == false) {
+        if (includeDefaults || (fieldType().tree().equals(DeprecatedParameters.Defaults.TREE)) == false) {
             builder.field(DeprecatedParameters.Names.TREE.getPreferredName(), fieldType().tree());
         }
 

--- a/server/src/main/java/org/opensearch/monitor/os/OsInfo.java
+++ b/server/src/main/java/org/opensearch/monitor/os/OsInfo.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.monitor.os;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.unit.TimeValue;
@@ -74,11 +73,7 @@ public class OsInfo implements ReportingService.Info {
         this.availableProcessors = in.readInt();
         this.allocatedProcessors = in.readInt();
         this.name = in.readOptionalString();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-            this.prettyName = in.readOptionalString();
-        } else {
-            this.prettyName = null;
-        }
+        this.prettyName = in.readOptionalString();
         this.arch = in.readOptionalString();
         this.version = in.readOptionalString();
     }
@@ -89,9 +84,7 @@ public class OsInfo implements ReportingService.Info {
         out.writeInt(availableProcessors);
         out.writeInt(allocatedProcessors);
         out.writeOptionalString(name);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-            out.writeOptionalString(prettyName);
-        }
+        out.writeOptionalString(prettyName);
         out.writeOptionalString(arch);
         out.writeOptionalString(version);
     }

--- a/server/src/main/java/org/opensearch/search/SearchHits.java
+++ b/server/src/main/java/org/opensearch/search/SearchHits.java
@@ -35,7 +35,6 @@ package org.opensearch.search;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.TotalHits.Relation;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -113,15 +112,9 @@ public final class SearchHits implements Writeable, ToXContentFragment, Iterable
                 hits[i] = new SearchHit(in);
             }
         }
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-            sortFields = in.readOptionalArray(Lucene::readSortField, SortField[]::new);
-            collapseField = in.readOptionalString();
-            collapseValues = in.readOptionalArray(Lucene::readSortValue, Object[]::new);
-        } else {
-            sortFields = null;
-            collapseField = null;
-            collapseValues = null;
-        }
+        sortFields = in.readOptionalArray(Lucene::readSortField, SortField[]::new);
+        collapseField = in.readOptionalString();
+        collapseValues = in.readOptionalArray(Lucene::readSortValue, Object[]::new);
     }
 
     @Override
@@ -138,11 +131,9 @@ public final class SearchHits implements Writeable, ToXContentFragment, Iterable
                 hit.writeTo(out);
             }
         }
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-            out.writeOptionalArray(Lucene::writeSortField, sortFields);
-            out.writeOptionalString(collapseField);
-            out.writeOptionalArray(Lucene::writeSortValue, collapseValues);
-        }
+        out.writeOptionalArray(Lucene::writeSortField, sortFields);
+        out.writeOptionalString(collapseField);
+        out.writeOptionalArray(Lucene::writeSortValue, collapseValues);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/SearchSortValues.java
+++ b/server/src/main/java/org/opensearch/search/SearchSortValues.java
@@ -33,7 +33,6 @@
 package org.opensearch.search;
 
 import org.apache.lucene.util.BytesRef;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -83,19 +82,13 @@ public class SearchSortValues implements ToXContentFragment, Writeable {
 
     SearchSortValues(StreamInput in) throws IOException {
         this.formattedSortValues = in.readArray(Lucene::readSortValue, Object[]::new);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-            this.rawSortValues = in.readArray(Lucene::readSortValue, Object[]::new);
-        } else {
-            this.rawSortValues = EMPTY_ARRAY;
-        }
+        this.rawSortValues = in.readArray(Lucene::readSortValue, Object[]::new);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeArray(Lucene::writeSortValue, this.formattedSortValues);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_6_6_0)) {
-            out.writeArray(Lucene::writeSortValue, this.rawSortValues);
-        }
+        out.writeArray(Lucene::writeSortValue, this.rawSortValues);
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/BuildTests.java
+++ b/server/src/test/java/org/opensearch/BuildTests.java
@@ -300,9 +300,7 @@ public class BuildTests extends OpenSearchTestCase {
         );
 
         final List<Version> versions = Version.getDeclaredVersions(LegacyESVersion.class);
-        final Version post63Pre67Version = randomFrom(
-            versions.stream().filter(v -> v.before(LegacyESVersion.V_6_7_0)).collect(Collectors.toList())
-        );
+
         final Version post67Pre70Version = randomFrom(
             versions.stream()
                 .filter(v -> v.onOrAfter(LegacyESVersion.V_6_7_0) && v.before(LegacyESVersion.V_7_0_0))
@@ -315,7 +313,6 @@ public class BuildTests extends OpenSearchTestCase {
             versions.stream().filter(v -> v.onOrAfter(Version.V_1_0_0)).collect(Collectors.toList())
         );
 
-        final WriteableBuild post63pre67 = copyWriteable(dockerBuild, writableRegistry(), WriteableBuild::new, post63Pre67Version);
         final WriteableBuild post67pre70 = copyWriteable(dockerBuild, writableRegistry(), WriteableBuild::new, post67Pre70Version);
         final WriteableBuild post70 = copyWriteable(dockerBuild, writableRegistry(), WriteableBuild::new, post70Version);
         final WriteableBuild post10OpenSearch = copyWriteable(
@@ -325,11 +322,9 @@ public class BuildTests extends OpenSearchTestCase {
             post10OpenSearchVersion
         );
 
-        assertThat(post63pre67.build.type(), equalTo(Build.Type.TAR));
         assertThat(post67pre70.build.type(), equalTo(dockerBuild.build.type()));
         assertThat(post70.build.type(), equalTo(dockerBuild.build.type()));
 
-        assertThat(post63pre67.build.getQualifiedVersion(), equalTo(post63Pre67Version.toString()));
         assertThat(post67pre70.build.getQualifiedVersion(), equalTo(post67Pre70Version.toString()));
         assertThat(post70.build.getQualifiedVersion(), equalTo(dockerBuild.build.getQualifiedVersion()));
         assertThat(post70.build.getDistribution(), equalTo(dockerBuild.build.getDistribution()));

--- a/server/src/test/java/org/opensearch/LegacyESVersionTests.java
+++ b/server/src/test/java/org/opensearch/LegacyESVersionTests.java
@@ -281,7 +281,7 @@ public class LegacyESVersionTests extends OpenSearchTestCase {
 
     public void testIsCompatible() {
         assertTrue(isCompatible(LegacyESVersion.V_6_8_0, LegacyESVersion.V_7_0_0));
-        assertFalse(isCompatible(LegacyESVersion.V_6_6_0, LegacyESVersion.V_7_0_0));
+        assertFalse(isCompatible(LegacyESVersion.fromString("6.6.0"), LegacyESVersion.V_7_0_0));
         assertFalse(isCompatible(LegacyESVersion.V_6_7_0, LegacyESVersion.V_7_0_0));
 
         assertFalse(isCompatible(LegacyESVersion.fromId(5000099), LegacyESVersion.fromString("6.0.0")));

--- a/server/src/test/java/org/opensearch/action/admin/cluster/state/ClusterStateRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/state/ClusterStateRequestTests.java
@@ -88,10 +88,8 @@ public class ClusterStateRequestTests extends OpenSearchTestCase {
             assertThat(deserializedCSRequest.blocks(), equalTo(clusterStateRequest.blocks()));
             assertThat(deserializedCSRequest.indices(), equalTo(clusterStateRequest.indices()));
             assertOptionsMatch(deserializedCSRequest.indicesOptions(), clusterStateRequest.indicesOptions());
-            if (testVersion.onOrAfter(LegacyESVersion.V_6_6_0)) {
-                assertThat(deserializedCSRequest.waitForMetadataVersion(), equalTo(clusterStateRequest.waitForMetadataVersion()));
-                assertThat(deserializedCSRequest.waitForTimeout(), equalTo(clusterStateRequest.waitForTimeout()));
-            }
+            assertThat(deserializedCSRequest.waitForMetadataVersion(), equalTo(clusterStateRequest.waitForMetadataVersion()));
+            assertThat(deserializedCSRequest.waitForTimeout(), equalTo(clusterStateRequest.waitForTimeout()));
         }
     }
 

--- a/server/src/test/java/org/opensearch/cluster/coordination/ClusterFormationFailureHelperTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/ClusterFormationFailureHelperTests.java
@@ -328,7 +328,7 @@ public class ClusterFormationFailureHelperTests extends OpenSearchTestCase {
                 new StatusInfo(HEALTHY, "healthy-info")
             ).getDescription(),
             is(
-                "master not discovered yet, this node has not previously joined a bootstrapped (v7+) cluster, and "
+                "master not discovered yet, this node has not previously joined a bootstrapped cluster, and "
                     + "[cluster.initial_master_nodes] is empty on this node: have discovered []; "
                     + "discovery will continue using [] from hosts providers and ["
                     + localNode
@@ -348,7 +348,7 @@ public class ClusterFormationFailureHelperTests extends OpenSearchTestCase {
                 new StatusInfo(HEALTHY, "healthy-info")
             ).getDescription(),
             is(
-                "master not discovered yet, this node has not previously joined a bootstrapped (v7+) cluster, and "
+                "master not discovered yet, this node has not previously joined a bootstrapped cluster, and "
                     + "[cluster.initial_master_nodes] is empty on this node: have discovered []; "
                     + "discovery will continue using ["
                     + otherAddress
@@ -370,7 +370,7 @@ public class ClusterFormationFailureHelperTests extends OpenSearchTestCase {
                 new StatusInfo(HEALTHY, "healthy-info")
             ).getDescription(),
             is(
-                "master not discovered yet, this node has not previously joined a bootstrapped (v7+) cluster, and "
+                "master not discovered yet, this node has not previously joined a bootstrapped cluster, and "
                     + "[cluster.initial_master_nodes] is empty on this node: have discovered ["
                     + otherNode
                     + "]; "
@@ -391,7 +391,7 @@ public class ClusterFormationFailureHelperTests extends OpenSearchTestCase {
                 new StatusInfo(HEALTHY, "healthy-info")
             ).getDescription(),
             is(
-                "master not discovered yet, this node has not previously joined a bootstrapped (v7+) cluster, and "
+                "master not discovered yet, this node has not previously joined a bootstrapped cluster, and "
                     + "this node must discover master-eligible nodes [other] to bootstrap a cluster: have discovered []; "
                     + "discovery will continue using [] from hosts providers and ["
                     + localNode

--- a/server/src/test/java/org/opensearch/index/mapper/ExternalMapper.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ExternalMapper.java
@@ -33,7 +33,6 @@
 package org.opensearch.index.mapper;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.collect.Iterators;
 import org.opensearch.common.geo.GeoPoint;
 import org.opensearch.common.geo.builders.PointBuilder;
@@ -102,9 +101,7 @@ public class ExternalMapper extends ParametrizedFieldMapper {
             BinaryFieldMapper binMapper = binBuilder.build(context);
             BooleanFieldMapper boolMapper = boolBuilder.build(context);
             GeoPointFieldMapper pointMapper = (GeoPointFieldMapper) latLonPointBuilder.build(context);
-            AbstractShapeGeometryFieldMapper<?, ?> shapeMapper = (context.indexCreatedVersion().before(LegacyESVersion.V_6_6_0))
-                ? legacyShapeBuilder.build(context)
-                : shapeBuilder.build(context);
+            AbstractShapeGeometryFieldMapper<?, ?> shapeMapper = shapeBuilder.build(context);
             FieldMapper stringMapper = (FieldMapper) stringBuilder.build(context);
             context.path().remove();
 

--- a/server/src/test/java/org/opensearch/index/query/GeoShapeQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/GeoShapeQueryBuilderTests.java
@@ -35,7 +35,6 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.action.get.GetRequest;
@@ -82,7 +81,7 @@ public abstract class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<Ge
     @Override
     protected Settings createTestIndexSettings() {
         // force the new shape impl
-        Version version = VersionUtils.randomVersionBetween(random(), LegacyESVersion.V_6_6_0, Version.CURRENT);
+        Version version = VersionUtils.randomIndexCompatibleVersion(random());
         return Settings.builder().put(super.createTestIndexSettings()).put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
     }
 


### PR DESCRIPTION
### Description
This PR removes the `LegacyESVersion.V_6_6_x` constants and all their usages.
 
### Issues Resolved
Part of #1674 
 
### Check List
- [x] All tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>
