### PR TITLE
Another attempt to fix o.o.transport.netty4.OpenSearchLoggingHandlerIT fails w/ stack overflow

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/opensearch/transport/netty4/OpenSearchLoggingHandlerIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/opensearch/transport/netty4/OpenSearchLoggingHandlerIT.java
@@ -53,6 +53,7 @@ public class OpenSearchLoggingHandlerIT extends OpenSearchNetty4IntegTestCase {
     public void setUp() throws Exception {
         super.setUp();
         appender = MockLogAppender.createForLoggers(
+            "^[^\n]+$", /* Only consider single line log statements */
             LogManager.getLogger(OpenSearchLoggingHandler.class),
             LogManager.getLogger(TransportLogger.class),
             LogManager.getLogger(TcpTransport.class)

--- a/test/framework/src/main/java/org/opensearch/test/MockLogAppender.java
+++ b/test/framework/src/main/java/org/opensearch/test/MockLogAppender.java
@@ -68,8 +68,12 @@ public class MockLogAppender extends AbstractAppender implements AutoCloseable {
      * write to a closed MockLogAppender instance.
      */
     public static MockLogAppender createForLoggers(Logger... loggers) throws IllegalAccessException {
+        return createForLoggers(".*(\n.*)*", loggers);
+    }
+
+    public static MockLogAppender createForLoggers(String filter, Logger... loggers) throws IllegalAccessException {
         final MockLogAppender appender = new MockLogAppender(
-            RegexFilter.createFilter(".*(\n.*)*", new String[0], false, null, null),
+            RegexFilter.createFilter(filter, new String[0], false, null, null),
             Collections.unmodifiableList(Arrays.asList(loggers))
         );
         appender.start();


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
This time no guesses, I was able to reproduce the issue. The Netty dumps raw messages (in hex) into logs and for some specific rare patterns (I have an example), the appender filter blows with `StrackOverflowError`. The change to appender filter to watch only for single line log statements (expressed in expectations) fixed the issue. 
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/1767
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
