### PR TITLE
Dependabot fix and pr actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,877 +4,867 @@ updates:
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /benchmarks/build.gradle
+  - directory: /benchmarks/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /buildSrc/build.gradle
+  - directory: /buildSrc/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /buildSrc/reaper/build.gradle
+  - directory: /buildSrc/reaper/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/build.gradle
+  - directory: /buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/archives/build.gradle
+  - directory: /buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/archives/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/archives/darwin-tar/build.gradle
+  - directory: /buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/archives/darwin-tar/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/archives/oss-darwin-tar/build.gradle
+  - directory: /buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/archives/oss-darwin-tar/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/bwc/bugfix/build.gradle
+  - directory: /buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/bwc/bugfix/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/bwc/minor/build.gradle
+  - directory: /buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/bwc/minor/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /buildSrc/src/testKit/opensearch-build-resources/build.gradle
+  - directory: /buildSrc/src/testKit/opensearch-build-resources/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /buildSrc/src/testKit/opensearch.build/build.gradle
+  - directory: /buildSrc/src/testKit/opensearch.build/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /buildSrc/src/testKit/reaper/build.gradle
+  - directory: /buildSrc/src/testKit/reaper/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /buildSrc/src/testKit/symbolic-link-preserving-tar/build.gradle
+  - directory: /buildSrc/src/testKit/symbolic-link-preserving-tar/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /buildSrc/src/testKit/testingConventions/build.gradle
+  - directory: /buildSrc/src/testKit/testingConventions/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /buildSrc/src/testKit/thirdPartyAudit/build.gradle
+  - directory: /buildSrc/src/testKit/thirdPartyAudit/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /buildSrc/src/testKit/thirdPartyAudit/sample_jars/build.gradle
+  - directory: /buildSrc/src/testKit/thirdPartyAudit/sample_jars/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /client/benchmark/build.gradle
+  - directory: /client/benchmark/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /client/client-benchmark-noop-api-plugin/build.gradle
+  - directory: /client/client-benchmark-noop-api-plugin/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /client/rest/build.gradle
+  - directory: /client/rest/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /client/rest-high-level/build.gradle
+  - directory: /client/rest-high-level/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /client/sniffer/build.gradle
+  - directory: /client/sniffer/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /client/test/build.gradle
+  - directory: /client/test/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /client/transport/build.gradle
+  - directory: /distribution/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/build.gradle
+  - directory: /distribution/archives/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/archives/build.gradle
+  - directory: /distribution/archives/darwin-tar/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/archives/darwin-tar/build.gradle
+  - directory: /distribution/archives/integ-test-zip/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/archives/integ-test-zip/build.gradle
+  - directory: /distribution/archives/linux-arm64-tar/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/archives/linux-arm64-tar/build.gradle
+  - directory: /distribution/archives/linux-tar/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/archives/linux-tar/build.gradle
+  - directory: /distribution/archives/no-jdk-darwin-tar/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/archives/no-jdk-darwin-tar/build.gradle
+  - directory: /distribution/archives/no-jdk-linux-tar/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/archives/no-jdk-linux-tar/build.gradle
+  - directory: /distribution/archives/no-jdk-windows-zip/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/archives/no-jdk-windows-zip/build.gradle
+  - directory: /distribution/archives/windows-zip/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/archives/windows-zip/build.gradle
+  - directory: /distribution/bwc/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/bwc/build.gradle
+  - directory: /distribution/bwc/bugfix/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/bwc/bugfix/build.gradle
+  - directory: /distribution/bwc/maintenance/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/bwc/maintenance/build.gradle
+  - directory: /distribution/bwc/minor/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/bwc/minor/build.gradle
+  - directory: /distribution/bwc/staged/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/bwc/staged/build.gradle
+  - directory: /distribution/docker/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/docker/build.gradle
+  - directory: /distribution/docker/docker-arm64-export/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/docker/docker-arm64-export/build.gradle
+  - directory: /distribution/docker/docker-build-context/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/docker/docker-build-context/build.gradle
+  - directory: /distribution/docker/docker-export/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/docker/docker-export/build.gradle
+  - directory: /distribution/packages/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/packages/build.gradle
+  - directory: /distribution/packages/arm64-deb/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/packages/arm64-deb/build.gradle
+  - directory: /distribution/packages/arm64-rpm/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/packages/arm64-rpm/build.gradle
+  - directory: /distribution/packages/deb/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/packages/deb/build.gradle
+  - directory: /distribution/packages/no-jdk-deb/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/packages/no-jdk-deb/build.gradle
+  - directory: /distribution/packages/no-jdk-rpm/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/packages/no-jdk-rpm/build.gradle
+  - directory: /distribution/packages/rpm/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/packages/rpm/build.gradle
+  - directory: /distribution/tools/java-version-checker/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/tools/java-version-checker/build.gradle
+  - directory: /distribution/tools/keystore-cli/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/tools/keystore-cli/build.gradle
+  - directory: /distribution/tools/launchers/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/tools/launchers/build.gradle
+  - directory: /distribution/tools/plugin-cli/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/tools/plugin-cli/build.gradle
+  - directory: /distribution/tools/upgrade-cli/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /distribution/tools/upgrade-cli/build.gradle
+  - directory: /doc-tools/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /doc-tools/build.gradle
+  - directory: /doc-tools/missing-doclet/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /doc-tools/missing-doclet/build.gradle
+  - directory: /libs/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /libs/build.gradle
+  - directory: /libs/cli/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /libs/cli/build.gradle
+  - directory: /libs/core/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /libs/core/build.gradle
+  - directory: /libs/dissect/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /libs/dissect/build.gradle
+  - directory: /libs/geo/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /libs/geo/build.gradle
+  - directory: /libs/grok/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /libs/grok/build.gradle
+  - directory: /libs/nio/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /libs/nio/build.gradle
+  - directory: /libs/plugin-classloader/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /libs/plugin-classloader/build.gradle
+  - directory: /libs/secure-sm/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /libs/secure-sm/build.gradle
+  - directory: /libs/ssl-config/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /libs/ssl-config/build.gradle
+  - directory: /libs/x-content/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /libs/x-content/build.gradle
+  - directory: /modules/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/build.gradle
+  - directory: /modules/aggs-matrix-stats/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/aggs-matrix-stats/build.gradle
+  - directory: /modules/analysis-common/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/analysis-common/build.gradle
+  - directory: /modules/geo/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/geo/build.gradle
+  - directory: /modules/ingest-common/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/ingest-common/build.gradle
+  - directory: /modules/ingest-geoip/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/ingest-geoip/build.gradle
+  - directory: /modules/ingest-user-agent/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/ingest-user-agent/build.gradle
+  - directory: /modules/lang-expression/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/lang-expression/build.gradle
+  - directory: /modules/lang-mustache/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/lang-mustache/build.gradle
+  - directory: /modules/lang-painless/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/lang-painless/build.gradle
+  - directory: /modules/lang-painless/spi/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/lang-painless/spi/build.gradle
+  - directory: /modules/mapper-extras/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/mapper-extras/build.gradle
+  - directory: /modules/opensearch-dashboards/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/opensearch-dashboards/build.gradle
+  - directory: /modules/parent-join/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/parent-join/build.gradle
+  - directory: /modules/percolator/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/percolator/build.gradle
+  - directory: /modules/rank-eval/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/rank-eval/build.gradle
+  - directory: /modules/reindex/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/reindex/build.gradle
+  - directory: /modules/repository-url/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/repository-url/build.gradle
+  - directory: /modules/systemd/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/systemd/build.gradle
+  - directory: /modules/transport-netty4/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /modules/transport-netty4/build.gradle
+  - directory: /plugins/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/build.gradle
+  - directory: /plugins/analysis-icu/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/analysis-icu/build.gradle
+  - directory: /plugins/analysis-kuromoji/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/analysis-kuromoji/build.gradle
+  - directory: /plugins/analysis-nori/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/analysis-nori/build.gradle
+  - directory: /plugins/analysis-phonetic/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/analysis-phonetic/build.gradle
+  - directory: /plugins/analysis-smartcn/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/analysis-smartcn/build.gradle
+  - directory: /plugins/analysis-stempel/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/analysis-stempel/build.gradle
+  - directory: /plugins/analysis-ukrainian/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/analysis-ukrainian/build.gradle
+  - directory: /plugins/discovery-azure-classic/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/discovery-azure-classic/build.gradle
+  - directory: /plugins/discovery-ec2/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/discovery-ec2/build.gradle
+  - directory: /plugins/discovery-ec2/qa/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/discovery-ec2/qa/build.gradle
+  - directory: /plugins/discovery-ec2/qa/amazon-ec2/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/discovery-ec2/qa/amazon-ec2/build.gradle
+  - directory: /plugins/discovery-gce/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/discovery-gce/build.gradle
+  - directory: /plugins/discovery-gce/qa/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/discovery-gce/qa/build.gradle
+  - directory: /plugins/discovery-gce/qa/gce/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/discovery-gce/qa/gce/build.gradle
+  - directory: /plugins/examples/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/examples/build.gradle
+  - directory: /plugins/examples/custom-settings/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/examples/custom-settings/build.gradle
+  - directory: /plugins/examples/custom-significance-heuristic/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/examples/custom-significance-heuristic/build.gradle
+  - directory: /plugins/examples/custom-suggester/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/examples/custom-suggester/build.gradle
+  - directory: /plugins/examples/painless-whitelist/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/examples/painless-whitelist/build.gradle
+  - directory: /plugins/examples/rescore/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/examples/rescore/build.gradle
+  - directory: /plugins/examples/rest-handler/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/examples/rest-handler/build.gradle
+  - directory: /plugins/examples/script-expert-scoring/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/examples/script-expert-scoring/build.gradle
+  - directory: /plugins/ingest-attachment/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/ingest-attachment/build.gradle
+  - directory: /plugins/mapper-annotated-text/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/mapper-annotated-text/build.gradle
+  - directory: /plugins/mapper-murmur3/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/mapper-murmur3/build.gradle
+  - directory: /plugins/mapper-size/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/mapper-size/build.gradle
+  - directory: /plugins/repository-azure/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/repository-azure/build.gradle
+  - directory: /plugins/repository-gcs/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/repository-gcs/build.gradle
+  - directory: /plugins/repository-hdfs/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/repository-hdfs/build.gradle
+  - directory: /plugins/repository-s3/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/repository-s3/build.gradle
+  - directory: /plugins/store-smb/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/store-smb/build.gradle
+  - directory: /plugins/transport-nio/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /plugins/transport-nio/build.gradle
+  - directory: /qa/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/build.gradle
+  - directory: /qa/ccs-unavailable-clusters/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/ccs-unavailable-clusters/build.gradle
+  - directory: /qa/die-with-dignity/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/die-with-dignity/build.gradle
+  - directory: /qa/evil-tests/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/evil-tests/build.gradle
+  - directory: /qa/full-cluster-restart/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/full-cluster-restart/build.gradle
+  - directory: /qa/logging-config/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/logging-config/build.gradle
+  - directory: /qa/mixed-cluster/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/mixed-cluster/build.gradle
+  - directory: /qa/multi-cluster-search/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/multi-cluster-search/build.gradle
+  - directory: /qa/no-bootstrap-tests/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/no-bootstrap-tests/build.gradle
+  - directory: /qa/os/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/os/build.gradle
+  - directory: /qa/os/centos-6/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/os/centos-6/build.gradle
+  - directory: /qa/os/centos-7/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/os/centos-7/build.gradle
+  - directory: /qa/os/debian-8/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/os/debian-8/build.gradle
+  - directory: /qa/os/debian-9/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/os/debian-9/build.gradle
+  - directory: /qa/os/fedora-28/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/os/fedora-28/build.gradle
+  - directory: /qa/os/fedora-29/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/os/fedora-29/build.gradle
+  - directory: /qa/os/oel-6/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/os/oel-6/build.gradle
+  - directory: /qa/os/oel-7/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/os/oel-7/build.gradle
+  - directory: /qa/os/sles-12/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/os/sles-12/build.gradle
+  - directory: /qa/os/ubuntu-1604/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/os/ubuntu-1604/build.gradle
+  - directory: /qa/os/ubuntu-1804/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/os/ubuntu-1804/build.gradle
+  - directory: /qa/os/windows-2012r2/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/os/windows-2012r2/build.gradle
+  - directory: /qa/os/windows-2016/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/os/windows-2016/build.gradle
+  - directory: /qa/remote-clusters/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/remote-clusters/build.gradle
+  - directory: /qa/repository-multi-version/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/repository-multi-version/build.gradle
+  - directory: /qa/rolling-upgrade/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/rolling-upgrade/build.gradle
+  - directory: /qa/smoke-test-http/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/smoke-test-client/build.gradle
+  - directory: /qa/smoke-test-ingest-disabled/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/smoke-test-http/build.gradle
+  - directory: /qa/smoke-test-ingest-with-all-dependencies/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/smoke-test-ingest-disabled/build.gradle
+  - directory: /qa/smoke-test-multinode/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/smoke-test-ingest-with-all-dependencies/build.gradle
+  - directory: /qa/smoke-test-plugins/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/smoke-test-multinode/build.gradle
+  - directory: /qa/translog-policy/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/smoke-test-plugins/build.gradle
+  - directory: /qa/unconfigured-node-name/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/translog-policy/build.gradle
+  - directory: /qa/verify-version-constants/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/unconfigured-node-name/build.gradle
+  - directory: /qa/wildfly/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/verify-version-constants/build.gradle
+  - directory: /rest-api-spec/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /qa/wildfly/build.gradle
+  - directory: /sandbox/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /rest-api-spec/build.gradle
+  - directory: /sandbox/libs/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /sandbox/build.gradle
+  - directory: /sandbox/modules/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /sandbox/libs/build.gradle
+  - directory: /sandbox/plugins/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /sandbox/modules/build.gradle
+  - directory: /server/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /sandbox/plugins/build.gradle
+  - directory: /test/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /server/build.gradle
+  - directory: /test/external-modules/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /test/build.gradle
+  - directory: /test/external-modules/delayed-aggs/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /test/external-modules/build.gradle
+  - directory: /test/fixtures/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /test/external-modules/delayed-aggs/build.gradle
+  - directory: /test/fixtures/azure-fixture/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /test/fixtures/build.gradle
+  - directory: /test/fixtures/gcs-fixture/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /test/fixtures/azure-fixture/build.gradle
+  - directory: /test/fixtures/hdfs-fixture/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /test/fixtures/gcs-fixture/build.gradle
+  - directory: /test/fixtures/krb5kdc-fixture/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /test/fixtures/hdfs-fixture/build.gradle
+  - directory: /test/fixtures/minio-fixture/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /test/fixtures/krb5kdc-fixture/build.gradle
+  - directory: /test/fixtures/old-elasticsearch/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /test/fixtures/minio-fixture/build.gradle
+  - directory: /test/fixtures/s3-fixture/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /test/fixtures/old-elasticsearch/build.gradle
+  - directory: /test/framework/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:
       interval: weekly
