### PR TITLE
Upgrading Shadow plugin to 7.1.2

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -111,7 +111,7 @@ dependencies {
   api 'org.apache.rat:apache-rat:0.13'
   api 'commons-io:commons-io:2.7'
   api "net.java.dev.jna:jna:5.5.0"
-  api 'com.github.jengelman.gradle.plugins:shadow:6.0.0'
+  api 'gradle.plugin.com.github.johnrengelman:shadow:7.1.2'
   api 'de.thetaphi:forbiddenapis:3.0'
   api 'com.avast.gradle:gradle-docker-compose-plugin:0.14.12'
   api 'org.apache.maven:maven-model:3.6.2'

--- a/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchTestBasePlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchTestBasePlugin.java
@@ -217,7 +217,7 @@ public class OpenSearchTestBasePlugin implements Plugin<Project> {
                     .getByName(SourceSet.MAIN_SOURCE_SET_NAME)
                     .getRuntimeClasspath();
                 // Add any "shadow" dependencies. These are dependencies that are *not* bundled into the shadow JAR
-                Configuration shadowConfig = project.getConfigurations().getByName(ShadowBasePlugin.getCONFIGURATION_NAME());
+                Configuration shadowConfig = project.getConfigurations().getByName(ShadowBasePlugin.CONFIGURATION_NAME);
                 // Add the shadow JAR artifact itself
                 FileCollection shadowJar = project.files(project.getTasks().named("shadowJar"));
 

--- a/buildSrc/src/main/java/org/opensearch/gradle/PublishPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/PublishPlugin.java
@@ -107,7 +107,7 @@ public class PublishPlugin implements Plugin<Project> {
                 root.appendNode("name", project.getName());
                 root.appendNode("description", project.getDescription());
                 Node dependenciesNode = (Node) ((NodeList) root.get("dependencies")).get(0);
-                project.getConfigurations().getByName(ShadowBasePlugin.getCONFIGURATION_NAME()).getAllDependencies().all(dependency -> {
+                project.getConfigurations().getByName(ShadowBasePlugin.CONFIGURATION_NAME).getAllDependencies().all(dependency -> {
                     if (dependency instanceof ProjectDependency) {
                         Node dependencyNode = dependenciesNode.appendNode("dependency");
                         dependencyNode.appendNode("groupId", dependency.getGroup());


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Upgrading Shadow gradle plugin to 7.1.2.
Shadow plugin is used for publishing jars
and this upgrades Log4J dependency for build.
Ref: https://github.com/johnrengelman/shadow/releases/tag/7.1.2
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
