### PR TITLE
[Backport 1.x] Support first and last parameter for missing bucket ordering in composite aggregation

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeAggregator.java
@@ -70,6 +70,7 @@ import org.opensearch.search.aggregations.LeafBucketCollector;
 import org.opensearch.search.aggregations.MultiBucketCollector;
 import org.opensearch.search.aggregations.MultiBucketConsumerService;
 import org.opensearch.search.aggregations.bucket.BucketsAggregator;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.searchafter.SearchAfterBuilder;
 import org.opensearch.search.sort.SortAndFormats;
@@ -89,6 +90,7 @@ final class CompositeAggregator extends BucketsAggregator {
     private final int size;
     private final List<String> sourceNames;
     private final int[] reverseMuls;
+    private final MissingOrder[] missingOrders;
     private final List<DocValueFormat> formats;
     private final CompositeKey rawAfterKey;
 
@@ -117,6 +119,7 @@ final class CompositeAggregator extends BucketsAggregator {
         this.size = size;
         this.sourceNames = Arrays.stream(sourceConfigs).map(CompositeValuesSourceConfig::name).collect(Collectors.toList());
         this.reverseMuls = Arrays.stream(sourceConfigs).mapToInt(CompositeValuesSourceConfig::reverseMul).toArray();
+        this.missingOrders = Arrays.stream(sourceConfigs).map(CompositeValuesSourceConfig::missingOrder).toArray(MissingOrder[]::new);
         this.formats = Arrays.stream(sourceConfigs).map(CompositeValuesSourceConfig::format).collect(Collectors.toList());
         this.sources = new SingleDimensionValuesSource[sourceConfigs.length];
         // check that the provided size is not greater than the search.max_buckets setting
@@ -189,7 +192,15 @@ final class CompositeAggregator extends BucketsAggregator {
             CompositeKey key = queue.toCompositeKey(slot);
             InternalAggregations aggs = subAggsForBuckets[slot];
             int docCount = queue.getDocCount(slot);
-            buckets[queue.size()] = new InternalComposite.InternalBucket(sourceNames, formats, key, reverseMuls, docCount, aggs);
+            buckets[queue.size()] = new InternalComposite.InternalBucket(
+                sourceNames,
+                formats,
+                key,
+                reverseMuls,
+                missingOrders,
+                docCount,
+                aggs
+            );
         }
         CompositeKey lastBucket = num > 0 ? buckets[num - 1].getRawKey() : null;
         return new InternalAggregation[] {
@@ -201,6 +212,7 @@ final class CompositeAggregator extends BucketsAggregator {
                 Arrays.asList(buckets),
                 lastBucket,
                 reverseMuls,
+                missingOrders,
                 earlyTerminated,
                 metadata()
             ) };
@@ -208,7 +220,18 @@ final class CompositeAggregator extends BucketsAggregator {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalComposite(name, size, sourceNames, formats, Collections.emptyList(), null, reverseMuls, false, metadata());
+        return new InternalComposite(
+            name,
+            size,
+            sourceNames,
+            formats,
+            Collections.emptyList(),
+            null,
+            reverseMuls,
+            missingOrders,
+            false,
+            metadata()
+        );
     }
 
     private void finishLeaf() {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesSourceConfig.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesSourceConfig.java
@@ -37,6 +37,7 @@ import org.opensearch.common.Nullable;
 import org.opensearch.common.util.BigArrays;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.search.aggregations.support.ValuesSource;
 import org.opensearch.search.sort.SortOrder;
 
@@ -62,6 +63,7 @@ public class CompositeValuesSourceConfig {
     private final DocValueFormat format;
     private final int reverseMul;
     private final boolean missingBucket;
+    private final MissingOrder missingOrder;
     private final boolean hasScript;
     private final SingleDimensionValuesSourceProvider singleDimensionValuesSourceProvider;
 
@@ -83,6 +85,7 @@ public class CompositeValuesSourceConfig {
         DocValueFormat format,
         SortOrder order,
         boolean missingBucket,
+        MissingOrder missingOrder,
         boolean hasScript,
         SingleDimensionValuesSourceProvider singleDimensionValuesSourceProvider
     ) {
@@ -94,6 +97,7 @@ public class CompositeValuesSourceConfig {
         this.missingBucket = missingBucket;
         this.hasScript = hasScript;
         this.singleDimensionValuesSourceProvider = singleDimensionValuesSourceProvider;
+        this.missingOrder = missingOrder;
     }
 
     /**
@@ -130,6 +134,13 @@ public class CompositeValuesSourceConfig {
      */
     boolean missingBucket() {
         return missingBucket;
+    }
+
+    /**
+     * Return the {@link MissingOrder} for the config.
+     */
+    MissingOrder missingOrder() {
+        return missingOrder;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesSourceParserHelper.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesSourceParserHelper.java
@@ -43,6 +43,7 @@ import org.opensearch.common.xcontent.ToXContent.Params;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.script.Script;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.search.aggregations.support.ValueType;
 
 import java.io.IOException;
@@ -54,6 +55,7 @@ public class CompositeValuesSourceParserHelper {
     static <VB extends CompositeValuesSourceBuilder<VB>, T> void declareValuesSourceFields(AbstractObjectParser<VB, T> objectParser) {
         objectParser.declareField(VB::field, XContentParser::text, new ParseField("field"), ObjectParser.ValueType.STRING);
         objectParser.declareBoolean(VB::missingBucket, new ParseField("missing_bucket"));
+        objectParser.declareString(VB::missingOrder, new ParseField(MissingOrder.NAME));
 
         objectParser.declareField(VB::userValuetypeHint, p -> {
             ValueType valueType = ValueType.lenientParse(p.text());

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/DateHistogramValuesSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/DateHistogramValuesSourceBuilder.java
@@ -52,6 +52,7 @@ import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval
 import org.opensearch.search.aggregations.bucket.histogram.DateIntervalConsumer;
 import org.opensearch.search.aggregations.bucket.histogram.DateIntervalWrapper;
 import org.opensearch.search.aggregations.bucket.histogram.Histogram;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.search.aggregations.support.CoreValuesSourceType;
 import org.opensearch.search.aggregations.support.ValuesSource;
 import org.opensearch.search.aggregations.support.ValuesSourceConfig;
@@ -81,6 +82,7 @@ public class DateHistogramValuesSourceBuilder extends CompositeValuesSourceBuild
             boolean hasScript, // probably redundant with the config, but currently we check this two different ways...
             String format,
             boolean missingBucket,
+            MissingOrder missingOrder,
             SortOrder order
         );
     }
@@ -288,7 +290,7 @@ public class DateHistogramValuesSourceBuilder extends CompositeValuesSourceBuild
         builder.register(
             REGISTRY_KEY,
             org.opensearch.common.collect.List.of(CoreValuesSourceType.DATE, CoreValuesSourceType.NUMERIC),
-            (valuesSourceConfig, rounding, name, hasScript, format, missingBucket, order) -> {
+            (valuesSourceConfig, rounding, name, hasScript, format, missingBucket, missingOrder, order) -> {
                 ValuesSource.Numeric numeric = (ValuesSource.Numeric) valuesSourceConfig.getValuesSource();
                 // TODO once composite is plugged in to the values source registry or at least understands Date values source types use it
                 // here
@@ -304,6 +306,7 @@ public class DateHistogramValuesSourceBuilder extends CompositeValuesSourceBuild
                     docValueFormat,
                     order,
                     missingBucket,
+                    missingOrder,
                     hasScript,
                     (
                         BigArrays bigArrays,
@@ -319,6 +322,7 @@ public class DateHistogramValuesSourceBuilder extends CompositeValuesSourceBuild
                             roundingValuesSource::round,
                             compositeValuesSourceConfig.format(),
                             compositeValuesSourceConfig.missingBucket(),
+                            compositeValuesSourceConfig.missingOrder(),
                             size,
                             compositeValuesSourceConfig.reverseMul()
                         );
@@ -339,6 +343,6 @@ public class DateHistogramValuesSourceBuilder extends CompositeValuesSourceBuild
         Rounding rounding = dateHistogramInterval.createRounding(timeZone(), offset);
         return queryShardContext.getValuesSourceRegistry()
             .getAggregator(REGISTRY_KEY, config)
-            .apply(config, rounding, name, config.script() != null, format(), missingBucket(), order());
+            .apply(config, rounding, name, config.script() != null, format(), missingBucket(), missingOrder(), order());
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/GeoTileGridValuesSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/GeoTileGridValuesSourceBuilder.java
@@ -49,6 +49,7 @@ import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.bucket.geogrid.CellIdSource;
 import org.opensearch.search.aggregations.bucket.geogrid.GeoTileGridAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.geogrid.GeoTileUtils;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.search.aggregations.support.CoreValuesSourceType;
 import org.opensearch.search.aggregations.support.ValuesSource;
 import org.opensearch.search.aggregations.support.ValuesSourceConfig;
@@ -72,6 +73,7 @@ public class GeoTileGridValuesSourceBuilder extends CompositeValuesSourceBuilder
             boolean hasScript, // probably redundant with the config, but currently we check this two different ways...
             String format,
             boolean missingBucket,
+            MissingOrder missingOrder,
             SortOrder order
         );
     }
@@ -103,7 +105,7 @@ public class GeoTileGridValuesSourceBuilder extends CompositeValuesSourceBuilder
         builder.register(
             REGISTRY_KEY,
             CoreValuesSourceType.GEOPOINT,
-            (valuesSourceConfig, precision, boundingBox, name, hasScript, format, missingBucket, order) -> {
+            (valuesSourceConfig, precision, boundingBox, name, hasScript, format, missingBucket, missingOrder, order) -> {
                 ValuesSource.GeoPoint geoPoint = (ValuesSource.GeoPoint) valuesSourceConfig.getValuesSource();
                 // is specified in the builder.
                 final MappedFieldType fieldType = valuesSourceConfig.fieldType();
@@ -115,6 +117,7 @@ public class GeoTileGridValuesSourceBuilder extends CompositeValuesSourceBuilder
                     DocValueFormat.GEOTILE,
                     order,
                     missingBucket,
+                    missingOrder,
                     hasScript,
                     (
                         BigArrays bigArrays,
@@ -132,6 +135,7 @@ public class GeoTileGridValuesSourceBuilder extends CompositeValuesSourceBuilder
                             LongUnaryOperator.identity(),
                             compositeValuesSourceConfig.format(),
                             compositeValuesSourceConfig.missingBucket(),
+                            compositeValuesSourceConfig.missingOrder(),
                             size,
                             compositeValuesSourceConfig.reverseMul()
                         );
@@ -220,7 +224,7 @@ public class GeoTileGridValuesSourceBuilder extends CompositeValuesSourceBuilder
     protected CompositeValuesSourceConfig innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config) throws IOException {
         return queryShardContext.getValuesSourceRegistry()
             .getAggregator(REGISTRY_KEY, config)
-            .apply(config, precision, geoBoundingBox(), name, script() != null, format(), missingBucket(), order());
+            .apply(config, precision, geoBoundingBox(), name, script() != null, format(), missingBucket(), missingOrder(), order());
     }
 
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/GeoTileValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/GeoTileValuesSource.java
@@ -39,6 +39,7 @@ import org.opensearch.common.util.BigArrays;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.bucket.geogrid.GeoTileUtils;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 
 import java.io.IOException;
 import java.util.function.LongUnaryOperator;
@@ -57,10 +58,11 @@ class GeoTileValuesSource extends LongValuesSource {
         LongUnaryOperator rounding,
         DocValueFormat format,
         boolean missingBucket,
+        MissingOrder missingOrder,
         int size,
         int reverseMul
     ) {
-        super(bigArrays, fieldType, docValuesFunc, rounding, format, missingBucket, size, reverseMul);
+        super(bigArrays, fieldType, docValuesFunc, rounding, format, missingBucket, missingOrder, size, reverseMul);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/GlobalOrdinalValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/GlobalOrdinalValuesSource.java
@@ -46,6 +46,7 @@ import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.StringFieldType;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.LeafBucketCollector;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 
 import java.io.IOException;
 
@@ -71,10 +72,11 @@ class GlobalOrdinalValuesSource extends SingleDimensionValuesSource<BytesRef> {
         CheckedFunction<LeafReaderContext, SortedSetDocValues, IOException> docValuesFunc,
         DocValueFormat format,
         boolean missingBucket,
+        MissingOrder missingOrder,
         int size,
         int reverseMul
     ) {
-        super(bigArrays, format, type, missingBucket, size, reverseMul);
+        super(bigArrays, format, type, missingBucket, missingOrder, size, reverseMul);
         this.docValuesFunc = docValuesFunc;
         this.values = bigArrays.newLongArray(Math.min(size, 100), false);
     }
@@ -87,16 +89,34 @@ class GlobalOrdinalValuesSource extends SingleDimensionValuesSource<BytesRef> {
 
     @Override
     int compare(int from, int to) {
+        if (missingBucket) {
+            int result = missingOrder.compare(() -> values.get(from) == -1, () -> values.get(to) == -1, reverseMul);
+            if (MissingOrder.unknownOrder(result) == false) {
+                return result;
+            }
+        }
         return Long.compare(values.get(from), values.get(to)) * reverseMul;
     }
 
     @Override
     int compareCurrent(int slot) {
+        if (missingBucket) {
+            int result = missingOrder.compare(() -> currentValue == -1, () -> values.get(slot) == -1, reverseMul);
+            if (MissingOrder.unknownOrder(result) == false) {
+                return result;
+            }
+        }
         return Long.compare(currentValue, values.get(slot)) * reverseMul;
     }
 
     @Override
     int compareCurrentWithAfter() {
+        if (missingBucket) {
+            int result = missingOrder.compare(() -> currentValue == -1, () -> afterValueGlobalOrd == -1, reverseMul);
+            if (MissingOrder.unknownOrder(result) == false) {
+                return result;
+            }
+        }
         int cmp = Long.compare(currentValue, afterValueGlobalOrd);
         if (cmp == 0 && isTopValueInsertionPoint) {
             // the top value is missing in this shard, the comparison is against

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/HistogramValuesSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/HistogramValuesSourceBuilder.java
@@ -42,6 +42,7 @@ import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.search.aggregations.bucket.histogram.Histogram;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.search.aggregations.support.CoreValuesSourceType;
 import org.opensearch.search.aggregations.support.ValuesSource;
 import org.opensearch.search.aggregations.support.ValuesSourceConfig;
@@ -67,6 +68,7 @@ public class HistogramValuesSourceBuilder extends CompositeValuesSourceBuilder<H
             boolean hasScript, // probably redundant with the config, but currently we check this two different ways...
             String format,
             boolean missingBucket,
+            MissingOrder missingOrder,
             SortOrder order
         );
     }
@@ -92,7 +94,7 @@ public class HistogramValuesSourceBuilder extends CompositeValuesSourceBuilder<H
         builder.register(
             REGISTRY_KEY,
             org.opensearch.common.collect.List.of(CoreValuesSourceType.DATE, CoreValuesSourceType.NUMERIC),
-            (valuesSourceConfig, interval, name, hasScript, format, missingBucket, order) -> {
+            (valuesSourceConfig, interval, name, hasScript, format, missingBucket, missingOrder, order) -> {
                 ValuesSource.Numeric numeric = (ValuesSource.Numeric) valuesSourceConfig.getValuesSource();
                 final HistogramValuesSource vs = new HistogramValuesSource(numeric, interval);
                 final MappedFieldType fieldType = valuesSourceConfig.fieldType();
@@ -103,6 +105,7 @@ public class HistogramValuesSourceBuilder extends CompositeValuesSourceBuilder<H
                     valuesSourceConfig.format(),
                     order,
                     missingBucket,
+                    missingOrder,
                     hasScript,
                     (
                         BigArrays bigArrays,
@@ -117,6 +120,7 @@ public class HistogramValuesSourceBuilder extends CompositeValuesSourceBuilder<H
                             numericValuesSource::doubleValues,
                             compositeValuesSourceConfig.format(),
                             compositeValuesSourceConfig.missingBucket(),
+                            compositeValuesSourceConfig.missingOrder(),
                             size,
                             compositeValuesSourceConfig.reverseMul()
                         );
@@ -194,6 +198,6 @@ public class HistogramValuesSourceBuilder extends CompositeValuesSourceBuilder<H
     protected CompositeValuesSourceConfig innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config) throws IOException {
         return queryShardContext.getValuesSourceRegistry()
             .getAggregator(REGISTRY_KEY, config)
-            .apply(config, interval, name, script() != null, format(), missingBucket(), order());
+            .apply(config, interval, name, script() != null, format(), missingBucket(), missingOrder(), order());
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -34,6 +34,7 @@ package org.opensearch.search.aggregations.bucket.composite;
 
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.LegacyESVersion;
+import org.opensearch.Version;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -43,6 +44,7 @@ import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregations;
 import org.opensearch.search.aggregations.InternalMultiBucketAggregation;
 import org.opensearch.search.aggregations.KeyComparable;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 
 import java.io.IOException;
 import java.util.AbstractMap;
@@ -64,6 +66,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
     private final List<InternalBucket> buckets;
     private final CompositeKey afterKey;
     private final int[] reverseMuls;
+    private final MissingOrder[] missingOrders;
     private final List<String> sourceNames;
     private final List<DocValueFormat> formats;
 
@@ -77,6 +80,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         List<InternalBucket> buckets,
         CompositeKey afterKey,
         int[] reverseMuls,
+        MissingOrder[] missingOrders,
         boolean earlyTerminated,
         Map<String, Object> metadata
     ) {
@@ -87,6 +91,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         this.afterKey = afterKey;
         this.size = size;
         this.reverseMuls = reverseMuls;
+        this.missingOrders = missingOrders;
         this.earlyTerminated = earlyTerminated;
     }
 
@@ -103,7 +108,13 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
             }
         }
         this.reverseMuls = in.readIntArray();
-        this.buckets = in.readList((input) -> new InternalBucket(input, sourceNames, formats, reverseMuls));
+        if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
+            this.missingOrders = in.readArray(MissingOrder::readFromStream, MissingOrder[]::new);
+        } else {
+            this.missingOrders = new MissingOrder[reverseMuls.length];
+            Arrays.fill(this.missingOrders, MissingOrder.DEFAULT);
+        }
+        this.buckets = in.readList((input) -> new InternalBucket(input, sourceNames, formats, reverseMuls, missingOrders));
         if (in.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
             this.afterKey = in.readBoolean() ? new CompositeKey(in) : null;
         } else {
@@ -122,6 +133,9 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
             }
         }
         out.writeIntArray(reverseMuls);
+        if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
+            out.writeArray((output, order) -> order.writeTo(output), missingOrders);
+        }
         out.writeList(buckets);
         if (out.getVersion().onOrAfter(LegacyESVersion.V_6_3_0)) {
             out.writeBoolean(afterKey != null);
@@ -129,6 +143,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
                 afterKey.writeTo(out);
             }
         }
+
         if (out.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
             out.writeBoolean(earlyTerminated);
         }
@@ -151,7 +166,18 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
          * keep the <code>afterKey</code> of the original aggregation in order
          * to be able to retrieve the next page even if all buckets have been filtered.
          */
-        return new InternalComposite(name, size, sourceNames, formats, newBuckets, afterKey, reverseMuls, earlyTerminated, getMetadata());
+        return new InternalComposite(
+            name,
+            size,
+            sourceNames,
+            formats,
+            newBuckets,
+            afterKey,
+            reverseMuls,
+            missingOrders,
+            earlyTerminated,
+            getMetadata()
+        );
     }
 
     @Override
@@ -161,6 +187,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
             prototype.formats,
             prototype.key,
             prototype.reverseMuls,
+            prototype.missingOrders,
             prototype.docCount,
             aggregations
         );
@@ -246,7 +273,18 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
             lastKey = lastBucket.getRawKey();
         }
         reduceContext.consumeBucketsAndMaybeBreak(result.size());
-        return new InternalComposite(name, size, sourceNames, reducedFormats, result, lastKey, reverseMuls, earlyTerminated, metadata);
+        return new InternalComposite(
+            name,
+            size,
+            sourceNames,
+            reducedFormats,
+            result,
+            lastKey,
+            reverseMuls,
+            missingOrders,
+            earlyTerminated,
+            metadata
+        );
     }
 
     @Override
@@ -264,7 +302,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
          * just whatever formats make sense for *its* index. This can be real
          * trouble when the index doing the reducing is unmapped. */
         List<DocValueFormat> reducedFormats = buckets.get(0).formats;
-        return new InternalBucket(sourceNames, reducedFormats, buckets.get(0).key, reverseMuls, docCount, aggs);
+        return new InternalBucket(sourceNames, reducedFormats, buckets.get(0).key, reverseMuls, missingOrders, docCount, aggs);
     }
 
     @Override
@@ -277,12 +315,13 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         return Objects.equals(size, that.size)
             && Objects.equals(buckets, that.buckets)
             && Objects.equals(afterKey, that.afterKey)
-            && Arrays.equals(reverseMuls, that.reverseMuls);
+            && Arrays.equals(reverseMuls, that.reverseMuls)
+            && Arrays.equals(missingOrders, that.missingOrders);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), size, buckets, afterKey, Arrays.hashCode(reverseMuls));
+        return Objects.hash(super.hashCode(), size, buckets, afterKey, Arrays.hashCode(reverseMuls), Arrays.hashCode(missingOrders));
     }
 
     private static class BucketIterator implements Comparable<BucketIterator> {
@@ -312,6 +351,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         private final long docCount;
         private final InternalAggregations aggregations;
         private final transient int[] reverseMuls;
+        private final transient MissingOrder[] missingOrders;
         private final transient List<String> sourceNames;
         private final transient List<DocValueFormat> formats;
 
@@ -320,6 +360,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
             List<DocValueFormat> formats,
             CompositeKey key,
             int[] reverseMuls,
+            MissingOrder[] missingOrders,
             long docCount,
             InternalAggregations aggregations
         ) {
@@ -327,15 +368,23 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
             this.docCount = docCount;
             this.aggregations = aggregations;
             this.reverseMuls = reverseMuls;
+            this.missingOrders = missingOrders;
             this.sourceNames = sourceNames;
             this.formats = formats;
         }
 
-        InternalBucket(StreamInput in, List<String> sourceNames, List<DocValueFormat> formats, int[] reverseMuls) throws IOException {
+        InternalBucket(
+            StreamInput in,
+            List<String> sourceNames,
+            List<DocValueFormat> formats,
+            int[] reverseMuls,
+            MissingOrder[] missingOrders
+        ) throws IOException {
             this.key = new CompositeKey(in);
             this.docCount = in.readVLong();
             this.aggregations = InternalAggregations.readFrom(in);
             this.reverseMuls = reverseMuls;
+            this.missingOrders = missingOrders;
             this.sourceNames = sourceNames;
             this.formats = formats;
         }
@@ -411,13 +460,15 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         @Override
         public int compareKey(InternalBucket other) {
             for (int i = 0; i < key.size(); i++) {
-                if (key.get(i) == null) {
-                    if (other.key.get(i) == null) {
+                // lambda function require final variable.
+                final int index = i;
+                int result = missingOrders[i].compare(() -> key.get(index) == null, () -> other.key.get(index) == null, reverseMuls[i]);
+                if (MissingOrder.unknownOrder(result) == false) {
+                    if (result == 0) {
                         continue;
+                    } else {
+                        return result;
                     }
-                    return -1 * reverseMuls[i];
-                } else if (other.key.get(i) == null) {
-                    return reverseMuls[i];
                 }
                 assert key.get(i).getClass() == other.key.get(i).getClass();
                 @SuppressWarnings("unchecked")

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/TermsValuesSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/TermsValuesSourceBuilder.java
@@ -43,6 +43,7 @@ import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.script.Script;
 import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.search.aggregations.support.CoreValuesSourceType;
 import org.opensearch.search.aggregations.support.ValuesSource;
 import org.opensearch.search.aggregations.support.ValuesSourceConfig;
@@ -68,6 +69,7 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
             boolean hasScript, // probably redundant with the config, but currently we check this two different ways...
             String format,
             boolean missingBucket,
+            MissingOrder missingOrder,
             SortOrder order
         );
     }
@@ -111,7 +113,7 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
         builder.register(
             REGISTRY_KEY,
             org.opensearch.common.collect.List.of(CoreValuesSourceType.DATE, CoreValuesSourceType.NUMERIC, CoreValuesSourceType.BOOLEAN),
-            (valuesSourceConfig, name, hasScript, format, missingBucket, order) -> {
+            (valuesSourceConfig, name, hasScript, format, missingBucket, missingOrder, order) -> {
                 final DocValueFormat docValueFormat;
                 if (format == null && valuesSourceConfig.valueSourceType() == CoreValuesSourceType.DATE) {
                     // defaults to the raw format on date fields (preserve timestamp as longs).
@@ -126,6 +128,7 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
                     docValueFormat,
                     order,
                     missingBucket,
+                    missingOrder,
                     hasScript,
                     (
                         BigArrays bigArrays,
@@ -142,6 +145,7 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
                                 vs::doubleValues,
                                 compositeValuesSourceConfig.format(),
                                 compositeValuesSourceConfig.missingBucket(),
+                                compositeValuesSourceConfig.missingOrder(),
                                 size,
                                 compositeValuesSourceConfig.reverseMul()
                             );
@@ -156,6 +160,7 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
                                 rounding,
                                 compositeValuesSourceConfig.format(),
                                 compositeValuesSourceConfig.missingBucket(),
+                                compositeValuesSourceConfig.missingOrder(),
                                 size,
                                 compositeValuesSourceConfig.reverseMul()
                             );
@@ -170,13 +175,14 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
         builder.register(
             REGISTRY_KEY,
             org.opensearch.common.collect.List.of(CoreValuesSourceType.BYTES, CoreValuesSourceType.IP),
-            (valuesSourceConfig, name, hasScript, format, missingBucket, order) -> new CompositeValuesSourceConfig(
+            (valuesSourceConfig, name, hasScript, format, missingBucket, missingOrder, order) -> new CompositeValuesSourceConfig(
                 name,
                 valuesSourceConfig.fieldType(),
                 valuesSourceConfig.getValuesSource(),
                 valuesSourceConfig.format(),
                 order,
                 missingBucket,
+                missingOrder,
                 hasScript,
                 (
                     BigArrays bigArrays,
@@ -193,6 +199,7 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
                             vs::globalOrdinalsValues,
                             compositeValuesSourceConfig.format(),
                             compositeValuesSourceConfig.missingBucket(),
+                            compositeValuesSourceConfig.missingOrder(),
                             size,
                             compositeValuesSourceConfig.reverseMul()
                         );
@@ -205,6 +212,7 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
                             vs::bytesValues,
                             compositeValuesSourceConfig.format(),
                             compositeValuesSourceConfig.missingBucket(),
+                            compositeValuesSourceConfig.missingOrder(),
                             size,
                             compositeValuesSourceConfig.reverseMul()
                         );
@@ -224,6 +232,6 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
     protected CompositeValuesSourceConfig innerBuild(QueryShardContext queryShardContext, ValuesSourceConfig config) throws IOException {
         return queryShardContext.getValuesSourceRegistry()
             .getAggregator(REGISTRY_KEY, config)
-            .apply(config, name, script() != null, format(), missingBucket(), order());
+            .apply(config, name, script() != null, format(), missingBucket(), missingOrder(), order());
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/missing/MissingOrder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/missing/MissingOrder.java
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.bucket.missing;
+
+import org.opensearch.common.inject.Provider;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+
+import java.io.IOException;
+import java.util.Locale;
+
+/**
+ * Composite Aggregation Missing bucket order.
+ */
+public enum MissingOrder implements Writeable {
+    /**
+     * missing first.
+     */
+    FIRST {
+        @Override
+        public int compare(Provider<Boolean> leftIsMissing, Provider<Boolean> rightIsMissing, int reverseMul) {
+            if (leftIsMissing.get()) {
+                return rightIsMissing.get() ? 0 : -1;
+            } else if (rightIsMissing.get()) {
+                return 1;
+            }
+            return MISSING_ORDER_UNKNOWN;
+        }
+
+        @Override
+        public String toString() {
+            return "first";
+        }
+    },
+
+    /**
+     * missing last.
+     */
+    LAST {
+        @Override
+        public int compare(Provider<Boolean> leftIsMissing, Provider<Boolean> rightIsMissing, int reverseMul) {
+            if (leftIsMissing.get()) {
+                return rightIsMissing.get() ? 0 : 1;
+            } else if (rightIsMissing.get()) {
+                return -1;
+            }
+            return MISSING_ORDER_UNKNOWN;
+        }
+
+        @Override
+        public String toString() {
+            return "last";
+        }
+    },
+
+    /**
+     * Default: ASC missing first / DESC missing last
+     */
+    DEFAULT {
+        @Override
+        public int compare(Provider<Boolean> leftIsMissing, Provider<Boolean> rightIsMissing, int reverseMul) {
+            if (leftIsMissing.get()) {
+                return rightIsMissing.get() ? 0 : -1 * reverseMul;
+            } else if (rightIsMissing.get()) {
+                return reverseMul;
+            }
+            return MISSING_ORDER_UNKNOWN;
+        }
+
+        @Override
+        public String toString() {
+            return "default";
+        }
+    };
+
+    public static final String NAME = "missing_order";
+
+    private static int MISSING_ORDER_UNKNOWN = Integer.MIN_VALUE;
+
+    public static MissingOrder readFromStream(StreamInput in) throws IOException {
+        return in.readEnum(MissingOrder.class);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeEnum(this);
+    }
+
+    public static boolean isDefault(MissingOrder order) {
+        return order == DEFAULT;
+    }
+
+    public static MissingOrder fromString(String order) {
+        return valueOf(order.toUpperCase(Locale.ROOT));
+    }
+
+    public static boolean unknownOrder(int v) {
+        return v == MISSING_ORDER_UNKNOWN;
+    }
+
+    public abstract int compare(Provider<Boolean> leftIsMissing, Provider<Boolean> rightIsMissing, int reverseMul);
+}

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/CompositeAggregationBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/CompositeAggregationBuilderTests.java
@@ -37,6 +37,7 @@ import org.opensearch.script.Script;
 import org.opensearch.search.aggregations.BaseAggregationTestCase;
 import org.opensearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.search.sort.SortOrder;
 
 import java.util.ArrayList;
@@ -69,6 +70,7 @@ public class CompositeAggregationBuilderTests extends BaseAggregationTestCase<Co
         if (randomBoolean()) {
             histo.missingBucket(true);
         }
+        histo.missingOrder(randomFrom(MissingOrder.values()));
         return histo;
     }
 
@@ -94,6 +96,7 @@ public class CompositeAggregationBuilderTests extends BaseAggregationTestCase<Co
         if (randomBoolean()) {
             terms.missingBucket(true);
         }
+        terms.missingOrder(randomFrom(MissingOrder.values()));
         return terms;
     }
 
@@ -108,6 +111,7 @@ public class CompositeAggregationBuilderTests extends BaseAggregationTestCase<Co
             histo.missingBucket(true);
         }
         histo.interval(randomDoubleBetween(Math.nextUp(0), Double.MAX_VALUE, false));
+        histo.missingOrder(randomFrom(MissingOrder.values()));
         return histo;
     }
 

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesCollectorQueueTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesCollectorQueueTests.java
@@ -63,6 +63,7 @@ import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.AggregatorTestCase;
 import org.opensearch.search.aggregations.LeafBucketCollector;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -277,6 +278,7 @@ public class CompositeValuesCollectorQueueTests extends AggregatorTestCase {
                         value -> value,
                         DocValueFormat.RAW,
                         missingBucket,
+                        MissingOrder.DEFAULT,
                         size,
                         1
                     );
@@ -287,6 +289,7 @@ public class CompositeValuesCollectorQueueTests extends AggregatorTestCase {
                         context -> FieldData.sortableLongBitsToDoubles(DocValues.getSortedNumeric(context.reader(), fieldType.name())),
                         DocValueFormat.RAW,
                         missingBucket,
+                        MissingOrder.DEFAULT,
                         size,
                         1
                     );
@@ -300,6 +303,7 @@ public class CompositeValuesCollectorQueueTests extends AggregatorTestCase {
                             context -> DocValues.getSortedSet(context.reader(), fieldType.name()),
                             DocValueFormat.RAW,
                             missingBucket,
+                            MissingOrder.DEFAULT,
                             size,
                             1
                         );
@@ -311,6 +315,7 @@ public class CompositeValuesCollectorQueueTests extends AggregatorTestCase {
                             context -> FieldData.toString(DocValues.getSortedSet(context.reader(), fieldType.name())),
                             DocValueFormat.RAW,
                             missingBucket,
+                            MissingOrder.DEFAULT,
                             size,
                             1
                         );

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/InternalCompositeTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/InternalCompositeTests.java
@@ -39,6 +39,7 @@ import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregations;
 import org.opensearch.search.aggregations.ParsedAggregation;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.test.InternalMultiBucketAggregationTestCase;
 import org.junit.After;
 
@@ -71,6 +72,7 @@ public class InternalCompositeTests extends InternalMultiBucketAggregationTestCa
     private List<String> sourceNames;
     private List<DocValueFormat> formats;
     private int[] reverseMuls;
+    private MissingOrder[] missingOrders;
     private int[] types;
     private int size;
 
@@ -100,10 +102,12 @@ public class InternalCompositeTests extends InternalMultiBucketAggregationTestCa
         sourceNames = new ArrayList<>();
         formats = new ArrayList<>();
         reverseMuls = new int[numFields];
+        missingOrders = new MissingOrder[numFields];
         types = new int[numFields];
         for (int i = 0; i < numFields; i++) {
             sourceNames.add("field_" + i);
             reverseMuls[i] = randomBoolean() ? 1 : -1;
+            missingOrders[i] = randomFrom(MissingOrder.values());
             int type = randomIntBetween(0, 2);
             types[i] = type;
             formats.add(randomDocValueFormat(type == 0));
@@ -182,6 +186,7 @@ public class InternalCompositeTests extends InternalMultiBucketAggregationTestCa
                 formats,
                 key,
                 reverseMuls,
+                missingOrders,
                 1L,
                 aggregations
             );
@@ -189,7 +194,18 @@ public class InternalCompositeTests extends InternalMultiBucketAggregationTestCa
         }
         Collections.sort(buckets, (o1, o2) -> o1.compareKey(o2));
         CompositeKey lastBucket = buckets.size() > 0 ? buckets.get(buckets.size() - 1).getRawKey() : null;
-        return new InternalComposite(name, size, sourceNames, formats, buckets, lastBucket, reverseMuls, randomBoolean(), metadata);
+        return new InternalComposite(
+            name,
+            size,
+            sourceNames,
+            formats,
+            buckets,
+            lastBucket,
+            reverseMuls,
+            missingOrders,
+            randomBoolean(),
+            metadata
+        );
     }
 
     @Override
@@ -214,6 +230,7 @@ public class InternalCompositeTests extends InternalMultiBucketAggregationTestCa
                         formats,
                         createCompositeKey(),
                         reverseMuls,
+                        missingOrders,
                         randomLongBetween(1, 100),
                         InternalAggregations.EMPTY
                     )
@@ -239,6 +256,7 @@ public class InternalCompositeTests extends InternalMultiBucketAggregationTestCa
             buckets,
             lastBucket,
             reverseMuls,
+            missingOrders,
             randomBoolean(),
             metadata
         );
@@ -295,6 +313,7 @@ public class InternalCompositeTests extends InternalMultiBucketAggregationTestCa
             emptyList(),
             null,
             reverseMuls,
+            missingOrders,
             true,
             emptyMap()
         );

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/SingleDimensionValuesSourceTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/composite/SingleDimensionValuesSourceTests.java
@@ -47,6 +47,7 @@ import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
 import org.opensearch.test.OpenSearchTestCase;
 
 import static org.mockito.Mockito.mock;
@@ -62,6 +63,7 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
             context -> null,
             DocValueFormat.RAW,
             false,
+            MissingOrder.DEFAULT,
             1,
             1
         );
