### PR TITLE
build: introduce support for reproducible builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -274,6 +274,14 @@ allprojects {
     javadoc.options.addStringOption('Xdoclint:all,-missing', '-quiet')
   }
 
+  // support for reproducible builds
+  tasks.withType(AbstractArchiveTask).configureEach {
+    // ignore file timestamps
+    // be consistent in archive file order
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+  }
+
   project.afterEvaluate {
     // Handle javadoc dependencies across projects. Order matters: the linksOffline for
     // org.opensearch:opensearch must be the last one or all the links for the

--- a/buildSrc/src/main/java/org/opensearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -121,7 +121,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             params.setGradleJavaVersion(Jvm.current().getJavaVersion());
             params.setGitRevision(gitInfo.getRevision());
             params.setGitOrigin(gitInfo.getOrigin());
-            params.setBuildDate(ZonedDateTime.now(ZoneOffset.UTC));
+            params.setBuildDate(Util.getBuildDate(ZonedDateTime.now(ZoneOffset.UTC)));
             params.setTestSeed(getTestSeed());
             params.setIsCi(System.getenv("JENKINS_URL") != null);
             params.setIsInternal(isInternal);

--- a/buildSrc/src/main/java/org/opensearch/gradle/util/Util.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/util/Util.java
@@ -48,6 +48,9 @@ import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -186,5 +189,18 @@ public class Util {
                 return getter.get();
             }
         };
+    }
+
+    public static ZonedDateTime getBuildDate(ZonedDateTime defaultValue) {
+        final String sourceDateEpoch = System.getenv("SOURCE_DATE_EPOCH");
+        if (sourceDateEpoch != null) {
+            try {
+                return ZonedDateTime.ofInstant(Instant.ofEpochSecond(Long.parseLong(sourceDateEpoch)), ZoneOffset.UTC);
+            } catch (NumberFormatException e) {
+                throw new GradleException("Sysprop [SOURCE_DATE_EPOCH] must be of type [long]", e);
+            }
+        } else {
+            return defaultValue;
+        }
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -55,7 +55,6 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.LiveIndexWriterConfig;
-import org.apache.lucene.index.LogByteSizeMergePolicy;
 import org.apache.lucene.index.LogDocMergePolicy;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.NoMergePolicy;


### PR DESCRIPTION
### Description
Add support for reproducible builds

Reproducible builds is an initiative to create an independently-verifiable path from source to binary code [1]. This can be done by:
- Make all archive tasks in gradle reproducible by ignoring timestamp on files [2]
- Preserve the order in side the archives [2]
- Ensure GlobalBuildInfoPlugin.java use [SOURCE_DATE_EPOCH] when available

[SOURCE_DATE_EPOCH]: https://reproducible-builds.org/docs/source-date-epoch/
[1]: https://reproducible-builds.org/
[2]: https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives

### Issues Resolved
N/A
 
### Check List
- [-] New functionality includes testing.
  - [-] All tests pass
- [x] New functionality has been documented.
  - [-] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
