### PR TITLE
Bump forbiddenapis from 3.0 to 3.2 in /buildSrc (#2113)

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -112,7 +112,7 @@ dependencies {
   api 'commons-io:commons-io:2.7'
   api "net.java.dev.jna:jna:5.5.0"
   api 'com.github.jengelman.gradle.plugins:shadow:6.0.0'
-  api 'de.thetaphi:forbiddenapis:3.0'
+  api 'de.thetaphi:forbiddenapis:3.2'
   api 'com.avast.gradle:gradle-docker-compose-plugin:0.12.1'
   api 'org.apache.maven:maven-model:3.6.2'
   api 'com.networknt:json-schema-validator:1.0.36'


### PR DESCRIPTION
Backport https://github.com/opensearch-project/OpenSearch/commit/3faeec8c53058a5f8cc9d7a2e645fe7c9a1d48da from https://github.com/opensearch-project/OpenSearch/pull/2113