### PR TITLE
[Backport] [1.2] [FEATURE] Add OPENSEARCH_JAVA_HOME env to override JAVA_HOME (#2040)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -484,6 +484,7 @@ def sh_install_deps(config,
     cat \<\<SUDOERS_VARS > /etc/sudoers.d/opensearch_vars
 Defaults   env_keep += "JAVA_HOME"
 Defaults   env_keep += "SYSTEM_JAVA_HOME"
+Defaults   env_keep += "OPENSEARCH_JAVA_HOME"
 SUDOERS_VARS
     chmod 0440 /etc/sudoers.d/opensearch_vars
   SHELL

--- a/distribution/packages/src/common/env/opensearch
+++ b/distribution/packages/src/common/env/opensearch
@@ -6,7 +6,7 @@
 #OPENSEARCH_HOME=/usr/share/opensearch
 
 # OpenSearch Java path
-#JAVA_HOME=
+#OPENSEARCH_JAVA_HOME=
 
 # OpenSearch configuration directory
 # Note: this setting will be shared with command-line tools

--- a/distribution/packages/src/deb/init.d/opensearch
+++ b/distribution/packages/src/deb/init.d/opensearch
@@ -66,8 +66,9 @@ DAEMON=$OPENSEARCH_HOME/bin/opensearch
 DAEMON_OPTS="-d -p $PID_FILE"
 
 export OPENSEARCH_JAVA_OPTS
-export JAVA_HOME
 export OPENSEARCH_PATH_CONF
+export JAVA_HOME
+export OPENSEARCH_JAVA_HOME
 
 if [ ! -x "$DAEMON" ]; then
 	echo "The opensearch startup script does not exists or it is not executable, tried: $DAEMON"

--- a/distribution/packages/src/rpm/init.d/opensearch
+++ b/distribution/packages/src/rpm/init.d/opensearch
@@ -53,6 +53,7 @@ export OPENSEARCH_JAVA_OPTS
 export JAVA_HOME
 export OPENSEARCH_PATH_CONF
 export OPENSEARCH_STARTUP_SLEEP_TIME
+export OPENSEARCH_JAVA_HOME
 
 lockfile=/var/lock/subsys/$prog
 

--- a/distribution/src/bin/opensearch-env
+++ b/distribution/src/bin/opensearch-env
@@ -35,8 +35,11 @@ OPENSEARCH_HOME=`dirname "$OPENSEARCH_HOME"`
 # now set the classpath
 OPENSEARCH_CLASSPATH="$OPENSEARCH_HOME/lib/*"
 
-# now set the path to java
-if [ ! -z "$JAVA_HOME" ]; then
+# now set the path to java: OPENSEARCH_JAVA_HOME -> JAVA_HOME -> bundled JDK
+if [ ! -z "$OPENSEARCH_JAVA_HOME" ]; then
+  JAVA="$OPENSEARCH_JAVA_HOME/bin/java"
+  JAVA_TYPE="OPENSEARCH_JAVA_HOME"
+elif [ ! -z "$JAVA_HOME" ]; then
   JAVA="$JAVA_HOME/bin/java"
   JAVA_TYPE="JAVA_HOME"
 else

--- a/distribution/src/bin/opensearch-env.bat
+++ b/distribution/src/bin/opensearch-env.bat
@@ -39,16 +39,19 @@ if "%1" == "nojava" (
    exit /b
 )
 
-rem compariing to empty string makes this equivalent to bash -v check on env var
+rem comparing to empty string makes this equivalent to bash -v check on env var
 rem and allows to effectively force use of the bundled jdk when launching OpenSearch
-rem by setting JAVA_HOME=
-if "%JAVA_HOME%" == "" (
+rem by setting OPENSEARCH_JAVA_HOME= and JAVA_HOME= 
+if not "%OPENSEARCH_JAVA_HOME%" == "" (
+  set JAVA="%OPENSEARCH_JAVA_HOME%\bin\java.exe"
+  set JAVA_TYPE=OPENSEARCH_JAVA_HOME 
+) else if not "%JAVA_HOME%" == "" (
+  set JAVA="%JAVA_HOME%\bin\java.exe"
+  set JAVA_TYPE=JAVA_HOME
+) else (
   set JAVA="%OPENSEARCH_HOME%\jdk\bin\java.exe"
   set JAVA_HOME="%OPENSEARCH_HOME%\jdk"
   set JAVA_TYPE=bundled jdk
-) else (
-  set JAVA="%JAVA_HOME%\bin\java.exe"
-  set JAVA_TYPE=JAVA_HOME
 )
 
 if not exist !JAVA! (

--- a/qa/os/src/test/java/org/opensearch/packaging/test/PackagingTestCase.java
+++ b/qa/os/src/test/java/org/opensearch/packaging/test/PackagingTestCase.java
@@ -33,6 +33,7 @@
 package org.opensearch.packaging.test;
 
 import com.carrotsearch.randomizedtesting.JUnit3MethodProvider;
+import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.carrotsearch.randomizedtesting.RandomizedRunner;
 import com.carrotsearch.randomizedtesting.annotations.TestCaseOrdering;
 import com.carrotsearch.randomizedtesting.annotations.TestGroup;
@@ -182,9 +183,17 @@ public abstract class PackagingTestCase extends Assert {
 
         sh.reset();
         if (distribution().hasJdk == false) {
-            Platforms.onLinux(() -> sh.getEnv().put("JAVA_HOME", systemJavaHome));
-            Platforms.onWindows(() -> sh.getEnv().put("JAVA_HOME", systemJavaHome));
+            // Randomly switch between JAVA_HOME and OPENSEARCH_JAVA_HOME
+            final String javaHomeEnv = randomBoolean() ? "JAVA_HOME" : "OPENSEARCH_JAVA_HOME";
+            logger.info("Using " + javaHomeEnv);
+
+            Platforms.onLinux(() -> sh.getEnv().put(javaHomeEnv, systemJavaHome));
+            Platforms.onWindows(() -> sh.getEnv().put(javaHomeEnv, systemJavaHome));
         }
+    }
+
+    private boolean randomBoolean() {
+        return RandomizedContext.current().getRandom().nextBoolean();
     }
 
     @After


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Backport of https://github.com/opensearch-project/OpenSearch/pull/2040 to 1.2
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/1872
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
