### PR TITLE
[Backport 1.1] Replace JCenter with Maven Central. (#1057)

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -94,7 +94,8 @@ tasks.withType(JavaCompile).configureEach {
  *****************************************************************************/
 
 repositories {
-  jcenter()
+  mavenCentral()
+  gradlePluginPortal()
 }
 
 dependencies {

--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/OpenSearchTestBasePluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/OpenSearchTestBasePluginFuncTest.groovy
@@ -53,7 +53,7 @@ class OpenSearchTestBasePluginFuncTest extends AbstractGradleFuncTest {
             }
 
             repositories {
-                jcenter()
+                mavenCentral()
             }
 
             dependencies {

--- a/buildSrc/src/main/java/org/opensearch/gradle/RepositoriesSetupPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/RepositoriesSetupPlugin.java
@@ -82,7 +82,7 @@ public class RepositoriesSetupPlugin implements Plugin<Project> {
             // such that we don't have to pass hardcoded files to gradle
             repos.mavenLocal();
         }
-        repos.jcenter();
+        repos.mavenCentral();
 
         String luceneVersion = VersionProperties.getLucene();
         if (luceneVersion.contains("-snapshot")) {

--- a/buildSrc/src/testKit/opensearch.build/build.gradle
+++ b/buildSrc/src/testKit/opensearch.build/build.gradle
@@ -39,7 +39,7 @@ repositories {
       artifact()
     }
   }
-  jcenter()
+  mavenCentral()
 }
 
 repositories {
@@ -53,7 +53,7 @@ repositories {
       artifact()
     }
   }
-  jcenter()
+  mavenCentral()
 }
 
 // todo remove offending rules

--- a/buildSrc/src/testKit/testingConventions/build.gradle
+++ b/buildSrc/src/testKit/testingConventions/build.gradle
@@ -18,7 +18,7 @@ allprojects {
   apply plugin: 'opensearch.build'
 
   repositories {
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     testImplementation "junit:junit:4.13.1"

--- a/buildSrc/src/testKit/thirdPartyAudit/build.gradle
+++ b/buildSrc/src/testKit/thirdPartyAudit/build.gradle
@@ -36,7 +36,7 @@ repositories {
       artifact()
     }
   }
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
On February 3 2021, JFrog [announced](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) the shutdown of JCenter. Later on April 27 2021, an update was provided that the repository will only be read only and new package and versions are no longer accepted on JCenter.  This means we should no longer use JCenter for our central artifacts repository.

This change replaces JCenter with Maven Central as per the Gradle recommendation - https://blog.gradle.org/jcenter-shutdown

Signed-off-by: Rabi Panda <adnapibar@gmail.com>

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
