### PR TITLE
[backport] add max expansion support to wildcard interval

### DIFF
--- a/server/src/main/java/org/opensearch/index/query/IntervalsSourceProvider.java
+++ b/server/src/main/java/org/opensearch/index/query/IntervalsSourceProvider.java
@@ -40,6 +40,7 @@ import org.apache.lucene.queries.intervals.IntervalsSource;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.LegacyESVersion;
+import org.opensearch.Version;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.io.stream.NamedWriteable;
@@ -637,17 +638,24 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         private final String pattern;
         private final String analyzer;
         private final String useField;
+        private final Integer maxExpansions;
 
-        public Wildcard(String pattern, String analyzer, String useField) {
+        public Wildcard(String pattern, String analyzer, String useField, Integer maxExpansions) {
             this.pattern = pattern;
             this.analyzer = analyzer;
             this.useField = useField;
+            this.maxExpansions = (maxExpansions != null && maxExpansions > 0) ? maxExpansions : null;
         }
 
         public Wildcard(StreamInput in) throws IOException {
             this.pattern = in.readString();
             this.analyzer = in.readOptionalString();
             this.useField = in.readOptionalString();
+            if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
+                this.maxExpansions = in.readOptionalVInt();
+            } else {
+                this.maxExpansions = null;
+            }
         }
 
         @Override
@@ -665,11 +673,14 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
                     analyzer = fieldType.getTextSearchInfo().getSearchAnalyzer();
                 }
                 BytesRef normalizedTerm = analyzer.normalize(useField, pattern);
-                source = Intervals.fixField(useField, Intervals.wildcard(normalizedTerm));
+                IntervalsSource wildcardSource = maxExpansions == null
+                    ? Intervals.wildcard(normalizedTerm)
+                    : Intervals.wildcard(normalizedTerm, maxExpansions);
+                source = Intervals.fixField(useField, wildcardSource);
             } else {
                 checkPositions(fieldType);
                 BytesRef normalizedTerm = analyzer.normalize(fieldType.name(), pattern);
-                source = Intervals.wildcard(normalizedTerm);
+                source = maxExpansions == null ? Intervals.wildcard(normalizedTerm) : Intervals.wildcard(normalizedTerm, maxExpansions);
             }
             return source;
         }
@@ -694,12 +705,13 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
             Wildcard wildcard = (Wildcard) o;
             return Objects.equals(pattern, wildcard.pattern)
                 && Objects.equals(analyzer, wildcard.analyzer)
-                && Objects.equals(useField, wildcard.useField);
+                && Objects.equals(useField, wildcard.useField)
+                && Objects.equals(maxExpansions, wildcard.maxExpansions);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(pattern, analyzer, useField);
+            return Objects.hash(pattern, analyzer, useField, maxExpansions);
         }
 
         @Override
@@ -712,6 +724,9 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
             out.writeString(pattern);
             out.writeOptionalString(analyzer);
             out.writeOptionalString(useField);
+            if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
+                out.writeOptionalVInt(maxExpansions);
+            }
         }
 
         @Override
@@ -724,6 +739,9 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
             if (useField != null) {
                 builder.field("use_field", useField);
             }
+            if (maxExpansions != null) {
+                builder.field("max_expansions", maxExpansions);
+            }
             builder.endObject();
             return builder;
         }
@@ -732,12 +750,14 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
             String term = (String) args[0];
             String analyzer = (String) args[1];
             String useField = (String) args[2];
-            return new Wildcard(term, analyzer, useField);
+            Integer maxExpansions = (Integer) args[3];
+            return new Wildcard(term, analyzer, useField, maxExpansions);
         });
         static {
             PARSER.declareString(constructorArg(), new ParseField("pattern"));
             PARSER.declareString(optionalConstructorArg(), new ParseField("analyzer"));
             PARSER.declareString(optionalConstructorArg(), new ParseField("use_field"));
+            PARSER.declareInt(optionalConstructorArg(), new ParseField("max_expansions"));
         }
 
         public static Wildcard fromXContent(XContentParser parser) throws IOException {
@@ -754,6 +774,10 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
 
         String getUseField() {
             return useField;
+        }
+
+        Integer getMaxExpansions() {
+            return maxExpansions;
         }
     }
 

--- a/server/src/test/java/org/opensearch/index/query/WildcardIntervalsSourceProviderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/WildcardIntervalsSourceProviderTests.java
@@ -51,7 +51,8 @@ public class WildcardIntervalsSourceProviderTests extends AbstractSerializingTes
         return new Wildcard(
             randomAlphaOfLength(10),
             randomBoolean() ? randomAlphaOfLength(10) : null,
-            randomBoolean() ? randomAlphaOfLength(10) : null
+            randomBoolean() ? randomAlphaOfLength(10) : null,
+            randomBoolean() ? randomIntBetween(-1, Integer.MAX_VALUE) : null
         );
     }
 
@@ -60,7 +61,8 @@ public class WildcardIntervalsSourceProviderTests extends AbstractSerializingTes
         String wildcard = instance.getPattern();
         String analyzer = instance.getAnalyzer();
         String useField = instance.getUseField();
-        switch (between(0, 2)) {
+        Integer maxExpansions = instance.getMaxExpansions();
+        switch (between(0, 3)) {
             case 0:
                 wildcard += "a";
                 break;
@@ -70,10 +72,13 @@ public class WildcardIntervalsSourceProviderTests extends AbstractSerializingTes
             case 2:
                 useField = useField == null ? randomAlphaOfLength(5) : null;
                 break;
+            case 3:
+                maxExpansions = maxExpansions == null ? randomIntBetween(1, Integer.MAX_VALUE) : null;
+                break;
             default:
                 throw new AssertionError("Illegal randomisation branch");
         }
-        return new Wildcard(wildcard, analyzer, useField);
+        return new Wildcard(wildcard, analyzer, useField, maxExpansions);
     }
 
     @Override


### PR DESCRIPTION
### Description

Add support for setting the max expansions on a wildcard interval.
The default value is still 128 and the max value is bounded by
`BooleanQuery.getMaxClauseCount()`.

1x backport of #1916 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
