### PR TITLE
Changes to enable “shouldForward” gating

### DIFF
--- a/server/src/main/java/org/opensearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/opensearch/action/bulk/TransportShardBulkAction.java
@@ -269,6 +269,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
                         context.getLocationToSync(),
                         null,
                         context.getPrimary(),
+                        context.getPrimary().shouldForward(),
                         logger
                     )
                 );

--- a/server/src/main/java/org/opensearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/opensearch/action/support/replication/ReplicationOperation.java
@@ -151,7 +151,7 @@ public class ReplicationOperation<
     private void handlePrimaryResult(final PrimaryResultT primaryResult) {
         this.primaryResult = primaryResult;
         final ReplicaRequest replicaRequest = primaryResult.replicaRequest();
-        if (replicaRequest != null) {
+        if (replicaRequest != null && primaryResult.shouldForward()) {
             if (logger.isTraceEnabled()) {
                 logger.trace("[{}] op [{}] completed on primary for request [{}]", primary.routingEntry().shardId(), opType, request);
             }
@@ -621,5 +621,7 @@ public class ReplicationOperation<
          * @param listener calllback that is invoked after post replication actions have completed
          * */
         void runPostReplicationActions(ActionListener<Void> listener);
+
+        boolean shouldForward();
     }
 }

--- a/server/src/main/java/org/opensearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/opensearch/action/support/replication/TransportReplicationAction.java
@@ -558,12 +558,18 @@ public abstract class TransportReplicationAction<
         protected final ReplicaRequest replicaRequest;
         public final Response finalResponseIfSuccessful;
         public final Exception finalFailure;
+        public final boolean shouldForward;
 
         /**
          * Result of executing a primary operation
          * expects <code>finalResponseIfSuccessful</code> or <code>finalFailure</code> to be not-null
          */
-        public PrimaryResult(ReplicaRequest replicaRequest, Response finalResponseIfSuccessful, Exception finalFailure) {
+        public PrimaryResult(
+            ReplicaRequest replicaRequest,
+            Response finalResponseIfSuccessful,
+            Exception finalFailure,
+            boolean shouldForward
+        ) {
             assert finalFailure != null ^ finalResponseIfSuccessful != null : "either a response or a failure has to be not null, "
                 + "found ["
                 + finalFailure
@@ -573,6 +579,11 @@ public abstract class TransportReplicationAction<
             this.replicaRequest = replicaRequest;
             this.finalResponseIfSuccessful = finalResponseIfSuccessful;
             this.finalFailure = finalFailure;
+            this.shouldForward = shouldForward;
+        }
+
+        public PrimaryResult(ReplicaRequest replicaRequest, Response finalResponseIfSuccessful, Exception finalFailure) {
+            this(replicaRequest, finalResponseIfSuccessful, finalFailure, true);
         }
 
         public PrimaryResult(ReplicaRequest replicaRequest, Response replicationResponse) {
@@ -598,6 +609,11 @@ public abstract class TransportReplicationAction<
             } else {
                 listener.onResponse(null);
             }
+        }
+
+        @Override
+        public boolean shouldForward() {
+            return shouldForward;
         }
     }
 

--- a/server/src/main/java/org/opensearch/action/support/replication/TransportWriteAction.java
+++ b/server/src/main/java/org/opensearch/action/support/replication/TransportWriteAction.java
@@ -279,9 +279,10 @@ public abstract class TransportWriteAction<
             @Nullable Location location,
             @Nullable Exception operationFailure,
             IndexShard primary,
+            boolean shouldForward,
             Logger logger
         ) {
-            super(request, finalResponse, operationFailure);
+            super(request, finalResponse, operationFailure, shouldForward);
             this.location = location;
             this.primary = primary;
             this.logger = logger;
@@ -291,6 +292,17 @@ public abstract class TransportWriteAction<
                 + "] translog location and ["
                 + operationFailure
                 + "] failure";
+        }
+
+        public WritePrimaryResult(
+            ReplicaRequest request,
+            @Nullable Response finalResponse,
+            @Nullable Location location,
+            @Nullable Exception operationFailure,
+            IndexShard primary,
+            Logger logger
+        ) {
+            this(request, finalResponse, location, operationFailure, primary, true, logger);
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -835,8 +835,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         boolean isRetry,
         SourceToParse sourceToParse
     ) throws IOException {
-        Boolean isSegRepEnabled = indexSettings.getValue(IndexSettings.INDEX_SEGMENT_REPLICATION_SETTING);
-        if (isSegRepEnabled != null && isSegRepEnabled) {
+        if (isSegmentReplicationEnabled()) {
             Engine.Index index;
             try {
                 index = parseSourceAndPrepareIndex(
@@ -4095,5 +4094,18 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
     RetentionLeaseSyncer getRetentionLeaseSyncer() {
         return retentionLeaseSyncer;
+    }
+
+    /**
+     * Controls whether requests should be forwarded from the
+     * primary to the replica.
+     */
+    public boolean shouldForward() {
+        // Eventually this will also incorporate the presence of pluggable translog
+        return !isSegmentReplicationEnabled();
+    }
+
+    private boolean isSegmentReplicationEnabled() {
+        return indexSettings.getValue(IndexSettings.INDEX_SEGMENT_REPLICATION_SETTING);
     }
 }

--- a/server/src/test/java/org/opensearch/action/admin/indices/close/TransportVerifyShardBeforeCloseActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/close/TransportVerifyShardBeforeCloseActionTests.java
@@ -415,6 +415,14 @@ public class TransportVerifyShardBeforeCloseActionTests extends OpenSearchTestCa
             listener.onResponse(null);
         }
 
+        /**
+         * Default implementation.
+         */
+        @Override
+        public boolean shouldForward() {
+            return true;
+        }
+
         public ReplicationResponse.ShardInfo getShardInfo() {
             return shardInfo.get();
         }

--- a/server/src/test/java/org/opensearch/action/support/replication/ReplicationOperationTests.java
+++ b/server/src/test/java/org/opensearch/action/support/replication/ReplicationOperationTests.java
@@ -669,6 +669,14 @@ public class ReplicationOperationTests extends OpenSearchTestCase {
                 listener.onResponse(null);
             }
 
+            /**
+             * Default implementation.
+             */
+            @Override
+            public boolean shouldForward() {
+                return true;
+            }
+
             public ShardInfo getShardInfo() {
                 return shardInfo;
             }

--- a/test/framework/src/main/java/org/opensearch/index/replication/OpenSearchIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/replication/OpenSearchIndexLevelReplicationTestCase.java
@@ -869,6 +869,14 @@ public abstract class OpenSearchIndexLevelReplicationTestCase extends IndexShard
             public void runPostReplicationActions(ActionListener<Void> listener) {
                 listener.onResponse(null);
             }
+
+            /**
+             * Default implementation
+             */
+            @Override
+            public boolean shouldForward() {
+                return true;
+            }
         }
 
     }


### PR DESCRIPTION
This change adds a shouldForward operation to the ReplicationOperation.PrimaryResult interface. This is used by the logic in ReplicationOperation to gate forwarding of the request to replicas. The TransportReplicationAction.PrimaryResult subclass incorporates a member variable to store this value. The value is eventually populated by the WritePrimaryResult constructor, based on a new IndexShard API. This API internally depends on the segment-replication setting.

Meanwhile, other implementing classes just use a defuault hard-coded implementation to maintain backwards compatibility.

Signed-off-by: Kartik Ganesh <gkart@amazon.com>

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
