### PR TITLE
Override Default Distribution Download Url with Custom Distribution Url When User Passes a Url

### DIFF
--- a/buildSrc/src/test/java/org/opensearch/gradle/DistributionDownloadPluginTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/DistributionDownloadPluginTests.java
@@ -79,6 +79,27 @@ public class DistributionDownloadPluginTests extends GradleUnitTestCase {
         assertEquals(distro.getVersion(), VersionProperties.getOpenSearch());
     }
 
+    public void testCustomDistributionUrlForNull() {
+        Project project = createProject(null, false);
+        assertNull(project.findProperty("customDistributionUrl"));
+    }
+
+    public void testCustomDistributionUrlWithUrl() {
+        Project project = createProject(null, false);
+        String customUrl = "https://artifacts.opensearch.org";
+        project.getExtensions().getExtraProperties().set("customDistributionUrl", customUrl);
+        DistributionDownloadPlugin plugin = project.getPlugins().getPlugin(DistributionDownloadPlugin.class);
+        plugin.setupDistributions(project);
+        assertEquals(project.property("testCustomDistributionUrlProperty").toString(), customUrl);
+    }
+
+    public void testCustomDistributionUrlWithoutUrl() {
+        Project project = createProject(null, false);
+        DistributionDownloadPlugin plugin = project.getPlugins().getPlugin(DistributionDownloadPlugin.class);
+        plugin.setupDistributions(project);
+        assertFalse(project.hasProperty("testCustomDistributionUrlProperty"));
+    }
+
     public void testBadVersionFormat() {
         assertDistroError(
             createProject(null, false),


### PR DESCRIPTION
Signed-off-by: Rishikesh1159 <rishireddy1159@gmail.com>

### Description
This PR overrides default distribution url with custom distribution url passes by user. Previous discussions regarding this PR can be found in PR #1737 
 
### Issues Resolved
#1240 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