@@ -79,6 +81,7 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
             context -> null,
             DocValueFormat.RAW,
             true,
+            MissingOrder.DEFAULT,
             1,
             1
         );
@@ -92,13 +95,24 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
             context -> null,
             DocValueFormat.RAW,
             false,
+            MissingOrder.DEFAULT,
             0,
             -1
         );
         assertNull(source.createSortedDocsProducerOrNull(reader, null));
 
         MappedFieldType ip = new IpFieldMapper.IpFieldType("ip");
-        source = new BinaryValuesSource(BigArrays.NON_RECYCLING_INSTANCE, (b) -> {}, ip, context -> null, DocValueFormat.RAW, false, 1, 1);
+        source = new BinaryValuesSource(
+            BigArrays.NON_RECYCLING_INSTANCE,
+            (b) -> {},
+            ip,
+            context -> null,
+            DocValueFormat.RAW,
+            false,
+            MissingOrder.DEFAULT,
+            1,
+            1
+        );
         assertNull(source.createSortedDocsProducerOrNull(reader, null));
     }
 
@@ -110,6 +124,7 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
             context -> null,
             DocValueFormat.RAW,
             false,
+            MissingOrder.DEFAULT,
             1,
             1
         );
@@ -120,7 +135,16 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
         assertNull(source.createSortedDocsProducerOrNull(reader, new TermQuery(new Term("foo", "bar"))));
         assertNull(source.createSortedDocsProducerOrNull(reader, new TermQuery(new Term("keyword", "toto)"))));
 
