### PR TITLE
Remove unwanted unreleased versions

### DIFF
--- a/server/src/main/java/org/opensearch/Version.java
+++ b/server/src/main/java/org/opensearch/Version.java
@@ -71,9 +71,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_EMPTY = new Version(V_EMPTY_ID, org.apache.lucene.util.Version.LATEST);
 
     public static final Version V_1_0_0 = new Version(1000099, org.apache.lucene.util.Version.LUCENE_8_8_2);
-    public static final Version V_1_0_1 = new Version(1000199, org.apache.lucene.util.Version.LUCENE_8_8_2);
     public static final Version V_1_1_0 = new Version(1010099, org.apache.lucene.util.Version.LUCENE_8_9_0);
-    public static final Version V_1_1_1 = new Version(1010199, org.apache.lucene.util.Version.LUCENE_8_9_0);
     public static final Version V_1_2_0 = new Version(1020099, org.apache.lucene.util.Version.LUCENE_8_10_1);
     public static final Version V_1_2_1 = new Version(1020199, org.apache.lucene.util.Version.LUCENE_8_10_1);
     public static final Version V_1_2_2 = new Version(1020299, org.apache.lucene.util.Version.LUCENE_8_10_1);

--- a/server/src/test/java/org/opensearch/VersionTests.java
+++ b/server/src/test/java/org/opensearch/VersionTests.java
@@ -49,7 +49,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import static org.opensearch.Version.V_1_1_1;
 import static org.opensearch.Version.V_1_3_0;
 import static org.opensearch.Version.MASK;
 import static org.opensearch.test.VersionUtils.allVersions;
@@ -68,6 +67,7 @@ import static org.hamcrest.Matchers.sameInstance;
 public class VersionTests extends OpenSearchTestCase {
 
     public void testVersionComparison() {
+        Version V_1_1_1 = Version.fromString("1.1.1");
         assertThat(V_1_1_1.before(V_1_3_0), is(true));
         assertThat(V_1_1_1.before(V_1_1_1), is(false));
         assertThat(V_1_3_0.before(V_1_1_1), is(false));


### PR DESCRIPTION
### Description
Latest release is `1.2.3` 
Hence, only last major (`2.0.0`), last minor(`1.3.0`) and (`1.2.4`) can be unreleased
 
### Issues Resolved
Resolves #1855 
 
### Check List
- [x] All tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>