### PR TITLE
[BUG] Wait for outstanding requests to complete in LastSuccessfulSett…

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/index/ShardIndexingPressureSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/ShardIndexingPressureSettingsIT.java
@@ -403,14 +403,7 @@ public class ShardIndexingPressureSettingsIT extends OpenSearchIntegTestCase {
         secondSuccessFuture = client(coordinatingOnlyNode).bulk(bulkRequest);
         Thread.sleep(25);
 
-        assertBusy(
-            () -> {
-                assertEquals(
-                    coordinatingShardTracker.getCoordinatingOperationTracker().getPerformanceTracker().getTotalOutstandingRequests(),
-                    2
-                );
-            }
-        );
+        waitForTwoOutstandingRequests(coordinatingShardTracker);
 
         // This request breaches the threshold and hence will be rejected
         expectThrows(OpenSearchRejectedExecutionException.class, () -> client(coordinatingOnlyNode).bulk(bulkRequest).actionGet());
@@ -645,6 +638,7 @@ public class ShardIndexingPressureSettingsIT extends OpenSearchIntegTestCase {
                 IndexingPressureService.class,
                 coordinatingOnlyNode
             ).getShardIndexingPressure().getShardIndexingPressureTracker(shardId);
+            waitForTwoOutstandingRequests(coordinatingShardTracker);
             expectThrows(OpenSearchRejectedExecutionException.class, () -> client(coordinatingOnlyNode).bulk(bulkRequest).actionGet());
             assertEquals(1, coordinatingShardTracker.getCoordinatingOperationTracker().getRejectionTracker().getTotalRejections());
             assertEquals(
@@ -657,6 +651,7 @@ public class ShardIndexingPressureSettingsIT extends OpenSearchIntegTestCase {
             ShardIndexingPressureTracker primaryShardTracker = internalCluster().getInstance(IndexingPressureService.class, primaryName)
                 .getShardIndexingPressure()
                 .getShardIndexingPressureTracker(shardId);
+            waitForTwoOutstandingRequests(primaryShardTracker);
             expectThrows(OpenSearchRejectedExecutionException.class, () -> client(primaryName).bulk(bulkRequest).actionGet());
             assertEquals(1, primaryShardTracker.getCoordinatingOperationTracker().getRejectionTracker().getTotalRejections());
             assertEquals(
@@ -927,6 +922,12 @@ public class ShardIndexingPressureSettingsIT extends OpenSearchIntegTestCase {
     private String getCoordinatingOnlyNode() {
         return client().admin().cluster().prepareState().get().getState().nodes().getCoordinatingOnlyNodes().iterator().next().value
             .getName();
+    }
+
+    private static void waitForTwoOutstandingRequests(ShardIndexingPressureTracker tracker) throws Exception {
+        assertBusy(
+            () -> { assertEquals(tracker.getCoordinatingOperationTracker().getPerformanceTracker().getTotalOutstandingRequests(), 2); }
+        );
     }
 
     private void restartCluster(Settings settings) throws Exception {


### PR DESCRIPTION
…ingsUpdate test

Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
The change adds wait for outstanding requests to avoid failure due to occasional processing delays in previous requests. This change fixes the timeout issue in `testShardIndexingPressureLastSuccessfulSettingsUpdate` method. A previous fix was done for `testShardIndexingPressureEnforcedEnabledDisabledSetting` test [here](https://github.com/opensearch-project/OpenSearch/pull/1925). 
 
### Issues Resolved
[1843](https://github.com/opensearch-project/OpenSearch/issues/1843)

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
