### PR TITLE
Use Version.compareMajor instead of using equals operator

### DIFF
--- a/server/src/test/java/org/opensearch/cluster/coordination/JoinTaskExecutorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/JoinTaskExecutorTests.java
@@ -122,7 +122,7 @@ public class JoinTaskExecutorTests extends OpenSearchTestCase {
             expectThrows(IllegalStateException.class, () -> JoinTaskExecutor.ensureMajorVersionBarrier(oldMajor, minNodeVersion));
         }
 
-        final Version minGoodVersion = maxNodeVersion.major == minNodeVersion.major ?
+        final Version minGoodVersion = maxNodeVersion.compareMajor(minNodeVersion) == 0 ?
         // we have to stick with the same major
             minNodeVersion : maxNodeVersion.minimumCompatibilityVersion();
         final Version justGood = randomVersionBetween(random(), minGoodVersion, maxCompatibleVersion(minNodeVersion));


### PR DESCRIPTION

### Description
This test fails due to equality check of majors between OpenSearch Version 1.x and LegacyESVersion 7.x. They should be equivalent but in this case the check fails and LegacyVersion.v6.8.x is chosen which was removed in 52508d5.

This change fixes the comparison logic by using `Version.compareMajor` method instead.

### Issues Resolved

Discovered in #1866
Log - https://ci.opensearch.org/logs/ci/workflow/OpenSearch_CI/PR_Checks/Gradle_Check/gradle_check_1837.log
 
### Check List
- [x] All tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


Signed-off-by: Rabi Panda <adnapibar@gmail.com>
