### PR TITLE
Add Task Id in thread context for Transport and Rest requests

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -473,6 +473,9 @@ public class TasksIT extends OpenSearchIntegTestCase {
 
                     @Override
                     public void waitForTaskCompletion(Task task) {}
+
+                    @Override
+                    public void onThreadContextUpdate(Task task, Boolean taskIdAdded) {}
                 });
             }
             // Need to run the task in a separate thread because node client's .execute() is blocked by our task listener
@@ -653,6 +656,9 @@ public class TasksIT extends OpenSearchIntegTestCase {
                     public void waitForTaskCompletion(Task task) {
                         waitForWaitingToStart.countDown();
                     }
+
+                    @Override
+                    public void onThreadContextUpdate(Task task, Boolean taskIdAdded) {}
 
                     @Override
                     public void onTaskRegistered(Task task) {}

--- a/server/src/main/java/org/opensearch/tasks/TaskManager.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskManager.java
@@ -492,8 +492,7 @@ public class TaskManager implements ClusterStateApplier {
                     assert cancellationListeners == null;
                     toRun = listener;
                 } else {
-                    toRun = () -> {
-                    };
+                    toRun = () -> {};
                     if (listener != null) {
                         if (cancellationListeners == null) {
                             cancellationListeners = new ArrayList<>();
@@ -597,8 +596,7 @@ public class TaskManager implements ClusterStateApplier {
                     assert childTaskCompletedListeners == null;
                     toRun = onChildTasksCompleted;
                 } else {
-                    toRun = () -> {
-                    };
+                    toRun = () -> {};
                     if (childTaskCompletedListeners == null) {
                         childTaskCompletedListeners = new ArrayList<>();
                     }
@@ -630,9 +628,7 @@ public class TaskManager implements ClusterStateApplier {
                 final ChannelPendingTaskTracker removedTracker = channelPendingTaskTrackers.remove(channel);
                 assert removedTracker == tracker;
                 cancelTasksOnChannelClosed(tracker.drainTasks());
-            }, e -> {
-                assert false : new AssertionError("must not be here", e);
-            }));
+            }, e -> { assert false : new AssertionError("must not be here", e); }));
         }
         return () -> tracker.removeTask(task);
     }
@@ -686,8 +682,7 @@ public class TaskManager implements ClusterStateApplier {
                 @Override
                 protected void doRun() {
                     for (CancellableTask task : tasks) {
-                        cancelTaskAndDescendants(task, "channel was closed", false, ActionListener.wrap(() -> {
-                        }));
+                        cancelTaskAndDescendants(task, "channel was closed", false, ActionListener.wrap(() -> {}));
                     }
                 }
             });

--- a/server/src/main/java/org/opensearch/tasks/TaskManager.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskManager.java
@@ -468,7 +468,12 @@ public class TaskManager implements ClusterStateApplier {
         }
 
         ThreadContext threadContext = threadPool.getThreadContext();
-        ThreadContext.StoredContext storedContext = threadContext.newStoredContext(true);
+
+        if (threadContext.getTransient(TASK_ID) != null) {
+            logger.warn("Task Id already present in the thread context. Overwriting");
+        }
+
+        ThreadContext.StoredContext storedContext = threadContext.newStoredContext(true, Collections.singletonList(TASK_ID));
         threadContext.putTransient(TASK_ID, task.getId());
         return storedContext;
     }

--- a/server/src/main/java/org/opensearch/transport/RequestHandlerRegistry.java
+++ b/server/src/main/java/org/opensearch/transport/RequestHandlerRegistry.java
@@ -37,6 +37,7 @@ import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lease.Releasables;
 import org.opensearch.search.internal.ShardSearchRequest;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.tasks.CancellableTask;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
