### PR TITLE
Using Github App to trigger CI for auto-backport

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,8 +13,16 @@ jobs:
       pull-requests: write
     name: Backport
     steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+
       - name: Backport
         uses: VachaShah/backport@v1.1.4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.github_app_token.outputs.token }}
           branch_name: backport/backport-${{ github.event.number }}


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Using Github App token in the auto-backport workflow to trigger CI on auto-backport PRs since events created by `secrets.GITHUB_TOKEN` cannot trigger other workflows. Reference: https://github.community/t/triggering-a-new-workflow-from-another-workflow/16250
 
### Issues Resolved
Part 1 of #1962 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
