### PR TITLE
Using custom branch name for auto backporting PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,6 +14,7 @@ jobs:
     name: Backport
     steps:
       - name: Backport
-        uses: tibdex/backport@v1
+        uses: VachaShah/backport@v1.1.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch_name: backport/backport-${{ github.event.number }}


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Fixes the issue for custom branch name for auto backport workflow. This will help in defining permissions properly for branches. For now, I have added the custom branch name changes in my [fork](https://github.com/VachaShah/backport) of the GHA repo, hence I am using a release version from my forked repo. Once the concerned change is merged to the backport GHA repo [tibdex/backport](https://github.com/tibdex/backport), I will update the GHA repo name.

After this PR is merged, I will verify it by running the backport workflow on a PR.
 
### Issues Resolved
#1712 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
