### PR TITLE
[WIP] Attempt to fix :test:fixtures:s3-fixture:composeUp fails due to HTTP connection issue

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -113,7 +113,7 @@ dependencies {
   api "net.java.dev.jna:jna:5.5.0"
   api 'com.github.jengelman.gradle.plugins:shadow:6.0.0'
   api 'de.thetaphi:forbiddenapis:3.0'
-  api 'com.avast.gradle:gradle-docker-compose-plugin:0.12.1'
+  api 'com.avast.gradle:gradle-docker-compose-plugin:0.14.12'
   api 'org.apache.maven:maven-model:3.6.2'
   api 'com.networknt:json-schema-validator:1.0.36'
   api 'com.fasterxml.jackson.core:jackson-databind:2.12.5'


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Attempt to fix `:test:fixtures:s3-fixture:composeUp` fails due to HTTP connection issue by introducing configurable property `dockerComposeHttpTimeout` with default value of 120 seconds. To change it, the standard `ExtraPropertiesExtension`  is used:

```
ext {
   dockerComposeHttpTimeout = 180
}
```

The timeout seems to be taken into account (simulated failures are below);

```
ERROR: for minio-fixture-other  HTTPConnectionPool(host='127.0.0.1', port=2375): Read timed out. (read timeout=180)

ERROR: for minio-fixture  HTTPConnectionPool(host='127.0.0.1', port=2375): Read timed out. (read timeout=180)
An HTTP request took too long to complete. Retry with --verbose to obtain debug information.
If you encounter this issue regularly because of slow network conditions, consider setting COMPOSE_HTTP_TIMEOUT to a higher value (current value: 180).

```
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/1806
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
