### PR TITLE
Adding shards per node constraint for predictability to testClusterGr…

### DIFF
--- a/server/src/test/java/org/opensearch/cluster/routing/MovePrimaryFirstTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/MovePrimaryFirstTests.java
@@ -12,15 +12,11 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.cluster.ClusterStateListener;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.stream.Stream;
 
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 
@@ -60,7 +56,8 @@ public class MovePrimaryFirstTests extends OpenSearchIntegTestCase {
     public void testClusterGreenAfterPartialRelocation() throws InterruptedException {
         internalCluster().startMasterOnlyNodes(1);
         final String z1 = "zone-1", z2 = "zone-2";
-        final int primaryShardCount = 100;
+        // Primary shard count should be even for equal distribution across two nodes
+        final int primaryShardCount = 6;
         final String z1n1 = startDataOnlyNode(z1);
         ensureGreen();
         createAndIndex("foo", 1, primaryShardCount);
@@ -73,8 +70,9 @@ public class MovePrimaryFirstTests extends OpenSearchIntegTestCase {
         // Enable cluster level setting for moving primaries first and keep new
         // zone nodes excluded to prevent any shard relocation
         ClusterUpdateSettingsRequest settingsRequest = new ClusterUpdateSettingsRequest();
-        settingsRequest.persistentSettings(
-            Settings.builder().put("cluster.routing.allocation.move.primary_first", true).put("cluster.routing.allocation.exclude.zone", z2)
+        settingsRequest.persistentSettings(Settings.builder()
+            .put("cluster.routing.allocation.move.primary_first", true)
+            .put("cluster.routing.allocation.exclude.zone", z2)
         );
         client().admin().cluster().updateSettings(settingsRequest).actionGet();
 
@@ -88,24 +86,17 @@ public class MovePrimaryFirstTests extends OpenSearchIntegTestCase {
             if (event.routingTableChanged()) {
                 final RoutingNodes routingNodes = event.state().getRoutingNodes();
                 int startedCount = 0;
-                List<ShardRouting> initz2n1 = new ArrayList<>(), initz2n2 = new ArrayList<>();
                 for (Iterator<RoutingNode> it = routingNodes.iterator(); it.hasNext();) {
                     RoutingNode routingNode = it.next();
                     final String nodeName = routingNode.node().getName();
-                    if (nodeName.equals(z2n1)) {
+                    if (nodeName.equals(z2n1) || nodeName.equals(z2n2)) {
                         startedCount += routingNode.numberOfShardsWithState(ShardRoutingState.STARTED);
-                        initz2n1 = routingNode.shardsWithState(ShardRoutingState.INITIALIZING);
-                    } else if (nodeName.equals(z2n2)) {
-                        startedCount += routingNode.numberOfShardsWithState(ShardRoutingState.STARTED);
-                        initz2n2 = routingNode.shardsWithState(ShardRoutingState.INITIALIZING);
                     }
                 }
-                if (!Stream.concat(initz2n1.stream(), initz2n2.stream()).anyMatch(s -> s.primary())) {
-                    // All primaries are relocated before 60% of total shards are started on new nodes
-                    final int totalShardCount = primaryShardCount * 2;
-                    if (primaryShardCount <= startedCount && startedCount <= 3 * totalShardCount / 5) {
-                        primaryMoveLatch.countDown();
-                    }
+
+                // Count down the latch once all the primary shards have initialized on nodes in zone-2
+                if (startedCount == primaryShardCount) {
+                    primaryMoveLatch.countDown();
                 }
             }
         };
@@ -113,15 +104,23 @@ public class MovePrimaryFirstTests extends OpenSearchIntegTestCase {
 
         // Exclude zone1 nodes for allocation and await latch count down
         settingsRequest = new ClusterUpdateSettingsRequest();
-        settingsRequest.persistentSettings(Settings.builder().put("cluster.routing.allocation.exclude.zone", z1));
+        settingsRequest.persistentSettings(
+            Settings.builder()
+                .put("cluster.routing.allocation.exclude.zone", z1)
+                // Total shards per node constraint is added to pause the relocation after primary shards
+                // have relocated to allow time for node shutdown and validate yellow cluster
+                .put("cluster.routing.allocation.total_shards_per_node", primaryShardCount/2)
+        );
         client().admin().cluster().updateSettings(settingsRequest);
         primaryMoveLatch.await();
 
-        // Shutdown both nodes in zone and ensure cluster stays green
+        // Shutdown both nodes in zone 1 and ensure cluster does not become red
         try {
             internalCluster().stopRandomNode(InternalTestCluster.nameFilter(z1n1));
             internalCluster().stopRandomNode(InternalTestCluster.nameFilter(z1n2));
         } catch (Exception e) {}
-        ensureGreen(TimeValue.timeValueSeconds(60));
+        // Due to shards per node constraint cluster cannot be green
+        // Since yellow suffices for this test, not removing shards constraint
+        ensureYellow();
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/routing/MovePrimaryFirstTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/MovePrimaryFirstTests.java
@@ -49,15 +49,17 @@ public class MovePrimaryFirstTests extends OpenSearchIntegTestCase {
     }
 
     /**
-     * Creates two nodes each in two zones and shuts down nodes in one zone
-     * after relocating half the number of shards. Since, primaries are relocated
-     * first, cluster should stay green as primary should have relocated
+     * Creates two nodes each in two zones and shuts down nodes in zone1 after
+     * relocating half the number of shards. Shards per node constraint ensures
+     * that exactly 50% of shards relocate to nodes in zone2 giving time to shut down
+     * nodes in zone1. Since primaries are relocated first as movePrimaryFirst is
+     * enabled, cluster should not become red and zone2 nodes have all the primaries
      */
     public void testClusterGreenAfterPartialRelocation() throws InterruptedException {
         internalCluster().startMasterOnlyNodes(1);
         final String z1 = "zone-1", z2 = "zone-2";
-        // Primary shard count should be even for equal distribution across two nodes
         final int primaryShardCount = 6;
+        assertTrue("Primary shard count must be even for equal distribution across two nodes", primaryShardCount % 2 == 0);
         final String z1n1 = startDataOnlyNode(z1);
         ensureGreen();
         createAndIndex("foo", 1, primaryShardCount);

--- a/server/src/test/java/org/opensearch/cluster/routing/MovePrimaryFirstTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/MovePrimaryFirstTests.java
@@ -70,9 +70,8 @@ public class MovePrimaryFirstTests extends OpenSearchIntegTestCase {
         // Enable cluster level setting for moving primaries first and keep new
         // zone nodes excluded to prevent any shard relocation
         ClusterUpdateSettingsRequest settingsRequest = new ClusterUpdateSettingsRequest();
-        settingsRequest.persistentSettings(Settings.builder()
-            .put("cluster.routing.allocation.move.primary_first", true)
-            .put("cluster.routing.allocation.exclude.zone", z2)
+        settingsRequest.persistentSettings(
+            Settings.builder().put("cluster.routing.allocation.move.primary_first", true).put("cluster.routing.allocation.exclude.zone", z2)
         );
         client().admin().cluster().updateSettings(settingsRequest).actionGet();
 
@@ -109,7 +108,7 @@ public class MovePrimaryFirstTests extends OpenSearchIntegTestCase {
                 .put("cluster.routing.allocation.exclude.zone", z1)
                 // Total shards per node constraint is added to pause the relocation after primary shards
                 // have relocated to allow time for node shutdown and validate yellow cluster
-                .put("cluster.routing.allocation.total_shards_per_node", primaryShardCount/2)
+                .put("cluster.routing.allocation.total_shards_per_node", primaryShardCount / 2)
         );
         client().admin().cluster().updateSettings(settingsRequest);
         primaryMoveLatch.await();


### PR DESCRIPTION
…eenAfterPartialRelocation

Signed-off-by: Ankit Jain <jain.ankitk@gmail.com>

### Description
The test was failing due to some replica shards initializing and completing before last primary shard could finish initializing. Added shards per node constraint to prevent this from happening. The test has become really lightweight, completes in less than 5 seconds mostly and ran locally without any failure more than 500 times
 
### Issues Resolved
#1957 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [] New functionality has been documented.
  - [] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
