### PR TITLE
[Backport 1.x] Install plugin command help (#2193)

### DIFF
--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/InstallPluginCommand.java
@@ -218,11 +218,23 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
             Arrays.asList("b", "batch"),
             "Enable batch mode explicitly, automatic confirmation of security permission"
         );
-        this.arguments = parser.nonOptions("plugin id");
+        this.arguments = parser.nonOptions("plugin <name|Zip File|URL>");
     }
 
     @Override
     protected void printAdditionalHelp(Terminal terminal) {
+        terminal.println("Plugins are packaged as zip files. Each packaged plugin must contain a plugin properties file.");
+        terminal.println("");
+
+        // List possible plugin id inputs
+        terminal.println("The install command takes a plugin id, which may be any of the following:");
+        terminal.println("  An official opensearch plugin name");
+        terminal.println("  Maven coordinates to a plugin zip");
+        terminal.println("  A URL to a plugin zip");
+        terminal.println("  A local zip file");
+        terminal.println("");
+
+        // List official opensearch plugin names
         terminal.println("The following official plugins may be installed by name:");
         for (String plugin : OFFICIAL_PLUGINS) {
             terminal.println("  " + plugin);

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
@@ -828,6 +828,31 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         }
     }
 
+    public void testPluginsHelpNonOptionArgumentsOutput() throws Exception {
+        MockTerminal terminal = new MockTerminal();
+        new InstallPluginCommand() {
+            @Override
+            protected boolean addShutdownHook() {
+                return false;
+            }
+        }.main(new String[] { "--help" }, terminal);
+        try (BufferedReader reader = new BufferedReader(new StringReader(terminal.getOutput()))) {
+
+            // grab first line of --help output
+            String line = reader.readLine();
+
+            // find the beginning of Non-option arguments list
+            while (line.contains("Non-option arguments:") == false) {
+                line = reader.readLine();
+            }
+
+            // check that non option agrument list contains correct string
+            line = reader.readLine();
+            assertThat(line, containsString("<name|Zip File|URL>"));
+
+        }
+    }
+
     public void testInstallMisspelledOfficialPlugins() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
 


### PR DESCRIPTION
* edited opensearch-plugin install help output to include plugin URL

Signed-off-by: Joshua Palis <jpalis@amazon.com>

* fixed unit test for plugin install help output by correctly identifying the beginning og the non-option argument list

Signed-off-by: Joshua Palis <jpalis@amazon.com>

* added comments to install plugins help non option argument ouput unit test

Signed-off-by: Joshua Palis <jpalis@amazon.com>

* fixed format violation

Signed-off-by: Joshua Palis <jpalis@amazon.com>

* added additional details on valid plugin ids and how to use plugin URLs

Signed-off-by: Joshua Palis <jpalis@amazon.com>

* added additional information to plugin install help output

Signed-off-by: Joshua Palis <jpalis@amazon.com>

Co-authored-by: Joshua Palis <jpalis@amazon.com>
(cherry picked from commit b251d2b565b918708a1612ec16d1916122c7805d)
Signed-off-by: Joshua Palis <jpalis@amazon.com>

### Description
Resolve DCO check failure 
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
