### PR TITLE
Attempt to fix "Intermittent java.lang.Exception: Suite timeout exceeded (>= 1200000 msec)

### DIFF
--- a/distribution/tools/plugin-cli/build.gradle
+++ b/distribution/tools/plugin-cli/build.gradle
@@ -49,6 +49,7 @@ tasks.named("dependencyLicenses").configure {
 test {
   // TODO: find a way to add permissions for the tests in this module
   systemProperty 'tests.security.manager', 'false'
+  jvmArgs += [ "-Djava.security.egd=file:/dev/urandom" ]
 }
 
 /*


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
We have seen this issue before on `main` (and fixed it as part of https://github.com/opensearch-project/OpenSearch/pull/1358/files#diff-1a51c2f0353076590c29fbdc710bcdf9289345866c2497ecce07f91819fe6dc9R52), but seems like `1.x` is also running into this problem from time to time.
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/1826
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
