### PR TITLE
Remove type end-points from NOOP bulk and search action

### DIFF
--- a/client/client-benchmark-noop-api-plugin/src/main/java/org/opensearch/plugin/noop/action/bulk/RestNoopBulkAction.java
+++ b/client/client-benchmark-noop-api-plugin/src/main/java/org/opensearch/plugin/noop/action/bulk/RestNoopBulkAction.java
@@ -67,9 +67,7 @@ public class RestNoopBulkAction extends BaseRestHandler {
                 new Route(POST, "/_noop_bulk"),
                 new Route(PUT, "/_noop_bulk"),
                 new Route(POST, "/{index}/_noop_bulk"),
-                new Route(PUT, "/{index}/_noop_bulk"),
-                new Route(POST, "/{index}/{type}/_noop_bulk"),
-                new Route(PUT, "/{index}/{type}/_noop_bulk")
+                new Route(PUT, "/{index}/_noop_bulk")
             )
         );
     }
@@ -83,7 +81,6 @@ public class RestNoopBulkAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         BulkRequest bulkRequest = Requests.bulkRequest();
         String defaultIndex = request.param("index");
-        String defaultType = request.param("type");
         String defaultRouting = request.param("routing");
         String defaultPipeline = request.param("pipeline");
         Boolean defaultRequireAlias = request.paramAsBoolean("require_alias", null);

--- a/client/client-benchmark-noop-api-plugin/src/main/java/org/opensearch/plugin/noop/action/search/RestNoopSearchAction.java
+++ b/client/client-benchmark-noop-api-plugin/src/main/java/org/opensearch/plugin/noop/action/search/RestNoopSearchAction.java
@@ -53,9 +53,7 @@ public class RestNoopSearchAction extends BaseRestHandler {
                 new Route(GET, "/_noop_search"),
                 new Route(POST, "/_noop_search"),
                 new Route(GET, "/{index}/_noop_search"),
-                new Route(POST, "/{index}/_noop_search"),
-                new Route(GET, "/{index}/{type}/_noop_search"),
-                new Route(POST, "/{index}/{type}/_noop_search")
+                new Route(POST, "/{index}/_noop_search")
             )
         );
     }


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Removes type specific end-points from no-op bulk and search APIs. 

Other changes were implemented in

1.  https://github.com/opensearch-project/OpenSearch/pull/2215 
2. https://github.com/opensearch-project/OpenSearch/pull/2239

Relates #1940  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
