### PR TITLE
[Remove] 6x skip from yml

### DIFF
--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/30_tokenizers.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/30_tokenizers.yml
@@ -24,9 +24,6 @@
 
 ---
 "ngram_exception":
-    - skip:
-        version: " - 6.99.99"
-        reason: only starting from version 7.x this throws an error
     - do:
         catch: /The difference between max_gram and min_gram in NGram Tokenizer must be less than or equal to[:] \[1\] but was \[2\]\. This limit can be set by changing the \[index.max_ngram_diff\] index level setting\./
         indices.analyze:

--- a/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/30_search_template.yml
+++ b/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/30_search_template.yml
@@ -141,10 +141,6 @@
 
 ---
 "Test with new response format":
-  - skip:
-      version: " - 6.99.99"
-      reason: hits.total is returned as an object in 7.0.0
-
   - do:
       index:
         index:  test

--- a/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/50_multi_search_template.yml
+++ b/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/50_multi_search_template.yml
@@ -174,10 +174,6 @@ setup:
 
 ---
 "Test with rest_total_hits_as_int":
-  - skip:
-      version: " - 6.99.99"
-      reason: hits.total is returned as an object in 7.0.0
-
   - do:
       put_script:
         id: stored_template_1

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/30_search.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/30_search.yml
@@ -452,10 +452,6 @@
 ---
 
 "Exception on negative score":
-    - skip:
-        version: " - 6.99.99"
-        reason: "check on negative scores was added from 7.0.0 on"
-
     - do:
         index:
             index: test

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/70_mov_fn_agg.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/70_mov_fn_agg.yml
@@ -1,10 +1,6 @@
 # Sanity integration test to make sure the custom context and whitelist work for moving_fn pipeline agg
 #
 setup:
-  - skip:
-      version: " - 6.3.99"
-      reason:  "moving_fn added in 6.4.0"
-
   - do:
       indices.create:
         index: test

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/80_script_score.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/80_script_score.yml
@@ -1,10 +1,6 @@
 # Integration tests for ScriptScoreQuery using Painless
 
 setup:
-  - skip:
-      version: " - 6.99.99"
-      reason: "script score query was introduced in 7.0.0"
-
 ---
 "Math functions":
 

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/80_script_score.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/80_script_score.yml
@@ -1,6 +1,4 @@
 # Integration tests for ScriptScoreQuery using Painless
-
-setup:
 ---
 "Math functions":
 

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/90_interval_query_filter.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/90_interval_query_filter.yml
@@ -1,8 +1,4 @@
 setup:
-  - skip:
-      version: " - 6.99.99"
-      reason:  "Implemented in 7.0"
-
   - do:
       indices.create:
         index:  test

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/rank_feature/10_basic.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/rank_feature/10_basic.yml
@@ -1,8 +1,4 @@
 setup:
-  - skip:
-      version: " - 6.99.99"
-      reason: "The rank feature field/query was introduced in 7.0.0"
-
   - do:
       indices.create:
           index: test

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/rank_features/10_basic.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/rank_features/10_basic.yml
@@ -1,8 +1,4 @@
 setup:
-  - skip:
-      version: " - 6.99.99"
-      reason: "The rank_features field was introduced in 7.0.0"
-
   - do:
       indices.create:
           index: test

--- a/modules/percolator/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
+++ b/modules/percolator/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
@@ -1,10 +1,5 @@
 ---
 "Test percolator basics via rest":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       indices.create:
         index: queries_index
@@ -74,7 +69,7 @@
               percolate:
                 field: query
                 index: documents_index
-                id: some_id 
+                id: some_id
   - match:  { hits.total:     1  }
 
   - do:

--- a/modules/rank-eval/src/yamlRestTest/resources/rest-api-spec/test/rank_eval/10_basic.yml
+++ b/modules/rank-eval/src/yamlRestTest/resources/rest-api-spec/test/rank_eval/10_basic.yml
@@ -40,11 +40,6 @@ setup:
 
 ---
 "Response format":
-
-  - skip:
-      version: " - 6.2.99"
-      reason: response format was updated in 6.3
-
   - do:
       rank_eval:
         index: foo,
@@ -121,11 +116,6 @@ setup:
 
 ---
 "Mean Reciprocal Rank":
