### PR TITLE
Fixing org.opensearch.monitor.os.OsProbeTests::testLogWarnCpuMessageOlyOnes when CGroups are not available

### DIFF
--- a/server/src/test/java/org/opensearch/monitor/os/OsProbeTests.java
+++ b/server/src/test/java/org/opensearch/monitor/os/OsProbeTests.java
@@ -41,6 +41,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assume.assumeThat;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -295,6 +296,7 @@ public class OsProbeTests extends OpenSearchTestCase {
             }
         };
 
+        assumeThat("CGroups are not available", noCpuStatsOsProbe.areCgroupStatsAvailable(), is(true));
         noCpuStatsOsProbe.osStats();
         // no nr_throttled and throttled_time
         verify(logger, times(2)).warn(anyString());


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
The newly added `org.opensearch.monitor.os.OsProbeTests::testLogWarnCpuMessageOlyOnes` test case always assumes that CGroups are available but this may not be the case. The test fails otherwise:

```
org.opensearch.monitor.os.OsProbeTests > testLogWarnCpuMessageOnlyOnes FAILED                                                                                                                                                                                                                                                                                                               
    Wanted but not invoked:                                                                                                                                                                                                                                                                                                                                                                 
    logger.warn(<any string>);                                                                                                                                                                                                                                                                                                                                                              
    -> at org.opensearch.monitor.os.OsProbeTests.testLogWarnCpuMessageOnlyOnes(OsProbeTests.java:300)                                                                                                                                                                                                                                                                                       
    Actually, there were zero interactions with this mock.                                                                                                                                                                                                                                                                                                                                  
        at __randomizedtesting.SeedInfo.seed([98F51BCCE98CC711:506380649692FF1F]:0)                                                                                                                                                                                                                                                                                                         
        at app//org.opensearch.monitor.os.OsProbeTests.testLogWarnCpuMessageOnlyOnes(OsProbeTests.java:300) 
```
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
