### PR TITLE
Using pull_request_target in place of pull_request

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,6 +1,6 @@
 name: Backport
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
       - labeled


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Updating `pull_request` to `pull_request_target` to allow the permissions for the GITHUB_TOKEN because even with the permissions block added to the workflow file, the permissions in the [workflow run](https://github.com/opensearch-project/OpenSearch/runs/4887125705?check_suite_focus=true) default to read on `pull_request`. Reference: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
