### PR TITLE
Bump forbiddenapis from 3.0 to 3.2 in /buildSrc (#2113)

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -112,8 +112,8 @@ dependencies {
   api 'commons-io:commons-io:2.7'
   api "net.java.dev.jna:jna:5.5.0"
   api 'com.github.jengelman.gradle.plugins:shadow:6.0.0'
-  api 'de.thetaphi:forbiddenapis:3.0'
-  api 'com.avast.gradle:gradle-docker-compose-plugin:0.12.1'
+  api 'de.thetaphi:forbiddenapis:3.2'
+  api 'com.avast.gradle:gradle-docker-compose-plugin:0.14.12'
   api 'org.apache.maven:maven-model:3.6.2'
   api 'com.networknt:json-schema-validator:1.0.36'
   api "com.fasterxml.jackson.core:jackson-databind:${props.getProperty('jackson')}"


### PR DESCRIPTION
Bumps forbiddenapis from 3.0 to 3.2.

---
updated-dependencies:
- dependency-name: de.thetaphi:forbiddenapis
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
(cherry picked from commit 4432ce2a574ac1c15a234a3c7a079fd670bc97ff)

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
