### PR TITLE
Fix flaky test case - string profiler via global ordinals

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -830,6 +830,10 @@ setup:
           { "str": "cow", "number": 1 }
           { "index": {} }
           { "str": "pig", "number": 1 }
+  - do:
+      indices.forcemerge:
+        index: test_1
+        max_num_segments: 1
 
   - do:
       search:


### PR DESCRIPTION
forcemerge to one segment before executing aggregation query.

Signed-off-by: Peng Huo <penghuo@gmail.com>

### Description
The purpose of this test is to make sure correct segments collect type is used. When preparing test data, it is possible that docs in single bulk request are indexed into 2 segments which cause test failed randomly and not reproduce-able.

We add `test_1/_forcemerge?max_num_segments=1` in test cases to force merge segments.

### Test Done
Re-run flaky test 500 times, all successful. 
```
for i in {1..500}; do ./gradlew ":rest-api-spec:yamlRestTest" --tests "org.opensearch.test.rest.ClientYamlTestSuiteIT" -Dtests.method="test {p0=search.aggregation/20_terms/string profiler via global ordinals}"; done
```
 
### Issues Resolved
#2176 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
