### PR TITLE
Remove LegacyESVersion.V_6_8_x constants

### DIFF
--- a/server/src/main/java/org/opensearch/LegacyESVersion.java
+++ b/server/src/main/java/org/opensearch/LegacyESVersion.java
@@ -46,24 +46,6 @@ import java.lang.reflect.Field;
  */
 public class LegacyESVersion extends Version {
 
-    public static final LegacyESVersion V_6_8_0 = new LegacyESVersion(6080099, org.apache.lucene.util.Version.LUCENE_7_7_0);
-    public static final LegacyESVersion V_6_8_1 = new LegacyESVersion(6080199, org.apache.lucene.util.Version.LUCENE_7_7_0);
-    public static final LegacyESVersion V_6_8_2 = new LegacyESVersion(6080299, org.apache.lucene.util.Version.LUCENE_7_7_0);
-    public static final LegacyESVersion V_6_8_3 = new LegacyESVersion(6080399, org.apache.lucene.util.Version.LUCENE_7_7_0);
-    public static final LegacyESVersion V_6_8_4 = new LegacyESVersion(6080499, org.apache.lucene.util.Version.LUCENE_7_7_2);
-    public static final LegacyESVersion V_6_8_5 = new LegacyESVersion(6080599, org.apache.lucene.util.Version.LUCENE_7_7_2);
-    public static final LegacyESVersion V_6_8_6 = new LegacyESVersion(6080699, org.apache.lucene.util.Version.LUCENE_7_7_2);
-    public static final LegacyESVersion V_6_8_7 = new LegacyESVersion(6080799, org.apache.lucene.util.Version.LUCENE_7_7_2);
-    public static final LegacyESVersion V_6_8_8 = new LegacyESVersion(6080899, org.apache.lucene.util.Version.LUCENE_7_7_2);
-    // Version constant for Lucene 7.7.3 release with index corruption bug fix
-    private static final org.apache.lucene.util.Version LUCENE_7_7_3 = org.apache.lucene.util.Version.fromBits(7, 7, 3);
-    public static final LegacyESVersion V_6_8_9 = new LegacyESVersion(6080999, LUCENE_7_7_3);
-    public static final LegacyESVersion V_6_8_10 = new LegacyESVersion(6081099, LUCENE_7_7_3);
-    public static final LegacyESVersion V_6_8_11 = new LegacyESVersion(6081199, LUCENE_7_7_3);
-    public static final LegacyESVersion V_6_8_12 = new LegacyESVersion(6081299, LUCENE_7_7_3);
-    public static final LegacyESVersion V_6_8_13 = new LegacyESVersion(6081399, LUCENE_7_7_3);
-    public static final LegacyESVersion V_6_8_14 = new LegacyESVersion(6081499, LUCENE_7_7_3);
-    public static final LegacyESVersion V_6_8_15 = new LegacyESVersion(6081599, org.apache.lucene.util.Version.LUCENE_7_7_3);
     public static final LegacyESVersion V_7_0_0 = new LegacyESVersion(7000099, org.apache.lucene.util.Version.LUCENE_8_0_0);
     public static final LegacyESVersion V_7_0_1 = new LegacyESVersion(7000199, org.apache.lucene.util.Version.LUCENE_8_0_0);
     public static final LegacyESVersion V_7_1_0 = new LegacyESVersion(7010099, org.apache.lucene.util.Version.LUCENE_8_0_0);

--- a/server/src/main/java/org/opensearch/OpenSearchException.java
+++ b/server/src/main/java/org/opensearch/OpenSearchException.java
@@ -1561,7 +1561,7 @@ public class OpenSearchException extends RuntimeException implements ToXContentF
             org.opensearch.index.shard.ShardNotInPrimaryModeException.class,
             org.opensearch.index.shard.ShardNotInPrimaryModeException::new,
             155,
-            LegacyESVersion.V_6_8_1
+            UNKNOWN_VERSION_ADDED
         ),
         RETENTION_LEASE_INVALID_RETAINING_SEQUENCE_NUMBER_EXCEPTION(
             org.opensearch.index.seqno.RetentionLeaseInvalidRetainingSeqNoException.class,

--- a/server/src/main/java/org/opensearch/Version.java
+++ b/server/src/main/java/org/opensearch/Version.java
@@ -329,15 +329,20 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     }
 
     protected Version computeMinCompatVersion() {
-        if (major == 1) {
-            return LegacyESVersion.V_6_8_0;
+        if (major == 1 || major == 7) {
+            // we don't have LegacyESVersion.V_6 constants, so set it to its last minor
+            return LegacyESVersion.fromId(6080099);
         } else if (major == 2) {
             return LegacyESVersion.V_7_10_0;
         } else if (major == 6) {
             // force the minimum compatibility for version 6 to 5.6 since we don't reference version 5 anymore
-            return Version.fromId(5060099);
-        } else if (major >= 7) {
-            // all major versions from 7 onwards are compatible with last minor series of the previous major
+            return LegacyESVersion.fromId(5060099);
+        }
+        /*
+         * TODO - uncomment this logic from OpenSearch version 3 onwards
+         *
+        else if (major >= 3) {
+            // all major versions from 3 onwards are compatible with last minor series of the previous major
             Version bwcVersion = null;
 
             for (int i = DeclaredVersionsHolder.DECLARED_VERSIONS.size() - 1; i >= 0; i--) {
@@ -351,6 +356,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
             }
             return bwcVersion == null ? this : bwcVersion;
         }
+         */
 
         return Version.min(this, fromId(maskId((int) major * 1000000 + 0 * 10000 + 99)));
     }

--- a/server/src/main/java/org/opensearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/opensearch/transport/TransportHandshaker.java
@@ -132,7 +132,7 @@ final class TransportHandshaker {
         // 2. if remote node is 6.8 then it would be 5.6.0
         // 3. if remote node is OpenSearch 1.x then it would be 6.7.99
         if ((this.version.onOrAfter(Version.V_1_0_0) && this.version.before(Version.V_2_0_0))
-            && (stream.getVersion().equals(LegacyESVersion.V_6_8_0) || stream.getVersion().equals(Version.fromId(5060099)))) {
+            && (stream.getVersion().equals(LegacyESVersion.fromId(6080099)) || stream.getVersion().equals(Version.fromId(5060099)))) {
             channel.sendResponse(new HandshakeResponse(LegacyESVersion.V_7_10_2));
         } else {
             channel.sendResponse(new HandshakeResponse(this.version));

--- a/server/src/test/java/org/opensearch/LegacyESVersionTests.java
+++ b/server/src/test/java/org/opensearch/LegacyESVersionTests.java
@@ -25,7 +25,6 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.opensearch.LegacyESVersion.V_6_8_15;
 import static org.opensearch.LegacyESVersion.V_7_0_0;
 import static org.opensearch.test.VersionUtils.randomLegacyVersion;
 import static org.opensearch.VersionTests.isCompatible;
@@ -37,6 +36,7 @@ import static org.opensearch.VersionTests.isCompatible;
 public class LegacyESVersionTests extends OpenSearchTestCase {
 
     public void testVersionComparison() {
+        Version V_6_8_15 = LegacyESVersion.fromString("6.8.15");
         assertThat(V_6_8_15.before(V_7_0_0), is(true));
         assertThat(V_6_8_15.before(V_6_8_15), is(false));
         assertThat(V_7_0_0.before(V_6_8_15), is(false));
@@ -59,7 +59,6 @@ public class LegacyESVersionTests extends OpenSearchTestCase {
         assertTrue(LegacyESVersion.fromString("5.0.0-alpha24").before(LegacyESVersion.fromString("5.0.0-beta0")));
 
         assertThat(V_6_8_15, is(lessThan(V_7_0_0)));
-        assertThat(V_6_8_15.compareTo(V_6_8_15), is(0));
         assertThat(V_7_0_0, is(greaterThan(V_6_8_15)));
 
         // compare opensearch version to LegacyESVersion
@@ -147,7 +146,8 @@ public class LegacyESVersionTests extends OpenSearchTestCase {
 
         // from 7.0 on we are supporting the latest minor of the previous major... this might fail once we add a new version ie. 5.x is
         // released since we need to bump the supported minor in Version#minimumCompatibilityVersion()
-        LegacyESVersion lastVersion = LegacyESVersion.V_6_8_0; // TODO: remove this once min compat version is a constant instead of method
+        Version lastVersion = LegacyESVersion.fromString("6.8.0"); // TODO: remove this once min compat version is a constant instead of
+                                                                   // method
         assertEquals(lastVersion.major, LegacyESVersion.V_7_0_0.minimumCompatibilityVersion().major);
         assertEquals(
             "did you miss to bump the minor in Version#minimumCompatibilityVersion()",
@@ -280,7 +280,7 @@ public class LegacyESVersionTests extends OpenSearchTestCase {
     }
 
     public void testIsCompatible() {
-        assertTrue(isCompatible(LegacyESVersion.V_6_8_0, LegacyESVersion.V_7_0_0));
+        assertTrue(isCompatible(LegacyESVersion.fromString("6.8.0"), LegacyESVersion.V_7_0_0));
         assertFalse(isCompatible(LegacyESVersion.fromString("6.6.0"), LegacyESVersion.V_7_0_0));
         assertFalse(isCompatible(LegacyESVersion.fromString("6.7.0"), LegacyESVersion.V_7_0_0));
 

--- a/server/src/test/java/org/opensearch/VersionTests.java
+++ b/server/src/test/java/org/opensearch/VersionTests.java
@@ -204,7 +204,7 @@ public class VersionTests extends OpenSearchTestCase {
 
     /** test opensearch min wire compatibility */
     public void testOpenSearchMinCompatVersion() {
-        Version opensearchVersion = VersionUtils.randomOpenSearchVersion(random());
+        Version opensearchVersion = Version.CURRENT;
         // opensearch 1.x minCompat is Legacy 6.8.0
         // opensearch 2.x minCompat is Legacy 7.10.0
         // opensearch 3.x minCompat is 1.{last minor version}.0

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -642,16 +642,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         assertEquals(2048, MetadataCreateIndexService.calculateNumRoutingShards(1024, Version.CURRENT));
         assertEquals(4096, MetadataCreateIndexService.calculateNumRoutingShards(2048, Version.CURRENT));
 
-        Version latestV6 = VersionUtils.getPreviousVersion(LegacyESVersion.V_7_0_0);
         int numShards = randomIntBetween(1, 1000);
-        assertEquals(numShards, MetadataCreateIndexService.calculateNumRoutingShards(numShards, latestV6));
-        assertEquals(
-            numShards,
-            MetadataCreateIndexService.calculateNumRoutingShards(
-                numShards,
-                VersionUtils.randomVersionBetween(random(), VersionUtils.getFirstVersion(), latestV6)
-            )
-        );
 
         for (int i = 0; i < 1000; i++) {
             int randomNumShards = randomIntBetween(1, 10000);

--- a/server/src/test/java/org/opensearch/common/lucene/uid/VersionsTests.java
+++ b/server/src/test/java/org/opensearch/common/lucene/uid/VersionsTests.java
@@ -52,7 +52,6 @@ import org.opensearch.test.VersionUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static org.opensearch.common.lucene.uid.VersionsAndSeqNoResolver.loadDocIdAndVersion;
@@ -216,17 +215,8 @@ public class VersionsTests extends OpenSearchTestCase {
     }
 
     public void testLuceneVersionOnUnknownVersions() {
-        List<Version> allVersions = VersionUtils.allVersions();
-
-        // should have the same Lucene version as the latest 6.x version
-        Version version = LegacyESVersion.fromString("6.88.50");
-        assertEquals(
-            allVersions.get(Collections.binarySearch(allVersions, LegacyESVersion.V_7_0_0) - 1).luceneVersion,
-            version.luceneVersion
-        );
-
         // between two known versions, should use the lucene version of the previous version
-        version = LegacyESVersion.fromString("7.10.50");
+        Version version = LegacyESVersion.fromString("7.10.50");
         assertEquals(VersionUtils.getPreviousVersion(Version.fromString("7.10.3")).luceneVersion, version.luceneVersion);
 
         // too old version, major should be the oldest supported lucene version minus 1

--- a/server/src/test/java/org/opensearch/common/rounding/RoundingDuelTests.java
+++ b/server/src/test/java/org/opensearch/common/rounding/RoundingDuelTests.java
@@ -32,12 +32,9 @@
 
 package org.opensearch.common.rounding;
 
-import org.opensearch.LegacyESVersion;
-import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.joda.time.DateTimeZone;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.test.OpenSearchTestCase;
-import org.opensearch.test.VersionUtils;
-import org.joda.time.DateTimeZone;
 
 import java.time.ZoneOffset;
 
@@ -47,31 +44,6 @@ public class RoundingDuelTests extends OpenSearchTestCase {
 
     // dont include nano/micro seconds as rounding would become zero then and throw an exception
     private static final String[] ALLOWED_TIME_SUFFIXES = new String[] { "d", "h", "ms", "s", "m" };
-
-    public void testSerialization() throws Exception {
-        org.opensearch.common.Rounding.DateTimeUnit randomDateTimeUnit = randomFrom(org.opensearch.common.Rounding.DateTimeUnit.values());
-        org.opensearch.common.Rounding rounding;
-        boolean oldNextRoundingValueWorks;
-        if (randomBoolean()) {
-            rounding = org.opensearch.common.Rounding.builder(randomDateTimeUnit).timeZone(ZoneOffset.UTC).build();
-            oldNextRoundingValueWorks = true;
-        } else {
-            rounding = org.opensearch.common.Rounding.builder(timeValue()).timeZone(ZoneOffset.UTC).build();
-            oldNextRoundingValueWorks = false;
-        }
-        BytesStreamOutput output = new BytesStreamOutput();
-        output.setVersion(VersionUtils.getPreviousVersion(LegacyESVersion.V_7_0_0));
-        rounding.writeTo(output);
-
-        Rounding roundingJoda = Rounding.Streams.read(output.bytes().streamInput());
-        org.opensearch.common.Rounding roundingJavaTime = org.opensearch.common.Rounding.read(output.bytes().streamInput());
-
-        int randomInt = randomIntBetween(1, 1_000_000_000);
-        assertThat(roundingJoda.round(randomInt), is(roundingJavaTime.round(randomInt)));
-        if (oldNextRoundingValueWorks) {
-            assertThat(roundingJoda.nextRoundingValue(randomInt), is(roundingJavaTime.nextRoundingValue(randomInt)));
-        }
-    }
 
     public void testDuellingImplementations() {
         org.opensearch.common.Rounding.DateTimeUnit randomDateTimeUnit = randomFrom(org.opensearch.common.Rounding.DateTimeUnit.values());


### PR DESCRIPTION
### Description
This commit removes all usages of the `LegacyESVersion.V_6_8_x` constants from the codebase.

### Issues Resolved
Part of #1674
 
### Check List
- [x] All tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>