### PR TITLE
[Backport] [1.x] RestIntegTestTask fails because of missed log4j-core dependency (#1815)

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/test/rest/RestTestUtil.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/test/rest/RestTestUtil.java
@@ -94,6 +94,12 @@ public class RestTestUtil {
         } else {
             project.getDependencies()
                 .add(sourceSet.getImplementationConfigurationName(), "org.opensearch.test:framework:" + VersionProperties.getOpenSearch());
+            // The log4j-core is optional dependency of the org.opensearch.test:framework. needs explicit introduction
+            project.getDependencies()
+                .add(
+                    sourceSet.getImplementationConfigurationName(),
+                    "org.apache.logging.log4j:log4j-core:" + VersionProperties.getVersions().get("log4j")
+                );
         }
 
     }


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Backport of https://github.com/opensearch-project/OpenSearch/pull/1815 to 1.x

Using opensearch.yaml-rest-test Gradle plugin outside of the OpenSearch core (fe, in plugins), for example yamlRestTest, fails with the following exception:

```
> Task :yamlRestTest

org.opensearch.path.to.plugin.RenameClientYamlTestSuiteIT > initializationError FAILED
    java.lang.NoClassDefFoundError: org/apache/logging/log4j/core/Layout
```

Since the log4j-core is declared as optional, it is not being picked up. Adding it as an explicit dependency does not solve the problem either (see please opensearch-project/opensearch-plugin-template-java#16 for more details) because the task uses dedicated configuration `yamlRestTestImplementation` and only its dependencies.
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/1814
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
