### PR TITLE
Backport/backport 2048,2074 to 1.x

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingNode.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingNode.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**
@@ -84,7 +85,7 @@ public class RoutingNode implements Iterable<ShardRouting> {
             return this.shardTuple.v2().get(shardId);
         }
 
-        public ShardRouting add(ShardRouting shardRouting) {
+        public ShardRouting put(ShardRouting shardRouting) {
             return put(shardRouting.shardId(), shardRouting);
         }
 
@@ -114,22 +115,10 @@ public class RoutingNode implements Iterable<ShardRouting> {
 
         @Override
         public Iterator<ShardRouting> iterator() {
-            final Iterator<ShardRouting> primaryIterator = Collections.unmodifiableCollection(this.shardTuple.v1().values()).iterator();
-            final Iterator<ShardRouting> replicaIterator = Collections.unmodifiableCollection(this.shardTuple.v2().values()).iterator();
-            return new Iterator<ShardRouting>() {
-                @Override
-                public boolean hasNext() {
-                    return primaryIterator.hasNext() || replicaIterator.hasNext();
-                }
-
-                @Override
-                public ShardRouting next() {
-                    if (primaryIterator.hasNext()) {
-                        return primaryIterator.next();
-                    }
-                    return replicaIterator.next();
-                }
-            };
+            return Stream.concat(
+                Collections.unmodifiableCollection(this.shardTuple.v1().values()).stream(),
+                Collections.unmodifiableCollection(this.shardTuple.v2().values()).stream()
+            ).iterator();
         }
     }
 
@@ -217,7 +206,7 @@ public class RoutingNode implements Iterable<ShardRouting> {
      */
     void add(ShardRouting shard) {
         assert invariant();
-        if (shards.add(shard) != null) {
+        if (shards.put(shard) != null) {
             throw new IllegalStateException(
                 "Trying to add a shard "
                     + shard.shardId()

--- a/server/src/test/java/org/opensearch/cluster/routing/MovePrimaryFirstTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/MovePrimaryFirstTests.java
@@ -12,6 +12,7 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.cluster.ClusterStateListener;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
@@ -121,6 +122,6 @@ public class MovePrimaryFirstTests extends OpenSearchIntegTestCase {
             internalCluster().stopRandomNode(InternalTestCluster.nameFilter(z1n1));
             internalCluster().stopRandomNode(InternalTestCluster.nameFilter(z1n2));
         } catch (Exception e) {}
-        ensureGreen();
+        ensureGreen(TimeValue.timeValueSeconds(60));
     }
 }


### PR DESCRIPTION
Signed-off-by: Ankit Jain <jain.ankitk@gmail.com>

### Description
The issue is caused due to one of the primary shard being initialized and some replica starts meanwhile. Hence, latch is counted down as half shards are already initialized. Making the check more robust by ensuring no primaries are initializing and not more than 20% of replicas have started on new nodes
 
### Issues Resolved
#1957 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [] New functionality has been documented.
  - [] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).