### PR TITLE
[Remove] remaining type usage in Client and AbstractClient

### DIFF
--- a/modules/analysis-common/src/internalClusterTest/java/org/opensearch/analysis/common/QueryStringWithAnalyzersIT.java
+++ b/modules/analysis-common/src/internalClusterTest/java/org/opensearch/analysis/common/QueryStringWithAnalyzersIT.java
@@ -76,7 +76,7 @@ public class QueryStringWithAnalyzersIT extends OpenSearchIntegTestCase {
                 .addMapping("type1", "field1", "type=text,analyzer=my_analyzer", "field2", "type=text,analyzer=my_analyzer")
         );
 
-        client().prepareIndex("test", "type1", "1").setSource("field1", "foo bar baz", "field2", "not needed").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "foo bar baz", "field2", "not needed").get();
         refresh();
 
         SearchResponse response = client().prepareSearch("test")

--- a/modules/analysis-common/src/test/java/org/opensearch/analysis/common/HighlighterWithAnalyzersTests.java
+++ b/modules/analysis-common/src/test/java/org/opensearch/analysis/common/HighlighterWithAnalyzersTests.java
@@ -137,7 +137,7 @@ public class HighlighterWithAnalyzersTests extends OpenSearchIntegTestCase {
                         .putList("analysis.analyzer.search_autocomplete.filter", "lowercase", "wordDelimiter")
                 )
         );
-        client().prepareIndex("test", "test", "1").setSource("name", "ARCOTEL Hotels Deutschland").get();
+        client().prepareIndex("test").setId("1").setSource("name", "ARCOTEL Hotels Deutschland").get();
         refresh();
         SearchResponse search = client().prepareSearch("test")
             .setQuery(matchQuery("name.autocomplete", "deut tel").operator(Operator.OR))
@@ -173,7 +173,8 @@ public class HighlighterWithAnalyzersTests extends OpenSearchIntegTestCase {
         );
 
         ensureGreen();
-        client().prepareIndex("test", "test", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 "body",
                 "Test: http://www.facebook.com http://elasticsearch.org "
@@ -235,7 +236,7 @@ public class HighlighterWithAnalyzersTests extends OpenSearchIntegTestCase {
         );
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "0").setSource("field1", "The quick brown fox jumps over the lazy dog").get();
+        client().prepareIndex("test").setId("0").setSource("field1", "The quick brown fox jumps over the lazy dog").get();
         refresh();
         for (String highlighterType : new String[] { "plain", "fvh", "unified" }) {
             logger.info("--> highlighting (type=" + highlighterType + ") and searching on field1");
@@ -263,10 +264,12 @@ public class HighlighterWithAnalyzersTests extends OpenSearchIntegTestCase {
 
         ensureGreen();
 
-        client().prepareIndex("first_test_index", "type1", "0")
+        client().prepareIndex("first_test_index")
+            .setId("0")
             .setSource("field0", "The quick brown fox jumps over the lazy dog", "field1", "The quick brown fox jumps over the lazy dog")
             .get();
-        client().prepareIndex("first_test_index", "type1", "1")
+        client().prepareIndex("first_test_index")
+            .setId("1")
             .setSource("field1", "The quick browse button is a fancy thing, right bro?")
             .get();
         refresh();
@@ -344,7 +347,8 @@ public class HighlighterWithAnalyzersTests extends OpenSearchIntegTestCase {
                 )
         );
         // with synonyms
-        client().prepareIndex("second_test_index", "doc", "0")
+        client().prepareIndex("second_test_index")
+            .setId("0")
             .setSource(
                 "type",
                 "type2",
@@ -354,10 +358,11 @@ public class HighlighterWithAnalyzersTests extends OpenSearchIntegTestCase {
                 "The quick brown fox jumps over the lazy dog"
             )
             .get();
-        client().prepareIndex("second_test_index", "doc", "1")
+        client().prepareIndex("second_test_index")
+            .setId("1")
             .setSource("type", "type2", "field4", "The quick browse button is a fancy thing, right bro?")
             .get();
-        client().prepareIndex("second_test_index", "doc", "2").setSource("type", "type2", "field4", "a quick fast blue car").get();
+        client().prepareIndex("second_test_index").setId("2").setSource("type", "type2", "field4", "a quick fast blue car").get();
         refresh();
 
         source = searchSource().postFilter(termQuery("type", "type2"))

--- a/modules/ingest-common/src/internalClusterTest/java/org/opensearch/ingest/common/IngestRestartIT.java
+++ b/modules/ingest-common/src/internalClusterTest/java/org/opensearch/ingest/common/IngestRestartIT.java
@@ -178,7 +178,8 @@ public class IngestRestartIT extends OpenSearchIntegTestCase {
         checkPipelineExists.accept(pipelineIdWithoutScript);
         checkPipelineExists.accept(pipelineIdWithScript);
 
-        client().prepareIndex("index", "doc", "1")
+        client().prepareIndex("index")
+            .setId("1")
             .setSource("x", 0)
             .setPipeline(pipelineIdWithoutScript)
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
@@ -186,7 +187,8 @@ public class IngestRestartIT extends OpenSearchIntegTestCase {
 
         IllegalStateException exception = expectThrows(
             IllegalStateException.class,
-            () -> client().prepareIndex("index", "doc", "2")
+            () -> client().prepareIndex("index")
+                .setId("2")
                 .setSource("x", 0)
                 .setPipeline(pipelineIdWithScript)
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
@@ -236,7 +238,8 @@ public class IngestRestartIT extends OpenSearchIntegTestCase {
         );
         client().admin().cluster().preparePutPipeline("_id", pipeline, XContentType.JSON).get();
 
-        client().prepareIndex("index", "doc", "1")
+        client().prepareIndex("index")
+            .setId("1")
             .setSource("x", 0)
             .setPipeline("_id")
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
@@ -254,7 +257,8 @@ public class IngestRestartIT extends OpenSearchIntegTestCase {
         internalCluster().fullRestart();
         ensureYellow("index");
 
-        client().prepareIndex("index", "doc", "2")
+        client().prepareIndex("index")
+            .setId("2")
             .setSource("x", 0)
             .setPipeline("_id")
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
@@ -275,7 +279,8 @@ public class IngestRestartIT extends OpenSearchIntegTestCase {
         );
         client().admin().cluster().preparePutPipeline("_id", pipeline, XContentType.JSON).get();
 
-        client().prepareIndex("index", "doc", "1")
+        client().prepareIndex("index")
+            .setId("1")
             .setSource("x", 0)
             .setPipeline("_id")
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
@@ -288,7 +293,8 @@ public class IngestRestartIT extends OpenSearchIntegTestCase {
         logger.info("Stopping");
         internalCluster().restartNode(node, new InternalTestCluster.RestartCallback());
 
-        client(ingestNode).prepareIndex("index", "doc", "2")
+        client(ingestNode).prepareIndex("index")
+            .setId("2")
             .setSource("x", 0)
             .setPipeline("_id")
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)

--- a/modules/lang-expression/src/internalClusterTest/java/org/opensearch/script/expression/MoreExpressionIT.java
+++ b/modules/lang-expression/src/internalClusterTest/java/org/opensearch/script/expression/MoreExpressionIT.java
@@ -100,7 +100,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
     public void testBasic() throws Exception {
         createIndex("test");
         ensureGreen("test");
-        client().prepareIndex("test", "doc", "1").setSource("foo", 4).setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("foo", 4).setRefreshPolicy(IMMEDIATE).get();
         SearchResponse rsp = buildRequest("doc['foo'] + 1").get();
         assertEquals(1, rsp.getHits().getTotalHits().value);
         assertEquals(5.0, rsp.getHits().getAt(0).field("foo").getValue(), 0.0D);
@@ -109,7 +109,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
     public void testFunction() throws Exception {
         createIndex("test");
         ensureGreen("test");
-        client().prepareIndex("test", "doc", "1").setSource("foo", 4).setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("foo", 4).setRefreshPolicy(IMMEDIATE).get();
         SearchResponse rsp = buildRequest("doc['foo'] + abs(1)").get();
         assertSearchResponse(rsp);
         assertEquals(1, rsp.getHits().getTotalHits().value);
@@ -119,7 +119,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
     public void testBasicUsingDotValue() throws Exception {
         createIndex("test");
         ensureGreen("test");
-        client().prepareIndex("test", "doc", "1").setSource("foo", 4).setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("foo", 4).setRefreshPolicy(IMMEDIATE).get();
         SearchResponse rsp = buildRequest("doc['foo'].value + 1").get();
         assertEquals(1, rsp.getHits().getTotalHits().value);
         assertEquals(5.0, rsp.getHits().getAt(0).field("foo").getValue(), 0.0D);
@@ -130,9 +130,9 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
         ensureGreen("test");
         indexRandom(
             true,
-            client().prepareIndex("test", "doc", "1").setSource("text", "hello goodbye"),
-            client().prepareIndex("test", "doc", "2").setSource("text", "hello hello hello goodbye"),
-            client().prepareIndex("test", "doc", "3").setSource("text", "hello hello goodebye")
+            client().prepareIndex("test").setId("1").setSource("text", "hello goodbye"),
+            client().prepareIndex("test").setId("2").setSource("text", "hello hello hello goodbye"),
+            client().prepareIndex("test").setId("3").setSource("text", "hello hello goodebye")
         );
         ScriptScoreFunctionBuilder score = ScoreFunctionBuilders.scriptFunction(
             new Script(ScriptType.INLINE, "expression", "1 / _score", Collections.emptyMap())
@@ -162,8 +162,8 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
         ensureGreen("test");
         indexRandom(
             true,
-            client().prepareIndex("test", "doc", "1").setSource("id", 1, "date0", "2015-04-28T04:02:07Z", "date1", "1985-09-01T23:11:01Z"),
-            client().prepareIndex("test", "doc", "2").setSource("id", 2, "date0", "2013-12-25T11:56:45Z", "date1", "1983-10-13T23:15:00Z")
+            client().prepareIndex("test").setId("1").setSource("id", 1, "date0", "2015-04-28T04:02:07Z", "date1", "1985-09-01T23:11:01Z"),
+            client().prepareIndex("test").setId("2").setSource("id", 2, "date0", "2013-12-25T11:56:45Z", "date1", "1983-10-13T23:15:00Z")
         );
         SearchResponse rsp = buildRequest("doc['date0'].getSeconds() - doc['date0'].getMinutes()").get();
         assertEquals(2, rsp.getHits().getTotalHits().value);
@@ -192,8 +192,8 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
         ensureGreen("test");
         indexRandom(
             true,
-            client().prepareIndex("test", "doc", "1").setSource("id", 1, "date0", "2015-04-28T04:02:07Z", "date1", "1985-09-01T23:11:01Z"),
-            client().prepareIndex("test", "doc", "2").setSource("id", 2, "date0", "2013-12-25T11:56:45Z", "date1", "1983-10-13T23:15:00Z")
+            client().prepareIndex("test").setId("1").setSource("id", 1, "date0", "2015-04-28T04:02:07Z", "date1", "1985-09-01T23:11:01Z"),
+            client().prepareIndex("test").setId("2").setSource("id", 2, "date0", "2013-12-25T11:56:45Z", "date1", "1983-10-13T23:15:00Z")
         );
         SearchResponse rsp = buildRequest("doc['date0'].date.secondOfMinute - doc['date0'].date.minuteOfHour").get();
         assertEquals(2, rsp.getHits().getTotalHits().value);
@@ -241,9 +241,9 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("test", "doc", "1").setSource(doc1),
-            client().prepareIndex("test", "doc", "2").setSource(doc2),
-            client().prepareIndex("test", "doc", "3").setSource(doc3)
+            client().prepareIndex("test").setId("1").setSource(doc1),
+            client().prepareIndex("test").setId("2").setSource(doc2),
+            client().prepareIndex("test").setId("3").setSource(doc3)
         );
 
         SearchResponse rsp = buildRequest("doc['double0'].count() + doc['double1'].count()").get();
@@ -324,7 +324,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
     public void testInvalidDateMethodCall() throws Exception {
         OpenSearchAssertions.assertAcked(prepareCreate("test").addMapping("doc", "double", "type=double"));
         ensureGreen("test");
-        indexRandom(true, client().prepareIndex("test", "doc", "1").setSource("double", "178000000.0"));
+        indexRandom(true, client().prepareIndex("test").setId("1").setSource("double", "178000000.0"));
         try {
             buildRequest("doc['double'].getYear()").get();
             fail();
@@ -347,8 +347,8 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
         ensureGreen("test");
         indexRandom(
             true,
-            client().prepareIndex("test", "doc", "1").setSource("id", 1, "x", 4),
-            client().prepareIndex("test", "doc", "2").setSource("id", 2, "y", 2)
+            client().prepareIndex("test").setId("1").setSource("id", 1, "x", 4),
+            client().prepareIndex("test").setId("2").setSource("id", 2, "y", 2)
         );
         SearchResponse rsp = buildRequest("doc['x'] + 1").get();
         OpenSearchAssertions.assertSearchResponse(rsp);
@@ -361,7 +361,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
     public void testMissingField() throws Exception {
         createIndex("test");
         ensureGreen("test");
-        client().prepareIndex("test", "doc", "1").setSource("x", 4).setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("x", 4).setRefreshPolicy(IMMEDIATE).get();
         try {
             buildRequest("doc['bogus']").get();
             fail("Expected missing field to cause failure");
@@ -380,9 +380,9 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
         ensureGreen("test");
         indexRandom(
             true,
-            client().prepareIndex("test", "doc", "1").setSource("id", 1, "x", 10),
-            client().prepareIndex("test", "doc", "2").setSource("id", 2, "x", 3),
-            client().prepareIndex("test", "doc", "3").setSource("id", 3, "x", 5)
+            client().prepareIndex("test").setId("1").setSource("id", 1, "x", 10),
+            client().prepareIndex("test").setId("2").setSource("id", 2, "x", 3),
+            client().prepareIndex("test").setId("3").setSource("id", 3, "x", 5)
         );
         // a = int, b = double, c = long
         String script = "doc['x'] * a + b + ((c + doc['x']) > 5000000009 ? 1 : 0)";
@@ -395,7 +395,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
     }
 
     public void testCompileFailure() {
-        client().prepareIndex("test", "doc", "1").setSource("x", 1).setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("x", 1).setRefreshPolicy(IMMEDIATE).get();
         try {
             buildRequest("garbage%@#%@").get();
             fail("Expected expression compilation failure");
@@ -406,7 +406,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
     }
 
     public void testNonNumericParam() {
-        client().prepareIndex("test", "doc", "1").setSource("x", 1).setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("x", 1).setRefreshPolicy(IMMEDIATE).get();
         try {
             buildRequest("a", "a", "astring").get();
             fail("Expected string parameter to cause failure");
@@ -421,7 +421,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
     }
 
     public void testNonNumericField() {
-        client().prepareIndex("test", "doc", "1").setSource("text", "this is not a number").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("text", "this is not a number").setRefreshPolicy(IMMEDIATE).get();
         try {
             buildRequest("doc['text.keyword']").get();
             fail("Expected text field to cause execution failure");
@@ -436,7 +436,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
     }
 
     public void testInvalidGlobalVariable() {
-        client().prepareIndex("test", "doc", "1").setSource("foo", 5).setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("foo", 5).setRefreshPolicy(IMMEDIATE).get();
         try {
             buildRequest("bogus").get();
             fail("Expected bogus variable to cause execution failure");
@@ -451,7 +451,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
     }
 
     public void testDocWithoutField() {
-        client().prepareIndex("test", "doc", "1").setSource("foo", 5).setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("foo", 5).setRefreshPolicy(IMMEDIATE).get();
         try {
             buildRequest("doc").get();
             fail("Expected doc variable without field to cause execution failure");
@@ -466,7 +466,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
     }
 
     public void testInvalidFieldMember() {
-        client().prepareIndex("test", "doc", "1").setSource("foo", 5).setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("foo", 5).setRefreshPolicy(IMMEDIATE).get();
         try {
             buildRequest("doc['foo'].bogus").get();
             fail("Expected bogus field member to cause execution failure");
@@ -486,9 +486,9 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
         ensureGreen("test");
         indexRandom(
             true,
-            client().prepareIndex("test", "doc", "1").setSource("x", 5, "y", 1.2),
-            client().prepareIndex("test", "doc", "2").setSource("x", 10, "y", 1.4),
-            client().prepareIndex("test", "doc", "3").setSource("x", 13, "y", 1.8)
+            client().prepareIndex("test").setId("1").setSource("x", 5, "y", 1.2),
+            client().prepareIndex("test").setId("2").setSource("x", 10, "y", 1.4),
+            client().prepareIndex("test").setId("3").setSource("x", 13, "y", 1.8)
         );
 
         SearchRequestBuilder req = client().prepareSearch().setIndices("test");
@@ -532,9 +532,9 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
         ensureGreen("test");
         indexRandom(
             true,
-            client().prepareIndex("test", "doc", "1").setSource("text", "hello"),
-            client().prepareIndex("test", "doc", "2").setSource("text", "goodbye"),
-            client().prepareIndex("test", "doc", "3").setSource("text", "hello")
+            client().prepareIndex("test").setId("1").setSource("text", "hello"),
+            client().prepareIndex("test").setId("2").setSource("text", "goodbye"),
+            client().prepareIndex("test").setId("3").setSource("text", "hello")
         );
 
         SearchRequestBuilder req = client().prepareSearch().setIndices("test");
@@ -564,7 +564,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
         try {
             createIndex("test_index");
             ensureGreen("test_index");
-            indexRandom(true, client().prepareIndex("test_index", "doc", "1").setSource("text_field", "text"));
+            indexRandom(true, client().prepareIndex("test_index").setId("1").setSource("text_field", "text"));
             UpdateRequestBuilder urb = client().prepareUpdate().setIndex("test_index");
             urb.setId("1");
             urb.setScript(new Script(ScriptType.INLINE, ExpressionScriptEngine.NAME, "0", Collections.emptyMap()));
@@ -584,11 +584,11 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
         ensureGreen("agg_index");
         indexRandom(
             true,
-            client().prepareIndex("agg_index", "doc", "1").setSource("one", 1.0, "two", 2.0, "three", 3.0, "four", 4.0),
-            client().prepareIndex("agg_index", "doc", "2").setSource("one", 2.0, "two", 2.0, "three", 3.0, "four", 4.0),
-            client().prepareIndex("agg_index", "doc", "3").setSource("one", 3.0, "two", 2.0, "three", 3.0, "four", 4.0),
-            client().prepareIndex("agg_index", "doc", "4").setSource("one", 4.0, "two", 2.0, "three", 3.0, "four", 4.0),
-            client().prepareIndex("agg_index", "doc", "5").setSource("one", 5.0, "two", 2.0, "three", 3.0, "four", 4.0)
+            client().prepareIndex("agg_index").setId("1").setSource("one", 1.0, "two", 2.0, "three", 3.0, "four", 4.0),
+            client().prepareIndex("agg_index").setId("2").setSource("one", 2.0, "two", 2.0, "three", 3.0, "four", 4.0),
+            client().prepareIndex("agg_index").setId("3").setSource("one", 3.0, "two", 2.0, "three", 3.0, "four", 4.0),
+            client().prepareIndex("agg_index").setId("4").setSource("one", 4.0, "two", 2.0, "three", 3.0, "four", 4.0),
+            client().prepareIndex("agg_index").setId("5").setSource("one", 5.0, "two", 2.0, "three", 3.0, "four", 4.0)
         );
         SearchResponse response = client().prepareSearch("agg_index")
             .addAggregation(
@@ -648,7 +648,8 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
         xContentBuilder.endObject().endObject().endObject().endObject();
         assertAcked(prepareCreate("test").addMapping("type1", xContentBuilder));
         ensureGreen();
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("name", "test")
@@ -695,9 +696,9 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
         ensureGreen();
         indexRandom(
             true,
-            client().prepareIndex("test", "doc", "1").setSource("id", 1, "price", 1.0, "vip", true),
-            client().prepareIndex("test", "doc", "2").setSource("id", 2, "price", 2.0, "vip", false),
-            client().prepareIndex("test", "doc", "3").setSource("id", 3, "price", 2.0, "vip", false)
+            client().prepareIndex("test").setId("1").setSource("id", 1, "price", 1.0, "vip", true),
+            client().prepareIndex("test").setId("2").setSource("id", 2, "price", 2.0, "vip", false),
+            client().prepareIndex("test").setId("3").setSource("id", 3, "price", 2.0, "vip", false)
         );
         // access .value
         SearchResponse rsp = buildRequest("doc['vip'].value").get();
@@ -728,8 +729,8 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
         ensureGreen("test");
         indexRandom(
             true,
-            client().prepareIndex("test", "doc", "1").setSource("id", 1, "foo", 1.0),
-            client().prepareIndex("test", "doc", "2").setSource("id", 2, "foo", 0.0)
+            client().prepareIndex("test").setId("1").setSource("id", 1, "foo", 1.0),
+            client().prepareIndex("test").setId("2").setSource("id", 2, "foo", 0.0)
         );
         SearchRequestBuilder builder = buildRequest("doc['foo'].value");
         Script script = new Script(ScriptType.INLINE, "expression", "doc['foo'].value", Collections.emptyMap());

--- a/modules/lang-expression/src/internalClusterTest/java/org/opensearch/script/expression/StoredExpressionIT.java
+++ b/modules/lang-expression/src/internalClusterTest/java/org/opensearch/script/expression/StoredExpressionIT.java
@@ -69,7 +69,7 @@ public class StoredExpressionIT extends OpenSearchIntegTestCase {
             .setId("script1")
             .setContent(new BytesArray("{\"script\": {\"lang\": \"expression\", \"source\": \"2\"} }"), XContentType.JSON)
             .get();
-        client().prepareIndex("test", "scriptTest", "1").setSource("{\"theField\":\"foo\"}", XContentType.JSON).get();
+        client().prepareIndex("test").setId("1").setSource("{\"theField\":\"foo\"}", XContentType.JSON).get();
         try {
             client().prepareUpdate("test", "1").setScript(new Script(ScriptType.STORED, null, "script1", Collections.emptyMap())).get();
             fail("update script should have been rejected");

--- a/modules/lang-mustache/src/internalClusterTest/java/org/opensearch/script/mustache/MultiSearchTemplateIT.java
+++ b/modules/lang-mustache/src/internalClusterTest/java/org/opensearch/script/mustache/MultiSearchTemplateIT.java
@@ -66,7 +66,8 @@ public class MultiSearchTemplateIT extends OpenSearchIntegTestCase {
         final int numDocs = randomIntBetween(10, 100);
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
-            indexRequestBuilders[i] = client().prepareIndex("msearch", "test", String.valueOf(i))
+            indexRequestBuilders[i] = client().prepareIndex("msearch")
+                .setId(String.valueOf(i))
                 .setSource("odd", (i % 2 == 0), "group", (i % 3));
         }
         indexRandom(true, indexRequestBuilders);

--- a/modules/lang-mustache/src/internalClusterTest/java/org/opensearch/script/mustache/SearchTemplateIT.java
+++ b/modules/lang-mustache/src/internalClusterTest/java/org/opensearch/script/mustache/SearchTemplateIT.java
@@ -68,8 +68,8 @@ public class SearchTemplateIT extends OpenSearchSingleNodeTestCase {
     @Before
     public void setup() throws IOException {
         createIndex("test");
-        client().prepareIndex("test", "type", "1").setSource(jsonBuilder().startObject().field("text", "value1").endObject()).get();
-        client().prepareIndex("test", "type", "2").setSource(jsonBuilder().startObject().field("text", "value2").endObject()).get();
+        client().prepareIndex("test").setId("1").setSource(jsonBuilder().startObject().field("text", "value1").endObject()).get();
+        client().prepareIndex("test").setId("2").setSource(jsonBuilder().startObject().field("text", "value2").endObject()).get();
         client().admin().indices().prepareRefresh().get();
     }
 
@@ -185,11 +185,11 @@ public class SearchTemplateIT extends OpenSearchSingleNodeTestCase {
         assertNotNull(getResponse.getSource());
 
         BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
-        bulkRequestBuilder.add(client().prepareIndex("test", "type", "1").setSource("{\"theField\":\"foo\"}", XContentType.JSON));
-        bulkRequestBuilder.add(client().prepareIndex("test", "type", "2").setSource("{\"theField\":\"foo 2\"}", XContentType.JSON));
-        bulkRequestBuilder.add(client().prepareIndex("test", "type", "3").setSource("{\"theField\":\"foo 3\"}", XContentType.JSON));
-        bulkRequestBuilder.add(client().prepareIndex("test", "type", "4").setSource("{\"theField\":\"foo 4\"}", XContentType.JSON));
-        bulkRequestBuilder.add(client().prepareIndex("test", "type", "5").setSource("{\"theField\":\"bar\"}", XContentType.JSON));
+        bulkRequestBuilder.add(client().prepareIndex("test").setId("1").setSource("{\"theField\":\"foo\"}", XContentType.JSON));
+        bulkRequestBuilder.add(client().prepareIndex("test").setId("2").setSource("{\"theField\":\"foo 2\"}", XContentType.JSON));
+        bulkRequestBuilder.add(client().prepareIndex("test").setId("3").setSource("{\"theField\":\"foo 3\"}", XContentType.JSON));
+        bulkRequestBuilder.add(client().prepareIndex("test").setId("4").setSource("{\"theField\":\"foo 4\"}", XContentType.JSON));
+        bulkRequestBuilder.add(client().prepareIndex("test").setId("5").setSource("{\"theField\":\"bar\"}", XContentType.JSON));
         bulkRequestBuilder.get();
         client().admin().indices().prepareRefresh().get();
 
@@ -229,11 +229,11 @@ public class SearchTemplateIT extends OpenSearchSingleNodeTestCase {
         assertAcked(client().admin().cluster().preparePutStoredScript().setId("3").setContent(new BytesArray(script), XContentType.JSON));
 
         BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
-        bulkRequestBuilder.add(client().prepareIndex("test", "type", "1").setSource("{\"theField\":\"foo\"}", XContentType.JSON));
-        bulkRequestBuilder.add(client().prepareIndex("test", "type", "2").setSource("{\"theField\":\"foo 2\"}", XContentType.JSON));
-        bulkRequestBuilder.add(client().prepareIndex("test", "type", "3").setSource("{\"theField\":\"foo 3\"}", XContentType.JSON));
-        bulkRequestBuilder.add(client().prepareIndex("test", "type", "4").setSource("{\"theField\":\"foo 4\"}", XContentType.JSON));
-        bulkRequestBuilder.add(client().prepareIndex("test", "type", "5").setSource("{\"theField\":\"bar\"}", XContentType.JSON));
+        bulkRequestBuilder.add(client().prepareIndex("test").setId("1").setSource("{\"theField\":\"foo\"}", XContentType.JSON));
+        bulkRequestBuilder.add(client().prepareIndex("test").setId("2").setSource("{\"theField\":\"foo 2\"}", XContentType.JSON));
+        bulkRequestBuilder.add(client().prepareIndex("test").setId("3").setSource("{\"theField\":\"foo 3\"}", XContentType.JSON));
+        bulkRequestBuilder.add(client().prepareIndex("test").setId("4").setSource("{\"theField\":\"foo 4\"}", XContentType.JSON));
+        bulkRequestBuilder.add(client().prepareIndex("test").setId("5").setSource("{\"theField\":\"bar\"}", XContentType.JSON));
         bulkRequestBuilder.get();
         client().admin().indices().prepareRefresh().get();
 
@@ -270,9 +270,7 @@ public class SearchTemplateIT extends OpenSearchSingleNodeTestCase {
         createIndex("testindex");
         ensureGreen("testindex");
 
-        client().prepareIndex("testindex", "test", "1")
-            .setSource(jsonBuilder().startObject().field("searchtext", "dev1").endObject())
-            .get();
+        client().prepareIndex("testindex").setId("1").setSource(jsonBuilder().startObject().field("searchtext", "dev1").endObject()).get();
         client().admin().indices().prepareRefresh().get();
 
         int iterations = randomIntBetween(2, 11);
@@ -354,11 +352,11 @@ public class SearchTemplateIT extends OpenSearchSingleNodeTestCase {
             client().admin().cluster().preparePutStoredScript().setId("4").setContent(new BytesArray(multiQuery), XContentType.JSON)
         );
         BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
-        bulkRequestBuilder.add(client().prepareIndex("test", "type", "1").setSource("{\"theField\":\"foo\"}", XContentType.JSON));
-        bulkRequestBuilder.add(client().prepareIndex("test", "type", "2").setSource("{\"theField\":\"foo 2\"}", XContentType.JSON));
-        bulkRequestBuilder.add(client().prepareIndex("test", "type", "3").setSource("{\"theField\":\"foo 3\"}", XContentType.JSON));
-        bulkRequestBuilder.add(client().prepareIndex("test", "type", "4").setSource("{\"theField\":\"foo 4\"}", XContentType.JSON));
-        bulkRequestBuilder.add(client().prepareIndex("test", "type", "5").setSource("{\"theField\":\"bar\"}", XContentType.JSON));
+        bulkRequestBuilder.add(client().prepareIndex("test").setId("1").setSource("{\"theField\":\"foo\"}", XContentType.JSON));
+        bulkRequestBuilder.add(client().prepareIndex("test").setId("2").setSource("{\"theField\":\"foo 2\"}", XContentType.JSON));
+        bulkRequestBuilder.add(client().prepareIndex("test").setId("3").setSource("{\"theField\":\"foo 3\"}", XContentType.JSON));
+        bulkRequestBuilder.add(client().prepareIndex("test").setId("4").setSource("{\"theField\":\"foo 4\"}", XContentType.JSON));
+        bulkRequestBuilder.add(client().prepareIndex("test").setId("5").setSource("{\"theField\":\"bar\"}", XContentType.JSON));
         bulkRequestBuilder.get();
         client().admin().indices().prepareRefresh().get();
 

--- a/modules/mapper-extras/src/javaRestTest/java/org/opensearch/index/mapper/TokenCountFieldMapperIntegrationIT.java
+++ b/modules/mapper-extras/src/javaRestTest/java/org/opensearch/index/mapper/TokenCountFieldMapperIntegrationIT.java
@@ -187,7 +187,7 @@ public class TokenCountFieldMapperIntegrationIT extends OpenSearchIntegTestCase 
     }
 
     private IndexRequestBuilder prepareIndex(String id, String... texts) throws IOException {
-        return client().prepareIndex("test", "test", id).setSource("foo", texts);
+        return client().prepareIndex("test").setId(id).setSource("foo", texts);
     }
 
     private SearchResponse searchById(String id) {

--- a/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/BWCTemplateTests.java
+++ b/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/BWCTemplateTests.java
@@ -58,8 +58,8 @@ public class BWCTemplateTests extends OpenSearchSingleNodeTestCase {
         client().admin().indices().preparePutTemplate("packetbeat").setSource(packetBeat, XContentType.JSON).get();
         client().admin().indices().preparePutTemplate("filebeat").setSource(fileBeat, XContentType.JSON).get();
 
-        client().prepareIndex("metricbeat-foo", "doc", "1").setSource("message", "foo").get();
-        client().prepareIndex("packetbeat-foo", "doc", "1").setSource("message", "foo").get();
-        client().prepareIndex("filebeat-foo", "doc", "1").setSource("message", "foo").get();
+        client().prepareIndex("metricbeat-foo").setId("1").setSource("message", "foo").get();
+        client().prepareIndex("packetbeat-foo").setId("1").setSource("message", "foo").get();
+        client().prepareIndex("filebeat-foo").setId("1").setSource("message", "foo").get();
     }
 }

--- a/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/query/ChildQuerySearchIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/query/ChildQuerySearchIT.java
@@ -534,7 +534,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         createIndexRequest("test", "parent", "1", null, "p_field", 1).get();
         createIndexRequest("test", "child", "2", "1", "c_field", 1).get();
 
-        client().prepareIndex("test", "doc", "3").setSource("p_field", 1).get();
+        client().prepareIndex("test").setId("3").setSource("p_field", 1).get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch("test")
@@ -801,7 +801,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         createIndexRequest("test", "child", "2", "1", "c_field", 1).get();
         client().admin().indices().prepareFlush("test").get();
 
-        client().prepareIndex("test", "doc", "3").setSource("p_field", 2).get();
+        client().prepareIndex("test").setId("3").setSource("p_field", 2).get();
 
         refresh();
         SearchResponse searchResponse = client().prepareSearch("test")
@@ -1326,7 +1326,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         ensureGreen();
 
         String parentId = "p1";
-        client().prepareIndex("test", "doc", parentId).setSource("p_field", "1").get();
+        client().prepareIndex("test").setId(parentId).setSource("p_field", "1").get();
         refresh();
 
         try {

--- a/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/query/InnerHitsIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/query/InnerHitsIT.java
@@ -644,7 +644,7 @@ public class InnerHitsIT extends ParentChildTestCase {
         assertAcked(prepareCreate("index2"));
         createIndexRequest("index1", "parent_type", "1", null, "nested_type", Collections.singletonMap("key", "value")).get();
         createIndexRequest("index1", "child_type", "2", "1").get();
-        client().prepareIndex("index2", "type", "3").setSource("key", "value").get();
+        client().prepareIndex("index2").setId("3").setSource("key", "value").get();
         refresh();
 
         SearchResponse response = client().prepareSearch("index1", "index2")

--- a/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/query/ParentChildTestCase.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/query/ParentChildTestCase.java
@@ -129,7 +129,7 @@ public abstract class ParentChildTestCase extends OpenSearchIntegTestCase {
         String name = type;
         type = "doc";
 
-        IndexRequestBuilder indexRequestBuilder = client().prepareIndex(index, type, id);
+        IndexRequestBuilder indexRequestBuilder = client().prepareIndex(index).setId(id);
         Map<String, Object> joinField = new HashMap<>();
         if (parentId != null) {
             joinField.put("name", name);

--- a/modules/percolator/src/internalClusterTest/java/org/opensearch/percolator/PercolatorQuerySearchIT.java
+++ b/modules/percolator/src/internalClusterTest/java/org/opensearch/percolator/PercolatorQuerySearchIT.java
@@ -104,13 +104,16 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
                 .addMapping("type", "id", "type=keyword", "field1", "type=keyword", "field2", "type=keyword", "query", "type=percolator")
         );
 
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("id", "1").field("query", matchAllQuery()).endObject())
             .get();
-        client().prepareIndex("test", "type", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(jsonBuilder().startObject().field("id", "2").field("query", matchQuery("field1", "value")).endObject())
             .get();
-        client().prepareIndex("test", "type", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setSource(
                 jsonBuilder().startObject()
                     .field("id", "3")
@@ -195,13 +198,16 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
                 )
         );
 
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("query", rangeQuery("field1").from(10).to(12)).endObject())
             .get();
-        client().prepareIndex("test", "type", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(jsonBuilder().startObject().field("query", rangeQuery("field1").from(20).to(22)).endObject())
             .get();
-        client().prepareIndex("test", "type", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setSource(
                 jsonBuilder().startObject()
                     .field("query", boolQuery().must(rangeQuery("field1").from(10).to(12)).must(rangeQuery("field1").from(12).to(14)))
@@ -209,13 +215,16 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             )
             .get();
         client().admin().indices().prepareRefresh().get();
-        client().prepareIndex("test", "type", "4")
+        client().prepareIndex("test")
+            .setId("4")
             .setSource(jsonBuilder().startObject().field("query", rangeQuery("field2").from(10).to(12)).endObject())
             .get();
-        client().prepareIndex("test", "type", "5")
+        client().prepareIndex("test")
+            .setId("5")
             .setSource(jsonBuilder().startObject().field("query", rangeQuery("field2").from(20).to(22)).endObject())
             .get();
-        client().prepareIndex("test", "type", "6")
+        client().prepareIndex("test")
+            .setId("6")
             .setSource(
                 jsonBuilder().startObject()
                     .field("query", boolQuery().must(rangeQuery("field2").from(10).to(12)).must(rangeQuery("field2").from(12).to(14)))
@@ -223,13 +232,16 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             )
             .get();
         client().admin().indices().prepareRefresh().get();
-        client().prepareIndex("test", "type", "7")
+        client().prepareIndex("test")
+            .setId("7")
             .setSource(jsonBuilder().startObject().field("query", rangeQuery("field3").from("192.168.1.0").to("192.168.1.5")).endObject())
             .get();
-        client().prepareIndex("test", "type", "8")
+        client().prepareIndex("test")
+            .setId("8")
             .setSource(jsonBuilder().startObject().field("query", rangeQuery("field3").from("192.168.1.20").to("192.168.1.30")).endObject())
             .get();
-        client().prepareIndex("test", "type", "9")
+        client().prepareIndex("test")
+            .setId("9")
             .setSource(
                 jsonBuilder().startObject()
                     .field(
@@ -240,7 +252,8 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
                     .endObject()
             )
             .get();
-        client().prepareIndex("test", "type", "10")
+        client().prepareIndex("test")
+            .setId("10")
             .setSource(
                 jsonBuilder().startObject()
                     .field(
@@ -315,7 +328,8 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
                 )
         );
 
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("query", geoDistanceQuery("field1").point(52.18, 4.38).distance(50, DistanceUnit.KILOMETERS))
@@ -324,7 +338,8 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             )
             .get();
 
-        client().prepareIndex("test", "type", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(
                 jsonBuilder().startObject()
                     .field("query", geoBoundingBoxQuery("field1").setCorners(52.3, 4.4, 52.1, 4.6))
@@ -333,7 +348,8 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             )
             .get();
 
-        client().prepareIndex("test", "type", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setSource(
                 jsonBuilder().startObject()
                     .field(
@@ -367,13 +383,16 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
                 .addMapping("type", "id", "type=keyword", "field1", "type=keyword", "field2", "type=keyword", "query", "type=percolator")
         );
 
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("id", "1").field("query", matchAllQuery()).endObject())
             .get();
-        client().prepareIndex("test", "type", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(jsonBuilder().startObject().field("id", "2").field("query", matchQuery("field1", "value")).endObject())
             .get();
-        client().prepareIndex("test", "type", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setSource(
                 jsonBuilder().startObject()
                     .field("id", "3")
@@ -382,9 +401,9 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             )
             .get();
 
-        client().prepareIndex("test", "type", "4").setSource("{\"id\": \"4\"}", XContentType.JSON).get();
-        client().prepareIndex("test", "type", "5").setSource(XContentType.JSON, "id", "5", "field1", "value").get();
-        client().prepareIndex("test", "type", "6").setSource(XContentType.JSON, "id", "6", "field1", "value", "field2", "value").get();
+        client().prepareIndex("test").setId("4").setSource("{\"id\": \"4\"}", XContentType.JSON).get();
+        client().prepareIndex("test").setId("5").setSource(XContentType.JSON, "id", "5", "field1", "value").get();
+        client().prepareIndex("test").setId("6").setSource(XContentType.JSON, "id", "6", "field1", "value", "field2", "value").get();
         client().admin().indices().prepareRefresh().get();
 
         logger.info("percolating empty doc");
@@ -422,9 +441,9 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
                 .addMapping("type", "_source", "enabled=false", "field1", "type=keyword", "query", "type=percolator")
         );
 
-        client().prepareIndex("test", "type", "1").setSource(jsonBuilder().startObject().field("query", matchAllQuery()).endObject()).get();
+        client().prepareIndex("test").setId("1").setSource(jsonBuilder().startObject().field("query", matchAllQuery()).endObject()).get();
 
-        client().prepareIndex("test", "type", "2").setSource("{}", XContentType.JSON).get();
+        client().prepareIndex("test").setId("2").setSource("{}", XContentType.JSON).get();
         client().admin().indices().prepareRefresh().get();
 
         logger.info("percolating empty doc with source disabled");
@@ -443,10 +462,12 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
                 .addMapping("type", "id", "type=keyword", "field1", "type=text", "field2", "type=text", "query", "type=percolator")
         );
 
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("id", 1).field("query", commonTermsQuery("field1", "quick brown fox")).endObject())
             .get();
-        client().prepareIndex("test", "type", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(
                 jsonBuilder().startObject()
                     .field("id", 2)
@@ -454,7 +475,8 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
                     .endObject()
             )
             .get();
-        client().prepareIndex("test", "type", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setSource(
                 jsonBuilder().startObject()
                     .field("id", 3)
@@ -469,7 +491,8 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             .get();
         client().admin().indices().prepareRefresh().get();
 
-        client().prepareIndex("test", "type", "4")
+        client().prepareIndex("test")
+            .setId("4")
             .setSource(
                 jsonBuilder().startObject()
                     .field("id", 4)
@@ -489,7 +512,8 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             .get();
 
         // doesn't match
-        client().prepareIndex("test", "type", "5")
+        client().prepareIndex("test")
+            .setId("5")
             .setSource(
                 jsonBuilder().startObject()
                     .field("id", 5)
@@ -543,23 +567,28 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
                 .prepareCreate("test")
                 .addMapping("type", "id", "type=keyword", "field1", fieldMapping, "query", "type=percolator")
         );
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("id", "1").field("query", matchQuery("field1", "brown fox")).endObject())
             .execute()
             .actionGet();
-        client().prepareIndex("test", "type", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(jsonBuilder().startObject().field("id", "2").field("query", matchQuery("field1", "lazy dog")).endObject())
             .execute()
             .actionGet();
-        client().prepareIndex("test", "type", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setSource(jsonBuilder().startObject().field("id", "3").field("query", termQuery("field1", "jumps")).endObject())
             .execute()
             .actionGet();
-        client().prepareIndex("test", "type", "4")
+        client().prepareIndex("test")
+            .setId("4")
             .setSource(jsonBuilder().startObject().field("id", "4").field("query", termQuery("field1", "dog")).endObject())
             .execute()
             .actionGet();
-        client().prepareIndex("test", "type", "5")
+        client().prepareIndex("test")
+            .setId("5")
             .setSource(jsonBuilder().startObject().field("id", "5").field("query", termQuery("field1", "fox")).endObject())
             .execute()
             .actionGet();
@@ -783,10 +812,12 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
                 .prepareCreate("test")
                 .addMapping("type", "field", "type=text,position_increment_gap=5", "query", "type=percolator")
         );
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("query", new MatchPhraseQueryBuilder("field", "brown fox").slop(4)).endObject())
             .get();
-        client().prepareIndex("test", "type", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(jsonBuilder().startObject().field("query", new MatchPhraseQueryBuilder("field", "brown fox").slop(5)).endObject())
             .get();
         client().admin().indices().prepareRefresh().get();
@@ -868,10 +899,12 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
         );
 
         // Acceptable:
-        client().prepareIndex("test1", "type", "1")
+        client().prepareIndex("test1")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field(queryFieldName, matchQuery("field", "value")).endObject())
             .get();
-        client().prepareIndex("test2", "type", "1")
+        client().prepareIndex("test2")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .startObject("object_field")
@@ -901,7 +934,8 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
 
         // Unacceptable:
         MapperParsingException e = expectThrows(MapperParsingException.class, () -> {
-            client().prepareIndex("test2", "type", "1")
+            client().prepareIndex("test2")
+                .setId("1")
                 .setSource(
                     jsonBuilder().startObject()
                         .startArray("object_field")
@@ -944,7 +978,8 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject();
         assertAcked(client().admin().indices().prepareCreate("test").addMapping("employee", mapping));
-        client().prepareIndex("test", "employee", "q1")
+        client().prepareIndex("test")
+            .setId("q1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("id", "q1")
@@ -960,7 +995,8 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             )
             .get();
         // this query should never match as it doesn't use nested query:
-        client().prepareIndex("test", "employee", "q2")
+        client().prepareIndex("test")
+            .setId("q2")
             .setSource(
                 jsonBuilder().startObject()
                     .field("id", "q2")
@@ -970,7 +1006,8 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             .get();
         client().admin().indices().prepareRefresh().get();
 
-        client().prepareIndex("test", "employee", "q3")
+        client().prepareIndex("test")
+            .setId("q3")
             .setSource(jsonBuilder().startObject().field("id", "q3").field("query", QueryBuilders.matchAllQuery()).endObject())
             .get();
         client().admin().indices().prepareRefresh().get();
@@ -1101,15 +1138,18 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
     public void testPercolatorQueryViaMultiSearch() throws Exception {
         assertAcked(client().admin().indices().prepareCreate("test").addMapping("type", "field1", "type=text", "query", "type=percolator"));
 
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("query", matchQuery("field1", "b")).field("a", "b").endObject())
             .execute()
             .actionGet();
-        client().prepareIndex("test", "type", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(jsonBuilder().startObject().field("query", matchQuery("field1", "c")).endObject())
             .execute()
             .actionGet();
-        client().prepareIndex("test", "type", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setSource(
                 jsonBuilder().startObject()
                     .field("query", boolQuery().must(matchQuery("field1", "b")).must(matchQuery("field1", "c")))
@@ -1117,11 +1157,13 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             )
             .execute()
             .actionGet();
-        client().prepareIndex("test", "type", "4")
+        client().prepareIndex("test")
+            .setId("4")
             .setSource(jsonBuilder().startObject().field("query", matchAllQuery()).endObject())
             .execute()
             .actionGet();
-        client().prepareIndex("test", "type", "5")
+        client().prepareIndex("test")
+            .setId("5")
             .setSource(jsonBuilder().startObject().field("field1", "c").endObject())
             .execute()
             .actionGet();

--- a/modules/percolator/src/test/java/org/opensearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/opensearch/percolator/PercolatorFieldMapperTests.java
@@ -634,7 +634,7 @@ public class PercolatorFieldMapperTests extends OpenSearchSingleNodeTestCase {
 
     public void testQueryWithRewrite() throws Exception {
         addQueryFieldMappings();
-        client().prepareIndex("remote", "doc", "1").setSource("field", "value").get();
+        client().prepareIndex("remote").setId("1").setSource("field", "value").get();
         QueryBuilder queryBuilder = termsLookupQuery("field", new TermsLookup("remote", "1", "field"));
         ParsedDocument doc = mapperService.documentMapper("doc")
             .parse(

--- a/modules/percolator/src/test/java/org/opensearch/percolator/PercolatorQuerySearchTests.java
+++ b/modules/percolator/src/test/java/org/opensearch/percolator/PercolatorQuerySearchTests.java
@@ -97,7 +97,8 @@ public class PercolatorQuerySearchTests extends OpenSearchSingleNodeTestCase {
 
     public void testPercolateScriptQuery() throws IOException {
         client().admin().indices().prepareCreate("index").addMapping("type", "query", "type=percolator").get();
-        client().prepareIndex("index", "type", "1")
+        client().prepareIndex("index")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field(
@@ -151,7 +152,8 @@ public class PercolatorQuerySearchTests extends OpenSearchSingleNodeTestCase {
                 .setSettings(Settings.builder().put(BitsetFilterCache.INDEX_LOAD_RANDOM_ACCESS_FILTERS_EAGERLY_SETTING.getKey(), false))
                 .addMapping("employee", mapping)
         );
-        client().prepareIndex("test", "employee", "q1")
+        client().prepareIndex("test")
+            .setId("q1")
             .setSource(
                 jsonBuilder().startObject()
                     .field(
@@ -238,7 +240,8 @@ public class PercolatorQuerySearchTests extends OpenSearchSingleNodeTestCase {
         mapping.endObject();
         createIndex("test", client().admin().indices().prepareCreate("test").addMapping("employee", mapping));
         Script script = new Script(ScriptType.INLINE, MockScriptPlugin.NAME, "use_fielddata_please", Collections.emptyMap());
-        client().prepareIndex("test", "employee", "q1")
+        client().prepareIndex("test")
+            .setId("q1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("query", QueryBuilders.nestedQuery("employees", QueryBuilders.scriptQuery(script), ScoreMode.Avg))
@@ -279,7 +282,8 @@ public class PercolatorQuerySearchTests extends OpenSearchSingleNodeTestCase {
     public void testMapUnmappedFieldAsText() throws IOException {
         Settings.Builder settings = Settings.builder().put("index.percolator.map_unmapped_fields_as_text", true);
         createIndex("test", settings.build(), "query", "query", "type=percolator");
-        client().prepareIndex("test", "query", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("query", matchQuery("field1", "value")).endObject())
             .get();
         client().admin().indices().prepareRefresh().get();
@@ -310,10 +314,12 @@ public class PercolatorQuerySearchTests extends OpenSearchSingleNodeTestCase {
             "type=percolator"
         );
 
-        client().prepareIndex("test", "_doc", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("query", rangeQuery("field2").from("now-1h").to("now+1h")).endObject())
             .get();
-        client().prepareIndex("test", "_doc", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(
                 jsonBuilder().startObject()
                     .field(
@@ -325,7 +331,8 @@ public class PercolatorQuerySearchTests extends OpenSearchSingleNodeTestCase {
             .get();
 
         Script script = new Script(ScriptType.INLINE, MockScriptPlugin.NAME, "1==1", Collections.emptyMap());
-        client().prepareIndex("test", "_doc", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setSource(
                 jsonBuilder().startObject()
                     .field("query", boolQuery().filter(scriptQuery(script)).filter(rangeQuery("field2").from("now-1h").to("now+1h")))

--- a/modules/reindex/src/internalClusterTest/java/org/opensearch/client/documentation/ReindexDocumentationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/opensearch/client/documentation/ReindexDocumentationIT.java
@@ -302,7 +302,7 @@ public class ReindexDocumentationIT extends OpenSearchIntegTestCase {
             false,
             true,
             IntStream.range(0, numDocs)
-                .mapToObj(i -> client().prepareIndex(INDEX_NAME, "_doc", Integer.toString(i)).setSource("n", Integer.toString(i)))
+                .mapToObj(i -> client().prepareIndex(INDEX_NAME).setId(Integer.toString(i)).setSource("n", Integer.toString(i)))
                 .collect(Collectors.toList())
         );
 

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/DeleteByQueryBasicTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/DeleteByQueryBasicTests.java
@@ -74,13 +74,13 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
     public void testBasics() throws Exception {
         indexRandom(
             true,
-            client().prepareIndex("test", "test", "1").setSource("foo", "a"),
-            client().prepareIndex("test", "test", "2").setSource("foo", "a"),
-            client().prepareIndex("test", "test", "3").setSource("foo", "b"),
-            client().prepareIndex("test", "test", "4").setSource("foo", "c"),
-            client().prepareIndex("test", "test", "5").setSource("foo", "d"),
-            client().prepareIndex("test", "test", "6").setSource("foo", "e"),
-            client().prepareIndex("test", "test", "7").setSource("foo", "f")
+            client().prepareIndex("test").setId("1").setSource("foo", "a"),
+            client().prepareIndex("test").setId("2").setSource("foo", "a"),
+            client().prepareIndex("test").setId("3").setSource("foo", "b"),
+            client().prepareIndex("test").setId("4").setSource("foo", "c"),
+            client().prepareIndex("test").setId("5").setSource("foo", "d"),
+            client().prepareIndex("test").setId("6").setSource("foo", "e"),
+            client().prepareIndex("test").setId("7").setSource("foo", "f")
         );
 
         assertHitCount(client().prepareSearch("test").setSize(0).get(), 7);
@@ -109,7 +109,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
 
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < docs; i++) {
-            builders.add(client().prepareIndex("test", "doc", String.valueOf(i)).setSource("fields1", 1));
+            builders.add(client().prepareIndex("test").setId(String.valueOf(i)).setSource("fields1", 1));
         }
         indexRandom(true, true, true, builders);
 
@@ -134,7 +134,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
 
             for (int j = 0; j < docs; j++) {
                 boolean candidate = (j < candidates[i]);
-                builders.add(client().prepareIndex("test-" + i, "doc", String.valueOf(j)).setSource("candidate", candidate));
+                builders.add(client().prepareIndex("test-" + i).setId(String.valueOf(j)).setSource("candidate", candidate));
             }
         }
         indexRandom(true, true, true, builders);
@@ -151,7 +151,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
     }
 
     public void testDeleteByQueryWithMissingIndex() throws Exception {
-        indexRandom(true, client().prepareIndex("test", "test", "1").setSource("foo", "a"));
+        indexRandom(true, client().prepareIndex("test").setId("1").setSource("foo", "a"));
         assertHitCount(client().prepareSearch().setSize(0).get(), 1);
 
         try {
@@ -171,7 +171,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
 
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < docs; i++) {
-            builders.add(client().prepareIndex("test", "test", String.valueOf(i)).setRouting(String.valueOf(i)).setSource("field1", 1));
+            builders.add(client().prepareIndex("test").setId(String.valueOf(i)).setRouting(String.valueOf(i)).setSource("field1", 1));
         }
         indexRandom(true, true, true, builders);
 
@@ -199,7 +199,8 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < docs; i++) {
             builders.add(
-                client().prepareIndex("test", "test", Integer.toString(i))
+                client().prepareIndex("test")
+                    .setId(Integer.toString(i))
                     .setRouting(randomAlphaOfLengthBetween(1, 5))
                     .setSource("foo", "bar")
             );
@@ -217,7 +218,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
     }
 
     public void testDeleteByQueryWithDateMath() throws Exception {
-        indexRandom(true, client().prepareIndex("test", "type", "1").setSource("d", "2013-01-01"));
+        indexRandom(true, client().prepareIndex("test").setId("1").setSource("d", "2013-01-01"));
 
         DeleteByQueryRequestBuilder delete = deleteByQuery().source("test").filter(rangeQuery("d").to("now-1h"));
         assertThat(delete.refresh(true).get(), matcher().deleted(1L));
@@ -231,7 +232,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
         final int docs = randomIntBetween(1, 50);
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < docs; i++) {
-            builders.add(client().prepareIndex("test", "test", Integer.toString(i)).setSource("field", 1));
+            builders.add(client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", 1));
         }
         indexRandom(true, true, true, builders);
 
@@ -311,13 +312,13 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
     public void testSlices() throws Exception {
         indexRandom(
             true,
-            client().prepareIndex("test", "test", "1").setSource("foo", "a"),
-            client().prepareIndex("test", "test", "2").setSource("foo", "a"),
-            client().prepareIndex("test", "test", "3").setSource("foo", "b"),
-            client().prepareIndex("test", "test", "4").setSource("foo", "c"),
-            client().prepareIndex("test", "test", "5").setSource("foo", "d"),
-            client().prepareIndex("test", "test", "6").setSource("foo", "e"),
-            client().prepareIndex("test", "test", "7").setSource("foo", "f")
+            client().prepareIndex("test").setId("1").setSource("foo", "a"),
+            client().prepareIndex("test").setId("2").setSource("foo", "a"),
+            client().prepareIndex("test").setId("3").setSource("foo", "b"),
+            client().prepareIndex("test").setId("4").setSource("foo", "c"),
+            client().prepareIndex("test").setId("5").setSource("foo", "d"),
+            client().prepareIndex("test").setId("6").setSource("foo", "e"),
+            client().prepareIndex("test").setId("7").setSource("foo", "f")
         );
         assertHitCount(client().prepareSearch("test").setSize(0).get(), 7);
 
@@ -348,7 +349,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
             docs.put(indexName, new ArrayList<>());
             int numDocs = between(5, 15);
             for (int i = 0; i < numDocs; i++) {
-                docs.get(indexName).add(client().prepareIndex(indexName, "test", Integer.toString(i)).setSource("foo", "a"));
+                docs.get(indexName).add(client().prepareIndex(indexName).setId(Integer.toString(i)).setSource("foo", "a"));
             }
         }
 

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/DeleteByQueryConcurrentTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/DeleteByQueryConcurrentTests.java
@@ -96,7 +96,7 @@ public class DeleteByQueryConcurrentTests extends ReindexTestCase {
 
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < docs; i++) {
-            builders.add(client().prepareIndex("test", "doc", String.valueOf(i)).setSource("foo", "bar"));
+            builders.add(client().prepareIndex("test").setId(String.valueOf(i)).setSource("foo", "bar"));
         }
         indexRandom(true, true, true, builders);
 

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/ReindexBasicTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/ReindexBasicTests.java
@@ -51,10 +51,10 @@ public class ReindexBasicTests extends ReindexTestCase {
     public void testFiltering() throws Exception {
         indexRandom(
             true,
-            client().prepareIndex("source", "test", "1").setSource("foo", "a"),
-            client().prepareIndex("source", "test", "2").setSource("foo", "a"),
-            client().prepareIndex("source", "test", "3").setSource("foo", "b"),
-            client().prepareIndex("source", "test", "4").setSource("foo", "c")
+            client().prepareIndex("source").setId("1").setSource("foo", "a"),
+            client().prepareIndex("source").setId("2").setSource("foo", "a"),
+            client().prepareIndex("source").setId("3").setSource("foo", "b"),
+            client().prepareIndex("source").setId("4").setSource("foo", "c")
         );
         assertHitCount(client().prepareSearch("source").setSize(0).get(), 4);
 
@@ -84,7 +84,7 @@ public class ReindexBasicTests extends ReindexTestCase {
         List<IndexRequestBuilder> docs = new ArrayList<>();
         int max = between(150, 500);
         for (int i = 0; i < max; i++) {
-            docs.add(client().prepareIndex("source", "test", Integer.toString(i)).setSource("foo", "a"));
+            docs.add(client().prepareIndex("source").setId(Integer.toString(i)).setSource("foo", "a"));
         }
 
         indexRandom(true, docs);
@@ -111,7 +111,7 @@ public class ReindexBasicTests extends ReindexTestCase {
         List<IndexRequestBuilder> docs = new ArrayList<>();
         int max = between(150, 500);
         for (int i = 0; i < max; i++) {
-            docs.add(client().prepareIndex("source", "test", Integer.toString(i)).setSource("foo", "a"));
+            docs.add(client().prepareIndex("source").setId(Integer.toString(i)).setSource("foo", "a"));
         }
 
         indexRandom(true, docs);
@@ -148,7 +148,7 @@ public class ReindexBasicTests extends ReindexTestCase {
             docs.put(indexName, new ArrayList<>());
             int numDocs = between(50, 200);
             for (int i = 0; i < numDocs; i++) {
-                docs.get(indexName).add(client().prepareIndex(indexName, typeName, "id_" + sourceIndex + "_" + i).setSource("foo", "a"));
+                docs.get(indexName).add(client().prepareIndex(indexName).setId("id_" + sourceIndex + "_" + i).setSource("foo", "a"));
             }
         }
 

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/ReindexFailureTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/ReindexFailureTests.java
@@ -56,7 +56,7 @@ public class ReindexFailureTests extends ReindexTestCase {
          * Create the destination index such that the copy will cause a mapping
          * conflict on every request.
          */
-        indexRandom(true, client().prepareIndex("dest", "_doc", "test").setSource("test", 10) /* Its a string in the source! */);
+        indexRandom(true, client().prepareIndex("dest").setId("test").setSource("test", 10) /* Its a string in the source! */);
 
         indexDocs(100);
 
@@ -77,7 +77,7 @@ public class ReindexFailureTests extends ReindexTestCase {
 
     public void testAbortOnVersionConflict() throws Exception {
         // Just put something in the way of the copy.
-        indexRandom(true, client().prepareIndex("dest", "_doc", "1").setSource("test", "test"));
+        indexRandom(true, client().prepareIndex("dest").setId("1").setSource("test", "test"));
 
         indexDocs(100);
 
@@ -139,7 +139,7 @@ public class ReindexFailureTests extends ReindexTestCase {
     private void indexDocs(int count) throws Exception {
         List<IndexRequestBuilder> docs = new ArrayList<>(count);
         for (int i = 0; i < count; i++) {
-            docs.add(client().prepareIndex("source", "_doc", Integer.toString(i)).setSource("test", "words words"));
+            docs.add(client().prepareIndex("source").setId(Integer.toString(i)).setSource("test", "words words"));
         }
         indexRandom(true, docs);
     }

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/ReindexVersioningTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/ReindexVersioningTests.java
@@ -127,7 +127,7 @@ public class ReindexVersioningTests extends ReindexTestCase {
     private void setupSourceAbsent() throws Exception {
         indexRandom(
             true,
-            client().prepareIndex("source", "_doc", "test").setVersionType(EXTERNAL).setVersion(SOURCE_VERSION).setSource("foo", "source")
+            client().prepareIndex("source").setId("test").setVersionType(EXTERNAL).setVersion(SOURCE_VERSION).setSource("foo", "source")
         );
 
         assertEquals(SOURCE_VERSION, client().prepareGet("source", "test").get().getVersion());
@@ -137,7 +137,7 @@ public class ReindexVersioningTests extends ReindexTestCase {
         setupSourceAbsent();
         indexRandom(
             true,
-            client().prepareIndex("dest", "_doc", "test").setVersionType(EXTERNAL).setVersion(version).setSource("foo", "dest")
+            client().prepareIndex("dest").setId("test").setVersionType(EXTERNAL).setVersion(version).setSource("foo", "dest")
         );
 
         assertEquals(version, client().prepareGet("dest", "test").get().getVersion());

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/RethrottleTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/RethrottleTests.java
@@ -99,7 +99,7 @@ public class RethrottleTests extends ReindexTestCase {
 
         List<IndexRequestBuilder> docs = new ArrayList<>();
         for (int i = 0; i < numSlices * 10; i++) {
-            docs.add(client().prepareIndex("test", "test", Integer.toString(i)).setSource("foo", "bar"));
+            docs.add(client().prepareIndex("test").setId(Integer.toString(i)).setSource("foo", "bar"));
         }
         indexRandom(true, docs);
 

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/UpdateByQueryBasicTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/UpdateByQueryBasicTests.java
@@ -50,10 +50,10 @@ public class UpdateByQueryBasicTests extends ReindexTestCase {
     public void testBasics() throws Exception {
         indexRandom(
             true,
-            client().prepareIndex("test", "test", "1").setSource("foo", "a"),
-            client().prepareIndex("test", "test", "2").setSource("foo", "a"),
-            client().prepareIndex("test", "test", "3").setSource("foo", "b"),
-            client().prepareIndex("test", "test", "4").setSource("foo", "c")
+            client().prepareIndex("test").setId("1").setSource("foo", "a"),
+            client().prepareIndex("test").setId("2").setSource("foo", "a"),
+            client().prepareIndex("test").setId("3").setSource("foo", "b"),
+            client().prepareIndex("test").setId("4").setSource("foo", "c")
         );
         assertHitCount(client().prepareSearch("test").setSize(0).get(), 4);
         assertEquals(1, client().prepareGet("test", "1").get().getVersion());
@@ -90,10 +90,10 @@ public class UpdateByQueryBasicTests extends ReindexTestCase {
     public void testSlices() throws Exception {
         indexRandom(
             true,
-            client().prepareIndex("test", "test", "1").setSource("foo", "a"),
-            client().prepareIndex("test", "test", "2").setSource("foo", "a"),
-            client().prepareIndex("test", "test", "3").setSource("foo", "b"),
-            client().prepareIndex("test", "test", "4").setSource("foo", "c")
+            client().prepareIndex("test").setId("1").setSource("foo", "a"),
+            client().prepareIndex("test").setId("2").setSource("foo", "a"),
+            client().prepareIndex("test").setId("3").setSource("foo", "b"),
+            client().prepareIndex("test").setId("4").setSource("foo", "c")
         );
         assertHitCount(client().prepareSearch("test").setSize(0).get(), 4);
         assertEquals(1, client().prepareGet("test", "1").get().getVersion());
@@ -138,7 +138,7 @@ public class UpdateByQueryBasicTests extends ReindexTestCase {
             docs.put(indexName, new ArrayList<>());
             int numDocs = between(5, 15);
             for (int i = 0; i < numDocs; i++) {
-                docs.get(indexName).add(client().prepareIndex(indexName, "test", Integer.toString(i)).setSource("foo", "a"));
+                docs.get(indexName).add(client().prepareIndex(indexName).setId(Integer.toString(i)).setSource("foo", "a"));
             }
         }
 

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/UpdateByQueryWhileModifyingTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/UpdateByQueryWhileModifyingTests.java
@@ -55,7 +55,7 @@ public class UpdateByQueryWhileModifyingTests extends ReindexTestCase {
 
     public void testUpdateWhileReindexing() throws Exception {
         AtomicReference<String> value = new AtomicReference<>(randomSimpleString(random()));
-        indexRandom(true, client().prepareIndex("test", "test", "test").setSource("test", value.get()));
+        indexRandom(true, client().prepareIndex("test").setId("test").setSource("test", value.get()));
 
         AtomicReference<Exception> failure = new AtomicReference<>();
         AtomicBoolean keepUpdating = new AtomicBoolean(true);
@@ -79,7 +79,8 @@ public class UpdateByQueryWhileModifyingTests extends ReindexTestCase {
                 GetResponse get = client().prepareGet("test", "test").get();
                 assertEquals(value.get(), get.getSource().get("test"));
                 value.set(randomSimpleString(random()));
-                IndexRequestBuilder index = client().prepareIndex("test", "test", "test")
+                IndexRequestBuilder index = client().prepareIndex("test")
+                    .setId("test")
                     .setSource("test", value.get())
                     .setRefreshPolicy(IMMEDIATE);
                 /*

--- a/plugins/analysis-icu/src/internalClusterTest/java/org/opensearch/index/mapper/ICUCollationKeywordFieldMapperIT.java
+++ b/plugins/analysis-icu/src/internalClusterTest/java/org/opensearch/index/mapper/ICUCollationKeywordFieldMapperIT.java
@@ -93,8 +93,8 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
         // both values should collate to same value
         indexRandom(
             true,
-            client().prepareIndex(index, type, "1").setSource("{\"id\":\"1\",\"collate\":\"" + equivalent[0] + "\"}", XContentType.JSON),
-            client().prepareIndex(index, type, "2").setSource("{\"id\":\"2\",\"collate\":\"" + equivalent[1] + "\"}", XContentType.JSON)
+            client().prepareIndex(index).setId("1").setSource("{\"id\":\"1\",\"collate\":\"" + equivalent[0] + "\"}", XContentType.JSON),
+            client().prepareIndex(index).setId("2").setSource("{\"id\":\"2\",\"collate\":\"" + equivalent[1] + "\"}", XContentType.JSON)
         );
 
         // searching for either of the terms should return both results since they collate to the same value
@@ -135,9 +135,10 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
         // everything should be indexed fine, no exceptions
         indexRandom(
             true,
-            client().prepareIndex(index, type, "1")
+            client().prepareIndex(index)
+                .setId("1")
                 .setSource("{\"id\":\"1\", \"collate\":[\"" + equivalent[0] + "\", \"" + equivalent[1] + "\"]}", XContentType.JSON),
-            client().prepareIndex(index, type, "2").setSource("{\"id\":\"2\",\"collate\":\"" + equivalent[2] + "\"}", XContentType.JSON)
+            client().prepareIndex(index).setId("2").setSource("{\"id\":\"2\",\"collate\":\"" + equivalent[2] + "\"}", XContentType.JSON)
         );
 
         // using sort mode = max, values B and C will be used for the sort
@@ -198,8 +199,8 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex(index, type, "1").setSource("{\"id\":\"1\",\"collate\":\"" + equivalent[0] + "\"}", XContentType.JSON),
-            client().prepareIndex(index, type, "2").setSource("{\"id\":\"2\",\"collate\":\"" + equivalent[1] + "\"}", XContentType.JSON)
+            client().prepareIndex(index).setId("1").setSource("{\"id\":\"1\",\"collate\":\"" + equivalent[0] + "\"}", XContentType.JSON),
+            client().prepareIndex(index).setId("2").setSource("{\"id\":\"2\",\"collate\":\"" + equivalent[1] + "\"}", XContentType.JSON)
         );
 
         // searching for either of the terms should return both results since they collate to the same value
@@ -244,8 +245,8 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex(index, type, "1").setSource("{\"id\":\"1\",\"collate\":\"" + equivalent[0] + "\"}", XContentType.JSON),
-            client().prepareIndex(index, type, "2").setSource("{\"id\":\"2\",\"collate\":\"" + equivalent[1] + "\"}", XContentType.JSON)
+            client().prepareIndex(index).setId("1").setSource("{\"id\":\"1\",\"collate\":\"" + equivalent[0] + "\"}", XContentType.JSON),
+            client().prepareIndex(index).setId("2").setSource("{\"id\":\"2\",\"collate\":\"" + equivalent[1] + "\"}", XContentType.JSON)
         );
 
         SearchRequest request = new SearchRequest().indices(index)
@@ -290,8 +291,8 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex(index, type, "1").setSource("{\"id\":\"1\",\"collate\":\"" + equivalent[0] + "\"}", XContentType.JSON),
-            client().prepareIndex(index, type, "2").setSource("{\"id\":\"2\",\"collate\":\"" + equivalent[1] + "\"}", XContentType.JSON)
+            client().prepareIndex(index).setId("1").setSource("{\"id\":\"1\",\"collate\":\"" + equivalent[0] + "\"}", XContentType.JSON),
+            client().prepareIndex(index).setId("2").setSource("{\"id\":\"2\",\"collate\":\"" + equivalent[1] + "\"}", XContentType.JSON)
         );
 
         SearchRequest request = new SearchRequest().indices(index)
@@ -336,9 +337,9 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex(index, type, "1").setSource("{\"id\":\"1\",\"collate\":\"foo bar\"}", XContentType.JSON),
-            client().prepareIndex(index, type, "2").setSource("{\"id\":\"2\",\"collate\":\"foobar\"}", XContentType.JSON),
-            client().prepareIndex(index, type, "3").setSource("{\"id\":\"3\",\"collate\":\"foo-bar\"}", XContentType.JSON)
+            client().prepareIndex(index).setId("1").setSource("{\"id\":\"1\",\"collate\":\"foo bar\"}", XContentType.JSON),
+            client().prepareIndex(index).setId("2").setSource("{\"id\":\"2\",\"collate\":\"foobar\"}", XContentType.JSON),
+            client().prepareIndex(index).setId("3").setSource("{\"id\":\"3\",\"collate\":\"foo-bar\"}", XContentType.JSON)
         );
 
         SearchRequest request = new SearchRequest().indices(index)
@@ -379,8 +380,8 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex(index, type, "1").setSource("{\"collate\":\"foobar-10\"}", XContentType.JSON),
-            client().prepareIndex(index, type, "2").setSource("{\"collate\":\"foobar-9\"}", XContentType.JSON)
+            client().prepareIndex(index).setId("1").setSource("{\"collate\":\"foobar-10\"}", XContentType.JSON),
+            client().prepareIndex(index).setId("2").setSource("{\"collate\":\"foobar-9\"}", XContentType.JSON)
         );
 
         SearchRequest request = new SearchRequest().indices(index)
@@ -419,10 +420,10 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex(index, type, "1").setSource("{\"id\":\"1\",\"collate\":\"résumé\"}", XContentType.JSON),
-            client().prepareIndex(index, type, "2").setSource("{\"id\":\"2\",\"collate\":\"Resume\"}", XContentType.JSON),
-            client().prepareIndex(index, type, "3").setSource("{\"id\":\"3\",\"collate\":\"resume\"}", XContentType.JSON),
-            client().prepareIndex(index, type, "4").setSource("{\"id\":\"4\",\"collate\":\"Résumé\"}", XContentType.JSON)
+            client().prepareIndex(index).setId("1").setSource("{\"id\":\"1\",\"collate\":\"résumé\"}", XContentType.JSON),
+            client().prepareIndex(index).setId("2").setSource("{\"id\":\"2\",\"collate\":\"Resume\"}", XContentType.JSON),
+            client().prepareIndex(index).setId("3").setSource("{\"id\":\"3\",\"collate\":\"resume\"}", XContentType.JSON),
+            client().prepareIndex(index).setId("4").setSource("{\"id\":\"4\",\"collate\":\"Résumé\"}", XContentType.JSON)
         );
 
         SearchRequest request = new SearchRequest().indices(index)
@@ -458,8 +459,8 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex(index, type, "1").setSource("{\"collate\":\"resume\"}", XContentType.JSON),
-            client().prepareIndex(index, type, "2").setSource("{\"collate\":\"Resume\"}", XContentType.JSON)
+            client().prepareIndex(index).setId("1").setSource("{\"collate\":\"resume\"}", XContentType.JSON),
+            client().prepareIndex(index).setId("2").setSource("{\"collate\":\"Resume\"}", XContentType.JSON)
         );
 
         SearchRequest request = new SearchRequest().indices(index)
@@ -507,8 +508,8 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex(index, type, "1").setSource("{\"id\":\"1\",\"collate\":\"" + equivalent[0] + "\"}", XContentType.JSON),
-            client().prepareIndex(index, type, "2").setSource("{\"id\":\"2\",\"collate\":\"" + equivalent[1] + "\"}", XContentType.JSON)
+            client().prepareIndex(index).setId("1").setSource("{\"id\":\"1\",\"collate\":\"" + equivalent[0] + "\"}", XContentType.JSON),
+            client().prepareIndex(index).setId("2").setSource("{\"id\":\"2\",\"collate\":\"" + equivalent[1] + "\"}", XContentType.JSON)
         );
 
         SearchRequest request = new SearchRequest().indices(index)

--- a/plugins/mapper-size/src/internalClusterTest/java/org/opensearch/index/mapper/size/SizeMappingIT.java
+++ b/plugins/mapper-size/src/internalClusterTest/java/org/opensearch/index/mapper/size/SizeMappingIT.java
@@ -136,7 +136,7 @@ public class SizeMappingIT extends OpenSearchIntegTestCase {
     public void testBasic() throws Exception {
         assertAcked(prepareCreate("test").addMapping("type", "_size", "enabled=true"));
         final String source = "{\"f\":10}";
-        indexRandom(true, client().prepareIndex("test", "type", "1").setSource(source, XContentType.JSON));
+        indexRandom(true, client().prepareIndex("test").setId("1").setSource(source, XContentType.JSON));
         GetResponse getResponse = client().prepareGet("test", "1").setStoredFields("_size").get();
         assertNotNull(getResponse.getField("_size"));
         assertEquals(source.length(), (int) getResponse.getField("_size").getValue());

--- a/plugins/repository-hdfs/src/test/java/org/opensearch/repositories/hdfs/HdfsTests.java
+++ b/plugins/repository-hdfs/src/test/java/org/opensearch/repositories/hdfs/HdfsTests.java
@@ -88,9 +88,9 @@ public class HdfsTests extends OpenSearchSingleNodeTestCase {
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            client().prepareIndex("test-idx-1", "doc", Integer.toString(i)).setSource("foo", "bar" + i).get();
-            client().prepareIndex("test-idx-2", "doc", Integer.toString(i)).setSource("foo", "bar" + i).get();
-            client().prepareIndex("test-idx-3", "doc", Integer.toString(i)).setSource("foo", "bar" + i).get();
+            client().prepareIndex("test-idx-1").setId(Integer.toString(i)).setSource("foo", "bar" + i).get();
+            client().prepareIndex("test-idx-2").setId(Integer.toString(i)).setSource("foo", "bar" + i).get();
+            client().prepareIndex("test-idx-3").setId(Integer.toString(i)).setSource("foo", "bar" + i).get();
         }
         client().admin().indices().prepareRefresh().get();
         assertThat(count(client, "test-idx-1"), equalTo(100L));

--- a/qa/smoke-test-http/src/test/java/org/opensearch/http/SearchRestCancellationIT.java
+++ b/qa/smoke-test-http/src/test/java/org/opensearch/http/SearchRestCancellationIT.java
@@ -226,7 +226,7 @@ public class SearchRestCancellationIT extends HttpSmokeTestCase {
             // Make sure we have a few segments
             BulkRequestBuilder bulkRequestBuilder = client().prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
             for (int j = 0; j < 20; j++) {
-                bulkRequestBuilder.add(client().prepareIndex("test", "_doc", Integer.toString(i * 5 + j)).setSource("field", "value"));
+                bulkRequestBuilder.add(client().prepareIndex("test").setId(Integer.toString(i * 5 + j)).setSource("field", "value"));
             }
             assertNoFailures(bulkRequestBuilder.get());
         }

--- a/server/src/internalClusterTest/java/org/opensearch/action/IndicesRequestIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/IndicesRequestIT.java
@@ -258,7 +258,7 @@ public class IndicesRequestIT extends OpenSearchIntegTestCase {
         interceptTransportActions(updateShardActions);
 
         String indexOrAlias = randomIndexOrAlias();
-        client().prepareIndex(indexOrAlias, "type", "id").setSource("field", "value").get();
+        client().prepareIndex(indexOrAlias).setId("id").setSource("field", "value").get();
         UpdateRequest updateRequest = new UpdateRequest(indexOrAlias, "id").doc(Requests.INDEX_CONTENT_TYPE, "field1", "value1");
         UpdateResponse updateResponse = internalCluster().coordOnlyNodeClient().update(updateRequest).actionGet();
         assertEquals(DocWriteResponse.Result.UPDATED, updateResponse.getResult());
@@ -288,7 +288,7 @@ public class IndicesRequestIT extends OpenSearchIntegTestCase {
         interceptTransportActions(updateShardActions);
 
         String indexOrAlias = randomIndexOrAlias();
-        client().prepareIndex(indexOrAlias, "type", "id").setSource("field", "value").get();
+        client().prepareIndex(indexOrAlias).setId("id").setSource("field", "value").get();
         UpdateRequest updateRequest = new UpdateRequest(indexOrAlias, "id").script(
             new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "ctx.op='delete'", Collections.emptyMap())
         );
@@ -584,7 +584,7 @@ public class IndicesRequestIT extends OpenSearchIntegTestCase {
 
         String[] randomIndicesOrAliases = randomIndicesOrAliases();
         for (int i = 0; i < randomIndicesOrAliases.length; i++) {
-            client().prepareIndex(randomIndicesOrAliases[i], "type", "id-" + i).setSource("field", "value").get();
+            client().prepareIndex(randomIndicesOrAliases[i]).setId("id-" + i).setSource("field", "value").get();
         }
         refresh();
 
@@ -609,7 +609,7 @@ public class IndicesRequestIT extends OpenSearchIntegTestCase {
 
         String[] randomIndicesOrAliases = randomIndicesOrAliases();
         for (int i = 0; i < randomIndicesOrAliases.length; i++) {
-            client().prepareIndex(randomIndicesOrAliases[i], "type", "id-" + i).setSource("field", "value").get();
+            client().prepareIndex(randomIndicesOrAliases[i]).setId("id-" + i).setSource("field", "value").get();
         }
         refresh();
 

--- a/server/src/internalClusterTest/java/org/opensearch/action/RejectionActionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/RejectionActionIT.java
@@ -69,7 +69,7 @@ public class RejectionActionIT extends OpenSearchIntegTestCase {
 
     public void testSimulatedSearchRejectionLoad() throws Throwable {
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test", "type", Integer.toString(i)).setSource("field", "1").get();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "1").get();
         }
 
         int numberOfAsyncOps = randomIntBetween(200, 700);

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/HotThreadsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/HotThreadsIT.java
@@ -128,9 +128,9 @@ public class HotThreadsIT extends OpenSearchIntegTestCase {
 
             indexRandom(
                 true,
-                client().prepareIndex("test", "type1", "1").setSource("field1", "value1"),
-                client().prepareIndex("test", "type1", "2").setSource("field1", "value2"),
-                client().prepareIndex("test", "type1", "3").setSource("field1", "value3")
+                client().prepareIndex("test").setId("1").setSource("field1", "value1"),
+                client().prepareIndex("test").setId("2").setSource("field1", "value2"),
+                client().prepareIndex("test").setId("3").setSource("field1", "value3")
             );
             ensureSearchable();
             while (latch.getCount() > 0) {

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -319,9 +319,7 @@ public class TasksIT extends OpenSearchIntegTestCase {
         ensureGreen("test"); // Make sure all shards are allocated to catch replication tasks
         // ensures the mapping is available on all nodes so we won't retry the request (in case replicas don't have the right mapping).
         client().admin().indices().preparePutMapping("test").setType("doc").setSource("foo", "type=keyword").get();
-        client().prepareBulk()
-            .add(client().prepareIndex("test", "doc", "test_id").setSource("{\"foo\": \"bar\"}", XContentType.JSON))
-            .get();
+        client().prepareBulk().add(client().prepareIndex("test").setId("test_id").setSource("{\"foo\": \"bar\"}", XContentType.JSON)).get();
 
         // the bulk operation should produce one main task
         List<TaskInfo> topTask = findEvents(BulkAction.NAME, Tuple::v1);
@@ -370,7 +368,8 @@ public class TasksIT extends OpenSearchIntegTestCase {
         registerTaskManagerListeners(SearchAction.NAME + "[*]");  // shard task
         createIndex("test");
         ensureGreen("test"); // Make sure all shards are allocated to catch replication tasks
-        client().prepareIndex("test", "doc", "test_id")
+        client().prepareIndex("test")
+            .setId("test_id")
             .setSource("{\"foo\": \"bar\"}", XContentType.JSON)
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/ShrinkIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/ShrinkIndexIT.java
@@ -107,7 +107,8 @@ public class ShrinkIndexIT extends OpenSearchIntegTestCase {
         internalCluster().ensureAtLeastNumDataNodes(2);
         prepareCreate("source").setSettings(Settings.builder().put(indexSettings()).put("number_of_shards", shardSplits[0])).get();
         for (int i = 0; i < 20; i++) {
-            client().prepareIndex("source", "t1", Integer.toString(i))
+            client().prepareIndex("source")
+                .setId(Integer.toString(i))
                 .setSource("{\"foo\" : \"bar\", \"i\" : " + i + "}", XContentType.JSON)
                 .get();
         }
@@ -150,7 +151,8 @@ public class ShrinkIndexIT extends OpenSearchIntegTestCase {
         assertHitCount(client().prepareSearch("first_shrink").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), 20);
 
         for (int i = 0; i < 20; i++) { // now update
-            client().prepareIndex("first_shrink", "t1", Integer.toString(i))
+            client().prepareIndex("first_shrink")
+                .setId(Integer.toString(i))
                 .setSource("{\"foo\" : \"bar\", \"i\" : " + i + "}", XContentType.JSON)
                 .get();
         }
@@ -192,7 +194,8 @@ public class ShrinkIndexIT extends OpenSearchIntegTestCase {
         assertHitCount(client().prepareSearch("second_shrink").setSize(100).setQuery(new TermsQueryBuilder("foo", "bar")).get(), 20);
 
         for (int i = 0; i < 20; i++) { // now update
-            client().prepareIndex("second_shrink", "t1", Integer.toString(i))
+            client().prepareIndex("second_shrink")
+                .setId(Integer.toString(i))
                 .setSource("{\"foo\" : \"bar\", \"i\" : " + i + "}", XContentType.JSON)
                 .get();
         }
@@ -525,7 +528,8 @@ public class ShrinkIndexIT extends OpenSearchIntegTestCase {
                 .put("number_of_replicas", 0)
         ).addMapping("type", "id", "type=keyword,doc_values=true").get();
         for (int i = 0; i < 20; i++) {
-            client().prepareIndex("source", "type", Integer.toString(i))
+            client().prepareIndex("source")
+                .setId(Integer.toString(i))
                 .setSource("{\"foo\" : \"bar\", \"id\" : " + i + "}", XContentType.JSON)
                 .get();
         }

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/SplitIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/SplitIndexIT.java
@@ -150,7 +150,8 @@ public class SplitIndexIT extends OpenSearchIntegTestCase {
 
         BiFunction<String, Integer, IndexRequestBuilder> indexFunc = (index, id) -> {
             try {
-                return client().prepareIndex(index, "t1", Integer.toString(id))
+                return client().prepareIndex(index)
+                    .setId(Integer.toString(id))
                     .setSource(
                         jsonBuilder().startObject()
                             .field("foo", "bar")
@@ -523,7 +524,8 @@ public class SplitIndexIT extends OpenSearchIntegTestCase {
                 .put("number_of_replicas", 0)
         ).addMapping("type", "id", "type=keyword,doc_values=true").get();
         for (int i = 0; i < 20; i++) {
-            client().prepareIndex("source", "type", Integer.toString(i))
+            client().prepareIndex("source")
+                .setId(Integer.toString(i))
                 .setSource("{\"foo\" : \"bar\", \"id\" : " + i + "}", XContentType.JSON)
                 .get();
         }

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/flush/FlushBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/flush/FlushBlocksIT.java
@@ -55,7 +55,7 @@ public class FlushBlocksIT extends OpenSearchIntegTestCase {
 
         int docs = between(10, 100);
         for (int i = 0; i < docs; i++) {
-            client().prepareIndex("test", "type", "" + i).setSource("test", "init").execute().actionGet();
+            client().prepareIndex("test").setId("" + i).setSource("test", "init").execute().actionGet();
         }
 
         // Request is not blocked

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/forcemerge/ForceMergeBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/forcemerge/ForceMergeBlocksIT.java
@@ -57,7 +57,7 @@ public class ForceMergeBlocksIT extends OpenSearchIntegTestCase {
 
         int docs = between(10, 100);
         for (int i = 0; i < docs; i++) {
-            client().prepareIndex("test", "type", "" + i).setSource("test", "init").execute().actionGet();
+            client().prepareIndex("test").setId("" + i).setSource("test", "init").execute().actionGet();
         }
 
         // Request is not blocked

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/segments/IndicesSegmentsBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/segments/IndicesSegmentsBlocksIT.java
@@ -53,7 +53,7 @@ public class IndicesSegmentsBlocksIT extends OpenSearchIntegTestCase {
 
         int docs = between(10, 100);
         for (int i = 0; i < docs; i++) {
-            client().prepareIndex("test-blocks", "type", "" + i).setSource("test", "init").execute().actionGet();
+            client().prepareIndex("test-blocks").setId("" + i).setSource("test", "init").execute().actionGet();
         }
         client().admin().indices().prepareFlush("test-blocks").get();
 

--- a/server/src/internalClusterTest/java/org/opensearch/action/bulk/BulkProcessorClusterSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/bulk/BulkProcessorClusterSettingsIT.java
@@ -50,9 +50,9 @@ public class BulkProcessorClusterSettingsIT extends OpenSearchIntegTestCase {
         client().admin().cluster().prepareHealth("willwork").setWaitForGreenStatus().execute().actionGet();
 
         BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
-        bulkRequestBuilder.add(client().prepareIndex("willwork", "type1", "1").setSource("{\"foo\":1}", XContentType.JSON));
-        bulkRequestBuilder.add(client().prepareIndex("wontwork", "type1", "2").setSource("{\"foo\":2}", XContentType.JSON));
-        bulkRequestBuilder.add(client().prepareIndex("willwork", "type1", "3").setSource("{\"foo\":3}", XContentType.JSON));
+        bulkRequestBuilder.add(client().prepareIndex("willwork").setId("1").setSource("{\"foo\":1}", XContentType.JSON));
+        bulkRequestBuilder.add(client().prepareIndex("wontwork").setId("2").setSource("{\"foo\":2}", XContentType.JSON));
+        bulkRequestBuilder.add(client().prepareIndex("willwork").setId("3").setSource("{\"foo\":3}", XContentType.JSON));
         BulkResponse br = bulkRequestBuilder.get();
         BulkItemResponse[] responses = br.getItems();
         assertEquals(3, responses.length);

--- a/server/src/internalClusterTest/java/org/opensearch/action/bulk/BulkWithUpdatesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/bulk/BulkWithUpdatesIT.java
@@ -271,9 +271,9 @@ public class BulkWithUpdatesIT extends OpenSearchIntegTestCase {
         createIndex("test", Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).build());
         ensureGreen();
         BulkResponse bulkResponse = client().prepareBulk()
-            .add(client().prepareIndex("test", "type", "1").setCreate(true).setSource("field", "1"))
-            .add(client().prepareIndex("test", "type", "2").setCreate(true).setSource("field", "1"))
-            .add(client().prepareIndex("test", "type", "1").setSource("field", "2"))
+            .add(client().prepareIndex("test").setId("1").setCreate(true).setSource("field", "1"))
+            .add(client().prepareIndex("test").setId("2").setCreate(true).setSource("field", "1"))
+            .add(client().prepareIndex("test").setId("1").setSource("field", "2"))
             .get();
 
         assertEquals(DocWriteResponse.Result.CREATED, bulkResponse.getItems()[0].getResponse().getResult());
@@ -294,9 +294,9 @@ public class BulkWithUpdatesIT extends OpenSearchIntegTestCase {
         assertThat(bulkResponse.getItems()[2].getResponse().getSeqNo(), equalTo(4L));
 
         bulkResponse = client().prepareBulk()
-            .add(client().prepareIndex("test", "type", "e1").setSource("field", "1").setVersion(10).setVersionType(VersionType.EXTERNAL))
-            .add(client().prepareIndex("test", "type", "e2").setSource("field", "1").setVersion(10).setVersionType(VersionType.EXTERNAL))
-            .add(client().prepareIndex("test", "type", "e1").setSource("field", "2").setVersion(12).setVersionType(VersionType.EXTERNAL))
+            .add(client().prepareIndex("test").setId("e1").setSource("field", "1").setVersion(10).setVersionType(VersionType.EXTERNAL))
+            .add(client().prepareIndex("test").setId("e2").setSource("field", "1").setVersion(10).setVersionType(VersionType.EXTERNAL))
+            .add(client().prepareIndex("test").setId("e1").setSource("field", "2").setVersion(12).setVersionType(VersionType.EXTERNAL))
             .get();
 
         assertEquals(DocWriteResponse.Result.CREATED, bulkResponse.getItems()[0].getResponse().getResult());
@@ -538,7 +538,7 @@ public class BulkWithUpdatesIT extends OpenSearchIntegTestCase {
         for (int i = 0; i < numDocs;) {
             final BulkRequestBuilder builder = client().prepareBulk();
             for (int j = 0; j < bulk && i < numDocs; j++, i++) {
-                builder.add(client().prepareIndex("test", "type1", Integer.toString(i)).setSource("val", i));
+                builder.add(client().prepareIndex("test").setId(Integer.toString(i)).setSource("val", i));
             }
             logger.info("bulk indexing {}-{}", i - bulk, i - 1);
             BulkResponse response = builder.get();
@@ -692,7 +692,7 @@ public class BulkWithUpdatesIT extends OpenSearchIntegTestCase {
     public void testFailedRequestsOnClosedIndex() throws Exception {
         createIndex("bulkindex1");
 
-        client().prepareIndex("bulkindex1", "index1_type", "1").setSource("text", "test").get();
+        client().prepareIndex("bulkindex1").setId("1").setSource("text", "test").get();
         assertBusy(() -> assertAcked(client().admin().indices().prepareClose("bulkindex1")));
 
         BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(RefreshPolicy.IMMEDIATE);

--- a/server/src/internalClusterTest/java/org/opensearch/action/search/SearchProgressActionListenerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/search/SearchProgressActionListenerIT.java
@@ -213,7 +213,7 @@ public class SearchProgressActionListenerIT extends OpenSearchSingleNodeTestCase
         for (int i = 0; i < numIndices; i++) {
             String indexName = String.format(Locale.ROOT, "index-%03d", i);
             assertAcked(client.admin().indices().prepareCreate(indexName).get());
-            client.prepareIndex(indexName, "doc", Integer.toString(i)).setSource("number", i, "foo", "bar").get();
+            client.prepareIndex(indexName).setId(Integer.toString(i)).setSource("number", i, "foo", "bar").get();
         }
         client.admin().indices().prepareRefresh("index-*").get();
         ClusterSearchShardsResponse resp = client.admin().cluster().prepareSearchShards("index-*").get();

--- a/server/src/internalClusterTest/java/org/opensearch/action/support/WaitActiveShardCountIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/support/WaitActiveShardCountIT.java
@@ -63,9 +63,10 @@ public class WaitActiveShardCountIT extends OpenSearchIntegTestCase {
         assertAcked(createIndexResponse);
 
         // indexing, by default, will work (waiting for one shard copy only)
-        client().prepareIndex("test", "type1", "1").setSource(source("1", "test"), XContentType.JSON).execute().actionGet();
+        client().prepareIndex("test").setId("1").setSource(source("1", "test"), XContentType.JSON).execute().actionGet();
         try {
-            client().prepareIndex("test", "type1", "1")
+            client().prepareIndex("test")
+                .setId("1")
                 .setSource(source("1", "test"), XContentType.JSON)
                 .setWaitForActiveShards(2) // wait for 2 active shard copies
                 .setTimeout(timeValueMillis(100))
@@ -96,7 +97,8 @@ public class WaitActiveShardCountIT extends OpenSearchIntegTestCase {
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
 
         // this should work, since we now have two
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(source("1", "test"), XContentType.JSON)
             .setWaitForActiveShards(2)
             .setTimeout(timeValueSeconds(1))
@@ -104,7 +106,8 @@ public class WaitActiveShardCountIT extends OpenSearchIntegTestCase {
             .actionGet();
 
         try {
-            client().prepareIndex("test", "type1", "1")
+            client().prepareIndex("test")
+                .setId("1")
                 .setSource(source("1", "test"), XContentType.JSON)
                 .setWaitForActiveShards(ActiveShardCount.ALL)
                 .setTimeout(timeValueMillis(100))
@@ -138,7 +141,8 @@ public class WaitActiveShardCountIT extends OpenSearchIntegTestCase {
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
 
         // this should work, since we now have all shards started
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(source("1", "test"), XContentType.JSON)
             .setWaitForActiveShards(ActiveShardCount.ALL)
             .setTimeout(timeValueSeconds(1))

--- a/server/src/internalClusterTest/java/org/opensearch/action/termvectors/GetTermVectorsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/termvectors/GetTermVectorsIT.java
@@ -92,7 +92,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
             .endObject();
         assertAcked(prepareCreate("test").addAlias(new Alias("alias")).addMapping("type1", mapping));
 
-        client().prepareIndex("test", "type1", "666").setSource("field", "foo bar").execute().actionGet();
+        client().prepareIndex("test").setId("667").setSource("field", "foo bar").execute().actionGet();
         refresh();
         for (int i = 0; i < 20; i++) {
             ActionFuture<TermVectorsResponse> termVector = client().termVectors(new TermVectorsRequest(indexOrAlias(), "" + i));
@@ -119,7 +119,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         assertAcked(prepareCreate("test").addAlias(new Alias("alias")).addMapping("type1", mapping));
 
         // when indexing a field that simply has a question mark, the term vectors will be null
-        client().prepareIndex("test", "type1", "0").setSource("existingfield", "?").execute().actionGet();
+        client().prepareIndex("test").setId("0").setSource("existingfield", "?").execute().actionGet();
         refresh();
         ActionFuture<TermVectorsResponse> termVector = client().termVectors(
             new TermVectorsRequest(indexOrAlias(), "0").selectedFields(new String[] { "existingfield" })
@@ -147,7 +147,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         assertAcked(prepareCreate("test").addAlias(new Alias("alias")).addMapping("type1", mapping));
 
         // when indexing a field that simply has a question mark, the term vectors will be null
-        client().prepareIndex("test", "type1", "0").setSource("anotherexistingfield", 1).execute().actionGet();
+        client().prepareIndex("test").setId("0").setSource("anotherexistingfield", 1).execute().actionGet();
         refresh();
         ActionFuture<TermVectorsResponse> termVectors = client().termVectors(
             new TermVectorsRequest(indexOrAlias(), "0").selectedFields(randomBoolean() ? new String[] { "existingfield" } : null)
@@ -228,7 +228,8 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
                 )
         );
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i))
+            client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource(
                     jsonBuilder().startObject()
                         .field("field", "the quick brown fox jumps over the lazy dog")
@@ -336,7 +337,8 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
                 )
         );
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test", "_doc", Integer.toString(i))
+            client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource(
                     jsonBuilder().startObject()
                         .field("field", "the quick brown fox jumps over the lazy dog")
@@ -492,7 +494,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         ensureGreen();
 
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i)).setSource(source).execute().actionGet();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource(source).execute().actionGet();
             refresh();
         }
 
@@ -652,7 +654,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         assertAcked(prepareCreate("test").addAlias(new Alias("alias")).addMapping("type1", mapping));
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "0").setSource(source).get();
+        client().prepareIndex("test").setId("0").setSource(source).get();
         refresh();
 
         TermVectorsResponse response = client().prepareTermVectors(indexOrAlias(), "0").setSelectedFields("field*").get();
@@ -766,7 +768,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         ensureGreen();
 
         // index a single document with prepared source
-        client().prepareIndex("test", "type1", "0").setSource(source).get();
+        client().prepareIndex("test").setId("0").setSource(source).get();
         refresh();
 
         // create random per_field_analyzer and selected fields
@@ -840,7 +842,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         assertThat(response.isExists(), equalTo(false));
 
         logger.info("--> index doc 1");
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1", "field2", "value2").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value2").get();
 
         // From translog:
 
@@ -886,7 +888,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         }
 
         logger.info("--> index doc 1 again, so increasing the version");
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1", "field2", "value2").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value2").get();
 
         // From translog:
 
@@ -949,7 +951,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
             }
             tags.add(tag);
         }
-        indexRandom(true, client().prepareIndex("test", "type1", "1").setSource("tags", tags));
+        indexRandom(true, client().prepareIndex("test").setId("1").setSource("tags", tags));
 
         logger.info("Checking best tags by longest to shortest size ...");
         TermVectorsRequest.FilterSettings filterSettings = new TermVectorsRequest.FilterSettings();
@@ -985,7 +987,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
             }
             uniqueTags.add(tag);
         }
-        indexRandom(true, client().prepareIndex("test", "type1", "1").setSource("tags", tags));
+        indexRandom(true, client().prepareIndex("test").setId("1").setSource("tags", tags));
 
         logger.info("Checking best tags by highest to lowest term freq ...");
         TermVectorsRequest.FilterSettings filterSettings = new TermVectorsRequest.FilterSettings();
@@ -1016,7 +1018,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         List<String> tags = new ArrayList<>();
         for (int i = 0; i < numDocs; i++) {
             tags.add("tag_" + i);
-            builders.add(client().prepareIndex("test", "type1", i + "").setSource("tags", tags));
+            builders.add(client().prepareIndex("test").setId(i + "").setSource("tags", tags));
         }
         indexRandom(true, builders);
 
@@ -1044,7 +1046,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         ensureGreen();
 
         // index document
-        indexRandom(true, client().prepareIndex("test", "type1", "1").setSource("field1", "random permutation"));
+        indexRandom(true, client().prepareIndex("test").setId("1").setSource("field1", "random permutation"));
 
         // Get search shards
         ClusterSearchShardsResponse searchShardsResponse = client().admin().cluster().prepareSearchShards("test").get();

--- a/server/src/internalClusterTest/java/org/opensearch/action/termvectors/MultiTermVectorsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/termvectors/MultiTermVectorsIT.java
@@ -101,7 +101,7 @@ public class MultiTermVectorsIT extends AbstractTermVectorsTestCase {
         assertThat(response.getResponses()[0].getResponse().isExists(), equalTo(false));
 
         for (int i = 0; i < 3; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i)).setSource("field", "value" + i).get();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).get();
         }
 
         // Version from translog
@@ -150,7 +150,7 @@ public class MultiTermVectorsIT extends AbstractTermVectorsTestCase {
         assertThat(response.getResponses()[2].getFailure().getCause().getCause(), instanceOf(VersionConflictEngineException.class));
 
         for (int i = 0; i < 3; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i)).setSource("field", "value" + i).get();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).get();
         }
 
         // Version from translog

--- a/server/src/internalClusterTest/java/org/opensearch/aliases/IndexAliasesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/aliases/IndexAliasesIT.java
@@ -1305,7 +1305,7 @@ public class IndexAliasesIT extends OpenSearchIntegTestCase {
 
     public void testRemoveIndexAndReplaceWithAlias() throws InterruptedException, ExecutionException {
         assertAcked(client().admin().indices().prepareCreate("test"));
-        indexRandom(true, client().prepareIndex("test_2", "test", "test").setSource("test", "test"));
+        indexRandom(true, client().prepareIndex("test_2").setId("test").setSource("test", "test"));
         assertAliasesVersionIncreases(
             "test_2",
             () -> assertAcked(client().admin().indices().prepareAliases().addAlias("test_2", "test").removeIndex("test"))

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/MinimumMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/MinimumMasterNodesIT.java
@@ -121,7 +121,7 @@ public class MinimumMasterNodesIT extends OpenSearchIntegTestCase {
         NumShards numShards = getNumShards("test");
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i)).setSource("field", "value").execute().actionGet();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value").execute().actionGet();
         }
         // make sure that all shards recovered before trying to flush
         assertThat(
@@ -286,7 +286,7 @@ public class MinimumMasterNodesIT extends OpenSearchIntegTestCase {
         NumShards numShards = getNumShards("test");
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i)).setSource("field", "value").execute().actionGet();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value").execute().actionGet();
         }
         ensureGreen();
         // make sure that all shards recovered before trying to flush

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/NoMasterNodeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/NoMasterNodeIT.java
@@ -179,33 +179,35 @@ public class NoMasterNodeIT extends OpenSearchIntegTestCase {
         );
 
         checkWriteAction(
-            clientToMasterlessNode.prepareIndex("test", "type1", "1")
+            clientToMasterlessNode.prepareIndex("test")
+                .setId("1")
                 .setSource(XContentFactory.jsonBuilder().startObject().endObject())
                 .setTimeout(timeout)
         );
 
         checkWriteAction(
-            clientToMasterlessNode.prepareIndex("no_index", "type1", "1")
+            clientToMasterlessNode.prepareIndex("no_index")
+                .setId("1")
                 .setSource(XContentFactory.jsonBuilder().startObject().endObject())
                 .setTimeout(timeout)
         );
 
         BulkRequestBuilder bulkRequestBuilder = clientToMasterlessNode.prepareBulk();
         bulkRequestBuilder.add(
-            clientToMasterlessNode.prepareIndex("test", "type1", "1").setSource(XContentFactory.jsonBuilder().startObject().endObject())
+            clientToMasterlessNode.prepareIndex("test").setId("1").setSource(XContentFactory.jsonBuilder().startObject().endObject())
         );
         bulkRequestBuilder.add(
-            clientToMasterlessNode.prepareIndex("test", "type1", "2").setSource(XContentFactory.jsonBuilder().startObject().endObject())
+            clientToMasterlessNode.prepareIndex("test").setId("2").setSource(XContentFactory.jsonBuilder().startObject().endObject())
         );
         bulkRequestBuilder.setTimeout(timeout);
         checkWriteAction(bulkRequestBuilder);
 
         bulkRequestBuilder = clientToMasterlessNode.prepareBulk();
         bulkRequestBuilder.add(
-            clientToMasterlessNode.prepareIndex("no_index", "type1", "1").setSource(XContentFactory.jsonBuilder().startObject().endObject())
+            clientToMasterlessNode.prepareIndex("no_index").setId("1").setSource(XContentFactory.jsonBuilder().startObject().endObject())
         );
         bulkRequestBuilder.add(
-            clientToMasterlessNode.prepareIndex("no_index", "type1", "2").setSource(XContentFactory.jsonBuilder().startObject().endObject())
+            clientToMasterlessNode.prepareIndex("no_index").setId("2").setSource(XContentFactory.jsonBuilder().startObject().endObject())
         );
         bulkRequestBuilder.setTimeout(timeout);
         checkWriteAction(bulkRequestBuilder);
@@ -252,8 +254,8 @@ public class NoMasterNodeIT extends OpenSearchIntegTestCase {
             Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 3).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
         ).get();
         client().admin().cluster().prepareHealth("_all").setWaitForGreenStatus().get();
-        client().prepareIndex("test1", "type1", "1").setSource("field", "value1").get();
-        client().prepareIndex("test2", "type1", "1").setSource("field", "value1").get();
+        client().prepareIndex("test1").setId("1").setSource("field", "value1").get();
+        client().prepareIndex("test2").setId("1").setSource("field", "value1").get();
         refresh();
 
         ensureSearchable("test1", "test2");
@@ -306,7 +308,8 @@ public class NoMasterNodeIT extends OpenSearchIntegTestCase {
         }
 
         try {
-            clientToMasterlessNode.prepareIndex("test1", "type1", "1")
+            clientToMasterlessNode.prepareIndex("test1")
+                .setId("1")
                 .setSource(XContentFactory.jsonBuilder().startObject().endObject())
                 .setTimeout(timeout)
                 .get();

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/allocation/ClusterRerouteIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/allocation/ClusterRerouteIT.java
@@ -335,7 +335,7 @@ public class ClusterRerouteIT extends OpenSearchIntegTestCase {
         );
 
         if (closed == false) {
-            client().prepareIndex("test", "type", "1").setSource("field", "value").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
+            client().prepareIndex("test").setId("1").setSource("field", "value").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
         }
         final Index index = resolveIndex("test");
 

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/allocation/FilteringAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/allocation/FilteringAllocationIT.java
@@ -72,7 +72,7 @@ public class FilteringAllocationIT extends OpenSearchIntegTestCase {
         ensureGreen("test");
         logger.info("--> index some data");
         for (int i = 0; i < 100; i++) {
-            client().prepareIndex("test", "type", Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
         }
         client().admin().indices().prepareRefresh().execute().actionGet();
         assertThat(
@@ -187,7 +187,7 @@ public class FilteringAllocationIT extends OpenSearchIntegTestCase {
 
         logger.info("--> index some data");
         for (int i = 0; i < 100; i++) {
-            client().prepareIndex("test", "type", Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
         }
         client().admin().indices().prepareRefresh().execute().actionGet();
         assertThat(

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/RareClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/RareClusterStateIT.java
@@ -291,7 +291,7 @@ public class RareClusterStateIT extends OpenSearchIntegTestCase {
 
         // this request does not change the cluster state, because mapping is already created,
         // we don't await and cancel committed publication
-        ActionFuture<IndexResponse> docIndexResponse = client().prepareIndex("index", "type", "1").setSource("field", 42).execute();
+        ActionFuture<IndexResponse> docIndexResponse = client().prepareIndex("index").setId("1").setSource("field", 42).execute();
 
         // Wait a bit to make sure that the reason why we did not get a response
         // is that cluster state processing is blocked and not just that it takes
@@ -376,7 +376,7 @@ public class RareClusterStateIT extends OpenSearchIntegTestCase {
             assertNotNull(mapper.mappers().getMapper("field"));
         });
 
-        final ActionFuture<IndexResponse> docIndexResponse = client().prepareIndex("index", "type", "1").setSource("field", 42).execute();
+        final ActionFuture<IndexResponse> docIndexResponse = client().prepareIndex("index").setId("1").setSource("field", 42).execute();
 
         assertBusy(() -> assertTrue(client().prepareGet("index", "1").get().isExists()));
 
@@ -386,7 +386,7 @@ public class RareClusterStateIT extends OpenSearchIntegTestCase {
         // this request does not change the cluster state, because the mapping is dynamic,
         // we need to await and cancel committed publication
         ActionFuture<IndexResponse> dynamicMappingsFut = executeAndCancelCommittedPublication(
-            client().prepareIndex("index", "type", "2").setSource("field2", 42)
+            client().prepareIndex("index").setId("2").setSource("field2", 42)
         );
 
         // ...and wait for second mapping to be available on master

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
@@ -430,7 +430,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
         ensureStableCluster(2);
 
         logger.info("--> index 1 doc and ensure index is green");
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1").setRefreshPolicy(IMMEDIATE).get();
         ensureGreen("test");
         assertBusy(
             () -> internalCluster().getInstances(IndicesService.class)

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/MockDiskUsagesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/MockDiskUsagesIT.java
@@ -212,7 +212,7 @@ public class MockDiskUsagesIT extends OpenSearchIntegTestCase {
             assertThat("node2 has 2 shards", shardCountByNodeId.get(nodeIds.get(2)), equalTo(2));
         }
 
-        client().prepareIndex("test", "doc", "1").setSource("foo", "bar").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("foo", "bar").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
         assertSearchHits(client().prepareSearch("test").get(), "1");
 
         // Move all nodes above the low watermark so no shard movement can occur, and at least one node above the flood stage watermark so
@@ -249,7 +249,8 @@ public class MockDiskUsagesIT extends OpenSearchIntegTestCase {
         // Attempt to create a new document until DiskUsageMonitor unblocks the index
         assertBusy(() -> {
             try {
-                client().prepareIndex("test", "doc", "3")
+                client().prepareIndex("test")
+                    .setId("3")
                     .setSource("foo", "bar")
                     .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
                     .get();

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/shards/ClusterSearchShardsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/shards/ClusterSearchShardsIT.java
@@ -173,7 +173,7 @@ public class ClusterSearchShardsIT extends OpenSearchIntegTestCase {
 
         int docs = between(10, 100);
         for (int i = 0; i < docs; i++) {
-            client().prepareIndex("test-blocks", "type", "" + i).setSource("test", "init").execute().actionGet();
+            client().prepareIndex("test-blocks").setId("" + i).setSource("test", "init").execute().actionGet();
         }
         ensureGreen("test-blocks");
 

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/ClusterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/ClusterDisruptionIT.java
@@ -171,7 +171,8 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
                                 id = Integer.toString(idGenerator.incrementAndGet());
                                 int shard = Math.floorMod(Murmur3HashFunction.hash(id), numPrimaries);
                                 logger.trace("[{}] indexing id [{}] through node [{}] targeting shard [{}]", name, id, node, shard);
-                                IndexRequestBuilder indexRequestBuilder = client.prepareIndex("test", "type", id)
+                                IndexRequestBuilder indexRequestBuilder = client.prepareIndex("test")
+                                    .setId(id)
                                     .setSource(Collections.singletonMap(randomFrom(fieldNames), randomNonNegativeLong()), XContentType.JSON)
                                     .setTimeout(timeout);
 
@@ -511,7 +512,8 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
                 while (stopped.get() == false && docID.get() < 5000) {
                     String id = Integer.toString(docID.incrementAndGet());
                     try {
-                        IndexResponse response = client().prepareIndex(index, "_doc", id)
+                        IndexResponse response = client().prepareIndex(index)
+                            .setId(id)
                             .setSource(Collections.singletonMap("f" + randomIntBetween(1, 10), randomNonNegativeLong()), XContentType.JSON)
                             .get();
                         assertThat(response.getResult(), is(oneOf(CREATED, UPDATED)));

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/MasterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/MasterDisruptionIT.java
@@ -298,9 +298,9 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
         disruption.startDisrupting();
 
         BulkRequestBuilder bulk = client().prepareBulk();
-        bulk.add(client().prepareIndex("test", "doc", "2").setSource("{ \"f\": 1 }", XContentType.JSON));
-        bulk.add(client().prepareIndex("test", "doc", "3").setSource("{ \"g\": 1 }", XContentType.JSON));
-        bulk.add(client().prepareIndex("test", "doc", "4").setSource("{ \"f\": 1 }", XContentType.JSON));
+        bulk.add(client().prepareIndex("test").setId("2").setSource("{ \"f\": 1 }", XContentType.JSON));
+        bulk.add(client().prepareIndex("test").setId("3").setSource("{ \"g\": 1 }", XContentType.JSON));
+        bulk.add(client().prepareIndex("test").setId("4").setSource("{ \"f\": 1 }", XContentType.JSON));
         BulkResponse bulkResponse = bulk.get();
         assertTrue(bulkResponse.hasFailures());
 

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/SnapshotDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/SnapshotDisruptionIT.java
@@ -294,7 +294,7 @@ public class SnapshotDisruptionIT extends AbstractSnapshotIntegTestCase {
         final int numdocs = randomIntBetween(10, 100);
         IndexRequestBuilder[] builders = new IndexRequestBuilder[numdocs];
         for (int i = 0; i < builders.length; i++) {
-            builders[i] = client().prepareIndex(idxName, "type1", Integer.toString(i)).setSource("field1", "bar " + i);
+            builders[i] = client().prepareIndex(idxName).setId(Integer.toString(i)).setSource("field1", "bar " + i);
         }
         indexRandom(true, builders);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/env/NodeEnvironmentIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/env/NodeEnvironmentIT.java
@@ -104,7 +104,7 @@ public class NodeEnvironmentIT extends OpenSearchIntegTestCase {
         internalCluster().startNode(dataPathSettings);
 
         logger.info("--> indexing a simple document");
-        client().prepareIndex(indexName, "type1", "1").setSource("field1", "value1").get();
+        client().prepareIndex(indexName).setId("1").setSource("field1", "value1").get();
 
         logger.info("--> restarting the node without the data role");
         ex = expectThrows(

--- a/server/src/internalClusterTest/java/org/opensearch/env/NodeRepurposeCommandIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/env/NodeRepurposeCommandIT.java
@@ -65,7 +65,7 @@ public class NodeRepurposeCommandIT extends OpenSearchIntegTestCase {
         prepareCreate(indexName, Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0)).get();
 
         logger.info("--> indexing a simple document");
-        client().prepareIndex(indexName, "type1", "1").setSource("field1", "value1").get();
+        client().prepareIndex(indexName).setId("1").setSource("field1", "value1").get();
 
         ensureGreen();
 

--- a/server/src/internalClusterTest/java/org/opensearch/explain/ExplainActionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/explain/ExplainActionIT.java
@@ -63,7 +63,7 @@ public class ExplainActionIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test").addAlias(new Alias("alias")).setSettings(Settings.builder().put("index.refresh_interval", -1)));
         ensureGreen("test");
 
-        client().prepareIndex("test", "test", "1").setSource("field", "value1").get();
+        client().prepareIndex("test").setId("1").setSource("field", "value1").get();
 
         ExplainResponse response = client().prepareExplain(indexOrAlias(), "1").setQuery(QueryBuilders.matchAllQuery()).get();
         assertNotNull(response);
@@ -120,7 +120,8 @@ public class ExplainActionIT extends OpenSearchIntegTestCase {
         );
         ensureGreen("test");
 
-        client().prepareIndex("test", "test", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject().startObject("obj1").field("field1", "value1").field("field2", "value2").endObject().endObject()
             )
@@ -178,7 +179,8 @@ public class ExplainActionIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test").addAlias(new Alias("alias")));
         ensureGreen("test");
 
-        client().prepareIndex("test", "test", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject().startObject("obj1").field("field1", "value1").field("field2", "value2").endObject().endObject()
             )
@@ -215,7 +217,7 @@ public class ExplainActionIT extends OpenSearchIntegTestCase {
         );
         ensureGreen("test");
 
-        client().prepareIndex("test", "test", "1").setSource("field1", "value1", "field2", "value1").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value1").get();
         refresh();
 
         ExplainResponse response = client().prepareExplain("alias1", "1").setQuery(QueryBuilders.matchAllQuery()).get();
@@ -234,7 +236,7 @@ public class ExplainActionIT extends OpenSearchIntegTestCase {
         );
         ensureGreen("test");
 
-        client().prepareIndex("test", "test", "1").setSource("field1", "value1", "field2", "value1").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value1").get();
         refresh();
 
         ExplainResponse response = client().prepareExplain("alias1", "1")
@@ -261,7 +263,7 @@ public class ExplainActionIT extends OpenSearchIntegTestCase {
         String aMonthAgo = DateTimeFormatter.ISO_LOCAL_DATE.format(now.minusMonths(1));
         String aMonthFromNow = DateTimeFormatter.ISO_LOCAL_DATE.format(now.plusMonths(1));
 
-        client().prepareIndex("test", "type", "1").setSource("past", aMonthAgo, "future", aMonthFromNow).get();
+        client().prepareIndex("test").setId("1").setSource("past", aMonthAgo, "future", aMonthFromNow).get();
 
         refresh();
 

--- a/server/src/internalClusterTest/java/org/opensearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/GatewayIndexStateIT.java
@@ -174,7 +174,7 @@ public class GatewayIndexStateIT extends OpenSearchIntegTestCase {
         );
 
         logger.info("--> indexing a simple document");
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1").get();
 
         logger.info("--> closing test index...");
         assertAcked(client().admin().indices().prepareClose("test"));
@@ -188,14 +188,14 @@ public class GatewayIndexStateIT extends OpenSearchIntegTestCase {
 
         logger.info("--> trying to index into a closed index ...");
         try {
-            client().prepareIndex("test", "type1", "1").setSource("field1", "value1").execute().actionGet();
+            client().prepareIndex("test").setId("1").setSource("field1", "value1").execute().actionGet();
             fail();
         } catch (IndexClosedException e) {
             // all is well
         }
 
         logger.info("--> creating another index (test2) by indexing into it");
-        client().prepareIndex("test2", "type1", "1").setSource("field1", "value1").execute().actionGet();
+        client().prepareIndex("test2").setId("1").setSource("field1", "value1").execute().actionGet();
         logger.info("--> verifying that the state is green");
         ensureGreen();
 
@@ -234,7 +234,7 @@ public class GatewayIndexStateIT extends OpenSearchIntegTestCase {
 
         logger.info("--> trying to index into a closed index ...");
         try {
-            client().prepareIndex("test", "type1", "1").setSource("field1", "value1").execute().actionGet();
+            client().prepareIndex("test").setId("1").setSource("field1", "value1").execute().actionGet();
             fail();
         } catch (IndexClosedException e) {
             // all is well
@@ -259,7 +259,7 @@ public class GatewayIndexStateIT extends OpenSearchIntegTestCase {
         assertThat(getResponse.isExists(), equalTo(true));
 
         logger.info("--> indexing a simple document");
-        client().prepareIndex("test", "type1", "2").setSource("field1", "value1").execute().actionGet();
+        client().prepareIndex("test").setId("2").setSource("field1", "value1").execute().actionGet();
     }
 
     public void testJustMasterNode() throws Exception {
@@ -314,7 +314,7 @@ public class GatewayIndexStateIT extends OpenSearchIntegTestCase {
         internalCluster().startNodes(2);
 
         logger.info("--> indexing a simple document");
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1").setRefreshPolicy(IMMEDIATE).get();
 
         logger.info("--> waiting for green status");
         ClusterHealthResponse health = client().admin()
@@ -429,7 +429,7 @@ public class GatewayIndexStateIT extends OpenSearchIntegTestCase {
         logger.info("--> starting one node");
         internalCluster().startNode();
         logger.info("--> indexing a simple document");
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1").setRefreshPolicy(IMMEDIATE).get();
         logger.info("--> waiting for green status");
         if (usually()) {
             ensureYellow();
@@ -516,7 +516,7 @@ public class GatewayIndexStateIT extends OpenSearchIntegTestCase {
             )
             .get();
         logger.info("--> indexing a simple document");
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value one").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value one").setRefreshPolicy(IMMEDIATE).get();
         logger.info("--> waiting for green status");
         if (usually()) {
             ensureYellow();
@@ -567,7 +567,7 @@ public class GatewayIndexStateIT extends OpenSearchIntegTestCase {
     public void testArchiveBrokenClusterSettings() throws Exception {
         logger.info("--> starting one node");
         internalCluster().startNode();
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1").setRefreshPolicy(IMMEDIATE).get();
         logger.info("--> waiting for green status");
         if (usually()) {
             ensureYellow();

--- a/server/src/internalClusterTest/java/org/opensearch/gateway/QuorumGatewayIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/QuorumGatewayIT.java
@@ -66,11 +66,11 @@ public class QuorumGatewayIT extends OpenSearchIntegTestCase {
         final NumShards test = getNumShards("test");
 
         logger.info("--> indexing...");
-        client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject().field("field", "value1").endObject()).get();
+        client().prepareIndex("test").setId("1").setSource(jsonBuilder().startObject().field("field", "value1").endObject()).get();
         // We don't check for failures in the flush response: if we do we might get the following:
         // FlushNotAllowedEngineException[[test][1] recovery is in progress, flush [COMMIT_TRANSLOG] is not allowed]
         flush();
-        client().prepareIndex("test", "type1", "2").setSource(jsonBuilder().startObject().field("field", "value2").endObject()).get();
+        client().prepareIndex("test").setId("2").setSource(jsonBuilder().startObject().field("field", "value2").endObject()).get();
         refresh();
 
         for (int i = 0; i < 10; i++) {
@@ -95,7 +95,8 @@ public class QuorumGatewayIT extends OpenSearchIntegTestCase {
                     }, 30, TimeUnit.SECONDS);
 
                     logger.info("--> one node is closed -- index 1 document into the remaining nodes");
-                    activeClient.prepareIndex("test", "type1", "3")
+                    activeClient.prepareIndex("test")
+                        .setId("3")
                         .setSource(jsonBuilder().startObject().field("field", "value3").endObject())
                         .get();
                     assertNoFailures(activeClient.admin().indices().prepareRefresh().get());

--- a/server/src/internalClusterTest/java/org/opensearch/gateway/RecoveryFromGatewayIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/RecoveryFromGatewayIT.java
@@ -126,23 +126,28 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
         );
         assertAcked(prepareCreate("test").addMapping("type1", mapping, XContentType.JSON));
 
-        client().prepareIndex("test", "type1", "10990239")
+        client().prepareIndex("test")
+            .setId("10990239")
             .setSource(jsonBuilder().startObject().startArray("appAccountIds").value(14).value(179).endArray().endObject())
             .execute()
             .actionGet();
-        client().prepareIndex("test", "type1", "10990473")
+        client().prepareIndex("test")
+            .setId("10990473")
             .setSource(jsonBuilder().startObject().startArray("appAccountIds").value(14).endArray().endObject())
             .execute()
             .actionGet();
-        client().prepareIndex("test", "type1", "10990513")
+        client().prepareIndex("test")
+            .setId("10990513")
             .setSource(jsonBuilder().startObject().startArray("appAccountIds").value(14).value(179).endArray().endObject())
             .execute()
             .actionGet();
-        client().prepareIndex("test", "type1", "10990695")
+        client().prepareIndex("test")
+            .setId("10990695")
             .setSource(jsonBuilder().startObject().startArray("appAccountIds").value(14).endArray().endObject())
             .execute()
             .actionGet();
-        client().prepareIndex("test", "type1", "11026351")
+        client().prepareIndex("test")
+            .setId("11026351")
             .setSource(jsonBuilder().startObject().startArray("appAccountIds").value(14).endArray().endObject())
             .execute()
             .actionGet();
@@ -309,12 +314,14 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
 
     public void testSingleNodeWithFlush() throws Exception {
         internalCluster().startNode();
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("field", "value1").endObject())
             .execute()
             .actionGet();
         flush();
-        client().prepareIndex("test", "type1", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(jsonBuilder().startObject().field("field", "value2").endObject())
             .execute()
             .actionGet();
@@ -352,12 +359,14 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
         final String firstNode = internalCluster().startNode();
         internalCluster().startNode();
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("field", "value1").endObject())
             .execute()
             .actionGet();
         flush();
-        client().prepareIndex("test", "type1", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(jsonBuilder().startObject().field("field", "value2").endObject())
             .execute()
             .actionGet();
@@ -408,12 +417,14 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
         Settings node2DataPathSettings = internalCluster().dataPathSettings(nodes.get(1));
 
         assertAcked(client().admin().indices().prepareCreate("test"));
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("field", "value1").endObject())
             .execute()
             .actionGet();
         client().admin().indices().prepareFlush().execute().actionGet();
-        client().prepareIndex("test", "type1", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(jsonBuilder().startObject().field("field", "value2").endObject())
             .execute()
             .actionGet();
@@ -433,7 +444,8 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
         internalCluster().stopRandomDataNode();
 
         logger.info("--> one node is closed - start indexing data into the second one");
-        client().prepareIndex("test", "type1", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setSource(jsonBuilder().startObject().field("field", "value3").endObject())
             .execute()
             .actionGet();

--- a/server/src/internalClusterTest/java/org/opensearch/get/GetActionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/get/GetActionIT.java
@@ -94,7 +94,7 @@ public class GetActionIT extends OpenSearchIntegTestCase {
         assertThat(response.isExists(), equalTo(false));
 
         logger.info("--> index doc 1");
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1", "field2", "value2").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value2").get();
 
         logger.info("--> non realtime get 1");
         response = client().prepareGet(indexOrAlias(), "1").setRealtime(false).get();
@@ -181,7 +181,7 @@ public class GetActionIT extends OpenSearchIntegTestCase {
         assertThat(response.getField("field2"), nullValue());
 
         logger.info("--> update doc 1");
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1_1", "field2", "value2_1").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1_1", "field2", "value2_1").get();
 
         logger.info("--> realtime get 1");
         response = client().prepareGet(indexOrAlias(), "1").get();
@@ -191,7 +191,7 @@ public class GetActionIT extends OpenSearchIntegTestCase {
         assertThat(response.getSourceAsMap().get("field2").toString(), equalTo("value2_1"));
 
         logger.info("--> update doc 1 again");
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1_2", "field2", "value2_2").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1_2", "field2", "value2_2").get();
 
         response = client().prepareGet(indexOrAlias(), "1").get();
         assertThat(response.isExists(), equalTo(true));
@@ -217,7 +217,7 @@ public class GetActionIT extends OpenSearchIntegTestCase {
         } else {
             client().admin().indices().prepareCreate("index3").addAlias(new Alias("alias1").indexRouting("1").writeIndex(true)).get();
         }
-        IndexResponse indexResponse = client().prepareIndex("index1", "type", "id").setSource(Collections.singletonMap("foo", "bar")).get();
+        IndexResponse indexResponse = client().prepareIndex("index1").setId("id").setSource(Collections.singletonMap("foo", "bar")).get();
         assertThat(indexResponse.status().getStatus(), equalTo(RestStatus.CREATED.getStatus()));
 
         IllegalArgumentException exception = expectThrows(
@@ -244,7 +244,7 @@ public class GetActionIT extends OpenSearchIntegTestCase {
         assertThat(response.getResponses()[0].getResponse().isExists(), equalTo(false));
 
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i)).setSource("field", "value" + i).get();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).get();
         }
 
         response = client().prepareMultiGet()
@@ -308,7 +308,7 @@ public class GetActionIT extends OpenSearchIntegTestCase {
         assertThat(response.isExists(), equalTo(false));
         assertThat(response.isExists(), equalTo(false));
 
-        client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject().array("field", "1", "2").endObject()).get();
+        client().prepareIndex("test").setId("1").setSource(jsonBuilder().startObject().array("field", "1", "2").endObject()).get();
 
         response = client().prepareGet("test", "1").setStoredFields("field").get();
         assertThat(response.isExists(), equalTo(true));
@@ -339,7 +339,7 @@ public class GetActionIT extends OpenSearchIntegTestCase {
         assertThat(response.isExists(), equalTo(false));
 
         logger.info("--> index doc 1");
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1", "field2", "value2").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value2").get();
 
         // From translog:
 
@@ -383,7 +383,7 @@ public class GetActionIT extends OpenSearchIntegTestCase {
         }
 
         logger.info("--> index doc 1 again, so increasing the version");
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1", "field2", "value2").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value2").get();
 
         // From translog:
 
@@ -438,7 +438,7 @@ public class GetActionIT extends OpenSearchIntegTestCase {
         assertThat(response.getResponses()[0].getResponse().isExists(), equalTo(false));
 
         for (int i = 0; i < 3; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i)).setSource("field", "value" + i).get();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).get();
         }
 
         // Version from translog
@@ -488,7 +488,7 @@ public class GetActionIT extends OpenSearchIntegTestCase {
         assertThat(response.getResponses()[2].getFailure().getFailure(), instanceOf(VersionConflictEngineException.class));
 
         for (int i = 0; i < 3; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i)).setSource("field", "value" + i).get();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).get();
         }
 
         // Version from translog
@@ -562,7 +562,8 @@ public class GetActionIT extends OpenSearchIntegTestCase {
                 .setSettings(Settings.builder().put("index.refresh_interval", -1))
         );
 
-        client().prepareIndex("test", "my-type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().startObject("field1").field("field2", "value1").endObject().endObject())
             .get();
 
@@ -640,7 +641,7 @@ public class GetActionIT extends OpenSearchIntegTestCase {
 
         logger.info("indexing documents");
 
-        client().prepareIndex("my-index", "my-type", "1").setSource(source, XContentType.JSON).get();
+        client().prepareIndex("my-index").setId("1").setSource(source, XContentType.JSON).get();
 
         logger.info("checking real time retrieval");
 
@@ -732,7 +733,7 @@ public class GetActionIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test").addAlias(new Alias("alias")).setSource(createIndexSource, XContentType.JSON));
         ensureGreen();
 
-        client().prepareIndex("test", "_doc", "1").setRouting("routingValue").setId("1").setSource("{}", XContentType.JSON).get();
+        client().prepareIndex("test").setId("1").setRouting("routingValue").setId("1").setSource("{}", XContentType.JSON).get();
 
         String[] fieldsList = { "_routing" };
         // before refresh - document is only in translog

--- a/server/src/internalClusterTest/java/org/opensearch/index/FinalPipelineIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/FinalPipelineIT.java
@@ -203,7 +203,7 @@ public class FinalPipelineIT extends OpenSearchIntegTestCase {
         // this asserts that the final_pipeline was used, without us having to actually create the pipeline etc.
         final IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> client().prepareIndex("index", "_doc", "1").setSource(Collections.singletonMap("field", "value")).get()
+            () -> client().prepareIndex("index").setId("1").setSource(Collections.singletonMap("field", "value")).get()
         );
         assertThat(e, hasToString(containsString("pipeline with id [final_pipeline] does not exist")));
     }
@@ -218,7 +218,7 @@ public class FinalPipelineIT extends OpenSearchIntegTestCase {
         client().admin().cluster().putPipeline(new PutPipelineRequest("final_pipeline", finalPipelineBody, XContentType.JSON)).actionGet();
         final Settings settings = Settings.builder().put(IndexSettings.FINAL_PIPELINE.getKey(), "final_pipeline").build();
         createIndex("index", settings);
-        final IndexRequestBuilder index = client().prepareIndex("index", "_doc", "1");
+        final IndexRequestBuilder index = client().prepareIndex("index").setId("1");
         index.setSource(Collections.singletonMap("field", "value"));
         index.setPipeline("request_pipeline");
         index.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
@@ -247,7 +247,7 @@ public class FinalPipelineIT extends OpenSearchIntegTestCase {
             .put(IndexSettings.FINAL_PIPELINE.getKey(), "final_pipeline")
             .build();
         createIndex("index", settings);
-        final IndexRequestBuilder index = client().prepareIndex("index", "_doc", "1");
+        final IndexRequestBuilder index = client().prepareIndex("index").setId("1");
         index.setSource(Collections.singletonMap("field", "value"));
         index.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
         final IndexResponse response = index.get();
@@ -297,7 +297,7 @@ public class FinalPipelineIT extends OpenSearchIntegTestCase {
             .setOrder(finalPipelineOrder)
             .setSettings(finalPipelineSettings)
             .get();
-        final IndexRequestBuilder index = client().prepareIndex("index", "_doc", "1");
+        final IndexRequestBuilder index = client().prepareIndex("index").setId("1");
         index.setSource(Collections.singletonMap("field", "value"));
         index.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
         final IndexResponse response = index.get();
@@ -337,7 +337,7 @@ public class FinalPipelineIT extends OpenSearchIntegTestCase {
         // this asserts that the high_order_final_pipeline was selected, without us having to actually create the pipeline etc.
         final IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> client().prepareIndex("index", "_doc", "1").setSource(Collections.singletonMap("field", "value")).get()
+            () -> client().prepareIndex("index").setId("1").setSource(Collections.singletonMap("field", "value")).get()
         );
         assertThat(e, hasToString(containsString("pipeline with id [high_order_final_pipeline] does not exist")));
     }

--- a/server/src/internalClusterTest/java/org/opensearch/index/IndexSortIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/IndexSortIT.java
@@ -94,7 +94,8 @@ public class IndexSortIT extends OpenSearchIntegTestCase {
                 .putList("index.sort.field", "date", "numeric_dv", "keyword_dv")
         ).addMapping("test", TEST_MAPPING).get();
         for (int i = 0; i < 20; i++) {
-            client().prepareIndex("test", "test", Integer.toString(i))
+            client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource("numeric_dv", randomInt(), "keyword_dv", randomAlphaOfLengthBetween(10, 20))
                 .get();
         }

--- a/server/src/internalClusterTest/java/org/opensearch/index/WaitUntilRefreshIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/WaitUntilRefreshIT.java
@@ -83,7 +83,8 @@ public class WaitUntilRefreshIT extends OpenSearchIntegTestCase {
     }
 
     public void testIndex() {
-        IndexResponse index = client().prepareIndex("test", "index", "1")
+        IndexResponse index = client().prepareIndex("test")
+            .setId("1")
             .setSource("foo", "bar")
             .setRefreshPolicy(RefreshPolicy.WAIT_UNTIL)
             .get();
@@ -94,7 +95,7 @@ public class WaitUntilRefreshIT extends OpenSearchIntegTestCase {
 
     public void testDelete() throws InterruptedException, ExecutionException {
         // Index normally
-        indexRandom(true, client().prepareIndex("test", "test", "1").setSource("foo", "bar"));
+        indexRandom(true, client().prepareIndex("test").setId("1").setSource("foo", "bar"));
         assertSearchHits(client().prepareSearch("test").setQuery(matchQuery("foo", "bar")).get(), "1");
 
         // Now delete with blockUntilRefresh
@@ -106,7 +107,7 @@ public class WaitUntilRefreshIT extends OpenSearchIntegTestCase {
 
     public void testUpdate() throws InterruptedException, ExecutionException {
         // Index normally
-        indexRandom(true, client().prepareIndex("test", "test", "1").setSource("foo", "bar"));
+        indexRandom(true, client().prepareIndex("test").setId("1").setSource("foo", "bar"));
         assertSearchHits(client().prepareSearch("test").setQuery(matchQuery("foo", "bar")).get(), "1");
 
         // Update with RefreshPolicy.WAIT_UNTIL
@@ -141,7 +142,7 @@ public class WaitUntilRefreshIT extends OpenSearchIntegTestCase {
     public void testBulk() {
         // Index by bulk with RefreshPolicy.WAIT_UNTIL
         BulkRequestBuilder bulk = client().prepareBulk().setRefreshPolicy(RefreshPolicy.WAIT_UNTIL);
-        bulk.add(client().prepareIndex("test", "test", "1").setSource("foo", "bar"));
+        bulk.add(client().prepareIndex("test").setId("1").setSource("foo", "bar"));
         assertBulkSuccess(bulk.get());
         assertSearchHits(client().prepareSearch("test").setQuery(matchQuery("foo", "bar")).get(), "1");
 
@@ -169,7 +170,8 @@ public class WaitUntilRefreshIT extends OpenSearchIntegTestCase {
      */
     public void testNoRefreshInterval() throws InterruptedException, ExecutionException {
         client().admin().indices().prepareUpdateSettings("test").setSettings(singletonMap("index.refresh_interval", -1)).get();
-        ActionFuture<IndexResponse> index = client().prepareIndex("test", "index", "1")
+        ActionFuture<IndexResponse> index = client().prepareIndex("test")
+            .setId("1")
             .setSource("foo", "bar")
             .setRefreshPolicy(RefreshPolicy.WAIT_UNTIL)
             .execute();

--- a/server/src/internalClusterTest/java/org/opensearch/index/fielddata/FieldDataLoadingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/fielddata/FieldDataLoadingIT.java
@@ -60,7 +60,7 @@ public class FieldDataLoadingIT extends OpenSearchIntegTestCase {
         );
         ensureGreen();
 
-        client().prepareIndex("test", "type", "1").setSource("name", "name").get();
+        client().prepareIndex("test").setId("1").setSource("name", "name").get();
         client().admin().indices().prepareRefresh("test").get();
 
         ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();

--- a/server/src/internalClusterTest/java/org/opensearch/index/mapper/CopyToMapperIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/mapper/CopyToMapperIntegrationIT.java
@@ -56,7 +56,7 @@ public class CopyToMapperIntegrationIT extends OpenSearchIntegTestCase {
         int recordCount = between(1, 200);
 
         for (int i = 0; i < recordCount * 2; i++) {
-            client().prepareIndex("test-idx", "_doc", Integer.toString(i)).setSource("test_field", "test " + i, "even", i % 2 == 0).get();
+            client().prepareIndex("test-idx").setId(Integer.toString(i)).setSource("test_field", "test " + i, "even", i % 2 == 0).get();
         }
         client().admin().indices().prepareRefresh("test-idx").execute().actionGet();
 
@@ -92,7 +92,7 @@ public class CopyToMapperIntegrationIT extends OpenSearchIntegTestCase {
                 .endObject()
         );
         assertAcked(client().admin().indices().prepareCreate("test-idx").addMapping("_doc", mapping, XContentType.JSON));
-        client().prepareIndex("test-idx", "_doc", "1").setSource("foo", "bar").get();
+        client().prepareIndex("test-idx").setId("1").setSource("foo", "bar").get();
         client().admin().indices().prepareRefresh("test-idx").execute().actionGet();
         SearchResponse response = client().prepareSearch("test-idx").setQuery(QueryBuilders.termQuery("root.top.child", "bar")).get();
         assertThat(response.getHits().getTotalHits().value, equalTo(1L));

--- a/server/src/internalClusterTest/java/org/opensearch/index/mapper/DynamicMappingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/mapper/DynamicMappingIT.java
@@ -68,9 +68,9 @@ public class DynamicMappingIT extends OpenSearchIntegTestCase {
     public void testConflictingDynamicMappings() {
         // we don't use indexRandom because the order of requests is important here
         createIndex("index");
-        client().prepareIndex("index", "type", "1").setSource("foo", 3).get();
+        client().prepareIndex("index").setId("1").setSource("foo", 3).get();
         try {
-            client().prepareIndex("index", "type", "2").setSource("foo", "bar").get();
+            client().prepareIndex("index").setId("2").setSource("foo", "bar").get();
             fail("Indexing request should have failed!");
         } catch (MapperParsingException e) {
             // general case, the parsing code complains that it can't parse "bar" as a "long"
@@ -86,10 +86,10 @@ public class DynamicMappingIT extends OpenSearchIntegTestCase {
     public void testConflictingDynamicMappingsBulk() {
         // we don't use indexRandom because the order of requests is important here
         createIndex("index");
-        client().prepareIndex("index", "type", "1").setSource("foo", 3).get();
-        BulkResponse bulkResponse = client().prepareBulk().add(client().prepareIndex("index", "type", "1").setSource("foo", 3)).get();
+        client().prepareIndex("index").setId("1").setSource("foo", 3).get();
+        BulkResponse bulkResponse = client().prepareBulk().add(client().prepareIndex("index").setId("1").setSource("foo", 3)).get();
         assertFalse(bulkResponse.hasFailures());
-        bulkResponse = client().prepareBulk().add(client().prepareIndex("index", "type", "2").setSource("foo", "bar")).get();
+        bulkResponse = client().prepareBulk().add(client().prepareIndex("index").setId("2").setSource("foo", "bar")).get();
         assertTrue(bulkResponse.hasFailures());
     }
 
@@ -117,7 +117,7 @@ public class DynamicMappingIT extends OpenSearchIntegTestCase {
                         startLatch.await();
                         assertEquals(
                             DocWriteResponse.Result.CREATED,
-                            client().prepareIndex("index", "type", id).setSource("field" + id, "bar").get().getResult()
+                            client().prepareIndex("index").setId(id).setSource("field" + id, "bar").get().getResult()
                         );
                     } catch (Exception e) {
                         error.compareAndSet(null, e);

--- a/server/src/internalClusterTest/java/org/opensearch/index/mapper/MultiFieldsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/mapper/MultiFieldsIntegrationIT.java
@@ -69,7 +69,7 @@ public class MultiFieldsIntegrationIT extends OpenSearchIntegTestCase {
         assertThat(titleFields.get("not_analyzed"), notNullValue());
         assertThat(((Map<String, Object>) titleFields.get("not_analyzed")).get("type").toString(), equalTo("keyword"));
 
-        client().prepareIndex("my-index", "my-type", "1").setSource("title", "Multi fields").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("my-index").setId("1").setSource("title", "Multi fields").setRefreshPolicy(IMMEDIATE).get();
 
         SearchResponse searchResponse = client().prepareSearch("my-index").setQuery(matchQuery("title", "multi")).get();
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
@@ -90,7 +90,7 @@ public class MultiFieldsIntegrationIT extends OpenSearchIntegTestCase {
         assertThat(titleFields.get("uncased"), notNullValue());
         assertThat(((Map<String, Object>) titleFields.get("uncased")).get("analyzer").toString(), equalTo("whitespace"));
 
-        client().prepareIndex("my-index", "my-type", "1").setSource("title", "Multi fields").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("my-index").setId("1").setSource("title", "Multi fields").setRefreshPolicy(IMMEDIATE).get();
 
         searchResponse = client().prepareSearch("my-index").setQuery(matchQuery("title.uncased", "Multi")).get();
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
@@ -115,7 +115,7 @@ public class MultiFieldsIntegrationIT extends OpenSearchIntegTestCase {
         assertThat(bField.get("type").toString(), equalTo("keyword"));
 
         GeoPoint point = new GeoPoint(51, 19);
-        client().prepareIndex("my-index", "my-type", "1").setSource("a", point.toString()).setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("my-index").setId("1").setSource("a", point.toString()).setRefreshPolicy(IMMEDIATE).get();
         SearchResponse countResponse = client().prepareSearch("my-index")
             .setSize(0)
             .setQuery(constantScoreQuery(geoDistanceQuery("a").point(51, 19).distance(50, DistanceUnit.KILOMETERS)))
@@ -142,7 +142,7 @@ public class MultiFieldsIntegrationIT extends OpenSearchIntegTestCase {
         assertThat(bField.size(), equalTo(1));
         assertThat(bField.get("type").toString(), equalTo("keyword"));
 
-        client().prepareIndex("my-index", "my-type", "1").setSource("a", "complete me").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("my-index").setId("1").setSource("a", "complete me").setRefreshPolicy(IMMEDIATE).get();
         SearchResponse countResponse = client().prepareSearch("my-index").setSize(0).setQuery(matchQuery("a.b", "complete me")).get();
         assertThat(countResponse.getHits().getTotalHits().value, equalTo(1L));
     }
@@ -164,7 +164,7 @@ public class MultiFieldsIntegrationIT extends OpenSearchIntegTestCase {
         assertThat(bField.size(), equalTo(1));
         assertThat(bField.get("type").toString(), equalTo("keyword"));
 
-        client().prepareIndex("my-index", "my-type", "1").setSource("a", "127.0.0.1").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("my-index").setId("1").setSource("a", "127.0.0.1").setRefreshPolicy(IMMEDIATE).get();
         SearchResponse countResponse = client().prepareSearch("my-index").setSize(0).setQuery(matchQuery("a.b", "127.0.0.1")).get();
         assertThat(countResponse.getHits().getTotalHits().value, equalTo(1L));
     }

--- a/server/src/internalClusterTest/java/org/opensearch/index/query/plugin/CustomQueryParserIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/query/plugin/CustomQueryParserIT.java
@@ -54,7 +54,7 @@ public class CustomQueryParserIT extends OpenSearchIntegTestCase {
         super.setUp();
         createIndex("test");
         ensureGreen();
-        client().prepareIndex("index", "type", "1").setSource("field", "value").get();
+        client().prepareIndex("index").setId("1").setSource("field", "value").get();
         refresh();
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/index/seqno/GlobalCheckpointSyncIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/seqno/GlobalCheckpointSyncIT.java
@@ -82,7 +82,7 @@ public class GlobalCheckpointSyncIT extends OpenSearchIntegTestCase {
 
         for (int j = 0; j < 10; j++) {
             final String id = Integer.toString(j);
-            client().prepareIndex("test", "test", id).setSource("{\"foo\": " + id + "}", XContentType.JSON).get();
+            client().prepareIndex("test").setId(id).setSource("{\"foo\": " + id + "}", XContentType.JSON).get();
         }
 
         assertBusy(() -> {
@@ -194,7 +194,7 @@ public class GlobalCheckpointSyncIT extends OpenSearchIntegTestCase {
                 }
                 for (int j = 0; j < numberOfDocuments; j++) {
                     final String id = Integer.toString(index * numberOfDocuments + j);
-                    client().prepareIndex("test", "test", id).setSource("{\"foo\": " + id + "}", XContentType.JSON).get();
+                    client().prepareIndex("test").setId(id).setSource("{\"foo\": " + id + "}", XContentType.JSON).get();
                 }
                 try {
                     barrier.await();
@@ -251,7 +251,7 @@ public class GlobalCheckpointSyncIT extends OpenSearchIntegTestCase {
         }
         int numDocs = randomIntBetween(1, 20);
         for (int i = 0; i < numDocs; i++) {
-            client().prepareIndex("test", "test", Integer.toString(i)).setSource("{}", XContentType.JSON).get();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("{}", XContentType.JSON).get();
         }
         ensureGreen("test");
         assertBusy(() -> {

--- a/server/src/internalClusterTest/java/org/opensearch/index/shard/GlobalCheckpointListenersIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/shard/GlobalCheckpointListenersIT.java
@@ -88,7 +88,7 @@ public class GlobalCheckpointListenersIT extends OpenSearchSingleNodeTestCase {
                 }
 
             }, null);
-            client().prepareIndex("test", "_doc", Integer.toString(i)).setSource("{}", XContentType.JSON).get();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("{}", XContentType.JSON).get();
             assertBusy(() -> assertThat(globalCheckpoint.get(), equalTo((long) index)));
             // adding a listener expecting a lower global checkpoint should fire immediately
             final AtomicLong immediateGlobalCheckpint = new AtomicLong();

--- a/server/src/internalClusterTest/java/org/opensearch/index/shard/SearchIdleIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/shard/SearchIdleIT.java
@@ -102,7 +102,7 @@ public class SearchIdleIT extends OpenSearchSingleNodeTestCase {
         int numDocs = scaledRandomIntBetween(25, 100);
         totalNumDocs.set(numDocs);
         CountDownLatch indexingDone = new CountDownLatch(numDocs);
-        client().prepareIndex("test", "test", "0").setSource("{\"foo\" : \"bar\"}", XContentType.JSON).get();
+        client().prepareIndex("test").setId("0").setSource("{\"foo\" : \"bar\"}", XContentType.JSON).get();
         indexingDone.countDown(); // one doc is indexed above blocking
         IndexShard shard = indexService.getShard(0);
         boolean hasRefreshed = shard.scheduledRefresh();
@@ -133,7 +133,8 @@ public class SearchIdleIT extends OpenSearchSingleNodeTestCase {
         started.await();
         assertThat(count.applyAsLong(totalNumDocs.get()), equalTo(1L));
         for (int i = 1; i < numDocs; i++) {
-            client().prepareIndex("test", "test", "" + i)
+            client().prepareIndex("test")
+                .setId("" + i)
                 .setSource("{\"foo\" : \"bar\"}", XContentType.JSON)
                 .execute(new ActionListener<IndexResponse>() {
                     @Override
@@ -158,7 +159,7 @@ public class SearchIdleIT extends OpenSearchSingleNodeTestCase {
         IndexService indexService = createIndex("test", builder.build());
         assertFalse(indexService.getIndexSettings().isExplicitRefresh());
         ensureGreen();
-        client().prepareIndex("test", "test", "0").setSource("{\"foo\" : \"bar\"}", XContentType.JSON).get();
+        client().prepareIndex("test").setId("0").setSource("{\"foo\" : \"bar\"}", XContentType.JSON).get();
         IndexShard shard = indexService.getShard(0);
         assertFalse(shard.scheduledRefresh());
         assertTrue(shard.isSearchIdle());
@@ -166,7 +167,7 @@ public class SearchIdleIT extends OpenSearchSingleNodeTestCase {
         client().admin().indices().prepareRefresh().execute(ActionListener.wrap(refreshLatch::countDown));// async on purpose to make sure
                                                                                                           // it happens concurrently
         assertHitCount(client().prepareSearch().get(), 1);
-        client().prepareIndex("test", "test", "1").setSource("{\"foo\" : \"bar\"}", XContentType.JSON).get();
+        client().prepareIndex("test").setId("1").setSource("{\"foo\" : \"bar\"}", XContentType.JSON).get();
         assertFalse(shard.scheduledRefresh());
         assertTrue(shard.hasRefreshPending());
 
@@ -185,7 +186,7 @@ public class SearchIdleIT extends OpenSearchSingleNodeTestCase {
         // We need to ensure a `scheduledRefresh` triggered by the internal refresh setting update is executed before we index a new doc;
         // otherwise, it will compete to call `Engine#maybeRefresh` with the `scheduledRefresh` that we are going to verify.
         ensureNoPendingScheduledRefresh(indexService.getThreadPool());
-        client().prepareIndex("test", "test", "2").setSource("{\"foo\" : \"bar\"}", XContentType.JSON).get();
+        client().prepareIndex("test").setId("2").setSource("{\"foo\" : \"bar\"}", XContentType.JSON).get();
         assertTrue(shard.scheduledRefresh());
         assertFalse(shard.hasRefreshPending());
         assertTrue(shard.isSearchIdle());

--- a/server/src/internalClusterTest/java/org/opensearch/indexing/IndexActionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indexing/IndexActionIT.java
@@ -128,15 +128,15 @@ public class IndexActionIT extends OpenSearchIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        IndexResponse indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").execute().actionGet();
+        IndexResponse indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_1").execute().actionGet();
         assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
 
-        indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_2").execute().actionGet();
+        indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_2").execute().actionGet();
         assertEquals(DocWriteResponse.Result.UPDATED, indexResponse.getResult());
 
         client().prepareDelete("test", "1").execute().actionGet();
 
-        indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_2").execute().actionGet();
+        indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_2").execute().actionGet();
         assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
 
     }
@@ -145,14 +145,14 @@ public class IndexActionIT extends OpenSearchIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        IndexResponse indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").execute().actionGet();
+        IndexResponse indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_1").execute().actionGet();
         assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
 
         client().prepareDelete("test", "1").execute().actionGet();
 
         flush();
 
-        indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_2").execute().actionGet();
+        indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_2").execute().actionGet();
         assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
     }
 
@@ -194,7 +194,8 @@ public class IndexActionIT extends OpenSearchIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        IndexResponse indexResponse = client().prepareIndex("test", "type", "1")
+        IndexResponse indexResponse = client().prepareIndex("test")
+            .setId("1")
             .setSource("field1", "value1_1")
             .setVersion(123)
             .setVersionType(VersionType.EXTERNAL)
@@ -208,7 +209,7 @@ public class IndexActionIT extends OpenSearchIntegTestCase {
         ensureGreen();
 
         BulkResponse bulkResponse = client().prepareBulk()
-            .add(client().prepareIndex("test", "type", "1").setSource("field1", "value1_1"))
+            .add(client().prepareIndex("test").setId("1").setSource("field1", "value1_1"))
             .execute()
             .actionGet();
         assertThat(bulkResponse.hasFailures(), equalTo(false));
@@ -289,7 +290,7 @@ public class IndexActionIT extends OpenSearchIntegTestCase {
     public void testDocumentWithBlankFieldName() {
         MapperParsingException e = expectThrows(
             MapperParsingException.class,
-            () -> { client().prepareIndex("test", "type", "1").setSource("", "value1_2").execute().actionGet(); }
+            () -> { client().prepareIndex("test").setId("1").setSource("", "value1_2").execute().actionGet(); }
         );
         assertThat(e.getMessage(), containsString("failed to parse"));
         assertThat(e.getRootCause().getMessage(), containsString("field name cannot be an empty string"));

--- a/server/src/internalClusterTest/java/org/opensearch/indices/DateMathIndexExpressionsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/DateMathIndexExpressionsIntegrationIT.java
@@ -71,9 +71,9 @@ public class DateMathIndexExpressionsIntegrationIT extends OpenSearchIntegTestCa
         String dateMathExp1 = "<.marvel-{now/d}>";
         String dateMathExp2 = "<.marvel-{now/d-1d}>";
         String dateMathExp3 = "<.marvel-{now/d-2d}>";
-        client().prepareIndex(dateMathExp1, "type", "1").setSource("{}", XContentType.JSON).get();
-        client().prepareIndex(dateMathExp2, "type", "2").setSource("{}", XContentType.JSON).get();
-        client().prepareIndex(dateMathExp3, "type", "3").setSource("{}", XContentType.JSON).get();
+        client().prepareIndex(dateMathExp1).setId("1").setSource("{}", XContentType.JSON).get();
+        client().prepareIndex(dateMathExp2).setId("2").setSource("{}", XContentType.JSON).get();
+        client().prepareIndex(dateMathExp3).setId("3").setSource("{}", XContentType.JSON).get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch(dateMathExp1, dateMathExp2, dateMathExp3).get();
@@ -131,9 +131,9 @@ public class DateMathIndexExpressionsIntegrationIT extends OpenSearchIntegTestCa
         String dateMathExp1 = "<.marvel-{now/d}>";
         String dateMathExp2 = "<.marvel-{now/d-1d}>";
         String dateMathExp3 = "<.marvel-{now/d-2d}>";
-        client().prepareIndex(dateMathExp1, "type", "1").setSource("{}", XContentType.JSON).get();
-        client().prepareIndex(dateMathExp2, "type", "2").setSource("{}", XContentType.JSON).get();
-        client().prepareIndex(dateMathExp3, "type", "3").setSource("{}", XContentType.JSON).get();
+        client().prepareIndex(dateMathExp1).setId("1").setSource("{}", XContentType.JSON).get();
+        client().prepareIndex(dateMathExp2).setId("2").setSource("{}", XContentType.JSON).get();
+        client().prepareIndex(dateMathExp3).setId("3").setSource("{}", XContentType.JSON).get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch(dateMathExp1, dateMathExp2, dateMathExp3).get();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/IndicesOptionsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/IndicesOptionsIntegrationIT.java
@@ -361,7 +361,7 @@ public class IndicesOptionsIntegrationIT extends OpenSearchIntegTestCase {
         verify(getSettings(indices).setIndicesOptions(options), false);
 
         assertAcked(prepareCreate("foobar"));
-        client().prepareIndex("foobar", "type", "1").setSource("k", "v").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("foobar").setId("1").setSource("k", "v").setRefreshPolicy(IMMEDIATE).get();
 
         // Verify defaults for wildcards, with one wildcard expression and one existing index
         indices = new String[] { "foo*" };
@@ -455,7 +455,7 @@ public class IndicesOptionsIntegrationIT extends OpenSearchIntegTestCase {
 
     public void testAllMissingLenient() throws Exception {
         createIndex("test1");
-        client().prepareIndex("test1", "type", "1").setSource("k", "v").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test1").setId("1").setSource("k", "v").setRefreshPolicy(IMMEDIATE).get();
         SearchResponse response = client().prepareSearch("test2")
             .setIndicesOptions(IndicesOptions.lenientExpandOpen())
             .setQuery(matchAllQuery())

--- a/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
@@ -149,15 +149,15 @@ public class IndicesRequestCacheIT extends OpenSearchIntegTestCase {
         );
         indexRandom(
             true,
-            client.prepareIndex("index", "type", "1").setRouting("1").setSource("s", "2016-03-19"),
-            client.prepareIndex("index", "type", "2").setRouting("1").setSource("s", "2016-03-20"),
-            client.prepareIndex("index", "type", "3").setRouting("1").setSource("s", "2016-03-21"),
-            client.prepareIndex("index", "type", "4").setRouting("2").setSource("s", "2016-03-22"),
-            client.prepareIndex("index", "type", "5").setRouting("2").setSource("s", "2016-03-23"),
-            client.prepareIndex("index", "type", "6").setRouting("2").setSource("s", "2016-03-24"),
-            client.prepareIndex("index", "type", "7").setRouting("3").setSource("s", "2016-03-25"),
-            client.prepareIndex("index", "type", "8").setRouting("3").setSource("s", "2016-03-26"),
-            client.prepareIndex("index", "type", "9").setRouting("3").setSource("s", "2016-03-27")
+            client.prepareIndex("index").setId("1").setRouting("1").setSource("s", "2016-03-19"),
+            client.prepareIndex("index").setId("2").setRouting("1").setSource("s", "2016-03-20"),
+            client.prepareIndex("index").setId("3").setRouting("1").setSource("s", "2016-03-21"),
+            client.prepareIndex("index").setId("4").setRouting("2").setSource("s", "2016-03-22"),
+            client.prepareIndex("index").setId("5").setRouting("2").setSource("s", "2016-03-23"),
+            client.prepareIndex("index").setId("6").setRouting("2").setSource("s", "2016-03-24"),
+            client.prepareIndex("index").setId("7").setRouting("3").setSource("s", "2016-03-25"),
+            client.prepareIndex("index").setId("8").setRouting("3").setSource("s", "2016-03-26"),
+            client.prepareIndex("index").setId("9").setRouting("3").setSource("s", "2016-03-27")
         );
         ensureSearchable("index");
         assertCacheState(client, "index", 0, 0);
@@ -219,15 +219,15 @@ public class IndicesRequestCacheIT extends OpenSearchIntegTestCase {
         );
         indexRandom(
             true,
-            client.prepareIndex("index", "type", "1").setSource("s", "2016-03-19"),
-            client.prepareIndex("index", "type", "2").setSource("s", "2016-03-20"),
-            client.prepareIndex("index", "type", "3").setSource("s", "2016-03-21"),
-            client.prepareIndex("index", "type", "4").setSource("s", "2016-03-22"),
-            client.prepareIndex("index", "type", "5").setSource("s", "2016-03-23"),
-            client.prepareIndex("index", "type", "6").setSource("s", "2016-03-24"),
-            client.prepareIndex("index", "type", "7").setSource("other", "value"),
-            client.prepareIndex("index", "type", "8").setSource("s", "2016-03-26"),
-            client.prepareIndex("index", "type", "9").setSource("s", "2016-03-27")
+            client.prepareIndex("index").setId("1").setSource("s", "2016-03-19"),
+            client.prepareIndex("index").setId("2").setSource("s", "2016-03-20"),
+            client.prepareIndex("index").setId("3").setSource("s", "2016-03-21"),
+            client.prepareIndex("index").setId("4").setSource("s", "2016-03-22"),
+            client.prepareIndex("index").setId("5").setSource("s", "2016-03-23"),
+            client.prepareIndex("index").setId("6").setSource("s", "2016-03-24"),
+            client.prepareIndex("index").setId("7").setSource("other", "value"),
+            client.prepareIndex("index").setId("8").setSource("s", "2016-03-26"),
+            client.prepareIndex("index").setId("9").setSource("s", "2016-03-27")
         );
         ensureSearchable("index");
         assertCacheState(client, "index", 0, 0);
@@ -285,15 +285,15 @@ public class IndicesRequestCacheIT extends OpenSearchIntegTestCase {
         );
         indexRandom(
             true,
-            client.prepareIndex("index", "type", "1").setSource("d", "2014-01-01T00:00:00"),
-            client.prepareIndex("index", "type", "2").setSource("d", "2014-02-01T00:00:00"),
-            client.prepareIndex("index", "type", "3").setSource("d", "2014-03-01T00:00:00"),
-            client.prepareIndex("index", "type", "4").setSource("d", "2014-04-01T00:00:00"),
-            client.prepareIndex("index", "type", "5").setSource("d", "2014-05-01T00:00:00"),
-            client.prepareIndex("index", "type", "6").setSource("d", "2014-06-01T00:00:00"),
-            client.prepareIndex("index", "type", "7").setSource("d", "2014-07-01T00:00:00"),
-            client.prepareIndex("index", "type", "8").setSource("d", "2014-08-01T00:00:00"),
-            client.prepareIndex("index", "type", "9").setSource("d", "2014-09-01T00:00:00")
+            client.prepareIndex("index").setId("1").setSource("d", "2014-01-01T00:00:00"),
+            client.prepareIndex("index").setId("2").setSource("d", "2014-02-01T00:00:00"),
+            client.prepareIndex("index").setId("3").setSource("d", "2014-03-01T00:00:00"),
+            client.prepareIndex("index").setId("4").setSource("d", "2014-04-01T00:00:00"),
+            client.prepareIndex("index").setId("5").setSource("d", "2014-05-01T00:00:00"),
+            client.prepareIndex("index").setId("6").setSource("d", "2014-06-01T00:00:00"),
+            client.prepareIndex("index").setId("7").setSource("d", "2014-07-01T00:00:00"),
+            client.prepareIndex("index").setId("8").setSource("d", "2014-08-01T00:00:00"),
+            client.prepareIndex("index").setId("9").setSource("d", "2014-09-01T00:00:00")
         );
         ensureSearchable("index");
         assertCacheState(client, "index", 0, 0);
@@ -352,15 +352,15 @@ public class IndicesRequestCacheIT extends OpenSearchIntegTestCase {
         DateFormatter formatter = DateFormatter.forPattern("strict_date_optional_time");
         indexRandom(
             true,
-            client.prepareIndex("index-1", "type", "1").setSource("d", formatter.format(now)),
-            client.prepareIndex("index-1", "type", "2").setSource("d", formatter.format(now.minusDays(1))),
-            client.prepareIndex("index-1", "type", "3").setSource("d", formatter.format(now.minusDays(2))),
-            client.prepareIndex("index-2", "type", "4").setSource("d", formatter.format(now.minusDays(3))),
-            client.prepareIndex("index-2", "type", "5").setSource("d", formatter.format(now.minusDays(4))),
-            client.prepareIndex("index-2", "type", "6").setSource("d", formatter.format(now.minusDays(5))),
-            client.prepareIndex("index-3", "type", "7").setSource("d", formatter.format(now.minusDays(6))),
-            client.prepareIndex("index-3", "type", "8").setSource("d", formatter.format(now.minusDays(7))),
-            client.prepareIndex("index-3", "type", "9").setSource("d", formatter.format(now.minusDays(8)))
+            client.prepareIndex("index-1").setId("1").setSource("d", formatter.format(now)),
+            client.prepareIndex("index-1").setId("2").setSource("d", formatter.format(now.minusDays(1))),
+            client.prepareIndex("index-1").setId("3").setSource("d", formatter.format(now.minusDays(2))),
+            client.prepareIndex("index-2").setId("4").setSource("d", formatter.format(now.minusDays(3))),
+            client.prepareIndex("index-2").setId("5").setSource("d", formatter.format(now.minusDays(4))),
+            client.prepareIndex("index-2").setId("6").setSource("d", formatter.format(now.minusDays(5))),
+            client.prepareIndex("index-3").setId("7").setSource("d", formatter.format(now.minusDays(6))),
+            client.prepareIndex("index-3").setId("8").setSource("d", formatter.format(now.minusDays(7))),
+            client.prepareIndex("index-3").setId("9").setSource("d", formatter.format(now.minusDays(8)))
         );
         ensureSearchable("index-1", "index-2", "index-3");
         assertCacheState(client, "index-1", 0, 0);
@@ -429,15 +429,15 @@ public class IndicesRequestCacheIT extends OpenSearchIntegTestCase {
         assertAcked(client.admin().indices().prepareCreate("index").addMapping("type", "s", "type=date").setSettings(settings).get());
         indexRandom(
             true,
-            client.prepareIndex("index", "type", "1").setRouting("1").setSource("s", "2016-03-19"),
-            client.prepareIndex("index", "type", "2").setRouting("1").setSource("s", "2016-03-20"),
-            client.prepareIndex("index", "type", "3").setRouting("1").setSource("s", "2016-03-21"),
-            client.prepareIndex("index", "type", "4").setRouting("2").setSource("s", "2016-03-22"),
-            client.prepareIndex("index", "type", "5").setRouting("2").setSource("s", "2016-03-23"),
-            client.prepareIndex("index", "type", "6").setRouting("2").setSource("s", "2016-03-24"),
-            client.prepareIndex("index", "type", "7").setRouting("3").setSource("s", "2016-03-25"),
-            client.prepareIndex("index", "type", "8").setRouting("3").setSource("s", "2016-03-26"),
-            client.prepareIndex("index", "type", "9").setRouting("3").setSource("s", "2016-03-27")
+            client.prepareIndex("index").setId("1").setRouting("1").setSource("s", "2016-03-19"),
+            client.prepareIndex("index").setId("2").setRouting("1").setSource("s", "2016-03-20"),
+            client.prepareIndex("index").setId("3").setRouting("1").setSource("s", "2016-03-21"),
+            client.prepareIndex("index").setId("4").setRouting("2").setSource("s", "2016-03-22"),
+            client.prepareIndex("index").setId("5").setRouting("2").setSource("s", "2016-03-23"),
+            client.prepareIndex("index").setId("6").setRouting("2").setSource("s", "2016-03-24"),
+            client.prepareIndex("index").setId("7").setRouting("3").setSource("s", "2016-03-25"),
+            client.prepareIndex("index").setId("8").setRouting("3").setSource("s", "2016-03-26"),
+            client.prepareIndex("index").setId("9").setRouting("3").setSource("s", "2016-03-27")
         );
         ensureSearchable("index");
         assertCacheState(client, "index", 0, 0);
@@ -535,10 +535,7 @@ public class IndicesRequestCacheIT extends OpenSearchIntegTestCase {
                 .get()
         );
         ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
-        client.prepareIndex("index", "type", "1")
-            .setRouting("1")
-            .setSource("created_at", DateTimeFormatter.ISO_LOCAL_DATE.format(now))
-            .get();
+        client.prepareIndex("index").setId("1").setRouting("1").setSource("created_at", DateTimeFormatter.ISO_LOCAL_DATE.format(now)).get();
         // Force merge the index to ensure there can be no background merges during the subsequent searches that would invalidate the cache
         ForceMergeResponse forceMergeResponse = client.admin().indices().prepareForceMerge("index").setFlush(true).get();
         OpenSearchAssertions.assertAllSuccessful(forceMergeResponse);

--- a/server/src/internalClusterTest/java/org/opensearch/indices/mapping/ConcurrentDynamicTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/mapping/ConcurrentDynamicTemplateIT.java
@@ -80,7 +80,8 @@ public class ConcurrentDynamicTemplateIT extends OpenSearchIntegTestCase {
             for (int j = 0; j < numDocs; j++) {
                 Map<String, Object> source = new HashMap<>();
                 source.put(fieldName, "test-user");
-                client().prepareIndex("test", mappingType, Integer.toString(currentID++))
+                client().prepareIndex("test")
+                    .setId(Integer.toString(currentID++))
                     .setSource(source)
                     .execute(new ActionListener<IndexResponse>() {
                         @Override

--- a/server/src/internalClusterTest/java/org/opensearch/indices/mapping/UpdateMappingIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/mapping/UpdateMappingIntegrationIT.java
@@ -112,7 +112,8 @@ public class UpdateMappingIntegrationIT extends OpenSearchIntegTestCase {
             String type = "type";
             String fieldName = "field_" + type + "_" + rec;
             indexRequests.add(
-                client().prepareIndex("test", type, Integer.toString(rec))
+                client().prepareIndex("test")
+                    .setId(Integer.toString(rec))
                     .setTimeout(TimeValue.timeValueMinutes(5))
                     .setSource(fieldName, "some_value")
             );

--- a/server/src/internalClusterTest/java/org/opensearch/indices/memory/breaker/CircuitBreakerNoopIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/memory/breaker/CircuitBreakerNoopIT.java
@@ -70,7 +70,7 @@ public class CircuitBreakerNoopIT extends OpenSearchIntegTestCase {
         int docCount = scaledRandomIntBetween(300, 1000);
         List<IndexRequestBuilder> reqs = new ArrayList<>();
         for (long id = 0; id < docCount; id++) {
-            reqs.add(client.prepareIndex("cb-test", "type", Long.toString(id)).setSource("test", id));
+            reqs.add(client.prepareIndex("cb-test").setId(Long.toString(id)).setSource("test", id));
         }
         indexRandom(true, reqs);
 
@@ -87,7 +87,7 @@ public class CircuitBreakerNoopIT extends OpenSearchIntegTestCase {
         int docCount = scaledRandomIntBetween(300, 1000);
         List<IndexRequestBuilder> reqs = new ArrayList<>();
         for (long id = 0; id < docCount; id++) {
-            reqs.add(client.prepareIndex("cb-test", "type", Long.toString(id)).setSource("test", id));
+            reqs.add(client.prepareIndex("cb-test").setId(Long.toString(id)).setSource("test", id));
         }
         indexRandom(true, reqs);
 

--- a/server/src/internalClusterTest/java/org/opensearch/indices/memory/breaker/CircuitBreakerServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/memory/breaker/CircuitBreakerServiceIT.java
@@ -154,7 +154,7 @@ public class CircuitBreakerServiceIT extends OpenSearchIntegTestCase {
         int docCount = scaledRandomIntBetween(300, 1000);
         List<IndexRequestBuilder> reqs = new ArrayList<>();
         for (long id = 0; id < docCount; id++) {
-            reqs.add(client.prepareIndex("cb-test", "type", Long.toString(id)).setSource("test", "value" + id));
+            reqs.add(client.prepareIndex("cb-test").setId(Long.toString(id)).setSource("test", "value" + id));
         }
         indexRandom(true, false, true, reqs);
 
@@ -208,7 +208,7 @@ public class CircuitBreakerServiceIT extends OpenSearchIntegTestCase {
         int docCount = scaledRandomIntBetween(300, 1000);
         List<IndexRequestBuilder> reqs = new ArrayList<>();
         for (long id = 0; id < docCount; id++) {
-            reqs.add(client.prepareIndex("ramtest", "type", Long.toString(id)).setSource("test", "value" + id));
+            reqs.add(client.prepareIndex("ramtest").setId(Long.toString(id)).setSource("test", "value" + id));
         }
         indexRandom(true, false, true, reqs);
 
@@ -261,7 +261,7 @@ public class CircuitBreakerServiceIT extends OpenSearchIntegTestCase {
         int docCount = scaledRandomIntBetween(300, 1000);
         List<IndexRequestBuilder> reqs = new ArrayList<>();
         for (long id = 0; id < docCount; id++) {
-            reqs.add(client.prepareIndex("cb-test", "type", Long.toString(id)).setSource("test", id));
+            reqs.add(client.prepareIndex("cb-test").setId(Long.toString(id)).setSource("test", id));
         }
         indexRandom(true, reqs);
 
@@ -295,7 +295,7 @@ public class CircuitBreakerServiceIT extends OpenSearchIntegTestCase {
         int docCount = scaledRandomIntBetween(100, 1000);
         List<IndexRequestBuilder> reqs = new ArrayList<>();
         for (long id = 0; id < docCount; id++) {
-            reqs.add(client.prepareIndex("cb-test", "type", Long.toString(id)).setSource("test", id));
+            reqs.add(client.prepareIndex("cb-test").setId(Long.toString(id)).setSource("test", id));
         }
         indexRandom(true, reqs);
 

--- a/server/src/internalClusterTest/java/org/opensearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
@@ -169,7 +169,8 @@ public class RandomExceptionCircuitBreakerIT extends OpenSearchIntegTestCase {
         }
         for (int i = 0; i < numDocs; i++) {
             try {
-                client().prepareIndex("test", "type", "" + i)
+                client().prepareIndex("test")
+                    .setId("" + i)
                     .setTimeout(TimeValue.timeValueSeconds(1))
                     .setSource("test-str", randomUnicodeOfLengthBetween(5, 25), "test-num", i)
                     .get();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/recovery/IndexPrimaryRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/recovery/IndexPrimaryRelocationIT.java
@@ -71,7 +71,7 @@ public class IndexPrimaryRelocationIT extends OpenSearchIntegTestCase {
             @Override
             public void run() {
                 while (finished.get() == false && numAutoGenDocs.get() < 10_000) {
-                    IndexResponse indexResponse = client().prepareIndex("test", "type", "id").setSource("field", "value").get();
+                    IndexResponse indexResponse = client().prepareIndex("test").setId("id").setSource("field", "value").get();
                     assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
                     DeleteResponse deleteResponse = client().prepareDelete("test", "id").get();
                     assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());

--- a/server/src/internalClusterTest/java/org/opensearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/recovery/IndexRecoveryIT.java
@@ -1442,7 +1442,8 @@ public class IndexRecoveryIT extends OpenSearchIntegTestCase {
             .get();
         int numDocs = between(1, 10);
         for (int i = 0; i < numDocs; i++) {
-            client().prepareIndex("test", "_doc", "u" + i)
+            client().prepareIndex("test")
+                .setId("u" + i)
                 .setSource(singletonMap("test_field", Integer.toString(i)), XContentType.JSON)
                 .get();
         }

--- a/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateNumberOfReplicasIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateNumberOfReplicasIT.java
@@ -80,7 +80,8 @@ public class UpdateNumberOfReplicasIT extends OpenSearchIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.totalNumShards));
 
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i))
+            client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource(jsonBuilder().startObject().field("value", "test" + i).endObject())
                 .get();
         }

--- a/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateSettingsIT.java
@@ -506,11 +506,11 @@ public class UpdateSettingsIT extends OpenSearchIntegTestCase {
 
     public void testEngineGCDeletesSetting() throws Exception {
         createIndex("test");
-        client().prepareIndex("test", "type", "1").setSource("f", 1).setVersionType(VersionType.EXTERNAL).setVersion(1).get();
+        client().prepareIndex("test").setId("1").setSource("f", 1).setVersionType(VersionType.EXTERNAL).setVersion(1).get();
         client().prepareDelete("test", "1").setVersionType(VersionType.EXTERNAL).setVersion(2).get();
         // delete is still in cache this should fail
         assertRequestBuilderThrows(
-            client().prepareIndex("test", "type", "1").setSource("f", 3).setVersionType(VersionType.EXTERNAL).setVersion(1),
+            client().prepareIndex("test").setId("1").setSource("f", 3).setVersionType(VersionType.EXTERNAL).setVersion(1),
             VersionConflictEngineException.class
         );
         assertAcked(client().admin().indices().prepareUpdateSettings("test").setSettings(Settings.builder().put("index.gc_deletes", 0)));
@@ -524,7 +524,7 @@ public class UpdateSettingsIT extends OpenSearchIntegTestCase {
         }
 
         // delete should not be in cache
-        client().prepareIndex("test", "type", "1").setSource("f", 2).setVersionType(VersionType.EXTERNAL).setVersion(1);
+        client().prepareIndex("test").setId("1").setSource("f", 2).setVersionType(VersionType.EXTERNAL).setVersion(1);
     }
 
     public void testUpdateSettingsWithBlocks() {

--- a/server/src/internalClusterTest/java/org/opensearch/indices/state/CloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/state/CloseIndexIT.java
@@ -143,7 +143,7 @@ public class CloseIndexIT extends OpenSearchIntegTestCase {
             false,
             randomBoolean(),
             IntStream.range(0, nbDocs)
-                .mapToObj(i -> client().prepareIndex(indexName, "_doc", String.valueOf(i)).setSource("num", i))
+                .mapToObj(i -> client().prepareIndex(indexName).setId(String.valueOf(i)).setSource("num", i))
                 .collect(toList())
         );
 
@@ -164,7 +164,7 @@ public class CloseIndexIT extends OpenSearchIntegTestCase {
                 false,
                 randomBoolean(),
                 IntStream.range(0, randomIntBetween(1, 10))
-                    .mapToObj(i -> client().prepareIndex(indexName, "_doc", String.valueOf(i)).setSource("num", i))
+                    .mapToObj(i -> client().prepareIndex(indexName).setId(String.valueOf(i)).setSource("num", i))
                     .collect(toList())
             );
         }
@@ -207,7 +207,7 @@ public class CloseIndexIT extends OpenSearchIntegTestCase {
             false,
             randomBoolean(),
             IntStream.range(0, nbDocs)
-                .mapToObj(i -> client().prepareIndex(indexName, "_doc", String.valueOf(i)).setSource("num", i))
+                .mapToObj(i -> client().prepareIndex(indexName).setId(String.valueOf(i)).setSource("num", i))
                 .collect(toList())
         );
         ensureYellowAndNoInitializingShards(indexName);
@@ -268,7 +268,7 @@ public class CloseIndexIT extends OpenSearchIntegTestCase {
                     false,
                     randomBoolean(),
                     IntStream.range(0, 10)
-                        .mapToObj(n -> client().prepareIndex(indexName, "_doc", String.valueOf(n)).setSource("num", n))
+                        .mapToObj(n -> client().prepareIndex(indexName).setId(String.valueOf(n)).setSource("num", n))
                         .collect(toList())
                 );
             }
@@ -395,7 +395,7 @@ public class CloseIndexIT extends OpenSearchIntegTestCase {
             false,
             randomBoolean(),
             IntStream.range(0, nbDocs)
-                .mapToObj(i -> client().prepareIndex(indexName, "_doc", String.valueOf(i)).setSource("num", i))
+                .mapToObj(i -> client().prepareIndex(indexName).setId(String.valueOf(i)).setSource("num", i))
                 .collect(toList())
         );
         ensureGreen(indexName);

--- a/server/src/internalClusterTest/java/org/opensearch/indices/state/OpenCloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/state/OpenCloseIndexIT.java
@@ -320,7 +320,7 @@ public class OpenCloseIndexIT extends OpenSearchIntegTestCase {
         int docs = between(10, 100);
         IndexRequestBuilder[] builder = new IndexRequestBuilder[docs];
         for (int i = 0; i < docs; i++) {
-            builder[i] = client().prepareIndex("test", "type", "" + i).setSource("test", "init");
+            builder[i] = client().prepareIndex("test").setId("" + i).setSource("test", "init");
         }
         indexRandom(true, builder);
         if (randomBoolean()) {
@@ -342,7 +342,7 @@ public class OpenCloseIndexIT extends OpenSearchIntegTestCase {
 
         int docs = between(10, 100);
         for (int i = 0; i < docs; i++) {
-            client().prepareIndex("test", "type", "" + i).setSource("test", "init").execute().actionGet();
+            client().prepareIndex("test").setId("" + i).setSource("test", "init").execute().actionGet();
         }
 
         for (String blockSetting : Arrays.asList(SETTING_BLOCKS_READ, SETTING_BLOCKS_WRITE)) {
@@ -398,7 +398,7 @@ public class OpenCloseIndexIT extends OpenSearchIntegTestCase {
         final int nbDocs = randomIntBetween(0, 50);
         int uncommittedOps = 0;
         for (long i = 0; i < nbDocs; i++) {
-            final IndexResponse indexResponse = client().prepareIndex(indexName, "_doc", Long.toString(i)).setSource("field", i).get();
+            final IndexResponse indexResponse = client().prepareIndex(indexName).setId(Long.toString(i)).setSource("field", i).get();
             assertThat(indexResponse.status(), is(RestStatus.CREATED));
 
             if (rarely()) {

--- a/server/src/internalClusterTest/java/org/opensearch/indices/state/SimpleIndexStateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/state/SimpleIndexStateIT.java
@@ -75,7 +75,7 @@ public class SimpleIndexStateIT extends OpenSearchIntegTestCase {
         );
 
         logger.info("--> indexing a simple document");
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1").get();
 
         logger.info("--> closing test index...");
         assertAcked(client().admin().indices().prepareClose("test"));
@@ -86,7 +86,7 @@ public class SimpleIndexStateIT extends OpenSearchIntegTestCase {
 
         logger.info("--> trying to index into a closed index ...");
         try {
-            client().prepareIndex("test", "type1", "1").setSource("field1", "value1").get();
+            client().prepareIndex("test").setId("1").setSource("field1", "value1").get();
             fail();
         } catch (IndexClosedException e) {
             // all is well
@@ -109,7 +109,7 @@ public class SimpleIndexStateIT extends OpenSearchIntegTestCase {
         );
 
         logger.info("--> indexing a simple document");
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1").get();
     }
 
     public void testFastCloseAfterCreateContinuesCreateAfterOpen() {
@@ -150,7 +150,7 @@ public class SimpleIndexStateIT extends OpenSearchIntegTestCase {
         );
 
         logger.info("--> indexing a simple document");
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1").get();
     }
 
     public void testConsistencyAfterIndexCreationFailure() {

--- a/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
@@ -152,8 +152,8 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
                 .get()
         );
         ensureGreen();
-        client().prepareIndex("test", "type", "1").setSource("field", "value1", "field2", "value1").execute().actionGet();
-        client().prepareIndex("test", "type", "2").setSource("field", "value2", "field2", "value2").execute().actionGet();
+        client().prepareIndex("test").setId("1").setSource("field", "value1", "field2", "value1").execute().actionGet();
+        client().prepareIndex("test").setId("2").setSource("field", "value2", "field2", "value2").execute().actionGet();
         client().admin().indices().prepareRefresh().execute().actionGet();
 
         NodesStatsResponse nodesStats = client().admin().cluster().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
@@ -275,8 +275,8 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
         );
         ensureGreen();
         client().admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
-        client().prepareIndex("test", "type", "1").setSource("field", "value1").execute().actionGet();
-        client().prepareIndex("test", "type", "2").setSource("field", "value2").execute().actionGet();
+        client().prepareIndex("test").setId("1").setSource("field", "value1").execute().actionGet();
+        client().prepareIndex("test").setId("2").setSource("field", "value2").execute().actionGet();
         client().admin().indices().prepareRefresh().execute().actionGet();
 
         NodesStatsResponse nodesStats = client().admin().cluster().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
@@ -385,7 +385,8 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
         while (true) {
             IndexRequestBuilder[] builders = new IndexRequestBuilder[pageDocs];
             for (int i = 0; i < pageDocs; ++i) {
-                builders[i] = client().prepareIndex("idx", "type", Integer.toString(counter++))
+                builders[i] = client().prepareIndex("idx")
+                    .setId(Integer.toString(counter++))
                     .setSource(jsonBuilder().startObject().field("common", "field").field("str_value", "s" + i).endObject());
             }
             indexRandom(true, builders);
@@ -445,7 +446,8 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
         // index the data again...
         IndexRequestBuilder[] builders = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; ++i) {
-            builders[i] = client().prepareIndex("idx", "type", Integer.toString(i))
+            builders[i] = client().prepareIndex("idx")
+                .setId(Integer.toString(i))
                 .setSource(jsonBuilder().startObject().field("common", "field").field("str_value", "s" + i).endObject());
         }
         indexRandom(true, builders);
@@ -577,7 +579,7 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
                 sb.append(termUpto++);
                 sb.append(" some random text that keeps repeating over and over again hambone");
             }
-            client().prepareIndex("test", "type", "" + termUpto).setSource("field" + (i % 10), sb.toString()).get();
+            client().prepareIndex("test").setId("" + termUpto).setSource("field" + (i % 10), sb.toString()).get();
         }
         refresh();
         stats = client().admin().indices().prepareStats().execute().actionGet();
@@ -613,7 +615,7 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
                     sb.append(' ');
                     sb.append(termUpto++);
                 }
-                client().prepareIndex("test", "type", "" + termUpto).setSource("field" + (i % 10), sb.toString()).get();
+                client().prepareIndex("test").setId("" + termUpto).setSource("field" + (i % 10), sb.toString()).get();
                 if (i % 2 == 0) {
                     refresh();
                 }
@@ -639,9 +641,9 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
         createIndex("test1", "test2");
         ensureGreen();
 
-        client().prepareIndex("test1", "type", Integer.toString(1)).setSource("field", "value").execute().actionGet();
-        client().prepareIndex("test1", "type", Integer.toString(2)).setSource("field", "value").execute().actionGet();
-        client().prepareIndex("test2", "type", Integer.toString(1)).setSource("field", "value").execute().actionGet();
+        client().prepareIndex("test1").setId(Integer.toString(1)).setSource("field", "value").execute().actionGet();
+        client().prepareIndex("test1").setId(Integer.toString(2)).setSource("field", "value").execute().actionGet();
+        client().prepareIndex("test2").setId(Integer.toString(1)).setSource("field", "value").execute().actionGet();
         refresh();
 
         NumShards test1 = getNumShards("test1");
@@ -733,7 +735,8 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
 
         // index failed
         try {
-            client().prepareIndex("test1", "type", Integer.toString(1))
+            client().prepareIndex("test1")
+                .setId(Integer.toString(1))
                 .setSource("field", "value")
                 .setVersion(1)
                 .setVersionType(VersionType.EXTERNAL)
@@ -742,7 +745,8 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
             fail("Expected a version conflict");
         } catch (VersionConflictEngineException e) {}
         try {
-            client().prepareIndex("test2", "type", Integer.toString(1))
+            client().prepareIndex("test2")
+                .setId(Integer.toString(1))
                 .setSource("field", "value")
                 .setVersion(1)
                 .setVersionType(VersionType.EXTERNAL)
@@ -751,7 +755,8 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
             fail("Expected a version conflict");
         } catch (VersionConflictEngineException e) {}
         try {
-            client().prepareIndex("test2", "type", Integer.toString(1))
+            client().prepareIndex("test2")
+                .setId(Integer.toString(1))
                 .setSource("field", "value")
                 .setVersion(1)
                 .setVersionType(VersionType.EXTERNAL)
@@ -791,7 +796,7 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
         assertThat(stats.getTotal().getSearch(), nullValue());
 
         for (int i = 0; i < 20; i++) {
-            client().prepareIndex("test_index", "_doc", Integer.toString(i)).setSource("field", "value").execute().actionGet();
+            client().prepareIndex("test_index").setId(Integer.toString(i)).setSource("field", "value").execute().actionGet();
             client().admin().indices().prepareFlush().execute().actionGet();
         }
         client().admin().indices().prepareForceMerge().setMaxNumSegments(1).execute().actionGet();
@@ -837,9 +842,9 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
 
         ensureGreen();
 
-        client().prepareIndex("test_index", "_doc", Integer.toString(1)).setSource("field", "value").execute().actionGet();
-        client().prepareIndex("test_index", "_doc", Integer.toString(2)).setSource("field", "value").execute().actionGet();
-        client().prepareIndex("test_index_2", "type", Integer.toString(1)).setSource("field", "value").execute().actionGet();
+        client().prepareIndex("test_index").setId(Integer.toString(1)).setSource("field", "value").execute().actionGet();
+        client().prepareIndex("test_index").setId(Integer.toString(2)).setSource("field", "value").execute().actionGet();
+        client().prepareIndex("test_index_2").setId(Integer.toString(1)).setSource("field", "value").execute().actionGet();
 
         client().admin().indices().prepareRefresh().execute().actionGet();
         IndicesStatsRequestBuilder builder = client().admin().indices().prepareStats();
@@ -964,9 +969,9 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
 
         ensureGreen();
 
-        client().prepareIndex("test1", "_doc", Integer.toString(1)).setSource("field", "value").execute().actionGet();
-        client().prepareIndex("test1", "_doc", Integer.toString(2)).setSource("field", "value").execute().actionGet();
-        client().prepareIndex("test2", "_doc", Integer.toString(1)).setSource("field", "value").execute().actionGet();
+        client().prepareIndex("test1").setId(Integer.toString(1)).setSource("field", "value").execute().actionGet();
+        client().prepareIndex("test1").setId(Integer.toString(2)).setSource("field", "value").execute().actionGet();
+        client().prepareIndex("test2").setId(Integer.toString(1)).setSource("field", "value").execute().actionGet();
         refresh();
 
         int numShards1 = getNumShards("test1").totalNumShards;
@@ -1008,7 +1013,7 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
         );
         ensureGreen();
 
-        client().prepareIndex("test1", "_doc", Integer.toString(1)).setSource("{\"bar\":\"bar\",\"baz\":\"baz\"}", XContentType.JSON).get();
+        client().prepareIndex("test1").setId(Integer.toString(1)).setSource("{\"bar\":\"bar\",\"baz\":\"baz\"}", XContentType.JSON).get();
         refresh();
 
         IndicesStatsRequestBuilder builder = client().admin().indices().prepareStats();
@@ -1050,7 +1055,7 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
 
         ensureGreen();
 
-        client().prepareIndex("test1", "bar", Integer.toString(1)).setSource("foo", "bar").execute().actionGet();
+        client().prepareIndex("test1").setId(Integer.toString(1)).setSource("foo", "bar").execute().actionGet();
         refresh();
 
         client().prepareSearch("_all").setStats("bar", "baz").execute().actionGet();
@@ -1210,8 +1215,8 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
         indexRandom(
             false,
             true,
-            client().prepareIndex("index", "type", "1").setSource("foo", "bar"),
-            client().prepareIndex("index", "type", "2").setSource("foo", "baz")
+            client().prepareIndex("index").setId("1").setSource("foo", "bar"),
+            client().prepareIndex("index").setId("2").setSource("foo", "baz")
         );
         persistGlobalCheckpoint("index"); // Need to persist the global checkpoint for the soft-deletes retention MP.
         refresh();
@@ -1285,8 +1290,8 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("index", "type", "1").setSource("foo", "bar"),
-            client().prepareIndex("index", "type", "2").setSource("foo", "baz")
+            client().prepareIndex("index").setId("1").setSource("foo", "bar"),
+            client().prepareIndex("index").setId("2").setSource("foo", "baz")
         );
 
         assertBusy(() -> {
@@ -1353,7 +1358,7 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
                 }
                 while (!stop.get()) {
                     final String id = Integer.toString(idGenerator.incrementAndGet());
-                    final IndexResponse response = client().prepareIndex("test", "type", id).setSource("{}", XContentType.JSON).get();
+                    final IndexResponse response = client().prepareIndex("test").setId(id).setSource("{}", XContentType.JSON).get();
                     assertThat(response.getResult(), equalTo(DocWriteResponse.Result.CREATED));
                 }
             });

--- a/server/src/internalClusterTest/java/org/opensearch/indices/template/SimpleIndexTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/template/SimpleIndexTemplateIT.java
@@ -182,10 +182,7 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
         assertThat(response.getIndexTemplates(), hasSize(2));
 
         // index something into test_index, will match on both templates
-        client().prepareIndex("test_index", "type1", "1")
-            .setSource("field1", "value1", "field2", "value 2")
-            .setRefreshPolicy(IMMEDIATE)
-            .get();
+        client().prepareIndex("test_index").setId("1").setSource("field1", "value1", "field2", "value 2").setRefreshPolicy(IMMEDIATE).get();
 
         ensureGreen();
         SearchResponse searchResponse = client().prepareSearch("test_index")
@@ -200,10 +197,7 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
         // field2 is not stored.
         assertThat(searchResponse.getHits().getAt(0).field("field2"), nullValue());
 
-        client().prepareIndex("text_index", "type1", "1")
-            .setSource("field1", "value1", "field2", "value 2")
-            .setRefreshPolicy(IMMEDIATE)
-            .get();
+        client().prepareIndex("text_index").setId("1").setSource("field1", "value1", "field2", "value 2").setRefreshPolicy(IMMEDIATE).get();
 
         ensureGreen();
         // now only match on one template (template_1)
@@ -570,11 +564,11 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test_index"));
         ensureGreen();
 
-        client().prepareIndex("test_index", "_doc", "1").setSource("type", "type1", "field", "A value").get();
-        client().prepareIndex("test_index", "_doc", "2").setSource("type", "type2", "field", "B value").get();
-        client().prepareIndex("test_index", "_doc", "3").setSource("type", "typeX", "field", "C value").get();
-        client().prepareIndex("test_index", "_doc", "4").setSource("type", "typeY", "field", "D value").get();
-        client().prepareIndex("test_index", "_doc", "5").setSource("type", "typeZ", "field", "E value").get();
+        client().prepareIndex("test_index").setId("1").setSource("type", "type1", "field", "A value").get();
+        client().prepareIndex("test_index").setId("2").setSource("type", "type2", "field", "B value").get();
+        client().prepareIndex("test_index").setId("3").setSource("type", "typeX", "field", "C value").get();
+        client().prepareIndex("test_index").setId("4").setSource("type", "typeY", "field", "D value").get();
+        client().prepareIndex("test_index").setId("5").setSource("type", "typeZ", "field", "E value").get();
 
         GetAliasesResponse getAliasesResponse = client().admin().indices().prepareGetAliases().setIndices("test_index").get();
         assertThat(getAliasesResponse.getAliases().size(), equalTo(1));
@@ -637,8 +631,8 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
         assertThat(getAliasesResponse.getAliases().size(), equalTo(1));
         assertThat(getAliasesResponse.getAliases().get("test_index").size(), equalTo(1));
 
-        client().prepareIndex("test_index", "_doc", "1").setSource("field", "value1").get();
-        client().prepareIndex("test_index", "_doc", "2").setSource("field", "value2").get();
+        client().prepareIndex("test_index").setId("1").setSource("field", "value1").get();
+        client().prepareIndex("test_index").setId("2").setSource("field", "value2").get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch("test_index").get();
@@ -676,8 +670,8 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
         assertThat(getAliasesResponse.getAliases().size(), equalTo(1));
         assertThat(getAliasesResponse.getAliases().get("test_index").size(), equalTo(3));
 
-        client().prepareIndex("test_index", "_doc", "1").setSource("field", "value1").get();
-        client().prepareIndex("test_index", "_doc", "2").setSource("field", "value2").get();
+        client().prepareIndex("test_index").setId("1").setSource("field", "value1").get();
+        client().prepareIndex("test_index").setId("2").setSource("field", "value2").get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch("test_index").get();
@@ -838,7 +832,7 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
             .addAlias(new Alias("alias4").filter(termQuery("field", "value")))
             .get();
 
-        client().prepareIndex("a1", "test", "test").setSource("{}", XContentType.JSON).get();
+        client().prepareIndex("a1").setId("test").setSource("{}", XContentType.JSON).get();
         BulkResponse response = client().prepareBulk().add(new IndexRequest("a2").id("test").source("{}", XContentType.JSON)).get();
         assertThat(response.hasFailures(), is(false));
         assertThat(response.getItems()[0].isFailed(), equalTo(false));
@@ -854,7 +848,7 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
         // So the aliases defined in the index template for this index will not fail
         // even though the fields in the alias fields don't exist yet and indexing into
         // an index that doesn't exist yet will succeed
-        client().prepareIndex("b1", "test", "test").setSource("{}", XContentType.JSON).get();
+        client().prepareIndex("b1").setId("test").setSource("{}", XContentType.JSON).get();
 
         response = client().prepareBulk().add(new IndexRequest("b2").id("test").source("{}", XContentType.JSON)).get();
         assertThat(response.hasFailures(), is(false));
@@ -972,9 +966,9 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
             )
             .get();
 
-        client().prepareIndex("ax", "type1", "1").setSource("field1", "value1", "field2", "value2").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("ax").setId("1").setSource("field1", "value1", "field2", "value2").setRefreshPolicy(IMMEDIATE).get();
 
-        client().prepareIndex("bx", "type1", "1").setSource("field1", "value1", "field2", "value2").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("bx").setId("1").setSource("field1", "value1", "field2", "value2").setRefreshPolicy(IMMEDIATE).get();
 
         ensureGreen();
 

--- a/server/src/internalClusterTest/java/org/opensearch/ingest/IngestClientIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/ingest/IngestClientIT.java
@@ -256,14 +256,14 @@ public class IngestClientIT extends OpenSearchIntegTestCase {
         assertThat(getResponse.pipelines().size(), equalTo(1));
         assertThat(getResponse.pipelines().get(0).getId(), equalTo("_id"));
 
-        client().prepareIndex("test", "type", "1").setPipeline("_id").setSource("field", "value", "fail", false).get();
+        client().prepareIndex("test").setId("1").setPipeline("_id").setSource("field", "value", "fail", false).get();
 
         Map<String, Object> doc = client().prepareGet("test", "1").get().getSourceAsMap();
         assertThat(doc.get("field"), equalTo("value"));
         assertThat(doc.get("processed"), equalTo(true));
 
         client().prepareBulk()
-            .add(client().prepareIndex("test", "type", "2").setSource("field", "value2", "fail", false).setPipeline("_id"))
+            .add(client().prepareIndex("test").setId("2").setSource("field", "value2", "fail", false).setPipeline("_id"))
             .get();
         doc = client().prepareGet("test", "2").get().getSourceAsMap();
         assertThat(doc.get("field"), equalTo("value2"));

--- a/server/src/internalClusterTest/java/org/opensearch/mget/SimpleMgetIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/mget/SimpleMgetIT.java
@@ -62,7 +62,8 @@ public class SimpleMgetIT extends OpenSearchIntegTestCase {
     public void testThatMgetShouldWorkWithOneIndexMissing() throws IOException {
         createIndex("test");
 
-        client().prepareIndex("test", "test", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("foo", "bar").endObject())
             .setRefreshPolicy(IMMEDIATE)
             .get();
@@ -99,7 +100,8 @@ public class SimpleMgetIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test").addAlias(new Alias("multiIndexAlias")));
         assertAcked(prepareCreate("test2").addAlias(new Alias("multiIndexAlias")));
 
-        client().prepareIndex("test", "test", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("foo", "bar").endObject())
             .setRefreshPolicy(IMMEDIATE)
             .get();
@@ -139,7 +141,8 @@ public class SimpleMgetIT extends OpenSearchIntegTestCase {
                 )
         );
 
-        client().prepareIndex("alias1", "test", "1")
+        client().prepareIndex("alias1")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("foo", "bar").endObject())
             .setRefreshPolicy(IMMEDIATE)
             .get();
@@ -165,7 +168,7 @@ public class SimpleMgetIT extends OpenSearchIntegTestCase {
                 .endObject()
         );
         for (int i = 0; i < 100; i++) {
-            client().prepareIndex("test", "type", Integer.toString(i)).setSource(sourceBytesRef, XContentType.JSON).get();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource(sourceBytesRef, XContentType.JSON).get();
         }
 
         MultiGetRequestBuilder request = client().prepareMultiGet();
@@ -212,7 +215,8 @@ public class SimpleMgetIT extends OpenSearchIntegTestCase {
         final String id = routingKeyForShard("test", 0);
         final String routingOtherShard = routingKeyForShard("test", 1);
 
-        client().prepareIndex("test", "test", id)
+        client().prepareIndex("test")
+            .setId(id)
             .setRefreshPolicy(IMMEDIATE)
             .setRouting(routingOtherShard)
             .setSource(jsonBuilder().startObject().field("foo", "bar").endObject())

--- a/server/src/internalClusterTest/java/org/opensearch/recovery/FullRollingRestartIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/recovery/FullRollingRestartIT.java
@@ -73,14 +73,16 @@ public class FullRollingRestartIT extends OpenSearchIntegTestCase {
         final String healthTimeout = "1m";
 
         for (int i = 0; i < 1000; i++) {
-            client().prepareIndex("test", "type1", Long.toString(i))
+            client().prepareIndex("test")
+                .setId(Long.toString(i))
                 .setSource(MapBuilder.<String, Object>newMapBuilder().put("test", "value" + i).map())
                 .execute()
                 .actionGet();
         }
         flush();
         for (int i = 1000; i < 2000; i++) {
-            client().prepareIndex("test", "type1", Long.toString(i))
+            client().prepareIndex("test")
+                .setId(Long.toString(i))
                 .setSource(MapBuilder.<String, Object>newMapBuilder().put("test", "value" + i).map())
                 .execute()
                 .actionGet();
@@ -210,7 +212,8 @@ public class FullRollingRestartIT extends OpenSearchIntegTestCase {
         ).get();
 
         for (int i = 0; i < 100; i++) {
-            client().prepareIndex("test", "type1", Long.toString(i))
+            client().prepareIndex("test")
+                .setId(Long.toString(i))
                 .setSource(MapBuilder.<String, Object>newMapBuilder().put("test", "value" + i).map())
                 .execute()
                 .actionGet();

--- a/server/src/internalClusterTest/java/org/opensearch/recovery/RelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/recovery/RelocationIT.java
@@ -150,13 +150,13 @@ public class RelocationIT extends OpenSearchIntegTestCase {
 
         logger.info("--> index 10 docs");
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test", "type", Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
         }
         logger.info("--> flush so we have an actual index");
         client().admin().indices().prepareFlush().execute().actionGet();
         logger.info("--> index more docs so we have something in the translog");
         for (int i = 10; i < 20; i++) {
-            client().prepareIndex("test", "type", Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
         }
 
         logger.info("--> verifying count");
@@ -560,7 +560,7 @@ public class RelocationIT extends OpenSearchIntegTestCase {
         for (int i = 0; i < numDocs; i++) {
             String id = randomRealisticUnicodeOfLength(10) + String.valueOf(i);
             ids.add(id);
-            docs[i] = client().prepareIndex("test", "type1", id).setSource("field1", English.intToEnglish(i));
+            docs[i] = client().prepareIndex("test").setId(id).setSource("field1", English.intToEnglish(i));
         }
         indexRandom(true, docs);
         SearchResponse countResponse = client().prepareSearch("test").get();
@@ -578,7 +578,7 @@ public class RelocationIT extends OpenSearchIntegTestCase {
         for (int i = 0; i < numDocs; i++) {
             String id = randomRealisticUnicodeOfLength(10) + String.valueOf(numDocs + i);
             ids.add(id);
-            docs[i] = client().prepareIndex("test", "type1", id).setSource("field1", English.intToEnglish(numDocs + i));
+            docs[i] = client().prepareIndex("test").setId(id).setSource("field1", English.intToEnglish(numDocs + i));
         }
         indexRandom(true, docs);
 
@@ -614,13 +614,14 @@ public class RelocationIT extends OpenSearchIntegTestCase {
 
         logger.info("--> index 10 docs");
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test", "type", Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
         }
         logger.info("--> flush so we have an actual index");
         client().admin().indices().prepareFlush().execute().actionGet();
         logger.info("--> index more docs so we have something in the translog");
         for (int i = 10; i < 20; i++) {
-            client().prepareIndex("test", "type", Integer.toString(i))
+            client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL)
                 .setSource("field", "value" + i)
                 .execute();
@@ -671,7 +672,7 @@ public class RelocationIT extends OpenSearchIntegTestCase {
 
         logger.info("--> index 10 docs");
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test", "type", Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
         }
         logger.info("--> flush so we have an actual index");
         client().admin().indices().prepareFlush().execute().actionGet();
@@ -679,7 +680,8 @@ public class RelocationIT extends OpenSearchIntegTestCase {
         final List<ActionFuture<IndexResponse>> pendingIndexResponses = new ArrayList<>();
         for (int i = 10; i < 20; i++) {
             pendingIndexResponses.add(
-                client().prepareIndex("test", "type", Integer.toString(i))
+                client().prepareIndex("test")
+                    .setId(Integer.toString(i))
                     .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL)
                     .setSource("field", "value" + i)
                     .execute()
@@ -706,7 +708,8 @@ public class RelocationIT extends OpenSearchIntegTestCase {
         logger.info("--> index 100 docs while relocating");
         for (int i = 20; i < 120; i++) {
             pendingIndexResponses.add(
-                client().prepareIndex("test", "type", Integer.toString(i))
+                client().prepareIndex("test")
+                    .setId(Integer.toString(i))
                     .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL)
                     .setSource("field", "value" + i)
                     .execute()

--- a/server/src/internalClusterTest/java/org/opensearch/recovery/TruncatedRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/recovery/TruncatedRecoveryIT.java
@@ -122,7 +122,7 @@ public class TruncatedRecoveryIT extends OpenSearchIntegTestCase {
         List<IndexRequestBuilder> builder = new ArrayList<>();
         for (int i = 0; i < numDocs; i++) {
             String id = Integer.toString(i);
-            builder.add(client().prepareIndex("test", "type1", id).setSource("field1", English.intToEnglish(i), "the_id", id));
+            builder.add(client().prepareIndex("test").setId(id).setSource("field1", English.intToEnglish(i), "the_id", id));
         }
         indexRandom(true, builder);
         for (int i = 0; i < numDocs; i++) {

--- a/server/src/internalClusterTest/java/org/opensearch/routing/AliasResolveRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/routing/AliasResolveRoutingIT.java
@@ -61,9 +61,9 @@ public class AliasResolveRoutingIT extends OpenSearchIntegTestCase {
         client().admin().indices().prepareClose("test-1").get();
         indexRandom(
             true,
-            client().prepareIndex("test-0", "type1", "1").setSource("field1", "the quick brown fox jumps"),
-            client().prepareIndex("test-0", "type1", "2").setSource("field1", "quick brown"),
-            client().prepareIndex("test-0", "type1", "3").setSource("field1", "quick")
+            client().prepareIndex("test-0").setId("1").setSource("field1", "the quick brown fox jumps"),
+            client().prepareIndex("test-0").setId("2").setSource("field1", "quick brown"),
+            client().prepareIndex("test-0").setId("3").setSource("field1", "quick")
         );
         refresh("test-*");
         assertHitCount(

--- a/server/src/internalClusterTest/java/org/opensearch/routing/AliasRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/routing/AliasRoutingIT.java
@@ -63,7 +63,7 @@ public class AliasRoutingIT extends OpenSearchIntegTestCase {
         assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index("test").alias("alias0").routing("0")));
 
         logger.info("--> indexing with id [1], and routing [0] using alias");
-        client().prepareIndex("alias0", "type1", "1").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("alias0").setId("1").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
         logger.info("--> verifying get with no routing, should not find anything");
         for (int i = 0; i < 5; i++) {
             assertThat(client().prepareGet("test", "1").execute().actionGet().isExists(), equalTo(false));
@@ -109,7 +109,7 @@ public class AliasRoutingIT extends OpenSearchIntegTestCase {
         }
 
         logger.info("--> indexing with id [1], and routing [0] using alias");
-        client().prepareIndex("alias0", "type1", "1").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("alias0").setId("1").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
         logger.info("--> verifying get with no routing, should not find anything");
         for (int i = 0; i < 5; i++) {
             assertThat(client().prepareGet("test", "1").execute().actionGet().isExists(), equalTo(false));
@@ -134,7 +134,7 @@ public class AliasRoutingIT extends OpenSearchIntegTestCase {
         );
 
         logger.info("--> indexing with id [1], and routing [0] using alias");
-        client().prepareIndex("alias0", "type1", "1").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("alias0").setId("1").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
         logger.info("--> verifying get with no routing, should not find anything");
         for (int i = 0; i < 5; i++) {
             assertThat(client().prepareGet("test", "1").execute().actionGet().isExists(), equalTo(false));
@@ -245,7 +245,7 @@ public class AliasRoutingIT extends OpenSearchIntegTestCase {
         }
 
         logger.info("--> indexing with id [2], and routing [1] using alias");
-        client().prepareIndex("alias1", "type1", "2").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("alias1").setId("2").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
 
         logger.info("--> search with no routing, should fine two");
         for (int i = 0; i < 5; i++) {
@@ -491,7 +491,7 @@ public class AliasRoutingIT extends OpenSearchIntegTestCase {
         );
         ensureGreen(); // wait for events again to make sure we got the aliases on all nodes
         logger.info("--> indexing with id [1], and routing [0] using alias to test-a");
-        client().prepareIndex("alias-a0", "type1", "1").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("alias-a0").setId("1").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
         logger.info("--> verifying get with no routing, should not find anything");
         for (int i = 0; i < 5; i++) {
             assertThat(client().prepareGet("test-a", "1").execute().actionGet().isExists(), equalTo(false));
@@ -502,7 +502,7 @@ public class AliasRoutingIT extends OpenSearchIntegTestCase {
         }
 
         logger.info("--> indexing with id [0], and routing [1] using alias to test-b");
-        client().prepareIndex("alias-b1", "type1", "1").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("alias-b1").setId("1").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
         logger.info("--> verifying get with no routing, should not find anything");
         for (int i = 0; i < 5; i++) {
             assertThat(client().prepareGet("test-a", "1").execute().actionGet().isExists(), equalTo(false));
@@ -594,9 +594,9 @@ public class AliasRoutingIT extends OpenSearchIntegTestCase {
         assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index("index").alias("index_1").routing("1")));
 
         logger.info("--> indexing on index_1 which is an alias for index with routing [1]");
-        client().prepareIndex("index_1", "type1", "1").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("index_1").setId("1").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
         logger.info("--> indexing on index_2 which is a concrete index");
-        client().prepareIndex("index_2", "type2", "2").setSource("field", "value2").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("index_2").setId("2").setSource("field", "value2").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
 
         logger.info("--> search all on index_* should find two");
         for (int i = 0; i < 5; i++) {
@@ -625,9 +625,9 @@ public class AliasRoutingIT extends OpenSearchIntegTestCase {
         assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index("index").alias("index_1").routing("1")));
 
         logger.info("--> indexing on index_1 which is an alias for index with routing [1]");
-        client().prepareIndex("index_1", "type1", "1").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("index_1").setId("1").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
         logger.info("--> indexing on index_2 which is a concrete index");
-        client().prepareIndex("index_2", "type2", "2").setSource("field", "value2").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("index_2").setId("2").setSource("field", "value2").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
 
         SearchResponse searchResponse = client().prepareSearch("index_*")
             .setSearchType(SearchType.QUERY_THEN_FETCH)
@@ -650,7 +650,7 @@ public class AliasRoutingIT extends OpenSearchIntegTestCase {
         assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index("test").alias("alias").routing("3")));
 
         logger.info("--> indexing with id [0], and routing [3]");
-        client().prepareIndex("alias", "type1", "0").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("alias").setId("0").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
         logger.info("--> verifying get with no routing, should not find anything");
 
         logger.info("--> verifying get and search with routing, should find");
@@ -712,7 +712,7 @@ public class AliasRoutingIT extends OpenSearchIntegTestCase {
         );
 
         logger.info("--> indexing with id [1], and routing [4]");
-        client().prepareIndex("alias", "type1", "1").setSource("field", "value2").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("alias").setId("1").setSource("field", "value2").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
         logger.info("--> verifying get with no routing, should not find anything");
 
         logger.info("--> verifying get and search with routing, should find");

--- a/server/src/internalClusterTest/java/org/opensearch/routing/PartitionedRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/routing/PartitionedRoutingIT.java
@@ -249,7 +249,7 @@ public class PartitionedRoutingIT extends OpenSearchIntegTestCase {
                 String id = routingValue + "_" + String.valueOf(k);
                 routingToDocumentIds.get(routingValue).add(id);
 
-                client().prepareIndex(index, "type", id).setRouting(routingValue).setSource("foo", "bar").get();
+                client().prepareIndex(index).setId(id).setRouting(routingValue).setSource("foo", "bar").get();
             }
         }
 

--- a/server/src/internalClusterTest/java/org/opensearch/routing/SimpleRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/routing/SimpleRoutingIT.java
@@ -93,7 +93,8 @@ public class SimpleRoutingIT extends OpenSearchIntegTestCase {
         ensureGreen();
         String routingValue = findNonMatchingRoutingValue("test", "1");
         logger.info("--> indexing with id [1], and routing [{}]", routingValue);
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setRouting(routingValue)
             .setSource("field", "value1")
             .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
@@ -122,7 +123,8 @@ public class SimpleRoutingIT extends OpenSearchIntegTestCase {
         }
 
         logger.info("--> indexing with id [1], and routing [0]");
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setRouting(routingValue)
             .setSource("field", "value1")
             .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
@@ -143,7 +145,8 @@ public class SimpleRoutingIT extends OpenSearchIntegTestCase {
         String routingValue = findNonMatchingRoutingValue("test", "1");
 
         logger.info("--> indexing with id [1], and routing [{}]", routingValue);
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setRouting(routingValue)
             .setSource("field", "value1")
             .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
@@ -217,7 +220,8 @@ public class SimpleRoutingIT extends OpenSearchIntegTestCase {
 
         String secondRoutingValue = "1";
         logger.info("--> indexing with id [{}], and routing [{}]", routingValue, secondRoutingValue);
-        client().prepareIndex("test", "type1", routingValue)
+        client().prepareIndex("test")
+            .setId(routingValue)
             .setRouting(secondRoutingValue)
             .setSource("field", "value1")
             .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
@@ -364,7 +368,8 @@ public class SimpleRoutingIT extends OpenSearchIntegTestCase {
         String routingValue = findNonMatchingRoutingValue("test", "1");
 
         logger.info("--> indexing with id [1], and routing [{}]", routingValue);
-        client().prepareIndex(indexOrAlias(), "type1", "1")
+        client().prepareIndex(indexOrAlias())
+            .setId("1")
             .setRouting(routingValue)
             .setSource("field", "value1")
             .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
@@ -373,7 +378,7 @@ public class SimpleRoutingIT extends OpenSearchIntegTestCase {
 
         logger.info("--> indexing with id [1], with no routing, should fail");
         try {
-            client().prepareIndex(indexOrAlias(), "type1", "1").setSource("field", "value1").get();
+            client().prepareIndex(indexOrAlias()).setId("1").setSource("field", "value1").get();
             fail("index with missing routing when routing is required should fail");
         } catch (OpenSearchException e) {
             assertThat(e.unwrapCause(), instanceOf(RoutingMissingException.class));
@@ -555,9 +560,10 @@ public class SimpleRoutingIT extends OpenSearchIntegTestCase {
         ensureGreen();
         String routingValue = findNonMatchingRoutingValue("test", "1");
         logger.info("--> indexing with id [1], and routing [{}]", routingValue);
-        client().prepareIndex(indexOrAlias(), "type1", "1").setRouting(routingValue).setSource("field", "value1").get();
+        client().prepareIndex(indexOrAlias()).setId("1").setRouting(routingValue).setSource("field", "value1").get();
         logger.info("--> indexing with id [2], and routing [{}]", routingValue);
-        client().prepareIndex(indexOrAlias(), "type1", "2")
+        client().prepareIndex(indexOrAlias())
+            .setId("2")
             .setRouting(routingValue)
             .setSource("field", "value2")
             .setRefreshPolicy(RefreshPolicy.IMMEDIATE)

--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
@@ -113,7 +113,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             // Make sure we have a few segments
             BulkRequestBuilder bulkRequestBuilder = client().prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
             for (int j = 0; j < 20; j++) {
-                bulkRequestBuilder.add(client().prepareIndex("test", "type", Integer.toString(i * 5 + j)).setSource("field", "value"));
+                bulkRequestBuilder.add(client().prepareIndex("test").setId(Integer.toString(i * 5 + j)).setSource("field", "value"));
             }
             assertNoFailures(bulkRequestBuilder.get());
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchTimeoutIT.java
@@ -68,7 +68,7 @@ public class SearchTimeoutIT extends OpenSearchIntegTestCase {
 
     public void testSimpleTimeout() throws Exception {
         for (int i = 0; i < 32; i++) {
-            client().prepareIndex("test", "type", Integer.toString(i)).setSource("field", "value").get();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value").get();
         }
         refresh("test");
 
@@ -81,7 +81,7 @@ public class SearchTimeoutIT extends OpenSearchIntegTestCase {
     }
 
     public void testPartialResultsIntolerantTimeout() throws Exception {
-        client().prepareIndex("test", "type", "1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
 
         OpenSearchException ex = expectThrows(
             OpenSearchException.class,

--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchWithRejectionsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchWithRejectionsIT.java
@@ -61,7 +61,7 @@ public class SearchWithRejectionsIT extends OpenSearchIntegTestCase {
         ensureGreen("test");
         final int docs = scaledRandomIntBetween(20, 50);
         for (int i = 0; i < docs; i++) {
-            client().prepareIndex("test", "type", Integer.toString(i)).setSource("field", "value").get();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value").get();
         }
         IndicesStatsResponse indicesStats = client().admin().indices().prepareStats().get();
         assertThat(indicesStats.getTotal().getSearch().getOpenContexts(), equalTo(0L));

--- a/server/src/internalClusterTest/java/org/opensearch/search/StressSearchServiceReaperIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/StressSearchServiceReaperIT.java
@@ -63,7 +63,7 @@ public class StressSearchServiceReaperIT extends OpenSearchIntegTestCase {
         int num = randomIntBetween(100, 150);
         IndexRequestBuilder[] builders = new IndexRequestBuilder[num];
         for (int i = 0; i < builders.length; i++) {
-            builders[i] = client().prepareIndex("test", "type", "" + i).setSource("f", English.intToEnglish(i));
+            builders[i] = client().prepareIndex("test").setId("" + i).setSource("f", English.intToEnglish(i));
         }
         createIndex("test");
         indexRandom(true, builders);

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/EquivalenceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/EquivalenceIT.java
@@ -439,7 +439,7 @@ public class EquivalenceIT extends OpenSearchIntegTestCase {
         logger.info("Indexing [{}] docs", numDocs);
         List<IndexRequestBuilder> indexingRequests = new ArrayList<>();
         for (int i = 0; i < numDocs; ++i) {
-            indexingRequests.add(client().prepareIndex("idx", "type", Integer.toString(i)).setSource("double_value", randomDouble()));
+            indexingRequests.add(client().prepareIndex("idx").setId(Integer.toString(i)).setSource("double_value", randomDouble()));
         }
         indexRandom(true, indexingRequests);
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/FiltersAggsRewriteIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/FiltersAggsRewriteIT.java
@@ -52,9 +52,9 @@ public class FiltersAggsRewriteIT extends OpenSearchSingleNodeTestCase {
 
     public void testWrapperQueryIsRewritten() throws IOException {
         createIndex("test", Settings.EMPTY, "test", "title", "type=text");
-        client().prepareIndex("test", "test", "1").setSource("title", "foo bar baz").get();
-        client().prepareIndex("test", "test", "2").setSource("title", "foo foo foo").get();
-        client().prepareIndex("test", "test", "3").setSource("title", "bar baz bax").get();
+        client().prepareIndex("test").setId("1").setSource("title", "foo bar baz").get();
+        client().prepareIndex("test").setId("2").setSource("title", "foo foo foo").get();
+        client().prepareIndex("test").setId("3").setSource("title", "bar baz bax").get();
         client().admin().indices().prepareRefresh("test").get();
 
         XContentType xContentType = randomFrom(XContentType.values());

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/MissingValueIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/MissingValueIT.java
@@ -72,8 +72,9 @@ public class MissingValueIT extends OpenSearchIntegTestCase {
         );
         indexRandom(
             true,
-            client().prepareIndex("idx", "type", "1").setSource(),
-            client().prepareIndex("idx", "type", "2")
+            client().prepareIndex("idx").setId("1").setSource(),
+            client().prepareIndex("idx")
+                .setId("2")
                 .setSource("str", "foo", "long", 3L, "double", 5.5, "date", "2015-05-07", "location", "1,2")
         );
     }

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/AdjacencyMatrixIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/AdjacencyMatrixIT.java
@@ -92,19 +92,19 @@ public class AdjacencyMatrixIT extends OpenSearchIntegTestCase {
         for (int i = 0; i < numTag1Docs; i++) {
             numSingleTag1Docs++;
             XContentBuilder source = jsonBuilder().startObject().field("value", i + 1).field("tag", "tag1").endObject();
-            builders.add(client().prepareIndex("idx", "type", "" + i).setSource(source));
+            builders.add(client().prepareIndex("idx").setId("" + i).setSource(source));
             if (randomBoolean()) {
                 // randomly index the document twice so that we have deleted
                 // docs that match the filter
-                builders.add(client().prepareIndex("idx", "type", "" + i).setSource(source));
+                builders.add(client().prepareIndex("idx").setId("" + i).setSource(source));
             }
         }
         for (int i = numTag1Docs; i < (numTag1Docs + numTag2Docs); i++) {
             numSingleTag2Docs++;
             XContentBuilder source = jsonBuilder().startObject().field("value", i + 1).field("tag", "tag2").endObject();
-            builders.add(client().prepareIndex("idx", "type", "" + i).setSource(source));
+            builders.add(client().prepareIndex("idx").setId("" + i).setSource(source));
             if (randomBoolean()) {
-                builders.add(client().prepareIndex("idx", "type", "" + i).setSource(source));
+                builders.add(client().prepareIndex("idx").setId("" + i).setSource(source));
             }
         }
         for (int i = numTag1Docs + numTag2Docs; i < numDocs; i++) {
@@ -112,15 +112,16 @@ public class AdjacencyMatrixIT extends OpenSearchIntegTestCase {
             numTag1Docs++;
             numTag2Docs++;
             XContentBuilder source = jsonBuilder().startObject().field("value", i + 1).array("tag", "tag1", "tag2").endObject();
-            builders.add(client().prepareIndex("idx", "type", "" + i).setSource(source));
+            builders.add(client().prepareIndex("idx").setId("" + i).setSource(source));
             if (randomBoolean()) {
-                builders.add(client().prepareIndex("idx", "type", "" + i).setSource(source));
+                builders.add(client().prepareIndex("idx").setId("" + i).setSource(source));
             }
         }
         prepareCreate("empty_bucket_idx").addMapping("type", "value", "type=integer").get();
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field("value", i * 2).endObject())
             );
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramIT.java
@@ -149,7 +149,8 @@ public class DateHistogramIT extends OpenSearchIntegTestCase {
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field("value", i * 2).endObject())
             );
         }
@@ -1042,7 +1043,8 @@ public class DateHistogramIT extends OpenSearchIntegTestCase {
         IndexRequestBuilder[] reqs = new IndexRequestBuilder[5];
         ZonedDateTime date = date("2014-03-11T00:00:00+00:00");
         for (int i = 0; i < reqs.length; i++) {
-            reqs[i] = client().prepareIndex("idx2", "type", "" + i)
+            reqs[i] = client().prepareIndex("idx2")
+                .setId("" + i)
                 .setSource(jsonBuilder().startObject().timeField("date", date).endObject());
             date = date.plusHours(1);
         }
@@ -1327,7 +1329,8 @@ public class DateHistogramIT extends OpenSearchIntegTestCase {
         prepareCreate("idx2").addMapping("type", mappingJson, XContentType.JSON).get();
         IndexRequestBuilder[] reqs = new IndexRequestBuilder[5];
         for (int i = 0; i < reqs.length; i++) {
-            reqs[i] = client().prepareIndex("idx2", "type", "" + i)
+            reqs[i] = client().prepareIndex("idx2")
+                .setId("" + i)
                 .setSource(jsonBuilder().startObject().field("date", "10-03-2014").endObject());
         }
         indexRandom(true, reqs);
@@ -1616,8 +1619,8 @@ public class DateHistogramIT extends OpenSearchIntegTestCase {
         String date2 = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.format(date(2, 1));
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1").setSource("d", date),
-            client().prepareIndex("cache_test_idx", "type", "2").setSource("d", date2)
+            client().prepareIndex("cache_test_idx").setId("1").setSource("d", date),
+            client().prepareIndex("cache_test_idx").setId("2").setSource("d", date2)
         );
 
         // Make sure we are starting with a clear cache
@@ -1829,8 +1832,8 @@ public class DateHistogramIT extends OpenSearchIntegTestCase {
      */
     public void testDateNanosHistogram() throws Exception {
         assertAcked(prepareCreate("nanos").addMapping("_doc", "date", "type=date_nanos").get());
-        indexRandom(true, client().prepareIndex("nanos", "_doc", "1").setSource("date", "2000-01-01"));
-        indexRandom(true, client().prepareIndex("nanos", "_doc", "2").setSource("date", "2000-01-02"));
+        indexRandom(true, client().prepareIndex("nanos").setId("1").setSource("date", "2000-01-01"));
+        indexRandom(true, client().prepareIndex("nanos").setId("2").setSource("date", "2000-01-02"));
 
         // Search interval 24 hours
         SearchResponse r = client().prepareSearch("nanos")

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramOffsetIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramOffsetIT.java
@@ -85,7 +85,8 @@ public class DateHistogramOffsetIT extends OpenSearchIntegTestCase {
 
         IndexRequestBuilder[] reqs = new IndexRequestBuilder[numHours];
         for (int i = idxIdStart; i < idxIdStart + reqs.length; i++) {
-            reqs[i - idxIdStart] = client().prepareIndex("idx2", "type", "" + i)
+            reqs[i - idxIdStart] = client().prepareIndex("idx2")
+                .setId("" + i)
                 .setSource(jsonBuilder().startObject().timeField("date", date).endObject());
             date = date.plusHours(stepSizeHours);
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateRangeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateRangeIT.java
@@ -128,7 +128,8 @@ public class DateRangeIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", "value", "type=integer"));
         for (int i = 0; i < 2; i++) {
             docs.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field("value", i * 2).endObject())
             );
         }
@@ -918,9 +919,11 @@ public class DateRangeIT extends OpenSearchIntegTestCase {
         );
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1")
+            client().prepareIndex("cache_test_idx")
+                .setId("1")
                 .setSource(jsonBuilder().startObject().timeField("date", date(1, 1)).endObject()),
-            client().prepareIndex("cache_test_idx", "type", "2")
+            client().prepareIndex("cache_test_idx")
+                .setId("2")
                 .setSource(jsonBuilder().startObject().timeField("date", date(2, 1)).endObject())
         );
 
@@ -1070,9 +1073,9 @@ public class DateRangeIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate(indexName).addMapping("type", "date", "type=date,format=strict_hour_minute_second"));
         indexRandom(
             true,
-            client().prepareIndex(indexName, "type", "1").setSource(jsonBuilder().startObject().field("date", "00:16:40").endObject()),
-            client().prepareIndex(indexName, "type", "2").setSource(jsonBuilder().startObject().field("date", "00:33:20").endObject()),
-            client().prepareIndex(indexName, "type", "3").setSource(jsonBuilder().startObject().field("date", "00:50:00").endObject())
+            client().prepareIndex(indexName).setId("1").setSource(jsonBuilder().startObject().field("date", "00:16:40").endObject()),
+            client().prepareIndex(indexName).setId("2").setSource(jsonBuilder().startObject().field("date", "00:33:20").endObject()),
+            client().prepareIndex(indexName).setId("3").setSource(jsonBuilder().startObject().field("date", "00:50:00").endObject())
         );
 
         // using no format should work when to/from is compatible with format in
@@ -1132,9 +1135,9 @@ public class DateRangeIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate(indexName).addMapping("type", "date", "type=date,format=epoch_second"));
         indexRandom(
             true,
-            client().prepareIndex(indexName, "type", "1").setSource(jsonBuilder().startObject().field("date", 1002).endObject()),
-            client().prepareIndex(indexName, "type", "2").setSource(jsonBuilder().startObject().field("date", 2000).endObject()),
-            client().prepareIndex(indexName, "type", "3").setSource(jsonBuilder().startObject().field("date", 3008).endObject())
+            client().prepareIndex(indexName).setId("1").setSource(jsonBuilder().startObject().field("date", 1002).endObject()),
+            client().prepareIndex(indexName).setId("2").setSource(jsonBuilder().startObject().field("date", 2000).endObject()),
+            client().prepareIndex(indexName).setId("3").setSource(jsonBuilder().startObject().field("date", 3008).endObject())
         );
 
         // using no format should work when to/from is compatible with format in

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DiversifiedSamplerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DiversifiedSamplerIT.java
@@ -106,10 +106,12 @@ public class DiversifiedSamplerIT extends OpenSearchIntegTestCase {
 
         for (int i = 0; i < data.length; i++) {
             String[] parts = data[i].split(",");
-            client().prepareIndex("test", "book", "" + i)
+            client().prepareIndex("test")
+                .setId("" + i)
                 .setSource("author", parts[5], "name", parts[2], "genre", parts[8], "price", Float.parseFloat(parts[3]))
                 .get();
-            client().prepareIndex("idx_unmapped_author", "book", "" + i)
+            client().prepareIndex("idx_unmapped_author")
+                .setId("" + i)
                 .setSource("name", parts[2], "genre", parts[8], "price", Float.parseFloat(parts[3]))
                 .get();
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DoubleTermsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DoubleTermsIT.java
@@ -181,7 +181,8 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
         assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, i * 2).endObject())
             );
         }
@@ -985,8 +986,8 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
         );
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1").setSource("s", 1.5),
-            client().prepareIndex("cache_test_idx", "type", "2").setSource("s", 2.5)
+            client().prepareIndex("cache_test_idx").setId("1").setSource("s", 1.5),
+            client().prepareIndex("cache_test_idx").setId("2").setSource("s", 2.5)
         );
 
         // Make sure we are starting with a clear cache

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/FilterIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/FilterIT.java
@@ -73,7 +73,8 @@ public class FilterIT extends OpenSearchIntegTestCase {
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < numTag1Docs; i++) {
             builders.add(
-                client().prepareIndex("idx", "type", "" + i)
+                client().prepareIndex("idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field("value", i + 1).field("tag", "tag1").endObject())
             );
         }
@@ -83,16 +84,17 @@ public class FilterIT extends OpenSearchIntegTestCase {
                 .field("tag", "tag2")
                 .field("name", "name" + i)
                 .endObject();
-            builders.add(client().prepareIndex("idx", "type", "" + i).setSource(source));
+            builders.add(client().prepareIndex("idx").setId("" + i).setSource(source));
             if (randomBoolean()) {
                 // randomly index the document twice so that we have deleted docs that match the filter
-                builders.add(client().prepareIndex("idx", "type", "" + i).setSource(source));
+                builders.add(client().prepareIndex("idx").setId("" + i).setSource(source));
             }
         }
         prepareCreate("empty_bucket_idx").addMapping("type", "value", "type=integer").get();
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field("value", i * 2).endObject())
             );
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/FiltersIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/FiltersIT.java
@@ -80,10 +80,10 @@ public class FiltersIT extends OpenSearchIntegTestCase {
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < numTag1Docs; i++) {
             XContentBuilder source = jsonBuilder().startObject().field("value", i + 1).field("tag", "tag1").endObject();
-            builders.add(client().prepareIndex("idx", "type", "" + i).setSource(source));
+            builders.add(client().prepareIndex("idx").setId("" + i).setSource(source));
             if (randomBoolean()) {
                 // randomly index the document twice so that we have deleted docs that match the filter
-                builders.add(client().prepareIndex("idx", "type", "" + i).setSource(source));
+                builders.add(client().prepareIndex("idx").setId("" + i).setSource(source));
             }
         }
         for (int i = numTag1Docs; i < (numTag1Docs + numTag2Docs); i++) {
@@ -92,9 +92,9 @@ public class FiltersIT extends OpenSearchIntegTestCase {
                 .field("tag", "tag2")
                 .field("name", "name" + i)
                 .endObject();
-            builders.add(client().prepareIndex("idx", "type", "" + i).setSource(source));
+            builders.add(client().prepareIndex("idx").setId("" + i).setSource(source));
             if (randomBoolean()) {
-                builders.add(client().prepareIndex("idx", "type", "" + i).setSource(source));
+                builders.add(client().prepareIndex("idx").setId("" + i).setSource(source));
             }
         }
         for (int i = numTag1Docs + numTag2Docs; i < numDocs; i++) {
@@ -104,15 +104,16 @@ public class FiltersIT extends OpenSearchIntegTestCase {
                 .field("tag", "tag3")
                 .field("name", "name" + i)
                 .endObject();
-            builders.add(client().prepareIndex("idx", "type", "" + i).setSource(source));
+            builders.add(client().prepareIndex("idx").setId("" + i).setSource(source));
             if (randomBoolean()) {
-                builders.add(client().prepareIndex("idx", "type", "" + i).setSource(source));
+                builders.add(client().prepareIndex("idx").setId("" + i).setSource(source));
             }
         }
         prepareCreate("empty_bucket_idx").addMapping("type", "value", "type=integer").get();
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field("value", i * 2).endObject())
             );
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/GeoDistanceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/GeoDistanceIT.java
@@ -142,7 +142,8 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field("value", i * 2).field("location", "52.0945, 5.116").endObject())
             );
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/GlobalIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/GlobalIT.java
@@ -65,13 +65,15 @@ public class GlobalIT extends OpenSearchIntegTestCase {
         numDocs = randomIntBetween(3, 20);
         for (int i = 0; i < numDocs / 2; i++) {
             builders.add(
-                client().prepareIndex("idx", "type", "" + i + 1)
+                client().prepareIndex("idx")
+                    .setId("" + i + 1)
                     .setSource(jsonBuilder().startObject().field("value", i + 1).field("tag", "tag1").endObject())
             );
         }
         for (int i = numDocs / 2; i < numDocs; i++) {
             builders.add(
-                client().prepareIndex("idx", "type", "" + i + 1)
+                client().prepareIndex("idx")
+                    .setId("" + i + 1)
                     .setSource(
                         jsonBuilder().startObject().field("value", i + 1).field("tag", "tag2").field("name", "name" + i + 1).endObject()
                     )

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/HistogramIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/HistogramIT.java
@@ -183,7 +183,8 @@ public class HistogramIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, i * 2).endObject())
             );
         }
@@ -1126,8 +1127,8 @@ public class HistogramIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("decimal_values").addMapping("type", "d", "type=float").get());
         indexRandom(
             true,
-            client().prepareIndex("decimal_values", "type", "1").setSource("d", -0.6),
-            client().prepareIndex("decimal_values", "type", "2").setSource("d", 0.1)
+            client().prepareIndex("decimal_values").setId("1").setSource("d", -0.6),
+            client().prepareIndex("decimal_values").setId("2").setSource("d", 0.1)
         );
 
         SearchResponse r = client().prepareSearch("decimal_values")
@@ -1156,8 +1157,8 @@ public class HistogramIT extends OpenSearchIntegTestCase {
         );
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1").setSource("d", -0.6),
-            client().prepareIndex("cache_test_idx", "type", "2").setSource("d", 0.1)
+            client().prepareIndex("cache_test_idx").setId("1").setSource("d", -0.6),
+            client().prepareIndex("cache_test_idx").setId("2").setSource("d", 0.1)
         );
 
         // Make sure we are starting with a clear cache
@@ -1351,9 +1352,9 @@ public class HistogramIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test").addMapping("type", "d", "type=double").get());
         indexRandom(
             true,
-            client().prepareIndex("test", "type", "1").setSource("d", -0.6),
-            client().prepareIndex("test", "type", "2").setSource("d", 0.5),
-            client().prepareIndex("test", "type", "3").setSource("d", 0.1)
+            client().prepareIndex("test").setId("1").setSource("d", -0.6),
+            client().prepareIndex("test").setId("2").setSource("d", 0.5),
+            client().prepareIndex("test").setId("3").setSource("d", 0.1)
         );
 
         SearchResponse r = client().prepareSearch("test")

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/IpRangeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/IpRangeIT.java
@@ -75,9 +75,10 @@ public class IpRangeIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("idx", "type", "1").setSource("ip", "192.168.1.7", "ips", Arrays.asList("192.168.0.13", "192.168.1.2")),
-            client().prepareIndex("idx", "type", "2").setSource("ip", "192.168.1.10", "ips", Arrays.asList("192.168.1.25", "192.168.1.28")),
-            client().prepareIndex("idx", "type", "3")
+            client().prepareIndex("idx").setId("1").setSource("ip", "192.168.1.7", "ips", Arrays.asList("192.168.0.13", "192.168.1.2")),
+            client().prepareIndex("idx").setId("2").setSource("ip", "192.168.1.10", "ips", Arrays.asList("192.168.1.25", "192.168.1.28")),
+            client().prepareIndex("idx")
+                .setId("3")
                 .setSource("ip", "2001:db8::ff00:42:8329", "ips", Arrays.asList("2001:db8::ff00:42:8329", "2001:db8::ff00:42:8380"))
         );
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/IpTermsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/IpTermsIT.java
@@ -79,9 +79,9 @@ public class IpTermsIT extends AbstractTermsTestCase {
         assertAcked(prepareCreate("index").addMapping("type", "ip", "type=ip"));
         indexRandom(
             true,
-            client().prepareIndex("index", "type", "1").setSource("ip", "192.168.1.7"),
-            client().prepareIndex("index", "type", "2").setSource("ip", "192.168.1.7"),
-            client().prepareIndex("index", "type", "3").setSource("ip", "2001:db8::2:1")
+            client().prepareIndex("index").setId("1").setSource("ip", "192.168.1.7"),
+            client().prepareIndex("index").setId("2").setSource("ip", "192.168.1.7"),
+            client().prepareIndex("index").setId("3").setSource("ip", "2001:db8::2:1")
         );
 
         Script script = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['ip'].value", Collections.emptyMap());
@@ -107,9 +107,9 @@ public class IpTermsIT extends AbstractTermsTestCase {
         assertAcked(prepareCreate("index").addMapping("type", "ip", "type=ip"));
         indexRandom(
             true,
-            client().prepareIndex("index", "type", "1").setSource("ip", "192.168.1.7"),
-            client().prepareIndex("index", "type", "2").setSource("ip", "192.168.1.7"),
-            client().prepareIndex("index", "type", "3").setSource("ip", "2001:db8::2:1")
+            client().prepareIndex("index").setId("1").setSource("ip", "192.168.1.7"),
+            client().prepareIndex("index").setId("2").setSource("ip", "192.168.1.7"),
+            client().prepareIndex("index").setId("3").setSource("ip", "2001:db8::2:1")
         );
 
         Script script = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['ip']", Collections.emptyMap());
@@ -135,10 +135,10 @@ public class IpTermsIT extends AbstractTermsTestCase {
         assertAcked(prepareCreate("index").addMapping("type", "ip", "type=ip"));
         indexRandom(
             true,
-            client().prepareIndex("index", "type", "1").setSource("ip", "192.168.1.7"),
-            client().prepareIndex("index", "type", "2").setSource("ip", "192.168.1.7"),
-            client().prepareIndex("index", "type", "3").setSource("ip", "127.0.0.1"),
-            client().prepareIndex("index", "type", "4").setSource("not_ip", "something")
+            client().prepareIndex("index").setId("1").setSource("ip", "192.168.1.7"),
+            client().prepareIndex("index").setId("2").setSource("ip", "192.168.1.7"),
+            client().prepareIndex("index").setId("3").setSource("ip", "127.0.0.1"),
+            client().prepareIndex("index").setId("4").setSource("not_ip", "something")
         );
         SearchResponse response = client().prepareSearch("index")
             .addAggregation(AggregationBuilders.terms("my_terms").field("ip").missing("127.0.0.1").executionHint(randomExecutionHint()))

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/LongTermsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/LongTermsIT.java
@@ -168,7 +168,8 @@ public class LongTermsIT extends AbstractTermsTestCase {
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, i * 2).endObject())
             );
         }
@@ -933,8 +934,8 @@ public class LongTermsIT extends AbstractTermsTestCase {
         );
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1").setSource("s", 1),
-            client().prepareIndex("cache_test_idx", "type", "2").setSource("s", 2)
+            client().prepareIndex("cache_test_idx").setId("1").setSource("s", 1),
+            client().prepareIndex("cache_test_idx").setId("2").setSource("s", 2)
         );
 
         // Make sure we are starting with a clear cache

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/NestedIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/NestedIT.java
@@ -123,14 +123,15 @@ public class NestedIT extends OpenSearchIntegTestCase {
                 source = source.startObject().field("value", i + 1 + j).endObject();
             }
             source = source.endArray().endObject();
-            builders.add(client().prepareIndex("idx", "type", "" + i + 1).setSource(source));
+            builders.add(client().prepareIndex("idx").setId("" + i + 1).setSource(source));
         }
 
         prepareCreate("empty_bucket_idx").addMapping("type", "value", "type=integer", "nested", "type=nested").get();
         ensureGreen("empty_bucket_idx");
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(
                         jsonBuilder().startObject()
                             .field("value", i * 2)
@@ -178,7 +179,8 @@ public class NestedIT extends OpenSearchIntegTestCase {
         ensureGreen("idx_nested_nested_aggs");
 
         builders.add(
-            client().prepareIndex("idx_nested_nested_aggs", "type", "1")
+            client().prepareIndex("idx_nested_nested_aggs")
+                .setId("1")
                 .setSource(
                     jsonBuilder().startObject()
                         .startArray("nested1")
@@ -458,7 +460,8 @@ public class NestedIT extends OpenSearchIntegTestCase {
 
         List<IndexRequestBuilder> indexRequests = new ArrayList<>(2);
         indexRequests.add(
-            client().prepareIndex("idx2", "provider", "1")
+            client().prepareIndex("idx2")
+                .setId("1")
                 .setSource(
                     "{\"dates\": {\"month\": {\"label\": \"2014-11\", \"end\": \"2014-11-30\", \"start\": \"2014-11-01\"}, "
                         + "\"day\": \"2014-11-30\"}, \"comments\": [{\"cid\": 3,\"identifier\": \"29111\"}, {\"cid\": 4,\"tags\": ["
@@ -467,7 +470,8 @@ public class NestedIT extends OpenSearchIntegTestCase {
                 )
         );
         indexRequests.add(
-            client().prepareIndex("idx2", "provider", "2")
+            client().prepareIndex("idx2")
+                .setId("2")
                 .setSource(
                     "{\"dates\": {\"month\": {\"label\": \"2014-12\", \"end\": \"2014-12-31\", \"start\": \"2014-12-01\"}, "
                         + "\"day\": \"2014-12-03\"}, \"comments\": [{\"cid\": 1, \"identifier\": \"29111\"}, {\"cid\": 2,\"tags\": ["
@@ -544,7 +548,8 @@ public class NestedIT extends OpenSearchIntegTestCase {
         );
         ensureGreen("idx4");
 
-        client().prepareIndex("idx4", "product", "1")
+        client().prepareIndex("idx4")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("name", "product1")
@@ -563,7 +568,8 @@ public class NestedIT extends OpenSearchIntegTestCase {
                     .endObject()
             )
             .get();
-        client().prepareIndex("idx4", "product", "2")
+        client().prepareIndex("idx4")
+            .setId("2")
             .setSource(
                 jsonBuilder().startObject()
                     .field("name", "product2")
@@ -679,7 +685,8 @@ public class NestedIT extends OpenSearchIntegTestCase {
             )
         );
 
-        client().prepareIndex("classes", "class", "1")
+        client().prepareIndex("classes")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("name", "QueryBuilder")
@@ -718,7 +725,8 @@ public class NestedIT extends OpenSearchIntegTestCase {
                     .endObject()
             )
             .get();
-        client().prepareIndex("classes", "class", "2")
+        client().prepareIndex("classes")
+            .setId("2")
             .setSource(
                 jsonBuilder().startObject()
                     .field("name", "Document")

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/RangeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/RangeIT.java
@@ -139,7 +139,8 @@ public class RangeIT extends OpenSearchIntegTestCase {
         prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer").get();
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(
                         jsonBuilder().startObject()
                             // shift sequence by 1, to ensure we have negative values, and value 3 on the edge of the tested ranges
@@ -936,8 +937,8 @@ public class RangeIT extends OpenSearchIntegTestCase {
         );
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1").setSource(jsonBuilder().startObject().field("i", 1).endObject()),
-            client().prepareIndex("cache_test_idx", "type", "2").setSource(jsonBuilder().startObject().field("i", 2).endObject())
+            client().prepareIndex("cache_test_idx").setId("1").setSource(jsonBuilder().startObject().field("i", 1).endObject()),
+            client().prepareIndex("cache_test_idx").setId("2").setSource(jsonBuilder().startObject().field("i", 2).endObject())
         );
 
         // Make sure we are starting with a clear cache

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/ReverseNestedIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/ReverseNestedIT.java
@@ -569,7 +569,8 @@ public class ReverseNestedIT extends OpenSearchIntegTestCase {
                 .addMapping("product", mapping)
         );
 
-        client().prepareIndex("idx3", "product", "1")
+        client().prepareIndex("idx3")
+            .setId("1")
             .setRefreshPolicy(IMMEDIATE)
             .setSource(
                 jsonBuilder().startObject()

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/SamplerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/SamplerIT.java
@@ -105,10 +105,12 @@ public class SamplerIT extends OpenSearchIntegTestCase {
 
         for (int i = 0; i < data.length; i++) {
             String[] parts = data[i].split(",");
-            client().prepareIndex("test", "book", "" + i)
+            client().prepareIndex("test")
+                .setId("" + i)
                 .setSource("author", parts[5], "name", parts[2], "genre", parts[8], "price", Float.parseFloat(parts[3]))
                 .get();
-            client().prepareIndex("idx_unmapped_author", "book", "" + i)
+            client().prepareIndex("idx_unmapped_author")
+                .setId("" + i)
                 .setSource("name", parts[2], "genre", parts[8], "price", Float.parseFloat(parts[3]))
                 .get();
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
@@ -479,7 +479,7 @@ public class SignificantTermsSignificanceScoreIT extends OpenSearchIntegTestCase
         List<IndexRequestBuilder> indexRequestBuilders = new ArrayList<>();
         for (int i = 0; i < data.length; i++) {
             String[] parts = data[i].split("\t");
-            indexRequestBuilders.add(client().prepareIndex("test", "_doc", "" + i).setSource("class", parts[0], "text", parts[1]));
+            indexRequestBuilders.add(client().prepareIndex("test").setId("" + i).setSource("class", parts[0], "text", parts[1]));
         }
         indexRandom(true, false, indexRequestBuilders);
     }
@@ -581,8 +581,8 @@ public class SignificantTermsSignificanceScoreIT extends OpenSearchIntegTestCase
         );
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1").setSource("s", 1),
-            client().prepareIndex("cache_test_idx", "type", "2").setSource("s", 2)
+            client().prepareIndex("cache_test_idx").setId("1").setSource("s", 1),
+            client().prepareIndex("cache_test_idx").setId("2").setSource("s", 2)
         );
 
         // Make sure we are starting with a clear cache

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsDocCountErrorIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsDocCountErrorIT.java
@@ -81,7 +81,8 @@ public class TermsDocCountErrorIT extends OpenSearchIntegTestCase {
         int numUniqueTerms = between(2, numDocs / 2);
         for (int i = 0; i < numDocs; i++) {
             builders.add(
-                client().prepareIndex("idx", "type", "" + i)
+                client().prepareIndex("idx")
+                    .setId("" + i)
                     .setSource(
                         jsonBuilder().startObject()
                             .field(STRING_FIELD_NAME, "val" + randomInt(numUniqueTerms))
@@ -97,7 +98,8 @@ public class TermsDocCountErrorIT extends OpenSearchIntegTestCase {
         );
         for (int i = 0; i < numDocs; i++) {
             builders.add(
-                client().prepareIndex("idx_single_shard", "type", "" + i)
+                client().prepareIndex("idx_single_shard")
+                    .setId("" + i)
                     .setSource(
                         jsonBuilder().startObject()
                             .field(STRING_FIELD_NAME, "val" + randomInt(numUniqueTerms))
@@ -117,7 +119,8 @@ public class TermsDocCountErrorIT extends OpenSearchIntegTestCase {
         );
         for (int i = 0; i < numDocs; i++) {
             builders.add(
-                client().prepareIndex("idx_single_shard", "type", "" + i)
+                client().prepareIndex("idx_single_shard")
+                    .setId("" + i)
                     .setRouting(String.valueOf(randomInt(numRoutingValues)))
                     .setSource(
                         jsonBuilder().startObject()
@@ -147,7 +150,8 @@ public class TermsDocCountErrorIT extends OpenSearchIntegTestCase {
             for (int i = 0; i < entry.getValue(); i++) {
                 String term = entry.getKey();
                 builders.add(
-                    client().prepareIndex("idx_fixed_docs_0", "type", term + "-" + i)
+                    client().prepareIndex("idx_fixed_docs_0")
+                        .setId(term + "-" + i)
                         .setSource(jsonBuilder().startObject().field(STRING_FIELD_NAME, term).endObject())
                 );
             }
@@ -172,7 +176,8 @@ public class TermsDocCountErrorIT extends OpenSearchIntegTestCase {
             for (int i = 0; i < entry.getValue(); i++) {
                 String term = entry.getKey();
                 builders.add(
-                    client().prepareIndex("idx_fixed_docs_1", "type", term + "-" + i)
+                    client().prepareIndex("idx_fixed_docs_1")
+                        .setId(term + "-" + i)
                         .setSource(jsonBuilder().startObject().field(STRING_FIELD_NAME, term).field("shard", 1).endObject())
                 );
             }
@@ -195,7 +200,8 @@ public class TermsDocCountErrorIT extends OpenSearchIntegTestCase {
             for (int i = 0; i < entry.getValue(); i++) {
                 String term = entry.getKey();
                 builders.add(
-                    client().prepareIndex("idx_fixed_docs_2", "type", term + "-" + i)
+                    client().prepareIndex("idx_fixed_docs_2")
+                        .setId(term + "-" + i)
                         .setSource(jsonBuilder().startObject().field(STRING_FIELD_NAME, term).field("shard", 2).endObject())
                 );
             }

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/terms/StringTermsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/terms/StringTermsIT.java
@@ -222,7 +222,8 @@ public class StringTermsIT extends AbstractTermsTestCase {
 
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, i * 2).endObject())
             );
         }
@@ -1267,8 +1268,8 @@ public class StringTermsIT extends AbstractTermsTestCase {
         );
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1").setSource("s", "foo"),
-            client().prepareIndex("cache_test_idx", "type", "2").setSource("s", "bar")
+            client().prepareIndex("cache_test_idx").setId("1").setSource("s", "foo"),
+            client().prepareIndex("cache_test_idx").setId("2").setSource("s", "bar")
         );
 
         // Make sure we are starting with a clear cache

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/CardinalityIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/CardinalityIT.java
@@ -500,8 +500,8 @@ public class CardinalityIT extends OpenSearchIntegTestCase {
         );
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1").setSource("s", 1),
-            client().prepareIndex("cache_test_idx", "type", "2").setSource("s", 2)
+            client().prepareIndex("cache_test_idx").setId("1").setSource("s", 1),
+            client().prepareIndex("cache_test_idx").setId("2").setSource("s", 2)
         );
 
         // Make sure we are starting with a clear cache

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/ExtendedStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/ExtendedStatsIT.java
@@ -875,8 +875,8 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
         );
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1").setSource("s", 1),
-            client().prepareIndex("cache_test_idx", "type", "2").setSource("s", 2)
+            client().prepareIndex("cache_test_idx").setId("1").setSource("s", 1),
+            client().prepareIndex("cache_test_idx").setId("2").setSource("s", 2)
         );
 
         // Make sure we are starting with a clear cache

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/HDRPercentileRanksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/HDRPercentileRanksIT.java
@@ -591,8 +591,8 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
         );
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1").setSource("s", 1),
-            client().prepareIndex("cache_test_idx", "type", "2").setSource("s", 2)
+            client().prepareIndex("cache_test_idx").setId("1").setSource("s", 1),
+            client().prepareIndex("cache_test_idx").setId("2").setSource("s", 2)
         );
 
         // Make sure we are starting with a clear cache

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/HDRPercentilesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/HDRPercentilesIT.java
@@ -560,8 +560,8 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
         );
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1").setSource("s", 1),
-            client().prepareIndex("cache_test_idx", "type", "2").setSource("s", 2)
+            client().prepareIndex("cache_test_idx").setId("1").setSource("s", 1),
+            client().prepareIndex("cache_test_idx").setId("2").setSource("s", 2)
         );
 
         // Make sure we are starting with a clear cache

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
@@ -117,7 +117,8 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
             multiValueSample[i * 2] = firstMultiValueDatapoint;
             multiValueSample[(i * 2) + 1] = secondMultiValueDatapoint;
 
-            IndexRequestBuilder builder = client().prepareIndex("idx", "_doc", String.valueOf(i))
+            IndexRequestBuilder builder = client().prepareIndex("idx")
+                .setId(String.valueOf(i))
                 .setSource(
                     jsonBuilder().startObject()
                         .field("value", singleValueDatapoint)
@@ -141,7 +142,8 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
         builders = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", String.valueOf(i))
+                client().prepareIndex("empty_bucket_idx")
+                    .setId(String.valueOf(i))
                     .setSource(jsonBuilder().startObject().field("value", i * 2).endObject())
             );
         }
@@ -521,8 +523,8 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1").setSource("s", 1),
-            client().prepareIndex("cache_test_idx", "type", "2").setSource("s", 2)
+            client().prepareIndex("cache_test_idx").setId("1").setSource("s", 1),
+            client().prepareIndex("cache_test_idx").setId("2").setSource("s", 2)
         );
 
         // Make sure we are starting with a clear cache

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/ScriptedMetricIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/ScriptedMetricIT.java
@@ -293,7 +293,8 @@ public class ScriptedMetricIT extends OpenSearchIntegTestCase {
         numDocs = randomIntBetween(10, 100);
         for (int i = 0; i < numDocs; i++) {
             builders.add(
-                client().prepareIndex("idx", "type", "" + i)
+                client().prepareIndex("idx")
+                    .setId("" + i)
                     .setSource(
                         jsonBuilder().startObject().field("value", randomAlphaOfLengthBetween(5, 15)).field("l_value", i).endObject()
                     )
@@ -313,7 +314,8 @@ public class ScriptedMetricIT extends OpenSearchIntegTestCase {
         builders = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field("value", i * 2).endObject())
             );
         }
@@ -1187,8 +1189,8 @@ public class ScriptedMetricIT extends OpenSearchIntegTestCase {
         );
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1").setSource("s", 1),
-            client().prepareIndex("cache_test_idx", "type", "2").setSource("s", 2)
+            client().prepareIndex("cache_test_idx").setId("1").setSource("s", 1),
+            client().prepareIndex("cache_test_idx").setId("2").setSource("s", 2)
         );
 
         // Make sure we are starting with a clear cache

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/StatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/StatsIT.java
@@ -264,8 +264,8 @@ public class StatsIT extends AbstractNumericTestCase {
         );
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1").setSource("s", 1),
-            client().prepareIndex("cache_test_idx", "type", "2").setSource("s", 2)
+            client().prepareIndex("cache_test_idx").setId("1").setSource("s", 1),
+            client().prepareIndex("cache_test_idx").setId("2").setSource("s", 2)
         );
 
         // Make sure we are starting with a clear cache

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/SumIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/SumIT.java
@@ -242,8 +242,8 @@ public class SumIT extends AbstractNumericTestCase {
         );
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1").setSource("s", 1),
-            client().prepareIndex("cache_test_idx", "type", "2").setSource("s", 2)
+            client().prepareIndex("cache_test_idx").setId("1").setSource("s", 1),
+            client().prepareIndex("cache_test_idx").setId("2").setSource("s", 2)
         );
 
         // Make sure we are starting with a clear cache

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TDigestPercentileRanksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TDigestPercentileRanksIT.java
@@ -503,8 +503,8 @@ public class TDigestPercentileRanksIT extends AbstractNumericTestCase {
         );
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1").setSource("s", 1),
-            client().prepareIndex("cache_test_idx", "type", "2").setSource("s", 2)
+            client().prepareIndex("cache_test_idx").setId("1").setSource("s", 1),
+            client().prepareIndex("cache_test_idx").setId("2").setSource("s", 2)
         );
 
         // Make sure we are starting with a clear cache

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TDigestPercentilesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TDigestPercentilesIT.java
@@ -475,8 +475,8 @@ public class TDigestPercentilesIT extends AbstractNumericTestCase {
         );
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1").setSource("s", 1),
-            client().prepareIndex("cache_test_idx", "type", "2").setSource("s", 2)
+            client().prepareIndex("cache_test_idx").setId("1").setSource("s", 1),
+            client().prepareIndex("cache_test_idx").setId("2").setSource("s", 2)
         );
 
         // Make sure we are starting with a clear cache

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TopHitsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TopHitsIT.java
@@ -182,7 +182,8 @@ public class TopHitsIT extends OpenSearchIntegTestCase {
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < 50; i++) {
             builders.add(
-                client().prepareIndex("idx", "type", Integer.toString(i))
+                client().prepareIndex("idx")
+                    .setId(Integer.toString(i))
                     .setSource(
                         jsonBuilder().startObject()
                             .field(TERMS_AGGS_FIELD, "val" + (i / 10))
@@ -196,39 +197,48 @@ public class TopHitsIT extends OpenSearchIntegTestCase {
         }
 
         builders.add(
-            client().prepareIndex("field-collapsing", "type", "1")
+            client().prepareIndex("field-collapsing")
+                .setId("1")
                 .setSource(jsonBuilder().startObject().field("group", "a").field("text", "term x y z b").endObject())
         );
         builders.add(
-            client().prepareIndex("field-collapsing", "type", "2")
+            client().prepareIndex("field-collapsing")
+                .setId("2")
                 .setSource(jsonBuilder().startObject().field("group", "a").field("text", "term x y z n rare").field("value", 1).endObject())
         );
         builders.add(
-            client().prepareIndex("field-collapsing", "type", "3")
+            client().prepareIndex("field-collapsing")
+                .setId("3")
                 .setSource(jsonBuilder().startObject().field("group", "b").field("text", "x y z term").endObject())
         );
         builders.add(
-            client().prepareIndex("field-collapsing", "type", "4")
+            client().prepareIndex("field-collapsing")
+                .setId("4")
                 .setSource(jsonBuilder().startObject().field("group", "b").field("text", "x y term").endObject())
         );
         builders.add(
-            client().prepareIndex("field-collapsing", "type", "5")
+            client().prepareIndex("field-collapsing")
+                .setId("5")
                 .setSource(jsonBuilder().startObject().field("group", "b").field("text", "x term").endObject())
         );
         builders.add(
-            client().prepareIndex("field-collapsing", "type", "6")
+            client().prepareIndex("field-collapsing")
+                .setId("6")
                 .setSource(jsonBuilder().startObject().field("group", "b").field("text", "term rare").field("value", 3).endObject())
         );
         builders.add(
-            client().prepareIndex("field-collapsing", "type", "7")
+            client().prepareIndex("field-collapsing")
+                .setId("7")
                 .setSource(jsonBuilder().startObject().field("group", "c").field("text", "x y z term").endObject())
         );
         builders.add(
-            client().prepareIndex("field-collapsing", "type", "8")
+            client().prepareIndex("field-collapsing")
+                .setId("8")
                 .setSource(jsonBuilder().startObject().field("group", "c").field("text", "x y term b").endObject())
         );
         builders.add(
-            client().prepareIndex("field-collapsing", "type", "9")
+            client().prepareIndex("field-collapsing")
+                .setId("9")
                 .setSource(jsonBuilder().startObject().field("group", "c").field("text", "rare x term").field("value", 2).endObject())
         );
 
@@ -247,7 +257,8 @@ public class TopHitsIT extends OpenSearchIntegTestCase {
         }
 
         builders.add(
-            client().prepareIndex("articles", "article", "1")
+            client().prepareIndex("articles")
+                .setId("1")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("title", "title 1")
@@ -290,7 +301,8 @@ public class TopHitsIT extends OpenSearchIntegTestCase {
                 )
         );
         builders.add(
-            client().prepareIndex("articles", "article", "2")
+            client().prepareIndex("articles")
+                .setId("2")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("title", "title 2")
@@ -1142,8 +1154,8 @@ public class TopHitsIT extends OpenSearchIntegTestCase {
             );
             indexRandom(
                 true,
-                client().prepareIndex("cache_test_idx", "type", "1").setSource("s", 1),
-                client().prepareIndex("cache_test_idx", "type", "2").setSource("s", 2)
+                client().prepareIndex("cache_test_idx").setId("1").setSource("s", 1),
+                client().prepareIndex("cache_test_idx").setId("2").setSource("s", 2)
             );
 
             // Make sure we are starting with a clear cache

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/ValueCountIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/ValueCountIT.java
@@ -73,7 +73,8 @@ public class ValueCountIT extends OpenSearchIntegTestCase {
         createIndex("idx");
         createIndex("idx_unmapped");
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("idx", "type", "" + i)
+            client().prepareIndex("idx")
+                .setId("" + i)
                 .setSource(
                     jsonBuilder().startObject().field("value", i + 1).startArray("values").value(i + 2).value(i + 3).endArray().endObject()
                 )
@@ -243,8 +244,8 @@ public class ValueCountIT extends OpenSearchIntegTestCase {
         );
         indexRandom(
             true,
-            client().prepareIndex("cache_test_idx", "type", "1").setSource("s", 1),
-            client().prepareIndex("cache_test_idx", "type", "2").setSource("s", 2)
+            client().prepareIndex("cache_test_idx").setId("1").setSource("s", 1),
+            client().prepareIndex("cache_test_idx").setId("2").setSource("s", 2)
         );
 
         // Make sure we are starting with a clear cache

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/AvgBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/AvgBucketIT.java
@@ -103,7 +103,8 @@ public class AvgBucketIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, i * 2).endObject())
             );
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/DateDerivativeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/DateDerivativeIT.java
@@ -107,7 +107,8 @@ public class DateDerivativeIT extends OpenSearchIntegTestCase {
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field("value", i * 2).endObject())
             );
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/ExtendedStatsBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/ExtendedStatsBucketIT.java
@@ -107,7 +107,8 @@ public class ExtendedStatsBucketIT extends OpenSearchIntegTestCase {
             // creates 6 documents where the value of the field is 0, 1, 2, 3,
             // 3, 5
             builders.add(
-                client().prepareIndex("idx_gappy", "type", "" + i)
+                client().prepareIndex("idx_gappy")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, i == 4 ? 3 : i).endObject())
             );
         }
@@ -115,7 +116,8 @@ public class ExtendedStatsBucketIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, i * 2).endObject())
             );
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MaxBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MaxBucketIT.java
@@ -117,7 +117,8 @@ public class MaxBucketIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, i * 2).endObject())
             );
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MinBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MinBucketIT.java
@@ -103,7 +103,8 @@ public class MinBucketIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, i * 2).endObject())
             );
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/PercentilesBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/PercentilesBucketIT.java
@@ -107,7 +107,8 @@ public class PercentilesBucketIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, i * 2).endObject())
             );
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/StatsBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/StatsBucketIT.java
@@ -103,7 +103,8 @@ public class StatsBucketIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, i * 2).endObject())
             );
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/SumBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/SumBucketIT.java
@@ -103,7 +103,8 @@ public class SumBucketIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", "" + i)
+                client().prepareIndex("empty_bucket_idx")
+                    .setId("" + i)
                     .setSource(jsonBuilder().startObject().field(SINGLE_VALUED_FIELD_NAME, i * 2).endObject())
             );
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchRedStateIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchRedStateIndexIT.java
@@ -128,7 +128,7 @@ public class SearchRedStateIndexIT extends OpenSearchIntegTestCase {
         );
         ensureGreen();
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test", "type1", "" + i).setSource("field1", "value1").get();
+            client().prepareIndex("test").setId("" + i).setSource("field1", "value1").get();
         }
         refresh();
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWhileCreatingIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWhileCreatingIndexIT.java
@@ -78,7 +78,7 @@ public class SearchWhileCreatingIndexIT extends OpenSearchIntegTestCase {
         if (createIndex) {
             createIndex("test");
         }
-        client().prepareIndex("test", "type1", id).setSource("field", "test").get();
+        client().prepareIndex("test").setId(id).setSource("field", "test").get();
         RefreshResponse refreshResponse = client().admin().indices().prepareRefresh("test").get();
         // at least one shard should be successful when refreshing
         assertThat(refreshResponse.getSuccessfulShards(), greaterThanOrEqualTo(1));

--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWhileRelocatingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWhileRelocatingIT.java
@@ -72,7 +72,8 @@ public class SearchWhileRelocatingIT extends OpenSearchIntegTestCase {
         final int numDocs = between(10, 20);
         for (int i = 0; i < numDocs; i++) {
             indexBuilders.add(
-                client().prepareIndex("test", "type", Integer.toString(i))
+                client().prepareIndex("test")
+                    .setId(Integer.toString(i))
                     .setSource(
                         jsonBuilder().startObject()
                             .field("test", "value")

--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWithRandomExceptionsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWithRandomExceptionsIT.java
@@ -128,7 +128,8 @@ public class SearchWithRandomExceptionsIT extends OpenSearchIntegTestCase {
         boolean[] added = new boolean[numDocs];
         for (int i = 0; i < numDocs; i++) {
             try {
-                IndexResponse indexResponse = client().prepareIndex("test", "type", "" + i)
+                IndexResponse indexResponse = client().prepareIndex("test")
+                    .setId("" + i)
                     .setTimeout(TimeValue.timeValueSeconds(1))
                     .setSource("test", English.intToEnglish(i))
                     .get();

--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWithRandomIOExceptionsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWithRandomIOExceptionsIT.java
@@ -112,7 +112,7 @@ public class SearchWithRandomIOExceptionsIT extends OpenSearchIntegTestCase {
             numInitialDocs = between(10, 100);
             ensureGreen();
             for (int i = 0; i < numInitialDocs; i++) {
-                client().prepareIndex("test", "type", "init" + i).setSource("test", "init").get();
+                client().prepareIndex("test").setId("init" + i).setSource("test", "init").get();
             }
             client().admin().indices().prepareRefresh("test").execute().get();
             client().admin().indices().prepareFlush("test").execute().get();
@@ -160,7 +160,8 @@ public class SearchWithRandomIOExceptionsIT extends OpenSearchIntegTestCase {
         for (int i = 0; i < numDocs; i++) {
             added[i] = false;
             try {
-                IndexResponse indexResponse = client().prepareIndex("test", "type", Integer.toString(i))
+                IndexResponse indexResponse = client().prepareIndex("test")
+                    .setId(Integer.toString(i))
                     .setTimeout(TimeValue.timeValueSeconds(1))
                     .setSource("test", English.intToEnglish(i))
                     .get();

--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/InnerHitsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/InnerHitsIT.java
@@ -125,7 +125,8 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
 
         List<IndexRequestBuilder> requests = new ArrayList<>();
         requests.add(
-            client().prepareIndex("articles", "article", "1")
+            client().prepareIndex("articles")
+                .setId("1")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("title", "quick brown fox")
@@ -144,7 +145,8 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
                 )
         );
         requests.add(
-            client().prepareIndex("articles", "article", "2")
+            client().prepareIndex("articles")
+                .setId("2")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("title", "big gray elephant")
@@ -261,7 +263,7 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
                 source.startObject().field("x", "y").endObject();
             }
             source.endArray().endObject();
-            requestBuilders.add(client().prepareIndex("idx", "type", Integer.toString(i)).setSource(source));
+            requestBuilders.add(client().prepareIndex("idx").setId(Integer.toString(i)).setSource(source));
         }
         indexRandom(true, requestBuilders);
 
@@ -343,7 +345,8 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
 
         List<IndexRequestBuilder> requests = new ArrayList<>();
         requests.add(
-            client().prepareIndex("articles", "article", "1")
+            client().prepareIndex("articles")
+                .setId("1")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("title", "quick brown fox")
@@ -369,7 +372,8 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
                 )
         );
         requests.add(
-            client().prepareIndex("articles", "article", "2")
+            client().prepareIndex("articles")
+                .setId("2")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("title", "big gray elephant")
@@ -544,7 +548,8 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
 
         List<IndexRequestBuilder> requests = new ArrayList<>();
         requests.add(
-            client().prepareIndex("articles", "article", "1")
+            client().prepareIndex("articles")
+                .setId("1")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("title", "quick brown fox")
@@ -597,7 +602,8 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
 
         List<IndexRequestBuilder> requests = new ArrayList<>();
         requests.add(
-            client().prepareIndex("articles", "article", "1")
+            client().prepareIndex("articles")
+                .setId("1")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("title", "quick brown fox")
@@ -700,7 +706,8 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
         // index the message in an object form instead of an array
         requests = new ArrayList<>();
         requests.add(
-            client().prepareIndex("articles", "article", "1")
+            client().prepareIndex("articles")
+                .setId("1")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("title", "quick brown fox")
@@ -756,7 +763,8 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
         List<IndexRequestBuilder> requests = new ArrayList<>();
         int numDocs = randomIntBetween(2, 35);
         requests.add(
-            client().prepareIndex("test", "type1", "0")
+            client().prepareIndex("test")
+                .setId("0")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("field1", 0)
@@ -774,7 +782,8 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
                 )
         );
         requests.add(
-            client().prepareIndex("test", "type1", "1")
+            client().prepareIndex("test")
+                .setId("1")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("field1", 1)
@@ -794,7 +803,8 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
 
         for (int i = 2; i < numDocs; i++) {
             requests.add(
-                client().prepareIndex("test", "type1", String.valueOf(i))
+                client().prepareIndex("test")
+                    .setId(String.valueOf(i))
                     .setSource(
                         jsonBuilder().startObject()
                             .field("field1", i)
@@ -852,7 +862,8 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
 
     public void testNestedSource() throws Exception {
         assertAcked(prepareCreate("index1").addMapping("message", "comments", "type=nested"));
-        client().prepareIndex("index1", "message", "1")
+        client().prepareIndex("index1")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("message", "quick brown fox")
@@ -947,8 +958,8 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
     public void testInnerHitsWithIgnoreUnmapped() throws Exception {
         assertAcked(prepareCreate("index1").addMapping("_doc", "nested_type", "type=nested"));
         createIndex("index2");
-        client().prepareIndex("index1", "_doc", "1").setSource("nested_type", Collections.singletonMap("key", "value")).get();
-        client().prepareIndex("index2", "type", "3").setSource("key", "value").get();
+        client().prepareIndex("index1").setId("1").setSource("nested_type", Collections.singletonMap("key", "value")).get();
+        client().prepareIndex("index2").setId("3").setSource("key", "value").get();
         refresh();
 
         SearchResponse response = client().prepareSearch("index1", "index2")
@@ -971,7 +982,8 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
             .prepareUpdateSettings("index2")
             .setSettings(Collections.singletonMap(IndexSettings.MAX_INNER_RESULT_WINDOW_SETTING.getKey(), ArrayUtil.MAX_ARRAY_LENGTH))
             .get();
-        client().prepareIndex("index2", "type", "1")
+        client().prepareIndex("index2")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject().startArray("nested").startObject().field("field", "value1").endObject().endArray().endObject()
             )
@@ -988,7 +1000,8 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
 
     public void testTooHighResultWindow() throws Exception {
         assertAcked(prepareCreate("index2").addMapping("type", "nested", "type=nested"));
-        client().prepareIndex("index2", "type", "1")
+        client().prepareIndex("index2")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject().startArray("nested").startObject().field("field", "value1").endObject().endArray().endObject()
             )

--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/MatchedQueriesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/MatchedQueriesIT.java
@@ -61,9 +61,9 @@ public class MatchedQueriesIT extends OpenSearchIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1").setSource("name", "test1", "number", 1).get();
-        client().prepareIndex("test", "type1", "2").setSource("name", "test2", "number", 2).get();
-        client().prepareIndex("test", "type1", "3").setSource("name", "test3", "number", 3).get();
+        client().prepareIndex("test").setId("1").setSource("name", "test1", "number", 1).get();
+        client().prepareIndex("test").setId("2").setSource("name", "test2", "number", 2).get();
+        client().prepareIndex("test").setId("3").setSource("name", "test3", "number", 3).get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch()
@@ -111,9 +111,9 @@ public class MatchedQueriesIT extends OpenSearchIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1").setSource("name", "test", "title", "title1").get();
-        client().prepareIndex("test", "type1", "2").setSource("name", "test").get();
-        client().prepareIndex("test", "type1", "3").setSource("name", "test").get();
+        client().prepareIndex("test").setId("1").setSource("name", "test", "title", "title1").get();
+        client().prepareIndex("test").setId("2").setSource("name", "test").get();
+        client().prepareIndex("test").setId("3").setSource("name", "test").get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch()
@@ -162,9 +162,9 @@ public class MatchedQueriesIT extends OpenSearchIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1").setSource("name", "test", "title", "title1").get();
-        client().prepareIndex("test", "type1", "2").setSource("name", "test", "title", "title2").get();
-        client().prepareIndex("test", "type1", "3").setSource("name", "test", "title", "title3").get();
+        client().prepareIndex("test").setId("1").setSource("name", "test", "title", "title1").get();
+        client().prepareIndex("test").setId("2").setSource("name", "test", "title", "title2").get();
+        client().prepareIndex("test").setId("3").setSource("name", "test", "title", "title3").get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch()
@@ -202,7 +202,7 @@ public class MatchedQueriesIT extends OpenSearchIntegTestCase {
         createIndex("test1");
         ensureGreen();
 
-        client().prepareIndex("test1", "type1", "1").setSource("title", "title1").get();
+        client().prepareIndex("test1").setId("1").setSource("title", "title1").get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch()
@@ -224,7 +224,7 @@ public class MatchedQueriesIT extends OpenSearchIntegTestCase {
         createIndex("test1");
         ensureGreen();
 
-        client().prepareIndex("test1", "type1", "1").setSource("title", "title1").get();
+        client().prepareIndex("test1").setId("1").setSource("title", "title1").get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch()
@@ -246,7 +246,7 @@ public class MatchedQueriesIT extends OpenSearchIntegTestCase {
         createIndex("test1");
         ensureGreen();
 
-        client().prepareIndex("test1", "type1", "1").setSource("title", "title1").get();
+        client().prepareIndex("test1").setId("1").setSource("title", "title1").get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch()
@@ -268,7 +268,7 @@ public class MatchedQueriesIT extends OpenSearchIntegTestCase {
         createIndex("test1");
         ensureGreen();
 
-        client().prepareIndex("test1", "type1", "1").setSource("title", "title1").get();
+        client().prepareIndex("test1").setId("1").setSource("title", "title1").get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch()
@@ -290,7 +290,7 @@ public class MatchedQueriesIT extends OpenSearchIntegTestCase {
         createIndex("test1");
         ensureGreen();
 
-        client().prepareIndex("test1", "type1", "1").setSource("title", "title1 title2").get();
+        client().prepareIndex("test1").setId("1").setSource("title", "title1 title2").get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch()
@@ -315,8 +315,8 @@ public class MatchedQueriesIT extends OpenSearchIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1").setSource("content", "Lorem ipsum dolor sit amet").get();
-        client().prepareIndex("test", "type1", "2").setSource("content", "consectetur adipisicing elit").get();
+        client().prepareIndex("test").setId("1").setSource("content", "Lorem ipsum dolor sit amet").get();
+        client().prepareIndex("test").setId("2").setSource("content", "consectetur adipisicing elit").get();
         refresh();
 
         // Execute search at least two times to load it in cache
@@ -349,7 +349,7 @@ public class MatchedQueriesIT extends OpenSearchIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1").setSource("content", "Lorem ipsum dolor sit amet").get();
+        client().prepareIndex("test").setId("1").setSource("content", "Lorem ipsum dolor sit amet").get();
         refresh();
 
         MatchQueryBuilder matchQueryBuilder = matchQuery("content", "amet").queryName("abc");

--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/highlight/CustomHighlighterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/highlight/CustomHighlighterSearchIT.java
@@ -63,9 +63,8 @@ public class CustomHighlighterSearchIT extends OpenSearchIntegTestCase {
     protected void setup() throws Exception {
         indexRandom(
             true,
-            client().prepareIndex("test", "test", "1")
-                .setSource("name", "arbitrary content", "other_name", "foo", "other_other_name", "bar"),
-            client().prepareIndex("test", "test", "2").setSource("other_name", "foo", "other_other_name", "bar")
+            client().prepareIndex("test").setId("1").setSource("name", "arbitrary content", "other_name", "foo", "other_other_name", "bar"),
+            client().prepareIndex("test").setId("2").setSource("other_name", "foo", "other_other_name", "bar")
         );
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -187,7 +187,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .endObject();
         mappings.endObject();
         assertAcked(prepareCreate("test").addMapping("type", mappings));
-        client().prepareIndex("test", "type", "1").setSource(jsonBuilder().startObject().field("text", "foo").endObject()).get();
+        client().prepareIndex("test").setId("1").setSource(jsonBuilder().startObject().field("text", "foo").endObject()).get();
         refresh();
         SearchResponse search = client().prepareSearch()
             .setQuery(matchQuery("text", "foo"))
@@ -212,7 +212,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .endObject();
         mappings.endObject();
         assertAcked(prepareCreate("test").addMapping("type", mappings));
-        client().prepareIndex("test", "type", "1").setSource(jsonBuilder().startObject().field("text", "text").endObject()).get();
+        client().prepareIndex("test").setId("1").setSource(jsonBuilder().startObject().field("text", "text").endObject()).get();
         refresh();
         for (String type : ALL_TYPES) {
             SearchResponse search = client().prepareSearch()
@@ -241,7 +241,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .endObject();
         assertAcked(prepareCreate("test").addMapping("type", mappings));
 
-        client().prepareIndex("test", "type", "1").setSource("text", "foo").get();
+        client().prepareIndex("test").setId("1").setSource("text", "foo").get();
         refresh();
 
         for (String type : ALL_TYPES) {
@@ -271,7 +271,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .endObject();
         assertAcked(prepareCreate("test").addMapping("type", mappings));
 
-        client().prepareIndex("test", "type", "1").setSource("text", "foo bar").get();
+        client().prepareIndex("test").setId("1").setSource("text", "foo bar").get();
         refresh();
 
         for (String type : ALL_TYPES) {
@@ -298,7 +298,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .endObject();
         assertAcked(prepareCreate("test").addMapping("type", mappings));
 
-        client().prepareIndex("test", "type", "1").setSource("keyword", "foo").get();
+        client().prepareIndex("test").setId("1").setSource("keyword", "foo").get();
         refresh();
 
         HighlightBuilder builder = new HighlightBuilder().field(new Field("al*")).requireFieldMatch(false);
@@ -330,7 +330,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .endObject();
         mappings.endObject();
         assertAcked(prepareCreate("test").addMapping("type", mappings));
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("unstored_text", "text").field("text", "text").endObject())
             .get();
         refresh();
@@ -358,7 +359,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         for (int i = 0; i < 6000; i++) {
             builder.append("abc").append(" ");
         }
-        client().prepareIndex("test", "test", "1").setSource("name", builder.toString()).get();
+        client().prepareIndex("test").setId("1").setSource("name", builder.toString()).get();
         refresh();
         SearchResponse search = client().prepareSearch()
             .setQuery(constantScoreQuery(matchQuery("name", "abc")))
@@ -378,7 +379,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             )
         );
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 "no_long_term",
                 "This is a test where foo is highlighed and should be highlighted",
@@ -437,7 +439,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < indexRequestBuilders.length; i++) {
-            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+            indexRequestBuilders[i] = client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource(
                     XContentFactory.jsonBuilder()
                         .startObject()
@@ -506,7 +509,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < indexRequestBuilders.length; i++) {
-            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+            indexRequestBuilders[i] = client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource(
                     XContentFactory.jsonBuilder()
                         .startObject()
@@ -575,7 +579,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < indexRequestBuilders.length; i++) {
-            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+            indexRequestBuilders[i] = client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource(
                     XContentFactory.jsonBuilder()
                         .startObject()
@@ -654,12 +659,11 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         );
 
         String[] titles = new String[] { "This is a test on the highlighting bug present in opensearch", "The bug is bugging us" };
-        indexRandom(false, client().prepareIndex("test", "type1", "1").setSource("title", titles, "titleTV", titles));
+        indexRandom(false, client().prepareIndex("test").setId("1").setSource("title", titles, "titleTV", titles));
 
         indexRandom(
             true,
-            client().prepareIndex("test", "type1", "2")
-                .setSource("titleTV", new String[] { "some text to highlight", "highlight other text" })
+            client().prepareIndex("test").setId("2").setSource("titleTV", new String[] { "some text to highlight", "highlight other text" })
         );
 
         SearchResponse search = client().prepareSearch()
@@ -1273,7 +1277,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         int COUNT = between(20, 100);
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[COUNT];
         for (int i = 0; i < COUNT; i++) {
-            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i)).setSource("field1", "test " + i);
+            indexRequestBuilders[i] = client().prepareIndex("test").setId(Integer.toString(i)).setSource("field1", "test " + i);
         }
         logger.info("--> indexing docs");
         indexRandom(true, indexRequestBuilders);
@@ -1314,7 +1318,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < 5; i++) {
-            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+            indexRequestBuilders[i] = client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource("title", "This is a test on the highlighting bug present in opensearch");
         }
         indexRandom(true, indexRequestBuilders);
@@ -1341,7 +1346,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < 5; i++) {
-            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+            indexRequestBuilders[i] = client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource("title", "This is a test on the highlighting bug present in opensearch");
         }
         indexRandom(true, indexRequestBuilders);
@@ -1362,7 +1368,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < indexRequestBuilders.length; i++) {
-            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+            indexRequestBuilders[i] = client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource("title", "This is a html escaping highlighting test for *&? opensearch");
         }
         indexRandom(true, indexRequestBuilders);
@@ -1382,7 +1389,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < 5; i++) {
-            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+            indexRequestBuilders[i] = client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource("title", "This is a html escaping highlighting test for *&? opensearch");
         }
         indexRandom(true, indexRequestBuilders);
@@ -1424,7 +1432,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             )
         );
         ensureGreen();
-        client().prepareIndex("test", "type1", "1").setSource("title", "this is a test").get();
+        client().prepareIndex("test").setId("1").setSource("title", "this is a test").get();
         refresh();
 
         // simple search on body with standard analyzer with a simple field query
@@ -1472,7 +1480,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         );
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1").setSource("title", "this is a test").get();
+        client().prepareIndex("test").setId("1").setSource("title", "this is a test").get();
         refresh();
 
         // simple search on body with standard analyzer with a simple field query
@@ -1520,7 +1528,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         );
 
         ensureGreen();
-        client().prepareIndex("test", "type1", "1").setSource("title", "this is a test").get();
+        client().prepareIndex("test").setId("1").setSource("title", "this is a test").get();
         refresh();
 
         // simple search on body with standard analyzer with a simple field query
@@ -1567,7 +1575,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             )
         );
         ensureGreen();
-        client().prepareIndex("test", "type1", "1").setSource("title", "this is a test").get();
+        client().prepareIndex("test").setId("1").setSource("title", "this is a test").get();
         refresh();
 
         // simple search on body with standard analyzer with a simple field query
@@ -1593,7 +1601,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < 5; i++) {
-            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+            indexRequestBuilders[i] = client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource("title", "This is a test for the enabling fast vector highlighter");
         }
         indexRandom(true, indexRequestBuilders);
@@ -1631,7 +1640,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < indexRequestBuilders.length; i++) {
-            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+            indexRequestBuilders[i] = client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource("title", "This is a test for the workaround for the fast vector highlighting SOLR-3724");
         }
         indexRandom(true, indexRequestBuilders);
@@ -1686,7 +1696,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     public void testFSHHighlightAllMvFragments() throws Exception {
         assertAcked(prepareCreate("test").addMapping("type1", "tags", "type=text,term_vector=with_positions_offsets"));
         ensureGreen();
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 "tags",
                 new String[] {
@@ -1777,7 +1788,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     public void testPlainHighlightDifferentFragmenter() throws Exception {
         assertAcked(prepareCreate("test").addMapping("type1", "tags", "type=text"));
         ensureGreen();
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .array(
@@ -1888,7 +1900,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     public void testMissingStoredField() throws Exception {
         assertAcked(prepareCreate("test").addMapping("type1", "highlight_field", "type=text,store=true"));
         ensureGreen();
-        client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject().field("field", "highlight").endObject()).get();
+        client().prepareIndex("test").setId("1").setSource(jsonBuilder().startObject().field("field", "highlight").endObject()).get();
         refresh();
 
         // This query used to fail when the field to highlight was absent
@@ -1926,7 +1938,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         );
         ensureGreen();
 
-        client().prepareIndex("test", "test", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource("text", "opensearch test", "byte", 25, "short", 42, "int", 100, "long", -1, "float", 3.2f, "double", 42.42)
             .get();
         refresh();
@@ -1950,7 +1963,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             ).addMapping("type", "text", "type=text,analyzer=my_analyzer")
         );
         ensureGreen();
-        client().prepareIndex("test", "type", "1").setSource("text", "opensearch test").get();
+        client().prepareIndex("test").setId("1").setSource("text", "opensearch test").get();
         refresh();
 
         SearchResponse response = client().prepareSearch("test")
@@ -2362,7 +2375,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 "field1",
                 "The quick brown fox jumps over the lazy dog. The lazy red fox jumps over the quick dog. "
@@ -2394,7 +2408,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         );
         assertHighlight(searchResponse, 0, "field1", 1, 2, equalTo("The quick brown dog jumps over the lazy <field1>fox</field1>."));
 
-        client().prepareIndex("test", "type1", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(
                 "field1",
                 new String[] {
@@ -2546,7 +2561,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < 5; i++) {
-            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+            indexRequestBuilders[i] = client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource("title", "This is a html escaping highlighting test for *&? opensearch");
         }
         indexRandom(true, indexRequestBuilders);
@@ -2595,7 +2611,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             )
         );
         ensureGreen();
-        client().prepareIndex("test", "type1", "1").setSource("title", "this is a test . Second sentence.").get();
+        client().prepareIndex("test").setId("1").setSource("title", "this is a test . Second sentence.").get();
         refresh();
 
         // simple search on body with standard analyzer with a simple field query
@@ -2656,7 +2672,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         );
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1").setSource("title", "this is a test").get();
+        client().prepareIndex("test").setId("1").setSource("title", "this is a test").get();
         refresh();
 
         // simple search on body with standard analyzer with a simple field query
@@ -2697,7 +2713,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < indexRequestBuilders.length; i++) {
-            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+            indexRequestBuilders[i] = client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource("title", "This is a test for the postings highlighter");
         }
         indexRandom(true, indexRequestBuilders);
@@ -2985,7 +3002,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             // (https://github.com/elastic/elasticsearch/issues/4103)
             String prefix = randomAlphaOfLengthBetween(5, 30);
             prefixes.put(String.valueOf(i), prefix);
-            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+            indexRequestBuilders[i] = client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource("field1", "Sentence " + prefix + " test. Sentence two.");
         }
         logger.info("--> indexing docs");
@@ -3172,7 +3190,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         mappings.endObject();
         assertAcked(prepareCreate("test").addMapping("type", mappings));
 
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("text", "Arbitrary text field which will should not cause a failure").endObject())
             .get();
         refresh();
@@ -3212,7 +3231,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test").addMapping("jobs", mappings));
         ensureYellow();
 
-        client().prepareIndex("test", "jobs", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("jd", "some आवश्यकता है- आर्य समाज अनाथालय, 68 सिविल लाइन्स, बरेली को एक पुरूष" + " रस text")
@@ -3250,7 +3270,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         mappings.endObject();
         assertAcked(prepareCreate("test").addMapping("type", mappings));
 
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("keyword_field", "some text").endObject())
             .get();
         refresh();
@@ -3293,7 +3314,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         );
         prepareCreate("test").addMapping("type", mapping, XContentType.JSON).get();
 
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .startArray("foo")
@@ -3321,7 +3343,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testFunctionScoreQueryHighlight() throws Exception {
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("text", "brown").endObject())
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
@@ -3337,7 +3360,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testFiltersFunctionScoreQueryHighlight() throws Exception {
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("text", "brown").field("enable", "yes").endObject())
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
@@ -3374,9 +3398,9 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         DateFormatter formatter = DateFormatter.forPattern("strict_date_optional_time");
         indexRandom(
             true,
-            client().prepareIndex("index-1", "type", "1").setSource("d", formatter.format(now), "field", "hello world"),
-            client().prepareIndex("index-1", "type", "2").setSource("d", formatter.format(now.minusDays(1)), "field", "hello"),
-            client().prepareIndex("index-1", "type", "3").setSource("d", formatter.format(now.minusDays(2)), "field", "world")
+            client().prepareIndex("index-1").setId("1").setSource("d", formatter.format(now), "field", "hello world"),
+            client().prepareIndex("index-1").setId("2").setSource("d", formatter.format(now.minusDays(1)), "field", "hello"),
+            client().prepareIndex("index-1").setId("3").setSource("d", formatter.format(now.minusDays(2)), "field", "world")
         );
         ensureSearchable("index-1");
         for (int i = 0; i < 5; i++) {
@@ -3421,7 +3445,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         );
         prepareCreate("test").addMapping("type", mapping, XContentType.JSON).get();
 
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .startArray("foo")
@@ -3491,7 +3516,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         );
         ensureGreen();
 
-        client().prepareIndex("test", "doc", "0")
+        client().prepareIndex("test")
+            .setId("0")
             .setSource("keyword", "Hello World")
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();
@@ -3512,7 +3538,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test").addMapping("doc", "keyword", "type=keyword"));
         ensureGreen();
 
-        client().prepareIndex("test", "doc", "d33f85bf1e51e84d9ab38948db9f3a068e1fe5294f1d8603914ac8c7bcc39ca1")
+        client().prepareIndex("test")
+            .setId("d33f85bf1e51e84d9ab38948db9f3a068e1fe5294f1d8603914ac8c7bcc39ca1")
             .setSource("keyword", "Hello World")
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .get();

--- a/server/src/internalClusterTest/java/org/opensearch/search/fields/SearchFieldsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fields/SearchFieldsIT.java
@@ -208,7 +208,8 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
 
         client().admin().indices().preparePutMapping().setType("type1").setSource(mapping, XContentType.JSON).get();
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject().field("field1", "value1").field("field2", "value2").field("field3", "value3").endObject()
             )
@@ -302,19 +303,22 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
 
         client().admin().indices().preparePutMapping().setType("type1").setSource(mapping, XContentType.JSON).get();
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject().field("test", "value beck").field("num1", 1.0f).field("date", "1970-01-01T00:00:00").endObject()
             )
             .get();
         client().admin().indices().prepareFlush().get();
-        client().prepareIndex("test", "type1", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(
                 jsonBuilder().startObject().field("test", "value beck").field("num1", 2.0f).field("date", "1970-01-01T00:00:25").endObject()
             )
             .get();
         client().admin().indices().prepareFlush().get();
-        client().prepareIndex("test", "type1", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setSource(
                 jsonBuilder().startObject().field("test", "value beck").field("num1", 3.0f).field("date", "1970-01-01T00:02:00").endObject()
             )
@@ -403,9 +407,10 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
         indexRandom(
             true,
             false,
-            client().prepareIndex("test", "doc", "1")
+            client().prepareIndex("test")
+                .setId("1")
                 .setSource(jsonBuilder().startObject().field("date", "1970-01-01T00:00:00.000Z").endObject()),
-            client().prepareIndex("test", "doc", "2").setSource(jsonBuilder().startObject().field("date", date).endObject())
+            client().prepareIndex("test").setId("2").setSource(jsonBuilder().startObject().field("date", date).endObject())
         );
 
         SearchResponse response = client().prepareSearch()
@@ -443,7 +448,8 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
         int numDocs = randomIntBetween(1, 30);
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
-            indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i))
+            indexRequestBuilders[i] = client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource(jsonBuilder().startObject().field("num1", i).endObject());
         }
         indexRandom(true, indexRequestBuilders);
@@ -505,7 +511,8 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
     public void testScriptFieldUsingSource() throws Exception {
         createIndex("test");
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .startObject("obj1")
@@ -566,7 +573,7 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
     }
 
     public void testScriptFieldsForNullReturn() throws Exception {
-        client().prepareIndex("test", "type1", "1").setSource("foo", "bar").setRefreshPolicy("true").get();
+        client().prepareIndex("test").setId("1").setSource("foo", "bar").setRefreshPolicy("true").get();
 
         SearchResponse response = client().prepareSearch()
             .setQuery(matchAllQuery())
@@ -585,7 +592,8 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
     public void testPartialFields() throws Exception {
         createIndex("test");
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 XContentFactory.jsonBuilder()
                     .startObject()
@@ -666,7 +674,8 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
         client().admin().indices().preparePutMapping().setType("type1").setSource(mapping, XContentType.JSON).get();
 
         ZonedDateTime date = ZonedDateTime.of(2012, 3, 22, 0, 0, 0, 0, ZoneOffset.UTC);
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("byte_field", (byte) 1)
@@ -731,7 +740,8 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
     }
 
     public void testSearchFieldsMetadata() throws Exception {
-        client().prepareIndex("my-index", "my-type1", "1")
+        client().prepareIndex("my-index")
+            .setId("1")
             .setRouting("1")
             .setSource(jsonBuilder().startObject().field("field1", "value").endObject())
             .setRefreshPolicy(IMMEDIATE)
@@ -745,7 +755,8 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
     }
 
     public void testSearchFieldsNonLeafField() throws Exception {
-        client().prepareIndex("my-index", "my-type1", "1")
+        client().prepareIndex("my-index")
+            .setId("1")
             .setSource(jsonBuilder().startObject().startObject("field1").field("field2", "value1").endObject().endObject())
             .setRefreshPolicy(IMMEDIATE)
             .get();
@@ -817,7 +828,7 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
                 .endObject()
         );
 
-        client().prepareIndex("my-index", "doc", "1").setRefreshPolicy(IMMEDIATE).setSource(source, XContentType.JSON).get();
+        client().prepareIndex("my-index").setId("1").setRefreshPolicy(IMMEDIATE).setSource(source, XContentType.JSON).get();
 
         String field = "field1.field2.field3.field4";
 
@@ -831,7 +842,7 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
     // see #8203
     public void testSingleValueFieldDatatField() throws ExecutionException, InterruptedException {
         assertAcked(client().admin().indices().prepareCreate("test").addMapping("type", "test_field", "type=keyword").get());
-        indexRandom(true, client().prepareIndex("test", "type", "1").setSource("test_field", "foobar"));
+        indexRandom(true, client().prepareIndex("test").setId("1").setSource("test_field", "foobar"));
         refresh();
         SearchResponse searchResponse = client().prepareSearch("test")
             .setSource(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()).docValueField("test_field"))
@@ -898,7 +909,8 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
         client().admin().indices().preparePutMapping().setType("type1").setSource(mapping, XContentType.JSON).get();
 
         ZonedDateTime date = ZonedDateTime.of(2012, 3, 22, 0, 0, 0, 0, ZoneOffset.UTC);
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("text_field", "foo")
@@ -1124,7 +1136,8 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
         List<IndexRequestBuilder> reqs = new ArrayList<>();
         for (int i = 0; i < numDocs; ++i) {
             reqs.add(
-                client().prepareIndex("index", "type", Integer.toString(i))
+                client().prepareIndex("index")
+                    .setId(Integer.toString(i))
                     .setSource(
                         "s",
                         Integer.toString(i),
@@ -1382,7 +1395,8 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("test", "doc", "1")
+            client().prepareIndex("test")
+                .setId("1")
                 .setRouting("1")
                 .setSource(jsonBuilder().startObject().field("field1", "value").endObject())
         );

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/FunctionScoreFieldValueIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/FunctionScoreFieldValueIT.java
@@ -71,9 +71,9 @@ public class FunctionScoreFieldValueIT extends OpenSearchIntegTestCase {
             ).get()
         );
 
-        client().prepareIndex("test", "type1", "1").setSource("test", 5, "body", "foo").get();
-        client().prepareIndex("test", "type1", "2").setSource("test", 17, "body", "foo").get();
-        client().prepareIndex("test", "type1", "3").setSource("body", "bar").get();
+        client().prepareIndex("test").setId("1").setSource("test", 5, "body", "foo").get();
+        client().prepareIndex("test").setId("2").setSource("test", 17, "body", "foo").get();
+        client().prepareIndex("test").setId("3").setSource("body", "bar").get();
 
         refresh();
 
@@ -143,7 +143,7 @@ public class FunctionScoreFieldValueIT extends OpenSearchIntegTestCase {
             .get();
         assertEquals(response.getHits().getAt(0).getScore(), response.getHits().getAt(2).getScore(), 0);
 
-        client().prepareIndex("test", "type1", "2").setSource("test", -1, "body", "foo").get();
+        client().prepareIndex("test").setId("2").setSource("test", -1, "body", "foo").get();
         refresh();
 
         // -1 divided by 0 is infinity, which should provoke an exception.

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/FunctionScoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/FunctionScoreIT.java
@@ -189,7 +189,7 @@ public class FunctionScoreIT extends OpenSearchIntegTestCase {
         int scoreOffset = randomIntBetween(0, 2 * numDocs);
         int minScore = randomIntBetween(0, 2 * numDocs);
         for (int i = 0; i < numDocs; i++) {
-            docs.add(client().prepareIndex(INDEX, TYPE, Integer.toString(i)).setSource("num", i + scoreOffset));
+            docs.add(client().prepareIndex(INDEX).setId(Integer.toString(i)).setSource("num", i + scoreOffset));
         }
         indexRandom(true, docs);
         Script script = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "return (doc['num'].value)", Collections.emptyMap());

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/QueryRescorerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/QueryRescorerIT.java
@@ -92,7 +92,7 @@ public class QueryRescorerIT extends OpenSearchIntegTestCase {
         // this
         int iters = scaledRandomIntBetween(10, 20);
         for (int i = 0; i < iters; i++) {
-            client().prepareIndex("test", "type", Integer.toString(i)).setSource("f", Integer.toString(i)).get();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("f", Integer.toString(i)).get();
         }
         refresh();
 
@@ -142,9 +142,10 @@ public class QueryRescorerIT extends OpenSearchIntegTestCase {
             ).setSettings(Settings.builder().put(indexSettings()).put("index.number_of_shards", 1))
         );
 
-        client().prepareIndex("test", "type1", "1").setSource("field1", "the quick brown fox").get();
-        client().prepareIndex("test", "type1", "2").setSource("field1", "the quick lazy huge brown fox jumps over the tree ").get();
-        client().prepareIndex("test", "type1", "3")
+        client().prepareIndex("test").setId("1").setSource("field1", "the quick brown fox").get();
+        client().prepareIndex("test").setId("2").setSource("field1", "the quick lazy huge brown fox jumps over the tree ").get();
+        client().prepareIndex("test")
+            .setId("3")
             .setSource("field1", "quick huge brown", "field2", "the quick lazy huge brown fox jumps over the tree")
             .get();
         refresh();
@@ -207,21 +208,21 @@ public class QueryRescorerIT extends OpenSearchIntegTestCase {
                 .setSettings(builder.put("index.number_of_shards", 1))
         );
 
-        client().prepareIndex("test", "type1", "1").setSource("field1", "massachusetts avenue boston massachusetts").get();
-        client().prepareIndex("test", "type1", "2").setSource("field1", "lexington avenue boston massachusetts").get();
-        client().prepareIndex("test", "type1", "3").setSource("field1", "boston avenue lexington massachusetts").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "massachusetts avenue boston massachusetts").get();
+        client().prepareIndex("test").setId("2").setSource("field1", "lexington avenue boston massachusetts").get();
+        client().prepareIndex("test").setId("3").setSource("field1", "boston avenue lexington massachusetts").get();
         client().admin().indices().prepareRefresh("test").get();
-        client().prepareIndex("test", "type1", "4").setSource("field1", "boston road lexington massachusetts").get();
-        client().prepareIndex("test", "type1", "5").setSource("field1", "lexington street lexington massachusetts").get();
-        client().prepareIndex("test", "type1", "6").setSource("field1", "massachusetts avenue lexington massachusetts").get();
-        client().prepareIndex("test", "type1", "7").setSource("field1", "bosten street san franciso california").get();
+        client().prepareIndex("test").setId("4").setSource("field1", "boston road lexington massachusetts").get();
+        client().prepareIndex("test").setId("5").setSource("field1", "lexington street lexington massachusetts").get();
+        client().prepareIndex("test").setId("6").setSource("field1", "massachusetts avenue lexington massachusetts").get();
+        client().prepareIndex("test").setId("7").setSource("field1", "bosten street san franciso california").get();
         client().admin().indices().prepareRefresh("test").get();
-        client().prepareIndex("test", "type1", "8").setSource("field1", "hollywood boulevard los angeles california").get();
-        client().prepareIndex("test", "type1", "9").setSource("field1", "1st street boston massachussetts").get();
-        client().prepareIndex("test", "type1", "10").setSource("field1", "1st street boston massachusetts").get();
+        client().prepareIndex("test").setId("8").setSource("field1", "hollywood boulevard los angeles california").get();
+        client().prepareIndex("test").setId("9").setSource("field1", "1st street boston massachussetts").get();
+        client().prepareIndex("test").setId("10").setSource("field1", "1st street boston massachusetts").get();
         client().admin().indices().prepareRefresh("test").get();
-        client().prepareIndex("test", "type1", "11").setSource("field1", "2st street boston massachusetts").get();
-        client().prepareIndex("test", "type1", "12").setSource("field1", "3st street boston massachusetts").get();
+        client().prepareIndex("test").setId("11").setSource("field1", "2st street boston massachusetts").get();
+        client().prepareIndex("test").setId("12").setSource("field1", "3st street boston massachusetts").get();
         client().admin().indices().prepareRefresh("test").get();
         SearchResponse searchResponse = client().prepareSearch()
             .setQuery(QueryBuilders.matchQuery("field1", "lexington avenue massachusetts").operator(Operator.OR))
@@ -302,11 +303,11 @@ public class QueryRescorerIT extends OpenSearchIntegTestCase {
                 .setSettings(builder.put("index.number_of_shards", 1))
         );
 
-        client().prepareIndex("test", "type1", "3").setSource("field1", "massachusetts").get();
-        client().prepareIndex("test", "type1", "6").setSource("field1", "massachusetts avenue lexington massachusetts").get();
+        client().prepareIndex("test").setId("3").setSource("field1", "massachusetts").get();
+        client().prepareIndex("test").setId("6").setSource("field1", "massachusetts avenue lexington massachusetts").get();
         client().admin().indices().prepareRefresh("test").get();
-        client().prepareIndex("test", "type1", "1").setSource("field1", "lexington massachusetts avenue").get();
-        client().prepareIndex("test", "type1", "2").setSource("field1", "lexington avenue boston massachusetts road").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "lexington massachusetts avenue").get();
+        client().prepareIndex("test").setId("2").setSource("field1", "lexington avenue boston massachusetts road").get();
         client().admin().indices().prepareRefresh("test").get();
 
         SearchResponse searchResponse = client().prepareSearch()
@@ -388,11 +389,11 @@ public class QueryRescorerIT extends OpenSearchIntegTestCase {
                 .setSettings(builder.put("index.number_of_shards", 1))
         );
 
-        client().prepareIndex("test", "type1", "3").setSource("field1", "massachusetts").get();
-        client().prepareIndex("test", "type1", "6").setSource("field1", "massachusetts avenue lexington massachusetts").get();
+        client().prepareIndex("test").setId("3").setSource("field1", "massachusetts").get();
+        client().prepareIndex("test").setId("6").setSource("field1", "massachusetts avenue lexington massachusetts").get();
         client().admin().indices().prepareRefresh("test").get();
-        client().prepareIndex("test", "type1", "1").setSource("field1", "lexington massachusetts avenue").get();
-        client().prepareIndex("test", "type1", "2").setSource("field1", "lexington avenue boston massachusetts road").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "lexington massachusetts avenue").get();
+        client().prepareIndex("test").setId("2").setSource("field1", "lexington avenue boston massachusetts road").get();
         client().admin().indices().prepareRefresh("test").get();
 
         SearchResponse searchResponse = client().prepareSearch()
@@ -538,9 +539,10 @@ public class QueryRescorerIT extends OpenSearchIntegTestCase {
             )
         );
         ensureGreen();
-        client().prepareIndex("test", "type1", "1").setSource("field1", "the quick brown fox").get();
-        client().prepareIndex("test", "type1", "2").setSource("field1", "the quick lazy huge brown fox jumps over the tree").get();
-        client().prepareIndex("test", "type1", "3")
+        client().prepareIndex("test").setId("1").setSource("field1", "the quick brown fox").get();
+        client().prepareIndex("test").setId("2").setSource("field1", "the quick lazy huge brown fox jumps over the tree").get();
+        client().prepareIndex("test")
+            .setId("3")
             .setSource("field1", "quick huge brown", "field2", "the quick lazy huge brown fox jumps over the tree")
             .get();
         refresh();
@@ -800,7 +802,7 @@ public class QueryRescorerIT extends OpenSearchIntegTestCase {
         int numDocs = randomIntBetween(100, 150);
         IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
-            docs[i] = client().prepareIndex("test", "type1", String.valueOf(i)).setSource("field1", English.intToEnglish(i));
+            docs[i] = client().prepareIndex("test").setId(String.valueOf(i)).setSource("field1", English.intToEnglish(i));
         }
 
         indexRandom(true, dummyDocs, docs);
@@ -815,7 +817,7 @@ public class QueryRescorerIT extends OpenSearchIntegTestCase {
         settings.put(SETTING_NUMBER_OF_REPLICAS, 0);
         assertAcked(prepareCreate("test").setSettings(settings));
         for (int i = 0; i < 5; i++) {
-            client().prepareIndex("test", "type", "" + i).setSource("text", "hello world").get();
+            client().prepareIndex("test").setId("" + i).setSource("text", "hello world").get();
         }
         refresh();
 
@@ -831,7 +833,7 @@ public class QueryRescorerIT extends OpenSearchIntegTestCase {
     public void testRescorePhaseWithInvalidSort() throws Exception {
         assertAcked(prepareCreate("test"));
         for (int i = 0; i < 5; i++) {
-            client().prepareIndex("test", "type", "" + i).setSource("number", 0).get();
+            client().prepareIndex("test").setId("" + i).setSource("number", 0).get();
         }
         refresh();
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/RandomScoreFunctionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/RandomScoreFunctionIT.java
@@ -178,7 +178,8 @@ public class RandomScoreFunctionIT extends OpenSearchIntegTestCase {
 
         int docCount = randomIntBetween(100, 200);
         for (int i = 0; i < docCount; i++) {
-            client().prepareIndex("test", "type", "" + i)
+            client().prepareIndex("test")
+                .setId("" + i)
                 // we add 1 to the index field to make sure that the scripts below never compute log(0)
                 .setSource("body", randomFrom(Arrays.asList("foo", "bar", "baz")), "index", i + 1)
                 .get();

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoBoundingBoxQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoBoundingBoxQueryIT.java
@@ -72,7 +72,8 @@ public class GeoBoundingBoxQueryIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test").setSettings(settings).addMapping("type1", xContentBuilder));
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("name", "New York")
@@ -85,7 +86,8 @@ public class GeoBoundingBoxQueryIT extends OpenSearchIntegTestCase {
             .get();
 
         // to NY: 5.286 km
-        client().prepareIndex("test", "type1", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(
                 jsonBuilder().startObject()
                     .field("name", "Times Square")
@@ -98,7 +100,8 @@ public class GeoBoundingBoxQueryIT extends OpenSearchIntegTestCase {
             .get();
 
         // to NY: 0.4621 km
-        client().prepareIndex("test", "type1", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setSource(
                 jsonBuilder().startObject()
                     .field("name", "Tribeca")
@@ -111,7 +114,8 @@ public class GeoBoundingBoxQueryIT extends OpenSearchIntegTestCase {
             .get();
 
         // to NY: 1.055 km
-        client().prepareIndex("test", "type1", "4")
+        client().prepareIndex("test")
+            .setId("4")
             .setSource(
                 jsonBuilder().startObject()
                     .field("name", "Wall Street")
@@ -124,7 +128,8 @@ public class GeoBoundingBoxQueryIT extends OpenSearchIntegTestCase {
             .get();
 
         // to NY: 1.258 km
-        client().prepareIndex("test", "type1", "5")
+        client().prepareIndex("test")
+            .setId("5")
             .setSource(
                 jsonBuilder().startObject()
                     .field("name", "Soho")
@@ -137,7 +142,8 @@ public class GeoBoundingBoxQueryIT extends OpenSearchIntegTestCase {
             .get();
 
         // to NY: 2.029 km
-        client().prepareIndex("test", "type1", "6")
+        client().prepareIndex("test")
+            .setId("6")
             .setSource(
                 jsonBuilder().startObject()
                     .field("name", "Greenwich Village")
@@ -150,7 +156,8 @@ public class GeoBoundingBoxQueryIT extends OpenSearchIntegTestCase {
             .get();
 
         // to NY: 8.572 km
-        client().prepareIndex("test", "type1", "7")
+        client().prepareIndex("test")
+            .setId("7")
             .setSource(
                 jsonBuilder().startObject()
                     .field("name", "Brooklyn")
@@ -196,7 +203,8 @@ public class GeoBoundingBoxQueryIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test").setSettings(settings).addMapping("type1", xContentBuilder));
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("userid", 880)
@@ -210,7 +218,8 @@ public class GeoBoundingBoxQueryIT extends OpenSearchIntegTestCase {
             .setRefreshPolicy(IMMEDIATE)
             .get();
 
-        client().prepareIndex("test", "type1", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(
                 jsonBuilder().startObject()
                     .field("userid", 534)
@@ -274,7 +283,8 @@ public class GeoBoundingBoxQueryIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test").setSettings(settings).addMapping("type1", xContentBuilder));
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("userid", 880)
@@ -288,7 +298,8 @@ public class GeoBoundingBoxQueryIT extends OpenSearchIntegTestCase {
             .setRefreshPolicy(IMMEDIATE)
             .get();
 
-        client().prepareIndex("test", "type1", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(
                 jsonBuilder().startObject()
                     .field("userid", 534)

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoDistanceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoDistanceIT.java
@@ -134,7 +134,8 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
     }
 
     public void testDistanceScript() throws Exception {
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("name", "TestPosition")
@@ -202,7 +203,8 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
     }
 
     public void testGeoDistanceAggregation() throws IOException {
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("name", "TestPosition")

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoFilterIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoFilterIT.java
@@ -249,7 +249,7 @@ public class GeoFilterIT extends OpenSearchIntegTestCase {
             );
         BytesReference data = BytesReference.bytes(jsonBuilder().startObject().field("area", polygon).endObject());
 
-        client().prepareIndex("shapes", "polygon", "1").setSource(data, XContentType.JSON).get();
+        client().prepareIndex("shapes").setId("1").setSource(data, XContentType.JSON).get();
         client().admin().indices().prepareRefresh().get();
 
         // Point in polygon
@@ -312,7 +312,7 @@ public class GeoFilterIT extends OpenSearchIntegTestCase {
         );
 
         data = BytesReference.bytes(jsonBuilder().startObject().field("area", inverse).endObject());
-        client().prepareIndex("shapes", "polygon", "2").setSource(data, XContentType.JSON).get();
+        client().prepareIndex("shapes").setId("2").setSource(data, XContentType.JSON).get();
         client().admin().indices().prepareRefresh().get();
 
         // re-check point on polygon hole
@@ -351,7 +351,7 @@ public class GeoFilterIT extends OpenSearchIntegTestCase {
         );
 
         data = BytesReference.bytes(jsonBuilder().startObject().field("area", builder).endObject());
-        client().prepareIndex("shapes", "polygon", "1").setSource(data, XContentType.JSON).get();
+        client().prepareIndex("shapes").setId("1").setSource(data, XContentType.JSON).get();
         client().admin().indices().prepareRefresh().get();
 
         // Create a polygon crossing longitude 180 with hole.
@@ -364,7 +364,7 @@ public class GeoFilterIT extends OpenSearchIntegTestCase {
         );
 
         data = BytesReference.bytes(jsonBuilder().startObject().field("area", builder).endObject());
-        client().prepareIndex("shapes", "polygon", "1").setSource(data, XContentType.JSON).get();
+        client().prepareIndex("shapes").setId("1").setSource(data, XContentType.JSON).get();
         client().admin().indices().prepareRefresh().get();
 
         result = client().prepareSearch()

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoPolygonIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoPolygonIT.java
@@ -73,7 +73,8 @@ public class GeoPolygonIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("test", "type1", "1")
+            client().prepareIndex("test")
+                .setId("1")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("name", "New York")
@@ -84,7 +85,8 @@ public class GeoPolygonIT extends OpenSearchIntegTestCase {
                         .endObject()
                 ),
             // to NY: 5.286 km
-            client().prepareIndex("test", "type1", "2")
+            client().prepareIndex("test")
+                .setId("2")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("name", "Times Square")
@@ -95,7 +97,8 @@ public class GeoPolygonIT extends OpenSearchIntegTestCase {
                         .endObject()
                 ),
             // to NY: 0.4621 km
-            client().prepareIndex("test", "type1", "3")
+            client().prepareIndex("test")
+                .setId("3")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("name", "Tribeca")
@@ -106,7 +109,8 @@ public class GeoPolygonIT extends OpenSearchIntegTestCase {
                         .endObject()
                 ),
             // to NY: 1.055 km
-            client().prepareIndex("test", "type1", "4")
+            client().prepareIndex("test")
+                .setId("4")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("name", "Wall Street")
@@ -117,7 +121,8 @@ public class GeoPolygonIT extends OpenSearchIntegTestCase {
                         .endObject()
                 ),
             // to NY: 1.258 km
-            client().prepareIndex("test", "type1", "5")
+            client().prepareIndex("test")
+                .setId("5")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("name", "Soho")
@@ -128,7 +133,8 @@ public class GeoPolygonIT extends OpenSearchIntegTestCase {
                         .endObject()
                 ),
             // to NY: 2.029 km
-            client().prepareIndex("test", "type1", "6")
+            client().prepareIndex("test")
+                .setId("6")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("name", "Greenwich Village")
@@ -139,7 +145,8 @@ public class GeoPolygonIT extends OpenSearchIntegTestCase {
                         .endObject()
                 ),
             // to NY: 8.572 km
-            client().prepareIndex("test", "type1", "7")
+            client().prepareIndex("test")
+                .setId("7")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("name", "Brooklyn")

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoShapeIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoShapeIntegrationIT.java
@@ -185,7 +185,7 @@ public class GeoShapeIntegrationIT extends OpenSearchIntegTestCase {
                 .endObject()
         );
 
-        indexRandom(true, client().prepareIndex("test", "geometry", "0").setSource("shape", polygonGeoJson));
+        indexRandom(true, client().prepareIndex("test").setId("0").setSource("shape", polygonGeoJson));
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(matchAllQuery()).get();
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
     }
@@ -237,7 +237,7 @@ public class GeoShapeIntegrationIT extends OpenSearchIntegTestCase {
             + "    }\n"
             + "}";
 
-        indexRandom(true, client().prepareIndex("test", "doc", "0").setSource(source, XContentType.JSON).setRouting("ABC"));
+        indexRandom(true, client().prepareIndex("test").setId("0").setSource(source, XContentType.JSON).setRouting("ABC"));
 
         SearchResponse searchResponse = client().prepareSearch("test")
             .setQuery(geoShapeQuery("shape", "0", "doc").indexedShapeIndex("test").indexedShapeRouting("ABC"))
@@ -273,8 +273,8 @@ public class GeoShapeIntegrationIT extends OpenSearchIntegTestCase {
 
         String source = "{\n" + "    \"shape\" : \"POLYGON((179 0, -179 0, -179 2, 179 2, 179 0))\"" + "}";
 
-        indexRandom(true, client().prepareIndex("quad", "doc", "0").setSource(source, XContentType.JSON));
-        indexRandom(true, client().prepareIndex("vector", "doc", "0").setSource(source, XContentType.JSON));
+        indexRandom(true, client().prepareIndex("quad").setId("0").setSource(source, XContentType.JSON));
+        indexRandom(true, client().prepareIndex("vector").setId("0").setSource(source, XContentType.JSON));
 
         try {
             ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/LegacyGeoShapeIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/LegacyGeoShapeIntegrationIT.java
@@ -183,7 +183,7 @@ public class LegacyGeoShapeIntegrationIT extends OpenSearchIntegTestCase {
                 .endObject()
         );
 
-        indexRandom(true, client().prepareIndex("test", "geometry", "0").setSource("shape", polygonGeoJson));
+        indexRandom(true, client().prepareIndex("test").setId("0").setSource("shape", polygonGeoJson));
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(matchAllQuery()).get();
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
     }
@@ -215,7 +215,7 @@ public class LegacyGeoShapeIntegrationIT extends OpenSearchIntegTestCase {
             + "    }\n"
             + "}";
 
-        indexRandom(true, client().prepareIndex("test", "doc", "0").setSource(source, XContentType.JSON).setRouting("ABC"));
+        indexRandom(true, client().prepareIndex("test").setId("0").setSource(source, XContentType.JSON).setRouting("ABC"));
 
         SearchResponse searchResponse = client().prepareSearch("test")
             .setQuery(geoShapeQuery("shape", "0", "doc").indexedShapeIndex("test").indexedShapeRouting("ABC"))
@@ -238,7 +238,7 @@ public class LegacyGeoShapeIntegrationIT extends OpenSearchIntegTestCase {
         );
         ensureGreen();
 
-        indexRandom(true, client().prepareIndex("test", "_doc", "0").setSource("shape", (ToXContent) (builder, params) -> {
+        indexRandom(true, client().prepareIndex("test").setId("0").setSource("shape", (ToXContent) (builder, params) -> {
             builder.startObject()
                 .field("type", "circle")
                 .startArray("coordinates")

--- a/server/src/internalClusterTest/java/org/opensearch/search/morelikethis/MoreLikeThisIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/morelikethis/MoreLikeThisIT.java
@@ -313,7 +313,8 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
             XContentFactory.jsonBuilder().startObject().startObject("bar").startObject("properties").endObject().endObject().endObject()
         );
         client().admin().indices().prepareCreate("foo").addMapping("bar", mapping, XContentType.JSON).get();
-        client().prepareIndex("foo", "bar", "1")
+        client().prepareIndex("foo")
+            .setId("1")
             .setSource(jsonBuilder().startObject().startObject("foo").field("bar", "boz").endObject().endObject())
             .get();
         client().admin().indices().prepareRefresh("foo").get();
@@ -337,7 +338,8 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
         client().admin().indices().prepareCreate("foo").addMapping("bar", mapping, XContentType.JSON).get();
         ensureGreen();
 
-        client().prepareIndex("foo", "bar", "1")
+        client().prepareIndex("foo")
+            .setId("1")
             .setSource(jsonBuilder().startObject().startObject("foo").field("bar", "boz").endObject().endObject())
             .setRouting("2")
             .get();
@@ -364,7 +366,8 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
         );
         ensureGreen();
 
-        client().prepareIndex("foo", "bar", "1")
+        client().prepareIndex("foo")
+            .setId("1")
             .setSource(jsonBuilder().startObject().startObject("foo").field("bar", "boz").endObject().endObject())
             .setRouting("4000")
             .get();
@@ -395,10 +398,12 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
                 .endObject()
         ).get();
         ensureGreen();
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("string_value", "lucene index").field("int_value", 1).endObject())
             .get();
-        client().prepareIndex("test", "type", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(jsonBuilder().startObject().field("string_value", "opensearch index").field("int_value", 42).endObject())
             .get();
 
@@ -637,10 +642,10 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
         String[] values = { "aaaa", "bbbb", "cccc", "dddd", "eeee", "ffff", "gggg", "hhhh", "iiii", "jjjj" };
         List<IndexRequestBuilder> builders = new ArrayList<>(values.length + 1);
         // index one document with all the values
-        builders.add(client().prepareIndex("test", "type1", "0").setSource("text", values));
+        builders.add(client().prepareIndex("test").setId("0").setSource("text", values));
         // index each document with only one of the values
         for (int i = 0; i < values.length; i++) {
-            builders.add(client().prepareIndex("test", "type1", String.valueOf(i + 1)).setSource("text", values[i]));
+            builders.add(client().prepareIndex("test").setId(String.valueOf(i + 1)).setSource("text", values[i]));
         }
         indexRandom(true, builders);
 
@@ -674,7 +679,7 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
             for (int j = 1; j <= 10 - i; j++) {
                 text += j + " ";
             }
-            builders.add(client().prepareIndex("test", "type1", i + "").setSource("text", text));
+            builders.add(client().prepareIndex("test").setId(i + "").setSource("text", text));
         }
         indexRandom(true, builders);
 
@@ -708,7 +713,7 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
             doc.field("field" + i, generateRandomStringArray(5, 10, false) + "a"); // make sure they are not all empty
         }
         doc.endObject();
-        indexRandom(true, client().prepareIndex("test", "type1", "0").setSource(doc));
+        indexRandom(true, client().prepareIndex("test").setId("0").setSource(doc));
 
         logger.info("Checking the document matches ...");
         // routing to ensure we hit the shard with the doc
@@ -737,7 +742,8 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
         logger.info("Creating an index with a single document ...");
         indexRandom(
             true,
-            client().prepareIndex("test", MapperService.SINGLE_MAPPING_NAME, "1")
+            client().prepareIndex("test")
+                .setId("1")
                 .setSource(jsonBuilder().startObject().field("text", "Hello World!").field("date", "2009-01-01").endObject())
         );
 
@@ -788,7 +794,7 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
         logger.info("Indexing each field value of this document as a single document.");
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < numFields; i++) {
-            builders.add(client().prepareIndex("test", "type1", i + "").setSource("field" + i, i + ""));
+            builders.add(client().prepareIndex("test").setId(i + "").setSource("field" + i, i + ""));
         }
         indexRandom(true, builders);
 
@@ -826,9 +832,11 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("test", "type1", "1")
+            client().prepareIndex("test")
+                .setId("1")
                 .setSource(jsonBuilder().startObject().field("text", "hello world").field("text1", "opensearch").endObject()),
-            client().prepareIndex("test", "type1", "2")
+            client().prepareIndex("test")
+                .setId("2")
                 .setSource(jsonBuilder().startObject().field("text", "goodby moon").field("text1", "opensearch").endObject())
         );
 
@@ -850,9 +858,9 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
     }
 
     public void testWithRouting() throws IOException {
-        client().prepareIndex("index", "type", "1").setRouting("3").setSource("text", "this is a document").get();
-        client().prepareIndex("index", "type", "2").setRouting("1").setSource("text", "this is another document").get();
-        client().prepareIndex("index", "type", "3").setRouting("4").setSource("text", "this is yet another document").get();
+        client().prepareIndex("index").setId("1").setRouting("3").setSource("text", "this is a document").get();
+        client().prepareIndex("index").setId("2").setRouting("1").setSource("text", "this is another document").get();
+        client().prepareIndex("index").setId("3").setRouting("4").setSource("text", "this is yet another document").get();
         refresh("index");
 
         Item item = new Item("index", "2").routing("1");

--- a/server/src/internalClusterTest/java/org/opensearch/search/msearch/MultiSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/msearch/MultiSearchIT.java
@@ -49,8 +49,8 @@ public class MultiSearchIT extends OpenSearchIntegTestCase {
     public void testSimpleMultiSearch() {
         createIndex("test");
         ensureGreen();
-        client().prepareIndex("test", "type", "1").setSource("field", "xxx").get();
-        client().prepareIndex("test", "type", "2").setSource("field", "yyy").get();
+        client().prepareIndex("test").setId("1").setSource("field", "xxx").get();
+        client().prepareIndex("test").setId("2").setSource("field", "yyy").get();
         refresh();
         MultiSearchResponse response = client().prepareMultiSearch()
             .add(client().prepareSearch("test").setQuery(QueryBuilders.termQuery("field", "xxx")))
@@ -73,7 +73,7 @@ public class MultiSearchIT extends OpenSearchIntegTestCase {
         createIndex("test");
         int numDocs = randomIntBetween(0, 16);
         for (int i = 0; i < numDocs; i++) {
-            client().prepareIndex("test", "type", Integer.toString(i)).setSource("{}", XContentType.JSON).get();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("{}", XContentType.JSON).get();
         }
         refresh();
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/nested/SimpleNestedIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/nested/SimpleNestedIT.java
@@ -82,7 +82,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
         searchResponse = client().prepareSearch("test").setQuery(termQuery("n_field1", "n_value1_1")).get();
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("field1", "value1")
@@ -133,7 +134,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
 
         // add another doc, one that would match if it was not nested...
 
-        client().prepareIndex("test", "type1", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(
                 jsonBuilder().startObject()
                     .field("field1", "value1")
@@ -231,7 +233,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
         );
 
         ensureGreen();
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("field", "value")
@@ -389,7 +392,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
 
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("field1", "value1")
@@ -407,7 +411,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
             )
             .get();
 
-        client().prepareIndex("test", "type1", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(
                 jsonBuilder().startObject()
                     .field("field1", "value2")
@@ -448,7 +453,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
 
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("field1", "value1")
@@ -500,7 +506,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
         );
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("field1", 1)
@@ -515,7 +522,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
                     .endObject()
             )
             .get();
-        client().prepareIndex("test", "type1", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(
                 jsonBuilder().startObject()
                     .field("field1", 2)
@@ -530,7 +538,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
                     .endObject()
             )
             .get();
-        client().prepareIndex("test", "type1", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setSource(
                 jsonBuilder().startObject()
                     .field("field1", 3)
@@ -600,7 +609,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
         );
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("field1", 1)
@@ -617,7 +627,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
                     .endObject()
             )
             .get();
-        client().prepareIndex("test", "type1", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(
                 jsonBuilder().startObject()
                     .field("field1", 2)
@@ -636,7 +647,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
             .get();
         // Doc with missing nested docs if nested filter is used
         refresh();
-        client().prepareIndex("test", "type1", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setSource(
                 jsonBuilder().startObject()
                     .field("field1", 3)
@@ -739,7 +751,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
         );
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 "{\n"
                     + "  \"acl\": [\n"
@@ -793,7 +806,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
             )
             .get();
 
-        client().prepareIndex("test", "type1", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(
                 "{\n"
                     + "  \"acl\": [\n"
@@ -979,7 +993,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
         );
         ensureGreen();
 
-        client().prepareIndex("test", "test-type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 "{\n"
                     + "  \"nested1\": [\n"
@@ -997,7 +1012,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
             )
             .get();
 
-        client().prepareIndex("test", "test-type", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(
                 "{\n"
                     + "  \"nested1\": [\n"
@@ -1071,7 +1087,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
         ensureGreen();
 
         // sum: 11
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("grand_parent_values", 1L)
@@ -1113,7 +1130,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
             .get();
 
         // sum: 7
-        client().prepareIndex("test", "type1", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(
                 jsonBuilder().startObject()
                     .field("grand_parent_values", 2L)
@@ -1155,7 +1173,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
             .get();
 
         // sum: 2
-        client().prepareIndex("test", "type1", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setSource(
                 jsonBuilder().startObject()
                     .field("grand_parent_values", 3L)
@@ -1469,7 +1488,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
             )
         );
 
-        IndexResponse indexResponse1 = client().prepareIndex("test", "type", "1")
+        IndexResponse indexResponse1 = client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("officelocation", "gendale")
@@ -1522,7 +1542,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
             .get();
         assertTrue(indexResponse1.getShardInfo().getSuccessful() > 0);
 
-        IndexResponse indexResponse2 = client().prepareIndex("test", "type", "2")
+        IndexResponse indexResponse2 = client().prepareIndex("test")
+            .setId("2")
             .setSource(
                 jsonBuilder().startObject()
                     .field("officelocation", "gendale")
@@ -1603,8 +1624,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
         }
         assertAcked(prepareCreate("test").setSettings(settingsBuilder).addMapping("type"));
 
-        client().prepareIndex("test", "type", "0").setSource("field", "value").get();
-        client().prepareIndex("test", "type", "1").setSource("field", "value").get();
+        client().prepareIndex("test").setId("0").setSource("field", "value").get();
+        client().prepareIndex("test").setId("1").setSource("field", "value").get();
         refresh();
         ensureSearchable("test");
 
@@ -1623,11 +1644,11 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
             .endArray()
             .endObject();
         // index simple data
-        client().prepareIndex("test", "type", "2").setSource(builder).get();
-        client().prepareIndex("test", "type", "3").setSource(builder).get();
-        client().prepareIndex("test", "type", "4").setSource(builder).get();
-        client().prepareIndex("test", "type", "5").setSource(builder).get();
-        client().prepareIndex("test", "type", "6").setSource(builder).get();
+        client().prepareIndex("test").setId("2").setSource(builder).get();
+        client().prepareIndex("test").setId("3").setSource(builder).get();
+        client().prepareIndex("test").setId("4").setSource(builder).get();
+        client().prepareIndex("test").setId("5").setSource(builder).get();
+        client().prepareIndex("test").setId("6").setSource(builder).get();
         refresh();
         ensureSearchable("test");
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/preference/SearchPreferenceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/preference/SearchPreferenceIT.java
@@ -83,7 +83,7 @@ public class SearchPreferenceIT extends OpenSearchIntegTestCase {
         );
         ensureGreen();
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test", "type1", "" + i).setSource("field1", "value1").get();
+            client().prepareIndex("test").setId("" + i).setSource("field1", "value1").get();
         }
         refresh();
         internalCluster().stopRandomDataNode();

--- a/server/src/internalClusterTest/java/org/opensearch/search/profile/ProfilerSingleNodeNetworkTest.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/profile/ProfilerSingleNodeNetworkTest.java
@@ -35,7 +35,7 @@ public class ProfilerSingleNodeNetworkTest extends OpenSearchSingleNodeTestCase 
         int numDocs = randomIntBetween(100, 150);
         IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
-            docs[i] = client().prepareIndex("test", "type1", String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
+            docs[i] = client().prepareIndex("test").setId(String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
         }
 
         List<String> stringFields = Arrays.asList("field1");

--- a/server/src/internalClusterTest/java/org/opensearch/search/profile/query/QueryProfilerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/profile/query/QueryProfilerIT.java
@@ -67,7 +67,7 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
         int numDocs = randomIntBetween(100, 150);
         IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
-            docs[i] = client().prepareIndex("test", "type1", String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
+            docs[i] = client().prepareIndex("test").setId(String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
         }
 
         List<String> stringFields = Arrays.asList("field1");
@@ -121,7 +121,8 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
         int numDocs = randomIntBetween(100, 150);
         IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
-            docs[i] = client().prepareIndex("test", "type1", String.valueOf(i))
+            docs[i] = client().prepareIndex("test")
+                .setId(String.valueOf(i))
                 .setSource("id", String.valueOf(i), "field1", English.intToEnglish(i), "field2", i);
         }
 
@@ -199,7 +200,7 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
         int numDocs = randomIntBetween(100, 150);
         IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
-            docs[i] = client().prepareIndex("test", "type1", String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
+            docs[i] = client().prepareIndex("test").setId(String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
         }
 
         indexRandom(true, docs);
@@ -239,7 +240,7 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
         int numDocs = randomIntBetween(100, 150);
         IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
-            docs[i] = client().prepareIndex("test", "type1", String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
+            docs[i] = client().prepareIndex("test").setId(String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
         }
 
         indexRandom(true, docs);
@@ -299,7 +300,7 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
         int numDocs = randomIntBetween(100, 150);
         IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
-            docs[i] = client().prepareIndex("test", "type1", String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
+            docs[i] = client().prepareIndex("test").setId(String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
         }
 
         indexRandom(true, docs);
@@ -342,7 +343,7 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
         int numDocs = randomIntBetween(100, 150);
         IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
-            docs[i] = client().prepareIndex("test", "type1", String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
+            docs[i] = client().prepareIndex("test").setId(String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
         }
 
         indexRandom(true, docs);
@@ -382,7 +383,7 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
         int numDocs = randomIntBetween(100, 150);
         IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
-            docs[i] = client().prepareIndex("test", "type1", String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
+            docs[i] = client().prepareIndex("test").setId(String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
         }
 
         indexRandom(true, docs);
@@ -422,7 +423,7 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
         int numDocs = randomIntBetween(100, 150);
         IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
-            docs[i] = client().prepareIndex("test", "type1", String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
+            docs[i] = client().prepareIndex("test").setId(String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
         }
 
         indexRandom(true, docs);
@@ -462,7 +463,7 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
         int numDocs = randomIntBetween(100, 150);
         IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
-            docs[i] = client().prepareIndex("test", "type1", String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
+            docs[i] = client().prepareIndex("test").setId(String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
         }
 
         indexRandom(true, docs);
@@ -501,7 +502,8 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
         int numDocs = randomIntBetween(100, 150);
         IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
-            docs[i] = client().prepareIndex("test", "type1", String.valueOf(i))
+            docs[i] = client().prepareIndex("test")
+                .setId(String.valueOf(i))
                 .setSource("field1", English.intToEnglish(i) + " " + English.intToEnglish(i + 1), "field2", i);
         }
 
@@ -556,7 +558,7 @@ public class QueryProfilerIT extends OpenSearchIntegTestCase {
         int numDocs = randomIntBetween(100, 150);
         IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
-            docs[i] = client().prepareIndex("test", "type1", String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
+            docs[i] = client().prepareIndex("test").setId(String.valueOf(i)).setSource("field1", English.intToEnglish(i), "field2", i);
         }
 
         indexRandom(true, docs);

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/MultiMatchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/MultiMatchQueryIT.java
@@ -114,7 +114,8 @@ public class MultiMatchQueryIT extends OpenSearchIntegTestCase {
         int numDocs = scaledRandomIntBetween(50, 100);
         List<IndexRequestBuilder> builders = new ArrayList<>();
         builders.add(
-            client().prepareIndex("test", "test", "theone")
+            client().prepareIndex("test")
+                .setId("theone")
                 .setSource(
                     "id",
                     "theone",
@@ -133,7 +134,8 @@ public class MultiMatchQueryIT extends OpenSearchIntegTestCase {
                 )
         );
         builders.add(
-            client().prepareIndex("test", "test", "theother")
+            client().prepareIndex("test")
+                .setId("theother")
                 .setSource(
                     "id",
                     "theother",
@@ -151,7 +153,8 @@ public class MultiMatchQueryIT extends OpenSearchIntegTestCase {
         );
 
         builders.add(
-            client().prepareIndex("test", "test", "ultimate1")
+            client().prepareIndex("test")
+                .setId("ultimate1")
                 .setSource(
                     "id",
                     "ultimate1",
@@ -168,7 +171,8 @@ public class MultiMatchQueryIT extends OpenSearchIntegTestCase {
                 )
         );
         builders.add(
-            client().prepareIndex("test", "test", "ultimate2")
+            client().prepareIndex("test")
+                .setId("ultimate2")
                 .setSource(
                     "full_name",
                     "Man the Ultimate Ninja",
@@ -184,7 +188,8 @@ public class MultiMatchQueryIT extends OpenSearchIntegTestCase {
         );
 
         builders.add(
-            client().prepareIndex("test", "test", "anotherhero")
+            client().prepareIndex("test")
+                .setId("anotherhero")
                 .setSource(
                     "id",
                     "anotherhero",
@@ -202,7 +207,8 @@ public class MultiMatchQueryIT extends OpenSearchIntegTestCase {
         );
 
         builders.add(
-            client().prepareIndex("test", "test", "nowHero")
+            client().prepareIndex("test")
+                .setId("nowHero")
                 .setSource(
                     "id",
                     "nowHero",
@@ -229,7 +235,8 @@ public class MultiMatchQueryIT extends OpenSearchIntegTestCase {
             String first = RandomPicks.randomFrom(random(), firstNames);
             String last = randomPickExcept(lastNames, first);
             builders.add(
-                client().prepareIndex("test", "test", "" + i)
+                client().prepareIndex("test")
+                    .setId("" + i)
                     .setSource(
                         "id",
                         i,
@@ -1013,8 +1020,8 @@ public class MultiMatchQueryIT extends OpenSearchIntegTestCase {
         assertAcked(builder.addMapping("type", "title", "type=text", "body", "type=text"));
         ensureGreen();
         List<IndexRequestBuilder> builders = new ArrayList<>();
-        builders.add(client().prepareIndex(idx, "type", "1").setSource("title", "foo", "body", "bar"));
-        builders.add(client().prepareIndex(idx, "type", "2").setSource("title", "bar", "body", "foo"));
+        builders.add(client().prepareIndex(idx).setId("1").setSource("title", "foo", "body", "bar"));
+        builders.add(client().prepareIndex(idx).setId("2").setSource("title", "bar", "body", "foo"));
         indexRandom(true, false, builders);
 
         SearchResponse searchResponse = client().prepareSearch(idx)

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/QueryStringIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/QueryStringIT.java
@@ -90,9 +90,9 @@ public class QueryStringIT extends OpenSearchIntegTestCase {
 
     public void testBasicAllQuery() throws Exception {
         List<IndexRequestBuilder> reqs = new ArrayList<>();
-        reqs.add(client().prepareIndex("test", "_doc", "1").setSource("f1", "foo bar baz"));
-        reqs.add(client().prepareIndex("test", "_doc", "2").setSource("f2", "Bar"));
-        reqs.add(client().prepareIndex("test", "_doc", "3").setSource("f3", "foo bar baz"));
+        reqs.add(client().prepareIndex("test").setId("1").setSource("f1", "foo bar baz"));
+        reqs.add(client().prepareIndex("test").setId("2").setSource("f2", "Bar"));
+        reqs.add(client().prepareIndex("test").setId("3").setSource("f3", "foo bar baz"));
         indexRandom(true, false, reqs);
 
         SearchResponse resp = client().prepareSearch("test").setQuery(queryStringQuery("foo")).get();
@@ -110,8 +110,8 @@ public class QueryStringIT extends OpenSearchIntegTestCase {
 
     public void testWithDate() throws Exception {
         List<IndexRequestBuilder> reqs = new ArrayList<>();
-        reqs.add(client().prepareIndex("test", "_doc", "1").setSource("f1", "foo", "f_date", "2015/09/02"));
-        reqs.add(client().prepareIndex("test", "_doc", "2").setSource("f1", "bar", "f_date", "2015/09/01"));
+        reqs.add(client().prepareIndex("test").setId("1").setSource("f1", "foo", "f_date", "2015/09/02"));
+        reqs.add(client().prepareIndex("test").setId("2").setSource("f1", "bar", "f_date", "2015/09/01"));
         indexRandom(true, false, reqs);
 
         SearchResponse resp = client().prepareSearch("test").setQuery(queryStringQuery("foo bar")).get();
@@ -134,10 +134,10 @@ public class QueryStringIT extends OpenSearchIntegTestCase {
     public void testWithLotsOfTypes() throws Exception {
         List<IndexRequestBuilder> reqs = new ArrayList<>();
         reqs.add(
-            client().prepareIndex("test", "_doc", "1").setSource("f1", "foo", "f_date", "2015/09/02", "f_float", "1.7", "f_ip", "127.0.0.1")
+            client().prepareIndex("test").setId("1").setSource("f1", "foo", "f_date", "2015/09/02", "f_float", "1.7", "f_ip", "127.0.0.1")
         );
         reqs.add(
-            client().prepareIndex("test", "_doc", "2").setSource("f1", "bar", "f_date", "2015/09/01", "f_float", "1.8", "f_ip", "127.0.0.2")
+            client().prepareIndex("test").setId("2").setSource("f1", "bar", "f_date", "2015/09/01", "f_float", "1.8", "f_ip", "127.0.0.2")
         );
         indexRandom(true, false, reqs);
 
@@ -161,7 +161,7 @@ public class QueryStringIT extends OpenSearchIntegTestCase {
     public void testDocWithAllTypes() throws Exception {
         List<IndexRequestBuilder> reqs = new ArrayList<>();
         String docBody = copyToStringFromClasspath("/org/opensearch/search/query/all-example-document.json");
-        reqs.add(client().prepareIndex("test", "_doc", "1").setSource(docBody, XContentType.JSON));
+        reqs.add(client().prepareIndex("test").setId("1").setSource(docBody, XContentType.JSON));
         indexRandom(true, false, reqs);
 
         SearchResponse resp = client().prepareSearch("test").setQuery(queryStringQuery("foo")).get();
@@ -198,9 +198,9 @@ public class QueryStringIT extends OpenSearchIntegTestCase {
 
     public void testKeywordWithWhitespace() throws Exception {
         List<IndexRequestBuilder> reqs = new ArrayList<>();
-        reqs.add(client().prepareIndex("test", "_doc", "1").setSource("f2", "Foo Bar"));
-        reqs.add(client().prepareIndex("test", "_doc", "2").setSource("f1", "bar"));
-        reqs.add(client().prepareIndex("test", "_doc", "3").setSource("f1", "foo bar"));
+        reqs.add(client().prepareIndex("test").setId("1").setSource("f2", "Foo Bar"));
+        reqs.add(client().prepareIndex("test").setId("2").setSource("f1", "bar"));
+        reqs.add(client().prepareIndex("test").setId("3").setSource("f1", "foo bar"));
         indexRandom(true, false, reqs);
 
         SearchResponse resp = client().prepareSearch("test").setQuery(queryStringQuery("foo")).get();
@@ -224,7 +224,7 @@ public class QueryStringIT extends OpenSearchIntegTestCase {
         ensureGreen("test_1");
 
         List<IndexRequestBuilder> reqs = new ArrayList<>();
-        reqs.add(client().prepareIndex("test_1", "_doc", "1").setSource("f1", "foo", "f2", "eggplant"));
+        reqs.add(client().prepareIndex("test_1").setId("1").setSource("f1", "foo", "f2", "eggplant"));
         indexRandom(true, false, reqs);
 
         SearchResponse resp = client().prepareSearch("test_1")
@@ -239,8 +239,8 @@ public class QueryStringIT extends OpenSearchIntegTestCase {
 
     public void testPhraseQueryOnFieldWithNoPositions() throws Exception {
         List<IndexRequestBuilder> reqs = new ArrayList<>();
-        reqs.add(client().prepareIndex("test", "_doc", "1").setSource("f1", "foo bar", "f4", "eggplant parmesan"));
-        reqs.add(client().prepareIndex("test", "_doc", "2").setSource("f1", "foo bar", "f4", "chicken parmesan"));
+        reqs.add(client().prepareIndex("test").setId("1").setSource("f1", "foo bar", "f4", "eggplant parmesan"));
+        reqs.add(client().prepareIndex("test").setId("2").setSource("f1", "foo bar", "f4", "chicken parmesan"));
         indexRandom(true, false, reqs);
 
         SearchResponse resp = client().prepareSearch("test").setQuery(queryStringQuery("\"eggplant parmesan\"").lenient(true)).get();
@@ -289,7 +289,7 @@ public class QueryStringIT extends OpenSearchIntegTestCase {
 
         assertAcked(prepareCreate("ignoreunmappedfields").addMapping("_doc", builder));
 
-        client().prepareIndex("ignoreunmappedfields", "_doc", "1").setSource("field1", "foo bar baz").get();
+        client().prepareIndex("ignoreunmappedfields").setId("1").setSource("field1", "foo bar baz").get();
         refresh();
 
         QueryStringQueryBuilder qb = queryStringQuery("bar");
@@ -324,7 +324,7 @@ public class QueryStringIT extends OpenSearchIntegTestCase {
             ).addMapping("_doc", builder)
         );
 
-        client().prepareIndex("testindex", "_doc", "1").setSource("field_A0", "foo bar baz").get();
+        client().prepareIndex("testindex").setId("1").setSource("field_A0", "foo bar baz").get();
         refresh();
 
         // single field shouldn't trigger the limit
@@ -375,9 +375,9 @@ public class QueryStringIT extends OpenSearchIntegTestCase {
 
     public void testFieldAlias() throws Exception {
         List<IndexRequestBuilder> indexRequests = new ArrayList<>();
-        indexRequests.add(client().prepareIndex("test", "_doc", "1").setSource("f3", "text", "f2", "one"));
-        indexRequests.add(client().prepareIndex("test", "_doc", "2").setSource("f3", "value", "f2", "two"));
-        indexRequests.add(client().prepareIndex("test", "_doc", "3").setSource("f3", "another value", "f2", "three"));
+        indexRequests.add(client().prepareIndex("test").setId("1").setSource("f3", "text", "f2", "one"));
+        indexRequests.add(client().prepareIndex("test").setId("2").setSource("f3", "value", "f2", "two"));
+        indexRequests.add(client().prepareIndex("test").setId("3").setSource("f3", "another value", "f2", "three"));
         indexRandom(true, false, indexRequests);
 
         SearchResponse response = client().prepareSearch("test").setQuery(queryStringQuery("value").field("f3_alias")).get();
@@ -389,9 +389,9 @@ public class QueryStringIT extends OpenSearchIntegTestCase {
 
     public void testFieldAliasWithEmbeddedFieldNames() throws Exception {
         List<IndexRequestBuilder> indexRequests = new ArrayList<>();
-        indexRequests.add(client().prepareIndex("test", "_doc", "1").setSource("f3", "text", "f2", "one"));
-        indexRequests.add(client().prepareIndex("test", "_doc", "2").setSource("f3", "value", "f2", "two"));
-        indexRequests.add(client().prepareIndex("test", "_doc", "3").setSource("f3", "another value", "f2", "three"));
+        indexRequests.add(client().prepareIndex("test").setId("1").setSource("f3", "text", "f2", "one"));
+        indexRequests.add(client().prepareIndex("test").setId("2").setSource("f3", "value", "f2", "two"));
+        indexRequests.add(client().prepareIndex("test").setId("3").setSource("f3", "another value", "f2", "three"));
         indexRandom(true, false, indexRequests);
 
         SearchResponse response = client().prepareSearch("test").setQuery(queryStringQuery("f3_alias:value AND f2:three")).get();
@@ -403,9 +403,9 @@ public class QueryStringIT extends OpenSearchIntegTestCase {
 
     public void testFieldAliasWithWildcardField() throws Exception {
         List<IndexRequestBuilder> indexRequests = new ArrayList<>();
-        indexRequests.add(client().prepareIndex("test", "_doc", "1").setSource("f3", "text", "f2", "one"));
-        indexRequests.add(client().prepareIndex("test", "_doc", "2").setSource("f3", "value", "f2", "two"));
-        indexRequests.add(client().prepareIndex("test", "_doc", "3").setSource("f3", "another value", "f2", "three"));
+        indexRequests.add(client().prepareIndex("test").setId("1").setSource("f3", "text", "f2", "one"));
+        indexRequests.add(client().prepareIndex("test").setId("2").setSource("f3", "value", "f2", "two"));
+        indexRequests.add(client().prepareIndex("test").setId("3").setSource("f3", "another value", "f2", "three"));
         indexRandom(true, false, indexRequests);
 
         SearchResponse response = client().prepareSearch("test").setQuery(queryStringQuery("value").field("f3_*")).get();
@@ -417,7 +417,7 @@ public class QueryStringIT extends OpenSearchIntegTestCase {
 
     public void testFieldAliasOnDisallowedFieldType() throws Exception {
         List<IndexRequestBuilder> indexRequests = new ArrayList<>();
-        indexRequests.add(client().prepareIndex("test", "_doc", "1").setSource("f3", "text", "f2", "one"));
+        indexRequests.add(client().prepareIndex("test").setId("1").setSource("f3", "text", "f2", "one"));
         indexRandom(true, false, indexRequests);
 
         // The wildcard field matches aliases for both a text and geo_point field.

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/ScriptScoreQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/ScriptScoreQueryIT.java
@@ -91,7 +91,7 @@ public class ScriptScoreQueryIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test-index").addMapping("_doc", "field1", "type=text", "field2", "type=double"));
         int docCount = 10;
         for (int i = 1; i <= docCount; i++) {
-            client().prepareIndex("test-index", "_doc", "" + i).setSource("field1", "text" + (i % 2), "field2", i).get();
+            client().prepareIndex("test-index").setId("" + i).setSource("field1", "text" + (i % 2), "field2", i).get();
         }
         refresh();
 
@@ -117,7 +117,7 @@ public class ScriptScoreQueryIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test-index").addMapping("_doc", "field1", "type=text", "field2", "type=double"));
         int docCount = 10;
         for (int i = 1; i <= docCount; i++) {
-            client().prepareIndex("test-index", "_doc", "" + i).setSource("field1", "text" + i, "field2", i).get();
+            client().prepareIndex("test-index").setId("" + i).setSource("field1", "text" + i, "field2", i).get();
         }
         refresh();
 
@@ -138,9 +138,9 @@ public class ScriptScoreQueryIT extends OpenSearchIntegTestCase {
             prepareCreate("test-index2").setSettings(Settings.builder().put("index.number_of_shards", 1))
                 .addMapping("_doc", "field1", "type=date", "field2", "type=double")
         );
-        client().prepareIndex("test-index2", "_doc", "1").setSource("field1", "2019-09-01", "field2", 1).get();
-        client().prepareIndex("test-index2", "_doc", "2").setSource("field1", "2019-10-01", "field2", 2).get();
-        client().prepareIndex("test-index2", "_doc", "3").setSource("field1", "2019-11-01", "field2", 3).get();
+        client().prepareIndex("test-index2").setId("1").setSource("field1", "2019-09-01", "field2", 1).get();
+        client().prepareIndex("test-index2").setId("2").setSource("field1", "2019-10-01", "field2", 2).get();
+        client().prepareIndex("test-index2").setId("3").setSource("field1", "2019-11-01", "field2", 3).get();
         refresh();
 
         RangeQueryBuilder rangeQB = new RangeQueryBuilder("field1").from("2019-01-01"); // the query should be rewritten to from:null

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/SearchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/SearchQueryIT.java
@@ -163,9 +163,9 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
         createIndex("test");
         indexRandom(
             true,
-            client().prepareIndex("test", "type1", "1").setSource("field1", "the quick brown fox jumps"),
-            client().prepareIndex("test", "type1", "2").setSource("field1", "quick brown"),
-            client().prepareIndex("test", "type1", "3").setSource("field1", "quick")
+            client().prepareIndex("test").setId("1").setSource("field1", "the quick brown fox jumps"),
+            client().prepareIndex("test").setId("2").setSource("field1", "quick brown"),
+            client().prepareIndex("test").setId("3").setSource("field1", "quick")
         );
 
         assertHitCount(client().prepareSearch().setQuery(queryStringQuery("quick")).get(), 3L);
@@ -175,9 +175,9 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     // see https://github.com/elastic/elasticsearch/issues/3177
     public void testIssue3177() {
         createIndex("test");
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1").get();
-        client().prepareIndex("test", "type1", "2").setSource("field1", "value2").get();
-        client().prepareIndex("test", "type1", "3").setSource("field1", "value3").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1").get();
+        client().prepareIndex("test").setId("2").setSource("field1", "value2").get();
+        client().prepareIndex("test").setId("3").setSource("field1", "value3").get();
         ensureGreen();
         waitForRelocation();
         forceMerge();
@@ -214,9 +214,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test").addMapping("type1", "field1", "type=text,index_options=docs"));
         indexRandom(
             true,
-            client().prepareIndex("test", "type1", "1").setSource("field1", "quick brown fox", "field2", "quick brown fox"),
-            client().prepareIndex("test", "type1", "2")
-                .setSource("field1", "quick lazy huge brown fox", "field2", "quick lazy huge brown fox")
+            client().prepareIndex("test").setId("1").setSource("field1", "quick brown fox", "field2", "quick brown fox"),
+            client().prepareIndex("test").setId("2").setSource("field1", "quick lazy huge brown fox", "field2", "quick lazy huge brown fox")
         );
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(matchPhraseQuery("field2", "quick brown").slop(0)).get();
@@ -235,9 +234,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
         createIndex("test");
         indexRandom(
             true,
-            client().prepareIndex("test", "type1", "1").setSource("field1", "quick brown fox", "field2", "quick brown fox"),
-            client().prepareIndex("test", "type1", "2")
-                .setSource("field1", "quick lazy huge brown fox", "field2", "quick lazy huge brown fox")
+            client().prepareIndex("test").setId("1").setSource("field1", "quick brown fox", "field2", "quick brown fox"),
+            client().prepareIndex("test").setId("2").setSource("field1", "quick lazy huge brown fox", "field2", "quick lazy huge brown fox")
         );
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(constantScoreQuery(matchQuery("field1", "quick"))).get();
@@ -279,7 +277,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
         int num = scaledRandomIntBetween(100, 200);
         IndexRequestBuilder[] builders = new IndexRequestBuilder[num];
         for (int i = 0; i < builders.length; i++) {
-            builders[i] = client().prepareIndex("test_1", "type", "" + i).setSource("f", English.intToEnglish(i));
+            builders[i] = client().prepareIndex("test_1").setId("" + i).setSource("f", English.intToEnglish(i));
         }
         createIndex("test_1");
         indexRandom(true, builders);
@@ -316,8 +314,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
         createIndex("test");
         indexRandom(
             true,
-            client().prepareIndex("test", "type1", "1").setSource("foo", "bar"),
-            client().prepareIndex("test", "type1", "2").setSource("foo", "bar")
+            client().prepareIndex("test").setId("1").setSource("foo", "bar"),
+            client().prepareIndex("test").setId("2").setSource("foo", "bar")
         );
 
         int iters = scaledRandomIntBetween(100, 200);
@@ -344,10 +342,11 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
             .get();
         indexRandom(
             true,
-            client().prepareIndex("test", "type1", "3")
+            client().prepareIndex("test")
+                .setId("3")
                 .setSource("field1", "quick lazy huge brown pidgin", "field2", "the quick lazy huge brown fox jumps over the tree"),
-            client().prepareIndex("test", "type1", "1").setSource("field1", "the quick brown fox"),
-            client().prepareIndex("test", "type1", "2").setSource("field1", "the quick lazy huge brown fox jumps over the tree")
+            client().prepareIndex("test").setId("1").setSource("field1", "the quick brown fox"),
+            client().prepareIndex("test").setId("2").setSource("field1", "the quick lazy huge brown fox jumps over the tree")
         );
 
         SearchResponse searchResponse = client().prepareSearch()
@@ -441,7 +440,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     public void testQueryStringAnalyzedWildcard() throws Exception {
         createIndex("test");
 
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value_1", "field2", "value_2").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value_1", "field2", "value_2").get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(queryStringQuery("value*")).get();
@@ -463,7 +462,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     public void testLowercaseExpandedTerms() {
         createIndex("test");
 
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value_1", "field2", "value_2").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value_1", "field2", "value_2").get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(queryStringQuery("VALUE_3~1")).get();
@@ -485,7 +484,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
         ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
         String aMonthAgo = DateTimeFormatter.ISO_LOCAL_DATE.format(now.minusMonths(1));
         String aMonthFromNow = DateTimeFormatter.ISO_LOCAL_DATE.format(now.plusMonths(1));
-        client().prepareIndex("test", "type", "1").setSource("past", aMonthAgo, "future", aMonthFromNow).get();
+        client().prepareIndex("test").setId("1").setSource("past", aMonthAgo, "future", aMonthFromNow).get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(queryStringQuery("past:[now-2M/d TO now/d]")).get();
@@ -511,7 +510,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
         ZoneId timeZone = randomZone();
         String now = DateFormatter.forPattern("strict_date_optional_time").format(Instant.now().atZone(timeZone));
         logger.info(" --> Using time_zone [{}], now is [{}]", timeZone.getId(), now);
-        client().prepareIndex("test", "type", "1").setSource("past", now).get();
+        client().prepareIndex("test").setId("1").setSource("past", now).get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch()
@@ -526,8 +525,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
         // as with dynamic mappings some shards might be lacking behind and parse a different query
         assertAcked(prepareCreate("test").addMapping("type", "past", "type=date"));
 
-        client().prepareIndex("test", "type", "1").setSource("past", "2015-04-05T23:00:00+0000").get();
-        client().prepareIndex("test", "type", "2").setSource("past", "2015-04-06T00:00:00+0000").get();
+        client().prepareIndex("test").setId("1").setSource("past", "2015-04-05T23:00:00+0000").get();
+        client().prepareIndex("test").setId("2").setSource("past", "2015-04-06T00:00:00+0000").get();
         refresh();
 
         // Timezone set with dates
@@ -560,9 +559,9 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("test", "type1", "1").setSource("field1", "value1"),
-            client().prepareIndex("test", "type1", "2").setSource("field1", "value2"),
-            client().prepareIndex("test", "type1", "3").setSource("field1", "value3")
+            client().prepareIndex("test").setId("1").setSource("field1", "value1"),
+            client().prepareIndex("test").setId("2").setSource("field1", "value2"),
+            client().prepareIndex("test").setId("3").setSource("field1", "value3")
         );
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(constantScoreQuery(idsQuery().addIds("1", "3"))).get();
@@ -587,7 +586,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
         for (String indexName : indexNames) {
             assertAcked(client().admin().indices().prepareCreate(indexName));
 
-            indexRandom(true, client().prepareIndex(indexName, "type1", indexName + "1").setSource("field1", "value1"));
+            indexRandom(true, client().prepareIndex(indexName).setId(indexName + "1").setSource("field1", "value1"));
 
         }
 
@@ -621,7 +620,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("test", "type1", "1")
+            client().prepareIndex("test")
+                .setId("1")
                 .setSource(
                     jsonBuilder().startObject()
                         .startObject("obj1")
@@ -632,7 +632,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
                         .field("field2", "value2_1")
                         .endObject()
                 ),
-            client().prepareIndex("test", "type1", "2")
+            client().prepareIndex("test")
+                .setId("2")
                 .setSource(
                     jsonBuilder().startObject()
                         .startObject("obj1")
@@ -642,7 +643,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
                         .field("field1", "value1_2")
                         .endObject()
                 ),
-            client().prepareIndex("test", "type1", "3")
+            client().prepareIndex("test")
+                .setId("3")
                 .setSource(
                     jsonBuilder().startObject()
                         .startObject("obj2")
@@ -652,7 +654,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
                         .field("field2", "value2_3")
                         .endObject()
                 ),
-            client().prepareIndex("test", "type1", "4")
+            client().prepareIndex("test")
+                .setId("4")
                 .setSource(
                     jsonBuilder().startObject()
                         .startObject("obj2")
@@ -698,7 +701,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     public void testPassQueryOrFilterAsJSONString() throws Exception {
         createIndex("test");
 
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1_1", "field2", "value2_1").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1_1", "field2", "value2_1").setRefreshPolicy(IMMEDIATE).get();
 
         WrapperQueryBuilder wrapper = new WrapperQueryBuilder("{ \"term\" : { \"field1\" : \"value1_1\" } }");
         assertHitCount(client().prepareSearch().setQuery(wrapper).get(), 1L);
@@ -713,7 +716,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     public void testFiltersWithCustomCacheKey() throws Exception {
         createIndex("test");
 
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1").get();
         refresh();
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("field1", "value1"))).get();
         assertHitCount(searchResponse, 1L);
@@ -733,9 +736,9 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("test", "type1", "1").setSource("long", 1L, "double", 1.0d),
-            client().prepareIndex("test", "type1", "2").setSource("long", 2L, "double", 2.0d),
-            client().prepareIndex("test", "type1", "3").setSource("long", 3L, "double", 3.0d)
+            client().prepareIndex("test").setId("1").setSource("long", 1L, "double", 1.0d),
+            client().prepareIndex("test").setId("2").setSource("long", 2L, "double", 2.0d),
+            client().prepareIndex("test").setId("3").setSource("long", 3L, "double", 3.0d)
         );
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(matchQuery("long", "1")).get();
@@ -753,8 +756,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("test", "_doc", "1").setSource("text", "Unit"),
-            client().prepareIndex("test", "_doc", "2").setSource("text", "Unity")
+            client().prepareIndex("test").setId("1").setSource("text", "Unit"),
+            client().prepareIndex("test").setId("2").setSource("text", "Unity")
         );
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(matchQuery("text", "uniy").fuzziness("0")).get();
@@ -781,9 +784,9 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("test", "type1", "1").setSource("field1", "value1", "field2", "value4", "field3", "value3"),
-            client().prepareIndex("test", "type1", "2").setSource("field1", "value2", "field2", "value5", "field3", "value2"),
-            client().prepareIndex("test", "type1", "3").setSource("field1", "value3", "field2", "value6", "field3", "value1")
+            client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value4", "field3", "value3"),
+            client().prepareIndex("test").setId("2").setSource("field1", "value2", "field2", "value5", "field3", "value2"),
+            client().prepareIndex("test").setId("3").setSource("field1", "value3", "field2", "value6", "field3", "value1")
         );
 
         MultiMatchQueryBuilder builder = multiMatchQuery("value1 value2 value4", "field1", "field2");
@@ -825,7 +828,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
         assertSearchHits(searchResponse, "3", "1");
 
         // Test lenient
-        client().prepareIndex("test", "type1", "3").setSource("field1", "value7", "field2", "value8", "field4", 5).get();
+        client().prepareIndex("test").setId("3").setSource("field1", "value7", "field2", "value8", "field4", 5).get();
         refresh();
 
         builder = multiMatchQuery("value1", "field1", "field2", "field4");
@@ -846,8 +849,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
         assertAcked(
             prepareCreate("test").addMapping("type1", "field1", "type=text,analyzer=classic", "field2", "type=text,analyzer=classic")
         );
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1").get();
-        client().prepareIndex("test", "type1", "2").setSource("field1", "value2").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1").get();
+        client().prepareIndex("test").setId("2").setSource("field1", "value2").get();
         refresh();
 
         BoolQueryBuilder boolQuery = boolQuery().must(matchQuery("field1", "a").zeroTermsQuery(MatchQuery.ZeroTermsQuery.NONE))
@@ -869,8 +872,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
         assertAcked(
             prepareCreate("test").addMapping("type1", "field1", "type=text,analyzer=classic", "field2", "type=text,analyzer=classic")
         );
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value1", "field2", "value2").get();
-        client().prepareIndex("test", "type1", "2").setSource("field1", "value3", "field2", "value4").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value2").get();
+        client().prepareIndex("test").setId("2").setSource("field1", "value3", "field2", "value4").get();
         refresh();
 
         BoolQueryBuilder boolQuery = boolQuery().must(
@@ -893,8 +896,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
     public void testMultiMatchQueryMinShouldMatch() {
         createIndex("test");
-        client().prepareIndex("test", "type1", "1").setSource("field1", new String[] { "value1", "value2", "value3" }).get();
-        client().prepareIndex("test", "type1", "2").setSource("field2", "value1").get();
+        client().prepareIndex("test").setId("1").setSource("field1", new String[] { "value1", "value2", "value3" }).get();
+        client().prepareIndex("test").setId("2").setSource("field2", "value1").get();
         refresh();
 
         MultiMatchQueryBuilder multiMatchQuery = multiMatchQuery("value1 value2 foo", "field1", "field2");
@@ -939,8 +942,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
     public void testBoolQueryMinShouldMatchBiggerThanNumberOfShouldClauses() throws IOException {
         createIndex("test");
-        client().prepareIndex("test", "type1", "1").setSource("field1", new String[] { "value1", "value2", "value3" }).get();
-        client().prepareIndex("test", "type1", "2").setSource("field2", "value1").get();
+        client().prepareIndex("test").setId("1").setSource("field1", new String[] { "value1", "value2", "value3" }).get();
+        client().prepareIndex("test").setId("2").setSource("field2", "value1").get();
         refresh();
 
         BoolQueryBuilder boolQuery = boolQuery().must(termQuery("field1", "value1"))
@@ -971,8 +974,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
     public void testFuzzyQueryString() {
         createIndex("test");
-        client().prepareIndex("test", "type1", "1").setSource("str", "foobar", "date", "2012-02-01", "num", 12).get();
-        client().prepareIndex("test", "type1", "2").setSource("str", "fred", "date", "2012-02-05", "num", 20).get();
+        client().prepareIndex("test").setId("1").setSource("str", "foobar", "date", "2012-02-01", "num", 12).get();
+        client().prepareIndex("test").setId("2").setSource("str", "fred", "date", "2012-02-05", "num", 20).get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(queryStringQuery("str:foobaz~1")).get();
@@ -989,8 +992,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
         indexRandom(
             true,
             false,
-            client().prepareIndex("test", "type1", "1").setSource("important", "phrase match", "less_important", "nothing important"),
-            client().prepareIndex("test", "type1", "2").setSource("important", "nothing important", "less_important", "phrase match")
+            client().prepareIndex("test").setId("1").setSource("important", "phrase match", "less_important", "nothing important"),
+            client().prepareIndex("test").setId("2").setSource("important", "nothing important", "less_important", "phrase match")
         );
 
         SearchResponse searchResponse = client().prepareSearch()
@@ -1007,8 +1010,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
     public void testSpecialRangeSyntaxInQueryString() {
         createIndex("test");
-        client().prepareIndex("test", "type1", "1").setSource("str", "foobar", "date", "2012-02-01", "num", 12).get();
-        client().prepareIndex("test", "type1", "2").setSource("str", "fred", "date", "2012-02-05", "num", 20).get();
+        client().prepareIndex("test").setId("1").setSource("str", "foobar", "date", "2012-02-01", "num", 12).get();
+        client().prepareIndex("test").setId("2").setSource("str", "fred", "date", "2012-02-05", "num", 20).get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(queryStringQuery("num:>19")).get();
@@ -1040,10 +1043,10 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("test", "type", "1").setSource("term", "1"),
-            client().prepareIndex("test", "type", "2").setSource("term", "2"),
-            client().prepareIndex("test", "type", "3").setSource("term", "3"),
-            client().prepareIndex("test", "type", "4").setSource("term", "4")
+            client().prepareIndex("test").setId("1").setSource("term", "1"),
+            client().prepareIndex("test").setId("2").setSource("term", "2"),
+            client().prepareIndex("test").setId("3").setSource("term", "3"),
+            client().prepareIndex("test").setId("4").setSource("term", "4")
         );
 
         SearchResponse searchResponse = client().prepareSearch("test")
@@ -1060,10 +1063,10 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("test", "type", "1").setSource("str", "1", "lng", 1L, "dbl", 1.0d),
-            client().prepareIndex("test", "type", "2").setSource("str", "2", "lng", 2L, "dbl", 2.0d),
-            client().prepareIndex("test", "type", "3").setSource("str", "3", "lng", 3L, "dbl", 3.0d),
-            client().prepareIndex("test", "type", "4").setSource("str", "4", "lng", 4L, "dbl", 4.0d)
+            client().prepareIndex("test").setId("1").setSource("str", "1", "lng", 1L, "dbl", 1.0d),
+            client().prepareIndex("test").setId("2").setSource("str", "2", "lng", 2L, "dbl", 2.0d),
+            client().prepareIndex("test").setId("3").setSource("str", "3", "lng", 3L, "dbl", 3.0d),
+            client().prepareIndex("test").setId("4").setSource("str", "4", "lng", 4L, "dbl", 4.0d)
         );
 
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(constantScoreQuery(termsQuery("str", "1", "4"))).get();
@@ -1138,11 +1141,12 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("lookup", "type", "1").setSource("terms", new String[] { "1", "3" }),
-            client().prepareIndex("lookup", "type", "2").setSource("terms", new String[] { "2" }),
-            client().prepareIndex("lookup", "type", "3").setSource("terms", new String[] { "2", "4" }),
-            client().prepareIndex("lookup", "type", "4").setSource("other", "value"),
-            client().prepareIndex("lookup2", "type", "1")
+            client().prepareIndex("lookup").setId("1").setSource("terms", new String[] { "1", "3" }),
+            client().prepareIndex("lookup").setId("2").setSource("terms", new String[] { "2" }),
+            client().prepareIndex("lookup").setId("3").setSource("terms", new String[] { "2", "4" }),
+            client().prepareIndex("lookup").setId("4").setSource("other", "value"),
+            client().prepareIndex("lookup2")
+                .setId("1")
                 .setSource(
                     XContentFactory.jsonBuilder()
                         .startObject()
@@ -1156,7 +1160,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
                         .endArray()
                         .endObject()
                 ),
-            client().prepareIndex("lookup2", "type", "2")
+            client().prepareIndex("lookup2")
+                .setId("2")
                 .setSource(
                     XContentFactory.jsonBuilder()
                         .startObject()
@@ -1167,7 +1172,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
                         .endArray()
                         .endObject()
                 ),
-            client().prepareIndex("lookup2", "type", "3")
+            client().prepareIndex("lookup2")
+                .setId("3")
                 .setSource(
                     XContentFactory.jsonBuilder()
                         .startObject()
@@ -1181,11 +1187,11 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
                         .endArray()
                         .endObject()
                 ),
-            client().prepareIndex("lookup3", "type", "1").setSource("terms", new String[] { "1", "3" }),
-            client().prepareIndex("test", "type", "1").setSource("term", "1"),
-            client().prepareIndex("test", "type", "2").setSource("term", "2"),
-            client().prepareIndex("test", "type", "3").setSource("term", "3"),
-            client().prepareIndex("test", "type", "4").setSource("term", "4")
+            client().prepareIndex("lookup3").setId("1").setSource("terms", new String[] { "1", "3" }),
+            client().prepareIndex("test").setId("1").setSource("term", "1"),
+            client().prepareIndex("test").setId("2").setSource("term", "2"),
+            client().prepareIndex("test").setId("3").setSource("term", "3"),
+            client().prepareIndex("test").setId("4").setSource("term", "4")
         );
 
         SearchResponse searchResponse = client().prepareSearch("test")
@@ -1264,9 +1270,9 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     public void testBasicQueryById() throws Exception {
         assertAcked(prepareCreate("test"));
 
-        client().prepareIndex("test", "_doc", "1").setSource("field1", "value1").get();
-        client().prepareIndex("test", "_doc", "2").setSource("field1", "value2").get();
-        client().prepareIndex("test", "_doc", "3").setSource("field1", "value3").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1").get();
+        client().prepareIndex("test").setId("2").setSource("field1", "value2").get();
+        client().prepareIndex("test").setId("3").setSource("field1", "value3").get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(idsQuery().addIds("1", "2")).get();
@@ -1309,15 +1315,18 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
             )
         );
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource("num_byte", 1, "num_short", 1, "num_integer", 1, "num_long", 1, "num_float", 1, "num_double", 1)
             .get();
 
-        client().prepareIndex("test", "type1", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource("num_byte", 2, "num_short", 2, "num_integer", 2, "num_long", 2, "num_float", 2, "num_double", 2)
             .get();
 
-        client().prepareIndex("test", "type1", "17")
+        client().prepareIndex("test")
+            .setId("17")
             .setSource("num_byte", 17, "num_short", 17, "num_integer", 17, "num_long", 17, "num_float", 17, "num_double", 17)
             .get();
         refresh();
@@ -1423,10 +1432,10 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
             )
         );
 
-        client().prepareIndex("test", "type1", "1").setSource("field1", "test1", "num_long", 1).get();
-        client().prepareIndex("test", "type1", "2").setSource("field1", "test1", "num_long", 2).get();
-        client().prepareIndex("test", "type1", "3").setSource("field1", "test2", "num_long", 3).get();
-        client().prepareIndex("test", "type1", "4").setSource("field1", "test2", "num_long", 4).get();
+        client().prepareIndex("test").setId("1").setSource("field1", "test1", "num_long", 1).get();
+        client().prepareIndex("test").setId("2").setSource("field1", "test1", "num_long", 2).get();
+        client().prepareIndex("test").setId("3").setSource("field1", "test2", "num_long", 3).get();
+        client().prepareIndex("test").setId("4").setSource("field1", "test2", "num_long", 4).get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch("test")
@@ -1461,10 +1470,10 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("test", "test", "1").setSource("description", "foo other anything bar"),
-            client().prepareIndex("test", "test", "2").setSource("description", "foo other anything"),
-            client().prepareIndex("test", "test", "3").setSource("description", "foo other"),
-            client().prepareIndex("test", "test", "4").setSource("description", "foo")
+            client().prepareIndex("test").setId("1").setSource("description", "foo other anything bar"),
+            client().prepareIndex("test").setId("2").setSource("description", "foo other anything"),
+            client().prepareIndex("test").setId("3").setSource("description", "foo other"),
+            client().prepareIndex("test").setId("4").setSource("description", "foo")
         );
 
         SearchResponse searchResponse = client().prepareSearch("test")
@@ -1485,7 +1494,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("test", "test", "1").setSource("description", "it's cold outside, there's no kind of atmosphere")
+            client().prepareIndex("test").setId("1").setSource("description", "it's cold outside, there's no kind of atmosphere")
         );
 
         String json = "{ \"intervals\" : "
@@ -1509,10 +1518,10 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("test", "test", "1").setSource("description", "foo other anything bar"),
-            client().prepareIndex("test", "test", "2").setSource("description", "foo other anything"),
-            client().prepareIndex("test", "test", "3").setSource("description", "foo other"),
-            client().prepareIndex("test", "test", "4").setSource("description", "foo")
+            client().prepareIndex("test").setId("1").setSource("description", "foo other anything bar"),
+            client().prepareIndex("test").setId("2").setSource("description", "foo other anything"),
+            client().prepareIndex("test").setId("3").setSource("description", "foo other"),
+            client().prepareIndex("test").setId("4").setSource("description", "foo")
         );
 
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(spanOrQuery(spanTermQuery("description", "bar"))).get();
@@ -1527,10 +1536,10 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     public void testSpanMultiTermQuery() throws IOException {
         createIndex("test");
 
-        client().prepareIndex("test", "test", "1").setSource("description", "foo other anything bar", "count", 1).get();
-        client().prepareIndex("test", "test", "2").setSource("description", "foo other anything", "count", 2).get();
-        client().prepareIndex("test", "test", "3").setSource("description", "foo other", "count", 3).get();
-        client().prepareIndex("test", "test", "4").setSource("description", "fop", "count", 4).get();
+        client().prepareIndex("test").setId("1").setSource("description", "foo other anything bar", "count", 1).get();
+        client().prepareIndex("test").setId("2").setSource("description", "foo other anything", "count", 2).get();
+        client().prepareIndex("test").setId("3").setSource("description", "foo other", "count", 3).get();
+        client().prepareIndex("test").setId("4").setSource("description", "fop", "count", 4).get();
         refresh();
 
         SearchResponse response = client().prepareSearch("test")
@@ -1560,8 +1569,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     public void testSpanNot() throws IOException, ExecutionException, InterruptedException {
         createIndex("test");
 
-        client().prepareIndex("test", "test", "1").setSource("description", "the quick brown fox jumped over the lazy dog").get();
-        client().prepareIndex("test", "test", "2").setSource("description", "the quick black fox leaped over the sleeping dog").get();
+        client().prepareIndex("test").setId("1").setSource("description", "the quick brown fox jumped over the lazy dog").get();
+        client().prepareIndex("test").setId("2").setSource("description", "the quick black fox leaped over the sleeping dog").get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch("test")
@@ -1628,19 +1637,23 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
             )
         );
 
-        client().prepareIndex("test", "_doc", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setRouting("Y")
             .setSource("online", false, "bs", "Y", "ts", System.currentTimeMillis() - 100, "type", "s")
             .get();
-        client().prepareIndex("test", "_doc", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setRouting("X")
             .setSource("online", true, "bs", "X", "ts", System.currentTimeMillis() - 10000000, "type", "s")
             .get();
-        client().prepareIndex("test", "_doc", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setRouting(randomAlphaOfLength(2))
             .setSource("online", false, "ts", System.currentTimeMillis() - 100, "type", "bs")
             .get();
-        client().prepareIndex("test", "_doc", "4")
+        client().prepareIndex("test")
+            .setId("4")
             .setRouting(randomAlphaOfLength(2))
             .setSource("online", true, "ts", System.currentTimeMillis() - 123123, "type", "bs")
             .get();
@@ -1668,7 +1681,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     }
 
     public void testMultiFieldQueryString() {
-        client().prepareIndex("test", "s", "1").setSource("field1", "value1", "field2", "value2").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value2").setRefreshPolicy(IMMEDIATE).get();
 
         logger.info("regular");
         assertHitCount(client().prepareSearch("test").setQuery(queryStringQuery("value1").field("field1").field("field2")).get(), 1);
@@ -1691,7 +1704,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     public void testMultiMatchLenientIssue3797() {
         createIndex("test");
 
-        client().prepareIndex("test", "type1", "1").setSource("field1", 123, "field2", "value2").get();
+        client().prepareIndex("test").setId("1").setSource("field1", 123, "field2", "value2").get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch("test")
@@ -1711,10 +1724,10 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     public void testMinScore() throws ExecutionException, InterruptedException {
         createIndex("test");
 
-        client().prepareIndex("test", "test", "1").setSource("score", 1.5).get();
-        client().prepareIndex("test", "test", "2").setSource("score", 1.0).get();
-        client().prepareIndex("test", "test", "3").setSource("score", 2.0).get();
-        client().prepareIndex("test", "test", "4").setSource("score", 0.5).get();
+        client().prepareIndex("test").setId("1").setSource("score", 1.5).get();
+        client().prepareIndex("test").setId("2").setSource("score", 1.0).get();
+        client().prepareIndex("test").setId("3").setSource("score", 2.0).get();
+        client().prepareIndex("test").setId("4").setSource("score", 0.5).get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch("test")
@@ -1728,8 +1741,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     public void testQueryStringWithSlopAndFields() {
         assertAcked(prepareCreate("test"));
 
-        client().prepareIndex("test", "_doc", "1").setSource("desc", "one two three", "type", "customer").get();
-        client().prepareIndex("test", "_doc", "2").setSource("desc", "one two three", "type", "product").get();
+        client().prepareIndex("test").setId("1").setSource("desc", "one two three", "type", "customer").get();
+        client().prepareIndex("test").setId("2").setSource("desc", "one two three", "type", "product").get();
         refresh();
         {
             SearchResponse searchResponse = client().prepareSearch("test")
@@ -1774,12 +1787,12 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
         );
         indexRandom(
             true,
-            client().prepareIndex("test", "type", "1").setSource("field", 1000000000001L),
-            client().prepareIndex("test", "type", "2").setSource("field", 1000000000000L),
-            client().prepareIndex("test", "type", "3").setSource("field", 999999999999L),
-            client().prepareIndex("test", "type", "4").setSource("field", 1000000000002L),
-            client().prepareIndex("test", "type", "5").setSource("field", 1000000000003L),
-            client().prepareIndex("test", "type", "6").setSource("field", 999999999999L)
+            client().prepareIndex("test").setId("1").setSource("field", 1000000000001L),
+            client().prepareIndex("test").setId("2").setSource("field", 1000000000000L),
+            client().prepareIndex("test").setId("3").setSource("field", 999999999999L),
+            client().prepareIndex("test").setId("4").setSource("field", 1000000000002L),
+            client().prepareIndex("test").setId("5").setSource("field", 1000000000003L),
+            client().prepareIndex("test").setId("6").setSource("field", 999999999999L)
         );
 
         assertHitCount(client().prepareSearch("test").setSize(0).setQuery(rangeQuery("field").gte(1000000000000L)).get(), 4);
@@ -1791,11 +1804,12 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("test", "type1", "1").setSource("date", "2014-01-01", "num", 1),
-            client().prepareIndex("test", "type1", "2").setSource("date", "2013-12-31T23:00:00", "num", 2),
-            client().prepareIndex("test", "type1", "3").setSource("date", "2014-01-01T01:00:00", "num", 3),
+            client().prepareIndex("test").setId("1").setSource("date", "2014-01-01", "num", 1),
+            client().prepareIndex("test").setId("2").setSource("date", "2013-12-31T23:00:00", "num", 2),
+            client().prepareIndex("test").setId("3").setSource("date", "2014-01-01T01:00:00", "num", 3),
             // Now in UTC+1
-            client().prepareIndex("test", "type1", "4")
+            client().prepareIndex("test")
+                .setId("4")
                 .setSource("date", Instant.now().atZone(ZoneOffset.ofHours(1)).toInstant().toEpochMilli(), "num", 4)
         );
 
@@ -1892,8 +1906,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("test", "type1", "1").setSource("date_field", "Mi, 06 Dez 2000 02:55:00 -0800"),
-            client().prepareIndex("test", "type1", "2").setSource("date_field", "Do, 07 Dez 2000 02:55:00 -0800")
+            client().prepareIndex("test").setId("1").setSource("date_field", "Mi, 06 Dez 2000 02:55:00 -0800"),
+            client().prepareIndex("test").setId("2").setSource("date_field", "Do, 07 Dez 2000 02:55:00 -0800")
         );
 
         SearchResponse searchResponse = client().prepareSearch("test")
@@ -1909,7 +1923,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
     public void testSearchEmptyDoc() {
         assertAcked(prepareCreate("test").setSettings("{\"index.analysis.analyzer.default.type\":\"keyword\"}", XContentType.JSON));
-        client().prepareIndex("test", "type1", "1").setSource("{}", XContentType.JSON).get();
+        client().prepareIndex("test").setId("1").setSource("{}", XContentType.JSON).get();
 
         refresh();
         assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1L);
@@ -1919,8 +1933,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
         createIndex("test1");
         indexRandom(
             true,
-            client().prepareIndex("test1", "type1", "1").setSource("field", "Johnnie Walker Black Label"),
-            client().prepareIndex("test1", "type1", "2").setSource("field", "trying out OpenSearch")
+            client().prepareIndex("test1").setId("1").setSource("field", "Johnnie Walker Black Label"),
+            client().prepareIndex("test1").setId("2").setSource("field", "trying out OpenSearch")
         );
 
         SearchResponse searchResponse = client().prepareSearch()
@@ -1938,7 +1952,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
     public void testQueryStringParserCache() throws Exception {
         createIndex("test");
-        indexRandom(true, false, client().prepareIndex("test", "type", "1").setSource("nameTokens", "xyz"));
+        indexRandom(true, false, client().prepareIndex("test").setId("1").setSource("nameTokens", "xyz"));
 
         SearchResponse response = client().prepareSearch("test")
             .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
@@ -1964,7 +1978,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     public void testRangeQueryRangeFields_24744() throws Exception {
         assertAcked(prepareCreate("test").addMapping("type1", "int_range", "type=integer_range"));
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().startObject("int_range").field("gte", 10).field("lte", 20).endObject().endObject())
             .get();
         refresh();
@@ -1977,7 +1992,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     public void testRangeQueryTypeField_31476() throws Exception {
         assertAcked(prepareCreate("test").addMapping("foo", "field", "type=keyword"));
 
-        client().prepareIndex("test", "foo", "1").setSource("field", "value").get();
+        client().prepareIndex("test").setId("1").setSource("field", "value").get();
         refresh();
 
         RangeQueryBuilder range = new RangeQueryBuilder("_type").from("ape").to("zebra");
@@ -2111,7 +2126,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
                     .build()
             ).addMapping("_doc", "field1", "type=keyword,normalizer=lowercase_normalizer")
         );
-        client().prepareIndex("test", "_doc", "1").setSource("field1", "Bbb Aaa").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "Bbb Aaa").get();
         refresh();
 
         {
@@ -2138,7 +2153,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
                     .build()
             ).addMapping("_doc", "field1", "type=text,analyzer=lowercase_analyzer")
         );
-        client().prepareIndex("test", "_doc", "1").setSource("field1", "Bbb Aaa").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "Bbb Aaa").get();
         refresh();
 
         {
@@ -2166,7 +2181,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
                     .build()
             ).addMapping("_doc", "field", "type=keyword,normalizer=no_wildcard")
         );
-        client().prepareIndex("test", "_doc", "1").setSource("field", "label-1").get();
+        client().prepareIndex("test").setId("1").setSource("field", "label-1").get();
         refresh();
 
         WildcardQueryBuilder wildCardQuery = wildcardQuery("field", "la*");
@@ -2220,7 +2235,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
      */
     public void testIssueFuzzyInsideSpanMulti() {
         createIndex("test");
-        client().prepareIndex("test", "_doc", "1").setSource("field", "foobarbaz").get();
+        client().prepareIndex("test").setId("1").setSource("field", "foobarbaz").get();
         ensureGreen();
         refresh();
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/SimpleQueryStringIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/SimpleQueryStringIT.java
@@ -124,12 +124,12 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
         indexRandom(
             true,
             false,
-            client().prepareIndex("test", "type1", "1").setSource("body", "foo"),
-            client().prepareIndex("test", "type1", "2").setSource("body", "bar"),
-            client().prepareIndex("test", "type1", "3").setSource("body", "foo bar"),
-            client().prepareIndex("test", "type1", "4").setSource("body", "quux baz eggplant"),
-            client().prepareIndex("test", "type1", "5").setSource("body", "quux baz spaghetti"),
-            client().prepareIndex("test", "type1", "6").setSource("otherbody", "spaghetti")
+            client().prepareIndex("test").setId("1").setSource("body", "foo"),
+            client().prepareIndex("test").setId("2").setSource("body", "bar"),
+            client().prepareIndex("test").setId("3").setSource("body", "foo bar"),
+            client().prepareIndex("test").setId("4").setSource("body", "quux baz eggplant"),
+            client().prepareIndex("test").setId("5").setSource("body", "quux baz spaghetti"),
+            client().prepareIndex("test").setId("6").setSource("otherbody", "spaghetti")
         );
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar")).get();
@@ -175,10 +175,10 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
         indexRandom(
             true,
             false,
-            client().prepareIndex("test", "type1", "1").setSource("body", "foo"),
-            client().prepareIndex("test", "type1", "2").setSource("body", "bar"),
-            client().prepareIndex("test", "type1", "3").setSource("body", "foo bar"),
-            client().prepareIndex("test", "type1", "4").setSource("body", "foo baz bar")
+            client().prepareIndex("test").setId("1").setSource("body", "foo"),
+            client().prepareIndex("test").setId("2").setSource("body", "bar"),
+            client().prepareIndex("test").setId("3").setSource("body", "foo bar"),
+            client().prepareIndex("test").setId("4").setSource("body", "foo baz bar")
         );
 
         logger.info("--> query 1");
@@ -211,10 +211,10 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
         indexRandom(
             true,
             false,
-            client().prepareIndex("test", "type1", "5").setSource("body2", "foo", "other", "foo"),
-            client().prepareIndex("test", "type1", "6").setSource("body2", "bar", "other", "foo"),
-            client().prepareIndex("test", "type1", "7").setSource("body2", "foo bar", "other", "foo"),
-            client().prepareIndex("test", "type1", "8").setSource("body2", "foo baz bar", "other", "foo")
+            client().prepareIndex("test").setId("5").setSource("body2", "foo", "other", "foo"),
+            client().prepareIndex("test").setId("6").setSource("body2", "bar", "other", "foo"),
+            client().prepareIndex("test").setId("7").setSource("body2", "foo bar", "other", "foo"),
+            client().prepareIndex("test").setId("8").setSource("body2", "foo baz bar", "other", "foo")
         );
 
         logger.info("--> query 5");
@@ -257,7 +257,7 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
                     .endObject()
             )
         );
-        client().prepareIndex("test", "type1", "1").setSource("body", "foo bar baz").get();
+        client().prepareIndex("test").setId("1").setSource("body", "foo bar baz").get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo bar baz").field("body")).get();
@@ -281,12 +281,12 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
         createIndex("test");
         indexRandom(
             true,
-            client().prepareIndex("test", "type1", "1").setSource("body", "foo"),
-            client().prepareIndex("test", "type1", "2").setSource("body", "bar"),
-            client().prepareIndex("test", "type1", "3").setSource("body", "foo bar"),
-            client().prepareIndex("test", "type1", "4").setSource("body", "quux baz eggplant"),
-            client().prepareIndex("test", "type1", "5").setSource("body", "quux baz spaghetti"),
-            client().prepareIndex("test", "type1", "6").setSource("otherbody", "spaghetti")
+            client().prepareIndex("test").setId("1").setSource("body", "foo"),
+            client().prepareIndex("test").setId("2").setSource("body", "bar"),
+            client().prepareIndex("test").setId("3").setSource("body", "foo bar"),
+            client().prepareIndex("test").setId("4").setSource("body", "quux baz eggplant"),
+            client().prepareIndex("test").setId("5").setSource("body", "quux baz spaghetti"),
+            client().prepareIndex("test").setId("6").setSource("otherbody", "spaghetti")
         );
 
         SearchResponse searchResponse = client().prepareSearch()
@@ -339,8 +339,8 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
         createIndex("test1", "test2");
         indexRandom(
             true,
-            client().prepareIndex("test1", "type1", "1").setSource("field", "foo"),
-            client().prepareIndex("test2", "type1", "10").setSource("field", 5)
+            client().prepareIndex("test1").setId("1").setSource("field", "foo"),
+            client().prepareIndex("test2").setId("10").setSource("field", 5)
         );
         refresh();
 
@@ -362,8 +362,8 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
     public void testLenientFlagBeingTooLenient() throws Exception {
         indexRandom(
             true,
-            client().prepareIndex("test", "_doc", "1").setSource("num", 1, "body", "foo bar baz"),
-            client().prepareIndex("test", "_doc", "2").setSource("num", 2, "body", "eggplant spaghetti lasagna")
+            client().prepareIndex("test").setId("1").setSource("num", 1, "body", "foo bar baz"),
+            client().prepareIndex("test").setId("2").setSource("num", 2, "body", "eggplant spaghetti lasagna")
         );
 
         BoolQueryBuilder q = boolQuery().should(simpleQueryStringQuery("bar").field("num").field("body").lenient(true));
@@ -395,7 +395,7 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
             .prepareCreate("test1")
             .addMapping("type1", mapping, XContentType.JSON);
         mappingRequest.get();
-        indexRandom(true, client().prepareIndex("test1", "type1", "1").setSource("location", "Köln"));
+        indexRandom(true, client().prepareIndex("test1").setId("1").setSource("location", "Köln"));
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("Köln*").field("location")).get();
@@ -405,8 +405,8 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
     }
 
     public void testSimpleQueryStringUsesFieldAnalyzer() throws Exception {
-        client().prepareIndex("test", "type1", "1").setSource("foo", 123, "bar", "abc").get();
-        client().prepareIndex("test", "type1", "2").setSource("foo", 234, "bar", "bcd").get();
+        client().prepareIndex("test").setId("1").setSource("foo", 123, "bar", "abc").get();
+        client().prepareIndex("test").setId("2").setSource("foo", 234, "bar", "bcd").get();
 
         refresh();
 
@@ -416,8 +416,8 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
     }
 
     public void testSimpleQueryStringOnIndexMetaField() throws Exception {
-        client().prepareIndex("test", "type1", "1").setSource("foo", 123, "bar", "abc").get();
-        client().prepareIndex("test", "type1", "2").setSource("foo", 234, "bar", "bcd").get();
+        client().prepareIndex("test").setId("1").setSource("foo", 123, "bar", "abc").get();
+        client().prepareIndex("test").setId("2").setSource("foo", 234, "bar", "bcd").get();
 
         refresh();
 
@@ -447,7 +447,7 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
             .prepareCreate("test1")
             .addMapping("type1", mapping, XContentType.JSON);
         mappingRequest.get();
-        indexRandom(true, client().prepareIndex("test1", "type1", "1").setSource("body", "Some Text"));
+        indexRandom(true, client().prepareIndex("test1").setId("1").setSource("body", "Some Text"));
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("the*").field("body")).get();
@@ -461,9 +461,9 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
         ensureGreen("test");
 
         List<IndexRequestBuilder> reqs = new ArrayList<>();
-        reqs.add(client().prepareIndex("test", "_doc", "1").setSource("f1", "foo bar baz"));
-        reqs.add(client().prepareIndex("test", "_doc", "2").setSource("f2", "Bar"));
-        reqs.add(client().prepareIndex("test", "_doc", "3").setSource("f3", "foo bar baz"));
+        reqs.add(client().prepareIndex("test").setId("1").setSource("f1", "foo bar baz"));
+        reqs.add(client().prepareIndex("test").setId("2").setSource("f2", "Bar"));
+        reqs.add(client().prepareIndex("test").setId("3").setSource("f3", "foo bar baz"));
         indexRandom(true, false, reqs);
 
         SearchResponse resp = client().prepareSearch("test").setQuery(simpleQueryStringQuery("foo")).get();
@@ -485,8 +485,8 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
         ensureGreen("test");
 
         List<IndexRequestBuilder> reqs = new ArrayList<>();
-        reqs.add(client().prepareIndex("test", "_doc", "1").setSource("f1", "foo", "f_date", "2015/09/02"));
-        reqs.add(client().prepareIndex("test", "_doc", "2").setSource("f1", "bar", "f_date", "2015/09/01"));
+        reqs.add(client().prepareIndex("test").setId("1").setSource("f1", "foo", "f_date", "2015/09/02"));
+        reqs.add(client().prepareIndex("test").setId("2").setSource("f1", "bar", "f_date", "2015/09/01"));
         indexRandom(true, false, reqs);
 
         SearchResponse resp = client().prepareSearch("test").setQuery(simpleQueryStringQuery("foo bar")).get();
@@ -513,10 +513,10 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
 
         List<IndexRequestBuilder> reqs = new ArrayList<>();
         reqs.add(
-            client().prepareIndex("test", "_doc", "1").setSource("f1", "foo", "f_date", "2015/09/02", "f_float", "1.7", "f_ip", "127.0.0.1")
+            client().prepareIndex("test").setId("1").setSource("f1", "foo", "f_date", "2015/09/02", "f_float", "1.7", "f_ip", "127.0.0.1")
         );
         reqs.add(
-            client().prepareIndex("test", "_doc", "2").setSource("f1", "bar", "f_date", "2015/09/01", "f_float", "1.8", "f_ip", "127.0.0.2")
+            client().prepareIndex("test").setId("2").setSource("f1", "bar", "f_date", "2015/09/01", "f_float", "1.8", "f_ip", "127.0.0.2")
         );
         indexRandom(true, false, reqs);
 
@@ -544,7 +544,7 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
 
         List<IndexRequestBuilder> reqs = new ArrayList<>();
         String docBody = copyToStringFromClasspath("/org/opensearch/search/query/all-example-document.json");
-        reqs.add(client().prepareIndex("test", "_doc", "1").setSource(docBody, XContentType.JSON));
+        reqs.add(client().prepareIndex("test").setId("1").setSource(docBody, XContentType.JSON));
         indexRandom(true, false, reqs);
 
         SearchResponse resp = client().prepareSearch("test").setQuery(simpleQueryStringQuery("foo")).get();
@@ -588,9 +588,9 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
         ensureGreen("test");
 
         List<IndexRequestBuilder> reqs = new ArrayList<>();
-        reqs.add(client().prepareIndex("test", "_doc", "1").setSource("f2", "Foo Bar"));
-        reqs.add(client().prepareIndex("test", "_doc", "2").setSource("f1", "bar"));
-        reqs.add(client().prepareIndex("test", "_doc", "3").setSource("f1", "foo bar"));
+        reqs.add(client().prepareIndex("test").setId("1").setSource("f2", "Foo Bar"));
+        reqs.add(client().prepareIndex("test").setId("2").setSource("f1", "bar"));
+        reqs.add(client().prepareIndex("test").setId("3").setSource("f1", "foo bar"));
         indexRandom(true, false, reqs);
 
         SearchResponse resp = client().prepareSearch("test").setQuery(simpleQueryStringQuery("foo")).get();
@@ -632,7 +632,7 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
             ).addMapping("type1", builder)
         );
 
-        client().prepareIndex("toomanyfields", "type1", "1").setSource("field1", "foo bar baz").get();
+        client().prepareIndex("toomanyfields").setId("1").setSource("field1", "foo bar baz").get();
         refresh();
 
         doAssertLimitExceededException("*", CLUSTER_MAX_CLAUSE_COUNT + 1);
@@ -657,9 +657,9 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
         ensureGreen("test");
 
         List<IndexRequestBuilder> indexRequests = new ArrayList<>();
-        indexRequests.add(client().prepareIndex("test", "_doc", "1").setSource("f3", "text", "f2", "one"));
-        indexRequests.add(client().prepareIndex("test", "_doc", "2").setSource("f3", "value", "f2", "two"));
-        indexRequests.add(client().prepareIndex("test", "_doc", "3").setSource("f3", "another value", "f2", "three"));
+        indexRequests.add(client().prepareIndex("test").setId("1").setSource("f3", "text", "f2", "one"));
+        indexRequests.add(client().prepareIndex("test").setId("2").setSource("f3", "value", "f2", "two"));
+        indexRequests.add(client().prepareIndex("test").setId("3").setSource("f3", "another value", "f2", "three"));
         indexRandom(true, false, indexRequests);
 
         SearchResponse response = client().prepareSearch("test").setQuery(simpleQueryStringQuery("value").field("f3_alias")).get();
@@ -675,9 +675,9 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
         ensureGreen("test");
 
         List<IndexRequestBuilder> indexRequests = new ArrayList<>();
-        indexRequests.add(client().prepareIndex("test", "_doc", "1").setSource("f3", "text", "f2", "one"));
-        indexRequests.add(client().prepareIndex("test", "_doc", "2").setSource("f3", "value", "f2", "two"));
-        indexRequests.add(client().prepareIndex("test", "_doc", "3").setSource("f3", "another value", "f2", "three"));
+        indexRequests.add(client().prepareIndex("test").setId("1").setSource("f3", "text", "f2", "one"));
+        indexRequests.add(client().prepareIndex("test").setId("2").setSource("f3", "value", "f2", "two"));
+        indexRequests.add(client().prepareIndex("test").setId("3").setSource("f3", "another value", "f2", "three"));
         indexRandom(true, false, indexRequests);
 
         SearchResponse response = client().prepareSearch("test").setQuery(simpleQueryStringQuery("value").field("f3_*")).get();
@@ -693,7 +693,7 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
         ensureGreen("test");
 
         List<IndexRequestBuilder> indexRequests = new ArrayList<>();
-        indexRequests.add(client().prepareIndex("test", "_doc", "1").setSource("f3", "text", "f2", "one"));
+        indexRequests.add(client().prepareIndex("test").setId("1").setSource("f3", "text", "f2", "one"));
         indexRandom(true, false, indexRequests);
 
         // The wildcard field matches aliases for both a text and boolean field.

--- a/server/src/internalClusterTest/java/org/opensearch/search/scriptfilter/ScriptQuerySearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/scriptfilter/ScriptQuerySearchIT.java
@@ -133,11 +133,13 @@ public class ScriptQuerySearchIT extends OpenSearchIntegTestCase {
                 .addMapping("my-type", createMappingSource("binary"))
                 .setSettings(indexSettings())
         );
-        client().prepareIndex("my-index", "my-type", "1")
+        client().prepareIndex("my-index")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("binaryData", Base64.getEncoder().encodeToString(randomBytesDoc1)).endObject())
             .get();
         flush();
-        client().prepareIndex("my-index", "my-type", "2")
+        client().prepareIndex("my-index")
+            .setId("2")
             .setSource(jsonBuilder().startObject().field("binaryData", Base64.getEncoder().encodeToString(randomBytesDoc2)).endObject())
             .get();
         flush();
@@ -181,15 +183,18 @@ public class ScriptQuerySearchIT extends OpenSearchIntegTestCase {
 
     public void testCustomScriptBoost() throws Exception {
         createIndex("test");
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("test", "value beck").field("num1", 1.0f).endObject())
             .get();
         flush();
-        client().prepareIndex("test", "type1", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(jsonBuilder().startObject().field("test", "value beck").field("num1", 2.0f).endObject())
             .get();
         flush();
-        client().prepareIndex("test", "type1", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setSource(jsonBuilder().startObject().field("test", "value beck").field("num1", 3.0f).endObject())
             .get();
         refresh();

--- a/server/src/internalClusterTest/java/org/opensearch/search/scroll/DuelScrollIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/scroll/DuelScrollIT.java
@@ -155,7 +155,7 @@ public class DuelScrollIT extends OpenSearchIntegTestCase {
         }
 
         for (int i = 1; i <= numDocs; i++) {
-            IndexRequestBuilder indexRequestBuilder = client().prepareIndex("index", "type", String.valueOf(i));
+            IndexRequestBuilder indexRequestBuilder = client().prepareIndex("index").setId(String.valueOf(i));
             if (missingDocs.contains(i)) {
                 indexRequestBuilder.setSource("x", "y");
             } else {
@@ -230,7 +230,7 @@ public class DuelScrollIT extends OpenSearchIntegTestCase {
 
         IndexRequestBuilder[] builders = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; ++i) {
-            builders[i] = client().prepareIndex("test", "type", Integer.toString(i)).setSource("foo", random().nextBoolean());
+            builders[i] = client().prepareIndex("test").setId(Integer.toString(i)).setSource("foo", random().nextBoolean());
         }
         indexRandom(true, builders);
         return numDocs;

--- a/server/src/internalClusterTest/java/org/opensearch/search/scroll/SearchScrollIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/scroll/SearchScrollIT.java
@@ -106,7 +106,8 @@ public class SearchScrollIT extends OpenSearchIntegTestCase {
         client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         for (int i = 0; i < 100; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i))
+            client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource(jsonBuilder().startObject().field("field", i).endObject())
                 .get();
         }
@@ -161,7 +162,7 @@ public class SearchScrollIT extends OpenSearchIntegTestCase {
             } else if (i > 60) {
                 routing = "2";
             }
-            client().prepareIndex("test", "type1", Integer.toString(i)).setSource("field", i).setRouting(routing).get();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", i).setRouting(routing).get();
         }
 
         client().admin().indices().prepareRefresh().get();
@@ -220,7 +221,8 @@ public class SearchScrollIT extends OpenSearchIntegTestCase {
         client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         for (int i = 0; i < 500; i++) {
-            client().prepareIndex("test", "tweet", Integer.toString(i))
+            client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource(
                     jsonBuilder().startObject()
                         .field("user", "foobar")
@@ -262,7 +264,7 @@ public class SearchScrollIT extends OpenSearchIntegTestCase {
                 for (SearchHit searchHit : searchResponse.getHits().getHits()) {
                     Map<String, Object> map = searchHit.getSourceAsMap();
                     map.put("message", "update");
-                    client().prepareIndex("test", "tweet", searchHit.getId()).setSource(map).get();
+                    client().prepareIndex("test").setId(searchHit.getId()).setSource(map).get();
                 }
                 searchResponse = client().prepareSearchScroll(searchResponse.getScrollId()).setScroll(TimeValue.timeValueMinutes(2)).get();
             } while (searchResponse.getHits().getHits().length > 0);
@@ -297,7 +299,8 @@ public class SearchScrollIT extends OpenSearchIntegTestCase {
         client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         for (int i = 0; i < 100; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i))
+            client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource(jsonBuilder().startObject().field("field", i).endObject())
                 .get();
         }
@@ -416,7 +419,8 @@ public class SearchScrollIT extends OpenSearchIntegTestCase {
         client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         for (int i = 0; i < 100; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i))
+            client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource(jsonBuilder().startObject().field("field", i).endObject())
                 .get();
         }
@@ -490,7 +494,7 @@ public class SearchScrollIT extends OpenSearchIntegTestCase {
      * Tests that we use an optimization shrinking the batch to the size of the shard. Thus the Integer.MAX_VALUE window doesn't OOM us.
      */
     public void testDeepScrollingDoesNotBlowUp() throws Exception {
-        client().prepareIndex("index", "type", "1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).execute().get();
+        client().prepareIndex("index").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).execute().get();
         /*
          * Disable the max result window setting for this test because it'll reject the search's unreasonable batch size. We want
          * unreasonable batch sizes to just OOM.
@@ -521,7 +525,7 @@ public class SearchScrollIT extends OpenSearchIntegTestCase {
     }
 
     public void testThatNonExistingScrollIdReturnsCorrectException() throws Exception {
-        client().prepareIndex("index", "type", "1").setSource("field", "value").execute().get();
+        client().prepareIndex("index").setId("1").setSource("field", "value").execute().get();
         refresh();
 
         SearchResponse searchResponse = client().prepareSearch("index").setSize(1).setScroll("1m").get();
@@ -539,7 +543,7 @@ public class SearchScrollIT extends OpenSearchIntegTestCase {
                 Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
             ).addMapping("test", "no_field", "type=keyword", "some_field", "type=keyword")
         );
-        client().prepareIndex("test", "test", "1").setSource("some_field", "test").get();
+        client().prepareIndex("test").setId("1").setSource("some_field", "test").get();
         refresh();
 
         SearchResponse response = client().prepareSearch("test")
@@ -569,7 +573,7 @@ public class SearchScrollIT extends OpenSearchIntegTestCase {
     public void testCloseAndReopenOrDeleteWithActiveScroll() {
         createIndex("test");
         for (int i = 0; i < 100; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i)).setSource("field", i).get();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", i).get();
         }
         refresh();
         SearchResponse searchResponse = client().prepareSearch()
@@ -660,7 +664,8 @@ public class SearchScrollIT extends OpenSearchIntegTestCase {
     public void testInvalidScrollKeepAlive() throws IOException {
         createIndex("test");
         for (int i = 0; i < 2; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(i))
+            client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource(jsonBuilder().startObject().field("field", i).endObject())
                 .get();
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/searchafter/SearchAfterIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/searchafter/SearchAfterIT.java
@@ -67,7 +67,7 @@ public class SearchAfterIT extends OpenSearchIntegTestCase {
             client().admin().indices().prepareCreate("test").addMapping("type1", "field1", "type=long", "field2", "type=keyword").get()
         );
         ensureGreen();
-        indexRandom(true, client().prepareIndex("test", "type1", "0").setSource("field1", 0, "field2", "toto"));
+        indexRandom(true, client().prepareIndex("test").setId("0").setSource("field1", 0, "field2", "toto"));
         {
             SearchPhaseExecutionException e = expectThrows(
                 SearchPhaseExecutionException.class,
@@ -163,8 +163,8 @@ public class SearchAfterIT extends OpenSearchIntegTestCase {
         ensureGreen();
         indexRandom(
             true,
-            client().prepareIndex("test", "type1", "0").setSource("field1", 0),
-            client().prepareIndex("test", "type1", "1").setSource("field1", 100, "field2", "toto")
+            client().prepareIndex("test").setId("0").setSource("field1", 0),
+            client().prepareIndex("test").setId("1").setSource("field1", 100, "field2", "toto")
         );
         SearchResponse searchResponse = client().prepareSearch("test")
             .addSort("field1", SortOrder.ASC)
@@ -263,7 +263,7 @@ public class SearchAfterIT extends OpenSearchIntegTestCase {
                     builder.field("field" + Integer.toString(j), documents.get(i).get(j));
                 }
                 builder.endObject();
-                requests.add(client().prepareIndex(INDEX_NAME, TYPE_NAME, Integer.toString(i)).setSource(builder));
+                requests.add(client().prepareIndex(INDEX_NAME).setId(Integer.toString(i)).setSource(builder));
             }
             indexRandom(true, requests);
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
@@ -87,12 +87,12 @@ public class SimpleSearchIT extends OpenSearchIntegTestCase {
         createIndex("test");
         indexRandom(
             true,
-            client().prepareIndex("test", "type", "1").setSource("field", "value"),
-            client().prepareIndex("test", "type", "2").setSource("field", "value"),
-            client().prepareIndex("test", "type", "3").setSource("field", "value"),
-            client().prepareIndex("test", "type", "4").setSource("field", "value"),
-            client().prepareIndex("test", "type", "5").setSource("field", "value"),
-            client().prepareIndex("test", "type", "6").setSource("field", "value")
+            client().prepareIndex("test").setId("1").setSource("field", "value"),
+            client().prepareIndex("test").setId("2").setSource("field", "value"),
+            client().prepareIndex("test").setId("3").setSource("field", "value"),
+            client().prepareIndex("test").setId("4").setSource("field", "value"),
+            client().prepareIndex("test").setId("5").setSource("field", "value"),
+            client().prepareIndex("test").setId("6").setSource("field", "value")
         );
 
         int iters = scaledRandomIntBetween(10, 20);
@@ -136,10 +136,7 @@ public class SimpleSearchIT extends OpenSearchIntegTestCase {
             )
             .get();
 
-        client().prepareIndex("test", "type1", "1")
-            .setSource("from", "192.168.0.5", "to", "192.168.0.10")
-            .setRefreshPolicy(IMMEDIATE)
-            .get();
+        client().prepareIndex("test").setId("1").setSource("from", "192.168.0.5", "to", "192.168.0.10").setRefreshPolicy(IMMEDIATE).get();
 
         SearchResponse search = client().prepareSearch()
             .setQuery(boolQuery().must(rangeQuery("from").lte("192.168.0.7")).must(rangeQuery("to").gte("192.168.0.7")))
@@ -170,11 +167,11 @@ public class SimpleSearchIT extends OpenSearchIntegTestCase {
             .get();
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1").setSource("ip", "192.168.0.1").get();
-        client().prepareIndex("test", "type1", "2").setSource("ip", "192.168.0.2").get();
-        client().prepareIndex("test", "type1", "3").setSource("ip", "192.168.0.3").get();
-        client().prepareIndex("test", "type1", "4").setSource("ip", "192.168.1.4").get();
-        client().prepareIndex("test", "type1", "5").setSource("ip", "2001:db8::ff00:42:8329").get();
+        client().prepareIndex("test").setId("1").setSource("ip", "192.168.0.1").get();
+        client().prepareIndex("test").setId("2").setSource("ip", "192.168.0.2").get();
+        client().prepareIndex("test").setId("3").setSource("ip", "192.168.0.3").get();
+        client().prepareIndex("test").setId("4").setSource("ip", "192.168.1.4").get();
+        client().prepareIndex("test").setId("5").setSource("ip", "2001:db8::ff00:42:8329").get();
         refresh();
 
         SearchResponse search = client().prepareSearch().setQuery(boolQuery().must(QueryBuilders.termQuery("ip", "192.168.0.1"))).get();
@@ -217,7 +214,7 @@ public class SimpleSearchIT extends OpenSearchIntegTestCase {
     public void testSimpleId() {
         createIndex("test");
 
-        client().prepareIndex("test", "type", "XXX1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("XXX1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
         // id is not indexed, but lets see that we automatically convert to
         SearchResponse searchResponse = client().prepareSearch().setQuery(QueryBuilders.termQuery("_id", "XXX1")).get();
         assertHitCount(searchResponse, 1L);
@@ -228,8 +225,8 @@ public class SimpleSearchIT extends OpenSearchIntegTestCase {
 
     public void testSimpleDateRange() throws Exception {
         createIndex("test");
-        client().prepareIndex("test", "type1", "1").setSource("field", "2010-01-05T02:00").get();
-        client().prepareIndex("test", "type1", "2").setSource("field", "2010-01-06T02:00").get();
+        client().prepareIndex("test").setId("1").setSource("field", "2010-01-05T02:00").get();
+        client().prepareIndex("test").setId("2").setSource("field", "2010-01-06T02:00").get();
         ensureGreen();
         refresh();
         SearchResponse searchResponse = client().prepareSearch("test")
@@ -270,7 +267,7 @@ public class SimpleSearchIT extends OpenSearchIntegTestCase {
 
         for (int i = 1; i <= max; i++) {
             String id = String.valueOf(i);
-            docbuilders.add(client().prepareIndex("test", "type1", id).setSource("field", i));
+            docbuilders.add(client().prepareIndex("test").setId(id).setSource("field", i));
         }
 
         indexRandom(true, docbuilders);
@@ -306,7 +303,7 @@ public class SimpleSearchIT extends OpenSearchIntegTestCase {
 
         for (int i = max - 1; i >= 0; i--) {
             String id = String.valueOf(i);
-            docbuilders.add(client().prepareIndex("test", "type1", id).setSource("rank", i));
+            docbuilders.add(client().prepareIndex("test").setId(id).setSource("rank", i));
         }
 
         indexRandom(true, docbuilders);

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/FieldSortIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/FieldSortIT.java
@@ -142,7 +142,7 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
                 assertAcked(prepareCreate("test_" + i).addAlias(new Alias("test")));
             }
             if (i > 0) {
-                client().prepareIndex("test_" + i, "foo", "" + i).setSource("{\"entry\": " + i + "}", XContentType.JSON).get();
+                client().prepareIndex("test_" + i).setId("" + i).setSource("{\"entry\": " + i + "}", XContentType.JSON).get();
             }
         }
         refresh();
@@ -312,7 +312,7 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
                 sparseBytes.put(ref, docId);
             }
             src.endObject();
-            builders[i] = client().prepareIndex("test", "type", docId).setSource(src);
+            builders[i] = client().prepareIndex("test").setId(docId).setSource(src);
         }
         indexRandom(true, builders);
         {
@@ -361,7 +361,7 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
         ensureGreen();
 
         for (int i = 1; i < 101; i++) {
-            client().prepareIndex("test", "type", Integer.toString(i)).setSource("field", Integer.toString(i)).get();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", Integer.toString(i)).get();
         }
         refresh();
         SearchResponse searchResponse = client().prepareSearch("test")
@@ -373,7 +373,7 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
         assertThat(searchResponse.getHits().getAt(2).getSortValues()[0].toString(), equalTo("100"));
 
         // reindex and refresh
-        client().prepareIndex("test", "type", Integer.toString(1)).setSource("field", Integer.toString(1)).get();
+        client().prepareIndex("test").setId(Integer.toString(1)).setSource("field", Integer.toString(1)).get();
         refresh();
 
         searchResponse = client().prepareSearch("test")
@@ -385,7 +385,7 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
         assertThat(searchResponse.getHits().getAt(2).getSortValues()[0].toString(), equalTo("100"));
 
         // reindex - no refresh
-        client().prepareIndex("test", "type", Integer.toString(1)).setSource("field", Integer.toString(1)).get();
+        client().prepareIndex("test").setId(Integer.toString(1)).setSource("field", Integer.toString(1)).get();
 
         searchResponse = client().prepareSearch("test")
             .setQuery(matchAllQuery())
@@ -399,7 +399,7 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
         forceMerge();
         refresh();
 
-        client().prepareIndex("test", "type", Integer.toString(1)).setSource("field", Integer.toString(1)).get();
+        client().prepareIndex("test").setId(Integer.toString(1)).setSource("field", Integer.toString(1)).get();
         searchResponse = client().prepareSearch("test")
             .setQuery(matchAllQuery())
             .addSort(SortBuilders.fieldSort("field").order(SortOrder.ASC))
@@ -422,9 +422,9 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        client().prepareIndex("test", "type", "1").setSource("field", 2).get();
-        client().prepareIndex("test", "type", "2").setSource("field", 1).get();
-        client().prepareIndex("test", "type", "3").setSource("field", 0).get();
+        client().prepareIndex("test").setId("1").setSource("field", 2).get();
+        client().prepareIndex("test").setId("2").setSource("field", 1).get();
+        client().prepareIndex("test").setId("3").setSource("field", 0).get();
 
         refresh();
 
@@ -460,9 +460,9 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        client().prepareIndex("test", "type", "1").setSource("field", 2).get();
-        client().prepareIndex("test", "type", "2").setSource("field", 1).get();
-        client().prepareIndex("test", "type", "3").setSource("field", 0).get();
+        client().prepareIndex("test").setId("1").setSource("field", 2).get();
+        client().prepareIndex("test").setId("2").setSource("field", 1).get();
+        client().prepareIndex("test").setId("3").setSource("field", 0).get();
 
         refresh();
 
@@ -497,9 +497,9 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
     public void testIssue2986() {
         assertAcked(client().admin().indices().prepareCreate("test").addMapping("post", "field1", "type=keyword").get());
 
-        client().prepareIndex("test", "post", "1").setSource("{\"field1\":\"value1\"}", XContentType.JSON).get();
-        client().prepareIndex("test", "post", "2").setSource("{\"field1\":\"value2\"}", XContentType.JSON).get();
-        client().prepareIndex("test", "post", "3").setSource("{\"field1\":\"value3\"}", XContentType.JSON).get();
+        client().prepareIndex("test").setId("1").setSource("{\"field1\":\"value1\"}", XContentType.JSON).get();
+        client().prepareIndex("test").setId("2").setSource("{\"field1\":\"value2\"}", XContentType.JSON).get();
+        client().prepareIndex("test").setId("3").setSource("{\"field1\":\"value3\"}", XContentType.JSON).get();
         refresh();
         SearchResponse result = client().prepareSearch("test")
             .setQuery(matchAllQuery())
@@ -521,16 +521,16 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
             }
             assertAcked(client().admin().indices().prepareCreate("test").addMapping("type", "tag", "type=keyword").get());
             ensureGreen();
-            client().prepareIndex("test", "type", "1").setSource("tag", "alpha").get();
+            client().prepareIndex("test").setId("1").setSource("tag", "alpha").get();
             refresh();
 
-            client().prepareIndex("test", "type", "3").setSource("tag", "gamma").get();
+            client().prepareIndex("test").setId("3").setSource("tag", "gamma").get();
             refresh();
 
-            client().prepareIndex("test", "type", "4").setSource("tag", "delta").get();
+            client().prepareIndex("test").setId("4").setSource("tag", "delta").get();
 
             refresh();
-            client().prepareIndex("test", "type", "2").setSource("tag", "beta").get();
+            client().prepareIndex("test").setId("2").setSource("tag", "beta").get();
 
             refresh();
             SearchResponse resp = client().prepareSearch("test")
@@ -596,7 +596,8 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
         ensureGreen();
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            IndexRequestBuilder builder = client().prepareIndex("test", "type1", Integer.toString(i))
+            IndexRequestBuilder builder = client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource(
                     jsonBuilder().startObject()
                         .field("str_value", new String(new char[] { (char) (97 + i), (char) (97 + i) }))
@@ -818,13 +819,15 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
             )
         );
         ensureGreen();
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("id", "1").field("i_value", -1).field("d_value", -1.1).endObject())
             .get();
 
-        client().prepareIndex("test", "type1", "2").setSource(jsonBuilder().startObject().field("id", "2").endObject()).get();
+        client().prepareIndex("test").setId("2").setSource(jsonBuilder().startObject().field("id", "2").endObject()).get();
 
-        client().prepareIndex("test", "type1", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setSource(jsonBuilder().startObject().field("id", "1").field("i_value", 2).field("d_value", 2.2).endObject())
             .get();
 
@@ -885,13 +888,15 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
             )
         );
         ensureGreen();
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("id", "1").field("value", "a").endObject())
             .get();
 
-        client().prepareIndex("test", "type1", "2").setSource(jsonBuilder().startObject().field("id", "2").endObject()).get();
+        client().prepareIndex("test").setId("2").setSource(jsonBuilder().startObject().field("id", "2").endObject()).get();
 
-        client().prepareIndex("test", "type1", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setSource(jsonBuilder().startObject().field("id", "1").field("value", "c").endObject())
             .get();
 
@@ -957,7 +962,8 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
     public void testIgnoreUnmapped() throws Exception {
         createIndex("test");
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("id", "1").field("i_value", -1).field("d_value", -1.1).endObject())
             .get();
 
@@ -1037,7 +1043,8 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
         );
         ensureGreen();
 
-        client().prepareIndex("test", "type1", Integer.toString(1))
+        client().prepareIndex("test")
+            .setId(Integer.toString(1))
             .setSource(
                 jsonBuilder().startObject()
                     .array("long_values", 1L, 5L, 10L, 8L)
@@ -1050,7 +1057,8 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
                     .endObject()
             )
             .get();
-        client().prepareIndex("test", "type1", Integer.toString(2))
+        client().prepareIndex("test")
+            .setId(Integer.toString(2))
             .setSource(
                 jsonBuilder().startObject()
                     .array("long_values", 11L, 15L, 20L, 7L)
@@ -1063,7 +1071,8 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
                     .endObject()
             )
             .get();
-        client().prepareIndex("test", "type1", Integer.toString(3))
+        client().prepareIndex("test")
+            .setId(Integer.toString(3))
             .setSource(
                 jsonBuilder().startObject()
                     .array("long_values", 2L, 1L, 3L, -4L)
@@ -1351,7 +1360,8 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
             )
         );
         ensureGreen();
-        client().prepareIndex("test", "type1", Integer.toString(1))
+        client().prepareIndex("test")
+            .setId(Integer.toString(1))
             .setSource(jsonBuilder().startObject().array("string_values", "01", "05", "10", "08").endObject())
             .get();
 
@@ -1367,11 +1377,13 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
         assertThat(searchResponse.getHits().getAt(0).getId(), equalTo(Integer.toString(1)));
         assertThat(searchResponse.getHits().getAt(0).getSortValues()[0], equalTo("10"));
 
-        client().prepareIndex("test", "type1", Integer.toString(2))
+        client().prepareIndex("test")
+            .setId(Integer.toString(2))
             .setSource(jsonBuilder().startObject().array("string_values", "11", "15", "20", "07").endObject())
             .get();
         for (int i = 0; i < 15; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(300 + i))
+            client().prepareIndex("test")
+                .setId(Integer.toString(300 + i))
                 .setSource(jsonBuilder().startObject().array("some_other_field", "foobar").endObject())
                 .get();
         }
@@ -1387,11 +1399,13 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
         assertThat(searchResponse.getHits().getAt(1).getId(), equalTo(Integer.toString(1)));
         assertThat(searchResponse.getHits().getAt(1).getSortValues()[0], equalTo("10"));
 
-        client().prepareIndex("test", "type1", Integer.toString(3))
+        client().prepareIndex("test")
+            .setId(Integer.toString(3))
             .setSource(jsonBuilder().startObject().array("string_values", "02", "01", "03", "!4").endObject())
             .get();
         for (int i = 0; i < 15; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(300 + i))
+            client().prepareIndex("test")
+                .setId(Integer.toString(300 + i))
                 .setSource(jsonBuilder().startObject().array("some_other_field", "foobar").endObject())
                 .get();
         }
@@ -1411,7 +1425,8 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
         assertThat(searchResponse.getHits().getAt(2).getSortValues()[0], equalTo("03"));
 
         for (int i = 0; i < 15; i++) {
-            client().prepareIndex("test", "type1", Integer.toString(300 + i))
+            client().prepareIndex("test")
+                .setId(Integer.toString(300 + i))
                 .setSource(jsonBuilder().startObject().array("some_other_field", "foobar").endObject())
                 .get();
             refresh();
@@ -1443,7 +1458,7 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
             final int numDocs = randomIntBetween(10, 20);
             IndexRequestBuilder[] indexReqs = new IndexRequestBuilder[numDocs];
             for (int i = 0; i < numDocs; ++i) {
-                indexReqs[i] = client().prepareIndex("test", "type", Integer.toString(i)).setSource();
+                indexReqs[i] = client().prepareIndex("test").setId(Integer.toString(i)).setSource();
             }
             indexRandom(true, indexReqs);
 
@@ -1520,7 +1535,8 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
         );
         ensureGreen();
 
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .startArray("nested")
@@ -1534,7 +1550,8 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
                     .endObject()
             )
             .get();
-        client().prepareIndex("test", "type", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(
                 jsonBuilder().startObject()
                     .startArray("nested")
@@ -1625,7 +1642,7 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
         for (String index : new String[] { "test1", "test2" }) {
             List<IndexRequestBuilder> docs = new ArrayList<>();
             for (int i = 0; i < 256; i++) {
-                docs.add(client().prepareIndex(index, "type", Integer.toString(i)).setSource(sortField, i));
+                docs.add(client().prepareIndex(index).setId(Integer.toString(i)).setSource(sortField, i));
             }
             indexRandom(true, docs);
         }
@@ -1657,8 +1674,8 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test").addMapping("type", "ip", "type=ip"));
         indexRandom(
             true,
-            client().prepareIndex("test", "type", "1").setSource("ip", "192.168.1.7"),
-            client().prepareIndex("test", "type", "2").setSource("ip", "2001:db8::ff00:42:8329")
+            client().prepareIndex("test").setId("1").setSource("ip", "192.168.1.7"),
+            client().prepareIndex("test").setId("2").setSource("ip", "2001:db8::ff00:42:8329")
         );
 
         SearchResponse response = client().prepareSearch("test").addSort(SortBuilders.fieldSort("ip")).get();

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/GeoDistanceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/GeoDistanceIT.java
@@ -80,7 +80,8 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test").setSettings(settings).addMapping("type1", xContentBuilder));
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("names", "New York")
@@ -92,7 +93,8 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
             )
             .get();
 
-        client().prepareIndex("test", "type1", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(
                 jsonBuilder().startObject()
                     .field("names", "New York 2")
@@ -104,7 +106,8 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
             )
             .get();
 
-        client().prepareIndex("test", "type1", "3")
+        client().prepareIndex("test")
+            .setId("3")
             .setSource(
                 jsonBuilder().startObject()
                     .array("names", "Times Square", "Tribeca")
@@ -124,7 +127,8 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
             )
             .get();
 
-        client().prepareIndex("test", "type1", "4")
+        client().prepareIndex("test")
+            .setId("4")
             .setSource(
                 jsonBuilder().startObject()
                     .array("names", "Wall Street", "Soho")
@@ -144,7 +148,8 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
             )
             .get();
 
-        client().prepareIndex("test", "type1", "5")
+        client().prepareIndex("test")
+            .setId("5")
             .setSource(
                 jsonBuilder().startObject()
                     .array("names", "Greenwich Village", "Brooklyn")
@@ -271,7 +276,8 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test").setSettings(settings).addMapping("type1", xContentBuilder));
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .array("names", "Times Square", "Tribeca")
@@ -291,7 +297,8 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
             )
             .get();
 
-        client().prepareIndex("test", "type1", "2")
+        client().prepareIndex("test")
+            .setId("2")
             .setSource(jsonBuilder().startObject().array("names", "Wall Street", "Soho").endObject())
             .get();
 
@@ -346,7 +353,8 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("companies", "company", "1")
+            client().prepareIndex("companies")
+                .setId("1")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("name", "company 1")
@@ -361,7 +369,8 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
                         .endArray()
                         .endObject()
                 ),
-            client().prepareIndex("companies", "company", "2")
+            client().prepareIndex("companies")
+                .setId("2")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("name", "company 2")
@@ -385,7 +394,8 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
                         .endArray()
                         .endObject()
                 ),
-            client().prepareIndex("companies", "company", "3")
+            client().prepareIndex("companies")
+                .setId("3")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("name", "company 3")
@@ -408,7 +418,8 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
                         .endArray()
                         .endObject()
                 ),
-            client().prepareIndex("companies", "company", "4")
+            client().prepareIndex("companies")
+                .setId("4")
                 .setSource(
                     jsonBuilder().startObject()
                         .field("name", "company 4")
@@ -588,7 +599,7 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
         XContentBuilder source = JsonXContent.contentBuilder().startObject().field("pin", Geohash.stringEncode(lon, lat)).endObject();
 
         assertAcked(prepareCreate("locations").setSettings(settings).addMapping("location", mapping));
-        client().prepareIndex("locations", "location", "1").setCreate(true).setSource(source).get();
+        client().prepareIndex("locations").setId("1").setCreate(true).setSource(source).get();
         refresh();
         client().prepareGet("locations", "1").get();
 
@@ -612,7 +623,8 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test2"));
         ensureGreen();
 
-        client().prepareIndex("test1", "type1", "1")
+        client().prepareIndex("test1")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .array("names", "Times Square", "Tribeca")
@@ -632,7 +644,8 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
             )
             .get();
 
-        client().prepareIndex("test2", "type1", "2")
+        client().prepareIndex("test2")
+            .setId("2")
             .setSource(jsonBuilder().startObject().array("names", "Wall Street", "Soho").endObject())
             .get();
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/GeoDistanceSortBuilderIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/GeoDistanceSortBuilderIT.java
@@ -96,8 +96,8 @@ public class GeoDistanceSortBuilderIT extends OpenSearchIntegTestCase {
         logger.info("d2: {}", d2Builder);
         indexRandom(
             true,
-            client().prepareIndex("index", "type", "d1").setSource(d1Builder),
-            client().prepareIndex("index", "type", "d2").setSource(d2Builder)
+            client().prepareIndex("index").setId("d1").setSource(d1Builder),
+            client().prepareIndex("index").setId("d2").setSource(d2Builder)
         );
         GeoPoint[] q = new GeoPoint[2];
         if (randomBoolean()) {
@@ -187,8 +187,8 @@ public class GeoDistanceSortBuilderIT extends OpenSearchIntegTestCase {
         logger.info("d2: {}", d2Builder);
         indexRandom(
             true,
-            client().prepareIndex("index", "type", "d1").setSource(d1Builder),
-            client().prepareIndex("index", "type", "d2").setSource(d2Builder)
+            client().prepareIndex("index").setId("d1").setSource(d1Builder),
+            client().prepareIndex("index").setId("d2").setSource(d2Builder)
         );
         GeoPoint q = new GeoPoint(0, 0);
 
@@ -259,8 +259,8 @@ public class GeoDistanceSortBuilderIT extends OpenSearchIntegTestCase {
 
         indexRandom(
             true,
-            client().prepareIndex("index", "type", "d1").setSource(d1Builder),
-            client().prepareIndex("index", "type", "d2").setSource(d2Builder)
+            client().prepareIndex("index").setId("d1").setSource(d1Builder),
+            client().prepareIndex("index").setId("d2").setSource(d2Builder)
         );
 
         List<GeoPoint> qPoints = Arrays.asList(new GeoPoint(2, 1), new GeoPoint(2, 2), new GeoPoint(2, 3), new GeoPoint(2, 4));
@@ -309,9 +309,11 @@ public class GeoDistanceSortBuilderIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("index").addMapping("type", LOCATION_FIELD, "type=geo_point"));
         indexRandom(
             true,
-            client().prepareIndex("index", "type", "d1")
+            client().prepareIndex("index")
+                .setId("d1")
                 .setSource(jsonBuilder().startObject().startObject(LOCATION_FIELD).field("lat", 1).field("lon", 1).endObject().endObject()),
-            client().prepareIndex("index", "type", "d2")
+            client().prepareIndex("index")
+                .setId("d2")
                 .setSource(jsonBuilder().startObject().startObject(LOCATION_FIELD).field("lat", 1).field("lon", 2).endObject().endObject())
         );
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/SimpleSortIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/SimpleSortIT.java
@@ -173,7 +173,8 @@ public class SimpleSortIT extends OpenSearchIntegTestCase {
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             builders.add(
-                client().prepareIndex("test", "type1", Integer.toString(i))
+                client().prepareIndex("test")
+                    .setId(Integer.toString(i))
                     .setSource(
                         jsonBuilder().startObject()
                             .field("str_value", new String(new char[] { (char) (97 + i), (char) (97 + i) }))
@@ -265,7 +266,8 @@ public class SimpleSortIT extends OpenSearchIntegTestCase {
         ensureGreen();
 
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test", "type1", "" + i)
+            client().prepareIndex("test")
+                .setId("" + i)
                 .setSource(
                     jsonBuilder().startObject()
                         .field("ord", i)
@@ -282,7 +284,7 @@ public class SimpleSortIT extends OpenSearchIntegTestCase {
         }
 
         for (int i = 10; i < 20; i++) { // add some docs that don't have values in those fields
-            client().prepareIndex("test", "type1", "" + i).setSource(jsonBuilder().startObject().field("ord", i).endObject()).get();
+            client().prepareIndex("test").setId("" + i).setSource(jsonBuilder().startObject().field("ord", i).endObject()).get();
         }
         client().admin().indices().prepareRefresh("test").get();
 
@@ -464,7 +466,8 @@ public class SimpleSortIT extends OpenSearchIntegTestCase {
         );
         ensureGreen();
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test", "test", Integer.toString(i))
+            client().prepareIndex("test")
+                .setId(Integer.toString(i))
                 .setSource(jsonBuilder().startObject().field("value", "" + i).endObject())
                 .get();
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/SortFromPluginIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/SortFromPluginIT.java
@@ -33,9 +33,9 @@ public class SortFromPluginIT extends OpenSearchIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        client().prepareIndex("test", "type", "1").setSource("field", 2).get();
-        client().prepareIndex("test", "type", "2").setSource("field", 1).get();
-        client().prepareIndex("test", "type", "3").setSource("field", 0).get();
+        client().prepareIndex("test").setId("1").setSource("field", 2).get();
+        client().prepareIndex("test").setId("2").setSource("field", 1).get();
+        client().prepareIndex("test").setId("3").setSource("field", 0).get();
 
         refresh();
 
@@ -54,9 +54,9 @@ public class SortFromPluginIT extends OpenSearchIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        client().prepareIndex("test", "type", "1").setSource("field", 2).get();
-        client().prepareIndex("test", "type", "2").setSource("field", 1).get();
-        client().prepareIndex("test", "type", "3").setSource("field", 0).get();
+        client().prepareIndex("test").setId("1").setSource("field", 2).get();
+        client().prepareIndex("test").setId("2").setSource("field", 1).get();
+        client().prepareIndex("test").setId("3").setSource("field", 0).get();
 
         refresh();
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/source/MetadataFetchingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/source/MetadataFetchingIT.java
@@ -55,7 +55,7 @@ public class MetadataFetchingIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test"));
         ensureGreen();
 
-        client().prepareIndex("test", "_doc", "1").setSource("field", "value").get();
+        client().prepareIndex("test").setId("1").setSource("field", "value").get();
         refresh();
 
         SearchResponse response = client().prepareSearch("test").storedFields("_none_").setFetchSource(false).setVersion(true).get();
@@ -71,7 +71,7 @@ public class MetadataFetchingIT extends OpenSearchIntegTestCase {
     public void testInnerHits() {
         assertAcked(prepareCreate("test").addMapping("_doc", "nested", "type=nested"));
         ensureGreen();
-        client().prepareIndex("test", "_doc", "1").setSource("field", "value", "nested", Collections.singletonMap("title", "foo")).get();
+        client().prepareIndex("test").setId("1").setSource("field", "value", "nested", Collections.singletonMap("title", "foo")).get();
         refresh();
 
         SearchResponse response = client().prepareSearch("test")
@@ -98,7 +98,7 @@ public class MetadataFetchingIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("test"));
         ensureGreen();
 
-        client().prepareIndex("test", "_doc", "1").setSource("field", "value").setRouting("toto").get();
+        client().prepareIndex("test").setId("1").setSource("field", "value").setRouting("toto").get();
         refresh();
 
         SearchResponse response = client().prepareSearch("test").storedFields("_none_").setFetchSource(false).get();

--- a/server/src/internalClusterTest/java/org/opensearch/search/source/SourceFetchingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/source/SourceFetchingIT.java
@@ -62,7 +62,7 @@ public class SourceFetchingIT extends OpenSearchIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1").setSource("field1", "value", "field2", "value2").get();
+        client().prepareIndex("test").setId("1").setSource("field1", "value", "field2", "value2").get();
         refresh();
 
         SearchResponse response = client().prepareSearch("test").setFetchSource(false).get();
@@ -95,7 +95,7 @@ public class SourceFetchingIT extends OpenSearchIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "1").setSource("field", "value").get();
+        client().prepareIndex("test").setId("1").setSource("field", "value").get();
         refresh();
 
         SearchResponse response = client().prepareSearch("test").setFetchSource(new String[] { "*.notexisting", "field" }, null).get();

--- a/server/src/internalClusterTest/java/org/opensearch/search/stats/SearchStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/stats/SearchStatsIT.java
@@ -111,7 +111,7 @@ public class SearchStatsIT extends OpenSearchIntegTestCase {
         );
         int docsTest1 = scaledRandomIntBetween(3 * shardsIdx1, 5 * shardsIdx1);
         for (int i = 0; i < docsTest1; i++) {
-            client().prepareIndex("test1", "type", Integer.toString(i)).setSource("field", "value").get();
+            client().prepareIndex("test1").setId(Integer.toString(i)).setSource("field", "value").get();
             if (rarely()) {
                 refresh();
             }
@@ -123,7 +123,7 @@ public class SearchStatsIT extends OpenSearchIntegTestCase {
         );
         int docsTest2 = scaledRandomIntBetween(3 * shardsIdx2, 5 * shardsIdx2);
         for (int i = 0; i < docsTest2; i++) {
-            client().prepareIndex("test2", "type", Integer.toString(i)).setSource("field", "value").get();
+            client().prepareIndex("test2").setId(Integer.toString(i)).setSource("field", "value").get();
             if (rarely()) {
                 refresh();
             }
@@ -207,7 +207,8 @@ public class SearchStatsIT extends OpenSearchIntegTestCase {
         final int docs = scaledRandomIntBetween(20, 50);
         for (int s = 0; s < numAssignedShards(index); s++) {
             for (int i = 0; i < docs; i++) {
-                client().prepareIndex(index, "type", Integer.toString(s * docs + i))
+                client().prepareIndex(index)
+                    .setId(Integer.toString(s * docs + i))
                     .setSource("field", "value")
                     .setRouting(Integer.toString(s))
                     .get();

--- a/server/src/internalClusterTest/java/org/opensearch/search/suggest/ContextCompletionSuggestSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/suggest/ContextCompletionSuggestSearchIT.java
@@ -42,6 +42,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.Fuzziness;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.search.suggest.CompletionSuggestSearchIT.CompletionMappingBuilder;
 import org.opensearch.search.suggest.completion.CompletionSuggestionBuilder;
@@ -72,7 +73,6 @@ import static org.hamcrest.core.IsEqual.equalTo;
 public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
 
     private final String INDEX = RandomStrings.randomAsciiOfLength(random(), 10).toLowerCase(Locale.ROOT);
-    private final String TYPE = RandomStrings.randomAsciiOfLength(random(), 10).toLowerCase(Locale.ROOT);
     private final String FIELD = RandomStrings.randomAsciiOfLength(random(), 10).toLowerCase(Locale.ROOT);
 
     @Override
@@ -102,7 +102,7 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
                 source.field("type", "type" + i % 3);
             }
             source.endObject();
-            indexRequestBuilders.add(client().prepareIndex(INDEX, TYPE, "" + i).setSource(source));
+            indexRequestBuilders.add(client().prepareIndex(INDEX).setId("" + i).setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
         CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion(FIELD)
@@ -138,7 +138,7 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
                 source.field("type", "type" + i % 3);
             }
             source.endObject();
-            indexRequestBuilders.add(client().prepareIndex(INDEX, TYPE, "" + i).setSource(source));
+            indexRequestBuilders.add(client().prepareIndex(INDEX).setId("" + i).setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
         CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion(FIELD)
@@ -174,7 +174,7 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
                 source.field("type", "type" + i % 3);
             }
             source.endObject();
-            indexRequestBuilders.add(client().prepareIndex(INDEX, TYPE, "" + i).setSource(source));
+            indexRequestBuilders.add(client().prepareIndex(INDEX).setId("" + i).setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
         CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion(FIELD)
@@ -193,7 +193,8 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
         LinkedHashMap<String, ContextMapping<?>> map = new LinkedHashMap<>(Collections.singletonMap("cat", contextMapping));
         final CompletionMappingBuilder mapping = new CompletionMappingBuilder().context(map);
         createIndexAndMapping(mapping);
-        IndexResponse indexResponse = client().prepareIndex(INDEX, TYPE, "1")
+        IndexResponse indexResponse = client().prepareIndex(INDEX)
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .startObject(FIELD)
@@ -222,7 +223,8 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
         List<IndexRequestBuilder> indexRequestBuilders = new ArrayList<>();
         for (int i = 0; i < numDocs; i++) {
             indexRequestBuilders.add(
-                client().prepareIndex(INDEX, TYPE, "" + i)
+                client().prepareIndex(INDEX)
+                    .setId("" + i)
                     .setSource(
                         jsonBuilder().startObject()
                             .startObject(FIELD)
@@ -253,7 +255,8 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
         List<IndexRequestBuilder> indexRequestBuilders = new ArrayList<>();
         for (int i = 0; i < numDocs; i++) {
             indexRequestBuilders.add(
-                client().prepareIndex(INDEX, TYPE, "" + i)
+                client().prepareIndex(INDEX)
+                    .setId("" + i)
                     .setSource(
                         jsonBuilder().startObject()
                             .startObject(FIELD)
@@ -297,7 +300,7 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
                 .field("cat", "cat" + i % 2)
                 .field("type", "type" + i % 4)
                 .endObject();
-            indexRequestBuilders.add(client().prepareIndex(INDEX, TYPE, "" + i).setSource(source));
+            indexRequestBuilders.add(client().prepareIndex(INDEX).setId("" + i).setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
 
@@ -339,7 +342,7 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
                 .field("cat", "cat" + i % 2)
                 .field("type", "type" + i % 4)
                 .endObject();
-            indexRequestBuilders.add(client().prepareIndex(INDEX, TYPE, "" + i).setSource(source));
+            indexRequestBuilders.add(client().prepareIndex(INDEX).setId("" + i).setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
 
@@ -412,7 +415,7 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
                 source.field("type" + c, "type" + c + i % 4);
             }
             source.endObject();
-            indexRequestBuilders.add(client().prepareIndex(INDEX, TYPE, "" + i).setSource(source));
+            indexRequestBuilders.add(client().prepareIndex(INDEX).setId("" + i).setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
 
@@ -445,7 +448,7 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject();
-            indexRequestBuilders.add(client().prepareIndex(INDEX, TYPE, "" + i).setSource(source));
+            indexRequestBuilders.add(client().prepareIndex(INDEX).setId("" + i).setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
 
@@ -479,7 +482,7 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject();
-            indexRequestBuilders.add(client().prepareIndex(INDEX, TYPE, "" + i).setSource(source));
+            indexRequestBuilders.add(client().prepareIndex(INDEX).setId("" + i).setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
 
@@ -512,7 +515,7 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject();
-            indexRequestBuilders.add(client().prepareIndex(INDEX, TYPE, "" + i).setSource(source));
+            indexRequestBuilders.add(client().prepareIndex(INDEX).setId("" + i).setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
         CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion(FIELD)
@@ -554,7 +557,7 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject();
-            indexRequestBuilders.add(client().prepareIndex(INDEX, TYPE, "" + i).setSource(source));
+            indexRequestBuilders.add(client().prepareIndex(INDEX).setId("" + i).setSource(source));
         }
         indexRandom(true, indexRequestBuilders);
 
@@ -573,7 +576,6 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
     public void testGeoField() throws Exception {
         XContentBuilder mapping = jsonBuilder();
         mapping.startObject();
-        mapping.startObject(TYPE);
         mapping.startObject("properties");
         mapping.startObject("location");
         mapping.startObject("properties");
@@ -605,9 +607,8 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
         mapping.endObject();
         mapping.endObject();
         mapping.endObject();
-        mapping.endObject();
 
-        assertAcked(prepareCreate(INDEX).addMapping(TYPE, mapping));
+        assertAcked(prepareCreate(INDEX).addMapping(MapperService.SINGLE_MAPPING_NAME, mapping));
 
         XContentBuilder source1 = jsonBuilder().startObject()
             .startObject("location")
@@ -617,7 +618,7 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
             .array("input", "Hotel Amsterdam in Berlin")
             .endObject()
             .endObject();
-        client().prepareIndex(INDEX, TYPE, "1").setSource(source1).get();
+        client().prepareIndex(INDEX).setId("1").setSource(source1).get();
 
         XContentBuilder source2 = jsonBuilder().startObject()
             .startObject("location")
@@ -627,7 +628,7 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
             .array("input", "Hotel Berlin in Amsterdam")
             .endObject()
             .endObject();
-        client().prepareIndex(INDEX, TYPE, "2").setSource(source2).get();
+        client().prepareIndex(INDEX).setId("2").setSource(source2).get();
 
         refresh();
 
@@ -671,7 +672,7 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
                 .field("cat", "cat" + id % 2)
                 .field("type", "type" + id)
                 .endObject();
-            indexRequestBuilders.add(client().prepareIndex(INDEX, TYPE, "" + i).setSource(source));
+            indexRequestBuilders.add(client().prepareIndex(INDEX).setId("" + i).setSource(source));
         }
         String[] expected = new String[numUnique];
         for (int i = 0; i < numUnique; i++) {
@@ -705,7 +706,6 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
 
     private void createIndexAndMappingAndSettings(Settings settings, CompletionMappingBuilder completionMappingBuilder) throws IOException {
         XContentBuilder mapping = jsonBuilder().startObject()
-            .startObject(TYPE)
             .startObject("properties")
             .startObject(FIELD)
             .field("type", "completion")
@@ -747,14 +747,14 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
         for (String fieldName : categoryContextFields) {
             mapping.startObject(fieldName).field("type", randomBoolean() ? "keyword" : "text").endObject();
         }
-        mapping.endObject().endObject().endObject();
+        mapping.endObject().endObject();
 
         assertAcked(
             client().admin()
                 .indices()
                 .prepareCreate(INDEX)
                 .setSettings(Settings.builder().put(indexSettings()).put(settings))
-                .addMapping(TYPE, mapping)
+                .addMapping(MapperService.SINGLE_MAPPING_NAME, mapping)
                 .get()
         );
     }

--- a/server/src/internalClusterTest/java/org/opensearch/search/suggest/SuggestSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/suggest/SuggestSearchIT.java
@@ -804,9 +804,9 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
         ensureGreen();
         indexRandom(
             true,
-            client().prepareIndex("test", "type1", "1").setSource("field1", "foobar1").setRouting("1"),
-            client().prepareIndex("test", "type1", "2").setSource("field1", "foobar2").setRouting("2"),
-            client().prepareIndex("test", "type1", "3").setSource("field1", "foobar3").setRouting("3")
+            client().prepareIndex("test").setId("1").setSource("field1", "foobar1").setRouting("1"),
+            client().prepareIndex("test").setId("2").setSource("field1", "foobar2").setRouting("2"),
+            client().prepareIndex("test").setId("3").setSource("field1", "foobar3").setRouting("3")
         );
 
         Suggest suggest = searchSuggest(

--- a/server/src/internalClusterTest/java/org/opensearch/similarity/SimilarityIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/similarity/SimilarityIT.java
@@ -81,7 +81,8 @@ public class SimilarityIT extends OpenSearchIntegTestCase {
             .execute()
             .actionGet();
 
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource("field1", "the quick brown fox jumped over the lazy dog", "field2", "the quick brown fox jumped over the lazy dog")
             .setRefreshPolicy(IMMEDIATE)
             .execute()

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/MetadataLoadingDuringSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/MetadataLoadingDuringSnapshotRestoreIT.java
@@ -81,9 +81,9 @@ public class MetadataLoadingDuringSnapshotRestoreIT extends AbstractSnapshotInte
         createIndex("docs");
         indexRandom(
             true,
-            client().prepareIndex("docs", "doc", "1").setSource("rank", 1),
-            client().prepareIndex("docs", "doc", "2").setSource("rank", 2),
-            client().prepareIndex("docs", "doc", "3").setSource("rank", 3),
+            client().prepareIndex("docs").setId("1").setSource("rank", 1),
+            client().prepareIndex("docs").setId("2").setSource("rank", 2),
+            client().prepareIndex("docs").setId("3").setSource("rank", 3),
             client().prepareIndex("others").setSource("rank", 4),
             client().prepareIndex("others").setSource("rank", 5)
         );

--- a/server/src/internalClusterTest/java/org/opensearch/update/UpdateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/update/UpdateIT.java
@@ -328,7 +328,7 @@ public class UpdateIT extends OpenSearchIntegTestCase {
         );
         assertEquals("[1]: document missing", ex.getMessage());
 
-        client().prepareIndex("test", "type1", "1").setSource("field", 1).execute().actionGet();
+        client().prepareIndex("test").setId("1").setSource("field", 1).execute().actionGet();
 
         UpdateResponse updateResponse = client().prepareUpdate(indexOrAlias(), "1").setScript(fieldIncScript).execute().actionGet();
         assertThat(updateResponse.getVersion(), equalTo(2L));
@@ -399,7 +399,7 @@ public class UpdateIT extends OpenSearchIntegTestCase {
         }
 
         // check _source parameter
-        client().prepareIndex("test", "type1", "1").setSource("field1", 1, "field2", 2).execute().actionGet();
+        client().prepareIndex("test").setId("1").setSource("field1", 1, "field2", 2).execute().actionGet();
         updateResponse = client().prepareUpdate(indexOrAlias(), "1")
             .setScript(new Script(ScriptType.INLINE, UPDATE_SCRIPTS, FIELD_INC_SCRIPT, Collections.singletonMap("field", "field1")))
             .setFetchSource("field1", "field2")
@@ -414,7 +414,7 @@ public class UpdateIT extends OpenSearchIntegTestCase {
 
         // check updates without script
         // add new field
-        client().prepareIndex("test", "type1", "1").setSource("field", 1).execute().actionGet();
+        client().prepareIndex("test").setId("1").setSource("field", 1).execute().actionGet();
         client().prepareUpdate(indexOrAlias(), "1")
             .setDoc(XContentFactory.jsonBuilder().startObject().field("field2", 2).endObject())
             .execute()
@@ -446,7 +446,7 @@ public class UpdateIT extends OpenSearchIntegTestCase {
         testMap.put("commonkey", testMap2);
         testMap.put("map1", 8);
 
-        client().prepareIndex("test", "type1", "1").setSource("map", testMap).execute().actionGet();
+        client().prepareIndex("test").setId("1").setSource("map", testMap).execute().actionGet();
         client().prepareUpdate(indexOrAlias(), "1")
             .setDoc(XContentFactory.jsonBuilder().startObject().field("map", testMap3).endObject())
             .execute()
@@ -470,7 +470,7 @@ public class UpdateIT extends OpenSearchIntegTestCase {
         createTestIndex();
         ensureGreen();
 
-        IndexResponse result = client().prepareIndex("test", "type1", "1").setSource("field", 1).get();
+        IndexResponse result = client().prepareIndex("test").setId("1").setSource("field", 1).get();
         expectThrows(
             VersionConflictEngineException.class,
             () -> client().prepareUpdate(indexOrAlias(), "1")

--- a/server/src/internalClusterTest/java/org/opensearch/validate/SimpleValidateQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/validate/SimpleValidateQueryIT.java
@@ -255,7 +255,7 @@ public class SimpleValidateQueryIT extends OpenSearchIntegTestCase {
         String aMonthAgo = DateTimeFormatter.ISO_LOCAL_DATE.format(now.plus(1, ChronoUnit.MONTHS));
         String aMonthFromNow = DateTimeFormatter.ISO_LOCAL_DATE.format(now.minus(1, ChronoUnit.MONTHS));
 
-        client().prepareIndex("test", "type", "1").setSource("past", aMonthAgo, "future", aMonthFromNow).get();
+        client().prepareIndex("test").setId("1").setSource("past", aMonthAgo, "future", aMonthFromNow).get();
 
         refresh();
 
@@ -322,10 +322,10 @@ public class SimpleValidateQueryIT extends OpenSearchIntegTestCase {
             .addMapping("type1", "field", "type=text,analyzer=whitespace")
             .setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1))
             .get();
-        client().prepareIndex("test", "type1", "1").setSource("field", "quick lazy huge brown pidgin").get();
-        client().prepareIndex("test", "type1", "2").setSource("field", "the quick brown fox").get();
-        client().prepareIndex("test", "type1", "3").setSource("field", "the quick lazy huge brown fox jumps over the tree").get();
-        client().prepareIndex("test", "type1", "4").setSource("field", "the lazy dog quacks like a duck").get();
+        client().prepareIndex("test").setId("1").setSource("field", "quick lazy huge brown pidgin").get();
+        client().prepareIndex("test").setId("2").setSource("field", "the quick brown fox").get();
+        client().prepareIndex("test").setId("3").setSource("field", "the quick lazy huge brown fox jumps over the tree").get();
+        client().prepareIndex("test").setId("4").setSource("field", "the lazy dog quacks like a duck").get();
         refresh();
 
         // prefix queries
@@ -386,10 +386,10 @@ public class SimpleValidateQueryIT extends OpenSearchIntegTestCase {
             .get();
         // We are relying on specific routing behaviors for the result to be right, so
         // we cannot randomize the number of shards or change ids here.
-        client().prepareIndex("test", "type1", "1").setSource("field", "quick lazy huge brown pidgin").get();
-        client().prepareIndex("test", "type1", "2").setSource("field", "the quick brown fox").get();
-        client().prepareIndex("test", "type1", "3").setSource("field", "the quick lazy huge brown fox jumps over the tree").get();
-        client().prepareIndex("test", "type1", "4").setSource("field", "the lazy dog quacks like a duck").get();
+        client().prepareIndex("test").setId("1").setSource("field", "quick lazy huge brown pidgin").get();
+        client().prepareIndex("test").setId("2").setSource("field", "the quick brown fox").get();
+        client().prepareIndex("test").setId("3").setSource("field", "the quick lazy huge brown fox jumps over the tree").get();
+        client().prepareIndex("test").setId("4").setSource("field", "the lazy dog quacks like a duck").get();
         refresh();
 
         // prefix queries
@@ -490,7 +490,7 @@ public class SimpleValidateQueryIT extends OpenSearchIntegTestCase {
             .addMapping("_doc", "user", "type=integer", "followers", "type=integer")
             .setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 2).put("index.number_of_routing_shards", 2))
             .get();
-        client().prepareIndex("twitter", "_doc", "1").setSource("followers", new int[] { 1, 2, 3 }).get();
+        client().prepareIndex("twitter").setId("1").setSource("followers", new int[] { 1, 2, 3 }).get();
         refresh();
 
         TermsQueryBuilder termsLookupQuery = QueryBuilders.termsLookupQuery("user", new TermsLookup("twitter", "_doc", "1", "followers"));

--- a/server/src/internalClusterTest/java/org/opensearch/versioning/ConcurrentDocumentOperationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/versioning/ConcurrentDocumentOperationIT.java
@@ -55,7 +55,7 @@ public class ConcurrentDocumentOperationIT extends OpenSearchIntegTestCase {
         final AtomicReference<Throwable> failure = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(numberOfUpdates);
         for (int i = 0; i < numberOfUpdates; i++) {
-            client().prepareIndex("test", "type1", "1").setSource("field1", i).execute(new ActionListener<IndexResponse>() {
+            client().prepareIndex("test").setId("1").setSource("field1", i).execute(new ActionListener<IndexResponse>() {
                 @Override
                 public void onResponse(IndexResponse response) {
                     latch.countDown();

--- a/server/src/internalClusterTest/java/org/opensearch/versioning/ConcurrentSeqNoVersioningIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/versioning/ConcurrentSeqNoVersioningIT.java
@@ -160,7 +160,7 @@ public class ConcurrentSeqNoVersioningIT extends AbstractDisruptionTestCase {
 
         logger.info("--> Indexing initial doc for {} keys", numberOfKeys);
         List<Partition> partitions = IntStream.range(0, numberOfKeys)
-            .mapToObj(i -> client().prepareIndex("test", "type", "ID:" + i).setSource("value", -1).get())
+            .mapToObj(i -> client().prepareIndex("test").setId("ID:" + i).setSource("value", -1).get())
             .map(response -> new Partition(response.getId(), new Version(response.getPrimaryTerm(), response.getSeqNo())))
             .collect(Collectors.toList());
 

--- a/server/src/internalClusterTest/java/org/opensearch/versioning/SimpleVersioningIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/versioning/SimpleVersioningIT.java
@@ -81,7 +81,8 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
 
         // this should conflict with the delete command transaction which told us that the object was deleted at version 17.
         assertFutureThrows(
-            client().prepareIndex("test", "type", "1")
+            client().prepareIndex("test")
+                .setId("1")
                 .setSource("field1", "value1_1")
                 .setVersion(13)
                 .setVersionType(VersionType.EXTERNAL)
@@ -89,7 +90,8 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
             VersionConflictEngineException.class
         );
 
-        IndexResponse indexResponse = client().prepareIndex("test", "type", "1")
+        IndexResponse indexResponse = client().prepareIndex("test")
+            .setId("1")
             .setSource("field1", "value1_1")
             .setVersion(18)
             .setVersionType(VersionType.EXTERNAL)
@@ -101,21 +103,24 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
     public void testExternalGTE() throws Exception {
         createIndex("test");
 
-        IndexResponse indexResponse = client().prepareIndex("test", "type", "1")
+        IndexResponse indexResponse = client().prepareIndex("test")
+            .setId("1")
             .setSource("field1", "value1_1")
             .setVersion(12)
             .setVersionType(VersionType.EXTERNAL_GTE)
             .get();
         assertThat(indexResponse.getVersion(), equalTo(12L));
 
-        indexResponse = client().prepareIndex("test", "type", "1")
+        indexResponse = client().prepareIndex("test")
+            .setId("1")
             .setSource("field1", "value1_2")
             .setVersion(12)
             .setVersionType(VersionType.EXTERNAL_GTE)
             .get();
         assertThat(indexResponse.getVersion(), equalTo(12L));
 
-        indexResponse = client().prepareIndex("test", "type", "1")
+        indexResponse = client().prepareIndex("test")
+            .setId("1")
             .setSource("field1", "value1_2")
             .setVersion(14)
             .setVersionType(VersionType.EXTERNAL_GTE)
@@ -123,7 +128,8 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
         assertThat(indexResponse.getVersion(), equalTo(14L));
 
         assertRequestBuilderThrows(
-            client().prepareIndex("test", "type", "1")
+            client().prepareIndex("test")
+                .setId("1")
                 .setSource("field1", "value1_1")
                 .setVersion(13)
                 .setVersionType(VersionType.EXTERNAL_GTE),
@@ -170,7 +176,8 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        IndexResponse indexResponse = client().prepareIndex("test", "type", "1")
+        IndexResponse indexResponse = client().prepareIndex("test")
+            .setId("1")
             .setSource("field1", "value1_1")
             .setVersion(12)
             .setVersionType(VersionType.EXTERNAL)
@@ -178,7 +185,8 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
             .actionGet();
         assertThat(indexResponse.getVersion(), equalTo(12L));
 
-        indexResponse = client().prepareIndex("test", "type", "1")
+        indexResponse = client().prepareIndex("test")
+            .setId("1")
             .setSource("field1", "value1_1")
             .setVersion(14)
             .setVersionType(VersionType.EXTERNAL)
@@ -187,7 +195,8 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
         assertThat(indexResponse.getVersion(), equalTo(14L));
 
         assertFutureThrows(
-            client().prepareIndex("test", "type", "1")
+            client().prepareIndex("test")
+                .setId("1")
                 .setSource("field1", "value1_1")
                 .setVersion(13)
                 .setVersionType(VersionType.EXTERNAL)
@@ -230,7 +239,8 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
 
         // TODO: This behavior breaks rest api returning http status 201
         // good news is that it this is only the case until deletes GC kicks in.
-        indexResponse = client().prepareIndex("test", "type", "1")
+        indexResponse = client().prepareIndex("test")
+            .setId("1")
             .setSource("field1", "value1_1")
             .setVersion(19)
             .setVersionType(VersionType.EXTERNAL)
@@ -250,7 +260,8 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
         Thread.sleep(300); // gc works based on estimated sampled time. Give it a chance...
 
         // And now we have previous version return -1
-        indexResponse = client().prepareIndex("test", "type", "1")
+        indexResponse = client().prepareIndex("test")
+            .setId("1")
             .setSource("field1", "value1_1")
             .setVersion(20)
             .setVersionType(VersionType.EXTERNAL)
@@ -287,7 +298,8 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
             VersionConflictEngineException.class
         );
 
-        IndexResponse indexResponse = client().prepareIndex("test", "type", "1")
+        IndexResponse indexResponse = client().prepareIndex("test")
+            .setId("1")
             .setSource("field1", "value1_1")
             .setCreate(true)
             .execute()
@@ -299,26 +311,26 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        IndexResponse indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").execute().actionGet();
+        IndexResponse indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_1").execute().actionGet();
         assertThat(indexResponse.getSeqNo(), equalTo(0L));
         assertThat(indexResponse.getPrimaryTerm(), equalTo(1L));
 
-        indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_2").setIfSeqNo(0L).setIfPrimaryTerm(1).get();
+        indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_2").setIfSeqNo(0L).setIfPrimaryTerm(1).get();
         assertThat(indexResponse.getSeqNo(), equalTo(1L));
         assertThat(indexResponse.getPrimaryTerm(), equalTo(1L));
 
         assertFutureThrows(
-            client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").setIfSeqNo(10).setIfPrimaryTerm(1).execute(),
+            client().prepareIndex("test").setId("1").setSource("field1", "value1_1").setIfSeqNo(10).setIfPrimaryTerm(1).execute(),
             VersionConflictEngineException.class
         );
 
         assertFutureThrows(
-            client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").setIfSeqNo(10).setIfPrimaryTerm(2).execute(),
+            client().prepareIndex("test").setId("1").setSource("field1", "value1_1").setIfSeqNo(10).setIfPrimaryTerm(2).execute(),
             VersionConflictEngineException.class
         );
 
         assertFutureThrows(
-            client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").setIfSeqNo(1).setIfPrimaryTerm(2).execute(),
+            client().prepareIndex("test").setId("1").setSource("field1", "value1_1").setIfSeqNo(1).setIfPrimaryTerm(2).execute(),
             VersionConflictEngineException.class
         );
 
@@ -384,21 +396,21 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        IndexResponse indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").get();
+        IndexResponse indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_1").get();
         assertThat(indexResponse.getSeqNo(), equalTo(0L));
 
         client().admin().indices().prepareFlush().execute().actionGet();
-        indexResponse = client().prepareIndex("test", "type", "1").setSource("field1", "value1_2").setIfSeqNo(0).setIfPrimaryTerm(1).get();
+        indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_2").setIfSeqNo(0).setIfPrimaryTerm(1).get();
         assertThat(indexResponse.getSeqNo(), equalTo(1L));
 
         client().admin().indices().prepareFlush().execute().actionGet();
         assertRequestBuilderThrows(
-            client().prepareIndex("test", "type", "1").setSource("field1", "value1_1").setIfSeqNo(0).setIfPrimaryTerm(1),
+            client().prepareIndex("test").setId("1").setSource("field1", "value1_1").setIfSeqNo(0).setIfPrimaryTerm(1),
             VersionConflictEngineException.class
         );
 
         assertRequestBuilderThrows(
-            client().prepareIndex("test", "type", "1").setCreate(true).setSource("field1", "value1_1"),
+            client().prepareIndex("test").setId("1").setCreate(true).setSource("field1", "value1_1"),
             VersionConflictEngineException.class
         );
 
@@ -431,7 +443,7 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
         ensureGreen();
 
         BulkResponse bulkResponse = client().prepareBulk()
-            .add(client().prepareIndex("test", "type", "1").setSource("field1", "value1_1"))
+            .add(client().prepareIndex("test").setId("1").setSource("field1", "value1_1"))
             .execute()
             .actionGet();
         assertThat(bulkResponse.hasFailures(), equalTo(false));
@@ -723,7 +735,8 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
                                 }
                             } else {
                                 try {
-                                    idVersion.response = client().prepareIndex("test", "type", id)
+                                    idVersion.response = client().prepareIndex("test")
+                                        .setId(id)
                                         .setSource("foo", "bar")
                                         .setVersion(version)
                                         .setVersionType(VersionType.EXTERNAL)
@@ -806,7 +819,8 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
         client().admin().indices().prepareUpdateSettings("test").setSettings(newSettings).execute().actionGet();
 
         // Index a doc:
-        client().prepareIndex("test", "type", "id")
+        client().prepareIndex("test")
+            .setId("id")
             .setSource("foo", "bar")
             .setOpType(DocWriteRequest.OpType.INDEX)
             .setVersion(10)
@@ -846,7 +860,8 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
         client().admin().indices().prepareUpdateSettings("test").setSettings(newSettings).execute().actionGet();
 
         // Index a doc:
-        client().prepareIndex("test", "type", "id")
+        client().prepareIndex("test")
+            .setId("id")
             .setSource("foo", "bar")
             .setOpType(DocWriteRequest.OpType.INDEX)
             .setVersion(10)
@@ -869,14 +884,16 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
     public void testSpecialVersioning() {
         internalCluster().ensureAtLeastNumDataNodes(2);
         createIndex("test", Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).build());
-        IndexResponse doc1 = client().prepareIndex("test", "type", "1")
+        IndexResponse doc1 = client().prepareIndex("test")
+            .setId("1")
             .setSource("field", "value1")
             .setVersion(0)
             .setVersionType(VersionType.EXTERNAL)
             .execute()
             .actionGet();
         assertThat(doc1.getVersion(), equalTo(0L));
-        IndexResponse doc2 = client().prepareIndex("test", "type", "1")
+        IndexResponse doc2 = client().prepareIndex("test")
+            .setId("1")
             .setSource("field", "value2")
             .setVersion(Versions.MATCH_ANY)
             .setVersionType(VersionType.INTERNAL)
@@ -884,14 +901,16 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
             .actionGet();
         assertThat(doc2.getVersion(), equalTo(1L));
         client().prepareDelete("test", "1").get(); // v2
-        IndexResponse doc3 = client().prepareIndex("test", "type", "1")
+        IndexResponse doc3 = client().prepareIndex("test")
+            .setId("1")
             .setSource("field", "value3")
             .setVersion(Versions.MATCH_DELETED)
             .setVersionType(VersionType.INTERNAL)
             .execute()
             .actionGet();
         assertThat(doc3.getVersion(), equalTo(3L));
-        IndexResponse doc4 = client().prepareIndex("test", "type", "1")
+        IndexResponse doc4 = client().prepareIndex("test")
+            .setId("1")
             .setSource("field", "value4")
             .setVersion(4L)
             .setVersionType(VersionType.EXTERNAL_GTE)

--- a/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequest.java
@@ -229,7 +229,9 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
      * @param type   The mapping type
      * @param source The mapping source
      * @param xContentType The content type of the source
+     * @deprecated types are being removed
      */
+    @Deprecated
     public CreateIndexRequest mapping(String type, String source, XContentType xContentType) {
         return mapping(type, new BytesArray(source), xContentType);
     }
@@ -240,7 +242,9 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
      * @param type   The mapping type
      * @param source The mapping source
      * @param xContentType the content type of the mapping source
+     * @deprecated types are being removed
      */
+    @Deprecated
     private CreateIndexRequest mapping(String type, BytesReference source, XContentType xContentType) {
         Objects.requireNonNull(xContentType);
         Map<String, Object> mappingAsMap = XContentHelper.convertToMap(source, false, xContentType).v2();
@@ -260,7 +264,9 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
      *
      * @param type   The mapping type
      * @param source The mapping source
+     * @deprecated types are being removed
      */
+    @Deprecated
     public CreateIndexRequest mapping(String type, XContentBuilder source) {
         return mapping(type, BytesReference.bytes(source), source.contentType());
     }
@@ -270,7 +276,9 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
      *
      * @param type   The mapping type
      * @param source The mapping source
+     * @deprecated types are being removed
      */
+    @Deprecated
     public CreateIndexRequest mapping(String type, Map<String, ?> source) {
         if (mappings.containsKey(type)) {
             throw new IllegalStateException("mappings for type \"" + type + "\" were already defined");
@@ -292,7 +300,9 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
     /**
      * A specialized simplified mapping source method, takes the form of simple properties definition:
      * ("field1", "type=string,store=true").
+     * @deprecated types are being removed
      */
+    @Deprecated
     public CreateIndexRequest mapping(String type, Object... source) {
         mapping(type, PutMappingRequest.buildFromSimplifiedDef(type, source));
         return this;

--- a/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequestBuilder.java
@@ -115,6 +115,7 @@ public class CreateIndexRequestBuilder extends AcknowledgedRequestBuilder<
      * @param source The mapping source
      * @param xContentType The content type of the source
      */
+    @Deprecated
     public CreateIndexRequestBuilder addMapping(String type, String source, XContentType xContentType) {
         request.mapping(type, source, xContentType);
         return this;
@@ -133,7 +134,9 @@ public class CreateIndexRequestBuilder extends AcknowledgedRequestBuilder<
      *
      * @param type   The mapping type
      * @param source The mapping source
+     * @deprecated types are being removed
      */
+    @Deprecated
     public CreateIndexRequestBuilder addMapping(String type, XContentBuilder source) {
         request.mapping(type, source);
         return this;
@@ -144,7 +147,9 @@ public class CreateIndexRequestBuilder extends AcknowledgedRequestBuilder<
      *
      * @param type   The mapping type
      * @param source The mapping source
+     * @deprecated types are being removed
      */
+    @Deprecated
     public CreateIndexRequestBuilder addMapping(String type, Map<String, Object> source) {
         request.mapping(type, source);
         return this;
@@ -153,7 +158,9 @@ public class CreateIndexRequestBuilder extends AcknowledgedRequestBuilder<
     /**
      * A specialized simplified mapping source method, takes the form of simple properties definition:
      * ("field1", "type=string,store=true").
+     * @deprecated types are being removed
      */
+    @Deprecated
     public CreateIndexRequestBuilder addMapping(String type, Object... source) {
         request.mapping(type, source);
         return this;

--- a/server/src/main/java/org/opensearch/action/admin/indices/mapping/put/PutMappingRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/mapping/put/PutMappingRequest.java
@@ -263,9 +263,6 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
         try {
             XContentBuilder builder = XContentFactory.jsonBuilder();
             builder.startObject();
-            if (type != null) {
-                builder.startObject(type);
-            }
 
             for (int i = 0; i < source.length; i++) {
                 String fieldName = source[i++].toString();
@@ -302,9 +299,6 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
                 builder.endObject();
             }
             builder.endObject();
-            if (type != null) {
-                builder.endObject();
-            }
             builder.endObject();
             return builder;
         } catch (Exception e) {

--- a/server/src/main/java/org/opensearch/client/Client.java
+++ b/server/src/main/java/org/opensearch/client/Client.java
@@ -150,17 +150,6 @@ public interface Client extends OpenSearchClient, Releasable {
     IndexRequestBuilder prepareIndex(String index);
 
     /**
-     * Index a document associated with a given index and type.
-     * <p>
-     * The id is optional, if it is not provided, one will be generated automatically.
-     *
-     * @param index The index to index the document to
-     * @param type  The type to index the document to
-     * @param id    The id of the document
-     */
-    IndexRequestBuilder prepareIndex(String index, String type, @Nullable String id);
-
-    /**
      * Updates a document based on a script.
      *
      * @param request The update request

--- a/server/src/main/java/org/opensearch/client/support/AbstractClient.java
+++ b/server/src/main/java/org/opensearch/client/support/AbstractClient.java
@@ -448,12 +448,7 @@ public abstract class AbstractClient implements Client {
 
     @Override
     public IndexRequestBuilder prepareIndex(String index) {
-        return prepareIndex(index, null, null);
-    }
-
-    @Override
-    public IndexRequestBuilder prepareIndex(String index, String type, @Nullable String id) {
-        return prepareIndex().setIndex(index).setId(id);
+        return new IndexRequestBuilder(this, IndexAction.INSTANCE, index);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/tasks/TaskResultsService.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResultsService.java
@@ -169,7 +169,7 @@ public class TaskResultsService {
     }
 
     private void doStoreResult(TaskResult taskResult, ActionListener<Void> listener) {
-        IndexRequestBuilder index = client.prepareIndex(TASK_INDEX, TASK_TYPE, taskResult.getTask().getTaskId().toString());
+        IndexRequestBuilder index = client.prepareIndex(TASK_INDEX).setId(taskResult.getTask().getTaskId().toString());
         try (XContentBuilder builder = XContentFactory.contentBuilder(Requests.INDEX_CONTENT_TYPE)) {
             taskResult.toXContent(builder, ToXContent.EMPTY_PARAMS);
             index.setSource(builder);

--- a/server/src/test/java/org/opensearch/action/admin/indices/segments/IndicesSegmentsRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/segments/IndicesSegmentsRequestTests.java
@@ -65,7 +65,7 @@ public class IndicesSegmentsRequestTests extends OpenSearchSingleNodeTestCase {
         int numDocs = scaledRandomIntBetween(100, 1000);
         for (int j = 0; j < numDocs; ++j) {
             String id = Integer.toString(j);
-            client().prepareIndex("test", "type1", id).setSource("text", "sometext").get();
+            client().prepareIndex("test").setId(id).setSource("text", "sometext").get();
         }
         client().admin().indices().prepareFlush("test").get();
         client().admin().indices().prepareRefresh().get();

--- a/server/src/test/java/org/opensearch/action/admin/indices/stats/IndicesStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/stats/IndicesStatsTests.java
@@ -92,7 +92,7 @@ public class IndicesStatsTests extends OpenSearchSingleNodeTestCase {
                 .setSettings(Settings.builder().put("index.store.type", storeType.getSettingsKey()))
         );
         ensureGreen("test");
-        client().prepareIndex("test", "doc", "1").setSource("foo", "bar", "bar", "baz", "baz", 42).get();
+        client().prepareIndex("test").setId("1").setSource("foo", "bar", "bar", "baz", "baz", 42).get();
         client().admin().indices().prepareRefresh("test").get();
 
         IndicesStatsResponse rsp = client().admin().indices().prepareStats("test").get();
@@ -101,7 +101,7 @@ public class IndicesStatsTests extends OpenSearchSingleNodeTestCase {
         assertThat(stats.getCount(), greaterThan(0L));
 
         // now check multiple segments stats are merged together
-        client().prepareIndex("test", "doc", "2").setSource("foo", "bar", "bar", "baz", "baz", 43).get();
+        client().prepareIndex("test").setId("2").setSource("foo", "bar", "bar", "baz", "baz", 43).get();
         client().admin().indices().prepareRefresh("test").get();
 
         rsp = client().admin().indices().prepareStats("test").get();
@@ -129,7 +129,8 @@ public class IndicesStatsTests extends OpenSearchSingleNodeTestCase {
         createIndex("test", Settings.builder().put("refresh_interval", -1).build());
 
         // Index a document asynchronously so the request will only return when document is refreshed
-        ActionFuture<IndexResponse> index = client().prepareIndex("test", "test", "test")
+        ActionFuture<IndexResponse> index = client().prepareIndex("test")
+            .setId("test")
             .setSource("test", "test")
             .setRefreshPolicy(RefreshPolicy.WAIT_UNTIL)
             .execute();

--- a/server/src/test/java/org/opensearch/action/termvectors/GetTermVectorsTests.java
+++ b/server/src/test/java/org/opensearch/action/termvectors/GetTermVectorsTests.java
@@ -188,7 +188,8 @@ public class GetTermVectorsTests extends OpenSearchSingleNodeTestCase {
             .build();
         createIndex("test", setting, "type1", mapping);
 
-        client().prepareIndex("test", "type1", Integer.toString(1))
+        client().prepareIndex("test")
+            .setId(Integer.toString(1))
             .setSource(jsonBuilder().startObject().field("field", queryString).endObject())
             .execute()
             .actionGet();

--- a/server/src/test/java/org/opensearch/client/AbstractClientHeadersTestCase.java
+++ b/server/src/test/java/org/opensearch/client/AbstractClientHeadersTestCase.java
@@ -128,7 +128,8 @@ public abstract class AbstractClientHeadersTestCase extends OpenSearchTestCase {
             .cluster()
             .prepareDeleteStoredScript("id")
             .execute(new AssertingActionListener<>(DeleteStoredScriptAction.NAME, client.threadPool()));
-        client.prepareIndex("idx", "type", "id")
+        client.prepareIndex("idx")
+            .setId("id")
             .setSource("source", XContentType.JSON)
             .execute(new AssertingActionListener<>(IndexAction.NAME, client.threadPool()));
 

--- a/server/src/test/java/org/opensearch/index/IndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexServiceTests.java
@@ -300,7 +300,7 @@ public class IndexServiceTests extends OpenSearchSingleNodeTestCase {
         assertEquals(1000, refreshTask.getInterval().millis());
         assertTrue(indexService.getRefreshTask().mustReschedule());
         IndexShard shard = indexService.getShard(0);
-        client().prepareIndex("test", "test", "0").setSource("{\"foo\": \"bar\"}", XContentType.JSON).get();
+        client().prepareIndex("test").setId("0").setSource("{\"foo\": \"bar\"}", XContentType.JSON).get();
         // now disable the refresh
         client().admin()
             .indices()
@@ -321,7 +321,7 @@ public class IndexServiceTests extends OpenSearchSingleNodeTestCase {
         });
         assertFalse(refreshTask.isClosed());
         // refresh every millisecond
-        client().prepareIndex("test", "test", "1").setSource("{\"foo\": \"bar\"}", XContentType.JSON).get();
+        client().prepareIndex("test").setId("1").setSource("{\"foo\": \"bar\"}", XContentType.JSON).get();
         client().admin()
             .indices()
             .prepareUpdateSettings("test")
@@ -335,7 +335,7 @@ public class IndexServiceTests extends OpenSearchSingleNodeTestCase {
                 assertEquals(2, search.totalHits.value);
             }
         });
-        client().prepareIndex("test", "test", "2").setSource("{\"foo\": \"bar\"}", XContentType.JSON).get();
+        client().prepareIndex("test").setId("2").setSource("{\"foo\": \"bar\"}", XContentType.JSON).get();
         assertBusy(() -> {
             // this one becomes visible due to the scheduled refresh
             try (Engine.Searcher searcher = shard.acquireSearcher("test")) {
@@ -353,7 +353,7 @@ public class IndexServiceTests extends OpenSearchSingleNodeTestCase {
         IndexService indexService = createIndex("test", settings);
         ensureGreen("test");
         assertTrue(indexService.getRefreshTask().mustReschedule());
-        client().prepareIndex("test", "test", "1").setSource("{\"foo\": \"bar\"}", XContentType.JSON).get();
+        client().prepareIndex("test").setId("1").setSource("{\"foo\": \"bar\"}", XContentType.JSON).get();
         IndexShard shard = indexService.getShard(0);
         assertBusy(() -> assertFalse(shard.isSyncNeeded()));
     }
@@ -375,7 +375,7 @@ public class IndexServiceTests extends OpenSearchSingleNodeTestCase {
 
         assertNotNull(indexService.getFsyncTask());
         assertTrue(indexService.getFsyncTask().mustReschedule());
-        client().prepareIndex("test", "test", "1").setSource("{\"foo\": \"bar\"}", XContentType.JSON).get();
+        client().prepareIndex("test").setId("1").setSource("{\"foo\": \"bar\"}", XContentType.JSON).get();
         assertNotNull(indexService.getFsyncTask());
         final IndexShard shard = indexService.getShard(0);
         assertBusy(() -> assertFalse(shard.isSyncNeeded()));
@@ -402,7 +402,7 @@ public class IndexServiceTests extends OpenSearchSingleNodeTestCase {
         IndexService indexService = createIndex("test", settings);
         ensureGreen("test");
         assertTrue(indexService.getTrimTranslogTask().mustReschedule());
-        client().prepareIndex("test", "test", "1").setSource("{\"foo\": \"bar\"}", XContentType.JSON).get();
+        client().prepareIndex("test").setId("1").setSource("{\"foo\": \"bar\"}", XContentType.JSON).get();
         client().admin().indices().prepareFlush("test").get();
         client().admin()
             .indices()

--- a/server/src/test/java/org/opensearch/index/fieldstats/FieldStatsProviderRefreshTests.java
+++ b/server/src/test/java/org/opensearch/index/fieldstats/FieldStatsProviderRefreshTests.java
@@ -128,7 +128,7 @@ public class FieldStatsProviderRefreshTests extends OpenSearchSingleNodeTestCase
     }
 
     private void indexDocument(String id, String sValue) {
-        IndexResponse response = client().prepareIndex("index", "type", id).setSource("s", sValue).get();
+        IndexResponse response = client().prepareIndex("index").setId(id).setSource("s", sValue).get();
         assertThat(response.status(), anyOf(equalTo(RestStatus.OK), equalTo(RestStatus.CREATED)));
     }
 }

--- a/server/src/test/java/org/opensearch/index/termvectors/TermVectorsServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/termvectors/TermVectorsServiceTests.java
@@ -72,7 +72,7 @@ public class TermVectorsServiceTests extends OpenSearchSingleNodeTestCase {
         createIndex("test", Settings.EMPTY, "type1", mapping);
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "0").setSource("field", "foo bar").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("0").setSource("field", "foo bar").setRefreshPolicy(IMMEDIATE).get();
 
         IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         IndexService test = indicesService.indexService(resolveIndex("test"));
@@ -107,7 +107,7 @@ public class TermVectorsServiceTests extends OpenSearchSingleNodeTestCase {
         BulkRequestBuilder bulk = client().prepareBulk();
         for (int i = 0; i < max; i++) {
             bulk.add(
-                client().prepareIndex("test", "_doc", Integer.toString(i)).setSource("text", "the quick brown fox jumped over the lazy dog")
+                client().prepareIndex("test").setId(Integer.toString(i)).setSource("text", "the quick brown fox jumped over the lazy dog")
             );
         }
         bulk.get();
@@ -148,7 +148,7 @@ public class TermVectorsServiceTests extends OpenSearchSingleNodeTestCase {
         BulkRequestBuilder bulk = client().prepareBulk();
         for (int i = 0; i < max; i++) {
             bulk.add(
-                client().prepareIndex("test", "_doc", Integer.toString(i)).setSource("text", "the quick brown fox jumped over the lazy dog")
+                client().prepareIndex("test").setId(Integer.toString(i)).setSource("text", "the quick brown fox jumped over the lazy dog")
             );
         }
         bulk.get();

--- a/server/src/test/java/org/opensearch/indices/IndicesServiceCloseTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesServiceCloseTests.java
@@ -179,7 +179,7 @@ public class IndicesServiceCloseTests extends OpenSearchTestCase {
                 .prepareCreate("test")
                 .setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0))
         );
-        node.client().prepareIndex("test", "_doc", "1").setSource(Collections.emptyMap()).get();
+        node.client().prepareIndex("test").setId("1").setSource(Collections.emptyMap()).get();
         OpenSearchAssertions.assertAllSuccessful(node.client().admin().indices().prepareRefresh("test").get());
 
         assertEquals(2, indicesService.indicesRefCount.refCount());
@@ -213,7 +213,7 @@ public class IndicesServiceCloseTests extends OpenSearchTestCase {
                         .put(IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING.getKey(), true)
                 )
         );
-        node.client().prepareIndex("test", "_doc", "1").setSource(Collections.singletonMap("foo", 3L)).get();
+        node.client().prepareIndex("test").setId("1").setSource(Collections.singletonMap("foo", 3L)).get();
         OpenSearchAssertions.assertAllSuccessful(node.client().admin().indices().prepareRefresh("test").get());
 
         assertEquals(2, indicesService.indicesRefCount.refCount());
@@ -256,7 +256,7 @@ public class IndicesServiceCloseTests extends OpenSearchTestCase {
                         .put(IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING.getKey(), true)
                 )
         );
-        node.client().prepareIndex("test", "_doc", "1").setSource(Collections.singletonMap("foo", 3L)).get();
+        node.client().prepareIndex("test").setId("1").setSource(Collections.singletonMap("foo", 3L)).get();
         OpenSearchAssertions.assertAllSuccessful(node.client().admin().indices().prepareRefresh("test").get());
 
         assertEquals(2, indicesService.indicesRefCount.refCount());
@@ -298,7 +298,7 @@ public class IndicesServiceCloseTests extends OpenSearchTestCase {
                         .put(IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING.getKey(), true)
                 )
         );
-        node.client().prepareIndex("test", "_doc", "1").setSource(Collections.singletonMap("foo", 3L)).get();
+        node.client().prepareIndex("test").setId("1").setSource(Collections.singletonMap("foo", 3L)).get();
         OpenSearchAssertions.assertAllSuccessful(node.client().admin().indices().prepareRefresh("test").get());
 
         assertEquals(2, indicesService.indicesRefCount.refCount());

--- a/server/src/test/java/org/opensearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesServiceTests.java
@@ -272,7 +272,7 @@ public class IndicesServiceTests extends OpenSearchSingleNodeTestCase {
         assertNull(meta.index("test"));
 
         test = createIndex("test");
-        client().prepareIndex("test", "type", "1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
         client().admin().indices().prepareFlush("test").get();
         assertHitCount(client().prepareSearch("test").get(), 1);
         IndexMetadata secondMetadata = clusterService.state().metadata().index("test");

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -126,7 +126,7 @@ public class BlobStoreRepositoryTests extends OpenSearchSingleNodeTestCase {
         int numDocs = randomIntBetween(10, 20);
         for (int i = 0; i < numDocs; i++) {
             String id = Integer.toString(i);
-            client().prepareIndex(indexName, "type1", id).setSource("text", "sometext").get();
+            client().prepareIndex(indexName).setId(id).setSource("text", "sometext").get();
         }
         client().admin().indices().prepareFlush(indexName).get();
 

--- a/server/src/test/java/org/opensearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchServiceTests.java
@@ -222,7 +222,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
 
     public void testClearOnClose() {
         createIndex("index");
-        client().prepareIndex("index", "type", "1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("index").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
         SearchResponse searchResponse = client().prepareSearch("index").setSize(1).setScroll("1m").get();
         assertThat(searchResponse.getScrollId(), is(notNullValue()));
         SearchService service = getInstanceFromNode(SearchService.class);
@@ -234,7 +234,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
 
     public void testClearOnStop() {
         createIndex("index");
-        client().prepareIndex("index", "type", "1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("index").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
         SearchResponse searchResponse = client().prepareSearch("index").setSize(1).setScroll("1m").get();
         assertThat(searchResponse.getScrollId(), is(notNullValue()));
         SearchService service = getInstanceFromNode(SearchService.class);
@@ -246,7 +246,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
 
     public void testClearIndexDelete() {
         createIndex("index");
-        client().prepareIndex("index", "type", "1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("index").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
         SearchResponse searchResponse = client().prepareSearch("index").setSize(1).setScroll("1m").get();
         assertThat(searchResponse.getScrollId(), is(notNullValue()));
         SearchService service = getInstanceFromNode(SearchService.class);
@@ -259,7 +259,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
     public void testCloseSearchContextOnRewriteException() {
         // if refresh happens while checking the exception, the subsequent reference count might not match, so we switch it off
         createIndex("index", Settings.builder().put("index.refresh_interval", -1).build());
-        client().prepareIndex("index", "type", "1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("index").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
 
         SearchService service = getInstanceFromNode(SearchService.class);
         IndicesService indicesService = getInstanceFromNode(IndicesService.class);
@@ -278,7 +278,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
 
     public void testSearchWhileIndexDeleted() throws InterruptedException {
         createIndex("index");
-        client().prepareIndex("index", "type", "1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("index").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
 
         SearchService service = getInstanceFromNode(SearchService.class);
         IndicesService indicesService = getInstanceFromNode(IndicesService.class);
@@ -387,7 +387,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
 
     public void testSearchWhileIndexDeletedDoesNotLeakSearchContext() throws ExecutionException, InterruptedException {
         createIndex("index");
-        client().prepareIndex("index", "type", "1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("index").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
 
         IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         IndexService indexService = indicesService.indexServiceSafe(resolveIndex("index"));
@@ -633,7 +633,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
      */
     public void testMaxOpenScrollContexts() throws Exception {
         createIndex("index");
-        client().prepareIndex("index", "type", "1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("index").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
 
         final SearchService service = getInstanceFromNode(SearchService.class);
         final IndicesService indicesService = getInstanceFromNode(IndicesService.class);
@@ -958,7 +958,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
             ).canMatch()
         );
         // the source can match and can be rewritten to a match_none, but not the alias filter
-        final IndexResponse response = client().prepareIndex("index", "_doc", "1").setSource("id", "1").get();
+        final IndexResponse response = client().prepareIndex("index").setId("1").setSource("id", "1").get();
         assertEquals(RestStatus.CREATED, response.status());
         searchRequest.indices("alias").source(new SearchSourceBuilder().query(new TermQueryBuilder("id", "1")));
         assertFalse(
@@ -1050,7 +1050,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
         final SearchService service = getInstanceFromNode(SearchService.class);
         Index index = resolveIndex("throttled_threadpool_index");
         assertTrue(service.getIndicesService().indexServiceSafe(index).getIndexSettings().isSearchThrottled());
-        client().prepareIndex("throttled_threadpool_index", "_doc", "1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("throttled_threadpool_index").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
         SearchResponse searchResponse = client().prepareSearch("throttled_threadpool_index")
             .setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_FORBID_CLOSED)
             .setSize(1)
@@ -1104,7 +1104,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
             )
         ).actionGet();
 
-        client().prepareIndex("throttled_threadpool_index", "_doc", "1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("throttled_threadpool_index").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
         assertHitCount(client().prepareSearch().get(), 1L);
         assertHitCount(client().prepareSearch().setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_FORBID_CLOSED).get(), 1L);
     }
@@ -1116,7 +1116,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
             new InternalOrPrivateSettingsPlugin.UpdateInternalOrPrivateAction.Request("frozen_index", "index.frozen", "true")
         ).actionGet();
 
-        client().prepareIndex("frozen_index", "_doc", "1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("frozen_index").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
         assertHitCount(client().prepareSearch().get(), 0L);
         assertHitCount(client().prepareSearch().setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_FORBID_CLOSED).get(), 1L);
     }

--- a/server/src/test/java/org/opensearch/search/aggregations/AggregationCollectorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/AggregationCollectorTests.java
@@ -44,7 +44,7 @@ public class AggregationCollectorTests extends OpenSearchSingleNodeTestCase {
 
     public void testNeedsScores() throws Exception {
         IndexService index = createIndex("idx");
-        client().prepareIndex("idx", "type", "1").setSource("f", 5).execute().get();
+        client().prepareIndex("idx").setId("1").setSource("f", 5).execute().get();
         client().admin().indices().prepareRefresh("idx").get();
 
         // simple field aggregation, no scores needed

--- a/server/src/test/java/org/opensearch/search/aggregations/support/ValuesSourceConfigTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/support/ValuesSourceConfigTests.java
@@ -49,7 +49,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
 
     public void testKeyword() throws Exception {
         IndexService indexService = createIndex("index", Settings.EMPTY, "type", "bytes", "type=keyword");
-        client().prepareIndex("index", "type", "1").setSource("bytes", "abc").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("index").setId("1").setSource("bytes", "abc").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
             QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
@@ -75,7 +75,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
 
     public void testEmptyKeyword() throws Exception {
         IndexService indexService = createIndex("index", Settings.EMPTY, "type", "bytes", "type=keyword");
-        client().prepareIndex("index", "type", "1").setSource().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("index").setId("1").setSource().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
             QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
@@ -106,7 +106,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
 
     public void testUnmappedKeyword() throws Exception {
         IndexService indexService = createIndex("index", Settings.EMPTY, "type");
-        client().prepareIndex("index", "type", "1").setSource().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("index").setId("1").setSource().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
             QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
@@ -136,7 +136,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
 
     public void testLong() throws Exception {
         IndexService indexService = createIndex("index", Settings.EMPTY, "type", "long", "type=long");
-        client().prepareIndex("index", "type", "1").setSource("long", 42).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("index").setId("1").setSource("long", 42).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
             QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
@@ -162,7 +162,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
 
     public void testEmptyLong() throws Exception {
         IndexService indexService = createIndex("index", Settings.EMPTY, "type", "long", "type=long");
-        client().prepareIndex("index", "type", "1").setSource().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("index").setId("1").setSource().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
             QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
@@ -193,7 +193,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
 
     public void testUnmappedLong() throws Exception {
         IndexService indexService = createIndex("index", Settings.EMPTY, "type");
-        client().prepareIndex("index", "type", "1").setSource().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("index").setId("1").setSource().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
             QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
@@ -224,7 +224,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
 
     public void testBoolean() throws Exception {
         IndexService indexService = createIndex("index", Settings.EMPTY, "type", "bool", "type=boolean");
-        client().prepareIndex("index", "type", "1").setSource("bool", true).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("index").setId("1").setSource("bool", true).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
             QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
@@ -250,7 +250,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
 
     public void testEmptyBoolean() throws Exception {
         IndexService indexService = createIndex("index", Settings.EMPTY, "type", "bool", "type=boolean");
-        client().prepareIndex("index", "type", "1").setSource().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("index").setId("1").setSource().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
             QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
@@ -281,7 +281,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
 
     public void testUnmappedBoolean() throws Exception {
         IndexService indexService = createIndex("index", Settings.EMPTY, "type");
-        client().prepareIndex("index", "type", "1").setSource().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        client().prepareIndex("index").setId("1").setSource().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
             QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);
@@ -331,10 +331,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
 
     public void testFieldAlias() throws Exception {
         IndexService indexService = createIndex("index", Settings.EMPTY, "type", "field", "type=keyword", "alias", "type=alias,path=field");
-        client().prepareIndex("index", "type", "1")
-            .setSource("field", "value")
-            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-            .get();
+        client().prepareIndex("index").setId("1").setSource("field", "value").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
             QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);

--- a/server/src/test/java/org/opensearch/search/geo/GeoShapeQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/geo/GeoShapeQueryTests.java
@@ -152,14 +152,16 @@ public class GeoShapeQueryTests extends GeoQueryTests {
 
         String location = "\"geo\" : {\"type\":\"polygon\", \"coordinates\":[[[-10,-10],[10,-10],[10,10],[-10,10],[-10,-10]]]}";
 
-        client().prepareIndex("shapes", "type", "1")
+        client().prepareIndex("shapes")
+            .setId("1")
             .setSource(
                 String.format(Locale.ROOT, "{ %s, \"1\" : { %s, \"2\" : { %s, \"3\" : { %s } }} }", location, location, location, location),
                 XContentType.JSON
             )
             .setRefreshPolicy(IMMEDIATE)
             .get();
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .startObject("geo")
@@ -442,7 +444,8 @@ public class GeoShapeQueryTests extends GeoQueryTests {
         client().admin().indices().prepareCreate("test").addMapping("type1", mapping, XContentType.JSON).get();
         ensureGreen();
 
-        client().prepareIndex("test", "type1", "blakely")
+        client().prepareIndex("test")
+            .setId("blakely")
             .setSource(
                 jsonBuilder().startObject()
                     .field("name", "Blakely Island")
@@ -493,7 +496,8 @@ public class GeoShapeQueryTests extends GeoQueryTests {
 
         EnvelopeBuilder shape = new EnvelopeBuilder(new Coordinate(-45, 45), new Coordinate(45, -45));
 
-        client().prepareIndex("shapes", "shape_type", "Big_Rectangle")
+        client().prepareIndex("shapes")
+            .setId("Big_Rectangle")
             .setSource(jsonBuilder().startObject().field("shape", shape).endObject())
             .setRefreshPolicy(IMMEDIATE)
             .get();
@@ -546,7 +550,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
                 .actionGet();
         }
         XContentBuilder docSource = gcb.toXContent(jsonBuilder().startObject().field("geo"), null).endObject();
-        client().prepareIndex("test", "type", "1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
 
         GeoShapeQueryBuilder geoShapeQueryBuilder = QueryBuilders.geoShapeQuery("geo", pb);
         geoShapeQueryBuilder.relation(ShapeRelation.INTERSECTS);
@@ -587,7 +591,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
         }
 
         XContentBuilder docSource = gcb.toXContent(jsonBuilder().startObject().field("geo"), null).endObject();
-        client().prepareIndex("test", "type", "1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
 
         // index the mbr of the collection
         EnvelopeBuilder env = new EnvelopeBuilder(
@@ -595,7 +599,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
             new Coordinate(mbr.getMaxX(), mbr.getMinY())
         );
         docSource = env.toXContent(jsonBuilder().startObject().field("geo"), null).endObject();
-        client().prepareIndex("test", "type", "2").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("2").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
 
         ShapeBuilder filterShape = (gcb.getShapeAt(randomIntBetween(0, gcb.numShapes() - 1)));
         GeoShapeQueryBuilder filter = QueryBuilders.geoShapeQuery("geo", filterShape).relation(ShapeRelation.CONTAINS);
@@ -613,7 +617,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
         client().admin().indices().prepareCreate("test").addMapping("type", builder).execute().actionGet();
 
         XContentBuilder docSource = gcb.toXContent(jsonBuilder().startObject().field("geo"), null).endObject();
-        client().prepareIndex("test", "type", "1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
 
         ExistsQueryBuilder eqb = QueryBuilders.existsQuery("geo");
         SearchResponse result = client().prepareSearch("test").setQuery(eqb).get();
@@ -644,7 +648,8 @@ public class GeoShapeQueryTests extends GeoQueryTests {
 
         ShapeBuilder shape = RandomShapeGenerator.createShape(random());
         try {
-            client().prepareIndex("geo_points_only", "type1", "1")
+            client().prepareIndex("geo_points_only")
+                .setId("1")
                 .setSource(jsonBuilder().startObject().field("location", shape).endObject())
                 .setRefreshPolicy(IMMEDIATE)
                 .get();
@@ -683,14 +688,16 @@ public class GeoShapeQueryTests extends GeoQueryTests {
 
         // MULTIPOINT
         ShapeBuilder shape = RandomShapeGenerator.createShape(random(), RandomShapeGenerator.ShapeType.MULTIPOINT);
-        client().prepareIndex("geo_points_only", "type1", "1")
+        client().prepareIndex("geo_points_only")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("geo", shape).endObject())
             .setRefreshPolicy(IMMEDIATE)
             .get();
 
         // POINT
         shape = RandomShapeGenerator.createShape(random(), RandomShapeGenerator.ShapeType.POINT);
-        client().prepareIndex("geo_points_only", "type1", "2")
+        client().prepareIndex("geo_points_only")
+            .setId("2")
             .setSource(jsonBuilder().startObject().field("geo", shape).endObject())
             .setRefreshPolicy(IMMEDIATE)
             .get();
@@ -709,11 +716,13 @@ public class GeoShapeQueryTests extends GeoQueryTests {
 
         EnvelopeBuilder shape = new EnvelopeBuilder(new Coordinate(-45, 45), new Coordinate(45, -45));
 
-        client().prepareIndex("shapes", "shape_type", "Big_Rectangle")
+        client().prepareIndex("shapes")
+            .setId("Big_Rectangle")
             .setSource(jsonBuilder().startObject().field("shape", shape).endObject())
             .setRefreshPolicy(IMMEDIATE)
             .get();
-        client().prepareIndex("test", "type1", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(
                 jsonBuilder().startObject()
                     .field("name", "Document 1")
@@ -762,7 +771,8 @@ public class GeoShapeQueryTests extends GeoQueryTests {
         createIndex("test", Settings.EMPTY, "type", mapping);
 
         ShapeBuilder shape = RandomShapeGenerator.createShape(random(), RandomShapeGenerator.ShapeType.MULTIPOINT);
-        client().prepareIndex("test", "type", "1")
+        client().prepareIndex("test")
+            .setId("1")
             .setSource(jsonBuilder().startObject().field("location", shape).endObject())
             .setRefreshPolicy(IMMEDIATE)
             .get();
@@ -785,7 +795,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
         client().admin().indices().prepareCreate("test").addMapping("type", builder).get();
 
         XContentBuilder docSource = gcb.toXContent(jsonBuilder().startObject().field("geo"), null).endObject();
-        client().prepareIndex("test", "type", "1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
 
         ShapeBuilder filterShape = (gcb.getShapeAt(gcb.numShapes() - 1));
 
@@ -832,7 +842,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
             .endArray()
             .endObject()
             .endObject();
-        client().prepareIndex("test", "type", "1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
 
         GeoShapeQueryBuilder filter = QueryBuilders.geoShapeQuery(
             "geo",
@@ -946,7 +956,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
         EnvelopeBuilder envelopeBuilder = new EnvelopeBuilder(new Coordinate(178, 10), new Coordinate(-178, -10));
 
         XContentBuilder docSource = envelopeBuilder.toXContent(jsonBuilder().startObject().field("geo"), null).endObject();
-        client().prepareIndex("test", "type1", "1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("test").setId("1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
 
         ShapeBuilder filterShape = new PointBuilder(179, 0);
 

--- a/server/src/test/java/org/opensearch/test/search/aggregations/bucket/SharedSignificantTermsTestMethods.java
+++ b/server/src/test/java/org/opensearch/test/search/aggregations/bucket/SharedSignificantTermsTestMethods.java
@@ -104,13 +104,13 @@ public class SharedSignificantTermsTestMethods {
         );
         String[] gb = { "0", "1" };
         List<IndexRequestBuilder> indexRequestBuilderList = new ArrayList<>();
-        indexRequestBuilderList.add(client().prepareIndex(INDEX_NAME, DOC_TYPE, "1").setSource(TEXT_FIELD, "1", CLASS_FIELD, "1"));
-        indexRequestBuilderList.add(client().prepareIndex(INDEX_NAME, DOC_TYPE, "2").setSource(TEXT_FIELD, "1", CLASS_FIELD, "1"));
-        indexRequestBuilderList.add(client().prepareIndex(INDEX_NAME, DOC_TYPE, "3").setSource(TEXT_FIELD, "0", CLASS_FIELD, "0"));
-        indexRequestBuilderList.add(client().prepareIndex(INDEX_NAME, DOC_TYPE, "4").setSource(TEXT_FIELD, "0", CLASS_FIELD, "0"));
-        indexRequestBuilderList.add(client().prepareIndex(INDEX_NAME, DOC_TYPE, "5").setSource(TEXT_FIELD, gb, CLASS_FIELD, "1"));
-        indexRequestBuilderList.add(client().prepareIndex(INDEX_NAME, DOC_TYPE, "6").setSource(TEXT_FIELD, gb, CLASS_FIELD, "0"));
-        indexRequestBuilderList.add(client().prepareIndex(INDEX_NAME, DOC_TYPE, "7").setSource(TEXT_FIELD, "0", CLASS_FIELD, "0"));
+        indexRequestBuilderList.add(client().prepareIndex(INDEX_NAME).setId("1").setSource(TEXT_FIELD, "1", CLASS_FIELD, "1"));
+        indexRequestBuilderList.add(client().prepareIndex(INDEX_NAME).setId("2").setSource(TEXT_FIELD, "1", CLASS_FIELD, "1"));
+        indexRequestBuilderList.add(client().prepareIndex(INDEX_NAME).setId("3").setSource(TEXT_FIELD, "0", CLASS_FIELD, "0"));
+        indexRequestBuilderList.add(client().prepareIndex(INDEX_NAME).setId("4").setSource(TEXT_FIELD, "0", CLASS_FIELD, "0"));
+        indexRequestBuilderList.add(client().prepareIndex(INDEX_NAME).setId("5").setSource(TEXT_FIELD, gb, CLASS_FIELD, "1"));
+        indexRequestBuilderList.add(client().prepareIndex(INDEX_NAME).setId("6").setSource(TEXT_FIELD, gb, CLASS_FIELD, "0"));
+        indexRequestBuilderList.add(client().prepareIndex(INDEX_NAME).setId("7").setSource(TEXT_FIELD, "0", CLASS_FIELD, "0"));
         testCase.indexRandom(true, false, indexRequestBuilderList);
     }
 }

--- a/test/framework/src/main/java/org/opensearch/repositories/AbstractThirdPartyRepositoryTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/repositories/AbstractThirdPartyRepositoryTestCase.java
@@ -110,9 +110,9 @@ public abstract class AbstractThirdPartyRepositoryTestCase extends OpenSearchSin
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            client().prepareIndex("test-idx-1", "doc", Integer.toString(i)).setSource("foo", "bar" + i).get();
-            client().prepareIndex("test-idx-2", "doc", Integer.toString(i)).setSource("foo", "bar" + i).get();
-            client().prepareIndex("test-idx-3", "doc", Integer.toString(i)).setSource("foo", "bar" + i).get();
+            client().prepareIndex("test-idx-1").setId(Integer.toString(i)).setSource("foo", "bar" + i).get();
+            client().prepareIndex("test-idx-2").setId(Integer.toString(i)).setSource("foo", "bar" + i).get();
+            client().prepareIndex("test-idx-3").setId(Integer.toString(i)).setSource("foo", "bar" + i).get();
         }
         client().admin().indices().prepareRefresh().get();
 
@@ -182,9 +182,9 @@ public abstract class AbstractThirdPartyRepositoryTestCase extends OpenSearchSin
 
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            client().prepareIndex("test-idx-1", "doc", Integer.toString(i)).setSource("foo", "bar" + i).get();
-            client().prepareIndex("test-idx-2", "doc", Integer.toString(i)).setSource("foo", "bar" + i).get();
-            client().prepareIndex("test-idx-3", "doc", Integer.toString(i)).setSource("foo", "bar" + i).get();
+            client().prepareIndex("test-idx-1").setId(Integer.toString(i)).setSource("foo", "bar" + i).get();
+            client().prepareIndex("test-idx-2").setId(Integer.toString(i)).setSource("foo", "bar" + i).get();
+            client().prepareIndex("test-idx-3").setId(Integer.toString(i)).setSource("foo", "bar" + i).get();
         }
         client().admin().indices().prepareRefresh().get();
 

--- a/test/framework/src/main/java/org/opensearch/repositories/blobstore/OpenSearchBlobStoreRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/repositories/blobstore/OpenSearchBlobStoreRepositoryIntegTestCase.java
@@ -493,7 +493,8 @@ public abstract class OpenSearchBlobStoreRepositoryIntegTestCase extends OpenSea
     protected void addRandomDocuments(String name, int numDocs) throws InterruptedException {
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
-            indexRequestBuilders[i] = client().prepareIndex(name, name, Integer.toString(i))
+            indexRequestBuilders[i] = client().prepareIndex(name)
+                .setId(Integer.toString(i))
                 .setRouting(randomAlphaOfLength(randomIntBetween(1, 10)))
                 .setSource("field", "value");
         }

--- a/test/framework/src/main/java/org/opensearch/search/aggregations/metrics/AbstractNumericTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/search/aggregations/metrics/AbstractNumericTestCase.java
@@ -53,7 +53,8 @@ public abstract class AbstractNumericTestCase extends OpenSearchIntegTestCase {
         final int numDocs = 10;
         for (int i = 0; i < numDocs; i++) { // TODO randomize the size and the params in here?
             builders.add(
-                client().prepareIndex("idx", "type", String.valueOf(i))
+                client().prepareIndex("idx")
+                    .setId(String.valueOf(i))
                     .setSource(
                         jsonBuilder().startObject()
                             .field("value", i + 1)
@@ -79,7 +80,8 @@ public abstract class AbstractNumericTestCase extends OpenSearchIntegTestCase {
         builders = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
             builders.add(
-                client().prepareIndex("empty_bucket_idx", "type", String.valueOf(i))
+                client().prepareIndex("empty_bucket_idx")
+                    .setId(String.valueOf(i))
                     .setSource(jsonBuilder().startObject().field("value", i * 2).endObject())
             );
         }

--- a/test/framework/src/main/java/org/opensearch/test/BackgroundIndexer.java
+++ b/test/framework/src/main/java/org/opensearch/test/BackgroundIndexer.java
@@ -173,7 +173,7 @@ public class BackgroundIndexer implements AutoCloseable {
                                         bulkRequest.add(client.prepareIndex(index).setSource(generateSource(id, threadRandom)));
                                     } else {
                                         bulkRequest.add(
-                                            client.prepareIndex(index, type, Long.toString(id)).setSource(generateSource(id, threadRandom))
+                                            client.prepareIndex(index).setId(Long.toString(id)).setSource(generateSource(id, threadRandom))
                                         );
                                     }
                                 }
@@ -214,7 +214,8 @@ public class BackgroundIndexer implements AutoCloseable {
                                     }
                                 } else {
                                     try {
-                                        IndexResponse indexResponse = client.prepareIndex(index, type, Long.toString(id))
+                                        IndexResponse indexResponse = client.prepareIndex(index)
+                                            .setId(Long.toString(id))
                                             .setTimeout(timeout)
                                             .setSource(generateSource(id, threadRandom))
                                             .get();

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -1331,6 +1331,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
      *   client().prepareIndex(index, type).setSource(source).execute().actionGet();
      * </pre>
      */
+    @Deprecated
     protected final IndexResponse index(String index, String type, XContentBuilder source) {
         return client().prepareIndex(index).setSource(source).execute().actionGet();
     }
@@ -1342,7 +1343,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
      * </pre>
      */
     protected final IndexResponse index(String index, String type, String id, Map<String, Object> source) {
-        return client().prepareIndex(index, type, id).setSource(source).execute().actionGet();
+        return client().prepareIndex(index).setId(id).setSource(source).execute().actionGet();
     }
 
     /**
@@ -1351,8 +1352,9 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
      *   return client().prepareIndex(index, type, id).setSource(source).execute().actionGet();
      * </pre>
      */
+    @Deprecated
     protected final IndexResponse index(String index, String type, String id, XContentBuilder source) {
-        return client().prepareIndex(index, type, id).setSource(source).execute().actionGet();
+        return client().prepareIndex(index).setId(id).setSource(source).execute().actionGet();
     }
 
     /**
@@ -1361,8 +1363,9 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
      *   return client().prepareIndex(index, type, id).setSource(source).execute().actionGet();
      * </pre>
      */
+    @Deprecated
     protected final IndexResponse index(String index, String type, String id, Object... source) {
-        return client().prepareIndex(index, type, id).setSource(source).execute().actionGet();
+        return client().prepareIndex(index).setId(id).setSource(source).execute().actionGet();
     }
 
     /**
@@ -1373,8 +1376,9 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
      * <p>
      * where source is a JSON String.
      */
+    @Deprecated
     protected final IndexResponse index(String index, String type, String id, String source) {
-        return client().prepareIndex(index, type, id).setSource(source, XContentType.JSON).execute().actionGet();
+        return client().prepareIndex(index).setId(id).setSource(source, XContentType.JSON).execute().actionGet();
     }
 
     /**

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
@@ -304,7 +304,9 @@ public abstract class OpenSearchSingleNodeTestCase extends OpenSearchTestCase {
 
     /**
      * Create a new index on the singleton node with the provided index settings.
+     * @deprecated types are being removed
      */
+    @Deprecated
     protected IndexService createIndex(String index, Settings settings, String type, XContentBuilder mappings) {
         CreateIndexRequestBuilder createIndexRequestBuilder = client().admin().indices().prepareCreate(index).setSettings(settings);
         if (type != null && mappings != null) {
@@ -315,7 +317,9 @@ public abstract class OpenSearchSingleNodeTestCase extends OpenSearchTestCase {
 
     /**
      * Create a new index on the singleton node with the provided index settings.
+     * @deprecated types are being removed
      */
+    @Deprecated
     protected IndexService createIndex(String index, Settings settings, String type, Object... mappings) {
         CreateIndexRequestBuilder createIndexRequestBuilder = client().admin().indices().prepareCreate(index).setSettings(settings);
         if (type != null) {


### PR DESCRIPTION
Removes type parameter from remaining prepareIndex in Client and AbstractClient.

relates #1940
