### PR TITLE
Revert Backport 1.x PR #2191

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -35,8 +35,6 @@ So you want to contribute code to OpenSearch? Excellent! We're glad you're here.
       - [runtimeOnly](#runtimeonly)
       - [compileOnly](#compileonly)
       - [testImplementation](#testimplementation)
-    - [Gradle Plugins](#gradle-plugins)
-        - [Distribution Download Plugin](#distribution-download-plugin)
   - [Misc](#misc)
     - [git-secrets](#git-secrets)
   - [Submitting Changes](#submitting-changes)
@@ -286,15 +284,6 @@ somehow. OpenSearch plugins use this configuration to include dependencies that 
 
 Code that is on the classpath for compiling tests that are part of this project but not production code. The canonical example
 of this is `junit`.
-
-### Gradle Plugins
-
-#### Distribution Download Plugin
-
-The Distribution Download plugin downloads the latest version of OpenSearch by default, and supports overriding this behavior by setting `customDistributionUrl`.
-```
-./gradlew integTest -DcustomDistributionUrl="https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127/linux/x64/dist/opensearch-1.2.0-linux-x64.tar.gz"
-```
 
 ## Misc
 

--- a/buildSrc/src/main/java/org/opensearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/DistributionDownloadPlugin.java
@@ -105,6 +105,7 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
 
         setupResolutionsContainer(project);
         setupDistributionContainer(project, dockerSupport);
+        setupDownloadServiceRepo(project);
         project.afterEvaluate(this::setupDistributions);
     }
 
@@ -152,7 +153,6 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
                 dependencies.add(distribution.getExtracted().getName(), distributionDependency.getExtractedNotation());
             }
         }
-        setupDownloadServiceRepo(project);
     }
 
     private DistributionDependency resolveDependencyNotation(Project p, OpenSearchDistribution distribution) {
@@ -195,22 +195,16 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
         if (project.getRepositories().findByName(DOWNLOAD_REPO_NAME) != null) {
             return;
         }
-        Object customDistributionUrl = project.findProperty("customDistributionUrl");
-        // checks if custom Distribution Url has been passed by user from plugins
-        if (customDistributionUrl != null) {
-            addIvyRepo(project, DOWNLOAD_REPO_NAME, customDistributionUrl.toString(), FAKE_IVY_GROUP, "");
-            addIvyRepo(project, SNAPSHOT_REPO_NAME, customDistributionUrl.toString(), FAKE_SNAPSHOT_IVY_GROUP, "");
-        } else {
-            addIvyRepo(
-                project,
-                DOWNLOAD_REPO_NAME,
-                "https://artifacts.opensearch.org",
-                FAKE_IVY_GROUP,
-                "/releases" + RELEASE_PATTERN_LAYOUT,
-                "/release-candidates" + RELEASE_PATTERN_LAYOUT
-            );
-            addIvyRepo(project, SNAPSHOT_REPO_NAME, "https://artifacts.opensearch.org", FAKE_SNAPSHOT_IVY_GROUP, SNAPSHOT_PATTERN_LAYOUT);
-        }
+        addIvyRepo(
+            project,
+            DOWNLOAD_REPO_NAME,
+            "https://artifacts.opensearch.org",
+            FAKE_IVY_GROUP,
+            "/releases" + RELEASE_PATTERN_LAYOUT,
+            "/release-candidates" + RELEASE_PATTERN_LAYOUT
+        );
+
+        addIvyRepo(project, SNAPSHOT_REPO_NAME, "https://artifacts.opensearch.org", FAKE_SNAPSHOT_IVY_GROUP, SNAPSHOT_PATTERN_LAYOUT);
 
         addIvyRepo2(project, DOWNLOAD_REPO_NAME_ES, "https://artifacts-no-kpi.elastic.co", FAKE_IVY_GROUP_ES);
         addIvyRepo2(project, SNAPSHOT_REPO_NAME_ES, "https://snapshots-no-kpi.elastic.co", FAKE_SNAPSHOT_IVY_GROUP_ES);

--- a/buildSrc/src/test/java/org/opensearch/gradle/DistributionDownloadPluginTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/DistributionDownloadPluginTests.java
@@ -38,7 +38,6 @@ import org.opensearch.gradle.info.BuildParams;
 import org.opensearch.gradle.test.GradleUnitTestCase;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
-import org.gradle.api.internal.artifacts.repositories.DefaultIvyArtifactRepository;
 import org.gradle.testfixtures.ProjectBuilder;
 
 import java.io.File;
@@ -78,58 +77,6 @@ public class DistributionDownloadPluginTests extends GradleUnitTestCase {
     public void testVersionDefault() {
         OpenSearchDistribution distro = checkDistro(createProject(null, false), "testdistro", null, Type.ARCHIVE, Platform.LINUX, true);
         assertEquals(distro.getVersion(), VersionProperties.getOpenSearch());
-    }
-
-    public void testCustomDistributionUrlWithUrl() {
-        Project project = createProject(null, false);
-        String customUrl = "https://artifacts.opensearch.org/custom";
-        project.getExtensions().getExtraProperties().set("customDistributionUrl", customUrl);
-        DistributionDownloadPlugin plugin = project.getPlugins().getPlugin(DistributionDownloadPlugin.class);
-        plugin.setupDistributions(project);
-        assertEquals(4, project.getRepositories().size());
-        assertEquals(
-            ((DefaultIvyArtifactRepository) project.getRepositories().getAt("opensearch-downloads")).getUrl().toString(),
-            customUrl
-        );
-        assertEquals(
-            ((DefaultIvyArtifactRepository) project.getRepositories().getAt("opensearch-snapshots")).getUrl().toString(),
-            customUrl
-        );
-        assertEquals(
-            ((DefaultIvyArtifactRepository) project.getRepositories().getAt("elasticsearch-downloads")).getUrl().toString(),
-            "https://artifacts-no-kpi.elastic.co"
-        );
-        assertEquals(
-            ((DefaultIvyArtifactRepository) project.getRepositories().getAt("elasticsearch-snapshots")).getUrl().toString(),
-            "https://snapshots-no-kpi.elastic.co"
-        );
-    }
-
-    public void testCustomDistributionUrlWithoutUrl() {
-        Project project = createProject(null, false);
-        DistributionDownloadPlugin plugin = project.getPlugins().getPlugin(DistributionDownloadPlugin.class);
-        plugin.setupDistributions(project);
-        assertEquals(5, project.getRepositories().size());
-        assertEquals(
-            ((DefaultIvyArtifactRepository) project.getRepositories().getAt("opensearch-downloads")).getUrl().toString(),
-            "https://artifacts.opensearch.org"
-        );
-        assertEquals(
-            ((DefaultIvyArtifactRepository) project.getRepositories().getAt("opensearch-downloads2")).getUrl().toString(),
-            "https://artifacts.opensearch.org"
-        );
-        assertEquals(
-            ((DefaultIvyArtifactRepository) project.getRepositories().getAt("opensearch-snapshots")).getUrl().toString(),
-            "https://artifacts.opensearch.org"
-        );
-        assertEquals(
-            ((DefaultIvyArtifactRepository) project.getRepositories().getAt("elasticsearch-downloads")).getUrl().toString(),
-            "https://artifacts-no-kpi.elastic.co"
-        );
-        assertEquals(
-            ((DefaultIvyArtifactRepository) project.getRepositories().getAt("elasticsearch-snapshots")).getUrl().toString(),
-            "https://snapshots-no-kpi.elastic.co"
-        );
     }
 
     public void testBadVersionFormat() {


### PR DESCRIPTION
### Description
The alerting plugin build started to fail with this commit. This is now blocking the opensearch-build for 1.3

This reverts the backport commit to unblock the opensearch-build
 
### Issues Resolved
https://github.com/opensearch-project/alerting/issues/312
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
