### PR TITLE
Add hook to execute custom logic before Integ test task starts

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/StandaloneRestIntegTestTask.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/StandaloneRestIntegTestTask.java
@@ -31,6 +31,7 @@
 
 package org.opensearch.gradle.testclusters;
 
+import groovy.lang.Closure;
 import org.opensearch.gradle.FileSystemOperationsAware;
 import org.opensearch.gradle.test.Fixture;
 import org.opensearch.gradle.util.GradleUtils;
@@ -60,6 +61,7 @@ import java.util.List;
 public class StandaloneRestIntegTestTask extends Test implements TestClustersAware, FileSystemOperationsAware {
 
     private Collection<OpenSearchCluster> clusters = new HashSet<>();
+    private Closure<Void> beforeStart;
 
     public StandaloneRestIntegTestTask() {
         this.getOutputs()
@@ -84,6 +86,18 @@ public class StandaloneRestIntegTestTask extends Test implements TestClustersAwa
                 // Don't cache the output of this task if it's not running from a clean data directory.
                 t -> getClusters().stream().anyMatch(cluster -> cluster.isPreserveDataDir())
             );
+    }
+
+    // Hook for executing any custom logic before starting the task.
+    public void setBeforeStart(Closure<Void> closure) {
+        beforeStart = closure;
+    }
+
+    @Override
+    public void beforeStart() {
+        if (beforeStart != null) {
+            beforeStart.call(this);
+        }
     }
 
     @Override


### PR DESCRIPTION
### Description
Add hook to execute custom logic before the integ test starts. 
This is required for a workaround to enable the jacoco code coverage for Integ Tests.
 Related PR: https://github.com/opensearch-project/cross-cluster-replication/pull/284
### Issues Resolved
[[1926]](https://github.com/opensearch-project/OpenSearch/issues/1928)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
