### PR TITLE
Fixing auto backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   backport:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     name: Backport
     steps:
       - name: Backport


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
This should fix the backport workflow failures since the branch protection is relaxed in PR #1816. I tried with the similar set of permissions on my repo and the workflow ran successfully https://github.com/VachaShah/TestGithubActions/runs/4706516920?check_suite_focus=true. The default permissions are  `read` for all the scopes if not specified, for example: https://github.com/opensearch-project/OpenSearch/runs/4702581161?check_suite_focus=true

Note: I will add a backport label to a PR in this repo to verify.

### Issues Resolved
#1712 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