-  - directory: /test/fixtures/s3-fixture/build.gradle
-    open-pull-requests-limit: 10
-    package-ecosystem: gradle
-    schedule:
-      interval: weekly
-  - directory: /test/framework/build.gradle
-    open-pull-requests-limit: 10
-    package-ecosystem: gradle
-    schedule:
-      interval: weekly
-  - directory: /test/logger-usage/build.gradle
+  - directory: /test/logger-usage/
     open-pull-requests-limit: 10
     package-ecosystem: gradle
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,871 +1,871 @@
 updates:
   - directory: /
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /benchmarks/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /buildSrc/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /buildSrc/reaper/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/archives/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/archives/darwin-tar/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/archives/oss-darwin-tar/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/bwc/bugfix/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/bwc/minor/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /buildSrc/src/testKit/opensearch-build-resources/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /buildSrc/src/testKit/opensearch.build/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /buildSrc/src/testKit/reaper/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /buildSrc/src/testKit/symbolic-link-preserving-tar/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /buildSrc/src/testKit/testingConventions/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /buildSrc/src/testKit/thirdPartyAudit/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /buildSrc/src/testKit/thirdPartyAudit/sample_jars/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /client/benchmark/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /client/client-benchmark-noop-api-plugin/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /client/rest/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /client/rest-high-level/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /client/sniffer/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /client/test/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/archives/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/archives/darwin-tar/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/archives/integ-test-zip/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/archives/linux-arm64-tar/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/archives/linux-tar/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/archives/no-jdk-darwin-tar/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/archives/no-jdk-linux-tar/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/archives/no-jdk-windows-zip/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/archives/windows-zip/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/bwc/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/bwc/bugfix/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/bwc/maintenance/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/bwc/minor/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/bwc/staged/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/docker/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/docker/docker-arm64-export/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/docker/docker-build-context/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/docker/docker-export/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/packages/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/packages/arm64-deb/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/packages/arm64-rpm/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/packages/deb/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/packages/no-jdk-deb/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/packages/no-jdk-rpm/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/packages/rpm/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/tools/java-version-checker/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/tools/keystore-cli/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/tools/launchers/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/tools/plugin-cli/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /distribution/tools/upgrade-cli/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /doc-tools/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /doc-tools/missing-doclet/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /libs/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /libs/cli/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /libs/core/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /libs/dissect/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /libs/geo/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /libs/grok/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /libs/nio/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /libs/plugin-classloader/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /libs/secure-sm/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /libs/ssl-config/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /libs/x-content/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/aggs-matrix-stats/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/analysis-common/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/geo/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/ingest-common/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/ingest-geoip/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/ingest-user-agent/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/lang-expression/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/lang-mustache/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/lang-painless/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/lang-painless/spi/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/mapper-extras/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/opensearch-dashboards/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/parent-join/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/percolator/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/rank-eval/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/reindex/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/repository-url/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/systemd/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /modules/transport-netty4/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/analysis-icu/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/analysis-kuromoji/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/analysis-nori/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/analysis-phonetic/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/analysis-smartcn/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/analysis-stempel/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/analysis-ukrainian/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/discovery-azure-classic/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/discovery-ec2/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/discovery-ec2/qa/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/discovery-ec2/qa/amazon-ec2/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/discovery-gce/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/discovery-gce/qa/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/discovery-gce/qa/gce/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/examples/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/examples/custom-settings/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/examples/custom-significance-heuristic/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/examples/custom-suggester/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/examples/painless-whitelist/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/examples/rescore/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/examples/rest-handler/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/examples/script-expert-scoring/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/ingest-attachment/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/mapper-annotated-text/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/mapper-murmur3/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/mapper-size/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/repository-azure/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/repository-gcs/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/repository-hdfs/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/repository-s3/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/store-smb/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /plugins/transport-nio/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/ccs-unavailable-clusters/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/die-with-dignity/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/evil-tests/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/full-cluster-restart/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/logging-config/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/mixed-cluster/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/multi-cluster-search/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/no-bootstrap-tests/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/os/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/os/centos-6/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/os/centos-7/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/os/debian-8/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/os/debian-9/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/os/fedora-28/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/os/fedora-29/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/os/oel-6/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/os/oel-7/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/os/sles-12/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/os/ubuntu-1604/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/os/ubuntu-1804/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/os/windows-2012r2/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/os/windows-2016/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/remote-clusters/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/repository-multi-version/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/rolling-upgrade/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/smoke-test-http/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/smoke-test-ingest-disabled/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/smoke-test-ingest-with-all-dependencies/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/smoke-test-multinode/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/smoke-test-plugins/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/translog-policy/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/unconfigured-node-name/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/verify-version-constants/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /qa/wildfly/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /rest-api-spec/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /sandbox/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /sandbox/libs/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /sandbox/modules/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /sandbox/plugins/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /server/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /test/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /test/external-modules/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /test/external-modules/delayed-aggs/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /test/fixtures/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /test/fixtures/azure-fixture/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /test/fixtures/gcs-fixture/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /test/fixtures/hdfs-fixture/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /test/fixtures/krb5kdc-fixture/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /test/fixtures/minio-fixture/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /test/fixtures/old-elasticsearch/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /test/fixtures/s3-fixture/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /test/framework/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly
   - directory: /test/logger-usage/
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:
       interval: weekly

