### PR TITLE
Support unordered non-overlapping intervals

### DIFF
--- a/plugins/mapper-annotated-text/src/test/java/org/opensearch/index/mapper/annotatedtext/AnnotatedTextFieldTypeTests.java
+++ b/plugins/mapper-annotated-text/src/test/java/org/opensearch/index/mapper/annotatedtext/AnnotatedTextFieldTypeTests.java
@@ -42,6 +42,7 @@ import org.opensearch.index.mapper.ContentPath;
 import org.opensearch.index.mapper.FieldTypeTestCase;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.Mapper;
+import org.opensearch.index.query.IntervalMode;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -51,7 +52,7 @@ public class AnnotatedTextFieldTypeTests extends FieldTypeTestCase {
     public void testIntervals() throws IOException {
         MappedFieldType ft = new AnnotatedTextFieldMapper.AnnotatedTextFieldType("field", Collections.emptyMap());
         NamedAnalyzer a = new NamedAnalyzer("name", AnalyzerScope.INDEX, new StandardAnalyzer());
-        IntervalsSource source = ft.intervals("Donald Trump", 0, true, false, a, false);
+        IntervalsSource source = ft.intervals("Donald Trump", 0, IntervalMode.ORDERED, a, false);
         assertEquals(Intervals.phrase(Intervals.term("donald"), Intervals.term("trump")), source);
     }
 

--- a/plugins/mapper-annotated-text/src/test/java/org/opensearch/index/mapper/annotatedtext/AnnotatedTextFieldTypeTests.java
+++ b/plugins/mapper-annotated-text/src/test/java/org/opensearch/index/mapper/annotatedtext/AnnotatedTextFieldTypeTests.java
@@ -51,7 +51,7 @@ public class AnnotatedTextFieldTypeTests extends FieldTypeTestCase {
     public void testIntervals() throws IOException {
         MappedFieldType ft = new AnnotatedTextFieldMapper.AnnotatedTextFieldType("field", Collections.emptyMap());
         NamedAnalyzer a = new NamedAnalyzer("name", AnalyzerScope.INDEX, new StandardAnalyzer());
-        IntervalsSource source = ft.intervals("Donald Trump", 0, true, a, false);
+        IntervalsSource source = ft.intervals("Donald Trump", 0, true, false, a, false);
         assertEquals(Intervals.phrase(Intervals.term("donald"), Intervals.term("trump")), source);
     }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/230_interval_query.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/230_interval_query.yml
@@ -32,8 +32,8 @@ setup:
 ---
 "Test ordered matching":
   - skip:
-      version: " - 1.2.99"
-      reason: "mode introduced in 1.3"
+      version: " - 1.99.99"
+      reason: "mode introduced in 2.0"
   - do:
         search:
           index: test
@@ -62,8 +62,8 @@ setup:
 ---
 "Test explicit unordered matching":
   - skip:
-      version: " - 1.2.99"
-      reason: "mode introduced in 1.3"
+      version: " - 1.99.99"
+      reason: "mode introduced in 2.0"
   - do:
       search:
         index: test
@@ -79,8 +79,8 @@ setup:
 ---
 "Test unordered with overlap in match":
   - skip:
-        version: " - 1.2.99"
-        reason: "Implemented in 1.3"
+        version: " - 1.99.99"
+        reason: "Implemented in 2.0"
   - do:
       search:
         index: test
@@ -96,8 +96,8 @@ setup:
 ---
 "Test unordered with no overlap in match":
   - skip:
-      version: " - 1.2.99"
-      reason: "Implemented in 1.3"
+      version: " - 1.99.99"
+      reason: "Implemented in 2.0"
   - do:
       search:
         index: test
@@ -113,8 +113,8 @@ setup:
 ---
 "Test phrase matching":
   - skip:
-      version: " - 1.2.99"
-      reason: "mode introduced in 1.3"
+      version: " - 1.99.99"
+      reason: "mode introduced in 2.0"
   - do:
       search:
         index: test
@@ -145,8 +145,8 @@ setup:
 ---
 "Test ordered max_gaps matching":
   - skip:
-      version: " - 1.2.99"
-      reason: "mode introduced in 1.3"
+      version: " - 1.99.99"
+      reason: "mode introduced in 2.0"
   - do:
       search:
         index: test
@@ -163,8 +163,8 @@ setup:
 ---
 "Test ordered combination with disjunction":
   - skip:
-      version: " - 1.2.99"
-      reason: "mode introduced in 1.3"
+      version: " - 1.99.99"
+      reason: "mode introduced in 2.0"
   - do:
       search:
         index: test
@@ -188,8 +188,8 @@ setup:
 ---
 "Test ordered combination with max_gaps":
   - skip:
-      version: " - 1.2.99"
-      reason: "mode introduced in 1.3"
+      version: " - 1.99.99"
+      reason: "mode introduced in 2.0"
   - do:
       search:
         index: test
@@ -210,8 +210,8 @@ setup:
 ---
 "Test ordered combination":
   - skip:
-      version: " - 1.2.99"
-      reason: "mode introduced in 1.3"
+      version: " - 1.99.99"
+      reason: "mode introduced in 2.0"
   - do:
       search:
         index: test
@@ -231,8 +231,8 @@ setup:
 ---
 "Test unordered combination":
   - skip:
-      version: " - 1.2.99"
-      reason: "mode introduced in 1.3"
+      version: " - 1.99.99"
+      reason: "mode introduced in 2.0"
   - do:
       search:
         index: test
@@ -253,8 +253,8 @@ setup:
 ---
 "Test unordered combination with overlap":
   - skip:
-      version: " - 1.2.99"
-      reason: "Implemented in 1.3"
+      version: " - 1.99.99"
+      reason: "Implemented in 2.0"
   - do:
       search:
         index: test
@@ -276,8 +276,8 @@ setup:
 ---
 "Test unordered combination no overlap":
   - skip:
-      version: " - 1.2.99"
-      reason: "Implemented in 1.3"
+      version: " - 1.99.99"
+      reason: "Implemented in 2.0"
   - do:
       search:
         index: test
@@ -299,8 +299,8 @@ setup:
 ---
 "Test nested unordered combination with overlap":
   - skip:
-      version: " - 1.2.99"
-      reason: "Implemented in 1.3"
+      version: " - 1.99.99"
+      reason: "Implemented in 2.0"
   - do:
       search:
         index: test
@@ -324,8 +324,8 @@ setup:
 ---
 "Test nested unordered combination no overlap":
   - skip:
-      version: " - 1.2.99"
-      reason: "Implemented in 1.3"
+      version: " - 1.99.99"
+      reason: "Implemented in 2.0"
   - do:
       search:
         index: test
@@ -349,8 +349,8 @@ setup:
 ---
 "Test block combination":
   - skip:
-      version: " - 1.2.99"
-      reason: "mode introduced in 1.3"
+      version: " - 1.99.99"
+      reason: "mode introduced in 2.0"
   - do:
       search:
         index: test
@@ -372,8 +372,8 @@ setup:
 ---
 "Test containing":
   - skip:
-      version: " - 1.2.99"
-      reason: "mode introduced in 1.3"
+      version: " - 1.99.99"
+      reason: "mode introduced in 2.0"
   - do:
       search:
         index: test
@@ -398,8 +398,8 @@ setup:
 ---
 "Test not containing":
   - skip:
-      version: " - 1.2.99"
-      reason: "mode introduced in 1.3"
+      version: " - 1.99.99"
+      reason: "mode introduced in 2.0"
   - do:
       search:
         index: test
@@ -423,8 +423,8 @@ setup:
 ---
 "Test contained_by":
   - skip:
-      version: " - 1.2.99"
-      reason: "mode introduced in 1.3"
+      version: " - 1.99.99"
+      reason: "mode introduced in 2.0"
   - do:
       search:
         index: test
@@ -469,8 +469,8 @@ setup:
 ---
 "Test not_overlapping":
   - skip:
-      version: " - 1.2.99"
-      reason: "mode introduced in 1.3"
+      version: " - 1.99.99"
+      reason: "mode introduced in 2.0"
   - do:
       search:
         index: test
@@ -499,8 +499,8 @@ setup:
 ---
 "Test overlapping":
   - skip:
-      version: " - 1.2.99"
-      reason: "mode introduced in 1.3"
+      version: " - 1.99.99"
+      reason: "mode introduced in 2.0"
   - do:
       search:
         index: test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/230_interval_query.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/230_interval_query.yml
@@ -31,6 +31,9 @@ setup:
 
 ---
 "Test ordered matching":
+  - skip:
+      version: " - 1.2.99"
+      reason: "mode introduced in 1.3"
   - do:
         search:
           index: test
@@ -40,7 +43,7 @@ setup:
                 text:
                   match:
                     query: "cold outside"
-                    ordered: true
+                    mode: "ordered"
   - match: { hits.total.value: 2 }
 
 ---
@@ -58,6 +61,9 @@ setup:
 
 ---
 "Test explicit unordered matching":
+  - skip:
+      version: " - 1.2.99"
+      reason: "mode introduced in 1.3"
   - do:
       search:
         index: test
@@ -67,11 +73,14 @@ setup:
               text:
                 match:
                   query: "cold outside"
-                  ordered: false
+                  mode: "unordered"
   - match: { hits.total.value: 3 }
 
 ---
 "Test unordered with overlap in match":
+  - skip:
+        version: " - 1.2.99"
+        reason: "Implemented in 1.3"
   - do:
       search:
         index: test
@@ -81,11 +90,14 @@ setup:
               text:
                 match:
                   query: "cold wet it"
-                  ordered: false
+                  mode: "unordered"
   - match: { hits.total.value: 3 }
 
 ---
 "Test unordered with no overlap in match":
+  - skip:
+      version: " - 1.2.99"
+      reason: "Implemented in 1.3"
   - do:
       search:
         index: test
@@ -95,12 +107,14 @@ setup:
               text:
                 match:
                   query: "cold wet it"
-                  ordered: false
-                  overlap: false
+                  mode: "unordered_no_overlap"
   - match: { hits.total.value: 2 }
 
 ---
 "Test phrase matching":
+  - skip:
+      version: " - 1.2.99"
+      reason: "mode introduced in 1.3"
   - do:
       search:
         index: test
@@ -110,7 +124,7 @@ setup:
               text:
                 match:
                   query: "cold outside"
-                  ordered: true
+                  mode: "ordered"
                   max_gaps: 0
   - match: { hits.total.value: 1 }
 
@@ -130,6 +144,9 @@ setup:
 
 ---
 "Test ordered max_gaps matching":
+  - skip:
+      version: " - 1.2.99"
+      reason: "mode introduced in 1.3"
   - do:
       search:
         index: test
@@ -140,11 +157,14 @@ setup:
                 match:
                   query: "cold outside"
                   max_gaps: 0
-                  ordered: true
+                  mode: "ordered"
   - match: { hits.total.value: 1 }
 
 ---
 "Test ordered combination with disjunction":
+  - skip:
+      version: " - 1.2.99"
+      reason: "mode introduced in 1.3"
   - do:
       search:
         index: test
@@ -162,11 +182,14 @@ setup:
                               query: "outside"
                     - match:
                         query: "atmosphere"
-                  ordered: true
+                  mode: "ordered"
   - match: { hits.total.value: 1 }
 
 ---
 "Test ordered combination with max_gaps":
+  - skip:
+      version: " - 1.2.99"
+      reason: "mode introduced in 1.3"
   - do:
       search:
         index: test
@@ -181,11 +204,14 @@ setup:
                     - match:
                         query: "outside"
                   max_gaps: 0
-                  ordered: true
+                  mode: "ordered"
   - match: { hits.total.value: 1 }
 
 ---
 "Test ordered combination":
+  - skip:
+      version: " - 1.2.99"
+      reason: "mode introduced in 1.3"
   - do:
       search:
         index: test
@@ -199,11 +225,14 @@ setup:
                         query: "cold"
                     - match:
                         query: "outside"
-                  ordered: true
+                  mode: "ordered"
   - match: { hits.total.value: 2 }
 
 ---
 "Test unordered combination":
+  - skip:
+      version: " - 1.2.99"
+      reason: "mode introduced in 1.3"
   - do:
       search:
         index: test
@@ -218,11 +247,14 @@ setup:
                     - match:
                         query: "outside"
                   max_gaps: 1
-                  ordered: false
+                  mode: "unordered"
   - match: { hits.total.value: 2 }
 
 ---
 "Test unordered combination with overlap":
+  - skip:
+      version: " - 1.2.99"
+      reason: "Implemented in 1.3"
   - do:
       search:
         index: test
@@ -238,11 +270,14 @@ setup:
                         query: "wet"
                     - match:
                         query: "it"
-                  ordered: false
+                  mode: "unordered"
   - match: { hits.total.value: 3 }
 
 ---
 "Test unordered combination no overlap":
+  - skip:
+      version: " - 1.2.99"
+      reason: "Implemented in 1.3"
   - do:
       search:
         index: test
@@ -258,12 +293,14 @@ setup:
                         query: "wet"
                     - match:
                         query: "it"
-                  ordered: false
-                  overlap: false
+                  mode: "unordered_no_overlap"
   - match: { hits.total.value: 2 }
 
 ---
 "Test nested unordered combination with overlap":
+  - skip:
+      version: " - 1.2.99"
+      reason: "Implemented in 1.3"
   - do:
       search:
         index: test
@@ -281,11 +318,14 @@ setup:
                               query: "hot"
                     - match:
                         query: "cold"
-                  ordered: false
+                  mode: "unordered"
   - match: { hits.total.value: 6 }
 
 ---
 "Test nested unordered combination no overlap":
+  - skip:
+      version: " - 1.2.99"
+      reason: "Implemented in 1.3"
   - do:
       search:
         index: test
@@ -303,12 +343,14 @@ setup:
                               query: "hot"
                     - match:
                         query: "cold"
-                  ordered: false
-                  overlap: false
+                  mode: "unordered_no_overlap"
   - match: { hits.total.value: 2 }
 
 ---
 "Test block combination":
+  - skip:
+      version: " - 1.2.99"
+      reason: "mode introduced in 1.3"
   - do:
       search:
         index: test
@@ -322,13 +364,16 @@ setup:
                         query: "cold"
                     - match:
                         query: "outside"
-                  ordered: true
+                  mode: "ordered"
                   max_gaps: 0
   - match: { hits.total.value: 1 }
 
 
 ---
 "Test containing":
+  - skip:
+      version: " - 1.2.99"
+      reason: "mode introduced in 1.3"
   - do:
       search:
         index: test
@@ -342,7 +387,7 @@ setup:
                         query: "cold"
                     - match:
                         query: "outside"
-                  ordered: false
+                  mode: "unordered"
                   filter:
                     containing:
                       match:
@@ -352,6 +397,9 @@ setup:
 
 ---
 "Test not containing":
+  - skip:
+      version: " - 1.2.99"
+      reason: "mode introduced in 1.3"
   - do:
       search:
         index: test
@@ -365,7 +413,7 @@ setup:
                         query: "cold"
                     - match:
                         query: "outside"
-                  ordered: false
+                  mode: "unordered"
                   filter:
                     not_containing:
                       match:
@@ -374,6 +422,9 @@ setup:
 
 ---
 "Test contained_by":
+  - skip:
+      version: " - 1.2.99"
+      reason: "mode introduced in 1.3"
   - do:
       search:
         index: test
@@ -391,7 +442,7 @@ setup:
                               query: "cold"
                           - match:
                               query: "outside"
-                        ordered: false
+                        mode: "unordered"
   - match: { hits.total.value: 1 }
 
 ---
@@ -417,6 +468,9 @@ setup:
 
 ---
 "Test not_overlapping":
+  - skip:
+      version: " - 1.2.99"
+      reason: "mode introduced in 1.3"
   - do:
       search:
         index: test
@@ -430,7 +484,7 @@ setup:
                         query: "cold"
                     - match:
                         query: "outside"
-                  ordered: true
+                  mode: "ordered"
                   filter:
                     not_overlapping:
                       all_of:
@@ -439,14 +493,14 @@ setup:
                               query: "baby"
                           - match:
                               query: "there"
-                        ordered: false
+                        mode: "unordered"
   - match: { hits.total.value: 1 }
 
 ---
 "Test overlapping":
   - skip:
-      version: " - 7.1.99"
-      reason: "Implemented in 7.2"
+      version: " - 1.2.99"
+      reason: "mode introduced in 1.3"
   - do:
       search:
         index: test
@@ -456,12 +510,12 @@ setup:
               text:
                 match:
                   query: "cold outside"
-                  ordered: true
+                  mode: "ordered"
                   filter:
                     overlapping:
                       match:
                         query: "baby there"
-                        ordered: false
+                        mode: "unordered"
   - match: { hits.total.value: 1 }
   - match: { hits.hits.0._id: "3" }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/230_interval_query.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/230_interval_query.yml
@@ -17,13 +17,17 @@ setup:
           refresh: true
           body:
             - '{"index": {"_index": "test", "_id": "1"}}'
-            - '{"text" : "Some like it hot, some like it cold"}'
+            - '{"text" : "Some like hot and dry, some like it cold and wet"}'
             - '{"index": {"_index": "test", "_id": "2"}}'
             - '{"text" : "Its cold outside, theres no kind of atmosphere"}'
             - '{"index": {"_index": "test", "_id": "3"}}'
             - '{"text" : "Baby its cold there outside"}'
             - '{"index": {"_index": "test", "_id": "4"}}'
             - '{"text" : "Outside it is cold and wet"}'
+            - '{"index": {"_index": "test", "_id": "5"}}'
+            - '{"text" : "cold rain makes it wet"}'
+            - '{"index": {"_index": "test", "_id": "6"}}'
+            - '{"text" : "that is some cold cold rain"}'
 
 ---
 "Test ordered matching":
@@ -65,6 +69,35 @@ setup:
                   query: "cold outside"
                   ordered: false
   - match: { hits.total.value: 3 }
+
+---
+"Test unordered with overlap in match":
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            intervals:
+              text:
+                match:
+                  query: "cold wet it"
+                  ordered: false
+  - match: { hits.total.value: 3 }
+
+---
+"Test unordered with no overlap in match":
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            intervals:
+              text:
+                match:
+                  query: "cold wet it"
+                  ordered: false
+                  overlap: false
+  - match: { hits.total.value: 2 }
 
 ---
 "Test phrase matching":
@@ -189,6 +222,92 @@ setup:
   - match: { hits.total.value: 2 }
 
 ---
+"Test unordered combination with overlap":
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            intervals:
+              text:
+                all_of:
+                  intervals:
+                    - match:
+                        query: "cold"
+                    - match:
+                        query: "wet"
+                    - match:
+                        query: "it"
+                  ordered: false
+  - match: { hits.total.value: 3 }
+
+---
+"Test unordered combination no overlap":
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            intervals:
+              text:
+                all_of:
+                  intervals:
+                    - match:
+                        query: "cold"
+                    - match:
+                        query: "wet"
+                    - match:
+                        query: "it"
+                  ordered: false
+                  overlap: false
+  - match: { hits.total.value: 2 }
+
+---
+"Test nested unordered combination with overlap":
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            intervals:
+              text:
+                all_of:
+                  intervals:
+                    - any_of:
+                        intervals:
+                          - match:
+                              query: "cold"
+                          - match:
+                              query: "hot"
+                    - match:
+                        query: "cold"
+                  ordered: false
+  - match: { hits.total.value: 6 }
+
+---
+"Test nested unordered combination no overlap":
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            intervals:
+              text:
+                all_of:
+                  intervals:
+                    - any_of:
+                        intervals:
+                          - match:
+                              query: "cold"
+                          - match:
+                              query: "hot"
+                    - match:
+                        query: "cold"
+                  ordered: false
+                  overlap: false
+  - match: { hits.total.value: 2 }
+
+---
 "Test block combination":
   - do:
       search:
@@ -294,7 +413,7 @@ setup:
                               query: "cold"
                           - match:
                               query: "outside"
-  - match: { hits.total.value: 1 }
+  - match: { hits.total.value: 2 }
 
 ---
 "Test not_overlapping":

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/230_interval_query.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/230_interval_query.yml
@@ -30,7 +30,7 @@ setup:
             - '{"text" : "that is some cold cold rain"}'
 
 ---
-"Test ordered matching":
+"Test ordered matching with via mode":
   - skip:
       version: " - 1.99.99"
       reason: "mode introduced in 2.0"
@@ -47,6 +47,24 @@ setup:
   - match: { hits.total.value: 2 }
 
 ---
+"Test ordered matching":
+  - skip:
+      features: allowed_warnings
+  - do:
+      allowed_warnings:
+        - "Deprecated field [ordered] used, this field is unused and will be removed entirely"
+      search:
+        index: test
+        body:
+          query:
+            intervals:
+              text:
+                match:
+                  query: "cold outside"
+                  ordered: true
+  - match: { hits.total.value: 2 }
+
+---
 "Test default unordered matching":
   - do:
         search:
@@ -60,7 +78,7 @@ setup:
   - match: { hits.total.value: 3 }
 
 ---
-"Test explicit unordered matching":
+"Test explicit unordered matching via mode":
   - skip:
       version: " - 1.99.99"
       reason: "mode introduced in 2.0"
@@ -74,6 +92,24 @@ setup:
                 match:
                   query: "cold outside"
                   mode: "unordered"
+  - match: { hits.total.value: 3 }
+
+---
+"Test explicit unordered matching":
+  - skip:
+      features: allowed_warnings
+  - do:
+      allowed_warnings:
+        - "Deprecated field [ordered] used, this field is unused and will be removed entirely"
+      search:
+        index: test
+        body:
+          query:
+            intervals:
+              text:
+                match:
+                  query: "cold outside"
+                  ordered: false
   - match: { hits.total.value: 3 }
 
 ---
@@ -161,7 +197,7 @@ setup:
   - match: { hits.total.value: 1 }
 
 ---
-"Test ordered combination with disjunction":
+"Test ordered combination with disjunction via mode":
   - skip:
       version: " - 1.99.99"
       reason: "mode introduced in 2.0"
@@ -183,6 +219,32 @@ setup:
                     - match:
                         query: "atmosphere"
                   mode: "ordered"
+  - match: { hits.total.value: 1 }
+
+---
+"Test ordered combination with disjunction":
+  - skip:
+      features: allowed_warnings
+  - do:
+      allowed_warnings:
+        - "Deprecated field [ordered] used, this field is unused and will be removed entirely"
+      search:
+        index: test
+        body:
+          query:
+            intervals:
+              text:
+                all_of:
+                  intervals:
+                    - any_of:
+                        intervals:
+                          - match:
+                              query: "cold"
+                          - match:
+                              query: "outside"
+                    - match:
+                        query: "atmosphere"
+                  ordered: true
   - match: { hits.total.value: 1 }
 
 ---
@@ -229,7 +291,7 @@ setup:
   - match: { hits.total.value: 2 }
 
 ---
-"Test unordered combination":
+"Test unordered combination via mode":
   - skip:
       version: " - 1.99.99"
       reason: "mode introduced in 2.0"
@@ -248,6 +310,29 @@ setup:
                         query: "outside"
                   max_gaps: 1
                   mode: "unordered"
+  - match: { hits.total.value: 2 }
+
+---
+"Test unordered combination":
+  - skip:
+      features: allowed_warnings
+  - do:
+      allowed_warnings:
+        - "Deprecated field [ordered] used, this field is unused and will be removed entirely"
+      search:
+        index: test
+        body:
+          query:
+            intervals:
+              text:
+                all_of:
+                  intervals:
+                    - match:
+                        query: "cold"
+                    - match:
+                        query: "outside"
+                  max_gaps: 1
+                  ordered: false
   - match: { hits.total.value: 2 }
 
 ---

--- a/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
@@ -59,6 +59,7 @@ import org.opensearch.common.unit.Fuzziness;
 import org.opensearch.index.analysis.NamedAnalyzer;
 import org.opensearch.index.fielddata.IndexFieldData;
 import org.opensearch.index.query.DistanceFeatureQueryBuilder;
+import org.opensearch.index.query.IntervalMode;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.QueryShardException;
@@ -365,7 +366,7 @@ public abstract class MappedFieldType {
     /**
      * Create an {@link IntervalsSource} to be used for proximity queries
      */
-    public IntervalsSource intervals(String query, int max_gaps, boolean ordered, boolean overlap, NamedAnalyzer analyzer, boolean prefix)
+    public IntervalsSource intervals(String query, int max_gaps, IntervalMode mode, NamedAnalyzer analyzer, boolean prefix)
         throws IOException {
         throw new IllegalArgumentException(
             "Can only use interval queries on text fields - not on [" + name + "] which is of type [" + typeName() + "]"

--- a/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
@@ -365,7 +365,7 @@ public abstract class MappedFieldType {
     /**
      * Create an {@link IntervalsSource} to be used for proximity queries
      */
-    public IntervalsSource intervals(String query, int max_gaps, boolean ordered, NamedAnalyzer analyzer, boolean prefix)
+    public IntervalsSource intervals(String query, int max_gaps, boolean ordered, boolean overlap, NamedAnalyzer analyzer, boolean prefix)
         throws IOException {
         throw new IllegalArgumentException(
             "Can only use interval queries on text fields - not on [" + name + "] which is of type [" + typeName() + "]"

--- a/server/src/main/java/org/opensearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/TextFieldMapper.java
@@ -789,7 +789,7 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public IntervalsSource intervals(String text, int maxGaps, boolean ordered, NamedAnalyzer analyzer, boolean prefix)
+        public IntervalsSource intervals(String text, int maxGaps, boolean ordered, boolean overlap, NamedAnalyzer analyzer, boolean prefix)
             throws IOException {
             if (getTextSearchInfo().hasPositions() == false) {
                 throw new IllegalArgumentException("Cannot create intervals over field [" + name() + "] with no positions indexed");
@@ -805,7 +805,7 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
                 return Intervals.prefix(normalizedTerm);
             }
             IntervalBuilder builder = new IntervalBuilder(name(), analyzer == null ? getTextSearchInfo().getSearchAnalyzer() : analyzer);
-            return builder.analyzeText(text, maxGaps, ordered);
+            return builder.analyzeText(text, maxGaps, ordered, overlap);
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/TextFieldMapper.java
@@ -85,6 +85,7 @@ import org.opensearch.index.fielddata.IndexFieldData;
 import org.opensearch.index.fielddata.plain.PagedBytesIndexFieldData;
 import org.opensearch.index.mapper.Mapper.TypeParser.ParserContext;
 import org.opensearch.index.query.IntervalBuilder;
+import org.opensearch.index.query.IntervalMode;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.similarity.SimilarityProvider;
 import org.opensearch.search.aggregations.support.CoreValuesSourceType;
@@ -789,7 +790,7 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
         }
 
         @Override
-        public IntervalsSource intervals(String text, int maxGaps, boolean ordered, boolean overlap, NamedAnalyzer analyzer, boolean prefix)
+        public IntervalsSource intervals(String text, int maxGaps, IntervalMode mode, NamedAnalyzer analyzer, boolean prefix)
             throws IOException {
             if (getTextSearchInfo().hasPositions() == false) {
                 throw new IllegalArgumentException("Cannot create intervals over field [" + name() + "] with no positions indexed");
@@ -805,7 +806,7 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
                 return Intervals.prefix(normalizedTerm);
             }
             IntervalBuilder builder = new IntervalBuilder(name(), analyzer == null ? getTextSearchInfo().getSearchAnalyzer() : analyzer);
-            return builder.analyzeText(text, maxGaps, ordered, overlap);
+            return builder.analyzeText(text, maxGaps, mode);
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/index/query/IntervalBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/IntervalBuilder.java
@@ -69,21 +69,20 @@ public class IntervalBuilder {
     }
 
     public IntervalsSource analyzeText(String query, int maxGaps, boolean ordered) throws IOException {
-        return analyzeText(query, maxGaps, ordered, true);
+        return analyzeText(query, maxGaps, ordered ? IntervalMode.ORDERED : IntervalMode.UNORDERED);
     }
 
-    public IntervalsSource analyzeText(String query, int maxGaps, boolean ordered, boolean overlap) throws IOException {
+    public IntervalsSource analyzeText(String query, int maxGaps, IntervalMode mode) throws IOException {
         try (TokenStream ts = analyzer.tokenStream(field, query); CachingTokenFilter stream = new CachingTokenFilter(ts)) {
-            return analyzeText(stream, maxGaps, ordered, overlap);
+            return analyzeText(stream, maxGaps, mode);
         }
     }
 
     protected IntervalsSource analyzeText(CachingTokenFilter stream, int maxGaps, boolean ordered) throws IOException {
-        return analyzeText(stream, maxGaps, ordered, true);
+        return analyzeText(stream, maxGaps, ordered ? IntervalMode.ORDERED : IntervalMode.UNORDERED);
     }
 
-    protected IntervalsSource analyzeText(CachingTokenFilter stream, int maxGaps, boolean ordered, boolean overlap) throws IOException {
-
+    protected IntervalsSource analyzeText(CachingTokenFilter stream, int maxGaps, IntervalMode mode) throws IOException {
         TermToBytesRefAttribute termAtt = stream.getAttribute(TermToBytesRefAttribute.class);
         PositionIncrementAttribute posIncAtt = stream.addAttribute(PositionIncrementAttribute.class);
         PositionLengthAttribute posLenAtt = stream.addAttribute(PositionLengthAttribute.class);
@@ -122,15 +121,15 @@ public class IntervalBuilder {
             return analyzeTerm(stream);
         } else if (isGraph) {
             // graph
-            return combineSources(analyzeGraph(stream), maxGaps, ordered, overlap);
+            return combineSources(analyzeGraph(stream), maxGaps, mode);
         } else {
             // phrase
             if (hasSynonyms) {
                 // phrase with single-term synonyms
-                return analyzeSynonyms(stream, maxGaps, ordered, overlap);
+                return analyzeSynonyms(stream, maxGaps, mode);
             } else {
                 // simple phrase
-                return combineSources(analyzeTerms(stream), maxGaps, ordered, overlap);
+                return combineSources(analyzeTerms(stream), maxGaps, mode);
             }
         }
 
@@ -143,7 +142,7 @@ public class IntervalBuilder {
         return Intervals.term(BytesRef.deepCopyOf(bytesAtt.getBytesRef()));
     }
 
-    protected static IntervalsSource combineSources(List<IntervalsSource> sources, int maxGaps, boolean ordered, boolean overlap) {
+    protected static IntervalsSource combineSources(List<IntervalsSource> sources, int maxGaps, IntervalMode mode) {
         if (sources.size() == 0) {
             return NO_INTERVALS;
         }
@@ -151,25 +150,21 @@ public class IntervalBuilder {
             return sources.get(0);
         }
         IntervalsSource[] sourcesArray = sources.toArray(new IntervalsSource[0]);
-        if (maxGaps == 0 && ordered) {
+        if (maxGaps == 0 && mode == IntervalMode.ORDERED) {
             return Intervals.phrase(sourcesArray);
         }
         IntervalsSource inner;
-        if (ordered) {
+        if (mode == IntervalMode.ORDERED) {
             inner = Intervals.ordered(sourcesArray);
+        } else if (mode == IntervalMode.UNORDERED) {
+            inner = Intervals.unordered(sourcesArray);
         } else {
-            if (overlap) {
-                inner = Intervals.unordered(sourcesArray);
-            } else {
-                inner = Intervals.unorderedNoOverlaps(sourcesArray[0], sourcesArray[1]);
-                for (int sourceIdx = 2; sourceIdx < sourcesArray.length; sourceIdx++) {
-                    inner = Intervals.unorderedNoOverlaps(
-                        maxGaps == -1 ? inner : Intervals.maxgaps(maxGaps, inner),
-                        sourcesArray[sourceIdx]
-                    );
-                }
+            inner = Intervals.unorderedNoOverlaps(sourcesArray[0], sourcesArray[1]);
+            for (int sourceIdx = 2; sourceIdx < sourcesArray.length; sourceIdx++) {
+                inner = Intervals.unorderedNoOverlaps(maxGaps == -1 ? inner : Intervals.maxgaps(maxGaps, inner), sourcesArray[sourceIdx]);
             }
         }
+
         if (maxGaps == -1) {
             return inner;
         }
@@ -197,7 +192,7 @@ public class IntervalBuilder {
         return Intervals.extend(source, precedingSpaces, 0);
     }
 
-    protected IntervalsSource analyzeSynonyms(TokenStream ts, int maxGaps, boolean ordered, boolean overlap) throws IOException {
+    protected IntervalsSource analyzeSynonyms(TokenStream ts, int maxGaps, IntervalMode mode) throws IOException {
         List<IntervalsSource> terms = new ArrayList<>();
         List<IntervalsSource> synonyms = new ArrayList<>();
         TermToBytesRefAttribute bytesAtt = ts.addAttribute(TermToBytesRefAttribute.class);
@@ -222,7 +217,7 @@ public class IntervalBuilder {
         } else {
             terms.add(extend(Intervals.or(synonyms.toArray(new IntervalsSource[0])), spaces));
         }
-        return combineSources(terms, maxGaps, ordered, overlap);
+        return combineSources(terms, maxGaps, mode);
     }
 
     protected List<IntervalsSource> analyzeGraph(TokenStream source) throws IOException {
@@ -245,7 +240,7 @@ public class IntervalBuilder {
                 Iterator<TokenStream> it = graph.getFiniteStrings(start, end);
                 while (it.hasNext()) {
                     TokenStream ts = it.next();
-                    IntervalsSource phrase = combineSources(analyzeTerms(ts), 0, true, false);
+                    IntervalsSource phrase = combineSources(analyzeTerms(ts), 0, IntervalMode.ORDERED);
                     if (paths.size() >= maxClauseCount) {
                         throw new BooleanQuery.TooManyClauses();
                     }

--- a/server/src/main/java/org/opensearch/index/query/IntervalMode.java
+++ b/server/src/main/java/org/opensearch/index/query/IntervalMode.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.query;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+
+import java.io.IOException;
+
+public enum IntervalMode implements Writeable {
+    ORDERED(0),
+    UNORDERED(1),
+    UNORDERED_NO_OVERLAP(2);
+
+    private final int ordinal;
+
+    IntervalMode(int ordinal) {
+        this.ordinal = ordinal;
+    }
+
+    public static IntervalMode readFromStream(StreamInput in) throws IOException {
+        int ord = in.readVInt();
+        switch (ord) {
+            case (0):
+                return ORDERED;
+            case (1):
+                return UNORDERED;
+            case (2):
+                return UNORDERED_NO_OVERLAP;
+        }
+        throw new OpenSearchException("unknown serialized type [" + ord + "]");
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(this.ordinal);
+    }
+
+    public static IntervalMode fromString(String intervalMode) {
+        if (intervalMode == null) {
+            throw new IllegalArgumentException("cannot parse mode from null string");
+        }
+
+        for (IntervalMode mode : IntervalMode.values()) {
+            if (mode.name().equalsIgnoreCase(intervalMode)) {
+                return mode;
+            }
+        }
+        throw new IllegalArgumentException("no mode can be parsed from ordinal " + intervalMode);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/query/IntervalsSourceProvider.java
+++ b/server/src/main/java/org/opensearch/index/query/IntervalsSourceProvider.java
@@ -147,7 +147,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         public Match(StreamInput in) throws IOException {
             this.query = in.readString();
             this.maxGaps = in.readVInt();
-            if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
+            if (in.getVersion().onOrAfter(Version.V_2_0_0)) {
                 this.mode = IntervalMode.readFromStream(in);
             } else {
                 if (in.readBoolean()) {
@@ -219,7 +219,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(query);
             out.writeVInt(maxGaps);
-            if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
+            if (out.getVersion().onOrAfter(Version.V_2_0_0)) {
                 mode.writeTo(out);
             } else {
                 out.writeBoolean(mode == IntervalMode.ORDERED);
@@ -431,7 +431,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         }
 
         public Combine(StreamInput in) throws IOException {
-            if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
+            if (in.getVersion().onOrAfter(Version.V_2_0_0)) {
                 this.mode = IntervalMode.readFromStream(in);
             } else {
                 this.mode = in.readBoolean() ? IntervalMode.ORDERED : IntervalMode.UNORDERED;
@@ -484,7 +484,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
+            if (out.getVersion().onOrAfter(Version.V_2_0_0)) {
                 mode.writeTo(out);
             } else {
                 out.writeBoolean(mode == IntervalMode.ORDERED);

--- a/server/src/test/java/org/opensearch/index/query/CombineIntervalsSourceProviderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/CombineIntervalsSourceProviderTests.java
@@ -54,9 +54,10 @@ public class CombineIntervalsSourceProviderTests extends AbstractSerializingTest
     protected Combine mutateInstance(Combine instance) throws IOException {
         List<IntervalsSourceProvider> subSources = instance.getSubSources();
         boolean ordered = instance.isOrdered();
+        boolean overlap = instance.isOverlap();
         int maxGaps = instance.getMaxGaps();
         IntervalsSourceProvider.IntervalFilter filter = instance.getFilter();
-        switch (between(0, 3)) {
+        switch (between(0, 4)) {
             case 0:
                 subSources = subSources == null
                     ? IntervalQueryBuilderTests.createRandomSourceList(0, randomBoolean(), randomInt(5) + 1)
@@ -73,10 +74,13 @@ public class CombineIntervalsSourceProviderTests extends AbstractSerializingTest
                     ? IntervalQueryBuilderTests.createRandomNonNullFilter(0, randomBoolean())
                     : FilterIntervalsSourceProviderTests.mutateFilter(filter);
                 break;
+            case 4:
+                overlap = !overlap;
+                break;
             default:
                 throw new AssertionError("Illegal randomisation branch");
         }
-        return new Combine(subSources, ordered, maxGaps, filter);
+        return new Combine(subSources, ordered, overlap, maxGaps, filter);
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/index/query/CombineIntervalsSourceProviderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/CombineIntervalsSourceProviderTests.java
@@ -53,18 +53,23 @@ public class CombineIntervalsSourceProviderTests extends AbstractSerializingTest
     @Override
     protected Combine mutateInstance(Combine instance) throws IOException {
         List<IntervalsSourceProvider> subSources = instance.getSubSources();
-        boolean ordered = instance.isOrdered();
-        boolean overlap = instance.isOverlap();
+        IntervalMode mode = instance.getMode();
         int maxGaps = instance.getMaxGaps();
         IntervalsSourceProvider.IntervalFilter filter = instance.getFilter();
-        switch (between(0, 4)) {
+        switch (between(0, 3)) {
             case 0:
                 subSources = subSources == null
                     ? IntervalQueryBuilderTests.createRandomSourceList(0, randomBoolean(), randomInt(5) + 1)
                     : null;
                 break;
             case 1:
-                ordered = !ordered;
+                if (mode == IntervalMode.ORDERED) {
+                    mode = randomBoolean() ? IntervalMode.UNORDERED : IntervalMode.UNORDERED_NO_OVERLAP;
+                } else if (mode == IntervalMode.UNORDERED) {
+                    mode = randomBoolean() ? IntervalMode.ORDERED : IntervalMode.UNORDERED_NO_OVERLAP;
+                } else {
+                    mode = randomBoolean() ? IntervalMode.UNORDERED : IntervalMode.ORDERED;
+                }
                 break;
             case 2:
                 maxGaps++;
@@ -74,13 +79,10 @@ public class CombineIntervalsSourceProviderTests extends AbstractSerializingTest
                     ? IntervalQueryBuilderTests.createRandomNonNullFilter(0, randomBoolean())
                     : FilterIntervalsSourceProviderTests.mutateFilter(filter);
                 break;
-            case 4:
-                overlap = !overlap;
-                break;
             default:
                 throw new AssertionError("Illegal randomisation branch");
         }
-        return new Combine(subSources, ordered, overlap, maxGaps, filter);
+        return new Combine(subSources, mode, maxGaps, filter);
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/index/query/IntervalBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/IntervalBuilderTests.java
@@ -78,6 +78,19 @@ public class IntervalBuilderTests extends OpenSearchTestCase {
 
     }
 
+    public void testUnorderedNoOverlap() throws IOException {
+
+        CannedTokenStream ts = new CannedTokenStream(new Token("term1", 1, 2), new Token("term2", 3, 4), new Token("term3", 5, 6));
+
+        IntervalsSource source = BUILDER.analyzeText(new CachingTokenFilter(ts), -1, false, false);
+        IntervalsSource expected = Intervals.unorderedNoOverlaps(
+            Intervals.unorderedNoOverlaps(Intervals.term("term1"), Intervals.term("term2")),
+            Intervals.term("term3")
+        );
+
+        assertEquals(expected, source);
+    }
+
     public void testPhrase() throws IOException {
 
         CannedTokenStream ts = new CannedTokenStream(new Token("term1", 1, 2), new Token("term2", 3, 4), new Token("term3", 5, 6));

--- a/server/src/test/java/org/opensearch/index/query/IntervalBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/IntervalBuilderTests.java
@@ -82,7 +82,7 @@ public class IntervalBuilderTests extends OpenSearchTestCase {
 
         CannedTokenStream ts = new CannedTokenStream(new Token("term1", 1, 2), new Token("term2", 3, 4), new Token("term3", 5, 6));
 
-        IntervalsSource source = BUILDER.analyzeText(new CachingTokenFilter(ts), -1, false, false);
+        IntervalsSource source = BUILDER.analyzeText(new CachingTokenFilter(ts), -1, IntervalMode.UNORDERED_NO_OVERLAP);
         IntervalsSource expected = Intervals.unorderedNoOverlaps(
             Intervals.unorderedNoOverlaps(Intervals.term("term1"), Intervals.term("term2")),
             Intervals.term("term3")

--- a/server/src/test/java/org/opensearch/index/query/MatchIntervalsSourceProviderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/MatchIntervalsSourceProviderTests.java
@@ -54,10 +54,11 @@ public class MatchIntervalsSourceProviderTests extends AbstractSerializingTestCa
         String query = instance.getQuery();
         int maxGaps = instance.getMaxGaps();
         boolean isOrdered = instance.isOrdered();
+        boolean isOverlap = instance.isOverlap();
         String analyzer = instance.getAnalyzer();
         IntervalsSourceProvider.IntervalFilter filter = instance.getFilter();
         String useField = instance.getUseField();
-        switch (between(0, 5)) {
+        switch (between(0, 6)) {
             case 0:
                 query = randomAlphaOfLength(query.length() + 3);
                 break;
@@ -78,10 +79,13 @@ public class MatchIntervalsSourceProviderTests extends AbstractSerializingTestCa
             case 5:
                 useField = useField == null ? randomAlphaOfLength(5) : (useField + "foo");
                 break;
+            case 6:
+                isOverlap = !isOverlap;
+                break;
             default:
                 throw new AssertionError("Illegal randomisation branch");
         }
-        return new Match(query, maxGaps, isOrdered, analyzer, filter, useField);
+        return new Match(query, maxGaps, isOrdered, isOverlap, analyzer, filter, useField);
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/index/query/MatchIntervalsSourceProviderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/MatchIntervalsSourceProviderTests.java
@@ -53,12 +53,11 @@ public class MatchIntervalsSourceProviderTests extends AbstractSerializingTestCa
     protected Match mutateInstance(Match instance) throws IOException {
         String query = instance.getQuery();
         int maxGaps = instance.getMaxGaps();
-        boolean isOrdered = instance.isOrdered();
-        boolean isOverlap = instance.isOverlap();
+        IntervalMode mode = instance.getMode();
         String analyzer = instance.getAnalyzer();
         IntervalsSourceProvider.IntervalFilter filter = instance.getFilter();
         String useField = instance.getUseField();
-        switch (between(0, 6)) {
+        switch (between(0, 5)) {
             case 0:
                 query = randomAlphaOfLength(query.length() + 3);
                 break;
@@ -66,7 +65,13 @@ public class MatchIntervalsSourceProviderTests extends AbstractSerializingTestCa
                 maxGaps++;
                 break;
             case 2:
-                isOrdered = !isOrdered;
+                if (mode == IntervalMode.ORDERED) {
+                    mode = randomBoolean() ? IntervalMode.UNORDERED : IntervalMode.UNORDERED_NO_OVERLAP;
+                } else if (mode == IntervalMode.UNORDERED) {
+                    mode = randomBoolean() ? IntervalMode.ORDERED : IntervalMode.UNORDERED_NO_OVERLAP;
+                } else {
+                    mode = randomBoolean() ? IntervalMode.UNORDERED : IntervalMode.ORDERED;
+                }
                 break;
             case 3:
                 analyzer = analyzer == null ? randomAlphaOfLength(5) : null;
@@ -79,13 +84,10 @@ public class MatchIntervalsSourceProviderTests extends AbstractSerializingTestCa
             case 5:
                 useField = useField == null ? randomAlphaOfLength(5) : (useField + "foo");
                 break;
-            case 6:
-                isOverlap = !isOverlap;
-                break;
             default:
                 throw new AssertionError("Illegal randomisation branch");
         }
-        return new Match(query, maxGaps, isOrdered, isOverlap, analyzer, filter, useField);
+        return new Match(query, maxGaps, mode, analyzer, filter, useField);
     }
 
     @Override


### PR DESCRIPTION
### Description
This commit exposes Intervals.unorderedNoOverlaps (LUCENE-8828).  This commit does bwc checks against `Version.V_1_3_0` assuming it will be backported if merged.

### Issues Resolved
#2053 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
