### PR TITLE
Fixing org.opensearch.common.network.InetAddressesTests.testForStringIPv6WithScopeIdInput

### DIFF
--- a/server/src/test/java/org/opensearch/common/network/InetAddressesTests.java
+++ b/server/src/test/java/org/opensearch/common/network/InetAddressesTests.java
@@ -33,10 +33,17 @@ import org.opensearch.common.collect.Tuple;
 import org.opensearch.test.OpenSearchTestCase;
 import org.hamcrest.Matchers;
 
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.UnknownHostException;
+import java.util.Collections;
 import java.util.Enumeration;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assume.assumeThat;
 
 public class InetAddressesTests extends OpenSearchTestCase {
     public void testForStringBogusInput() {
@@ -147,11 +154,12 @@ public class InetAddressesTests extends OpenSearchTestCase {
         String scopeId = null;
         while (interfaces.hasMoreElements()) {
             final NetworkInterface nint = interfaces.nextElement();
-            if (nint.isLoopback()) {
+            if (nint.isLoopback() && Collections.list(nint.getInetAddresses()).stream().anyMatch(Inet6Address.class::isInstance)) {
                 scopeId = nint.getName();
                 break;
             }
         }
+        assumeThat("The loopback interface has no IPv6 address assigned", scopeId, is(not(nullValue())));
         assertNotNull(scopeId);
         String ipStr = "0:0:0:0:0:0:0:1%" + scopeId;
         InetAddress ipv6Addr = InetAddress.getByName(ipStr);


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description

There is a real possibility that loopback interface has no IPv6 address assigned (fe IPv6 is disabled, ...) but the test blindly assumes that loopback interface always has IPv6 address and as such, fails with ` java.net.UnknownHostException: no scope_id found` if that is not the case.

```
org.opensearch.common.network.InetAddressesTests > testForStringIPv6WithScopeIdInput FAILED
243 | java.net.UnknownHostException: no scope_id found
244 | at __randomizedtesting.SeedInfo.seed([D7519A98383FCD86:F581D4F66795B2D5]:0)
245 | at java.base/java.net.Inet6Address.deriveNumericScope(Inet6Address.java:538)
246 | at java.base/java.net.Inet6Address$Inet6AddressHolder.init(Inet6Address.java:247)
247 | at java.base/java.net.Inet6Address.initif(Inet6Address.java:495)
248 | at java.base/java.net.Inet6Address.initstr(Inet6Address.java:485)
249 | at java.base/java.net.Inet6Address.<init>(Inet6Address.java:404)
250 | at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1356)
251 | at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1301)
252 | at java.base/java.net.InetAddress.getByName(InetAddress.java:1251)
253 | at org.opensearch.common.network.InetAddressesTests.testForStringIPv6WithScopeIdInput(InetAddressesTests.java:157)
254

```
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/1887
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
