### PR TITLE
Support _first and _last parameter for missing bucket ordering in composite aggregation

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/BinaryValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/BinaryValuesSource.java
@@ -104,7 +104,7 @@ class BinaryValuesSource extends SingleDimensionValuesSource<BytesRef> {
     @Override
     int compare(int from, int to) {
         if (missingBucket) {
-            int result = missingOrder.compare(() -> values.get(from), Objects::isNull, () -> values.get(to), Objects::isNull, reverseMul);
+            int result = missingOrder.compare(() -> Objects.isNull(values.get(from)), () -> Objects.isNull(values.get(to)), reverseMul);
             if (!MissingOrder.unknownOrder(result)) {
                 return result;
             }
@@ -115,7 +115,7 @@ class BinaryValuesSource extends SingleDimensionValuesSource<BytesRef> {
     @Override
     int compareCurrent(int slot) {
         if (missingBucket) {
-            int result = missingOrder.compare(() -> currentValue, Objects::isNull, () -> values.get(slot), Objects::isNull, reverseMul);
+            int result = missingOrder.compare(() -> Objects.isNull(currentValue), () -> Objects.isNull(values.get(slot)), reverseMul);
             if (!MissingOrder.unknownOrder(result)) {
                 return result;
             }
@@ -126,7 +126,7 @@ class BinaryValuesSource extends SingleDimensionValuesSource<BytesRef> {
     @Override
     int compareCurrentWithAfter() {
         if (missingBucket) {
-            int result = missingOrder.compare(() -> currentValue, Objects::isNull, () -> afterValue, Objects::isNull, reverseMul);
+            int result = missingOrder.compare(() -> Objects.isNull(currentValue), () -> Objects.isNull(afterValue), reverseMul);
             if (!MissingOrder.unknownOrder(result)) {
                 return result;
             }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/BinaryValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/BinaryValuesSource.java
@@ -47,8 +47,10 @@ import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.StringFieldType;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.LeafBucketCollector;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.function.LongConsumer;
 
 /**
@@ -68,10 +70,11 @@ class BinaryValuesSource extends SingleDimensionValuesSource<BytesRef> {
         CheckedFunction<LeafReaderContext, SortedBinaryDocValues, IOException> docValuesFunc,
         DocValueFormat format,
         boolean missingBucket,
+        MissingOrder missingOrder,
         int size,
         int reverseMul
     ) {
-        super(bigArrays, format, fieldType, missingBucket, size, reverseMul);
+        super(bigArrays, format, fieldType, missingBucket, missingOrder, size, reverseMul);
         this.breakerConsumer = breakerConsumer;
         this.docValuesFunc = docValuesFunc;
         this.values = bigArrays.newObjectArray(Math.min(size, 100));
@@ -101,10 +104,9 @@ class BinaryValuesSource extends SingleDimensionValuesSource<BytesRef> {
     @Override
     int compare(int from, int to) {
         if (missingBucket) {
-            if (values.get(from) == null) {
-                return values.get(to) == null ? 0 : -1 * reverseMul;
-            } else if (values.get(to) == null) {
-                return reverseMul;
+            int result = missingOrder.compare(() -> values.get(from), Objects::isNull, () -> values.get(to), Objects::isNull, reverseMul);
+            if (!MissingOrder.unknownOrder(result)) {
+                return result;
             }
         }
         return compareValues(values.get(from), values.get(to));
@@ -113,10 +115,9 @@ class BinaryValuesSource extends SingleDimensionValuesSource<BytesRef> {
     @Override
     int compareCurrent(int slot) {
         if (missingBucket) {
-            if (currentValue == null) {
-                return values.get(slot) == null ? 0 : -1 * reverseMul;
-            } else if (values.get(slot) == null) {
-                return reverseMul;
+            int result = missingOrder.compare(() -> currentValue, Objects::isNull, () -> values.get(slot), Objects::isNull, reverseMul);
+            if (!MissingOrder.unknownOrder(result)) {
+                return result;
             }
         }
         return compareValues(currentValue, values.get(slot));
@@ -125,10 +126,9 @@ class BinaryValuesSource extends SingleDimensionValuesSource<BytesRef> {
     @Override
     int compareCurrentWithAfter() {
         if (missingBucket) {
-            if (currentValue == null) {
-                return afterValue == null ? 0 : -1 * reverseMul;
-            } else if (afterValue == null) {
-                return reverseMul;
+            int result = missingOrder.compare(() -> currentValue, Objects::isNull, () -> afterValue, Objects::isNull, reverseMul);
+            if (!MissingOrder.unknownOrder(result)) {
+                return result;
             }
         }
         return compareValues(currentValue, afterValue);

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesSourceBuilder.java
@@ -51,6 +51,8 @@ import java.io.IOException;
 import java.time.ZoneId;
 import java.util.Objects;
 
+import static org.opensearch.search.aggregations.bucket.missing.MissingOrder.fromString;
+
 /**
  * A {@link ValuesSource} builder for {@link CompositeAggregationBuilder}
  */
@@ -245,6 +247,10 @@ public abstract class CompositeValuesSourceBuilder<AB extends CompositeValuesSou
     public AB missingOrder(MissingOrder missingOrder) {
         this.missingOrder = missingOrder;
         return (AB) this;
+    }
+
+    public MissingOrder missingOrder(String missingOrder) {
+        return fromString(missingOrder);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesSourceBuilder.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.search.aggregations.bucket.composite;
 
+import org.opensearch.Version;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -39,6 +40,7 @@ import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.script.Script;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.search.aggregations.support.ValueType;
 import org.opensearch.search.aggregations.support.ValuesSource;
 import org.opensearch.search.aggregations.support.ValuesSourceConfig;
@@ -59,6 +61,7 @@ public abstract class CompositeValuesSourceBuilder<AB extends CompositeValuesSou
     private Script script = null;
     private ValueType userValueTypeHint = null;
     private boolean missingBucket = false;
+    private MissingOrder missingOrder = MissingOrder.DEFAULT;
     private SortOrder order = SortOrder.ASC;
     private String format = null;
 
@@ -76,6 +79,9 @@ public abstract class CompositeValuesSourceBuilder<AB extends CompositeValuesSou
             this.userValueTypeHint = ValueType.readFromStream(in);
         }
         this.missingBucket = in.readBoolean();
+        if (in.getVersion().onOrAfter(Version.V_2_0_0)) {
+            this.missingOrder = MissingOrder.readFromStream(in);
+        }
         this.order = SortOrder.readFromStream(in);
         this.format = in.readOptionalString();
     }
@@ -95,6 +101,9 @@ public abstract class CompositeValuesSourceBuilder<AB extends CompositeValuesSou
             userValueTypeHint.writeTo(out);
         }
         out.writeBoolean(missingBucket);
+        if (out.getVersion().onOrAfter(Version.V_2_0_0)) {
+            missingOrder.writeTo(out);
+        }
         order.writeTo(out);
         out.writeOptionalString(format);
         innerWriteTo(out);
@@ -120,6 +129,9 @@ public abstract class CompositeValuesSourceBuilder<AB extends CompositeValuesSou
         if (format != null) {
             builder.field("format", format);
         }
+        if (!MissingOrder.isDefault(missingOrder)) {
+            builder.field("missing_order", missingOrder.toString());
+        }
         builder.field("order", order);
         doXContentBody(builder, params);
         builder.endObject();
@@ -142,6 +154,7 @@ public abstract class CompositeValuesSourceBuilder<AB extends CompositeValuesSou
             && Objects.equals(script, that.script())
             && Objects.equals(userValueTypeHint, that.userValuetypeHint())
             && Objects.equals(missingBucket, that.missingBucket())
+            && Objects.equals(missingOrder, that.missingOrder())
             && Objects.equals(order, that.order())
             && Objects.equals(format, that.format());
     }
@@ -224,6 +237,21 @@ public abstract class CompositeValuesSourceBuilder<AB extends CompositeValuesSou
      */
     public boolean missingBucket() {
         return missingBucket;
+    }
+
+    /**
+     * Sets the {@link MissingOrder} to use to order missing value.
+     */
+    public AB missingOrder(MissingOrder missingOrder) {
+        this.missingOrder = missingOrder;
+        return (AB) this;
+    }
+
+    /**
+     * Missing value order. {@link MissingOrder}.
+     */
+    public MissingOrder missingOrder() {
+        return missingOrder;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesSourceConfig.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesSourceConfig.java
@@ -37,6 +37,7 @@ import org.opensearch.common.Nullable;
 import org.opensearch.common.util.BigArrays;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.search.aggregations.support.ValuesSource;
 import org.opensearch.search.sort.SortOrder;
 
@@ -62,6 +63,7 @@ public class CompositeValuesSourceConfig {
     private final DocValueFormat format;
     private final int reverseMul;
     private final boolean missingBucket;
+    private final MissingOrder missingOrder;
     private final boolean hasScript;
     private final SingleDimensionValuesSourceProvider singleDimensionValuesSourceProvider;
 
@@ -83,6 +85,7 @@ public class CompositeValuesSourceConfig {
         DocValueFormat format,
         SortOrder order,
         boolean missingBucket,
+        MissingOrder missingOrder,
         boolean hasScript,
         SingleDimensionValuesSourceProvider singleDimensionValuesSourceProvider
     ) {
@@ -94,6 +97,7 @@ public class CompositeValuesSourceConfig {
         this.missingBucket = missingBucket;
         this.hasScript = hasScript;
         this.singleDimensionValuesSourceProvider = singleDimensionValuesSourceProvider;
+        this.missingOrder = missingOrder;
     }
 
     /**
@@ -130,6 +134,13 @@ public class CompositeValuesSourceConfig {
      */
     boolean missingBucket() {
         return missingBucket;
+    }
+
+    /**
+     * If true, an explicit `null bucket represents documents with missing values.
+     */
+    MissingOrder missingOrder() {
+        return missingOrder;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesSourceParserHelper.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesSourceParserHelper.java
@@ -54,6 +54,7 @@ public class CompositeValuesSourceParserHelper {
     static <VB extends CompositeValuesSourceBuilder<VB>, T> void declareValuesSourceFields(AbstractObjectParser<VB, T> objectParser) {
         objectParser.declareField(VB::field, XContentParser::text, new ParseField("field"), ObjectParser.ValueType.STRING);
         objectParser.declareBoolean(VB::missingBucket, new ParseField("missing_bucket"));
+        objectParser.declareString(VB::missingOrder, new ParseField("missing_order"));
 
         objectParser.declareField(VB::userValuetypeHint, p -> {
             ValueType valueType = ValueType.lenientParse(p.text());

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/DateHistogramValuesSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/DateHistogramValuesSourceBuilder.java
@@ -52,6 +52,7 @@ import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval
 import org.opensearch.search.aggregations.bucket.histogram.DateIntervalConsumer;
 import org.opensearch.search.aggregations.bucket.histogram.DateIntervalWrapper;
 import org.opensearch.search.aggregations.bucket.histogram.Histogram;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.search.aggregations.support.CoreValuesSourceType;
 import org.opensearch.search.aggregations.support.ValuesSource;
 import org.opensearch.search.aggregations.support.ValuesSourceConfig;
@@ -81,6 +82,7 @@ public class DateHistogramValuesSourceBuilder extends CompositeValuesSourceBuild
             boolean hasScript, // probably redundant with the config, but currently we check this two different ways...
             String format,
             boolean missingBucket,
+            MissingOrder missingOrder,
             SortOrder order
         );
     }
@@ -288,7 +290,7 @@ public class DateHistogramValuesSourceBuilder extends CompositeValuesSourceBuild
         builder.register(
             REGISTRY_KEY,
             org.opensearch.common.collect.List.of(CoreValuesSourceType.DATE, CoreValuesSourceType.NUMERIC),
-            (valuesSourceConfig, rounding, name, hasScript, format, missingBucket, order) -> {
+            (valuesSourceConfig, rounding, name, hasScript, format, missingBucket, missingOrder, order) -> {
                 ValuesSource.Numeric numeric = (ValuesSource.Numeric) valuesSourceConfig.getValuesSource();
                 // TODO once composite is plugged in to the values source registry or at least understands Date values source types use it
                 // here
@@ -304,6 +306,7 @@ public class DateHistogramValuesSourceBuilder extends CompositeValuesSourceBuild
                     docValueFormat,
                     order,
                     missingBucket,
+                    missingOrder,
                     hasScript,
                     (
                         BigArrays bigArrays,
@@ -319,6 +322,7 @@ public class DateHistogramValuesSourceBuilder extends CompositeValuesSourceBuild
                             roundingValuesSource::round,
                             compositeValuesSourceConfig.format(),
                             compositeValuesSourceConfig.missingBucket(),
+                            compositeValuesSourceConfig.missingOrder(),
                             size,
                             compositeValuesSourceConfig.reverseMul()
                         );
@@ -339,6 +343,6 @@ public class DateHistogramValuesSourceBuilder extends CompositeValuesSourceBuild
         Rounding rounding = dateHistogramInterval.createRounding(timeZone(), offset);
         return queryShardContext.getValuesSourceRegistry()
             .getAggregator(REGISTRY_KEY, config)
-            .apply(config, rounding, name, config.script() != null, format(), missingBucket(), order());
+            .apply(config, rounding, name, config.script() != null, format(), missingBucket(), missingOrder(), order());
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/DoubleValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/DoubleValuesSource.java
@@ -47,7 +47,6 @@ import org.opensearch.search.aggregations.LeafBucketCollector;
 import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 
 import java.io.IOException;
-import java.util.Objects;
 
 /**
  * A {@link SingleDimensionValuesSource} for doubles.
@@ -92,7 +91,7 @@ class DoubleValuesSource extends SingleDimensionValuesSource<Double> {
     @Override
     int compare(int from, int to) {
         if (missingBucket) {
-            int result = missingOrder.compare(() -> bits.get(from), l -> l == false, () -> bits.get(to), r -> r == false, reverseMul);
+            int result = missingOrder.compare(() -> bits.get(from) == false, () -> bits.get(to) == false, reverseMul);
             if (!MissingOrder.unknownOrder(result)) {
                 return result;
             }
@@ -103,7 +102,7 @@ class DoubleValuesSource extends SingleDimensionValuesSource<Double> {
     @Override
     int compareCurrent(int slot) {
         if (missingBucket) {
-            int result = missingOrder.compare(() -> missingCurrentValue, l -> l, () -> bits.get(slot), r -> r == false, reverseMul);
+            int result = missingOrder.compare(() -> missingCurrentValue, () -> bits.get(slot) == false, reverseMul);
             if (!MissingOrder.unknownOrder(result)) {
                 return result;
             }
@@ -114,7 +113,7 @@ class DoubleValuesSource extends SingleDimensionValuesSource<Double> {
     @Override
     int compareCurrentWithAfter() {
         if (missingBucket) {
-            int result = missingOrder.compare(() -> missingCurrentValue, l -> l, () -> afterValue, Objects::isNull, reverseMul);
+            int result = missingOrder.compare(() -> missingCurrentValue, () -> afterValue == null, reverseMul);
             if (!MissingOrder.unknownOrder(result)) {
                 return result;
             }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/DoubleValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/DoubleValuesSource.java
@@ -44,8 +44,10 @@ import org.opensearch.index.fielddata.SortedNumericDoubleValues;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.LeafBucketCollector;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * A {@link SingleDimensionValuesSource} for doubles.
@@ -63,10 +65,11 @@ class DoubleValuesSource extends SingleDimensionValuesSource<Double> {
         CheckedFunction<LeafReaderContext, SortedNumericDoubleValues, IOException> docValuesFunc,
         DocValueFormat format,
         boolean missingBucket,
+        MissingOrder missingOrder,
         int size,
         int reverseMul
     ) {
-        super(bigArrays, format, fieldType, missingBucket, size, reverseMul);
+        super(bigArrays, format, fieldType, missingBucket, missingOrder, size, reverseMul);
         this.docValuesFunc = docValuesFunc;
         this.bits = missingBucket ? new BitArray(100, bigArrays) : null;
         this.values = bigArrays.newDoubleArray(Math.min(size, 100), false);
@@ -89,10 +92,9 @@ class DoubleValuesSource extends SingleDimensionValuesSource<Double> {
     @Override
     int compare(int from, int to) {
         if (missingBucket) {
-            if (bits.get(from) == false) {
-                return bits.get(to) ? -1 * reverseMul : 0;
-            } else if (bits.get(to) == false) {
-                return reverseMul;
+            int result = missingOrder.compare(() -> bits.get(from), l -> l == false, () -> bits.get(to), r -> r == false, reverseMul);
+            if (!MissingOrder.unknownOrder(result)) {
+                return result;
             }
         }
         return compareValues(values.get(from), values.get(to));
@@ -101,10 +103,9 @@ class DoubleValuesSource extends SingleDimensionValuesSource<Double> {
     @Override
     int compareCurrent(int slot) {
         if (missingBucket) {
-            if (missingCurrentValue) {
-                return bits.get(slot) ? -1 * reverseMul : 0;
-            } else if (bits.get(slot) == false) {
-                return reverseMul;
+            int result = missingOrder.compare(() -> missingCurrentValue, l -> l, () -> bits.get(slot), r -> r == false, reverseMul);
+            if (!MissingOrder.unknownOrder(result)) {
+                return result;
             }
         }
         return compareValues(currentValue, values.get(slot));
@@ -113,10 +114,9 @@ class DoubleValuesSource extends SingleDimensionValuesSource<Double> {
     @Override
     int compareCurrentWithAfter() {
         if (missingBucket) {
-            if (missingCurrentValue) {
-                return afterValue != null ? -1 * reverseMul : 0;
-            } else if (afterValue == null) {
-                return reverseMul;
+            int result = missingOrder.compare(() -> missingCurrentValue, l -> l, () -> afterValue, Objects::isNull, reverseMul);
+            if (!MissingOrder.unknownOrder(result)) {
+                return result;
             }
         }
         return compareValues(currentValue, afterValue);

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/GeoTileGridValuesSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/GeoTileGridValuesSourceBuilder.java
@@ -49,6 +49,7 @@ import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.bucket.geogrid.CellIdSource;
 import org.opensearch.search.aggregations.bucket.geogrid.GeoTileGridAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.geogrid.GeoTileUtils;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.search.aggregations.support.CoreValuesSourceType;
 import org.opensearch.search.aggregations.support.ValuesSource;
 import org.opensearch.search.aggregations.support.ValuesSourceConfig;
@@ -72,6 +73,7 @@ public class GeoTileGridValuesSourceBuilder extends CompositeValuesSourceBuilder
             boolean hasScript, // probably redundant with the config, but currently we check this two different ways...
             String format,
             boolean missingBucket,
+            MissingOrder missingOrder,
             SortOrder order
         );
     }
@@ -103,7 +105,7 @@ public class GeoTileGridValuesSourceBuilder extends CompositeValuesSourceBuilder
         builder.register(
             REGISTRY_KEY,
             CoreValuesSourceType.GEOPOINT,
-            (valuesSourceConfig, precision, boundingBox, name, hasScript, format, missingBucket, order) -> {
+            (valuesSourceConfig, precision, boundingBox, name, hasScript, format, missingBucket, missingOrder, order) -> {
                 ValuesSource.GeoPoint geoPoint = (ValuesSource.GeoPoint) valuesSourceConfig.getValuesSource();
                 // is specified in the builder.
                 final MappedFieldType fieldType = valuesSourceConfig.fieldType();
@@ -115,6 +117,7 @@ public class GeoTileGridValuesSourceBuilder extends CompositeValuesSourceBuilder
                     DocValueFormat.GEOTILE,
                     order,
                     missingBucket,
+                    missingOrder,
                     hasScript,
                     (
                         BigArrays bigArrays,
@@ -132,6 +135,7 @@ public class GeoTileGridValuesSourceBuilder extends CompositeValuesSourceBuilder
                             LongUnaryOperator.identity(),
                             compositeValuesSourceConfig.format(),
                             compositeValuesSourceConfig.missingBucket(),
+                            compositeValuesSourceConfig.missingOrder(),
                             size,
                             compositeValuesSourceConfig.reverseMul()
                         );
@@ -220,7 +224,7 @@ public class GeoTileGridValuesSourceBuilder extends CompositeValuesSourceBuilder
     protected CompositeValuesSourceConfig innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config) throws IOException {
         return queryShardContext.getValuesSourceRegistry()
             .getAggregator(REGISTRY_KEY, config)
-            .apply(config, precision, geoBoundingBox(), name, script() != null, format(), missingBucket(), order());
+            .apply(config, precision, geoBoundingBox(), name, script() != null, format(), missingBucket(), missingOrder(), order());
     }
 
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/GeoTileValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/GeoTileValuesSource.java
@@ -39,6 +39,7 @@ import org.opensearch.common.util.BigArrays;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.bucket.geogrid.GeoTileUtils;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 
 import java.io.IOException;
 import java.util.function.LongUnaryOperator;
@@ -57,10 +58,11 @@ class GeoTileValuesSource extends LongValuesSource {
         LongUnaryOperator rounding,
         DocValueFormat format,
         boolean missingBucket,
+        MissingOrder missingOrder,
         int size,
         int reverseMul
     ) {
-        super(bigArrays, fieldType, docValuesFunc, rounding, format, missingBucket, size, reverseMul);
+        super(bigArrays, fieldType, docValuesFunc, rounding, format, missingBucket, missingOrder, size, reverseMul);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/GlobalOrdinalValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/GlobalOrdinalValuesSource.java
@@ -46,6 +46,7 @@ import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.StringFieldType;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.LeafBucketCollector;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 
 import java.io.IOException;
 
@@ -71,10 +72,11 @@ class GlobalOrdinalValuesSource extends SingleDimensionValuesSource<BytesRef> {
         CheckedFunction<LeafReaderContext, SortedSetDocValues, IOException> docValuesFunc,
         DocValueFormat format,
         boolean missingBucket,
+        MissingOrder missingOrder,
         int size,
         int reverseMul
     ) {
-        super(bigArrays, format, type, missingBucket, size, reverseMul);
+        super(bigArrays, format, type, missingBucket, missingOrder, size, reverseMul);
         this.docValuesFunc = docValuesFunc;
         this.values = bigArrays.newLongArray(Math.min(size, 100), false);
     }
@@ -87,16 +89,34 @@ class GlobalOrdinalValuesSource extends SingleDimensionValuesSource<BytesRef> {
 
     @Override
     int compare(int from, int to) {
+        if (missingBucket) {
+            int result = missingOrder.compare(() -> values.get(from), l -> l == -1, () -> values.get(to), r -> r == -1, reverseMul);
+            if (!MissingOrder.unknownOrder(result)) {
+                return result;
+            }
+        }
         return Long.compare(values.get(from), values.get(to)) * reverseMul;
     }
 
     @Override
     int compareCurrent(int slot) {
+        if (missingBucket) {
+            int result = missingOrder.compare(() -> currentValue, l -> l == -1, () -> values.get(slot), r -> r == -1, reverseMul);
+            if (!MissingOrder.unknownOrder(result)) {
+                return result;
+            }
+        }
         return Long.compare(currentValue, values.get(slot)) * reverseMul;
     }
 
     @Override
     int compareCurrentWithAfter() {
+        if (missingBucket) {
+            int result = missingOrder.compare(() -> currentValue, l -> l == -1, () -> afterValueGlobalOrd, r -> r == -1, reverseMul);
+            if (!MissingOrder.unknownOrder(result)) {
+                return result;
+            }
+        }
         int cmp = Long.compare(currentValue, afterValueGlobalOrd);
         if (cmp == 0 && isTopValueInsertionPoint) {
             // the top value is missing in this shard, the comparison is against

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/GlobalOrdinalValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/GlobalOrdinalValuesSource.java
@@ -90,7 +90,7 @@ class GlobalOrdinalValuesSource extends SingleDimensionValuesSource<BytesRef> {
     @Override
     int compare(int from, int to) {
         if (missingBucket) {
-            int result = missingOrder.compare(() -> values.get(from), l -> l == -1, () -> values.get(to), r -> r == -1, reverseMul);
+            int result = missingOrder.compare(() -> values.get(from) == -1, () -> values.get(to) == -1, reverseMul);
             if (!MissingOrder.unknownOrder(result)) {
                 return result;
             }
@@ -101,7 +101,7 @@ class GlobalOrdinalValuesSource extends SingleDimensionValuesSource<BytesRef> {
     @Override
     int compareCurrent(int slot) {
         if (missingBucket) {
-            int result = missingOrder.compare(() -> currentValue, l -> l == -1, () -> values.get(slot), r -> r == -1, reverseMul);
+            int result = missingOrder.compare(() -> currentValue == -1, () -> values.get(slot) == -1, reverseMul);
             if (!MissingOrder.unknownOrder(result)) {
                 return result;
             }
@@ -112,7 +112,7 @@ class GlobalOrdinalValuesSource extends SingleDimensionValuesSource<BytesRef> {
     @Override
     int compareCurrentWithAfter() {
         if (missingBucket) {
-            int result = missingOrder.compare(() -> currentValue, l -> l == -1, () -> afterValueGlobalOrd, r -> r == -1, reverseMul);
+            int result = missingOrder.compare(() -> currentValue == -1, () -> afterValueGlobalOrd == -1, reverseMul);
             if (!MissingOrder.unknownOrder(result)) {
                 return result;
             }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/HistogramValuesSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/HistogramValuesSourceBuilder.java
@@ -42,6 +42,7 @@ import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.search.aggregations.bucket.histogram.Histogram;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.search.aggregations.support.CoreValuesSourceType;
 import org.opensearch.search.aggregations.support.ValuesSource;
 import org.opensearch.search.aggregations.support.ValuesSourceConfig;
@@ -67,6 +68,7 @@ public class HistogramValuesSourceBuilder extends CompositeValuesSourceBuilder<H
             boolean hasScript, // probably redundant with the config, but currently we check this two different ways...
             String format,
             boolean missingBucket,
+            MissingOrder missingOrder,
             SortOrder order
         );
     }
@@ -92,7 +94,7 @@ public class HistogramValuesSourceBuilder extends CompositeValuesSourceBuilder<H
         builder.register(
             REGISTRY_KEY,
             org.opensearch.common.collect.List.of(CoreValuesSourceType.DATE, CoreValuesSourceType.NUMERIC),
-            (valuesSourceConfig, interval, name, hasScript, format, missingBucket, order) -> {
+            (valuesSourceConfig, interval, name, hasScript, format, missingBucket, missingOrder, order) -> {
                 ValuesSource.Numeric numeric = (ValuesSource.Numeric) valuesSourceConfig.getValuesSource();
                 final HistogramValuesSource vs = new HistogramValuesSource(numeric, interval);
                 final MappedFieldType fieldType = valuesSourceConfig.fieldType();
@@ -103,6 +105,7 @@ public class HistogramValuesSourceBuilder extends CompositeValuesSourceBuilder<H
                     valuesSourceConfig.format(),
                     order,
                     missingBucket,
+                    missingOrder,
                     hasScript,
                     (
                         BigArrays bigArrays,
@@ -117,6 +120,7 @@ public class HistogramValuesSourceBuilder extends CompositeValuesSourceBuilder<H
                             numericValuesSource::doubleValues,
                             compositeValuesSourceConfig.format(),
                             compositeValuesSourceConfig.missingBucket(),
+                            compositeValuesSourceConfig.missingOrder(),
                             size,
                             compositeValuesSourceConfig.reverseMul()
                         );
@@ -194,6 +198,6 @@ public class HistogramValuesSourceBuilder extends CompositeValuesSourceBuilder<H
     protected CompositeValuesSourceConfig innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config) throws IOException {
         return queryShardContext.getValuesSourceRegistry()
             .getAggregator(REGISTRY_KEY, config)
-            .apply(config, interval, name, script() != null, format(), missingBucket(), order());
+            .apply(config, interval, name, script() != null, format(), missingBucket(), missingOrder(), order());
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/LongValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/LongValuesSource.java
@@ -54,8 +54,10 @@ import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.LeafBucketCollector;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.function.LongUnaryOperator;
 import java.util.function.ToLongFunction;
 
@@ -79,10 +81,11 @@ class LongValuesSource extends SingleDimensionValuesSource<Long> {
         LongUnaryOperator rounding,
         DocValueFormat format,
         boolean missingBucket,
+        MissingOrder missingOrder,
         int size,
         int reverseMul
     ) {
-        super(bigArrays, format, fieldType, missingBucket, size, reverseMul);
+        super(bigArrays, format, fieldType, missingBucket, missingOrder, size, reverseMul);
         this.bigArrays = bigArrays;
         this.docValuesFunc = docValuesFunc;
         this.rounding = rounding;
@@ -107,10 +110,9 @@ class LongValuesSource extends SingleDimensionValuesSource<Long> {
     @Override
     int compare(int from, int to) {
         if (missingBucket) {
-            if (bits.get(from) == false) {
-                return bits.get(to) ? -1 * reverseMul : 0;
-            } else if (bits.get(to) == false) {
-                return reverseMul;
+            int result = missingOrder.compare(() -> bits.get(from), l -> l == false, () -> bits.get(to), r -> r == false, reverseMul);
+            if (!MissingOrder.unknownOrder(result)) {
+                return result;
             }
         }
         return compareValues(values.get(from), values.get(to));
@@ -119,10 +121,9 @@ class LongValuesSource extends SingleDimensionValuesSource<Long> {
     @Override
     int compareCurrent(int slot) {
         if (missingBucket) {
-            if (missingCurrentValue) {
-                return bits.get(slot) ? -1 * reverseMul : 0;
-            } else if (bits.get(slot) == false) {
-                return reverseMul;
+            int result = missingOrder.compare(() -> missingCurrentValue, l -> l, () -> bits.get(slot), r -> r == false, reverseMul);
+            if (!MissingOrder.unknownOrder(result)) {
+                return result;
             }
         }
         return compareValues(currentValue, values.get(slot));
@@ -131,10 +132,9 @@ class LongValuesSource extends SingleDimensionValuesSource<Long> {
     @Override
     int compareCurrentWithAfter() {
         if (missingBucket) {
-            if (missingCurrentValue) {
-                return afterValue != null ? -1 * reverseMul : 0;
-            } else if (afterValue == null) {
-                return reverseMul;
+            int result = missingOrder.compare(() -> missingCurrentValue, l -> l, () -> afterValue, Objects::isNull, reverseMul);
+            if (!MissingOrder.unknownOrder(result)) {
+                return result;
             }
         }
         return compareValues(currentValue, afterValue);

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/LongValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/LongValuesSource.java
@@ -110,7 +110,7 @@ class LongValuesSource extends SingleDimensionValuesSource<Long> {
     @Override
     int compare(int from, int to) {
         if (missingBucket) {
-            int result = missingOrder.compare(() -> bits.get(from), l -> l == false, () -> bits.get(to), r -> r == false, reverseMul);
+            int result = missingOrder.compare(() -> bits.get(from) == false, () -> bits.get(to) == false, reverseMul);
             if (!MissingOrder.unknownOrder(result)) {
                 return result;
             }
@@ -121,7 +121,7 @@ class LongValuesSource extends SingleDimensionValuesSource<Long> {
     @Override
     int compareCurrent(int slot) {
         if (missingBucket) {
-            int result = missingOrder.compare(() -> missingCurrentValue, l -> l, () -> bits.get(slot), r -> r == false, reverseMul);
+            int result = missingOrder.compare(() -> missingCurrentValue, () -> bits.get(slot) == false, reverseMul);
             if (!MissingOrder.unknownOrder(result)) {
                 return result;
             }
@@ -132,7 +132,7 @@ class LongValuesSource extends SingleDimensionValuesSource<Long> {
     @Override
     int compareCurrentWithAfter() {
         if (missingBucket) {
-            int result = missingOrder.compare(() -> missingCurrentValue, l -> l, () -> afterValue, Objects::isNull, reverseMul);
+            int result = missingOrder.compare(() -> missingCurrentValue, () -> Objects.isNull(afterValue), reverseMul);
             if (!MissingOrder.unknownOrder(result)) {
                 return result;
             }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/SingleDimensionValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/SingleDimensionValuesSource.java
@@ -41,6 +41,7 @@ import org.opensearch.common.util.BigArrays;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.LeafBucketCollector;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.search.sort.SortOrder;
 
 import java.io.IOException;
@@ -54,6 +55,7 @@ abstract class SingleDimensionValuesSource<T extends Comparable<T>> implements R
     @Nullable
     protected final MappedFieldType fieldType;
     protected final boolean missingBucket;
+    protected final MissingOrder missingOrder;
 
     protected final int size;
     protected final int reverseMul;
@@ -67,6 +69,7 @@ abstract class SingleDimensionValuesSource<T extends Comparable<T>> implements R
      * @param format The format of the source.
      * @param fieldType The field type or null if the source is a script.
      * @param missingBucket If true, an explicit `null bucket represents documents with missing values.
+     * @param missingOrder The `null bucket's position.
      * @param size The number of values to record.
      * @param reverseMul -1 if the natural order ({@link SortOrder#ASC} should be reversed.
      */
@@ -75,6 +78,7 @@ abstract class SingleDimensionValuesSource<T extends Comparable<T>> implements R
         DocValueFormat format,
         @Nullable MappedFieldType fieldType,
         boolean missingBucket,
+        MissingOrder missingOrder,
         int size,
         int reverseMul
     ) {
@@ -82,6 +86,7 @@ abstract class SingleDimensionValuesSource<T extends Comparable<T>> implements R
         this.format = format;
         this.fieldType = fieldType;
         this.missingBucket = missingBucket;
+        this.missingOrder = missingOrder;
         this.size = size;
         this.reverseMul = reverseMul;
         this.afterValue = null;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/SingleDimensionValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/SingleDimensionValuesSource.java
@@ -46,6 +46,8 @@ import org.opensearch.search.sort.SortOrder;
 
 import java.io.IOException;
 
+import static org.opensearch.search.aggregations.bucket.missing.MissingOrder.LAST;
+
 /**
  * A source that can record and compare values of similar type.
  */
@@ -172,8 +174,11 @@ abstract class SingleDimensionValuesSource<T extends Comparable<T>> implements R
      * Returns true if a {@link SortedDocsProducer} should be used to optimize the execution.
      */
     protected boolean checkIfSortedDocsIsApplicable(IndexReader reader, MappedFieldType fieldType) {
-        if (fieldType == null || (missingBucket && afterValue == null) || fieldType.isSearchable() == false ||
-        // inverse of the natural order
+        if (fieldType == null
+            || (missingBucket && (afterValue == null || reverseMul == 1 && missingOrder == LAST))
+            || fieldType.isSearchable() == false
+            ||
+            // inverse of the natural order
             reverseMul == -1) {
             return false;
         }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/TermsValuesSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/TermsValuesSourceBuilder.java
@@ -43,6 +43,7 @@ import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.script.Script;
 import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.search.aggregations.support.CoreValuesSourceType;
 import org.opensearch.search.aggregations.support.ValuesSource;
 import org.opensearch.search.aggregations.support.ValuesSourceConfig;
@@ -68,6 +69,7 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
             boolean hasScript, // probably redundant with the config, but currently we check this two different ways...
             String format,
             boolean missingBucket,
+            MissingOrder missingOrder,
             SortOrder order
         );
     }
@@ -111,7 +113,7 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
         builder.register(
             REGISTRY_KEY,
             org.opensearch.common.collect.List.of(CoreValuesSourceType.DATE, CoreValuesSourceType.NUMERIC, CoreValuesSourceType.BOOLEAN),
-            (valuesSourceConfig, name, hasScript, format, missingBucket, order) -> {
+            (valuesSourceConfig, name, hasScript, format, missingBucket, missingOrder, order) -> {
                 final DocValueFormat docValueFormat;
                 if (format == null && valuesSourceConfig.valueSourceType() == CoreValuesSourceType.DATE) {
                     // defaults to the raw format on date fields (preserve timestamp as longs).
@@ -126,6 +128,7 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
                     docValueFormat,
                     order,
                     missingBucket,
+                    missingOrder,
                     hasScript,
                     (
                         BigArrays bigArrays,
@@ -142,6 +145,7 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
                                 vs::doubleValues,
                                 compositeValuesSourceConfig.format(),
                                 compositeValuesSourceConfig.missingBucket(),
+                                compositeValuesSourceConfig.missingOrder(),
                                 size,
                                 compositeValuesSourceConfig.reverseMul()
                             );
@@ -156,6 +160,7 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
                                 rounding,
                                 compositeValuesSourceConfig.format(),
                                 compositeValuesSourceConfig.missingBucket(),
+                                compositeValuesSourceConfig.missingOrder(),
                                 size,
                                 compositeValuesSourceConfig.reverseMul()
                             );
@@ -170,13 +175,14 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
         builder.register(
             REGISTRY_KEY,
             org.opensearch.common.collect.List.of(CoreValuesSourceType.BYTES, CoreValuesSourceType.IP),
-            (valuesSourceConfig, name, hasScript, format, missingBucket, order) -> new CompositeValuesSourceConfig(
+            (valuesSourceConfig, name, hasScript, format, missingBucket, missingOrder, order) -> new CompositeValuesSourceConfig(
                 name,
                 valuesSourceConfig.fieldType(),
                 valuesSourceConfig.getValuesSource(),
                 valuesSourceConfig.format(),
                 order,
                 missingBucket,
+                missingOrder,
                 hasScript,
                 (
                     BigArrays bigArrays,
@@ -193,6 +199,7 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
                             vs::globalOrdinalsValues,
                             compositeValuesSourceConfig.format(),
                             compositeValuesSourceConfig.missingBucket(),
+                            compositeValuesSourceConfig.missingOrder(),
                             size,
                             compositeValuesSourceConfig.reverseMul()
                         );
@@ -205,6 +212,7 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
                             vs::bytesValues,
                             compositeValuesSourceConfig.format(),
                             compositeValuesSourceConfig.missingBucket(),
+                            compositeValuesSourceConfig.missingOrder(),
                             size,
                             compositeValuesSourceConfig.reverseMul()
                         );
@@ -224,6 +232,6 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
     protected CompositeValuesSourceConfig innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config) throws IOException {
         return queryShardContext.getValuesSourceRegistry()
             .getAggregator(REGISTRY_KEY, config)
-            .apply(config, name, script() != null, format(), missingBucket(), order());
+            .apply(config, name, script() != null, format(), missingBucket(), missingOrder(), order());
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/missing/MissingOrder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/missing/MissingOrder.java
@@ -1,0 +1,146 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.bucket.missing;
+
+import org.opensearch.common.inject.Provider;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+
+import java.io.IOException;
+import java.util.function.Predicate;
+
+/**
+ * Composite Aggregation Missing bucket order.
+ *
+ */
+public enum MissingOrder implements Writeable {
+    /**
+     * missing first.
+     */
+    FIRST {
+        @Override
+        public <T, U> int compare(
+            Provider<T> left, Predicate<T> leftIsMissing, Provider<U> right, Predicate<U> rightIsMissing, int reverseMul) {
+            if (leftIsMissing.test(left.get())) {
+                return rightIsMissing.test(right.get()) ? -1 : 0;
+            } else if (rightIsMissing.test(right.get())) {
+                return 1;
+            }
+            return MISSING_ORDER_UNKNOWN;
+        }
+
+//        @Override public MissingOrder reverseOrder() {
+//            return LAST;
+//        }
+
+        @Override public String toString() {
+            return "_first";
+        }
+    },
+
+    /**
+     * missing last.
+     */
+    LAST {
+        @Override
+        public <T, U> int compare(
+            Provider<T> left, Predicate<T> leftIsMissing, Provider<U> right, Predicate<U> rightIsMissing, int reverseMul) {
+            if (leftIsMissing.test(left.get())) {
+                return rightIsMissing.test(right.get()) ? 1 : 0;
+            } else if (rightIsMissing.test(right.get())) {
+                return -1;
+            }
+            return MISSING_ORDER_UNKNOWN;
+        }
+
+//        @Override
+//        public MissingOrder reverseOrder() {
+//            return FIRST;
+//        }
+
+        @Override
+        public String toString() {
+            return "_last";
+        }
+    },
+
+    /**
+     * Default: ASC missing first / DESC missing last
+     */
+    DEFAULT {
+        @Override
+        public <T, U> int compare(
+            Provider<T> left, Predicate<T> leftIsMissing, Provider<U> right, Predicate<U> rightIsMissing, int reverseMul) {
+            if (leftIsMissing.test(left.get())) {
+                return rightIsMissing.test(right.get()) ? -1 * reverseMul : 0;
+            } else if (rightIsMissing.test(right.get())) {
+                return reverseMul;
+            }
+            return MISSING_ORDER_UNKNOWN;
+        }
+//
+//        @Override public int compareToAnyValue(int reverseMul) {
+//            return -1 * reverseMul;
+//        }
+//
+//        @Override public MissingOrder reverseOrder() {
+//            return DEFAULT_REVERSE;
+//        }
+
+        @Override public String toString() {
+            return "default";
+        }
+    };
+
+    /**
+     * Default: ASC missing first / DESC missing last
+     */
+//    DEFAULT_REVERSE {
+//        @Override public int compareToAnyValue(int reverseMul) {
+//            return reverseMul;
+//        }
+//
+//        @Override public MissingOrder reverseOrder() {
+//            return DEFAULT;
+//        }
+//
+//        @Override public String toString() {
+//            return "default reverse";
+//        }
+//    };
+
+    private static int MISSING_ORDER_UNKNOWN = Integer.MIN_VALUE;
+
+    public static MissingOrder readFromStream(StreamInput in) throws IOException {
+        return in.readEnum(MissingOrder.class);
+    }
+
+    @Override public void writeTo(StreamOutput out) throws IOException {
+        out.writeEnum(this);
+    }
+
+    public static boolean isDefault(MissingOrder order) {return order == DEFAULT;}
+
+    // Todo
+    public static MissingOrder fromString(String op) {
+        return DEFAULT;
+    }
+
+    public static boolean unknownOrder(int v) {
+        return v == MISSING_ORDER_UNKNOWN;
+    }
+
+//    public abstract int compareToAnyValue(int reverseMul);
+
+//    public abstract MissingOrder reverseOrder();
+
+    public abstract <T, U> int compare(
+        Provider<T> left, Predicate<T> leftIsMissing, Provider<U> right, Predicate<U> rightIsMissing, int reverseMul);
+}

--- a/server/src/main/java/org/opensearch/search/sort/SortOrder.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortOrder.java
@@ -35,7 +35,6 @@ package org.opensearch.search.sort;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
-import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 
 import java.io.IOException;
 import java.util.Comparator;

--- a/server/src/main/java/org/opensearch/search/sort/SortOrder.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortOrder.java
@@ -35,6 +35,7 @@ package org.opensearch.search.sort;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 
 import java.io.IOException;
 import java.util.Comparator;

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/CompositeAggregationBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/CompositeAggregationBuilderTests.java
@@ -37,6 +37,7 @@ import org.opensearch.script.Script;
 import org.opensearch.search.aggregations.BaseAggregationTestCase;
 import org.opensearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.search.sort.SortOrder;
 
 import java.util.ArrayList;
@@ -69,6 +70,7 @@ public class CompositeAggregationBuilderTests extends BaseAggregationTestCase<Co
         if (randomBoolean()) {
             histo.missingBucket(true);
         }
+        histo.missingOrder(randomFrom(MissingOrder.values()));
         return histo;
     }
 
@@ -94,6 +96,7 @@ public class CompositeAggregationBuilderTests extends BaseAggregationTestCase<Co
         if (randomBoolean()) {
             terms.missingBucket(true);
         }
+        terms.missingOrder(randomFrom(MissingOrder.values()));
         return terms;
     }
 
@@ -108,6 +111,7 @@ public class CompositeAggregationBuilderTests extends BaseAggregationTestCase<Co
             histo.missingBucket(true);
         }
         histo.interval(randomDoubleBetween(Math.nextUp(0), Double.MAX_VALUE, false));
+        histo.missingOrder(randomFrom(MissingOrder.values()));
         return histo;
     }
 

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesCollectorQueueTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesCollectorQueueTests.java
@@ -63,6 +63,7 @@ import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.AggregatorTestCase;
 import org.opensearch.search.aggregations.LeafBucketCollector;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -277,6 +278,7 @@ public class CompositeValuesCollectorQueueTests extends AggregatorTestCase {
                         value -> value,
                         DocValueFormat.RAW,
                         missingBucket,
+                        MissingOrder.DEFAULT,
                         size,
                         1
                     );
@@ -287,6 +289,7 @@ public class CompositeValuesCollectorQueueTests extends AggregatorTestCase {
                         context -> FieldData.sortableLongBitsToDoubles(DocValues.getSortedNumeric(context.reader(), fieldType.name())),
                         DocValueFormat.RAW,
                         missingBucket,
+                        MissingOrder.DEFAULT,
                         size,
                         1
                     );
@@ -300,6 +303,7 @@ public class CompositeValuesCollectorQueueTests extends AggregatorTestCase {
                             context -> DocValues.getSortedSet(context.reader(), fieldType.name()),
                             DocValueFormat.RAW,
                             missingBucket,
+                            MissingOrder.DEFAULT,
                             size,
                             1
                         );
@@ -311,6 +315,7 @@ public class CompositeValuesCollectorQueueTests extends AggregatorTestCase {
                             context -> FieldData.toString(DocValues.getSortedSet(context.reader(), fieldType.name())),
                             DocValueFormat.RAW,
                             missingBucket,
+                            MissingOrder.DEFAULT,
                             size,
                             1
                         );

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/SingleDimensionValuesSourceTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/SingleDimensionValuesSourceTests.java
@@ -47,6 +47,7 @@ import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.test.OpenSearchTestCase;
 
 import static org.mockito.Mockito.mock;
@@ -62,6 +63,7 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
             context -> null,
             DocValueFormat.RAW,
             false,
+            MissingOrder.DEFAULT,
             1,
             1
         );
@@ -79,6 +81,7 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
             context -> null,
             DocValueFormat.RAW,
             true,
+            MissingOrder.DEFAULT,
             1,
             1
         );
@@ -92,13 +95,24 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
             context -> null,
             DocValueFormat.RAW,
             false,
+            MissingOrder.DEFAULT,
             0,
             -1
         );
         assertNull(source.createSortedDocsProducerOrNull(reader, null));
 
         MappedFieldType ip = new IpFieldMapper.IpFieldType("ip");
-        source = new BinaryValuesSource(BigArrays.NON_RECYCLING_INSTANCE, (b) -> {}, ip, context -> null, DocValueFormat.RAW, false, 1, 1);
+        source = new BinaryValuesSource(
+            BigArrays.NON_RECYCLING_INSTANCE,
+            (b) -> {},
+            ip,
+            context -> null,
+            DocValueFormat.RAW,
+            false,
+            MissingOrder.DEFAULT,
+            1,
+            1
+        );
         assertNull(source.createSortedDocsProducerOrNull(reader, null));
     }
 
@@ -110,6 +124,7 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
             context -> null,
             DocValueFormat.RAW,
             false,
+            MissingOrder.DEFAULT,
             1,
             1
         );
@@ -120,7 +135,16 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
         assertNull(source.createSortedDocsProducerOrNull(reader, new TermQuery(new Term("foo", "bar"))));
         assertNull(source.createSortedDocsProducerOrNull(reader, new TermQuery(new Term("keyword", "toto)"))));
 
-        source = new GlobalOrdinalValuesSource(BigArrays.NON_RECYCLING_INSTANCE, keyword, context -> null, DocValueFormat.RAW, true, 1, 1);
+        source = new GlobalOrdinalValuesSource(
+            BigArrays.NON_RECYCLING_INSTANCE,
+            keyword,
+            context -> null,
+            DocValueFormat.RAW,
+            true,
+            MissingOrder.DEFAULT,
+            1,
+            1
+        );
         assertNull(source.createSortedDocsProducerOrNull(reader, new MatchAllDocsQuery()));
         assertNull(source.createSortedDocsProducerOrNull(reader, null));
         assertNull(source.createSortedDocsProducerOrNull(reader, new TermQuery(new Term("foo", "bar"))));
@@ -131,6 +155,7 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
             context -> null,
             DocValueFormat.RAW,
             false,
+            MissingOrder.DEFAULT,
             1,
             -1
         );
@@ -138,7 +163,16 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
         assertNull(source.createSortedDocsProducerOrNull(reader, new TermQuery(new Term("foo", "bar"))));
 
         final MappedFieldType ip = new IpFieldMapper.IpFieldType("ip");
-        source = new GlobalOrdinalValuesSource(BigArrays.NON_RECYCLING_INSTANCE, ip, context -> null, DocValueFormat.RAW, false, 1, 1);
+        source = new GlobalOrdinalValuesSource(
+            BigArrays.NON_RECYCLING_INSTANCE,
+            ip,
+            context -> null,
+            DocValueFormat.RAW,
+            false,
+            MissingOrder.DEFAULT,
+            1,
+            1
+        );
         assertNull(source.createSortedDocsProducerOrNull(reader, null));
         assertNull(source.createSortedDocsProducerOrNull(reader, new TermQuery(new Term("foo", "bar"))));
     }
@@ -159,6 +193,7 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
                     value -> value,
                     DocValueFormat.RAW,
                     false,
+                    MissingOrder.DEFAULT,
                     1,
                     1
                 );
@@ -192,6 +227,7 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
                     value -> value,
                     DocValueFormat.RAW,
                     true,
+                    MissingOrder.DEFAULT,
                     1,
                     1
                 );
@@ -213,6 +249,7 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
                     value -> value,
                     DocValueFormat.RAW,
                     false,
+                    MissingOrder.DEFAULT,
                     1,
                     -1
                 );
@@ -231,6 +268,7 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
                         context -> null,
                         DocValueFormat.RAW,
                         false,
+                        MissingOrder.DEFAULT,
                         1,
                         1
                     );


### PR DESCRIPTION
### Description
Support _first and _last parameter for missing bucket ordering in composite aggregation.
If missing_order is "_first" or "_last", regardless order, missing_bucket is at first or last respectively. for example, the following query will sort `product` asc and null bucket will be placed at last.
```
{
  "size": 0,
  "aggs": {
    "my_buckets": {
      "composite": {
        "sources": [
          {
            "product_name": {
              "terms": {
                "field": "product",
                "missing_bucket": true,
                "missing_order": "last",
                "order": "asc"
              }
            }
          }
        ]
      }
    }
  }
}
```
 
### Issues Resolved
#1899
 
### Check List
- [x ] New functionality includes testing.
  - [x ] All tests pass
- [ ] New functionality has been documented.
  - [x ] New functionality has javadoc added
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
