### PR TITLE
Add proxy username and password settings for Azure repository plugin

### DIFF
--- a/plugins/repository-azure/src/main/java/org/opensearch/repositories/azure/AzureRepositoryPlugin.java
+++ b/plugins/repository-azure/src/main/java/org/opensearch/repositories/azure/AzureRepositoryPlugin.java
@@ -94,13 +94,15 @@ public class AzureRepositoryPlugin extends Plugin implements RepositoryPlugin, R
             AzureStorageSettings.ENDPOINT_SUFFIX_SETTING,
             AzureStorageSettings.TIMEOUT_SETTING,
             AzureStorageSettings.MAX_RETRIES_SETTING,
-            AzureStorageSettings.PROXY_TYPE_SETTING,
-            AzureStorageSettings.PROXY_HOST_SETTING,
-            AzureStorageSettings.PROXY_PORT_SETTING,
             AzureStorageSettings.CONNECT_TIMEOUT_SETTING,
             AzureStorageSettings.WRITE_TIMEOUT_SETTING,
             AzureStorageSettings.READ_TIMEOUT_SETTING,
-            AzureStorageSettings.RESPONSE_TIMEOUT_SETTING
+            AzureStorageSettings.RESPONSE_TIMEOUT_SETTING,
+            AzureStorageSettings.PROXY_TYPE_SETTING,
+            AzureStorageSettings.PROXY_HOST_SETTING,
+            AzureStorageSettings.PROXY_PORT_SETTING,
+            AzureStorageSettings.PROXY_USERNAME_SETTING,
+            AzureStorageSettings.PROXY_PASSWORD_SETTING
         );
     }
 

--- a/plugins/repository-azure/src/main/java/org/opensearch/repositories/azure/ProxySettings.java
+++ b/plugins/repository-azure/src/main/java/org/opensearch/repositories/azure/ProxySettings.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.repositories.azure;
+
+import com.azure.core.http.ProxyOptions;
+import org.opensearch.common.Strings;
+import org.opensearch.common.settings.SettingsException;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Objects;
+
+public class ProxySettings {
+
+    public static final ProxySettings NO_PROXY_SETTINGS = new ProxySettings(ProxyType.DIRECT, null, -1, null, null);
+
+    private final ProxyType type;
+
+    private final InetAddress host;
+
+    private final String username;
+
+    private final String password;
+
+    private final int port;
+
+    public static enum ProxyType {
+        HTTP(ProxyOptions.Type.HTTP.name()),
+
+        /**
+         * Please use SOCKS4 instead
+         */
+        @Deprecated
+        SOCKS(ProxyOptions.Type.SOCKS4.name()),
+
+        SOCKS4(ProxyOptions.Type.SOCKS4.name()),
+
+        SOCKS5(ProxyOptions.Type.SOCKS5.name()),
+
+        DIRECT("DIRECT");
+
+        private final String name;
+
+        private ProxyType(String name) {
+            this.name = name;
+        }
+
+        public ProxyOptions.Type toProxyType() {
+            if (this == DIRECT) {
+                // We check it in settings,
+                // the probability that it could be thrown is small, but how knows
+                throw new SettingsException("Couldn't convert to Azure proxy type");
+            }
+            return ProxyOptions.Type.valueOf(name());
+        }
+
+    }
+
+    public ProxySettings(final ProxyType type, final InetAddress host, final int port, final String username, final String password) {
+        this.type = type;
+        this.host = host;
+        this.port = port;
+        this.username = username;
+        this.password = password;
+    }
+
+    public ProxyType getType() {
+        return this.type;
+    }
+
+    public InetSocketAddress getAddress() {
+        return new InetSocketAddress(host, port);
+    }
+
+    public String getUsername() {
+        return this.username;
+    }
+
+    public String getPassword() {
+        return this.password;
+    }
+
+    public boolean isAuthenticated() {
+        return Strings.isNullOrEmpty(username) == false && Strings.isNullOrEmpty(password) == false;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final ProxySettings that = (ProxySettings) o;
+        return port == that.port
+            && type == that.type
+            && Objects.equals(host, that.host)
+            && Objects.equals(username, that.username)
+            && Objects.equals(password, that.password);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, host, username, password, port);
+    }
+
+}

--- a/plugins/repository-azure/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/repository-azure/src/main/plugin-metadata/plugin-security.policy
@@ -38,4 +38,7 @@ grant {
   permission java.lang.RuntimePermission "accessDeclaredMembers";
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   permission java.lang.RuntimePermission "setContextClassLoader";
+
+  // azure client set Authenticator for proxy username/password
+  permission java.net.NetPermission "setDefaultAuthenticator";
 };


### PR DESCRIPTION
### Description
Now to configure Azure plugin to use any proxy you need to set username/password using standard process variables:

Such settings have 2 main problems:

- Storing password this way is insecure
- In case of password leaking it is necessary to restart all nodes in the cluster

To avoid of a such problem username and password security settings were added 
Storing username/password in security settings is more secure compare to process settings and in case of any problem with username and password such security settings could be reloaded without restart of each node in the cluster.

Re-loadable security settings:
- `azure.client.*.proxy.username` - Proxy user name
- `azure.client.*.proxy.password` - Proxy user password
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
