### PR TITLE
Add proxy settings for GCS repository plugin

### DIFF
--- a/plugins/repository-gcs/src/main/java/org/opensearch/repositories/gcs/GoogleCloudStoragePlugin.java
+++ b/plugins/repository-gcs/src/main/java/org/opensearch/repositories/gcs/GoogleCloudStoragePlugin.java
@@ -92,7 +92,12 @@ public class GoogleCloudStoragePlugin extends Plugin implements RepositoryPlugin
             GoogleCloudStorageClientSettings.CONNECT_TIMEOUT_SETTING,
             GoogleCloudStorageClientSettings.READ_TIMEOUT_SETTING,
             GoogleCloudStorageClientSettings.APPLICATION_NAME_SETTING,
-            GoogleCloudStorageClientSettings.TOKEN_URI_SETTING
+            GoogleCloudStorageClientSettings.TOKEN_URI_SETTING,
+            GoogleCloudStorageClientSettings.PROXY_TYPE_SETTING,
+            GoogleCloudStorageClientSettings.PROXY_HOST_SETTING,
+            GoogleCloudStorageClientSettings.PROXY_PORT_SETTING,
+            GoogleCloudStorageClientSettings.PROXY_USERNAME_SETTING,
+            GoogleCloudStorageClientSettings.PROXY_PASSWORD_SETTING
         );
     }
 

--- a/plugins/repository-gcs/src/main/java/org/opensearch/repositories/gcs/ProxySettings.java
+++ b/plugins/repository-gcs/src/main/java/org/opensearch/repositories/gcs/ProxySettings.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.repositories.gcs;
+
+import org.opensearch.common.Strings;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.util.Objects;
+
+public class ProxySettings {
+
+    public static final ProxySettings NO_PROXY_SETTINGS = new ProxySettings(Proxy.Type.DIRECT, null, -1, null, null);
+
+    private final Proxy.Type type;
+
+    private final InetAddress host;
+
+    private final String username;
+
+    private final String password;
+
+    private final int port;
+
+    public ProxySettings(final Proxy.Type type, final InetAddress host, final int port, final String username, final String password) {
+        this.type = type;
+        this.host = host;
+        this.port = port;
+        this.username = username;
+        this.password = password;
+    }
+
+    public Proxy.Type getType() {
+        return this.type;
+    }
+
+    public InetSocketAddress getAddress() {
+        return new InetSocketAddress(host, port);
+    }
+
+    public String getUsername() {
+        return this.username;
+    }
+
+    public String getPassword() {
+        return this.password;
+    }
+
+    public boolean isAuthenticated() {
+        return Strings.isNullOrEmpty(username) == false && Strings.isNullOrEmpty(password) == false;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ProxySettings that = (ProxySettings) o;
+        return port == that.port
+            && type == that.type
+            && Objects.equals(host, that.host)
+            && Objects.equals(username, that.username)
+            && Objects.equals(password, that.password);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, host, username, password, port);
+    }
+}

--- a/plugins/repository-gcs/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/repository-gcs/src/main/plugin-metadata/plugin-security.policy
@@ -40,4 +40,7 @@ grant {
 
   // gcs client opens socket connections for to access repository
   permission java.net.SocketPermission "*", "connect";
+
+  // gcs client set Authenticator for proxy username/password
+  permission java.net.NetPermission "setDefaultAuthenticator";
 };

--- a/plugins/repository-gcs/src/test/java/org/opensearch/repositories/gcs/GoogleCloudStorageServiceTests.java
+++ b/plugins/repository-gcs/src/test/java/org/opensearch/repositories/gcs/GoogleCloudStorageServiceTests.java
@@ -35,7 +35,7 @@ package org.opensearch.repositories.gcs;
 import com.google.auth.Credentials;
 import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.storage.Storage;
-
+import org.hamcrest.Matchers;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.settings.MockSecureSettings;
 import org.opensearch.common.settings.Setting;
@@ -43,7 +43,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.test.OpenSearchTestCase;
-import org.hamcrest.Matchers;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -51,9 +50,9 @@ import java.util.Base64;
 import java.util.Locale;
 import java.util.UUID;
 
-import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
 
 public class GoogleCloudStorageServiceTests extends OpenSearchTestCase {
 


### PR DESCRIPTION
### Description

Now to configure GCS plugin to use any proxy you need to set standard process variables:
- `proxyHost`
- `socksProxyHost`
- `proxyPort`
- `proxyUser` 
- `proxyPassword`

with proxy types prefix. 

Such settings have 2  main problems:
- Storing password this way is insecure
- In case of password leaking it is necessary to restart all nodes in the cluster

To avoid of a such problem all proxy settings were added to OS settings and security settings
Storing username/password in security settings is more secure compare to process settings and in case of any problem with username and password such security settings could be reloaded without restart of each node in the cluster.

Re-loadable security settings:
- `gcs.client.*.proxy.username` - Proxy user name
- `gcs.client.*.proxy.password` - Proxy user password

Static settings:
- `gcs.client.*.proxy.type` - java `Proxy.Type` names: `HTTP`, `SOCKS`. default is `DIRECT`
- `gcs.client.*.proxy.host` - Proxy host name
- `gcs.client.*.proxy.port` - Proxy port
 
Note: Such properties can be added for S3 and Azure as well, so I'm planning to add theme separate PRs.

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
