### PR TITLE
[PLEASE DO NOT REVIEW] Another attempt to fix o.o.transport.netty4.OpenSearchLoggingHandlerIT fails w/ stack overflow

### DIFF
--- a/test/framework/src/main/java/org/opensearch/test/MockLogAppender.java
+++ b/test/framework/src/main/java/org/opensearch/test/MockLogAppender.java
@@ -97,7 +97,14 @@ public class MockLogAppender extends AbstractAppender implements AutoCloseable {
     @Override
     public void append(LogEvent event) {
         for (LoggingExpectation expectation : expectations) {
-            expectation.match(event);
+            try {
+                expectation.match(event);
+            } catch (final StackOverflowError ex) {
+                System.err.println("StackOverflowError while checking: " + expectation.getClass().getName());
+                System.err.println("Event format: " + event.getMessage().getFormat());
+                System.err.println("Event: " + event.getMessage().getFormattedMessage());
+                throw ex;
+            }
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Another attempt to fix o.o.transport.netty4.OpenSearchLoggingHandlerIT fails w/ stack overflow, trying to pinpoint the exact place where StackOverflowError is happening.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
