### PR TITLE
Disable WhiteSource check on 1.x PRs

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -6,7 +6,7 @@
     "baseBranches": ["1.x"]
   },
   "checkRunSettings": {
-    "vulnerableCheckRunConclusionLevel": "failure",
+    "vulnerableCheckRunConclusionLevel": "none",
     "displayMode": "diff"
   },
   "issueSettings": {


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Disabling WhiteSource check since it is currently not working correctly on 1.x PRs. 

Reference: https://whitesource.atlassian.net/wiki/spaces/WD/pages/697696422/WhiteSource+for+GitHub.com#Check-Run-Settings-(checkRunSettings)
 
### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/1593#issuecomment-1058400217
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
