### PR TITLE
[BUG] Docker distribution builds are failing. Switching to http://vault.centos.org

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -63,7 +63,9 @@ FROM ${base_image}
 
 ENV OPENSEARCH_CONTAINER true
 
-RUN for iter in {1..10}; do \\
+RUN  sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \\
+     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-* && \\
+     for iter in {1..10}; do \\
       ${package_manager} update --setopt=tsflags=nodocs -y && \\
       ${package_manager} install --setopt=tsflags=nodocs -y \\
         nc shadow-utils zip unzip && \\


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Docker distribution builds are failing across the board

```
CentOS Linux 8 - AppStream                      144  B/s |  38  B     00:00    
| �[91mError: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
| �[0myum error: retry 1 in 10s
| CentOS Linux 8 - AppStream                      176  B/s |  38  B     00:00    
| �[91mError: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
| �[0myum error: retry 2 in 10s
| CentOS Linux 8 - AppStream                      228  B/s |  38  B     00:00    
| �[91mError: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
| �[0myum error: retry 3 in 10s
| CentOS Linux 8 - AppStream                      209  B/s |  38  B     00:00    
| �[91mError: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
| �[0myum error: retry 4 in 10s
| CentOS Linux 8 - AppStream                      405  B/s |  38  B     00:00    
| �[91mError: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
| �[0myum error: retry 5 in 10s
| CentOS Linux 8 - AppStream                       86  B/s |  38  B     00:00    
| �[91mError: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
| �[0myum error: retry 6 in 10s

```
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/2023
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