-
-  - skip:
-      version: " - 6.2.99"
-      reason: response format was updated in 6.3
-
   - do:
       rank_eval:
         body: {
@@ -160,11 +150,6 @@ setup:
 
 ---
 "Expected Reciprocal Rank":
-
-  - skip:
-      version: " - 6.3.99"
-      reason: ERR was introduced in 6.4
-
   - do:
       rank_eval:
         body: {

--- a/modules/rank-eval/src/yamlRestTest/resources/rest-api-spec/test/rank_eval/20_dcg.yml
+++ b/modules/rank-eval/src/yamlRestTest/resources/rest-api-spec/test/rank_eval/20_dcg.yml
@@ -1,10 +1,5 @@
 ---
 "Response format":
-
-  - skip:
-      version: " - 6.1.99"
-      reason: the ranking evaluation feature is available since 6.2
-
   - do:
       index:
         index:   foo

--- a/modules/rank-eval/src/yamlRestTest/resources/rest-api-spec/test/rank_eval/30_failures.yml
+++ b/modules/rank-eval/src/yamlRestTest/resources/rest-api-spec/test/rank_eval/30_failures.yml
@@ -1,10 +1,5 @@
 ---
 "Response format":
-
-  - skip:
-      version: " - 6.2.99"
-      reason: response format was updated in 6.3
-
   - do:
       index:
         index:   foo

--- a/modules/rank-eval/src/yamlRestTest/resources/rest-api-spec/test/rank_eval/40_rank_eval_templated.yml
+++ b/modules/rank-eval/src/yamlRestTest/resources/rest-api-spec/test/rank_eval/40_rank_eval_templated.yml
@@ -48,11 +48,6 @@ setup:
 
 ---
 "Basic rank-eval request with template":
-
-  - skip:
-      version: " - 6.1.99"
-      reason: the ranking evaluation feature is available since 6.2
-
   - do:
       rank_eval:
         body: {

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/10_basic.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/10_basic.yml
@@ -88,10 +88,6 @@
 
 ---
 "Response for version conflict (version powered)":
-  - skip:
-      version: "6.7.0 - "
-      reason: reindex moved to rely on sequence numbers for concurrency control
-
   - do:
       indices.create:
         index: test
@@ -145,10 +141,6 @@
 
 ---
 "Response for version conflict (seq no powered)":
-  - skip:
-      version: " - 6.6.99"
-      reason: reindex moved to rely on sequence numbers for concurrency control
-
   - do:
       indices.create:
         index: test

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/10_basic.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/10_basic.yml
@@ -88,6 +88,9 @@
 
 ---
 "Response for version conflict (version powered)":
+  - skip:
+      version: "6.7.0 - "
+      reason: reindex moved to rely on sequence numbers for concurrency control
   - do:
       indices.create:
         index: test

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/10_basic.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/10_basic.yml
@@ -73,6 +73,9 @@
 
 ---
 "Response for version conflict (version powered)":
+  - skip:
+      version: "6.7.0 - "
+      reason: reindex moved to rely on sequence numbers for concurrency control
   - do:
       indices.create:
         index: test

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/10_basic.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/10_basic.yml
@@ -73,9 +73,6 @@
 
 ---
 "Response for version conflict (version powered)":
-  - skip:
-      version: "6.7.0 - "
-      reason: reindex moved to rely on sequence numbers for concurrency control
   - do:
       indices.create:
         index: test
@@ -116,9 +113,6 @@
 
 ---
 "Response for version conflict (seq no powered)":
-  - skip:
-      version: " - 6.6.99"
-      reason: reindex moved to rely on sequence numbers for concurrency control
   - do:
       indices.create:
         index: test

--- a/plugins/mapper-annotated-text/src/yamlRestTest/resources/rest-api-spec/test/mapper_annotatedtext/10_basic.yml
+++ b/plugins/mapper-annotated-text/src/yamlRestTest/resources/rest-api-spec/test/mapper_annotatedtext/10_basic.yml
@@ -3,10 +3,6 @@
 
 ---
 "annotated highlighter on annotated text":
-  - skip:
-      version: " - 6.4.99"
-      reason: Annotated text type introduced in 6.5.0
-
   - do:
       indices.create:
         index: annotated
@@ -80,10 +76,6 @@
 
 ---
 "issue 39395 thread safety issue -requires multiple calls to reveal":
-  - skip:
-      version: " - 6.4.99"
-      reason: Annotated text type introduced in 6.5.0
-
   - do:
       indices.create:
         index: annotated

--- a/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/20_info.yml
+++ b/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/20_info.yml
@@ -96,10 +96,6 @@
 
 ---
 "skip_unavailable is returned as part of _remote/info response":
-  - skip:
-      version: " - 6.0.99"
-      reason: "skip_unavailable is only returned from 6.1.0 on"
-
   - do:
       cluster.get_settings:
         include_defaults: true

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/20_date_range.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/20_date_range.yml
@@ -80,9 +80,6 @@
 
 ---
 "Create index with java style index in 6":
-  - skip:
-      version: " - 6.7.99, 7.0.0 -"
-      reason: java.time patterns are allowed since 6.8
   - do:
       indices.create:
         index: java_for_range

--- a/qa/smoke-test-ingest-with-all-dependencies/src/test/resources/rest-api-spec/test/ingest/20_combine_processors.yml
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/test/resources/rest-api-spec/test/ingest/20_combine_processors.yml
@@ -1,10 +1,5 @@
 ---
 "Test with date processor":
-  - skip:
-      version: " - 6.9.99"
-      reason: pre-7.0.0 requires the 8 prefix for Java time formats, so would treat the format in this test as a Joda time format
-      features: "warnings"
-
   - do:
       ingest.put_pipeline:
         id: "_id"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/10_basic.yml
@@ -1,6 +1,6 @@
 ---
 "Array of objects":
-    - do:
+  - do:
       bulk:
         refresh: true
         body:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/10_basic.yml
@@ -1,11 +1,6 @@
 ---
 "Array of objects":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
-  - do:
+    - do:
       bulk:
         refresh: true
         body:
@@ -28,11 +23,6 @@
 
 ---
 "Empty _id":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       bulk:
         refresh: true
@@ -107,12 +97,6 @@
 
 ---
 "empty action":
-
-  - skip:
-      version: " - 6.99.99"
-      features: headers
-      reason: types are required in requests before 7.0.0
-
   - do:
       catch: /Malformed action\/metadata line \[3\], expected FIELD_NAME but found \[END_OBJECT\]/
       headers:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/10_basic.yml
@@ -97,6 +97,8 @@
 
 ---
 "empty action":
+  - skip:
+        features: headers
   - do:
       catch: /Malformed action\/metadata line \[3\], expected FIELD_NAME but found \[END_OBJECT\]/
       headers:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/20_list_of_strings.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/20_list_of_strings.yml
@@ -1,9 +1,5 @@
 ---
 "List of strings":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
   - do:
       bulk:
         refresh: true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/30_big_string.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/30_big_string.yml
@@ -1,9 +1,5 @@
 ---
 "One big string":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
   - do:
       bulk:
         refresh: true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/40_source.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/40_source.yml
@@ -1,9 +1,5 @@
 ---
 "Source filtering":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
   - do:
       index:
         refresh: true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/50_refresh.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/50_refresh.yml
@@ -1,9 +1,5 @@
 ---
 "refresh=true immediately makes changes are visible in search":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
   - do:
       bulk:
         refresh: true
@@ -20,10 +16,6 @@
 
 ---
 "refresh=empty string immediately makes changes are visible in search":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
   - do:
       bulk:
         refresh: ""
@@ -41,10 +33,6 @@
 
 ---
 "refresh=wait_for waits until changes are visible in search":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
   - do:
       bulk:
         refresh: wait_for

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/60_deprecated.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/60_deprecated.yml
@@ -1,12 +1,6 @@
 
 ---
 "Deprecated parameters should fail in Bulk query":
-
-   - skip:
-       version: " - 6.99.99"
-       reason:  some parameters are removed starting from 7.0, their equivalents without underscore are used instead
-       features: "warnings"
-
    - do:
        catch:  bad_request
        bulk:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/80_cas.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/80_cas.yml
@@ -1,10 +1,5 @@
 ---
 "Compare And Swap Sequence Numbers":
-
- - skip:
-      version: " - 6.99.99"
-      reason:  typeless API are add in 7.0.0
-
  - do:
       index:
           index:  test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/10_basic.yml
@@ -94,10 +94,6 @@
 
 ---
 "cluster health basic test, one index with wait for no initializing shards":
-  - skip:
-      version: " - 6.1.99"
-      reason: "wait_for_no_initializing_shards is introduced in 6.2.0"
-
   - do:
       indices.create:
         index: test_index

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.stats/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.stats/10_basic.yml
@@ -75,10 +75,6 @@
 
 ---
 "get cluster stats returns discovery types":
-  - skip:
-      version: " - 6.99.99"
-      reason:  "discovery types are added for v7.0.0"
-
   - do:
       cluster.stats: {}
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/create/70_nested.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/create/70_nested.yml
@@ -1,8 +1,5 @@
 ---
 setup:
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
   - do:
       indices.create:
           index: test_1
@@ -16,9 +13,6 @@ setup:
 
 ---
 "Indexing a doc with No. nested objects less or equal to index.mapping.nested_objects.limit should succeed":
-  - skip:
-      version: " - 6.99.99"
-      reason:  index.mapping.nested_objects setting has been added in 7.0.0
   - do:
       create:
           index:  test_1
@@ -29,9 +23,6 @@ setup:
 
 ---
 "Indexing a doc with No. nested objects more than index.mapping.nested_objects.limit should fail":
-  - skip:
-      version: " - 6.99.99"
-      reason:  index.mapping.nested_objects setting has been added in 7.0.0
   - do:
       catch: /The number of nested documents has exceeded the allowed limit of \[2\]. This limit can be set by changing the \[index.mapping.nested_objects.limit\] index level setting\./
       create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/exists/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/exists/10_basic.yml
@@ -1,9 +1,5 @@
 ---
 "Basic":
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       exists:
         index: test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/exists/70_defaults.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/exists/70_defaults.yml
@@ -1,9 +1,5 @@
 ---
 "Client-side default type":
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       index:
         index: test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/explain/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/explain/10_basic.yml
@@ -1,8 +1,4 @@
 setup:
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       indices.create:
           index: test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/explain/20_source_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/explain/20_source_filtering.yml
@@ -1,9 +1,5 @@
 ---
 "Source filtering":
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       index:
         index:  test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/explain/30_query_string.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/explain/30_query_string.yml
@@ -1,9 +1,5 @@
 ---
 "explain with query_string parameters":
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       indices.create:
           index:  test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/field_caps/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/field_caps/10_basic.yml
@@ -149,10 +149,6 @@ setup:
   - is_false: fields.geo.keyword.on_aggregatable_indices
 ---
 "Get date_nanos field caps":
-  - skip:
-      version: " - 6.99.99"
-      reason: date_nanos field mapping type has been introcued in 7.0
-
   - do:
         indices.create:
           include_type_name: false
@@ -204,10 +200,6 @@ setup:
   - is_false: fields.object\.nested2.keyword.non_searchable_indices
 ---
 "Get object and nested field caps":
-  - skip:
-      version: " - 6.99.99"
-      reason: object and nested fields are returned since 7.0
-
   - do:
       field_caps:
         index: 'test1,test2,test3'

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get/10_basic.yml
@@ -1,10 +1,5 @@
 ---
 "Basic":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       index:
         index: test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get/15_default_values.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get/15_default_values.yml
@@ -1,9 +1,5 @@
 ---
 "Default values":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
   - do:
       index:
         index: test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get/20_stored_fields.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get/20_stored_fields.yml
@@ -1,9 +1,5 @@
 ---
 "Stored fields":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
   - do:
       indices.create:
         index: test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get/70_source_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get/70_source_filtering.yml
@@ -1,9 +1,5 @@
 ---
 "Source filtering":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
   - do:
       indices.create:
         index: test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get/80_missing.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get/80_missing.yml
@@ -1,9 +1,5 @@
 ---
 "Missing document with catch":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
   - do:
       catch:   missing
       get:
@@ -12,10 +8,6 @@
 
 ---
 "Missing document with ignore":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
   - do:
       get:
         index:  test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get_source/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get_source/10_basic.yml
@@ -1,10 +1,5 @@
 ---
 "Basic":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       index:
         index: test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get_source/15_default_values.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get_source/15_default_values.yml
@@ -1,11 +1,5 @@
 ---
 "Default values":
-
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       index:
         index: test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get_source/70_source_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get_source/70_source_filtering.yml
@@ -1,11 +1,5 @@
 ---
 "Source filtering":
-
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       index:
         index:  test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/12_result.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/12_result.yml
@@ -1,9 +1,5 @@
 ---
 "Index result field":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
   - do:
       index:
           index:  test_index

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/30_cas.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/30_cas.yml
@@ -1,10 +1,5 @@
 ---
 "Compare And Swap Sequence Numbers":
-
- - skip:
-      version: " - 6.99.99"
-      reason:  typesless api was introduces in 7.0
-
  - do:
       index:
           index:  test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/20_analyze_limit.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/20_analyze_limit.yml
@@ -9,9 +9,6 @@ setup:
 
 ---
 "_analyze with No. generated tokens less than or equal to index.analyze.max_token_count should succeed":
-  - skip:
-      version: " - 6.99.99"
-      reason:  index.analyze.max_token_count setting has been added in 7.0.0
   - do:
       indices.analyze:
           index:  test_1
@@ -25,9 +22,6 @@ setup:
 
 ---
 "_analyze with No. generated tokens more than index.analyze.max_token_count should fail":
-  - skip:
-      version: " - 6.99.99"
-      reason:  index.analyze.max_token_count setting has been added in 7.0.0
   - do:
       catch: /The number of tokens produced by calling _analyze has exceeded the allowed maximum of \[3\]. This limit can be set by changing the \[index.analyze.max_token_count\] index level setting\./
       indices.analyze:
@@ -39,9 +33,6 @@ setup:
 
 ---
 "_analyze with explain with No. generated tokens more than index.analyze.max_token_count should fail":
-  - skip:
-      version: " - 6.99.99"
-      reason:  index.analyze.max_token_count setting has been added in 7.0.0
   - do:
       catch: /The number of tokens produced by calling _analyze has exceeded the allowed maximum of \[3\]. This limit can be set by changing the \[index.analyze.max_token_count\] index level setting\./
       indices.analyze:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.clear_cache/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.clear_cache/10_basic.yml
@@ -11,10 +11,6 @@
 
 ---
 "clear_cache with fielddata set to true":
-  - skip:
-      version: " - 6.2.99"
-      reason: fielddata was deprecated before 6.3.0
-
   - do:
       indices.clear_cache:
         fielddata: true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/10_basic.yml
@@ -1,9 +1,5 @@
 ---
 "Create index with mappings":
-
-  - skip:
-      version: " - 6.99.99"
-      reason:  include_type_name defaults to true before 7.0.0
   - do:
       indices.create:
         index: test_index
@@ -19,10 +15,6 @@
 
 ---
 "Create index with settings":
-
-  - skip:
-      version: " - 6.99.99"
-      reason:  include_type_name defaults to true before 7.0.0
   - do:
       indices.create:
         index: test_index
@@ -38,10 +30,6 @@
 
 ---
 "Create index":
-
-  - skip:
-      version: " - 6.99.99"
-      reason:  include_type_name defaults to true before 7.0.0
   - do:
       indices.create:
         index: test_index
@@ -51,10 +39,6 @@
 
 ---
 "Create index with wait_for_active_shards set to all":
-
-  - skip:
-      version: " - 6.99.99"
-      reason:  include_type_name defaults to true before 7.0.0
   - do:
       indices.create:
         index: test_index
@@ -68,10 +52,6 @@
 
 ---
 "Create index with aliases":
-
-  - skip:
-      version: " - 6.99.99"
-      reason:  include_type_name defaults to true before 7.0.0
   - do:
       indices.create:
         index: test_index
@@ -102,9 +82,6 @@
 
 ---
 "Create index with write aliases":
-  - skip:
-      version: " - 6.99.99"
-      reason: is_write_index is not implemented in ES <= 6.x
   - do:
       indices.create:
         index: test_index
@@ -138,9 +115,6 @@
 
 ---
 "Create index with explicit _doc type":
-  - skip:
-      version: " - 6.99.99"
-      reason: include_type_name defaults to true before 7.0
   - do:
       catch: bad_request
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.flush/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.flush/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 "Flush stats":
-  - skip:
-      version: " - 6.2.99"
-      reason: periodic flush stats is introduced in 6.3.0
   - do:
       indices.create:
         index: test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/11_basic_with_types.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/11_basic_with_types.yml
@@ -44,10 +44,6 @@ setup:
 
 ---
 "Test include_type_name":
-  - skip:
-      version: " - 6.6.99"
-      reason: the include_type_name parameter is not supported before 6.7
-
   - do:
       indices.get:
         include_type_name: true
@@ -66,10 +62,6 @@ setup:
 
 ---
 "Test include_type_name dafaults to false":
-  - skip:
-      version: " - 6.99.99"
-      reason: the include_type_name parameter default is different on 6.x and 7.0, so only test this on 7.0 clusters
-
   - do:
       indices.get:
         index: test_index

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_alias/30_wildcards.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_alias/30_wildcards.yml
@@ -26,9 +26,6 @@ setup:
 
 ---
 "Get aliases wildcard and simple exclusion":
-  - skip:
-      version: " - 6.99.99"
-      reason: Exclusions in the alias expression are not handled
   - do:
       indices.get_alias:
         name: test_blias_2,test_alias*,-test_alias_1
@@ -41,9 +38,6 @@ setup:
 
 ---
 "Get aliases and wildcard exclusion":
-  - skip:
-      version: " - 6.99.99"
-      reason: Exclusions in the alias expression are not handled
   - do:
       indices.get_alias:
         name: test_alias_1,test_blias_1,-test_alias*
@@ -66,9 +60,6 @@ setup:
 
 ---
 "Non-existent exclusion alias before wildcard returns 404":
-  - skip:
-      version: " - 6.99.99"
-      reason: Exclusions in the alias expression are not handled
   - do:
       catch: missing
       indices.get_alias:
@@ -97,9 +88,6 @@ setup:
 
 ---
 "Missing exclusions does not fire 404":
-  - skip:
-      version: " - 6.99.99"
-      reason: Exclusions in the alias expression are not handled
   - do:
       indices.get_alias:
         name: test_alias*,-non-existent,test_blias*,-test
@@ -112,9 +100,6 @@ setup:
 
 ---
 "Exclusion of non wildcarded aliases":
-  - skip:
-      version: " - 6.99.99"
-      reason: Exclusions in the alias expression are not handled
   - do:
       indices.get_alias:
         name: test_alias_1,test_blias_2,-test_alias*,-test_blias_2
@@ -123,9 +108,6 @@ setup:
 
 ---
 "Wildcard exclusions does not trigger 404":
-  - skip:
-      version: " - 6.99.99"
-      reason: Exclusions in the alias expression are not handled
   - do:
       catch: missing
       indices.get_alias:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 setup:
-  - skip:
-      version: " - 6.99.99"
-      reason: include_type_name defaults to true before 7.0
   - do:
         indices.create:
           index: test_index

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/20_missing_field.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/20_missing_field.yml
@@ -1,8 +1,5 @@
 ---
 "Return empty object if field doesn't exist, but type and index do":
-  - skip:
-      version: " - 6.99.99"
-      reason: include_type_name defaults to true before 7.0
   - do:
         indices.create:
           index: test_index

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/50_field_wildcards.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/50_field_wildcards.yml
@@ -1,8 +1,5 @@
 ---
 setup:
-  - skip:
-      version: " - 6.99.99"
-      reason: include_type_name defaults to true before 7.0
   - do:
         indices.create:
           index: test_index

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 setup:
-  - skip:
-      version: " - 6.99.99"
-      reason: include_type_name defaults to true before 7.0
   - do:
         indices.create:
           index: test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/30_missing_index.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/30_missing_index.yml
@@ -4,7 +4,7 @@
       catch: missing
       indices.get_mapping:
         index: test_index
-  
+
 ---
 "Index missing, no indexes":
   - do:
@@ -14,9 +14,6 @@
 
 ---
 "Index missing, ignore_unavailable=true":
-  - skip:
-      version: " - 6.99.99"
-      reason: ignore_unavailable was ignored in previous versions
   - do:
       indices.get_mapping:
         index: test_index

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/50_wildcard_expansion.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/50_wildcard_expansion.yml
@@ -102,9 +102,6 @@ setup:
 
 ---
 "Get test-* with wildcard_expansion=none":
- - skip:
-    version: " - 6.99.99"
-    reason: allow_no_indices (defaults to true) was ignored in previous versions
  - do:
     indices.get_mapping:
         index: test-x*
@@ -113,9 +110,6 @@ setup:
  - match: { '':  {} }
 ---
 "Get test-* with wildcard_expansion=none allow_no_indices=false":
- - skip:
-    version: " - 6.99.99"
-    reason: allow_no_indices was ignored in previous versions
  - do:
     catch: missing
     indices.get_mapping:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_settings/30_defaults.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_settings/30_defaults.yml
@@ -10,9 +10,6 @@ setup:
         index: test-index
 ---
 Test retrieval of default settings:
-  - skip:
-      version: " - 6.3.99"
-      reason: include_defaults will not work in mixed-mode clusters containing nodes pre-6.4
   - do:
       indices.get_settings:
         flat_settings: true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_template/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_template/10_basic.yml
@@ -1,7 +1,4 @@
 setup:
-  - skip:
-      version: " - 6.99.99"
-      reason: include_type_name defaults to true before 7.0.0
   - do:
       indices.put_template:
         name: test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/10_basic.yml
@@ -38,10 +38,6 @@
 
 ---
 "Open index with wait_for_active_shards set to all":
-  - skip:
-      version: " - 6.0.99"
-      reason: wait_for_active_shards parameter was added in 6.1.0
-
   - do:
       indices.create:
         index: test_index

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_alias/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_alias/10_basic.yml
@@ -59,11 +59,6 @@
 
 ---
 "Can set is_write_index":
-
-  - skip:
-      version: " - 6.3.99"
-      reason: "is_write_index is only available from 6.4.0 on"
-
   - do:
       indices.create:
         index: test_index

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_mapping/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_mapping/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 "Test Create and update mapping":
-  - skip:
-      version: " - 6.99.99"
-      reason: include_type_name defaults to true before 7.0
   - do:
       indices.create:
         index: test_index
@@ -53,10 +50,6 @@
 
 ---
 "Create index with invalid mappings":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: include_type_name defaults to true before 7.0
   - do:
       indices.create:
         index: test_index
@@ -71,10 +64,6 @@
 
 ---
 "Put mappings with explicit _doc type":
-  - skip:
-      version: " - 6.99.99"
-      reason: include_type_name defaults to true before 7.0
-
   - do:
       indices.create:
         index: test_index

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_mapping/20_mix_typeless_typeful.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_mapping/20_mix_typeless_typeful.yml
@@ -53,12 +53,6 @@
 
 ---
 "PUT mapping with _doc on an index that has types":
-
- - skip:
-      version: " - 6.6.99"
-      reason: include_type_name is only supported as of 6.7
-
-
  - do:
       indices.create:
           include_type_name: true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_mapping/all_path_options.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_mapping/all_path_options.yml
@@ -1,7 +1,4 @@
 setup:
-  - skip:
-      version: " - 6.99.99"
-      reason: include_type_name defaults to true before 7.0
   - do:
       indices.create:
         index: test_index1
@@ -162,4 +159,4 @@ setup:
       indices.get_mapping: {}
 
   - match: {test_index1.mappings.properties.text.type:     text}
- 
+

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_template/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_template/10_basic.yml
@@ -1,9 +1,5 @@
 ---
 "Put template":
-  - skip:
-      version: " - 6.99.99"
-      reason:  include_type_name defaults to true before 7.0.0
-
   - do:
       indices.put_template:
         name: test
@@ -28,10 +24,6 @@
 
 ---
 "Put multiple template":
-  - skip:
-      version: " - 6.99.99"
-      reason:  include_type_name defaults to true before 7.0.0
-
   - do:
       indices.put_template:
         name: test
@@ -56,10 +48,6 @@
 
 ---
 "Put template with empty mappings":
-  - skip:
-      version: " - 6.99.99"
-      reason:  include_type_name defaults to true before 7.0.0
-
   - do:
       indices.put_template:
         name: test
@@ -241,10 +229,6 @@
 
 ---
 "Put template with explicit _doc type":
-  - skip:
-      version: " - 6.99.99"
-      reason: include_type_name defaults to true before 7.0
-
   - do:
       catch: bad_request
       indices.put_template:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/30_max_size_condition.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/30_max_size_condition.yml
@@ -1,10 +1,5 @@
 ---
 "Rollover with max_size condition":
-
-  - skip:
-      version: " - 6.0.99"
-      reason: max_size condition is introduced in 6.1.0
-
   # create index with alias and replica
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/40_mapping.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/40_mapping.yml
@@ -1,9 +1,5 @@
 ---
 "Typeless mapping":
-  - skip:
-      version: " - 6.99.99"
-      reason:  include_type_name defaults to true before 7.0.0
-
   - do:
       indices.create:
         index: logs-1
@@ -44,10 +40,6 @@
 
 ---
 "Mappings with explicit _doc type":
-  - skip:
-      version: " - 6.99.99"
-      reason: include_type_name defaults to true before 7.0
-
   - do:
       indices.create:
         index: logs-1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yml
@@ -1,10 +1,5 @@
 ---
 "Shrink index via API":
-  - skip:
-      version: " - 6.9.99"
-      reason: expects warnings that pre-7.0.0 will not send
-      features: [warnings, arbitrary_key]
-
   # creates an index with one document solely allocated on a particular data node
   # and shrinks it into a new index with a single shard
   # we don't do the relocation to a single node after the index is created

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/30_copy_settings.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/30_copy_settings.yml
@@ -1,5 +1,7 @@
 ---
 "Copy settings during shrink index":
+  - skip:
+        features: allowed_warnings
   - do:
       nodes.info:
         node_id: data:true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/30_copy_settings.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/30_copy_settings.yml
@@ -1,10 +1,5 @@
 ---
 "Copy settings during shrink index":
-  - skip:
-      version: " - 6.9.99"
-      reason: expects warnings that pre-7.0.0 will not send
-      features: [allowed_warnings, arbitrary_key]
-
   - do:
       nodes.info:
         node_id: data:true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/10_basic.yml
@@ -29,11 +29,6 @@ setup:
 
 ---
 "Split index via API":
-  - skip:
-      version: " - 6.9.99"
-      reason: pre-7.0.0 will send warnings
-      features: "warnings"
-
   # make it read-only
   - do:
       indices.put_settings:
@@ -95,9 +90,6 @@ setup:
 
 ---
 "Split from 1 to N":
-  - skip:
-      version: " - 6.99.99"
-      reason: automatic preparation for splitting was added in 7.0.0
   - do:
       indices.create:
         index: source_one_shard
@@ -184,11 +176,6 @@ setup:
 
 ---
 "Create illegal split indices":
-  - skip:
-      version: " - 6.9.99"
-      reason: pre-7.0.0 will send warnings
-      features: "warnings"
-
   # try to do an illegal split with number_of_routing_shards set
   - do:
       catch: /illegal_argument_exception/

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/20_source_mapping.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/20_source_mapping.yml
@@ -1,10 +1,5 @@
 ---
 "Split index ignores target template mapping":
-  - skip:
-      version: " - 6.9.99"
-      reason: pre-7.0.0 will send warnings
-      features: "warnings"
-
   # create index
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
@@ -1,10 +1,5 @@
 ---
 "Copy settings during split index":
-  - skip:
-      version: " - 6.9.99"
-      reason: expects warnings that pre-7.0.0 will not send
-      features: [arbitrary_key, allowed_warnings]
-
   - do:
       nodes.info:
         node_id: data:true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
@@ -1,5 +1,7 @@
 ---
 "Copy settings during split index":
+  - skip:
+        features: allowed_warnings
   - do:
       nodes.info:
         node_id: data:true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/10_index.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/10_index.yml
@@ -39,10 +39,6 @@ setup:
 
 ---
 "Index - all":
-  - skip:
-      version: " - 6.3.99"
-      reason: "uuid is only available from 6.4.0 on"
-
   - do:
       indices.stats: { index: _all }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/20_translog.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/20_translog.yml
@@ -86,9 +86,6 @@
 
 ---
 "Translog last modified age stats":
-  - skip:
-      version: " - 6.2.99"
-      reason: translog last modified age stats was added in 6.3.0
   - do:
       index:
         index: test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/10_basic.yml
@@ -1,9 +1,5 @@
 ---
 "Basic multi-get":
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       indices.create:
           index:  test_2

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/12_non_existent_index.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/12_non_existent_index.yml
@@ -1,9 +1,5 @@
 ---
 "Non-existent index":
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       index:
           index:  test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/13_missing_metadata.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/13_missing_metadata.yml
@@ -1,9 +1,5 @@
 ---
 "Missing metadata":
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       index:
           index:  test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/15_ids.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/15_ids.yml
@@ -1,9 +1,5 @@
 ---
 "IDs":
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
         indices.create:
           index: test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/17_default_index.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/17_default_index.yml
@@ -1,9 +1,5 @@
 ---
 "Default index/type":
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       indices.create:
           index:  test_2

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/20_stored_fields.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/20_stored_fields.yml
@@ -1,9 +1,5 @@
 ---
 "Stored fields":
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       indices.create:
         index: test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/70_source_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/70_source_filtering.yml
@@ -1,8 +1,4 @@
 setup:
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       index:
         index:  test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/80_deprecated.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/80_deprecated.yml
@@ -1,11 +1,6 @@
 
 ---
 "Deprecated parameters should fail in Multi Get query":
-   - skip:
-       version: " - 6.99.99"
-       reason:  _version, _routing are removed starting from 7.0, their equivalents without underscore are used instead
-       features: "warnings"
-
    - do:
        index:
            index:  test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/msearch/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/msearch/10_basic.yml
@@ -94,10 +94,6 @@ setup:
 
 ---
 "Search with new response format":
-  - skip:
-      version: " - 6.99.99"
-      reason: hits.total is returned as an object in 7.0.0
-
   - do:
       msearch:
         body:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mtermvectors/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mtermvectors/10_basic.yml
@@ -1,7 +1,4 @@
 setup:
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
   - do:
       indices.create:
           index: testidx

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mtermvectors/20_deprecated.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mtermvectors/20_deprecated.yml
@@ -1,12 +1,5 @@
-setup:
 ---
 "Deprecated camel case and _ parameters should fail in Term Vectors query":
-
-   - skip:
-       version: " - 6.99.99"
-       reason:  camel case and _ parameters (e.g. versionType, _version_type) should fail from 7.0
-       features: "warnings"
-
    - do:
        indices.create:
            index: testidx

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mtermvectors/20_deprecated.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mtermvectors/20_deprecated.yml
@@ -1,8 +1,4 @@
 setup:
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
 ---
 "Deprecated camel case and _ parameters should fail in Term Vectors query":
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/10_basic.yml
@@ -198,9 +198,6 @@
 
 ---
 "Scroll cannot used the request cache":
-  - skip:
-      version: " - 6.99.99"
-      reason:  the error message has been added in v7.0.0
   - do:
       indices.create:
         index: test_scroll
@@ -217,9 +214,6 @@
 
 ---
 "Scroll with size 0":
-  - skip:
-      version: " - 6.1.99"
-      reason:  the error message has been added in v6.2.0
   - do:
       indices.create:
         index: test_scroll
@@ -237,10 +231,6 @@
 
 ---
 "Scroll max_score is null":
-  - skip:
-      version: " - 6.99.99"
-      reason:  max_score was set to 0 rather than null before 7.0
-
   - do:
       indices.create:
         index: test_scroll
@@ -285,9 +275,6 @@
 
 ---
 "Scroll with new response format":
-  - skip:
-      version: " - 6.9.99"
-      reason: hits.total is returned as an object in 7.0.0
   - do:
       indices.create:
         index: test_scroll

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/12_slices.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/12_slices.yml
@@ -103,10 +103,6 @@ setup:
 
 ---
 "Sliced scroll with invalid arguments":
-  - skip:
-      version: " - 6.99.99"
-      reason: Prior versions return 500 rather than 404
-
   - do:
         catch: bad_request
         search:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/20_keep_alive.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/20_keep_alive.yml
@@ -10,10 +10,6 @@
 
 ---
 "Max keep alive":
-  - skip:
-      version: " - 6.99.99"
-      reason: search.max_keep_alive was added in 7.0.0
-
   - do:
       index:
         index:  test_scroll

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/200_top_hits_metric.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/200_top_hits_metric.yml
@@ -49,10 +49,6 @@ setup:
 
 ---
 "top_hits aggregation with nested documents":
-  - skip:
-          version: " - 6.1.99"
-          reason: "<= 6.1 nodes don't always include index or id in nested top hits"
-
   - do:
       search:
         rest_total_hits_as_int: true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -702,11 +702,6 @@ setup:
 
 ---
 "Global ordinals are not loaded with the map execution hint":
-
-  - skip:
-      version: " - 6.99.99"
-      reason:  bug fixed in 7.0
-
   - do:
       index:
         refresh: true
@@ -752,11 +747,6 @@ setup:
 
 ---
 "Global ordinals are loaded with the global_ordinals execution hint":
-
-  - skip:
-      version: " - 6.99.99"
-      reason:  bug fixed in 7.0
-
   - do:
       index:
         refresh: true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -84,10 +84,6 @@ setup:
 
 ---
 "Simple Composite aggregation":
-  - skip:
-      version: " - 6.0.99"
-      reason:  this uses a new API that has been added in 6.1
-
   - do:
       search:
         rest_total_hits_as_int: true
@@ -113,11 +109,6 @@ setup:
 
 ---
 "Nested Composite aggregation":
-  - skip:
-      version: " - 6.0.99"
-      reason:  this uses a new API that has been added in 6.1
-
-
   - do:
       search:
         rest_total_hits_as_int: true
@@ -163,11 +154,6 @@ setup:
 
 ---
 "Aggregate After":
-  - skip:
-      version: " - 6.0.99"
-      reason:  this uses a new API that has been added in 6.1
-
-
   - do:
       search:
         rest_total_hits_as_int: true
@@ -205,11 +191,6 @@ setup:
 
 ---
 "Aggregate After Missing":
-  - skip:
-      version: " - 6.1.99"
-      reason:  bug fixed in 6.2.0
-
-
   - do:
       search:
         rest_total_hits_as_int: true
@@ -236,10 +217,6 @@ setup:
 
 ---
 "Invalid Composite aggregation":
-  - skip:
-      version: " - 6.0.99"
-      reason:  this uses a new API that has been added in 6.1
-
   - do:
       catch:      /\[composite\] aggregation cannot be used with a parent aggregation/
       search:
@@ -426,10 +403,6 @@ setup:
 
 ---
 "Composite aggregation with after_key in the response":
-  - skip:
-      version: " - 6.2.99"
-      reason:  starting in 6.3.0 after_key is returned in the response
-
   - do:
         search:
           rest_total_hits_as_int: true
@@ -455,10 +428,6 @@ setup:
 
 ---
 "Composite aggregation and array size":
-  - skip:
-      version: " - 6.99.99"
-      reason:  starting in 7.0 the composite aggregation throws an execption if the provided size is greater than search.max_buckets.
-
   - do:
         catch: /.*Trying to create too many buckets.*/
         search:
@@ -481,10 +450,6 @@ setup:
 
 ---
 "Composite aggregation with nested parent":
-  - skip:
-      version: " - 6.99.99"
-      reason:  the ability to set a nested parent aggregation was added in 7.0.
-
   - do:
         search:
           rest_total_hits_as_int: true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/250_moving_fn.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/250_moving_fn.yml
@@ -1,4 +1,3 @@
-setup:
 ---
 "Bad window":
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/250_moving_fn.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/250_moving_fn.yml
@@ -1,8 +1,4 @@
 setup:
-  - skip:
-        version: " - 6.3.99"
-        reason:  "moving_fn added in 6.4.0"
-
 ---
 "Bad window":
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/260_weighted_avg.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/260_weighted_avg.yml
@@ -1,7 +1,4 @@
 setup:
-  - skip:
-      version: " - 6.3.99"
-      reason: weighted_avg is only available as of 6.4.0
   - do:
       indices.create:
           index: test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/270_median_absolute_deviation_metric.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/270_median_absolute_deviation_metric.yml
@@ -1,7 +1,4 @@
 setup:
-  - skip:
-        version: " - 6.5.99"
-        reason:  "added in 6.6.0"
   - do:
         indices.create:
             index: test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/50_filter.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/50_filter.yml
@@ -31,10 +31,6 @@ setup:
 ---
 "Filter aggs with terms lookup and ensure it's cached":
   # Because the filter agg rewrites the terms lookup in the rewrite phase the request can be cached
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       search:
         rest_total_hits_as_int: true
@@ -78,10 +74,6 @@ setup:
 
 ---
 "As a child of terms":
-  - skip:
-      version: " - 6.99.99"
-      reason: the test is written for hits.total.value
-
   - do:
       bulk:
         refresh: true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/30_max_analyzed_offset.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/30_max_analyzed_offset.yml
@@ -28,9 +28,6 @@ setup:
 
 ---
 "Unified highlighter on a field WITHOUT OFFSETS exceeding index.highlight.max_analyzed_offset should FAIL":
-  - skip:
-      version: " - 6.99.99"
-      reason: index.highlight.max_analyzed_offset setting has been added in 7.0.0
   - do:
       catch: bad_request
       search:
@@ -42,9 +39,6 @@ setup:
 
 ---
 "Plain highlighter on a field WITHOUT OFFSETS exceeding index.highlight.max_analyzed_offset should FAIL":
-  - skip:
-      version: " - 6.99.99"
-      reason: index.highlight.max_analyzed_offset setting has been added in 7.0.0
   - do:
       catch: bad_request
       search:
@@ -56,9 +50,6 @@ setup:
 
 ---
 "Unified highlighter on a field WITH OFFSETS exceeding index.highlight.max_analyzed_offset should SUCCEED":
-  - skip:
-      version: " - 6.99.99"
-      reason: index.highligt.max_analyzed_offset setting has been added in 7.0.0
   - do:
       search:
           rest_total_hits_as_int: true
@@ -69,9 +60,6 @@ setup:
 
 ---
 "Plain highlighter on a field WITH OFFSETS exceeding index.highlight.max_analyzed_offset should FAIL":
-  - skip:
-      version: " - 6.99.99"
-      reason: index.highlight.max_analyzed_offset setting has been added in 7.0.0
   - do:
       catch: bad_request
       search:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
@@ -164,6 +164,8 @@ setup:
 
 ---
 "docvalue_fields with default format":
+  - skip:
+      features: allowed_warnings
   - do:
       allowed_warnings:
         - "[use_field_mapping] is a special format that was only used to ease the transition to 7.x. It has become the default and shouldn't be set explicitly anymore."

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
@@ -141,9 +141,6 @@ setup:
 
 ---
 "docvalue_fields":
-  - skip:
-      version: " - 6.9.99"
-      reason: Triggers a deprecation warning before 7.0
   - do:
       search:
         body:
@@ -152,9 +149,6 @@ setup:
 
 ---
 "multiple docvalue_fields":
-  - skip:
-      version: " - 6.9.99"
-      reason: Triggered a deprecation warning before 7.0
   - do:
       search:
         body:
@@ -163,9 +157,6 @@ setup:
 
 ---
 "docvalue_fields as url param":
-  - skip:
-      version: " - 6.99.99"
-      reason: Triggered a deprecation warning before 7.0
   - do:
       search:
         docvalue_fields: [ "count" ]
@@ -173,10 +164,6 @@ setup:
 
 ---
 "docvalue_fields with default format":
-  - skip:
-      version: " - 6.99.99"
-      reason: Only triggers warnings on 7.0+
-      features: allowed_warnings
   - do:
       allowed_warnings:
         - "[use_field_mapping] is a special format that was only used to ease the transition to 7.x. It has become the default and shouldn't be set explicitly anymore."
@@ -189,9 +176,6 @@ setup:
 
 ---
 "docvalue_fields with explicit format":
-  - skip:
-      version: " - 6.3.99"
-      reason: format option was added in 6.4
   - do:
       search:
         body:
@@ -202,9 +186,6 @@ setup:
 
 ---
 "docvalue_fields - double":
-  - skip:
-      version: " - 6.99.99"
-      reason: Triggered a deprecation warning before 7.0
   - do:
       search:
         body:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/110_field_collapsing.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/110_field_collapsing.yml
@@ -315,11 +315,6 @@ setup:
 
 ---
 "no hits and inner_hits max_score null":
-
-  - skip:
-      version: " - 6.99.99"
-      reason:  max_score was set to 0 rather than null before 7.0
-
   - do:
       search:
         rest_total_hits_as_int: true
@@ -390,11 +385,6 @@ setup:
 
 ---
 "field collapsing, inner_hits and version":
-
-  - skip:
-      version: " - 6.1.0"
-      reason:  "bug fixed in 6.1.1"
-
   - do:
       count:
         index: test
@@ -493,11 +483,6 @@ setup:
 
 ---
 "field collapsing, inner_hits and seq_no":
-
-  - skip:
-      version: " - 6.99.0"
-      reason:  "sequence numbers introduced in 7.0.0"
-
   - do:
       search:
         rest_total_hits_as_int: true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/160_exists_query.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/160_exists_query.yml
@@ -550,9 +550,6 @@ setup:
 
 ---
 "Test exists query on _index field":
-  - skip:
-      version: " - 6.0.99"
-      reason: exists on _index not supported prior to 6.1.0
   - do:
       search:
           rest_total_hits_as_int: true
@@ -566,9 +563,6 @@ setup:
 
 ---
 "Test exists query on _type field":
-  - skip:
-      version: " - 6.0.99"
-      reason: exists on _type not supported prior to 6.1.0
   - do:
       search:
           rest_total_hits_as_int: true
@@ -608,9 +602,6 @@ setup:
 
 ---
 "Test exists query on _source field":
-  - skip:
-      version: " - 6.0.99"
-      reason: exists on _source not supported prior to 6.1.0
   - do:
       catch: /query_shard_exception/
       search:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/170_terms_query.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/170_terms_query.yml
@@ -1,8 +1,5 @@
 ---
 "Terms Query with No.of terms exceeding index.max_terms_count should FAIL":
-  - skip:
-      version: " - 6.99.99"
-      reason: index.max_terms_count setting has been added in 7.0.0
   - do:
       indices.create:
           index: test_index

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/171_terms_query_with_types.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/171_terms_query_with_types.yml
@@ -1,5 +1,7 @@
 ---
 "Terms Query with No.of terms exceeding index.max_terms_count should FAIL":
+  - skip:
+      features: allowed_warnings
   - do:
       indices.create:
           include_type_name: true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/171_terms_query_with_types.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/171_terms_query_with_types.yml
@@ -1,9 +1,5 @@
 ---
 "Terms Query with No.of terms exceeding index.max_terms_count should FAIL":
-  - skip:
-      version: " - 6.99.99"
-      reason: index.max_terms_count setting has been added in 7.0.0
-      features: allowed_warnings
   - do:
       indices.create:
           include_type_name: true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/190_index_prefix_search.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/190_index_prefix_search.yml
@@ -1,8 +1,4 @@
 setup:
-  - skip:
-      version: " - 6.2.99"
-      reason: index_prefixes is only available as of 6.3.0
-
   - do:
       indices.create:
         index:  test
@@ -27,9 +23,6 @@ setup:
 
 ---
 "search with index prefixes":
-  - skip:
-      version: " - 6.2.99"
-      reason: index_prefixes is only available as of 6.3.0
   - do:
       search:
         rest_total_hits_as_int: true
@@ -85,10 +78,6 @@ setup:
 
 ---
 "search index prefixes with span_multi":
-  - skip:
-      version: " - 6.99.99"
-      reason: span_multi throws an exception with prefix fields on < versions
-
   - do:
       search:
         rest_total_hits_as_int: true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/200_ignore_malformed.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/200_ignore_malformed.yml
@@ -1,9 +1,5 @@
 ---
 setup:
-  - skip:
-      version: " - 6.3.99"
-      reason: _ignored was added in 6.4.0
-
   - do:
       indices.create:
           index:  test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/200_index_phrase_search.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/200_index_phrase_search.yml
@@ -1,8 +1,5 @@
 ---
 "search with indexed phrases":
-  - skip:
-      version: " - 6.99.99"
-      reason: index_phrase is only available as of 7.0.0
   - do:
       indices.create:
         index:  test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/20_default_values.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/20_default_values.yml
@@ -76,9 +76,6 @@ setup:
 
 ---
 "Search with new response format":
-  - skip:
-      version: " - 6.99.99"
-      reason: hits.total is returned as an object in 7.0.0
   - do:
       search:
         body:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/210_rescore_explain.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/210_rescore_explain.yml
@@ -1,8 +1,5 @@
 ---
 "Score should match explanation in rescore":
-  - skip:
-      version: " - 6.99.99"
-      reason: Explanation for rescoring was corrected after these versions
   - do:
       bulk:
         refresh: true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/230_interval_query.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/230_interval_query.yml
@@ -1,8 +1,4 @@
 setup:
-  - skip:
-      version: " - 6.99.99"
-      reason:  "Implemented in 7.0"
-
   - do:
         indices.create:
           index:  test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/240_date_nanos.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/240_date_nanos.yml
@@ -1,8 +1,4 @@
 setup:
-  - skip:
-      version: " - 6.99.99"
-      reason:  "Implemented in 7.0"
-
   - do:
       indices.create:
           index: date_ns

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/30_limits.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/30_limits.yml
@@ -64,10 +64,6 @@ setup:
 
 ---
 "Docvalues_fields size limit":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: "Triggers warnings before 7.0"
   - do:
       catch:      /Trying to retrieve too many docvalue_fields\. Must be less than or equal to[:] \[2\] but was \[3\]\. This limit can be set by changing the \[index.max_docvalue_fields_search\] index level setting\./
       search:
@@ -99,10 +95,6 @@ setup:
 
 ---
 "Regexp length limit":
-  - skip:
-      version: " - 6.99.99"
-      reason: "The regex length limit was introduced in 7.0.0"
-
   - do:
       catch: /The length of regex \[1110\] used in the Regexp Query request has exceeded the allowed maximum of \[1000\]\. This maximum can be set by changing the \[index.max_regex_length\] index level setting\./
       search:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.create/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.create/10_basic.yml
@@ -85,10 +85,6 @@ setup:
 
 ---
 "Create a snapshot for missing index":
-  - skip:
-      version: " - 6.0.0"
-      reason: ignore_unavailable default is false in 6.0.0
-
   - do:
       catch: missing
       snapshot.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get/10_basic.yml
@@ -96,10 +96,6 @@ setup:
 
 ---
 "Get snapshot info contains include_global_state":
-  - skip:
-      version: " - 6.1.99"
-      reason: "include_global_state field has been added in the response in 6.2.0"
-
   - do:
       indices.create:
         index: test_index

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/20_completion.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/20_completion.yml
@@ -292,10 +292,6 @@ setup:
 
 ---
 "Skip duplicates should work":
-  - skip:
-      version: " - 6.0.99"
-      reason: skip_duplicates was added in 6.1
-
   - do:
       index:
         index: test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/30_context.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/30_context.yml
@@ -277,10 +277,6 @@ setup:
 
 ---
 "Skip duplicates with contexts should work":
-  - skip:
-      version: " - 6.0.99"
-      reason: skip_duplicates was added in 6.1
-
   - do:
       index:
         index: test
@@ -333,10 +329,6 @@ setup:
 
 ---
 "Indexing and Querying without contexts is forbidden":
-  - skip:
-      version: " - 6.99.99"
-      reason: this feature was removed in 7.0
-
   - do:
       index:
         index: test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/50_completion_with_multi_fields.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/50_completion_with_multi_fields.yml
@@ -1,11 +1,6 @@
 
 ---
 "Search by suggestion and by keyword sub-field should work":
-
-  - skip:
-      version: " - 6.99.99"
-      reason:  "Search by suggestion with multi-fields was introduced 7.0.0"
-
   - do:
       indices.create:
         index: completion_with_sub_keyword
@@ -63,11 +58,6 @@
 
 ---
 "Search by suggestion on sub field should work":
-
-  - skip:
-      version: " - 6.99.99"
-      reason:  "Search by suggestion with multi-fields was introduced 7.0.0"
-
   - do:
       indices.create:
         index: completion_with_sub_completion
@@ -113,11 +103,6 @@
 
 ---
 "Search by suggestion on sub field with context should work":
-
-  - skip:
-      version: " - 6.99.99"
-      reason:  "Search by suggestion with multi-fields was introduced 7.0.0"
-
   - do:
       indices.create:
         index: completion_with_context
@@ -182,11 +167,6 @@
 
 ---
 "Search by suggestion on sub field with weight should work":
-
-  - skip:
-      version: " - 6.99.99"
-      reason:  "Search by suggestion with multi-fields was introduced 7.0.0"
-
   - do:
       indices.create:
         index: completion_with_weight
@@ -238,11 +218,6 @@
 
 ---
 "Search by suggestion on geofield-hash on sub field should work":
-
-  - skip:
-      version: " - 6.99.99"
-      reason:  "Search by suggestion with multi-fields was introduced 7.0.0"
-
   - do:
       indices.create:
         index: geofield_with_completion

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/tasks.list/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/tasks.list/10_basic.yml
@@ -22,11 +22,6 @@
 
 ---
 "tasks_list headers":
-  - skip:
-      version: " - 6.99.99"
-      features: headers
-      reason:  task headers has been added in 7.0.0
-
   - do:
       headers: { "X-Opaque-Id": "That is me" }
       tasks.list:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/tasks.list/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/tasks.list/10_basic.yml
@@ -22,6 +22,8 @@
 
 ---
 "tasks_list headers":
+  - skip:
+        features: headers
   - do:
       headers: { "X-Opaque-Id": "That is me" }
       tasks.list:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/termvectors/20_issue7121.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/termvectors/20_issue7121.yml
@@ -1,4 +1,3 @@
-setup:
 ---
 "Term vector API should return 'found: false' for docs between index and refresh":
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/termvectors/20_issue7121.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/termvectors/20_issue7121.yml
@@ -1,8 +1,4 @@
 setup:
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
 ---
 "Term vector API should return 'found: false' for docs between index and refresh":
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/termvectors/30_realtime.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/termvectors/30_realtime.yml
@@ -1,8 +1,4 @@
 setup:
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
 ---
 "Realtime Term Vectors":
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/termvectors/30_realtime.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/termvectors/30_realtime.yml
@@ -1,4 +1,3 @@
-setup:
 ---
 "Realtime Term Vectors":
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/10_doc.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/10_doc.yml
@@ -1,10 +1,5 @@
 ---
 "Partial document":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-
   - do:
       index:
           index:  test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/12_result.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/12_result.yml
@@ -1,9 +1,5 @@
 ---
 "Update result field":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
   - do:
       update:
           index:            test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/20_doc_upsert.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/20_doc_upsert.yml
@@ -1,9 +1,5 @@
 ---
 "Doc upsert":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
   - do:
       update:
           index:    test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/22_doc_as_upsert.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/22_doc_as_upsert.yml
@@ -1,9 +1,5 @@
 ---
 "Doc as upsert":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
   - do:
       update:
           index:            test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/80_source_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/80_source_filtering.yml
@@ -1,6 +1,6 @@
 ---
 "Source filtering":
-    - do:
+  - do:
       update:
           index:  test_1
           id:     1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/80_source_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/80_source_filtering.yml
@@ -1,10 +1,6 @@
 ---
 "Source filtering":
-
-  - skip:
-      version: " - 6.99.99"
-      reason: types are required in requests before 7.0.0
-  - do:
+    - do:
       update:
           index:  test_1
           id:     1


### PR DESCRIPTION
Remove all 6x skip versions from yaml tests since mix 2.0 and 6x clusters are
not supported.

relates #1674