### PR TITLE
[Backport] [1.x] Execution failed for task ':test:fixtures:azure/s3/hdfs/gcs-fixture:composeDown' (#1824)

### DIFF
--- a/test/fixtures/azure-fixture/build.gradle
+++ b/test/fixtures/azure-fixture/build.gradle
@@ -39,6 +39,10 @@ dependencies {
 
 preProcessFixture {
   dependsOn jar, configurations.runtimeClasspath
+  // always run the task, otherwise the folders won't be created
+  outputs.upToDateWhen { 
+    false 
+  }
   doLast {
     file("${testFixturesDir}/shared").mkdirs()
     project.copy {

--- a/test/fixtures/gcs-fixture/build.gradle
+++ b/test/fixtures/gcs-fixture/build.gradle
@@ -39,6 +39,10 @@ dependencies {
 
 preProcessFixture {
   dependsOn jar, configurations.runtimeClasspath
+  // always run the task, otherwise the folders won't be created
+  outputs.upToDateWhen { 
+    false 
+  }
   doLast {
     file("${testFixturesDir}/shared").mkdirs()
     project.copy {

--- a/test/fixtures/krb5kdc-fixture/build.gradle
+++ b/test/fixtures/krb5kdc-fixture/build.gradle
@@ -38,6 +38,10 @@ preProcessFixture.doLast {
 }
 
 postProcessFixture {
+  // always run the task, otherwise the folders won't be created
+  outputs.upToDateWhen { 
+    false 
+  }
   inputs.dir("${testFixturesDir}/shared")
   services.each { service ->
     File confTemplate = file("${testFixturesDir}/shared/${service}/krb5.conf.template")

--- a/test/fixtures/s3-fixture/build.gradle
+++ b/test/fixtures/s3-fixture/build.gradle
@@ -39,6 +39,10 @@ dependencies {
 
 preProcessFixture {
   dependsOn jar, configurations.runtimeClasspath
+  // always run the task, otherwise the folders won't be created
+  outputs.upToDateWhen { 
+    false 
+  }
   doLast {
     file("${testFixturesDir}/shared").mkdirs()
     project.copy {


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Backport of https://github.com/opensearch-project/OpenSearch/pull/1824 to 1.x
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/1821
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
