### PR TITLE
[Tests] ClusterHealthIT:testHealthOnMasterFailover - Increase master node timeout

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterHealthIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterHealthIT.java
@@ -374,7 +374,7 @@ public class ClusterHealthIT extends OpenSearchIntegTestCase {
                     .prepareHealth()
                     .setWaitForEvents(Priority.LANGUID)
                     .setWaitForGreenStatus()
-                    .setMasterNodeTimeout(TimeValue.timeValueMinutes(1))
+                    .setMasterNodeTimeout(TimeValue.timeValueMinutes(2))
                     .execute()
             );
             internalCluster().restartNode(internalCluster().getMasterName(), InternalTestCluster.EMPTY_CALLBACK);


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Increase master node timeout causing intermittent test failures.
 
### Issues Resolved
[[ClusterHealthIT:testHealthOnMasterFailover Failure 1693]](https://github.com/opensearch-project/OpenSearch/issues/1693)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
