### PR TITLE
Add max_expansions option to wildcard interval

### DIFF
--- a/server/src/main/java/org/opensearch/index/query/IntervalsSourceProvider.java
+++ b/server/src/main/java/org/opensearch/index/query/IntervalsSourceProvider.java
@@ -40,6 +40,7 @@ import org.apache.lucene.queries.intervals.IntervalsSource;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.LegacyESVersion;
+import org.opensearch.Version;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.io.stream.NamedWriteable;
@@ -650,7 +651,11 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
             this.pattern = in.readString();
             this.analyzer = in.readOptionalString();
             this.useField = in.readOptionalString();
-            this.maxExpansions = in.readOptionalVInt();
+            if (in.getVersion().onOrAfter(Version.V_2_0_0)) {
+                this.maxExpansions = in.readOptionalVInt();
+            } else {
+                this.maxExpansions = null;
+            }
         }
 
         @Override
@@ -719,7 +724,9 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
             out.writeString(pattern);
             out.writeOptionalString(analyzer);
             out.writeOptionalString(useField);
-            out.writeOptionalVInt(maxExpansions);
+            if (out.getVersion().onOrAfter(Version.V_2_0_0)) {
+                out.writeOptionalVInt(maxExpansions);
+            }
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/index/query/WildcardIntervalsSourceProviderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/WildcardIntervalsSourceProviderTests.java
@@ -51,7 +51,8 @@ public class WildcardIntervalsSourceProviderTests extends AbstractSerializingTes
         return new Wildcard(
             randomAlphaOfLength(10),
             randomBoolean() ? randomAlphaOfLength(10) : null,
-            randomBoolean() ? randomAlphaOfLength(10) : null
+            randomBoolean() ? randomAlphaOfLength(10) : null,
+            randomBoolean() ? randomIntBetween(-1, Integer.MAX_VALUE) : null
         );
     }
 
@@ -60,7 +61,8 @@ public class WildcardIntervalsSourceProviderTests extends AbstractSerializingTes
         String wildcard = instance.getPattern();
         String analyzer = instance.getAnalyzer();
         String useField = instance.getUseField();
-        switch (between(0, 2)) {
+        Integer maxExpansions = instance.getMaxExpansions();
+        switch (between(0, 3)) {
             case 0:
                 wildcard += "a";
                 break;
@@ -70,10 +72,13 @@ public class WildcardIntervalsSourceProviderTests extends AbstractSerializingTes
             case 2:
                 useField = useField == null ? randomAlphaOfLength(5) : null;
                 break;
+            case 3:
+                maxExpansions = maxExpansions == null ? randomIntBetween(1, Integer.MAX_VALUE) : null;
+                break;
             default:
                 throw new AssertionError("Illegal randomisation branch");
         }
-        return new Wildcard(wildcard, analyzer, useField);
+        return new Wildcard(wildcard, analyzer, useField, maxExpansions);
     }
 
     @Override


### PR DESCRIPTION
### Description
Add support for setting the max expansions on a wildcard interval.
The default value is still 128 and the max value is bounded by
`BooleanQuery.getMaxClauseCount()`.
 
### Issues Resolved
#1857 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