@@ -81,6 +82,8 @@ public class RequestHandlerRegistry<Request extends TransportRequest> {
 
     public void processMessageReceived(Request request, TransportChannel channel) throws Exception {
         final Task task = taskManager.register(channel.getChannelType(), action, request);
+        ThreadContext.StoredContext storedContext = taskManager.addTaskIdInThreadContext(task);
+
         Releasable unregisterTask = () -> taskManager.unregister(task);
         try {
             if (channel instanceof TcpTransportChannel && task instanceof CancellableTask) {
@@ -99,6 +102,7 @@ public class RequestHandlerRegistry<Request extends TransportRequest> {
             unregisterTask = null;
         } finally {
             Releasables.close(unregisterTask);
+            storedContext.restore();
         }
     }
 

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/RecordingTaskManagerListener.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/RecordingTaskManagerListener.java
@@ -75,6 +75,9 @@ public class RecordingTaskManagerListener implements MockTaskManagerListener {
     @Override
     public void waitForTaskCompletion(Task task) {}
 
+    @Override
+    public void onThreadContextUpdate(Task task, Boolean taskIdAdded) {}
+
     public synchronized List<Tuple<Boolean, TaskInfo>> getEvents() {
         return Collections.unmodifiableList(new ArrayList<>(events));
     }

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -66,6 +66,7 @@ import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskId;
 import org.opensearch.tasks.TaskInfo;
 import org.opensearch.test.tasks.MockTaskManager;
+import org.opensearch.test.tasks.MockTaskManagerListener;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
@@ -82,12 +83,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.opensearch.action.support.PlainActionFuture.newFuture;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
+import static org.opensearch.tasks.TaskManager.TASK_ID;
 
 public class TransportTasksActionTests extends TaskManagerTestCase {
 
@@ -646,6 +649,58 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         checkLatch.countDown();
         NodesResponse responses = future.get();
         assertEquals(0, responses.failureCount());
+    }
+
+    public void testTaskIdPersistsInThreadContext() {
+        Settings settings = Settings.builder().put(MockTaskManager.USE_MOCK_TASK_MANAGER_SETTING.getKey(), true).build();
+        setupTestNodes(settings);
+        connectNodes(testNodes);
+
+        final List<Long> taskIdsAddedToThreadContext = new ArrayList<>();
+        final List<Long> taskIdsRemovedFromThreadContext = new ArrayList<>();
+        final long[] actualTaskIdInThreadContext = new long[1];
+        final long[] expectedTaskIdInThreadContext = new long[1];
+
+        ((MockTaskManager) testNodes[0].transportService.getTaskManager()).addListener(new MockTaskManagerListener() {
+            @Override
+            public void waitForTaskCompletion(Task task) {
+            }
+
+            @Override
+            public void onThreadContextUpdate(Task task, Boolean taskIdAdded) {
+                if (taskIdAdded) {
+                    taskIdsAddedToThreadContext.add(task.getId());
+                } else {
+                    taskIdsRemovedFromThreadContext.add(task.getId());
+                }
+            }
+
+            @Override
+            public void onTaskRegistered(Task task) {
+            }
+
+            @Override
+            public void onTaskUnregistered(Task task) {
+                if (task.getAction().equals("action1")) {
+                    expectedTaskIdInThreadContext[0] = task.getId();
+                    actualTaskIdInThreadContext[0] = threadPool.getThreadContext().getTransient(TASK_ID);
+                }
+            }
+        });
+
+
+        TestTasksAction action = new TestTasksAction("action1", testNodes[0].clusterService, testNodes[0].transportService) {
+            @Override
+            protected void taskOperation(TestTasksRequest request, Task task, ActionListener<TestTaskResponse> listener) {
+                listener.onResponse(new TestTaskResponse(testNodes[0].getNodeId()));
+            }
+        };
+        TestTasksRequest testTasksRequest = new TestTasksRequest();
+        testTasksRequest.setActions("action1");
+        ActionTestUtils.executeBlocking(action, testTasksRequest);
+
+        assertEquals(expectedTaskIdInThreadContext[0], actualTaskIdInThreadContext[0]);
+        assertThat(taskIdsAddedToThreadContext, containsInAnyOrder(taskIdsRemovedFromThreadContext.toArray()));
     }
 
     /**

--- a/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionIngestTests.java
+++ b/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionIngestTests.java
@@ -91,6 +91,7 @@ import java.util.function.BiConsumer;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Answers.RETURNS_MOCKS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
@@ -224,7 +225,7 @@ public class TransportBulkActionIngestTests extends OpenSearchTestCase {
         remoteResponseHandler = ArgumentCaptor.forClass(TransportResponseHandler.class);
 
         // setup services that will be called by action
-        transportService = mock(TransportService.class);
+        transportService = mock(TransportService.class, RETURNS_MOCKS);
         clusterService = mock(ClusterService.class);
         localIngest = true;
         // setup nodes for local and remote

--- a/server/src/test/java/org/opensearch/tasks/TaskManagerTests.java
+++ b/server/src/test/java/org/opensearch/tasks/TaskManagerTests.java
@@ -39,6 +39,7 @@ import org.opensearch.common.lease.Releasables;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ConcurrentCollections;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
@@ -64,6 +65,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.in;
 import static org.mockito.Mockito.mock;
+import static org.opensearch.tasks.TaskManager.TASK_ID;
 
 public class TaskManagerTests extends OpenSearchTestCase {
     private ThreadPool threadPool;
@@ -89,6 +91,36 @@ public class TaskManagerTests extends OpenSearchTestCase {
             total += times.next().millis();
         }
         assertEquals(600000L, total);
+    }
+
+    public void testAddTaskIdToThreadContext() {
+        final TaskManager taskManager = new TaskManager(Settings.EMPTY, threadPool, Collections.emptySet());
+        final Task task = taskManager.register("transport", "test", new CancellableRequest("1"));
+        String key = "KEY";
+        String value = "VALUE";
+
+        // Prepare thread context
+        threadPool.getThreadContext().putHeader(key, value);
+        threadPool.getThreadContext().putTransient(key, value);
+        threadPool.getThreadContext().addResponseHeader(key, value);
+
+        ThreadContext.StoredContext storedContext = taskManager.addTaskIdInThreadContext(task);
+
+        // All headers should be preserved and Task Id should also be included in thread context
+        verifyThreadContextFixedHeaders(key, value);
+        assertEquals((long) threadPool.getThreadContext().getTransient(TASK_ID), task.getId());
+
+        storedContext.restore();
+
+        // Post restore only task id should be removed from the thread context
+        verifyThreadContextFixedHeaders(key, value);
+        assertNull(threadPool.getThreadContext().getTransient(TASK_ID));
+    }
+
+    private void verifyThreadContextFixedHeaders(String key, String value) {
+        assertEquals(threadPool.getThreadContext().getHeader(key), value);
+        assertEquals(threadPool.getThreadContext().getTransient(key), value);
+        assertEquals(threadPool.getThreadContext().getResponseHeaders().get(key).get(0), value);
     }
 
     public void testTrackingChannelTask() throws Exception {

--- a/test/framework/src/main/java/org/opensearch/test/tasks/MockTaskManager.java
+++ b/test/framework/src/main/java/org/opensearch/test/tasks/MockTaskManager.java
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.util.Supplier;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskAwareRequest;
 import org.opensearch.tasks.TaskManager;
@@ -125,6 +126,21 @@ public class MockTaskManager extends TaskManager {
             }
         }
         super.waitForTaskCompletion(task, untilInNanos);
+    }
+
+    @Override
+    public ThreadContext.StoredContext addTaskIdInThreadContext(Task task) {
+        for (MockTaskManagerListener listener : listeners) {
+            listener.onThreadContextUpdate(task, true);
+        }
+
+        ThreadContext.StoredContext storedContext = super.addTaskIdInThreadContext(task);
+        return () -> {
+            for (MockTaskManagerListener listener : listeners) {
+                    listener.onThreadContextUpdate(task, false);
+            }
+            storedContext.restore();
+        };
     }
 
     public void addListener(MockTaskManagerListener listener) {

--- a/test/framework/src/main/java/org/opensearch/test/tasks/MockTaskManagerListener.java
+++ b/test/framework/src/main/java/org/opensearch/test/tasks/MockTaskManagerListener.java
@@ -43,4 +43,10 @@ public interface MockTaskManagerListener {
     void onTaskUnregistered(Task task);
 
     void waitForTaskCompletion(Task task);
+
+    /**
+     *
+     * @param taskIdAdded if false then task id is removed from the thread context. Null if no change
+     */
+    void onThreadContextUpdate(Task task, Boolean taskIdAdded);
 }


### PR DESCRIPTION
### Description
This change is to include Task Id in thread context for all the Rest or Transport requests. This change is required majorly to implement task resource tracking which relies on the fact that Task Id will be available in Thread Context. 
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/1179
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
