### PR TITLE
Added timeout to ensureGreen() for testClusterGreenAfterPartialRelocation

### DIFF
--- a/server/src/test/java/org/opensearch/cluster/routing/MovePrimaryFirstTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/MovePrimaryFirstTests.java
@@ -12,6 +12,7 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.cluster.ClusterStateListener;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
@@ -112,6 +113,6 @@ public class MovePrimaryFirstTests extends OpenSearchIntegTestCase {
             internalCluster().stopRandomNode(InternalTestCluster.nameFilter(z1n1));
             internalCluster().stopRandomNode(InternalTestCluster.nameFilter(z1n2));
         } catch (Exception e) {}
-        ensureGreen();
+        ensureGreen(TimeValue.timeValueSeconds(60));
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -55,7 +55,6 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.LiveIndexWriterConfig;
-import org.apache.lucene.index.LogByteSizeMergePolicy;
 import org.apache.lucene.index.LogDocMergePolicy;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.NoMergePolicy;


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
The test `testClusterGreenAfterPartialRelocation` timed out while waiting for the cluster to become green. Increasing the timeout will help.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/1957
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
