### PR TITLE
[Backport] Enabling Sort Optimization to make use of Lucene

### DIFF
--- a/server/src/main/java/org/opensearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryPhase.java
@@ -34,34 +34,24 @@ package org.opensearch.search.query;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.PointValues;
 import org.apache.lucene.queries.MinDocQuery;
 import org.apache.lucene.queries.SearchAfterSortedDocQuery;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Collector;
-import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.ConstantScoreQuery;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
-import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TopFieldCollector;
-import org.apache.lucene.search.TopFieldDocs;
 import org.apache.lucene.search.TotalHits;
-import org.apache.lucene.search.Weight;
-import org.apache.lucene.util.FutureArrays;
 import org.opensearch.action.search.SearchShardTask;
 import org.opensearch.common.Booleans;
-import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
 import org.opensearch.common.util.concurrent.QueueResizingOpenSearchThreadPoolExecutor;
@@ -85,12 +75,7 @@ import org.opensearch.tasks.TaskCancelledException;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 
 import static org.opensearch.search.query.QueryCollectorContext.createEarlyTerminationCollectorContext;
@@ -98,7 +83,6 @@ import static org.opensearch.search.query.QueryCollectorContext.createFilteredCo
 import static org.opensearch.search.query.QueryCollectorContext.createMinScoreCollectorContext;
 import static org.opensearch.search.query.QueryCollectorContext.createMultiCollectorContext;
 import static org.opensearch.search.query.TopDocsCollectorContext.createTopDocsCollectorContext;
