### PR TITLE
[Deprecate] Setting explicit version on analysis component

### DIFF
--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/ArabicAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/ArabicAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class ArabicAnalyzerProvider extends AbstractIndexAnalyzerProvider<Arabic
             Analysis.parseStopWords(env, settings, ArabicAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        arabicAnalyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/ArmenianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/ArmenianAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class ArmenianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Arme
             Analysis.parseStopWords(env, settings, ArmenianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/BasqueAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/BasqueAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class BasqueAnalyzerProvider extends AbstractIndexAnalyzerProvider<Basque
             Analysis.parseStopWords(env, settings, BasqueAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/BengaliAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/BengaliAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class BengaliAnalyzerProvider extends AbstractIndexAnalyzerProvider<Benga
             Analysis.parseStopWords(env, settings, BengaliAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/BrazilianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/BrazilianAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class BrazilianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Bra
             Analysis.parseStopWords(env, settings, BrazilianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/BulgarianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/BulgarianAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class BulgarianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Bul
             Analysis.parseStopWords(env, settings, BulgarianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/CatalanAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/CatalanAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class CatalanAnalyzerProvider extends AbstractIndexAnalyzerProvider<Catal
             Analysis.parseStopWords(env, settings, CatalanAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/ChineseAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/ChineseAnalyzerProvider.java
@@ -50,8 +50,6 @@ public class ChineseAnalyzerProvider extends AbstractIndexAnalyzerProvider<Stand
         super(indexSettings, name, settings);
         // old index: best effort
         analyzer = new StandardAnalyzer(EnglishAnalyzer.ENGLISH_STOP_WORDS_SET);
-        analyzer.setVersion(version);
-
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/CjkAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/CjkAnalyzerProvider.java
@@ -49,7 +49,6 @@ public class CjkAnalyzerProvider extends AbstractIndexAnalyzerProvider<CJKAnalyz
         CharArraySet stopWords = Analysis.parseStopWords(env, settings, CJKAnalyzer.getDefaultStopSet());
 
         analyzer = new CJKAnalyzer(stopWords);
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/CzechAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/CzechAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class CzechAnalyzerProvider extends AbstractIndexAnalyzerProvider<CzechAn
             Analysis.parseStopWords(env, settings, CzechAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/DanishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/DanishAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class DanishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Danish
             Analysis.parseStopWords(env, settings, DanishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/DutchAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/DutchAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class DutchAnalyzerProvider extends AbstractIndexAnalyzerProvider<DutchAn
             Analysis.parseStopWords(env, settings, DutchAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/EnglishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/EnglishAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class EnglishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Engli
             Analysis.parseStopWords(env, settings, EnglishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/EstonianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/EstonianAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class EstonianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Esto
             Analysis.parseStopWords(env, settings, EstonianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/FinnishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/FinnishAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class FinnishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Finni
             Analysis.parseStopWords(env, settings, FinnishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/FrenchAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/FrenchAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class FrenchAnalyzerProvider extends AbstractIndexAnalyzerProvider<French
             Analysis.parseStopWords(env, settings, FrenchAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/GalicianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/GalicianAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class GalicianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Gali
             Analysis.parseStopWords(env, settings, GalicianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/GermanAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/GermanAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class GermanAnalyzerProvider extends AbstractIndexAnalyzerProvider<German
             Analysis.parseStopWords(env, settings, GermanAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/GreekAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/GreekAnalyzerProvider.java
@@ -46,7 +46,6 @@ public class GreekAnalyzerProvider extends AbstractIndexAnalyzerProvider<GreekAn
     GreekAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
         super(indexSettings, name, settings);
         analyzer = new GreekAnalyzer(Analysis.parseStopWords(env, settings, GreekAnalyzer.getDefaultStopSet()));
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/HindiAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/HindiAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class HindiAnalyzerProvider extends AbstractIndexAnalyzerProvider<HindiAn
             Analysis.parseStopWords(env, settings, HindiAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/HungarianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/HungarianAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class HungarianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Hun
             Analysis.parseStopWords(env, settings, HungarianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/IndonesianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/IndonesianAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class IndonesianAnalyzerProvider extends AbstractIndexAnalyzerProvider<In
             Analysis.parseStopWords(env, settings, IndonesianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/IrishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/IrishAnalyzerProvider.java
@@ -53,7 +53,6 @@ public class IrishAnalyzerProvider extends AbstractIndexAnalyzerProvider<IrishAn
             Analysis.parseStopWords(env, settings, IrishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/ItalianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/ItalianAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class ItalianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Itali
             Analysis.parseStopWords(env, settings, ItalianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/LatvianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/LatvianAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class LatvianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Latvi
             Analysis.parseStopWords(env, settings, LatvianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/LithuanianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/LithuanianAnalyzerProvider.java
@@ -53,7 +53,6 @@ public class LithuanianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Li
             Analysis.parseStopWords(env, settings, LithuanianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/NorwegianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/NorwegianAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class NorwegianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Nor
             Analysis.parseStopWords(env, settings, NorwegianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/PersianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/PersianAnalyzerProvider.java
@@ -46,7 +46,6 @@ public class PersianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Persi
     PersianAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
         super(indexSettings, name, settings);
         analyzer = new PersianAnalyzer(Analysis.parseStopWords(env, settings, PersianAnalyzer.getDefaultStopSet()));
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/PortugueseAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/PortugueseAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class PortugueseAnalyzerProvider extends AbstractIndexAnalyzerProvider<Po
             Analysis.parseStopWords(env, settings, PortugueseAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/RomanianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/RomanianAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class RomanianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Roma
             Analysis.parseStopWords(env, settings, RomanianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/RussianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/RussianAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class RussianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Russi
             Analysis.parseStopWords(env, settings, RussianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/SnowballAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/SnowballAnalyzerProvider.java
@@ -83,7 +83,6 @@ public class SnowballAnalyzerProvider extends AbstractIndexAnalyzerProvider<Snow
         CharArraySet stopWords = Analysis.parseStopWords(env, settings, defaultStopwords);
 
         analyzer = new SnowballAnalyzer(language, stopWords);
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/SoraniAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/SoraniAnalyzerProvider.java
@@ -53,7 +53,6 @@ public class SoraniAnalyzerProvider extends AbstractIndexAnalyzerProvider<Sorani
             Analysis.parseStopWords(env, settings, SoraniAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/SpanishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/SpanishAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class SpanishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Spani
             Analysis.parseStopWords(env, settings, SpanishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/SwedishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/SwedishAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class SwedishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Swedi
             Analysis.parseStopWords(env, settings, SwedishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/ThaiAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/ThaiAnalyzerProvider.java
@@ -46,7 +46,6 @@ public class ThaiAnalyzerProvider extends AbstractIndexAnalyzerProvider<ThaiAnal
     ThaiAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
         super(indexSettings, name, settings);
         analyzer = new ThaiAnalyzer(Analysis.parseStopWords(env, settings, ThaiAnalyzer.getDefaultStopSet()));
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/TurkishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/TurkishAnalyzerProvider.java
@@ -50,7 +50,6 @@ public class TurkishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Turki
             Analysis.parseStopWords(env, settings, TurkishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/modules/analysis-common/src/test/java/org/opensearch/analysis/common/CompoundAnalysisTests.java
+++ b/modules/analysis-common/src/test/java/org/opensearch/analysis/common/CompoundAnalysisTests.java
@@ -81,6 +81,7 @@ public class CompoundAnalysisTests extends OpenSearchTestCase {
                 hasItems("donau", "dampf", "schiff", "donaudampfschiff", "spargel", "creme", "suppe", "spargelcremesuppe")
             );
         }
+        assertWarnings("Setting [version] on analysis [custom7] is deprecated, no longer used, and will be removed in a future version.");
     }
 
     private List<String> analyze(Settings settings, String analyzerName, String text) throws IOException {

--- a/plugins/analysis-stempel/src/main/java/org/opensearch/index/analysis/pl/PolishAnalyzerProvider.java
+++ b/plugins/analysis-stempel/src/main/java/org/opensearch/index/analysis/pl/PolishAnalyzerProvider.java
@@ -46,7 +46,6 @@ public class PolishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Polish
         super(indexSettings, name, settings);
 
         analyzer = new PolishAnalyzer(PolishAnalyzer.getDefaultStopSet());
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/plugins/analysis-ukrainian/src/main/java/org/opensearch/index/analysis/UkrainianAnalyzerProvider.java
+++ b/plugins/analysis-ukrainian/src/main/java/org/opensearch/index/analysis/UkrainianAnalyzerProvider.java
@@ -48,7 +48,6 @@ public class UkrainianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Ukr
             Analysis.parseStopWords(env, settings, UkrainianMorfologikAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)
         );
-        analyzer.setVersion(version);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/analysis/AbstractIndexAnalyzerProvider.java
+++ b/server/src/main/java/org/opensearch/index/analysis/AbstractIndexAnalyzerProvider.java
@@ -33,7 +33,6 @@
 package org.opensearch.index.analysis;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.util.Version;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.AbstractIndexComponent;
 import org.opensearch.index.IndexSettings;
@@ -41,8 +40,6 @@ import org.opensearch.index.IndexSettings;
 public abstract class AbstractIndexAnalyzerProvider<T extends Analyzer> extends AbstractIndexComponent implements AnalyzerProvider<T> {
 
     private final String name;
-
-    protected final Version version;
 
     /**
      * Constructs a new analyzer component, with the index name and its settings and the analyzer name.
@@ -53,7 +50,7 @@ public abstract class AbstractIndexAnalyzerProvider<T extends Analyzer> extends 
     public AbstractIndexAnalyzerProvider(IndexSettings indexSettings, String name, Settings settings) {
         super(indexSettings);
         this.name = name;
-        this.version = Analysis.parseAnalysisVersion(this.indexSettings.getSettings(), settings, logger);
+        Analysis.parseAndDeprecateAnalysisVersion(name, settings);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/analysis/AbstractTokenFilterFactory.java
+++ b/server/src/main/java/org/opensearch/index/analysis/AbstractTokenFilterFactory.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.index.analysis;
 
-import org.apache.lucene.util.Version;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.AbstractIndexComponent;
 import org.opensearch.index.IndexSettings;
@@ -41,20 +40,14 @@ public abstract class AbstractTokenFilterFactory extends AbstractIndexComponent 
 
     private final String name;
 
-    protected final Version version;
-
     public AbstractTokenFilterFactory(IndexSettings indexSettings, String name, Settings settings) {
         super(indexSettings);
         this.name = name;
-        this.version = Analysis.parseAnalysisVersion(this.indexSettings.getSettings(), settings, logger);
+        Analysis.parseAndDeprecateAnalysisVersion(name, settings);
     }
 
     @Override
     public String name() {
         return this.name;
-    }
-
-    public final Version version() {
-        return version;
     }
 }

--- a/server/src/main/java/org/opensearch/index/analysis/AbstractTokenizerFactory.java
+++ b/server/src/main/java/org/opensearch/index/analysis/AbstractTokenizerFactory.java
@@ -32,23 +32,17 @@
 
 package org.opensearch.index.analysis;
 
-import org.apache.lucene.util.Version;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.AbstractIndexComponent;
 import org.opensearch.index.IndexSettings;
 
 public abstract class AbstractTokenizerFactory extends AbstractIndexComponent implements TokenizerFactory {
-    protected final Version version;
     private final String name;
 
     public AbstractTokenizerFactory(IndexSettings indexSettings, Settings settings, String name) {
         super(indexSettings);
-        this.version = Analysis.parseAnalysisVersion(this.indexSettings.getSettings(), settings, logger);
+        Analysis.parseAndDeprecateAnalysisVersion(name, settings);
         this.name = name;
-    }
-
-    public final Version version() {
-        return version;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/analysis/Analysis.java
+++ b/server/src/main/java/org/opensearch/index/analysis/Analysis.java
@@ -98,8 +98,10 @@ public class Analysis {
         // check for explicit version on the specific analyzer component
         String sVersion = settings.get("version");
         if (sVersion != null) {
-            DEPRECATION_LOGGER.deprecate("analyzer.version",
-                "Setting [version] on analysis [" + name + "] is deprecated, no longer used, and will be removed in a future version.");
+            DEPRECATION_LOGGER.deprecate(
+                "analyzer.version",
+                "Setting [version] on analysis [" + name + "] is deprecated, no longer used, and will be removed in a future version."
+            );
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/analysis/Analysis.java
+++ b/server/src/main/java/org/opensearch/index/analysis/Analysis.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.index.analysis;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.ar.ArabicAnalyzer;
 import org.apache.lucene.analysis.bg.BulgarianAnalyzer;
@@ -68,9 +67,8 @@ import org.apache.lucene.analysis.ru.RussianAnalyzer;
 import org.apache.lucene.analysis.sv.SwedishAnalyzer;
 import org.apache.lucene.analysis.th.ThaiAnalyzer;
 import org.apache.lucene.analysis.tr.TurkishAnalyzer;
-import org.apache.lucene.util.Version;
 import org.opensearch.common.Strings;
-import org.opensearch.common.lucene.Lucene;
+import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
 
@@ -93,19 +91,16 @@ import static java.util.Collections.unmodifiableMap;
 
 public class Analysis {
 
-    public static Version parseAnalysisVersion(Settings indexSettings, Settings settings, Logger logger) {
+    private static DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(Analysis.class);
+
+    /** version is deprecated and will be removed; this method parses explicit version and issues a deprecation warning */
+    public static void parseAndDeprecateAnalysisVersion(String name, Settings settings) {
         // check for explicit version on the specific analyzer component
         String sVersion = settings.get("version");
         if (sVersion != null) {
-            return Lucene.parseVersion(sVersion, Version.LATEST, logger);
+            DEPRECATION_LOGGER.deprecate("analyzer.version",
+                "Setting [version] on analysis [" + name + "] is deprecated, no longer used, and will be removed in a future version.");
         }
-        // check for explicit version on the index itself as default for all analysis components
-        sVersion = indexSettings.get("index.analysis.version");
-        if (sVersion != null) {
-            return Lucene.parseVersion(sVersion, Version.LATEST, logger);
-        }
-        // resolve the analysis version based on the version the index was created with
-        return org.opensearch.Version.indexCreated(indexSettings).luceneVersion;
     }
 
     public static CharArraySet parseStemExclusion(Settings settings, CharArraySet defaultStemExclusion) {

--- a/server/src/main/java/org/opensearch/index/analysis/PreBuiltAnalyzerProviderFactory.java
+++ b/server/src/main/java/org/opensearch/index/analysis/PreBuiltAnalyzerProviderFactory.java
@@ -60,17 +60,13 @@ public class PreBuiltAnalyzerProviderFactory extends PreConfiguredAnalysisCompon
     PreBuiltAnalyzerProviderFactory(String name, PreBuiltAnalyzers preBuiltAnalyzer) {
         super(name, new PreBuiltAnalyzersDelegateCache(name, preBuiltAnalyzer));
         this.create = preBuiltAnalyzer::getAnalyzer;
-        Analyzer analyzer = preBuiltAnalyzer.getAnalyzer(Version.CURRENT);
-        analyzer.setVersion(Version.CURRENT.luceneVersion);
-        current = new PreBuiltAnalyzerProvider(name, AnalyzerScope.INDICES, analyzer);
+        current = new PreBuiltAnalyzerProvider(name, AnalyzerScope.INDICES, preBuiltAnalyzer.getAnalyzer(Version.CURRENT));
     }
 
     public PreBuiltAnalyzerProviderFactory(String name, PreBuiltCacheFactory.CachingStrategy cache, Supplier<Analyzer> create) {
         super(name, cache);
         this.create = version -> create.get();
-        Analyzer analyzer = create.get();
-        analyzer.setVersion(Version.CURRENT.luceneVersion);
-        this.current = new PreBuiltAnalyzerProvider(name, AnalyzerScope.INDICES, analyzer);
+        this.current = new PreBuiltAnalyzerProvider(name, AnalyzerScope.INDICES, create.get());
     }
 
     @Override
@@ -88,7 +84,6 @@ public class PreBuiltAnalyzerProviderFactory extends PreConfiguredAnalysisCompon
     protected AnalyzerProvider<?> create(Version version) {
         assert Version.CURRENT.equals(version) == false;
         Analyzer analyzer = create.apply(version);
-        analyzer.setVersion(version.luceneVersion);
         return new PreBuiltAnalyzerProvider(getName(), AnalyzerScope.INDICES, analyzer);
     }
 

--- a/server/src/main/java/org/opensearch/index/analysis/SimpleAnalyzerProvider.java
+++ b/server/src/main/java/org/opensearch/index/analysis/SimpleAnalyzerProvider.java
@@ -44,7 +44,6 @@ public class SimpleAnalyzerProvider extends AbstractIndexAnalyzerProvider<Simple
     public SimpleAnalyzerProvider(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
         super(indexSettings, name, settings);
         this.simpleAnalyzer = new SimpleAnalyzer();
-        this.simpleAnalyzer.setVersion(version);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/analysis/StandardAnalyzerProvider.java
+++ b/server/src/main/java/org/opensearch/index/analysis/StandardAnalyzerProvider.java
@@ -48,7 +48,6 @@ public class StandardAnalyzerProvider extends AbstractIndexAnalyzerProvider<Stan
         CharArraySet stopWords = Analysis.parseStopWords(env, settings, defaultStopwords);
         int maxTokenLength = settings.getAsInt("max_token_length", StandardAnalyzer.DEFAULT_MAX_TOKEN_LENGTH);
         standardAnalyzer = new StandardAnalyzer(stopWords);
-        standardAnalyzer.setVersion(version);
         standardAnalyzer.setMaxTokenLength(maxTokenLength);
     }
 

--- a/server/src/main/java/org/opensearch/index/analysis/StopAnalyzerProvider.java
+++ b/server/src/main/java/org/opensearch/index/analysis/StopAnalyzerProvider.java
@@ -47,7 +47,6 @@ public class StopAnalyzerProvider extends AbstractIndexAnalyzerProvider<StopAnal
         super(indexSettings, name, settings);
         CharArraySet stopWords = Analysis.parseStopWords(env, settings, EnglishAnalyzer.ENGLISH_STOP_WORDS_SET);
         this.stopAnalyzer = new StopAnalyzer(stopWords);
-        this.stopAnalyzer.setVersion(version);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/analysis/WhitespaceAnalyzerProvider.java
+++ b/server/src/main/java/org/opensearch/index/analysis/WhitespaceAnalyzerProvider.java
@@ -44,7 +44,6 @@ public class WhitespaceAnalyzerProvider extends AbstractIndexAnalyzerProvider<Wh
     public WhitespaceAnalyzerProvider(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
         super(indexSettings, name, settings);
         this.analyzer = new WhitespaceAnalyzer();
-        this.analyzer.setVersion(version);
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/indices/analysis/AnalysisModuleTests.java
+++ b/server/src/test/java/org/opensearch/indices/analysis/AnalysisModuleTests.java
@@ -57,7 +57,6 @@ import org.opensearch.index.analysis.AnalysisRegistry;
 import org.opensearch.index.analysis.CharFilterFactory;
 import org.opensearch.index.analysis.CustomAnalyzer;
 import org.opensearch.index.analysis.IndexAnalyzers;
-import org.opensearch.index.analysis.NamedAnalyzer;
 import org.opensearch.index.analysis.PreConfiguredCharFilter;
 import org.opensearch.index.analysis.PreConfiguredTokenFilter;
 import org.opensearch.index.analysis.PreConfiguredTokenizer;
@@ -139,11 +138,13 @@ public class AnalysisModuleTests extends OpenSearchTestCase {
     public void testSimpleConfigurationJson() throws IOException {
         Settings settings = loadFromClasspath("/org/opensearch/index/analysis/test1.json");
         testSimpleConfiguration(settings);
+        assertWarnings("Setting [version] on analysis [custom7] is deprecated, no longer used, and will be removed in a future version.");
     }
 
     public void testSimpleConfigurationYaml() throws IOException {
         Settings settings = loadFromClasspath("/org/opensearch/index/analysis/test1.yml");
         testSimpleConfiguration(settings);
+        assertWarnings("Setting [version] on analysis [custom7] is deprecated, no longer used, and will be removed in a future version.");
     }
 
     public void testVersionedAnalyzers() throws Exception {
@@ -157,19 +158,8 @@ public class AnalysisModuleTests extends OpenSearchTestCase {
         AnalysisRegistry newRegistry = getNewRegistry(settings2);
         IndexAnalyzers indexAnalyzers = getIndexAnalyzers(newRegistry, settings2);
 
-        // registry always has the current version
-        assertThat(newRegistry.getAnalyzer("default"), is(instanceOf(NamedAnalyzer.class)));
-        NamedAnalyzer defaultNamedAnalyzer = (NamedAnalyzer) newRegistry.getAnalyzer("default");
-        assertThat(defaultNamedAnalyzer.analyzer(), is(instanceOf(StandardAnalyzer.class)));
-        assertEquals(Version.CURRENT.luceneVersion, defaultNamedAnalyzer.analyzer().getVersion());
-
-        // analysis service has the expected version
-        assertThat(indexAnalyzers.get("standard").analyzer(), is(instanceOf(StandardAnalyzer.class)));
-        assertEquals(version.luceneVersion, indexAnalyzers.get("standard").analyzer().getVersion());
-        assertEquals(version.luceneVersion, indexAnalyzers.get("stop").analyzer().getVersion());
-
         assertThat(indexAnalyzers.get("custom7").analyzer(), is(instanceOf(StandardAnalyzer.class)));
-        assertEquals(org.apache.lucene.util.Version.fromBits(3, 6, 0), indexAnalyzers.get("custom7").analyzer().getVersion());
+        assertWarnings("Setting [version] on analysis [custom7] is deprecated, no longer used, and will be removed in a future version.");
     }
 
     private void testSimpleConfiguration(Settings settings) throws IOException {

--- a/server/src/test/resources/org/opensearch/index/analysis/test1.json
+++ b/server/src/test/resources/org/opensearch/index/analysis/test1.json
@@ -35,6 +35,10 @@
                 "custom6":{
                     "tokenizer":"standard",
                     "position_increment_gap": 256
+                },
+                "custom7":{
+                    "type":"standard",
+                    "version": 3.6
                 }
             }
         }


### PR DESCRIPTION
Lucene 9 removes the ability to define an explicit version on an analysis component. In this PR the version parameter for an analysis component is deprecated at parse time and a warning issued to the user through the deprecation logger. A separate PR will completely remove the parameter in 2.0.0