### PR TITLE
Toggle replication strategy based on segrep index setting

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/IndexingMemoryControllerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/IndexingMemoryControllerIT.java
@@ -104,7 +104,7 @@ public class IndexingMemoryControllerIT extends OpenSearchSingleNodeTestCase {
                 config.retentionLeasesSupplier(),
                 config.getPrimaryTermSupplier(),
                 config.getTombstoneDocSupplier(),
-                config.isPrimary()
+                config.isReadOnly()
             );
         }
 

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -915,9 +915,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         if (indexSettings.getRefreshInterval().millis() > 0 || force) {
             for (IndexShard shard : this.shards.values()) {
                 try {
-                    if (shard.routingEntry().primary()) {
-                        shard.scheduledRefresh();
-                    }
+                    shard.scheduledRefresh();
                 } catch (IndexShardClosedException | AlreadyClosedException ex) {
                     // fine - continue;
                 }

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -653,6 +653,10 @@ public final class IndexSettings {
         this.indexMetadata = indexMetadata;
         numberOfShards = settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, null);
         isSegrepEnabled = settings.getAsBoolean(IndexMetadata.SETTING_SEGMENT_REPLICATION, false);
+<<<<<<< HEAD
+=======
+
+>>>>>>> 5950974c5a2 (toggle)
         this.searchThrottled = INDEX_SEARCH_THROTTLED.get(settings);
         this.queryStringLenient = QUERY_STRING_LENIENT_SETTING.get(settings);
         this.queryStringAnalyzeWildcard = QUERY_STRING_ANALYZE_WILDCARD.get(nodeSettings);
@@ -883,7 +887,7 @@ public final class IndexSettings {
     }
 
     public boolean isSegrepEnabled() {
-        return isSegrepEnabled;
+        return Boolean.TRUE.equals(isSegrepEnabled);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -653,10 +653,6 @@ public final class IndexSettings {
         this.indexMetadata = indexMetadata;
         numberOfShards = settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, null);
         isSegrepEnabled = settings.getAsBoolean(IndexMetadata.SETTING_SEGMENT_REPLICATION, false);
-<<<<<<< HEAD
-=======
-
->>>>>>> 5950974c5a2 (toggle)
         this.searchThrottled = INDEX_SEARCH_THROTTLED.get(settings);
         this.queryStringLenient = QUERY_STRING_LENIENT_SETTING.get(settings);
         this.queryStringAnalyzeWildcard = QUERY_STRING_ANALYZE_WILDCARD.get(nodeSettings);

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
@@ -95,7 +95,7 @@ public final class EngineConfig {
     private final CircuitBreakerService circuitBreakerService;
     private final LongSupplier globalCheckpointSupplier;
     private final Supplier<RetentionLeases> retentionLeasesSupplier;
-    private boolean isPrimary;
+    private boolean isReadOnly;
 
     /**
      * A supplier of the outstanding retention leases. This is used during merged operations to determine which operations that have been
@@ -171,7 +171,7 @@ public final class EngineConfig {
         Supplier<RetentionLeases> retentionLeasesSupplier,
         LongSupplier primaryTermSupplier,
         TombstoneDocSupplier tombstoneDocSupplier,
-        boolean isPrimary
+        boolean isReadOnly
     ) {
         this(
             shardId,
@@ -195,7 +195,7 @@ public final class EngineConfig {
             circuitBreakerService,
             globalCheckpointSupplier,
             retentionLeasesSupplier,
-            isPrimary,
+            isReadOnly,
             primaryTermSupplier,
             tombstoneDocSupplier
         );
@@ -226,7 +226,7 @@ public final class EngineConfig {
         CircuitBreakerService circuitBreakerService,
         LongSupplier globalCheckpointSupplier,
         Supplier<RetentionLeases> retentionLeasesSupplier,
-        boolean isPrimary,
+        boolean isReadOnly,
         LongSupplier primaryTermSupplier,
         TombstoneDocSupplier tombstoneDocSupplier
     ) {
@@ -241,7 +241,7 @@ public final class EngineConfig {
         this.codecService = codecService;
         this.eventListener = eventListener;
         codecName = indexSettings.getValue(INDEX_CODEC_SETTING);
-        this.isPrimary = isPrimary;
+        this.isReadOnly = isReadOnly;
         // We need to make the indexing buffer for this shard at least as large
         // as the amount of memory that is available for all engines on the
         // local node so that decisions to flush segments to disk are made by
@@ -463,8 +463,8 @@ public final class EngineConfig {
         return primaryTermSupplier;
     }
 
-    public boolean isPrimary() {
-        return isPrimary;
+    public boolean isReadOnly() {
+        return isReadOnly;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -350,7 +350,7 @@ public class InternalEngine extends Engine {
 
     @Override
     public void updateCurrentInfos(byte[] infosBytes, long gen, long seqNo) throws IOException {
-        assert engineConfig.isReadOnly() == true : "Only replicas should update Infos";
+        assert engineConfig.isReadOnly() == true : "Only read-only replicas should update Infos";
         SegmentInfos infos = SegmentInfos.readCommit(this.store.directory(), toIndexInput(infosBytes), gen);
         assert gen == infos.getGeneration();
         externalReaderManager.internalReaderManager.updateSegments(infos);

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -283,11 +283,11 @@ public class InternalEngine extends Engine {
                     historyUUID = null;
                     forceMergeUUID = null;
                 } else {
-                        writer = createWriter();
-                        bootstrapAppendOnlyInfoFromWriter(writer);
-                        final Map<String, String> commitData = commitDataAsMap(writer);
-                        historyUUID = loadHistoryUUID(commitData);
-                        forceMergeUUID = commitData.get(FORCE_MERGE_UUID_KEY);
+                    writer = createWriter();
+                    bootstrapAppendOnlyInfoFromWriter(writer);
+                    final Map<String, String> commitData = commitDataAsMap(writer);
+                    historyUUID = loadHistoryUUID(commitData);
+                    forceMergeUUID = commitData.get(FORCE_MERGE_UUID_KEY);
                 }
                 indexWriter = writer;
             } catch (IOException | TranslogCorruptedException e) {

--- a/server/src/main/java/org/opensearch/index/engine/OpenSearchReaderManager.java
+++ b/server/src/main/java/org/opensearch/index/engine/OpenSearchReaderManager.java
@@ -32,10 +32,6 @@
 
 package org.opensearch.index.engine;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.DirectoryReader;
@@ -44,10 +40,13 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.StandardDirectoryReader;
 import org.apache.lucene.search.ReferenceManager;
-
 import org.apache.lucene.search.SearcherManager;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.lucene.index.OpenSearchDirectoryReader;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Utility class to safely share {@link OpenSearchDirectoryReader} instances across

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -2068,9 +2068,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         // which settings changes could possibly have happened, so here we forcefully push any config changes to the new engine.
         onSettingsChanged();
         // TODO: Segrep - Fix
-        if (indexSettings.isSegrepEnabled() == false) {
-            assert assertSequenceNumbersInCommit();
-        }
+        assert assertSequenceNumbersInCommit();
         recoveryState.validateCurrentStage(RecoveryState.Stage.TRANSLOG);
     }
 
@@ -2718,9 +2716,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         assert assertPrimaryMode();
         verifyNotClosed();
         // TODO: Segrep - Fix retention leases
-        if (indexSettings.isSegrepEnabled() == false) {
-            replicationTracker.renewPeerRecoveryRetentionLeases();
-        }
+        replicationTracker.renewPeerRecoveryRetentionLeases();
         final Tuple<Boolean, RetentionLeases> retentionLeases = getRetentionLeases(true);
         if (retentionLeases.v1()) {
             logger.trace("syncing retention leases [{}] after expiration check", retentionLeases.v2());

--- a/server/src/main/java/org/opensearch/indices/recovery/MultiFileWriter.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/MultiFileWriter.java
@@ -48,6 +48,7 @@ import org.opensearch.transport.Transports;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
@@ -151,7 +152,9 @@ public class MultiFileWriter extends AbstractRefCounted implements Releasable {
                 + Arrays.toString(store.directory().listAll());
             // TODO: Segrep - toggle this with a setting. With segrep we don't want this fsync we will only fsync
             // when a new checkpoint is received.
-            // store.directory().sync(Collections.singleton(temporaryFileName));
+            if (store.indexSettings().isSegrepEnabled() == false) {
+                store.directory().sync(Collections.singleton(temporaryFileName));
+            }
             IndexOutput remove = removeOpenIndexOutputs(name);
             assert remove == null || remove == indexOutput; // remove maybe null if we got finished
         }

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -3440,7 +3440,7 @@ public class InternalEngineTests extends EngineTestCase {
             () -> RetentionLeases.EMPTY,
             primaryTerm::get,
             tombstoneDocSupplier(),
-            config.isPrimary()
+            config.isReadOnly()
         );
         expectThrows(EngineCreationFailureException.class, () -> new InternalEngine(brokenConfig));
 
@@ -3483,7 +3483,7 @@ public class InternalEngineTests extends EngineTestCase {
             config.getCircuitBreakerService(),
             config.getGlobalCheckpointSupplier(),
             config.retentionLeasesSupplier(),
-            config.isPrimary(),
+            config.isReadOnly(),
             config.getPrimaryTermSupplier(),
             config.getTombstoneDocSupplier()
         );
@@ -7105,7 +7105,7 @@ public class InternalEngineTests extends EngineTestCase {
                 config.retentionLeasesSupplier(),
                 config.getPrimaryTermSupplier(),
                 config.getTombstoneDocSupplier(),
-                config.isPrimary()
+                config.isReadOnly()
             );
             try (InternalEngine engine = createEngine(configWithWarmer)) {
                 assertThat(warmedUpReaders, empty());

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -4457,7 +4457,7 @@ public class IndexShardTests extends IndexShardTestCase {
                 config.retentionLeasesSupplier(),
                 config.getPrimaryTermSupplier(),
                 config.getTombstoneDocSupplier(),
-                config.isPrimary()
+                config.isReadOnly()
             );
             return new InternalEngine(configWithWarmer);
         });

--- a/server/src/test/java/org/opensearch/indices/IndexingMemoryControllerTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndexingMemoryControllerTests.java
@@ -422,7 +422,7 @@ public class IndexingMemoryControllerTests extends IndexShardTestCase {
             config.retentionLeasesSupplier(),
             config.getPrimaryTermSupplier(),
             config.getTombstoneDocSupplier(),
-            config.isPrimary()
+            config.isReadOnly()
         );
     }
 

--- a/test/framework/src/main/java/org/opensearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/EngineTestCase.java
@@ -268,7 +268,7 @@ public abstract class EngineTestCase extends OpenSearchTestCase {
             config.retentionLeasesSupplier(),
             config.getPrimaryTermSupplier(),
             tombstoneDocSupplier(),
-            config.isPrimary()
+            config.isReadOnly()
         );
     }
 
@@ -296,7 +296,7 @@ public abstract class EngineTestCase extends OpenSearchTestCase {
             config.retentionLeasesSupplier(),
             config.getPrimaryTermSupplier(),
             config.getTombstoneDocSupplier(),
-            config.isPrimary()
+            config.isReadOnly()
         );
     }
 
@@ -324,7 +324,7 @@ public abstract class EngineTestCase extends OpenSearchTestCase {
             config.retentionLeasesSupplier(),
             config.getPrimaryTermSupplier(),
             config.getTombstoneDocSupplier(),
-            config.isPrimary()
+            config.isReadOnly()
         );
     }
 
@@ -940,7 +940,7 @@ public abstract class EngineTestCase extends OpenSearchTestCase {
             config.retentionLeasesSupplier(),
             config.getPrimaryTermSupplier(),
             tombstoneDocSupplier,
-            config.isPrimary()
+            config.isReadOnly()
         );
     }
 


### PR DESCRIPTION
### Description
Docrep and segrep should be able to work in parallel with this change. Previously, commented code was breaking docrep
- test docrep by running IndexRecoveryIT 

Resolves #2197 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