-import static org.opensearch.search.query.TopDocsCollectorContext.shortcutTotalHitCount;
 
 /**
  * Query phase of a search request, used to run the query and get back from each shard information about the matching documents
@@ -168,7 +152,10 @@ public class QueryPhase {
         aggregationPhase.execute(searchContext);
 
         if (searchContext.getProfilers() != null) {
-            ProfileShardResult shardResults = SearchProfileShardResults.buildShardResults(searchContext.getProfilers());
+            ProfileShardResult shardResults = SearchProfileShardResults.buildShardResults(
+                searchContext.getProfilers(),
+                searchContext.request()
+            );
             searchContext.queryResult().profileResults(shardResults);
         }
     }
@@ -180,7 +167,6 @@ public class QueryPhase {
      */
     static boolean executeInternal(SearchContext searchContext) throws QueryPhaseExecutionException {
         final ContextIndexSearcher searcher = searchContext.searcher();
-        SortAndFormats sortAndFormatsForRewrittenNumericSort = null;
         final IndexReader reader = searcher.getIndexReader();
         QuerySearchResult queryResult = searchContext.queryResult();
         queryResult.searchTimedOut(false);
@@ -249,26 +235,9 @@ public class QueryPhase {
                 // this collector can filter documents during the collection
                 hasFilterCollector = true;
             }
-
-            CheckedConsumer<List<LeafReaderContext>, IOException> leafSorter = l -> {};
-            // try to rewrite numeric or date sort to the optimized distanceFeatureQuery
+            // optimizing sort on Numerics (long and date)
             if ((searchContext.sort() != null) && SYS_PROP_REWRITE_SORT) {
-                Query rewrittenQuery = tryRewriteLongSort(searchContext, searcher.getIndexReader(), query, hasFilterCollector);
-                if (rewrittenQuery != null) {
-                    query = rewrittenQuery;
-                    // modify sorts: add sort on _score as 1st sort, and move the sort on the original field as the 2nd sort
-                    SortField[] oldSortFields = searchContext.sort().sort.getSort();
-                    DocValueFormat[] oldFormats = searchContext.sort().formats;
-                    SortField[] newSortFields = new SortField[oldSortFields.length + 1];
-                    DocValueFormat[] newFormats = new DocValueFormat[oldSortFields.length + 1];
-                    newSortFields[0] = SortField.FIELD_SCORE;
-                    newFormats[0] = DocValueFormat.RAW;
-                    System.arraycopy(oldSortFields, 0, newSortFields, 1, oldSortFields.length);
-                    System.arraycopy(oldFormats, 0, newFormats, 1, oldFormats.length);
-                    sortAndFormatsForRewrittenNumericSort = searchContext.sort(); // stash SortAndFormats to restore it later
-                    searchContext.sort(new SortAndFormats(new Sort(newSortFields), newFormats));
-                    leafSorter = createLeafSorter(oldSortFields[0]);
-                }
+                enhanceSortOnNumeric(searchContext, searcher.getIndexReader());
             }
 
             boolean timeoutSet = scrollContext == null
@@ -300,20 +269,7 @@ public class QueryPhase {
             }
 
             try {
-                boolean shouldRescore;
-                // if we are optimizing sort and there are no other collectors
-                if (sortAndFormatsForRewrittenNumericSort != null && collectors.size() == 0 && searchContext.getProfilers() == null) {
-                    shouldRescore = searchWithCollectorManager(searchContext, searcher, query, leafSorter, timeoutSet);
-                } else {
-                    shouldRescore = searchWithCollector(searchContext, searcher, query, collectors, hasFilterCollector, timeoutSet);
-                }
-
-                // if we rewrote numeric long or date sort, restore fieldDocs based on the original sort
-                if (sortAndFormatsForRewrittenNumericSort != null) {
-                    searchContext.sort(sortAndFormatsForRewrittenNumericSort); // restore SortAndFormats
-                    restoreTopFieldDocs(queryResult, sortAndFormatsForRewrittenNumericSort);
-                }
-
+                boolean shouldRescore = searchWithCollector(searchContext, searcher, query, collectors, hasFilterCollector, timeoutSet);
                 ExecutorService executor = searchContext.indexShard().getThreadPool().executor(ThreadPool.Names.SEARCH);
                 if (executor instanceof QueueResizingOpenSearchThreadPoolExecutor) {
                     QueueResizingOpenSearchThreadPoolExecutor rExecutor = (QueueResizingOpenSearchThreadPoolExecutor) executor;
@@ -376,182 +332,25 @@ public class QueryPhase {
         return topDocsFactory.shouldRescore();
     }
 
-    /*
-     * We use collectorManager during sort optimization, where
-     * we have already checked that there are no other collectors, no filters,
-     * no search after, no scroll, no collapse, no track scores.
-     * Absence of all other collectors and parameters allows us to use TopFieldCollector directly.
-     */
-    private static boolean searchWithCollectorManager(
-        SearchContext searchContext,
-        ContextIndexSearcher searcher,
-        Query query,
-        CheckedConsumer<List<LeafReaderContext>, IOException> leafSorter,
-        boolean timeoutSet
-    ) throws IOException {
-        final IndexReader reader = searchContext.searcher().getIndexReader();
-        final int numHits = Math.min(searchContext.from() + searchContext.size(), Math.max(1, reader.numDocs()));
-        final SortAndFormats sortAndFormats = searchContext.sort();
-
-        int totalHitsThreshold;
-        TotalHits totalHits;
-        if (searchContext.trackTotalHitsUpTo() == SearchContext.TRACK_TOTAL_HITS_DISABLED) {
-            totalHitsThreshold = 1;
-            totalHits = new TotalHits(0, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
-        } else {
-            int hitCount = shortcutTotalHitCount(reader, query);
-            if (hitCount == -1) {
-                totalHitsThreshold = searchContext.trackTotalHitsUpTo();
-                totalHits = null; // will be computed via the collector
-            } else {
-                totalHitsThreshold = 1;
-                totalHits = new TotalHits(hitCount, TotalHits.Relation.EQUAL_TO); // don't compute hit counts via the collector
-            }
-        }
-
-        CollectorManager<TopFieldCollector, TopFieldDocs> sharedManager = TopFieldCollector.createSharedManager(
-            sortAndFormats.sort,
-            numHits,
-            null,
-            totalHitsThreshold
-        );
-
-        List<LeafReaderContext> leaves = new ArrayList<>(searcher.getIndexReader().leaves());
-        leafSorter.accept(leaves);
-        try {
-            Weight weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.TOP_SCORES, 1f);
-            searcher.search(leaves, weight, sharedManager, searchContext.queryResult(), sortAndFormats.formats, totalHits);
-        } catch (TimeExceededException e) {
-            assert timeoutSet : "TimeExceededException thrown even though timeout wasn't set";
-            if (searchContext.request().allowPartialSearchResults() == false) {
-                // Can't rethrow TimeExceededException because not serializable
-                throw new QueryPhaseExecutionException(searchContext.shardTarget(), "Time exceeded");
-            }
-            searchContext.queryResult().searchTimedOut(true);
-        }
-        return false; // no rescoring when sorting by field
-    }
-
-    private static Query tryRewriteLongSort(SearchContext searchContext, IndexReader reader, Query query, boolean hasFilterCollector)
-        throws IOException {
-        if ((searchContext.from() + searchContext.size()) <= 0) return null;
-        if (searchContext.searchAfter() != null) return null; // TODO: handle sort optimization with search after
-        if (searchContext.scrollContext() != null) return null;
-        if (searchContext.collapse() != null) return null;
-        if (searchContext.trackScores()) return null;
-        if (searchContext.aggregations() != null) return null;
+    private static void enhanceSortOnNumeric(SearchContext searchContext, IndexReader reader) {
         if (canEarlyTerminate(reader, searchContext.sort())) {
             // disable this optimization if index sorting matches the query sort since it's already optimized by index searcher
-            return null;
+            return;
         }
         Sort sort = searchContext.sort().sort;
         SortField sortField = sort.getSort()[0];
-        if (SortField.Type.LONG.equals(IndexSortConfig.getSortFieldType(sortField)) == false) return null;
+        if (SortField.Type.LONG.equals(IndexSortConfig.getSortFieldType(sortField)) == false) return;
 
         // check if this is a field of type Long or Date, that is indexed and has doc values
         String fieldName = sortField.getField();
-        if (fieldName == null) return null; // happens when _score or _doc is the 1st sort field
-        if (searchContext.mapperService() == null) return null; // mapperService can be null in tests
+        if (fieldName == null) return; // happens when _score or _doc is the 1st sort field
+        if (searchContext.mapperService() == null) return; // mapperService can be null in tests
         final MappedFieldType fieldType = searchContext.mapperService().fieldType(fieldName);
-        if (fieldType == null) return null; // for unmapped fields, default behaviour depending on "unmapped_type" flag
-        if ((fieldType.typeName().equals("long") == false) && (fieldType instanceof DateFieldType == false)) return null;
-        if (fieldType.isSearchable() == false) return null;
-        if (fieldType.hasDocValues() == false) return null;
-
-        // check that all sorts are actual document fields or _doc
-        for (int i = 1; i < sort.getSort().length; i++) {
-            SortField sField = sort.getSort()[i];
-            String sFieldName = sField.getField();
-            if (sFieldName == null) {
-                if (SortField.FIELD_DOC.equals(sField) == false) return null;
-            } else {
-                // TODO: find out how to cover _script sort that don't use _score
-                if (searchContext.mapperService().fieldType(sFieldName) == null) return null; // could be _script sort that uses _score
-            }
-        }
-
-        // check that setting of missing values allows optimization
-        if (sortField.getMissingValue() == null) return null;
-        Long missingValue = (Long) sortField.getMissingValue();
-        boolean missingValuesAccordingToSort = (sortField.getReverse() && (missingValue == Long.MIN_VALUE))
-            || ((sortField.getReverse() == false) && (missingValue == Long.MAX_VALUE));
-        if (missingValuesAccordingToSort == false) return null;
-
-        int docCount = PointValues.getDocCount(reader, fieldName);
-        // is not worth to run optimization on small index
-        if (docCount <= 512) return null;
-
-        // check for multiple values
-        if (PointValues.size(reader, fieldName) != docCount) return null; // TODO: handle multiple values
-
-        // check if the optimization makes sense with the track_total_hits setting
-        if (searchContext.trackTotalHitsUpTo() == Integer.MAX_VALUE) {
-            // with filter, we can't pre-calculate hitsCount, we need to explicitly calculate them => optimization does't make sense
-            if (hasFilterCollector) return null;
-            // if we can't pre-calculate hitsCount based on the query type, optimization does't make sense
-            if (shortcutTotalHitCount(reader, query) == -1) return null;
-        }
-
-        byte[] minValueBytes = PointValues.getMinPackedValue(reader, fieldName);
-        byte[] maxValueBytes = PointValues.getMaxPackedValue(reader, fieldName);
-        if ((maxValueBytes == null) || (minValueBytes == null)) return null;
-        long minValue = LongPoint.decodeDimension(minValueBytes, 0);
-        long maxValue = LongPoint.decodeDimension(maxValueBytes, 0);
-
-        Query rewrittenQuery;
-        if (minValue == maxValue) {
-            rewrittenQuery = new DocValuesFieldExistsQuery(fieldName);
-        } else {
-            if (indexFieldHasDuplicateData(reader, fieldName)) return null;
-            long origin = (sortField.getReverse()) ? maxValue : minValue;
-            long pivotDistance = (maxValue - minValue) >>> 1; // division by 2 on the unsigned representation to avoid overflow
-            if (pivotDistance == 0) { // 0 if maxValue = (minValue + 1)
-                pivotDistance = 1;
-            }
-            rewrittenQuery = LongPoint.newDistanceFeatureQuery(sortField.getField(), 1, origin, pivotDistance);
-        }
-        rewrittenQuery = new BooleanQuery.Builder().add(query, BooleanClause.Occur.FILTER) // filter for original query
-            .add(rewrittenQuery, BooleanClause.Occur.SHOULD) // should for rewrittenQuery
-            .build();
-        return rewrittenQuery;
-    }
-
-    /**
-     * Creates a sorter of {@link LeafReaderContext} that orders leaves depending on the minimum
-     * value and the sort order of the provided <code>sortField</code>.
-     */
-    static CheckedConsumer<List<LeafReaderContext>, IOException> createLeafSorter(SortField sortField) {
-        return leaves -> {
-            long[] sortValues = new long[leaves.size()];
-            long missingValue = (long) sortField.getMissingValue();
-            for (LeafReaderContext ctx : leaves) {
-                PointValues values = ctx.reader().getPointValues(sortField.getField());
-                if (values == null) {
-                    sortValues[ctx.ord] = missingValue;
-                } else {
-                    byte[] sortValue = sortField.getReverse() ? values.getMaxPackedValue() : values.getMinPackedValue();
-                    sortValues[ctx.ord] = sortValue == null ? missingValue : LongPoint.decodeDimension(sortValue, 0);
-                }
-            }
-            Comparator<LeafReaderContext> comparator = Comparator.comparingLong(l -> sortValues[l.ord]);
-            if (sortField.getReverse()) {
-                comparator = comparator.reversed();
-            }
-            Collections.sort(leaves, comparator);
-        };
-    }
-
-    /**
-     * Restore fieldsDocs to remove the first _score
-     */
-    private static void restoreTopFieldDocs(QuerySearchResult result, SortAndFormats originalSortAndFormats) {
-        TopDocs topDocs = result.topDocs().topDocs;
-        for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
-            FieldDoc fieldDoc = (FieldDoc) scoreDoc;
-            fieldDoc.fields = Arrays.copyOfRange(fieldDoc.fields, 1, fieldDoc.fields.length);
-        }
-        TopFieldDocs newTopDocs = new TopFieldDocs(topDocs.totalHits, topDocs.scoreDocs, originalSortAndFormats.sort.getSort());
-        result.topDocs(new TopDocsAndMaxScore(newTopDocs, Float.NaN), originalSortAndFormats.formats);
+        if (fieldType == null) return; // for unmapped fields, default behaviour depending on "unmapped_type" flag
+        if ((fieldType.typeName().equals("long") == false) && (fieldType instanceof DateFieldType == false)) return;
+        if (fieldType.isSearchable() == false) return;
+        if (fieldType.hasDocValues() == false) return;
+        sortField.setCanUsePoints();
     }
 
     /**
@@ -586,82 +385,6 @@ public class QueryPhase {
             }
         }
         return true;
-    }
-
-    /**
-     * Returns true if more than 50% of data in the index have the same value
-     * The evaluation is approximation based on finding the median value and estimating its count
-     */
-    private static boolean indexFieldHasDuplicateData(IndexReader reader, String field) throws IOException {
-        long docsNoDupl = 0; // number of docs in segments with NO duplicate data that would benefit optimization
-        long docsDupl = 0; // number of docs in segments with duplicate data that would NOT benefit optimization
-        for (LeafReaderContext lrc : reader.leaves()) {
-            PointValues pointValues = lrc.reader().getPointValues(field);
-            if (pointValues == null) continue;
-            int docCount = pointValues.getDocCount();
-            if (docCount <= 512) { // skipping small segments as estimateMedianCount doesn't work well on them
-                continue;
-            }
-            assert (pointValues.size() == docCount); // TODO: modify the code to handle multiple values
-            int duplDocCount = docCount / 2; // expected doc count of duplicate data
-            if (pointsHaveDuplicateData(pointValues, duplDocCount)) {
-                docsDupl += docCount;
-            } else {
-                docsNoDupl += docCount;
-            }
-        }
-        return (docsDupl > docsNoDupl);
-    }
-
-    static boolean pointsHaveDuplicateData(PointValues pointValues, int duplDocCount) throws IOException {
-        long minValue = LongPoint.decodeDimension(pointValues.getMinPackedValue(), 0);
-        long maxValue = LongPoint.decodeDimension(pointValues.getMaxPackedValue(), 0);
-        boolean hasDuplicateData = true;
-        while ((minValue < maxValue) && hasDuplicateData) {
-            long midValue = Math.floorDiv(minValue, 2) + Math.floorDiv(maxValue, 2); // to avoid overflow first divide each value by 2
-            long countLeft = estimatePointCount(pointValues, minValue, midValue);
-            long countRight = estimatePointCount(pointValues, midValue + 1, maxValue);
-            if ((countLeft >= countRight) && (countLeft > duplDocCount)) {
-                maxValue = midValue;
-            } else if ((countRight > countLeft) && (countRight > duplDocCount)) {
-                minValue = midValue + 1;
-            } else {
-                hasDuplicateData = false;
-            }
-        }
-        return hasDuplicateData;
-    }
-
-    private static long estimatePointCount(PointValues pointValues, long minValue, long maxValue) {
-        final byte[] minValueAsBytes = new byte[Long.BYTES];
-        LongPoint.encodeDimension(minValue, minValueAsBytes, 0);
-        final byte[] maxValueAsBytes = new byte[Long.BYTES];
-        LongPoint.encodeDimension(maxValue, maxValueAsBytes, 0);
-
-        PointValues.IntersectVisitor visitor = new PointValues.IntersectVisitor() {
-            @Override
-            public void grow(int count) {}
-
-            @Override
-            public void visit(int docID) {}
-
-            @Override
-            public void visit(int docID, byte[] packedValue) {}
-
-            @Override
-            public PointValues.Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
-                if (FutureArrays.compareUnsigned(minPackedValue, 0, Long.BYTES, maxValueAsBytes, 0, Long.BYTES) > 0
-                    || FutureArrays.compareUnsigned(maxPackedValue, 0, Long.BYTES, minValueAsBytes, 0, Long.BYTES) < 0) {
-                    return PointValues.Relation.CELL_OUTSIDE_QUERY;
-                }
-                if (FutureArrays.compareUnsigned(minPackedValue, 0, Long.BYTES, minValueAsBytes, 0, Long.BYTES) < 0
-                    || FutureArrays.compareUnsigned(maxPackedValue, 0, Long.BYTES, maxValueAsBytes, 0, Long.BYTES) > 0) {
-                    return PointValues.Relation.CELL_CROSSES_QUERY;
-                }
-                return PointValues.Relation.CELL_INSIDE_QUERY;
-            }
-        };
-        return pointValues.estimatePointCount(visitor);
     }
 
     private static class TimeExceededException extends RuntimeException {}

--- a/server/src/main/java/org/opensearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryPhase.java
@@ -152,10 +152,7 @@ public class QueryPhase {
         aggregationPhase.execute(searchContext);
 
         if (searchContext.getProfilers() != null) {
-            ProfileShardResult shardResults = SearchProfileShardResults.buildShardResults(
-                searchContext.getProfilers(),
-                searchContext.request()
-            );
+            ProfileShardResult shardResults = SearchProfileShardResults.buildShardResults(searchContext.getProfilers());
             searchContext.queryResult().profileResults(shardResults);
         }
     }

--- a/test/framework/src/main/java/org/opensearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/opensearch/test/TestSearchContext.java
@@ -109,7 +109,7 @@ public class TestSearchContext extends SearchContext {
     private int terminateAfter = DEFAULT_TERMINATE_AFTER;
     private SearchContextAggregations aggregations;
     private ScrollContext scrollContext;
-
+    private FieldDoc searchAfter;
     private final long originNanoTime = System.nanoTime();
     private final Map<String, SearchExtBuilder> searchExtBuilders = new HashMap<>();
 
@@ -393,13 +393,14 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public SearchContext searchAfter(FieldDoc searchAfter) {
-        return null;
+    public SearchContext searchAfter(FieldDoc searchAfterDoc) {
+        this.searchAfter = searchAfterDoc;
+        return this;
     }
 
     @Override
     public FieldDoc searchAfter() {
-        return null;
+        return searchAfter;
     }
 
     @Override


### PR DESCRIPTION
### Description
This PR is backport of PR #1974. It removes sort optimization code present in OpenSearch because from Lucence 8.10.1, Numeric sort optimization is already done in Lucene Comparators. Now Lucene also supports sort optimization with search_after queries.
 
### Issues Resolved
#1570 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
