### PR TITLE
[Backport] [1.x] Fixing org.opensearch.common.network.InetAddressesTests.testForStringPv6WithScopeIdInput (#1913)

### DIFF
--- a/server/src/test/java/org/opensearch/common/network/InetAddressesTests.java
+++ b/server/src/test/java/org/opensearch/common/network/InetAddressesTests.java
@@ -33,10 +33,17 @@ import org.opensearch.common.collect.Tuple;
 import org.opensearch.test.OpenSearchTestCase;
 import org.hamcrest.Matchers;
 
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.UnknownHostException;
+import java.util.Collections;
 import java.util.Enumeration;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assume.assumeThat;
 
 public class InetAddressesTests extends OpenSearchTestCase {
     public void testForStringBogusInput() {
@@ -147,11 +154,12 @@ public class InetAddressesTests extends OpenSearchTestCase {
         String scopeId = null;
         while (interfaces.hasMoreElements()) {
             final NetworkInterface nint = interfaces.nextElement();
-            if (nint.isLoopback()) {
+            if (nint.isLoopback() && Collections.list(nint.getInetAddresses()).stream().anyMatch(Inet6Address.class::isInstance)) {
                 scopeId = nint.getName();
                 break;
             }
         }
+        assumeThat("The loopback interface has no IPv6 address assigned", scopeId, is(not(nullValue())));
         assertNotNull(scopeId);
         String ipStr = "0:0:0:0:0:0:0:1%" + scopeId;
         InetAddress ipv6Addr = InetAddress.getByName(ipStr);


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Backport of https://github.com/opensearch-project/OpenSearch/pull/1913 to 1.x
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/1887
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
