### PR TITLE
[Backport 1.2] Docker distribution builds are failing. Switching to http://vault.centos.org

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -63,7 +63,9 @@ FROM ${base_image}
 
 ENV OPENSEARCH_CONTAINER true
 
-RUN for iter in {1..10}; do \\
+RUN  sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \\
+     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-* && \\
+     for iter in {1..10}; do \\
       ${package_manager} update --setopt=tsflags=nodocs -y && \\
       ${package_manager} install --setopt=tsflags=nodocs -y \\
         nc shadow-utils zip unzip && \\


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Backport of https://github.com/opensearch-project/OpenSearch/pull/2024 to the 1.2 branch.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/2023
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
