### PR TITLE
Log warning in rest client response handler 

### DIFF
--- a/client/rest/src/main/java/org/opensearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClient.java
@@ -343,6 +343,7 @@ public class RestClient implements Closeable {
         if (isSuccessfulResponse(statusCode) || request.ignoreErrorCodes.contains(response.getStatusLine().getStatusCode())) {
             onResponse(node);
             if (request.warningsHandler.warningsShouldFailRequest(response.getWarnings())) {
+                logger.warn(Arrays.toString(response.getWarnings().toArray()));
                 throw new WarningFailureException(response);
             }
             return new ResponseOrResponseException(response);


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Log warnings in rest client response handler causing test failures. This change is to get insights on warnings which is causing the test failures in gradle check.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
