### PR TITLE
Auto-increment next development iteration.

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,52 @@
+name: Increment Version
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:  
+  build:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fetch Tag and Version Information
+        run: |
+          TAG=$(echo "${GITHUB_REF#refs/*/}")
+          CURRENT_VERSION_ARRAY=($(echo "$TAG" | tr . '\n'))
+          BASE=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:2}")
+          CURRENT_VERSION=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:3}")
+          CURRENT_VERSION_UNDERSCORE=$(IFS=_ ; echo "V_${CURRENT_VERSION_ARRAY[*]:0:3}")
+          CURRENT_VERSION_ARRAY[2]=$((CURRENT_VERSION_ARRAY[2]+1))
+          NEXT_VERSION=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:3}")
+          NEXT_VERSION_UNDERSCORE=$(IFS=_ ; echo "V_${CURRENT_VERSION_ARRAY[*]:0:3}")
+          NEXT_VERSION_ID=$(IFS=0 ; echo "${CURRENT_VERSION_ARRAY[*]:0:3}99")
+          echo "TAG=$TAG" >> $GITHUB_ENV
+          echo "BASE=$BASE" >> $GITHUB_ENV
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+          echo "CURRENT_VERSION_UNDERSCORE=$CURRENT_VERSION_UNDERSCORE" >> $GITHUB_ENV
+          echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_ENV
+          echo "NEXT_VERSION_UNDERSCORE=$NEXT_VERSION_UNDERSCORE" >> $GITHUB_ENV
+          echo "NEXT_VERSION_ID=$NEXT_VERSION_ID" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.BASE }}
+      - name: Increment Version
+        run: |
+          echo Incrementing $CURRENT_VERSION to $NEXT_VERSION
+          echo "  - \"$CURRENT_VERSION\"" >> .ci/bwcVersions
+          sed -i "s/opensearch        = $CURRENT_VERSION/opensearch        = $NEXT_VERSION/g" buildSrc/version.properties
+          echo Adding $NEXT_VERSION_UNDERSCORE after $CURRENT_VERSION_UNDERSCORE
+          sed -i "s/public static final Version $CURRENT_VERSION_UNDERSCORE = new Version(\([[:digit:]]\+\)\(.*\));/\0\n    public static final Version $NEXT_VERSION_UNDERSCORE = new Version($NEXT_VERSION_ID\2);/g" server/src/main/java/org/opensearch/Version.java
+          sed -i "s/CURRENT = $CURRENT_VERSION_UNDERSCORE;/CURRENT = $NEXT_VERSION_UNDERSCORE;/g" server/src/main/java/org/opensearch/Version.java
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          base: ${{ env.BASE }}
+          commit-message: Incremented version to ${{ env.NEXT_VERSION }}
+          delete-branch: true
+          title: '[AUTO] Incremented version to ${{ env.NEXT_VERSION }}.'
+          body: |
+            I've noticed that a new tag ${{ env.TAG }} was pushed, and incremented the version from ${{ env.CURRENT_VERSION }} to ${{ env.NEXT_VERSION }}.

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -17,6 +17,7 @@ jobs:
           TAG=$(echo "${GITHUB_REF#refs/*/}")
           CURRENT_VERSION_ARRAY=($(echo "$TAG" | tr . '\n'))
           BASE=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:2}")
+          BASE_X=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:1}.x")
           CURRENT_VERSION=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:3}")
           CURRENT_VERSION_UNDERSCORE=$(IFS=_ ; echo "V_${CURRENT_VERSION_ARRAY[*]:0:3}")
           CURRENT_VERSION_ARRAY[2]=$((CURRENT_VERSION_ARRAY[2]+1))
@@ -25,6 +26,7 @@ jobs:
           NEXT_VERSION_ID=$(IFS=0 ; echo "${CURRENT_VERSION_ARRAY[*]:0:3}99")
           echo "TAG=$TAG" >> $GITHUB_ENV
           echo "BASE=$BASE" >> $GITHUB_ENV
+          echo "BASE_X=$BASE_X" >> $GITHUB_ENV
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
           echo "CURRENT_VERSION_UNDERSCORE=$CURRENT_VERSION_UNDERSCORE" >> $GITHUB_ENV
           echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_ENV
@@ -33,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.BASE }}
-      - name: Increment Version
+      - name: Increment Patch Version
         run: |
           echo Incrementing $CURRENT_VERSION to $NEXT_VERSION
           echo "  - \"$CURRENT_VERSION\"" >> .ci/bwcVersions