--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -1,0 +1,39 @@
+name: Dependabot PR actions
+on: pull_request
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Update Gradle SHAs
+        run: |
+          ./gradlew updateSHAs
+
+      - name: Commit the changes
+        uses: stefanzweifel/git-auto-commit-action@v4.7.2
+        with:
+          commit_message: Updating SHAs
+          branch: ${{ github.head_ref }}
+          commit_user_name: dependabot[bot]
+          commit_user_email: support@github.com
+          commit_options: '--signoff'
+
+      - name: Run spotless
+        run: |
+          ./gradlew spotlessApply
+
+      - name: Commit the changes
+        uses: stefanzweifel/git-auto-commit-action@v4.7.2
+        with:
+          commit_message: Spotless formatting
+          branch: ${{ github.head_ref }}
+          commit_user_name: dependabot[bot]
+          commit_user_email: support@github.com
+          commit_options: '--signoff'

--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -1,16 +1,26 @@
 name: Dependabot PR actions
 on: pull_request
-permissions:
-  pull-requests: write
-  contents: write
 
 jobs:
   dependabot:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          token: ${{ steps.github_app_token.outputs.token }}
 
       - name: Update Gradle SHAs
         run: |


### PR DESCRIPTION
### Description
This PR fixes dependabot integrations:
1. Updates the paths for the nested directories so all the `build.gradle` can be scanned.
2. Adds a workflow for running on dependabot PRs to run `./gradlew updateSHAs` and `./gradlew spotlessApply` on dependabot generated PRs since dependabot only updates the version in the `build.gradle`.

Note: I tried these updates on my fork and dependabot successfully opened PRs and the `dependabot_pr` workflow successfully updated them with the updateSHAs and spotless (if required). https://github.com/VachaShah/OpenSearch/pulls

The current open pr limit is being set to 1, once the PRs open correctly with the auto commits (along with CI triggers), I will go and update the limits to 10.

### Issues Resolved
#1897 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
