### PR TITLE
[Remove] Setting explicit version on analysis component

### DIFF
--- a/modules/analysis-common/src/test/java/org/opensearch/analysis/common/CompoundAnalysisTests.java
+++ b/modules/analysis-common/src/test/java/org/opensearch/analysis/common/CompoundAnalysisTests.java
@@ -81,7 +81,6 @@ public class CompoundAnalysisTests extends OpenSearchTestCase {
                 hasItems("donau", "dampf", "schiff", "donaudampfschiff", "spargel", "creme", "suppe", "spargelcremesuppe")
             );
         }
-        assertWarnings("Setting [version] on analysis [custom7] is deprecated, no longer used, and will be removed in a future version.");
     }
 
     private List<String> analyze(Settings settings, String analyzerName, String text) throws IOException {

--- a/server/src/main/java/org/opensearch/index/analysis/AbstractIndexAnalyzerProvider.java
+++ b/server/src/main/java/org/opensearch/index/analysis/AbstractIndexAnalyzerProvider.java
@@ -50,7 +50,6 @@ public abstract class AbstractIndexAnalyzerProvider<T extends Analyzer> extends 
     public AbstractIndexAnalyzerProvider(IndexSettings indexSettings, String name, Settings settings) {
         super(indexSettings);
         this.name = name;
-        Analysis.parseAndDeprecateAnalysisVersion(name, settings);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/analysis/AbstractTokenFilterFactory.java
+++ b/server/src/main/java/org/opensearch/index/analysis/AbstractTokenFilterFactory.java
@@ -43,7 +43,6 @@ public abstract class AbstractTokenFilterFactory extends AbstractIndexComponent 
     public AbstractTokenFilterFactory(IndexSettings indexSettings, String name, Settings settings) {
         super(indexSettings);
         this.name = name;
-        Analysis.parseAndDeprecateAnalysisVersion(name, settings);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/analysis/AbstractTokenizerFactory.java
+++ b/server/src/main/java/org/opensearch/index/analysis/AbstractTokenizerFactory.java
@@ -41,7 +41,6 @@ public abstract class AbstractTokenizerFactory extends AbstractIndexComponent im
 
     public AbstractTokenizerFactory(IndexSettings indexSettings, Settings settings, String name) {
         super(indexSettings);
-        Analysis.parseAndDeprecateAnalysisVersion(name, settings);
         this.name = name;
     }
 

--- a/server/src/main/java/org/opensearch/index/analysis/Analysis.java
+++ b/server/src/main/java/org/opensearch/index/analysis/Analysis.java
@@ -68,7 +68,6 @@ import org.apache.lucene.analysis.sv.SwedishAnalyzer;
 import org.apache.lucene.analysis.th.ThaiAnalyzer;
 import org.apache.lucene.analysis.tr.TurkishAnalyzer;
 import org.opensearch.common.Strings;
-import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
 
@@ -90,20 +89,6 @@ import java.util.Set;
 import static java.util.Collections.unmodifiableMap;
 
 public class Analysis {
-
-    private static DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(Analysis.class);
-
-    /** version is deprecated and will be removed; this method parses explicit version and issues a deprecation warning */
-    public static void parseAndDeprecateAnalysisVersion(String name, Settings settings) {
-        // check for explicit version on the specific analyzer component
-        String sVersion = settings.get("version");
-        if (sVersion != null) {
-            DEPRECATION_LOGGER.deprecate(
-                "analyzer.version",
-                "Setting [version] on analysis [" + name + "] is deprecated, no longer used, and will be removed in a future version."
-            );
-        }
-    }
 
     public static CharArraySet parseStemExclusion(Settings settings, CharArraySet defaultStemExclusion) {
         String value = settings.get("stem_exclusion");

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -55,7 +55,6 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.LiveIndexWriterConfig;
-import org.apache.lucene.index.LogByteSizeMergePolicy;
 import org.apache.lucene.index.LogDocMergePolicy;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.NoMergePolicy;

--- a/server/src/test/java/org/opensearch/indices/analysis/AnalysisModuleTests.java
+++ b/server/src/test/java/org/opensearch/indices/analysis/AnalysisModuleTests.java
@@ -39,7 +39,6 @@ import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.hunspell.Dictionary;
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.NIOFSDirectory;
@@ -92,7 +91,6 @@ import static org.apache.lucene.analysis.BaseTokenStreamTestCase.assertTokenStre
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 
 public class AnalysisModuleTests extends OpenSearchTestCase {
     private final Settings emptyNodeSettings = Settings.builder()
@@ -138,28 +136,11 @@ public class AnalysisModuleTests extends OpenSearchTestCase {
     public void testSimpleConfigurationJson() throws IOException {
         Settings settings = loadFromClasspath("/org/opensearch/index/analysis/test1.json");
         testSimpleConfiguration(settings);
-        assertWarnings("Setting [version] on analysis [custom7] is deprecated, no longer used, and will be removed in a future version.");
     }
 
     public void testSimpleConfigurationYaml() throws IOException {
         Settings settings = loadFromClasspath("/org/opensearch/index/analysis/test1.yml");
         testSimpleConfiguration(settings);
-        assertWarnings("Setting [version] on analysis [custom7] is deprecated, no longer used, and will be removed in a future version.");
-    }
-
-    public void testVersionedAnalyzers() throws Exception {
-        String yaml = "/org/opensearch/index/analysis/test1.yml";
-        Version version = VersionUtils.randomVersion(random());
-        Settings settings2 = Settings.builder()
-            .loadFromStream(yaml, getClass().getResourceAsStream(yaml), false)
-            .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
-            .put(IndexMetadata.SETTING_VERSION_CREATED, version)
-            .build();
-        AnalysisRegistry newRegistry = getNewRegistry(settings2);
-        IndexAnalyzers indexAnalyzers = getIndexAnalyzers(newRegistry, settings2);
-
-        assertThat(indexAnalyzers.get("custom7").analyzer(), is(instanceOf(StandardAnalyzer.class)));
-        assertWarnings("Setting [version] on analysis [custom7] is deprecated, no longer used, and will be removed in a future version.");
     }
 
     private void testSimpleConfiguration(Settings settings) throws IOException {

--- a/server/src/test/resources/org/opensearch/index/analysis/test1.json
+++ b/server/src/test/resources/org/opensearch/index/analysis/test1.json
@@ -35,10 +35,6 @@
                 "custom6":{
                     "tokenizer":"standard",
                     "position_increment_gap": 256
-                },
-                "custom7":{
-                    "type":"standard",
-                    "version": 3.6
                 }
             }
         }

--- a/server/src/test/resources/org/opensearch/index/analysis/test1.yml
+++ b/server/src/test/resources/org/opensearch/index/analysis/test1.yml
@@ -25,6 +25,3 @@ index :
       custom6 :
         tokenizer : standard
         position_increment_gap: 256
-      custom7 :
-        type : standard
-        version: 3.6


### PR DESCRIPTION
Removal of deprecated setting in #1978. 

Lucene 9 removes the ability to define an explicit version on an analysis
component so remove the the version parameter and deprecation warning
prohibiting users from explicitly setting versioned analyzers.