### PR TITLE
Attempt to fix o.o.transport.netty4.OpenSearchLoggingHandlerIT fails w/ stack overflow by hardening test expectation patterns

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/opensearch/transport/netty4/OpenSearchLoggingHandlerIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/opensearch/transport/netty4/OpenSearchLoggingHandlerIT.java
@@ -66,12 +66,13 @@ public class OpenSearchLoggingHandlerIT extends OpenSearchNetty4IntegTestCase {
 
     @TestLogging(value = "org.opensearch.transport.netty4.OpenSearchLoggingHandler:trace,org.opensearch.transport.TransportLogger:trace", reason = "to ensure we log network events on TRACE level")
     public void testLoggingHandler() {
-        final String writePattern = ".*\\[length: \\d+"
+        final String writePattern = "^.*\\[length: \\d+"
             + ", request id: \\d+"
             + ", type: request"
-            + ", version: .*"
+            + ", version: [^,]+"
+            + ", header size: \\d+B"
             + ", action: cluster:monitor/nodes/hot_threads\\[n\\]\\]"
-            + " WRITE: \\d+B";
+            + " WRITE: \\d+B$";
         final MockLogAppender.LoggingExpectation writeExpectation = new MockLogAppender.PatternSeenEventExpectation(
             "hot threads request",
             TransportLogger.class.getCanonicalName(),
@@ -86,12 +87,12 @@ public class OpenSearchLoggingHandlerIT extends OpenSearchNetty4IntegTestCase {
             "*FLUSH*"
         );
 
-        final String readPattern = ".*\\[length: \\d+"
+        final String readPattern = "^.*\\[length: \\d+"
             + ", request id: \\d+"
             + ", type: request"
-            + ", version: .*"
+            + ", version: [^,]+"
             + ", action: cluster:monitor/nodes/hot_threads\\[n\\]\\]"
-            + " READ: \\d+B";
+            + " READ: \\d+B$";
 
         final MockLogAppender.LoggingExpectation readExpectation = new MockLogAppender.PatternSeenEventExpectation(
             "hot threads request",


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Attempt to fix `o.o.transport.netty4.OpenSearchLoggingHandlerIT` fails w/ stack overflow by hardening test expectation patterns. I was not able to reproduce the issue locally but suspects are: `Log4j` (specific message) and our own `MockLogAppender.LoggingExpectation`. At least, if the issue continues to manifest, we should be able to exclude `MockLogAppender.LoggingExpectation` from suspects.
 
### Issues Resolved
Possibly closes https://github.com/opensearch-project/OpenSearch/issues/1767
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
