### PR TITLE
[Remove] index.merge.policy.max_merge_at_once_explicit

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -118,7 +118,6 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 MergePolicyConfig.INDEX_MERGE_POLICY_EXPUNGE_DELETES_ALLOWED_SETTING,
                 MergePolicyConfig.INDEX_MERGE_POLICY_FLOOR_SEGMENT_SETTING,
                 MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGE_AT_ONCE_SETTING,
-                MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGE_AT_ONCE_EXPLICIT_SETTING,
                 MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGED_SEGMENT_SETTING,
                 MergePolicyConfig.INDEX_MERGE_POLICY_SEGMENTS_PER_TIER_SETTING,
                 MergePolicyConfig.INDEX_MERGE_POLICY_RECLAIM_DELETES_WEIGHT_SETTING,

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -714,8 +714,6 @@ public final class IndexSettings {
             MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGE_AT_ONCE_SETTING,
             mergePolicyConfig::setMaxMergesAtOnce
         );
-        // todo: remove this in 2.0.0 since it was removed in lucene 9
-        scopedSettings.addSettingsUpdateConsumer(MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGE_AT_ONCE_EXPLICIT_SETTING, noop -> {});
         scopedSettings.addSettingsUpdateConsumer(
             MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGED_SEGMENT_SETTING,
             mergePolicyConfig::setMaxMergedSegment

--- a/server/src/main/java/org/opensearch/index/MergePolicyConfig.java
+++ b/server/src/main/java/org/opensearch/index/MergePolicyConfig.java
@@ -163,15 +163,6 @@ public final class MergePolicyConfig {
         Property.Dynamic,
         Property.IndexScope
     );
-    @Deprecated
-    public static final Setting<Integer> INDEX_MERGE_POLICY_MAX_MERGE_AT_ONCE_EXPLICIT_SETTING = Setting.intSetting(
-        "index.merge.policy.max_merge_at_once_explicit",
-        30,
-        2,
-        Property.Deprecated,
-        Property.Dynamic,
-        Property.IndexScope
-    );
     public static final Setting<ByteSizeValue> INDEX_MERGE_POLICY_MAX_MERGED_SEGMENT_SETTING = Setting.byteSizeSetting(
         "index.merge.policy.max_merged_segment",
         DEFAULT_MAX_MERGED_SEGMENT,
@@ -209,7 +200,6 @@ public final class MergePolicyConfig {
         double forceMergeDeletesPctAllowed = indexSettings.getValue(INDEX_MERGE_POLICY_EXPUNGE_DELETES_ALLOWED_SETTING); // percentage
         ByteSizeValue floorSegment = indexSettings.getValue(INDEX_MERGE_POLICY_FLOOR_SEGMENT_SETTING);
         int maxMergeAtOnce = indexSettings.getValue(INDEX_MERGE_POLICY_MAX_MERGE_AT_ONCE_SETTING);
-        int maxMergeAtOnceExplicit = indexSettings.getValue(INDEX_MERGE_POLICY_MAX_MERGE_AT_ONCE_EXPLICIT_SETTING);
         // TODO is this really a good default number for max_merge_segment, what happens for large indices,
         // won't they end up with many segments?
         ByteSizeValue maxMergedSegment = indexSettings.getValue(INDEX_MERGE_POLICY_MAX_MERGED_SEGMENT_SETTING);
@@ -228,19 +218,17 @@ public final class MergePolicyConfig {
         mergePolicy.setForceMergeDeletesPctAllowed(forceMergeDeletesPctAllowed);
         mergePolicy.setFloorSegmentMB(floorSegment.getMbFrac());
         mergePolicy.setMaxMergeAtOnce(maxMergeAtOnce);
-        mergePolicy.setMaxMergeAtOnceExplicit(maxMergeAtOnceExplicit);
         mergePolicy.setMaxMergedSegmentMB(maxMergedSegment.getMbFrac());
         mergePolicy.setSegmentsPerTier(segmentsPerTier);
         mergePolicy.setDeletesPctAllowed(deletesPctAllowed);
         if (logger.isTraceEnabled()) {
             logger.trace(
                 "using [tiered] merge mergePolicy with expunge_deletes_allowed[{}], floor_segment[{}],"
-                    + " max_merge_at_once[{}], max_merge_at_once_explicit[{}], max_merged_segment[{}], segments_per_tier[{}],"
+                    + " max_merge_at_once[{}], max_merged_segment[{}], segments_per_tier[{}],"
                     + " deletes_pct_allowed[{}]",
                 forceMergeDeletesPctAllowed,
                 floorSegment,
                 maxMergeAtOnce,
-                maxMergeAtOnceExplicit,
                 maxMergedSegment,
                 segmentsPerTier,
                 deletesPctAllowed

--- a/server/src/main/java/org/opensearch/index/OpenSearchTieredMergePolicy.java
+++ b/server/src/main/java/org/opensearch/index/OpenSearchTieredMergePolicy.java
@@ -99,17 +99,6 @@ final class OpenSearchTieredMergePolicy extends FilterMergePolicy {
         return regularMergePolicy.getMaxMergeAtOnce();
     }
 
-    @Deprecated
-    public void setMaxMergeAtOnceExplicit(int maxMergeAtOnceExplicit) {
-        regularMergePolicy.setMaxMergeAtOnceExplicit(maxMergeAtOnceExplicit);
-        forcedMergePolicy.setMaxMergeAtOnceExplicit(maxMergeAtOnceExplicit);
-    }
-
-    @Deprecated
-    public int getMaxMergeAtOnceExplicit() {
-        return forcedMergePolicy.getMaxMergeAtOnceExplicit();
-    }
-
     // only setter that must NOT delegate to the forced merge policy
     public void setMaxMergedSegmentMB(double mbFrac) {
         regularMergePolicy.setMaxMergedSegmentMB(mbFrac);

--- a/server/src/test/java/org/opensearch/index/MergePolicySettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/MergePolicySettingsTests.java
@@ -156,19 +156,6 @@ public class MergePolicySettingsTests extends OpenSearchTestCase {
             MergePolicyConfig.DEFAULT_MAX_MERGE_AT_ONCE - 1
         );
 
-        assertEquals(((OpenSearchTieredMergePolicy) indexSettings.getMergePolicy()).getMaxMergeAtOnceExplicit(), 30);
-        indexSettings.updateIndexMetadata(
-            newIndexMeta(
-                "index",
-                Settings.builder().put(MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGE_AT_ONCE_EXPLICIT_SETTING.getKey(), 29).build()
-            )
-        );
-        assertWarnings(
-            "[index.merge.policy.max_merge_at_once_explicit] setting was "
-                + "deprecated in OpenSearch and will be removed in a future release! See the breaking changes "
-                + "documentation for the next major version."
-        );
-
         assertEquals(
             ((OpenSearchTieredMergePolicy) indexSettings.getMergePolicy()).getMaxMergedSegmentMB(),
             MergePolicyConfig.DEFAULT_MAX_MERGED_SEGMENT.getMbFrac(),
@@ -252,7 +239,6 @@ public class MergePolicySettingsTests extends OpenSearchTestCase {
             ((OpenSearchTieredMergePolicy) indexSettings.getMergePolicy()).getMaxMergeAtOnce(),
             MergePolicyConfig.DEFAULT_MAX_MERGE_AT_ONCE
         );
-        assertEquals(((OpenSearchTieredMergePolicy) indexSettings.getMergePolicy()).getMaxMergeAtOnceExplicit(), 30);
         assertEquals(
             ((OpenSearchTieredMergePolicy) indexSettings.getMergePolicy()).getMaxMergedSegmentMB(),
             new ByteSizeValue(MergePolicyConfig.DEFAULT_MAX_MERGED_SEGMENT.getBytes() + 1).getMbFrac(),

--- a/server/src/test/java/org/opensearch/index/OpenSearchTieredMergePolicyTests.java
+++ b/server/src/test/java/org/opensearch/index/OpenSearchTieredMergePolicyTests.java
@@ -69,12 +69,6 @@ public class OpenSearchTieredMergePolicyTests extends OpenSearchTestCase {
         assertEquals(42, policy.regularMergePolicy.getMaxMergeAtOnce());
     }
 
-    public void testSetMaxMergeAtOnceExplicit() {
-        OpenSearchTieredMergePolicy policy = new OpenSearchTieredMergePolicy();
-        policy.setMaxMergeAtOnceExplicit(42);
-        assertEquals(42, policy.forcedMergePolicy.getMaxMergeAtOnceExplicit());
-    }
-
     public void testSetSegmentsPerTier() {
         OpenSearchTieredMergePolicy policy = new OpenSearchTieredMergePolicy();
         policy.setSegmentsPerTier(42);

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -55,7 +55,6 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.LiveIndexWriterConfig;
-import org.apache.lucene.index.LogByteSizeMergePolicy;
 import org.apache.lucene.index.LogDocMergePolicy;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.NoMergePolicy;


### PR DESCRIPTION
Removal of deprecated parameter in #1981

Deprecated `max_merge_at_once_explicit` parameter is removed since it has been removed in lucene 9 and deprecated in opensearch 1.3