### PR TITLE
[TEST] Fix FsHealthServiceTest by increasing the timeout period before checking the FS health after restoring the FS status

### DIFF
--- a/server/src/test/java/org/opensearch/monitor/fs/FsHealthServiceTests.java
+++ b/server/src/test/java/org/opensearch/monitor/fs/FsHealthServiceTests.java
@@ -230,7 +230,7 @@ public class FsHealthServiceTests extends OpenSearchTestCase {
             disruptFileSystemProvider.injectIODelay.set(false);
             waitUntil(
                 () -> fsHealthSrvc.getHealth().getStatus() == HEALTHY,
-                delayBetweenChecks + (3 * refreshInterval),
+                delayBetweenChecks + (4 * refreshInterval),
                 TimeUnit.MILLISECONDS
             );
             fsHealth = fsHealthSrvc.getHealth();


### PR DESCRIPTION
### Description

Although there has been a commit https://github.com/opensearch-project/OpenSearch/commit/baa10b9b203d20e585471d93b9aa538a3f681585 that aimed to fix the test failure in #1567, there is still a failure reported in https://github.com/opensearch-project/OpenSearch/issues/1567#issuecomment-996021163.
The PR gives another try to fix the unit test `testFailsHealthOnHungIOBeyondHealthyTimeout()` in class `FsHealthServiceTests` by extending the timeout period again, based on the idea in https://github.com/opensearch-project/OpenSearch/issues/1567#issuecomment-989021906.

- Increase the max waiting time between cancelling the IO hanging and checking the File System health status. Increase the `3x` multiplier to `4x` that applied to `refreshInterval`.

For more detail about the past attempt to fix the test, please see PR https://github.com/opensearch-project/OpenSearch/pull/1692 

### Issues Resolved
Fix #1567
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
