### PR TITLE
Fixing build failures after Flavor Serialization backport

### DIFF
--- a/server/src/main/java/org/opensearch/Build.java
+++ b/server/src/main/java/org/opensearch/Build.java
@@ -214,8 +214,7 @@ public class Build {
         // TODO - clean this up when OSS flavor is removed in all of the code base
         // (Integ test zip still write OSS as distribution)
         // See issue: https://github.com/opendistro-for-elasticsearch/search/issues/159
-        // todo change to V_1_3_0 after backporting
-        if (in.getVersion().before(Version.V_2_0_0)) {
+        if (in.getVersion().before(Version.V_1_3_0)) {
             String flavor = in.readString();
         }
         // be lenient when reading on the wire, the enumeration values from other versions might be different than what we know
@@ -242,8 +241,7 @@ public class Build {
         // The following block is kept for existing BWS tests to pass.
         // TODO - clean up this code when we remove all v6 bwc tests.
         // TODO - clean this up when OSS flavor is removed in all of the code base
-        // todo change to V_1_3_0 after backporting
-        if (out.getVersion().before(Version.V_2_0_0)) {
+        if (out.getVersion().before(Version.V_1_3_0)) {
             out.writeString("oss");
         }
         final Type buildType = build.type();


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Fixing build failures after Flavor Serialization backport (https://github.com/opensearch-project/OpenSearch/pull/1757)
 
### Issues Resolved
Multiple builds are failing:
 - https://ci.opensearch.org/logs/ci/workflow/OpenSearch_CI/PR_Checks/Gradle_Check/gradle_check_1804.log
 - https://ci.opensearch.org/logs/ci/workflow/OpenSearch_CI/PR_Checks/Gradle_Check/gradle_check_1801.log
 - ...
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