@@ -45,8 +47,49 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           base: ${{ env.BASE }}
+          branch: 'create-pull-request/patch-${{ env.BASE }}'
           commit-message: Incremented version to ${{ env.NEXT_VERSION }}
           delete-branch: true
           title: '[AUTO] Incremented version to ${{ env.NEXT_VERSION }}.'
           body: |
             I've noticed that a new tag ${{ env.TAG }} was pushed, and incremented the version from ${{ env.CURRENT_VERSION }} to ${{ env.NEXT_VERSION }}.
+
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.BASE_X }}
+      - name: Add bwc version to .X branch
+        run: |
+          echo Adding bwc version $NEXT_VERSION after $CURRENT_VERSION
+          sed -i "s/- \"$CURRENT_VERSION\"/\0\n  - \"$NEXT_VERSION\"/g" .ci/bwcVersions
+          echo Adding $NEXT_VERSION_UNDERSCORE after $CURRENT_VERSION_UNDERSCORE
+          sed -i "s/public static final Version $CURRENT_VERSION_UNDERSCORE = new Version(\([[:digit:]]\+\)\(.*\));/\0\n    public static final Version $NEXT_VERSION_UNDERSCORE = new Version($NEXT_VERSION_ID\2);/g" server/src/main/java/org/opensearch/Version.java
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          base: ${{ env.BASE_X }}
+          branch: 'create-pull-request/patch-${{ env.BASE_X }}'
+          commit-message: Added bwc version ${{ env.NEXT_VERSION }}
+          delete-branch: true
+          title: '[AUTO] [${{ env.BASE_X }}] Added bwc version ${{ env.NEXT_VERSION }}.'
+          body: |
+            I've noticed that a new tag ${{ env.TAG }} was pushed, and added a bwc version ${{ env.NEXT_VERSION }}.
+
+      - uses: actions/checkout@v2
+        with:
+          ref: main
+      - name: Add bwc version to main branch
+        run: |
+          echo Adding bwc version $NEXT_VERSION after $CURRENT_VERSION
+          sed -i "s/- \"$CURRENT_VERSION\"/\0\n  - \"$NEXT_VERSION\"/g" .ci/bwcVersions
+          echo Adding $NEXT_VERSION_UNDERSCORE after $CURRENT_VERSION_UNDERSCORE
+          sed -i "s/public static final Version $CURRENT_VERSION_UNDERSCORE = new Version(\([[:digit:]]\+\)\(.*\));/\0\n    public static final Version $NEXT_VERSION_UNDERSCORE = new Version($NEXT_VERSION_ID\2);/g" server/src/main/java/org/opensearch/Version.java
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          base: main
+          branch: 'create-pull-request/patch-main'
+          commit-message: Added bwc version ${{ env.NEXT_VERSION }}
+          delete-branch: true
+          title: '[AUTO] [main] Added bwc version ${{ env.NEXT_VERSION }}.'
+          body: |
+            I've noticed that a new tag ${{ env.TAG }} was pushed, and added a bwc version ${{ env.NEXT_VERSION }}.


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Adds a workflow that increments the version of OpenSearch whenever a new X.Y.Z tag is pushed. 

To test this I pushed a 1.2.4 tag to my branch, `git tag -d 1.2.4 ; git tag 1.2.4 ; git push origin :1.2.4 ; git push origin --tags`. That's what would happen if we were to release 1.2.4 tomorrow.

- Successful run: https://github.com/dblock/OpenSearch/actions/runs/1631531500
- PRs generated: 
   https://github.com/dblock/OpenSearch/pull/2
   https://github.com/dblock/OpenSearch/pull/3
   https://github.com/dblock/OpenSearch/pull/6

The new workflow produces 3 PRs similar to https://github.com/opensearch-project/OpenSearch/pull/1758 and backport PRs into main, and 1.x. It removes the manual steps that start triggering the whole automation to produce the next patch release.

![Screen Shot 2021-12-28 at 2 05 35 PM](https://user-images.githubusercontent.com/542335/147598738-9224a75b-52b6-4bd5-9eee-4fca3ae91efe.png)


It's possible that this implementation could be done differently/better using gradle, and potentially reused by other components "as is", but I think it's a good enough start because it saves a bunch of manual work.

### Issues Resolved

Part of https://github.com/opensearch-project/opensearch-build/issues/1375.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
