### PR TITLE
[Backport 1.x] Replace JCenter with Maven Central. (#1057) and update plugin repository order.

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -94,7 +94,8 @@ tasks.withType(JavaCompile).configureEach {
  *****************************************************************************/
 
 repositories {
-  jcenter()
+  mavenCentral()
+  gradlePluginPortal()
 }
 
 dependencies {

--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/OpenSearchTestBasePluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/OpenSearchTestBasePluginFuncTest.groovy
@@ -53,7 +53,7 @@ class OpenSearchTestBasePluginFuncTest extends AbstractGradleFuncTest {
             }
 
             repositories {
-                jcenter()
+                mavenCentral()
             }
 
             dependencies {

--- a/buildSrc/src/main/java/org/opensearch/gradle/RepositoriesSetupPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/RepositoriesSetupPlugin.java
@@ -82,7 +82,7 @@ public class RepositoriesSetupPlugin implements Plugin<Project> {
             // such that we don't have to pass hardcoded files to gradle
             repos.mavenLocal();
         }
-        repos.jcenter();
+        repos.mavenCentral();
 
         String luceneVersion = VersionProperties.getLucene();
         if (luceneVersion.contains("-snapshot")) {

--- a/buildSrc/src/testKit/opensearch.build/build.gradle
+++ b/buildSrc/src/testKit/opensearch.build/build.gradle
@@ -39,7 +39,7 @@ repositories {
       artifact()
     }
   }
-  jcenter()
+  mavenCentral()
 }
 
 repositories {
@@ -53,7 +53,7 @@ repositories {
       artifact()
     }
   }
-  jcenter()
+  mavenCentral()
 }
 
 // todo remove offending rules

--- a/buildSrc/src/testKit/testingConventions/build.gradle
+++ b/buildSrc/src/testKit/testingConventions/build.gradle
@@ -18,7 +18,7 @@ allprojects {
   apply plugin: 'opensearch.build'
 
   repositories {
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     testImplementation "junit:junit:4.13.1"

--- a/buildSrc/src/testKit/thirdPartyAudit/build.gradle
+++ b/buildSrc/src/testKit/thirdPartyAudit/build.gradle
@@ -36,7 +36,7 @@ repositories {
       artifact()
     }
   }
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,13 @@
  * GitHub history for details.
  */
 
+pluginManagement {
+  repositories {
+    mavenCentral()
+    gradlePluginPortal()
+  }
+}
+
 plugins {
   id "com.gradle.enterprise" version "3.5"
 }


### PR DESCRIPTION
This is a backport of #1057 to the 1.2 branch.  It also includes a change to update plugin repository order in settings.gradle so that plugin dependencies attempt to fetch from maven central before defaulting to the default set by gradlePluginPortal, which is bintray.