### PR TITLE
[BWC] Ensure 2.x compatibility with Legacy 7.10.x

### DIFF
--- a/server/src/main/java/org/opensearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/opensearch/transport/TransportHandshaker.java
@@ -129,9 +129,11 @@ final class TransportHandshaker {
             );
         }
         // 1. if remote node is 7.x, then StreamInput version would be 6.8.0
-        if (this.version.onOrAfter(Version.V_2_0_0) && (stream.getVersion().equals(LegacyESVersion.fromId(6080099)))) {
-            // send 7.10.2 in response to ensure compatibility w/ Legacy 7.10.x nodes
-            // for rolling upgrade support
+        // 2. if remote node is 6.8 then it would be 5.6.0
+        // 3. if remote node is OpenSearch 1.x then it would be 6.7.99
+        if ((this.version.onOrAfter(Version.V_1_0_0) && this.version.before(Version.fromId(3000099 ^ Version.MASK)))
+            && (stream.getVersion().equals(LegacyESVersion.fromId(6080099)) || stream.getVersion().equals(Version.fromId(5060099)))) {
+            // send 7.10.2 in response to ensure compatibility w/ Legacy 7.10.x nodes for rolling upgrade support
             channel.sendResponse(new HandshakeResponse(LegacyESVersion.V_7_10_2));
         } else {
             channel.sendResponse(new HandshakeResponse(this.version));

--- a/server/src/main/java/org/opensearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/opensearch/transport/TransportHandshaker.java
@@ -63,6 +63,9 @@ final class TransportHandshaker {
     private final ThreadPool threadPool;
     private final HandshakeRequestSender handshakeRequestSender;
 
+    // @todo remove in 3.0.0
+    private static final Version V_3_0_0 = Version.fromId(3000099 ^ Version.MASK);
+
     TransportHandshaker(Version version, ThreadPool threadPool, HandshakeRequestSender handshakeRequestSender) {
         this.version = version;
         this.threadPool = threadPool;
@@ -131,7 +134,7 @@ final class TransportHandshaker {
         // 1. if remote node is 7.x, then StreamInput version would be 6.8.0
         // 2. if remote node is 6.8 then it would be 5.6.0
         // 3. if remote node is OpenSearch 1.x then it would be 6.7.99
-        if ((this.version.onOrAfter(Version.V_1_0_0) && this.version.before(Version.fromId(3000099 ^ Version.MASK)))
+        if ((this.version.onOrAfter(Version.V_1_0_0) && this.version.before(V_3_0_0))
             && (stream.getVersion().equals(LegacyESVersion.fromId(6080099)) || stream.getVersion().equals(Version.fromId(5060099)))) {
             // send 7.10.2 in response to ensure compatibility w/ Legacy 7.10.x nodes for rolling upgrade support
             channel.sendResponse(new HandshakeResponse(LegacyESVersion.V_7_10_2));

--- a/server/src/main/java/org/opensearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/opensearch/transport/TransportHandshaker.java
@@ -129,10 +129,9 @@ final class TransportHandshaker {
             );
         }
         // 1. if remote node is 7.x, then StreamInput version would be 6.8.0
-        // 2. if remote node is 6.8 then it would be 5.6.0
-        // 3. if remote node is OpenSearch 1.x then it would be 6.7.99
-        if ((this.version.onOrAfter(Version.V_1_0_0) && this.version.before(Version.V_2_0_0))
-            && (stream.getVersion().equals(LegacyESVersion.fromId(6080099)) || stream.getVersion().equals(Version.fromId(5060099)))) {
+        if (this.version.onOrAfter(Version.V_2_0_0) && (stream.getVersion().equals(LegacyESVersion.fromId(6080099)))) {
+            // send 7.10.2 in response to ensure compatibility w/ Legacy 7.10.x nodes
+            // for rolling upgrade support
             channel.sendResponse(new HandshakeResponse(LegacyESVersion.V_7_10_2));
         } else {
             channel.sendResponse(new HandshakeResponse(this.version));

--- a/server/src/main/java/org/opensearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/opensearch/transport/TransportHandshaker.java
@@ -64,7 +64,7 @@ final class TransportHandshaker {
     private final HandshakeRequestSender handshakeRequestSender;
 
     // @todo remove in 3.0.0
-    private static final Version V_3_0_0 = Version.fromId(3000099 ^ Version.MASK);
+    static final Version V_3_0_0 = Version.fromId(3000099 ^ Version.MASK);
 
     TransportHandshaker(Version version, ThreadPool threadPool, HandshakeRequestSender handshakeRequestSender) {
         this.version = version;

--- a/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
@@ -2226,10 +2226,12 @@ public abstract class AbstractSimpleTransportTestCase extends OpenSearchTestCase
                 TransportRequestOptions.Type.STATE
             );
             try (Transport.Connection connection = serviceA.openConnection(node, builder.build())) {
-                // OpenSearch [1.0:2.0) in bwc mode should only "upgrade" to Legacy v7.10.2
+                // OpenSearch [1.0:3.0) in bwc mode should only "upgrade" to Legacy v7.10.2
                 assertEquals(
                     connection.getVersion(),
-                    version.onOrAfter(Version.V_1_0_0) && version.before(Version.V_2_0_0) ? LegacyESVersion.V_7_10_2 : version
+                    version.onOrAfter(Version.V_1_0_0) && version.before(Version.fromId(3000099 ^ Version.MASK))
+                        ? LegacyESVersion.V_7_10_2
+                        : version
                 );
             }
         }
@@ -2275,7 +2277,9 @@ public abstract class AbstractSimpleTransportTestCase extends OpenSearchTestCase
             PlainActionFuture<Transport.Connection> future = PlainActionFuture.newFuture();
             serviceA.getOriginalTransport().openConnection(node, connectionProfile, future);
             try (Transport.Connection connection = future.actionGet()) {
-                assertEquals(Version.V_2_0_0, connection.getVersion());
+                // OpenSearch sends a handshake version spoofed as Legacy version 7_10_2
+                // todo change for OpenSearch 3.0.0 when Legacy compatibility is removed
+                assertEquals(LegacyESVersion.V_7_10_2, connection.getVersion());
             }
         }
     }

--- a/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
@@ -107,6 +107,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
+import static org.opensearch.transport.TransportHandshaker.V_3_0_0;
 import static org.opensearch.transport.TransportService.NOOP_TRANSPORT_INTERCEPTOR;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -2229,9 +2230,7 @@ public abstract class AbstractSimpleTransportTestCase extends OpenSearchTestCase
                 // OpenSearch [1.0:3.0) in bwc mode should only "upgrade" to Legacy v7.10.2
                 assertEquals(
                     connection.getVersion(),
-                    version.onOrAfter(Version.V_1_0_0) && version.before(Version.fromId(3000099 ^ Version.MASK))
-                        ? LegacyESVersion.V_7_10_2
-                        : version
+                    version.onOrAfter(Version.V_1_0_0) && version.before(V_3_0_0) ? LegacyESVersion.V_7_10_2 : version
                 );
             }
         }


### PR DESCRIPTION
This PR fixes `TransportHandshaker` to send a spoofed Legacy 7.10.2 mincompat
version to ensure OpenSearch 2.x nodes can join a Legacy 7.10.x cluster for
rolling upgrade support. Without this change 7.10.x and OpenSearch 2.x mixed
cluster bwc tests were failing.