### PR TITLE
[1x] Deprecate index.merge.policy.max_merge_at_once_explicit (#1981)

### DIFF
--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -713,10 +713,8 @@ public final class IndexSettings {
             MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGE_AT_ONCE_SETTING,
             mergePolicyConfig::setMaxMergesAtOnce
         );
-        scopedSettings.addSettingsUpdateConsumer(
-            MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGE_AT_ONCE_EXPLICIT_SETTING,
-            mergePolicyConfig::setMaxMergesAtOnceExplicit
-        );
+        // todo: remove this in 2.0.0 since it was removed in lucene 9
+        scopedSettings.addSettingsUpdateConsumer(MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGE_AT_ONCE_EXPLICIT_SETTING, noop -> {});
         scopedSettings.addSettingsUpdateConsumer(
             MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGED_SEGMENT_SETTING,
             mergePolicyConfig::setMaxMergedSegment

--- a/server/src/main/java/org/opensearch/index/MergePolicyConfig.java
+++ b/server/src/main/java/org/opensearch/index/MergePolicyConfig.java
@@ -76,11 +76,6 @@ import org.opensearch.common.unit.ByteSizeValue;
  *     Maximum number of segments to be merged at a time during "normal" merging.
  *     Default is <code>10</code>.
  *
- * <li><code>index.merge.policy.max_merge_at_once_explicit</code>:
- *
- *     Maximum number of segments to be merged at a time, during force merge or
- *     expungeDeletes. Default is <code>30</code>.
- *
  * <li><code>index.merge.policy.max_merged_segment</code>:
  *
  *     Maximum sized segment to produce during normal merging (not explicit
@@ -136,7 +131,6 @@ public final class MergePolicyConfig {
     public static final double DEFAULT_EXPUNGE_DELETES_ALLOWED = 10d;
     public static final ByteSizeValue DEFAULT_FLOOR_SEGMENT = new ByteSizeValue(2, ByteSizeUnit.MB);
     public static final int DEFAULT_MAX_MERGE_AT_ONCE = 10;
-    public static final int DEFAULT_MAX_MERGE_AT_ONCE_EXPLICIT = 30;
     public static final ByteSizeValue DEFAULT_MAX_MERGED_SEGMENT = new ByteSizeValue(5, ByteSizeUnit.GB);
     public static final double DEFAULT_SEGMENTS_PER_TIER = 10.0d;
     public static final double DEFAULT_RECLAIM_DELETES_WEIGHT = 2.0d;
@@ -169,10 +163,12 @@ public final class MergePolicyConfig {
         Property.Dynamic,
         Property.IndexScope
     );
+    @Deprecated
     public static final Setting<Integer> INDEX_MERGE_POLICY_MAX_MERGE_AT_ONCE_EXPLICIT_SETTING = Setting.intSetting(
         "index.merge.policy.max_merge_at_once_explicit",
-        DEFAULT_MAX_MERGE_AT_ONCE_EXPLICIT,
+        30,
         2,
+        Property.Deprecated,
         Property.Dynamic,
         Property.IndexScope
     );
@@ -258,10 +254,6 @@ public final class MergePolicyConfig {
 
     void setMaxMergedSegment(ByteSizeValue maxMergedSegment) {
         mergePolicy.setMaxMergedSegmentMB(maxMergedSegment.getMbFrac());
-    }
-
-    void setMaxMergesAtOnceExplicit(Integer maxMergeAtOnceExplicit) {
-        mergePolicy.setMaxMergeAtOnceExplicit(maxMergeAtOnceExplicit);
     }
 
     void setMaxMergesAtOnce(Integer maxMergeAtOnce) {

--- a/server/src/main/java/org/opensearch/index/OpenSearchTieredMergePolicy.java
+++ b/server/src/main/java/org/opensearch/index/OpenSearchTieredMergePolicy.java
@@ -99,11 +99,13 @@ final class OpenSearchTieredMergePolicy extends FilterMergePolicy {
         return regularMergePolicy.getMaxMergeAtOnce();
     }
 
+    @Deprecated
     public void setMaxMergeAtOnceExplicit(int maxMergeAtOnceExplicit) {
         regularMergePolicy.setMaxMergeAtOnceExplicit(maxMergeAtOnceExplicit);
         forcedMergePolicy.setMaxMergeAtOnceExplicit(maxMergeAtOnceExplicit);
     }
 
+    @Deprecated
     public int getMaxMergeAtOnceExplicit() {
         return forcedMergePolicy.getMaxMergeAtOnceExplicit();
     }

--- a/server/src/test/java/org/opensearch/index/MergePolicySettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/MergePolicySettingsTests.java
@@ -156,24 +156,17 @@ public class MergePolicySettingsTests extends OpenSearchTestCase {
             MergePolicyConfig.DEFAULT_MAX_MERGE_AT_ONCE - 1
         );
 
-        assertEquals(
-            ((OpenSearchTieredMergePolicy) indexSettings.getMergePolicy()).getMaxMergeAtOnceExplicit(),
-            MergePolicyConfig.DEFAULT_MAX_MERGE_AT_ONCE_EXPLICIT
-        );
+        assertEquals(((OpenSearchTieredMergePolicy) indexSettings.getMergePolicy()).getMaxMergeAtOnceExplicit(), 30);
         indexSettings.updateIndexMetadata(
             newIndexMeta(
                 "index",
-                Settings.builder()
-                    .put(
-                        MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGE_AT_ONCE_EXPLICIT_SETTING.getKey(),
-                        MergePolicyConfig.DEFAULT_MAX_MERGE_AT_ONCE_EXPLICIT - 1
-                    )
-                    .build()
+                Settings.builder().put(MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGE_AT_ONCE_EXPLICIT_SETTING.getKey(), 29).build()
             )
         );
-        assertEquals(
-            ((OpenSearchTieredMergePolicy) indexSettings.getMergePolicy()).getMaxMergeAtOnceExplicit(),
-            MergePolicyConfig.DEFAULT_MAX_MERGE_AT_ONCE_EXPLICIT - 1
+        assertWarnings(
+            "[index.merge.policy.max_merge_at_once_explicit] setting was "
+                + "deprecated in OpenSearch and will be removed in a future release! See the breaking changes "
+                + "documentation for the next major version."
         );
 
         assertEquals(
@@ -259,10 +252,7 @@ public class MergePolicySettingsTests extends OpenSearchTestCase {
             ((OpenSearchTieredMergePolicy) indexSettings.getMergePolicy()).getMaxMergeAtOnce(),
             MergePolicyConfig.DEFAULT_MAX_MERGE_AT_ONCE
         );
-        assertEquals(
-            ((OpenSearchTieredMergePolicy) indexSettings.getMergePolicy()).getMaxMergeAtOnceExplicit(),
-            MergePolicyConfig.DEFAULT_MAX_MERGE_AT_ONCE_EXPLICIT
-        );
+        assertEquals(((OpenSearchTieredMergePolicy) indexSettings.getMergePolicy()).getMaxMergeAtOnceExplicit(), 30);
         assertEquals(
             ((OpenSearchTieredMergePolicy) indexSettings.getMergePolicy()).getMaxMergedSegmentMB(),
             new ByteSizeValue(MergePolicyConfig.DEFAULT_MAX_MERGED_SEGMENT.getBytes() + 1).getMbFrac(),

--- a/server/src/test/java/org/opensearch/index/MergePolicySettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/MergePolicySettingsTests.java
@@ -263,6 +263,12 @@ public class MergePolicySettingsTests extends OpenSearchTestCase {
             MergePolicyConfig.DEFAULT_DELETES_PCT_ALLOWED,
             0
         );
+
+        assertWarnings(
+            "[index.merge.policy.max_merge_at_once_explicit] setting was "
+                + "deprecated in OpenSearch and will be removed in a future release! See the breaking changes "
+                + "documentation for the next major version."
+        );
     }
 
     public Settings build(String value) {

--- a/server/src/test/java/org/opensearch/index/MergePolicySettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/MergePolicySettingsTests.java
@@ -163,11 +163,6 @@ public class MergePolicySettingsTests extends OpenSearchTestCase {
                 Settings.builder().put(MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGE_AT_ONCE_EXPLICIT_SETTING.getKey(), 29).build()
             )
         );
-        assertWarnings(
-            "[index.merge.policy.max_merge_at_once_explicit] setting was "
-                + "deprecated in OpenSearch and will be removed in a future release! See the breaking changes "
-                + "documentation for the next major version."
-        );
 
         assertEquals(
             ((OpenSearchTieredMergePolicy) indexSettings.getMergePolicy()).getMaxMergedSegmentMB(),


### PR DESCRIPTION
Backport of #1981. max_merge_at_once_explicit is removed in lucene 9 so the index setting is deprecated for removal in the next major release.