-        source = new GlobalOrdinalValuesSource(BigArrays.NON_RECYCLING_INSTANCE, keyword, context -> null, DocValueFormat.RAW, true, 1, 1);
+        source = new GlobalOrdinalValuesSource(
+            BigArrays.NON_RECYCLING_INSTANCE,
+            keyword,
+            context -> null,
+            DocValueFormat.RAW,
+            true,
+            MissingOrder.DEFAULT,
+            1,
+            1
+        );
         assertNull(source.createSortedDocsProducerOrNull(reader, new MatchAllDocsQuery()));
         assertNull(source.createSortedDocsProducerOrNull(reader, null));
         assertNull(source.createSortedDocsProducerOrNull(reader, new TermQuery(new Term("foo", "bar"))));
@@ -131,6 +155,7 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
             context -> null,
             DocValueFormat.RAW,
             false,
+            MissingOrder.DEFAULT,
             1,
             -1
         );
@@ -138,7 +163,16 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
         assertNull(source.createSortedDocsProducerOrNull(reader, new TermQuery(new Term("foo", "bar"))));
 
         final MappedFieldType ip = new IpFieldMapper.IpFieldType("ip");
-        source = new GlobalOrdinalValuesSource(BigArrays.NON_RECYCLING_INSTANCE, ip, context -> null, DocValueFormat.RAW, false, 1, 1);
+        source = new GlobalOrdinalValuesSource(
+            BigArrays.NON_RECYCLING_INSTANCE,
+            ip,
+            context -> null,
+            DocValueFormat.RAW,
+            false,
+            MissingOrder.DEFAULT,
+            1,
+            1
+        );
         assertNull(source.createSortedDocsProducerOrNull(reader, null));
         assertNull(source.createSortedDocsProducerOrNull(reader, new TermQuery(new Term("foo", "bar"))));
     }
@@ -159,6 +193,7 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
                     value -> value,
                     DocValueFormat.RAW,
                     false,
+                    MissingOrder.DEFAULT,
                     1,
                     1
                 );
@@ -192,6 +227,7 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
                     value -> value,
                     DocValueFormat.RAW,
                     true,
+                    MissingOrder.DEFAULT,
                     1,
                     1
                 );
@@ -213,6 +249,7 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
                     value -> value,
                     DocValueFormat.RAW,
                     false,
+                    MissingOrder.DEFAULT,
                     1,
                     -1
                 );
@@ -231,6 +268,7 @@ public class SingleDimensionValuesSourceTests extends OpenSearchTestCase {
                         context -> null,
                         DocValueFormat.RAW,
                         false,
+                        MissingOrder.DEFAULT,
                         1,
                         1
                     );


### PR DESCRIPTION
### Description
Backporting #1942 and #2005 to 1.x branch.

Passed,  `./gradlew ':server:test' -Dtests.iters=100 --tests "org.opensearch.search.aggregations.bucket.composite.CompositeAggregatorTests"` 
Passed, `./gradlew precommit`

### Issues Resolved
#1899 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
