### PR TITLE
[Backport] [1.x] Add 'key' field to 'function_score' query function definition in explanation response

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/DecayFunctionScoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/DecayFunctionScoreIT.java
@@ -52,6 +52,7 @@ import org.opensearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.opensearch.index.query.functionscore.FunctionScoreQueryBuilder.FilterFunctionBuilder;
 import org.opensearch.index.query.functionscore.ScoreFunctionBuilders;
 import org.opensearch.search.MultiValueMode;
+import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.VersionUtils;
@@ -78,7 +79,9 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertOrderedSearchHits;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchHits;
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
@@ -625,6 +628,76 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
         assertThat(sh.getAt(0).getId(), equalTo("1"));
         assertThat((double) sh.getAt(0).getScore(), closeTo(2.0, 1.e-5));
 
+    }
+
+    public void testCombineModesExplain() throws Exception {
+        assertAcked(
+            prepareCreate("test").addMapping(
+                "type1",
+                jsonBuilder().startObject()
+                    .startObject("type1")
+                    .startObject("properties")
+                    .startObject("test")
+                    .field("type", "text")
+                    .endObject()
+                    .startObject("num")
+                    .field("type", "double")
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject()
+            )
+        );
+
+        client().prepareIndex()
+            .setId("1")
+            .setIndex("test")
+            .setRefreshPolicy(IMMEDIATE)
+            .setSource(jsonBuilder().startObject().field("test", "value value").field("num", 1.0).endObject())
+            .get();
+
+        FunctionScoreQueryBuilder baseQuery = functionScoreQuery(
+            constantScoreQuery(termQuery("test", "value")).queryName("query1"),
+            ScoreFunctionBuilders.weightFactorFunction(2, "weight1")
+        );
+        // decay score should return 0.5 for this function and baseQuery should return 2.0f as it's score
+        ActionFuture<SearchResponse> response = client().search(
+            searchRequest().searchType(SearchType.QUERY_THEN_FETCH)
+                .source(
+                    searchSource().explain(true)
+                        .query(
+                            functionScoreQuery(baseQuery, gaussDecayFunction("num", 0.0, 1.0, null, 0.5, "func2")).boostMode(
+                                CombineFunction.MULTIPLY
+                            )
+                        )
+                )
+        );
+        SearchResponse sr = response.actionGet();
+        SearchHits sh = sr.getHits();
+        assertThat(sh.getTotalHits().value, equalTo((long) (1)));
+        assertThat(sh.getAt(0).getId(), equalTo("1"));
+        assertThat(sh.getAt(0).getExplanation().getDetails(), arrayWithSize(2));
+        assertThat(sh.getAt(0).getExplanation().getDetails()[0].getDetails(), arrayWithSize(2));
+        // "description": "ConstantScore(test:value) (_name: query1)"
+        assertThat(
+            sh.getAt(0).getExplanation().getDetails()[0].getDetails()[0].getDescription(),
+            equalTo("ConstantScore(test:value) (_name: query1)")
+        );
+        assertThat(sh.getAt(0).getExplanation().getDetails()[0].getDetails()[1].getDetails(), arrayWithSize(2));
+        assertThat(sh.getAt(0).getExplanation().getDetails()[0].getDetails()[1].getDetails()[0].getDetails(), arrayWithSize(2));
+        // "description": "constant score 1.0(_name: func1) - no function provided"
+        assertThat(
+            sh.getAt(0).getExplanation().getDetails()[0].getDetails()[1].getDetails()[0].getDetails()[0].getDescription(),
+            equalTo("constant score 1.0(_name: weight1) - no function provided")
+        );
+        // "description": "exp(-0.5*pow(MIN[Math.max(Math.abs(1.0(=doc value) - 0.0(=origin))) - 0.0(=offset), 0)],2.0)/0.7213475204444817,
+        // _name: func2)"
+        assertThat(sh.getAt(0).getExplanation().getDetails()[1].getDetails(), arrayWithSize(2));
+        assertThat(sh.getAt(0).getExplanation().getDetails()[1].getDetails()[0].getDetails(), arrayWithSize(1));
+        assertThat(
+            sh.getAt(0).getExplanation().getDetails()[1].getDetails()[0].getDetails()[0].getDescription(),
+            containsString("_name: func2")
+        );
     }
 
     public void testExceptionThrownIfScaleLE0() throws Exception {
@@ -1231,5 +1304,133 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
         assertSearchHits(sr, "1", "2");
         sh = sr.getHits();
         assertThat((double) (sh.getAt(0).getScore()), closeTo((sh.getAt(1).getScore()), 1.e-6d));
+    }
+
+    public void testDistanceScoreGeoLinGaussExplain() throws Exception {
+        assertAcked(
+            prepareCreate("test").addMapping(
+                "type1",
+                jsonBuilder().startObject()
+                    .startObject("type1")
+                    .startObject("properties")
+                    .startObject("test")
+                    .field("type", "text")
+                    .endObject()
+                    .startObject("loc")
+                    .field("type", "geo_point")
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject()
+            )
+        );
+
+        List<IndexRequestBuilder> indexBuilders = new ArrayList<>();
+        indexBuilders.add(
+            client().prepareIndex()
+                .setId("1")
+                .setIndex("test")
+                .setSource(
+                    jsonBuilder().startObject()
+                        .field("test", "value")
+                        .startObject("loc")
+                        .field("lat", 10)
+                        .field("lon", 20)
+                        .endObject()
+                        .endObject()
+                )
+        );
+        indexBuilders.add(
+            client().prepareIndex()
+                .setId("2")
+                .setIndex("test")
+                .setSource(
+                    jsonBuilder().startObject()
+                        .field("test", "value")
+                        .startObject("loc")
+                        .field("lat", 11)
+                        .field("lon", 22)
+                        .endObject()
+                        .endObject()
+                )
+        );
+
+        indexRandom(true, indexBuilders);
+
+        // Test Gauss
+        List<Float> lonlat = new ArrayList<>();
+        lonlat.add(20f);
+        lonlat.add(11f);
+
+        final String queryName = "query1";
+        final String functionName = "func1";
+        ActionFuture<SearchResponse> response = client().search(
+            searchRequest().searchType(SearchType.QUERY_THEN_FETCH)
+                .source(
+                    searchSource().explain(true)
+                        .query(
+                            functionScoreQuery(baseQuery.queryName(queryName), gaussDecayFunction("loc", lonlat, "1000km", functionName))
+                        )
+                )
+        );
+        SearchResponse sr = response.actionGet();
+        SearchHits sh = sr.getHits();
+        assertThat(sh.getTotalHits().value, equalTo(2L));
+        assertThat(sh.getAt(0).getId(), equalTo("1"));
+        assertThat(sh.getAt(1).getId(), equalTo("2"));
+        assertExplain(queryName, functionName, sr);
+
+        response = client().search(
+            searchRequest().searchType(SearchType.QUERY_THEN_FETCH)
+                .source(
+                    searchSource().explain(true)
+                        .query(
+                            functionScoreQuery(baseQuery.queryName(queryName), linearDecayFunction("loc", lonlat, "1000km", functionName))
+                        )
+                )
+        );
+
+        sr = response.actionGet();
+        sh = sr.getHits();
+        assertThat(sh.getTotalHits().value, equalTo(2L));
+        assertThat(sh.getAt(0).getId(), equalTo("1"));
+        assertThat(sh.getAt(1).getId(), equalTo("2"));
+        assertExplain(queryName, functionName, sr);
+
+        response = client().search(
+            searchRequest().searchType(SearchType.QUERY_THEN_FETCH)
+                .source(
+                    searchSource().explain(true)
+                        .query(
+                            functionScoreQuery(
+                                baseQuery.queryName(queryName),
+                                exponentialDecayFunction("loc", lonlat, "1000km", functionName)
+                            )
+                        )
+                )
+        );
+
+        sr = response.actionGet();
+        sh = sr.getHits();
+        assertThat(sh.getTotalHits().value, equalTo(2L));
+        assertThat(sh.getAt(0).getId(), equalTo("1"));
+        assertThat(sh.getAt(1).getId(), equalTo("2"));
+        assertExplain(queryName, functionName, sr);
+    }
+
+    private void assertExplain(final String queryName, final String functionName, SearchResponse sr) {
+        SearchHit firstHit = sr.getHits().getAt(0);
+        assertThat(firstHit.getExplanation().getDetails(), arrayWithSize(2));
+        // "description": "*:* (_name: query1)"
+        assertThat(firstHit.getExplanation().getDetails()[0].getDescription().toString(), containsString("_name: " + queryName));
+        assertThat(firstHit.getExplanation().getDetails()[1].getDetails(), arrayWithSize(2));
+        // "description": "random score function (seed: 12345678, field: _seq_no, _name: func1)"
+        assertThat(firstHit.getExplanation().getDetails()[1].getDetails()[0].getDetails(), arrayWithSize(1));
+        // "description": "exp(-0.5*pow(MIN of: [Math.max(arcDistance(10.999999972991645, 21.99999994598329(=doc value),11.0, 20.0(=origin))
+        // - 0.0(=offset), 0)],2.0)/7.213475204444817E11, _name: func1)"
+        assertThat(
+            firstHit.getExplanation().getDetails()[1].getDetails()[0].getDetails()[0].getDescription().toString(),
+            containsString("_name: " + functionName)
+        );
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/ExplainableScriptIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/ExplainableScriptIT.java
@@ -38,6 +38,7 @@ import org.opensearch.action.index.IndexRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchType;
 import org.opensearch.common.lucene.search.function.CombineFunction;
+import org.opensearch.common.lucene.search.function.Functions;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.fielddata.ScriptDocValues;
 import org.opensearch.plugins.Plugin;
@@ -72,6 +73,7 @@ import static org.opensearch.index.query.QueryBuilders.functionScoreQuery;
 import static org.opensearch.index.query.QueryBuilders.termQuery;
 import static org.opensearch.index.query.functionscore.ScoreFunctionBuilders.scriptFunction;
 import static org.opensearch.search.builder.SearchSourceBuilder.searchSource;
+import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -121,8 +123,17 @@ public class ExplainableScriptIT extends OpenSearchIntegTestCase {
 
         @Override
         public Explanation explain(Explanation subQueryScore) throws IOException {
+            return explain(subQueryScore, null);
+        }
+
+        @Override
+        public Explanation explain(Explanation subQueryScore, String functionName) throws IOException {
             Explanation scoreExp = Explanation.match(subQueryScore.getValue(), "_score: ", subQueryScore);
-            return Explanation.match((float) (execute(null)), "This script returned " + execute(null), scoreExp);
+            return Explanation.match(
+                (float) (execute(null)),
+                "This script" + Functions.nameOrEmptyFunc(functionName) + " returned " + execute(null),
+                scoreExp
+            );
         }
 
         @Override
@@ -174,4 +185,36 @@ public class ExplainableScriptIT extends OpenSearchIntegTestCase {
             idCounter--;
         }
     }
+
+    public void testExplainScriptWithName() throws InterruptedException, IOException, ExecutionException {
+        List<IndexRequestBuilder> indexRequests = new ArrayList<>();
+        indexRequests.add(
+            client().prepareIndex("test", "type")
+                .setId(Integer.toString(1))
+                .setSource(jsonBuilder().startObject().field("number_field", 1).field("text", "text").endObject())
+        );
+        indexRandom(true, true, indexRequests);
+        client().admin().indices().prepareRefresh().get();
+        ensureYellow();
+        SearchResponse response = client().search(
+            searchRequest().searchType(SearchType.QUERY_THEN_FETCH)
+                .source(
+                    searchSource().explain(true)
+                        .query(
+                            functionScoreQuery(
+                                termQuery("text", "text"),
+                                scriptFunction(new Script(ScriptType.INLINE, "test", "explainable_script", Collections.emptyMap()), "func1")
+                            ).boostMode(CombineFunction.REPLACE)
+                        )
+                )
+        ).actionGet();
+
+        OpenSearchAssertions.assertNoFailures(response);
+        SearchHits hits = response.getHits();
+        assertThat(hits.getTotalHits().value, equalTo(1L));
+        assertThat(hits.getHits()[0].getId(), equalTo("1"));
+        assertThat(hits.getHits()[0].getExplanation().getDetails(), arrayWithSize(2));
+        assertThat(hits.getHits()[0].getExplanation().getDetails()[0].getDescription(), containsString("_name: func1"));
+    }
+
 }

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/FunctionScoreFieldValueIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/FunctionScoreFieldValueIT.java
@@ -35,10 +35,13 @@ package org.opensearch.search.functionscore;
 import org.opensearch.action.search.SearchPhaseExecutionException;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.lucene.search.function.FieldValueFactorFunction;
+import org.opensearch.search.SearchHit;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.arrayWithSize;
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.opensearch.index.query.QueryBuilders.functionScoreQuery;
 import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
@@ -162,5 +165,48 @@ public class FunctionScoreFieldValueIT extends OpenSearchIntegTestCase {
             // This is fine, the query will throw an exception if executed
             // locally, instead of just having failures
         }
+    }
+
+    public void testFieldValueFactorExplain() throws IOException {
+        assertAcked(
+            prepareCreate("test").addMapping(
+                "type1",
+                jsonBuilder().startObject()
+                    .startObject("type1")
+                    .startObject("properties")
+                    .startObject("test")
+                    .field("type", randomFrom(new String[] { "short", "float", "long", "integer", "double" }))
+                    .endObject()
+                    .startObject("body")
+                    .field("type", "text")
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject()
+            ).get()
+        );
+
+        client().prepareIndex("test", "type1", "1").setSource("test", 5, "body", "foo").get();
+        client().prepareIndex("test", "type1", "2").setSource("test", 17, "body", "foo").get();
+        client().prepareIndex("test", "type1", "3").setSource("body", "bar").get();
+
+        refresh();
+
+        // document 2 scores higher because 17 > 5
+        final String functionName = "func1";
+        final String queryName = "query";
+        SearchResponse response = client().prepareSearch("test")
+            .setExplain(true)
+            .setQuery(
+                functionScoreQuery(simpleQueryStringQuery("foo").queryName(queryName), fieldValueFactorFunction("test", functionName))
+            )
+            .get();
+        assertOrderedSearchHits(response, "2", "1");
+        SearchHit firstHit = response.getHits().getAt(0);
+        assertThat(firstHit.getExplanation().getDetails(), arrayWithSize(2));
+        // "description": "sum of: (_name: query)"
+        assertThat(firstHit.getExplanation().getDetails()[0].getDescription(), containsString("_name: " + queryName));
+        // "description": "field value function(_name: func1): none(doc['test'].value * factor=1.0)"
+        assertThat(firstHit.getExplanation().getDetails()[1].toString(), containsString("_name: " + functionName));
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/FunctionScorePluginIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/FunctionScorePluginIT.java
@@ -180,7 +180,7 @@ public class FunctionScorePluginIT extends OpenSearchIntegTestCase {
             }
 
             @Override
-            public Explanation explainFunction(String distanceString, double distanceVal, double scale) {
+            public Explanation explainFunction(String distanceString, double distanceVal, double scale, String functionName) {
                 return Explanation.match((float) distanceVal, "" + distanceVal);
             }
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/RandomScoreFunctionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/RandomScoreFunctionIT.java
@@ -63,6 +63,7 @@ import static org.opensearch.script.MockScriptPlugin.NAME;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -286,6 +287,37 @@ public class RandomScoreFunctionIT extends OpenSearchIntegTestCase {
         assertEquals(1, resp.getHits().getTotalHits().value);
         SearchHit firstHit = resp.getHits().getAt(0);
         assertThat(firstHit.getExplanation().toString(), containsString("" + seed));
+    }
+
+    public void testSeedAndNameReportedInExplain() throws Exception {
+        createIndex("test");
+        ensureGreen();
+        index("test", "type", "1", jsonBuilder().startObject().endObject());
+        flush();
+        refresh();
+
+        int seed = 12345678;
+
+        final String queryName = "query1";
+        final String functionName = "func1";
+        SearchResponse resp = client().prepareSearch("test")
+            .setQuery(
+                functionScoreQuery(
+                    matchAllQuery().queryName(queryName),
+                    randomFunction(functionName).seed(seed).setField(SeqNoFieldMapper.NAME)
+                )
+            )
+            .setExplain(true)
+            .get();
+        assertNoFailures(resp);
+        assertEquals(1, resp.getHits().getTotalHits().value);
+        SearchHit firstHit = resp.getHits().getAt(0);
+        assertThat(firstHit.getExplanation().getDetails(), arrayWithSize(2));
+        // "description": "*:* (_name: query1)"
+        assertThat(firstHit.getExplanation().getDetails()[0].getDescription().toString(), containsString("_name: " + queryName));
+        assertThat(firstHit.getExplanation().getDetails()[1].getDetails(), arrayWithSize(2));
+        // "description": "random score function (seed: 12345678, field: _seq_no, _name: func1)"
+        assertThat(firstHit.getExplanation().getDetails()[1].getDetails()[0].getDescription().toString(), containsString("seed: " + seed));
     }
 
     public void testNoDocs() throws Exception {

--- a/server/src/main/java/org/opensearch/common/lucene/search/function/FieldValueFactorFunction.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/function/FieldValueFactorFunction.java
@@ -35,6 +35,7 @@ package org.opensearch.common.lucene.search.function;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Explanation;
 import org.opensearch.OpenSearchException;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -55,6 +56,8 @@ public class FieldValueFactorFunction extends ScoreFunction {
     private final String field;
     private final float boostFactor;
     private final Modifier modifier;
+    private final String functionName;
+
     /**
      * Value used if the document is missing the field.
      */
@@ -68,12 +71,24 @@ public class FieldValueFactorFunction extends ScoreFunction {
         Double missing,
         IndexNumericFieldData indexFieldData
     ) {
+        this(field, boostFactor, modifierType, missing, indexFieldData, null);
+    }
+
+    public FieldValueFactorFunction(
+        String field,
+        float boostFactor,
+        Modifier modifierType,
+        Double missing,
+        IndexNumericFieldData indexFieldData,
+        @Nullable String functionName
+    ) {
         super(CombineFunction.MULTIPLY);
         this.field = field;
         this.boostFactor = boostFactor;
         this.modifier = modifierType;
         this.indexFieldData = indexFieldData;
         this.missing = missing;
+        this.functionName = functionName;
     }
 
     @Override
@@ -127,7 +142,7 @@ public class FieldValueFactorFunction extends ScoreFunction {
                     (float) score,
                     String.format(
                         Locale.ROOT,
-                        "field value function: %s(doc['%s'].value%s * factor=%s)",
+                        "field value function" + Functions.nameOrEmptyFunc(functionName) + ": %s(doc['%s'].value%s * factor=%s)",
                         modifierStr,
                         field,
                         defaultStr,

--- a/server/src/main/java/org/opensearch/common/lucene/search/function/Functions.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/function/Functions.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.lucene.search.function;
+
+import org.apache.lucene.search.Explanation;
+import org.opensearch.common.Strings;
+import org.opensearch.index.query.AbstractQueryBuilder;
+import org.opensearch.index.query.functionscore.FunctionScoreQueryBuilder;
+
+/**
+ * Helper utility class for functions
+ */
+public final class Functions {
+    private Functions() {}
+
+    /**
+     * Return function name wrapped into brackets or empty string, for example: '(_name: func1)'
+     * @param functionName function name
+     * @return function name wrapped into brackets or empty string
+     */
+    public static String nameOrEmptyFunc(final String functionName) {
+        if (!Strings.isNullOrEmpty(functionName)) {
+            return "(" + AbstractQueryBuilder.NAME_FIELD.getPreferredName() + ": " + functionName + ")";
+        } else {
+            return "";
+        }
+    }
+
+    /**
+     * Return function name as an argument or empty string, for example: ', _name: func1'
+     * @param functionName function name
+     * @return function name as an argument or empty string
+     */
+    public static String nameOrEmptyArg(final String functionName) {
+        if (!Strings.isNullOrEmpty(functionName)) {
+            return ", " + FunctionScoreQueryBuilder.NAME_FIELD.getPreferredName() + ": " + functionName;
+        } else {
+            return "";
+        }
+    }
+
+    /**
+     * Enrich explanation with query name
+     * @param explanation explanation
+     * @param queryName query name
+     * @return explanation enriched with query name
+     */
+    public static Explanation explainWithName(Explanation explanation, String queryName) {
+        if (Strings.isNullOrEmpty(queryName)) {
+            return explanation;
+        } else {
+            final String description = explanation.getDescription() + " " + nameOrEmptyFunc(queryName);
+            if (explanation.isMatch()) {
+                return Explanation.match(explanation.getValue(), description, explanation.getDetails());
+            } else {
+                return Explanation.noMatch(description, explanation.getDetails());
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/common/lucene/search/function/RandomScoreFunction.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/function/RandomScoreFunction.java
@@ -35,6 +35,7 @@ import com.carrotsearch.hppc.BitMixer;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.util.StringHelper;
+import org.opensearch.common.Nullable;
 import org.opensearch.index.fielddata.IndexFieldData;
 import org.opensearch.index.fielddata.LeafFieldData;
 import org.opensearch.index.fielddata.SortedBinaryDocValues;
@@ -50,6 +51,7 @@ public class RandomScoreFunction extends ScoreFunction {
     private final int originalSeed;
     private final int saltedSeed;
     private final IndexFieldData<?> fieldData;
+    private final String functionName;
 
     /**
      * Creates a RandomScoreFunction.
@@ -59,10 +61,23 @@ public class RandomScoreFunction extends ScoreFunction {
      * @param uidFieldData The field data for _uid to use for generating consistent random values for the same id
      */
     public RandomScoreFunction(int seed, int salt, IndexFieldData<?> uidFieldData) {
+        this(seed, salt, uidFieldData, null);
+    }
+
+    /**
+     * Creates a RandomScoreFunction.
+     *
+     * @param seed A seed for randomness
+     * @param salt A value to salt the seed with, ideally unique to the running node/index
+     * @param uidFieldData The field data for _uid to use for generating consistent random values for the same id
+     * @param functionName The function name
+     */
+    public RandomScoreFunction(int seed, int salt, IndexFieldData<?> uidFieldData, @Nullable String functionName) {
         super(CombineFunction.MULTIPLY);
         this.originalSeed = seed;
         this.saltedSeed = BitMixer.mix(seed, salt);
         this.fieldData = uidFieldData;
+        this.functionName = functionName;
     }
 
     @Override
@@ -97,7 +112,7 @@ public class RandomScoreFunction extends ScoreFunction {
                 String field = fieldData == null ? null : fieldData.getFieldName();
                 return Explanation.match(
                     (float) score(docId, subQueryScore.getValue().floatValue()),
-                    "random score function (seed: " + originalSeed + ", field: " + field + ")"
+                    "random score function (seed: " + originalSeed + ", field: " + field + Functions.nameOrEmptyArg(functionName) + ")"
                 );
             }
         };

--- a/server/src/main/java/org/opensearch/common/lucene/search/function/ScriptScoreQuery.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/function/ScriptScoreQuery.java
@@ -50,6 +50,7 @@ import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.BulkScorer;
 import org.apache.lucene.util.Bits;
 import org.opensearch.Version;
+import org.opensearch.common.Nullable;
 import org.opensearch.script.ScoreScript;
 import org.opensearch.script.ScoreScript.ExplanationHolder;
 import org.opensearch.script.Script;
@@ -69,6 +70,7 @@ public class ScriptScoreQuery extends Query {
     private final String indexName;
     private final int shardId;
     private final Version indexVersion;
+    private final String queryName;
 
     public ScriptScoreQuery(
         Query subQuery,
@@ -79,7 +81,21 @@ public class ScriptScoreQuery extends Query {
         int shardId,
         Version indexVersion
     ) {
+        this(subQuery, null, script, scriptBuilder, minScore, indexName, shardId, indexVersion);
+    }
+
+    public ScriptScoreQuery(
+        Query subQuery,
+        @Nullable String queryName,
+        Script script,
+        ScoreScript.LeafFactory scriptBuilder,
+        Float minScore,
+        String indexName,
+        int shardId,
+        Version indexVersion
+    ) {
         this.subQuery = subQuery;
+        this.queryName = queryName;
         this.script = script;
         this.scriptBuilder = scriptBuilder;
         this.minScore = minScore;
@@ -92,7 +108,7 @@ public class ScriptScoreQuery extends Query {
     public Query rewrite(IndexReader reader) throws IOException {
         Query newQ = subQuery.rewrite(reader);
         if (newQ != subQuery) {
-            return new ScriptScoreQuery(newQ, script, scriptBuilder, minScore, indexName, shardId, indexVersion);
+            return new ScriptScoreQuery(newQ, queryName, script, scriptBuilder, minScore, indexName, shardId, indexVersion);
         }
         return super.rewrite(reader);
     }
@@ -140,7 +156,7 @@ public class ScriptScoreQuery extends Query {
 
             @Override
             public Explanation explain(LeafReaderContext context, int doc) throws IOException {
-                Explanation subQueryExplanation = subQueryWeight.explain(context, doc);
+                Explanation subQueryExplanation = Functions.explainWithName(subQueryWeight.explain(context, doc), queryName);
                 if (subQueryExplanation.isMatch() == false) {
                     return subQueryExplanation;
                 }
@@ -210,7 +226,8 @@ public class ScriptScoreQuery extends Query {
     @Override
     public String toString(String field) {
         StringBuilder sb = new StringBuilder();
-        sb.append("script_score (").append(subQuery.toString(field)).append(", script: ");
+        sb.append("script_score (").append(subQuery.toString(field));
+        sb.append(Functions.nameOrEmptyArg(queryName)).append(", script: ");
         sb.append("{" + script.toString() + "}");
         return sb.toString();
     }
@@ -225,12 +242,13 @@ public class ScriptScoreQuery extends Query {
             && script.equals(that.script)
             && Objects.equals(minScore, that.minScore)
             && indexName.equals(that.indexName)
-            && indexVersion.equals(that.indexVersion);
+            && indexVersion.equals(that.indexVersion)
+            && Objects.equals(queryName, that.queryName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(subQuery, script, minScore, indexName, shardId, indexVersion);
+        return Objects.hash(subQuery, script, minScore, indexName, shardId, indexVersion, queryName);
     }
 
     private static class ScriptScorer extends Scorer {

--- a/server/src/main/java/org/opensearch/index/query/QueryBuilders.java
+++ b/server/src/main/java/org/opensearch/index/query/QueryBuilders.java
@@ -33,6 +33,7 @@
 package org.opensearch.index.query;
 
 import org.apache.lucene.search.join.ScoreMode;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.geo.GeoPoint;
 import org.opensearch.common.geo.ShapeRelation;
@@ -464,7 +465,17 @@ public final class QueryBuilders {
      * @param function The function builder used to custom score
      */
     public static FunctionScoreQueryBuilder functionScoreQuery(ScoreFunctionBuilder function) {
-        return new FunctionScoreQueryBuilder(function);
+        return functionScoreQuery(function, null);
+    }
+
+    /**
+     * A query that allows to define a custom scoring function.
+     *
+     * @param function The function builder used to custom score
+     * @param queryName The query name
+     */
+    public static FunctionScoreQueryBuilder functionScoreQuery(ScoreFunctionBuilder function, @Nullable String queryName) {
+        return new FunctionScoreQueryBuilder(function, queryName);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/query/ScriptQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/ScriptQueryBuilder.java
@@ -43,9 +43,11 @@ import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 import org.opensearch.OpenSearchException;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.lucene.search.function.Functions;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.script.FilterScript;
@@ -153,17 +155,19 @@ public class ScriptQueryBuilder extends AbstractQueryBuilder<ScriptQueryBuilder>
         }
         FilterScript.Factory factory = context.compile(script, FilterScript.CONTEXT);
         FilterScript.LeafFactory filterScript = factory.newFactory(script.getParams(), context.lookup());
-        return new ScriptQuery(script, filterScript);
+        return new ScriptQuery(script, filterScript, queryName);
     }
 
     static class ScriptQuery extends Query {
 
         final Script script;
         final FilterScript.LeafFactory filterScript;
+        final String queryName;
 
-        ScriptQuery(Script script, FilterScript.LeafFactory filterScript) {
+        ScriptQuery(Script script, FilterScript.LeafFactory filterScript, @Nullable String queryName) {
             this.script = script;
             this.filterScript = filterScript;
+            this.queryName = queryName;
         }
 
         @Override
@@ -171,6 +175,7 @@ public class ScriptQueryBuilder extends AbstractQueryBuilder<ScriptQueryBuilder>
             StringBuilder buffer = new StringBuilder();
             buffer.append("ScriptQuery(");
             buffer.append(script);
+            buffer.append(Functions.nameOrEmptyArg(queryName));
             buffer.append(")");
             return buffer.toString();
         }

--- a/server/src/main/java/org/opensearch/index/query/functionscore/DecayFunction.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/DecayFunction.java
@@ -33,6 +33,7 @@
 package org.opensearch.index.query.functionscore;
 
 import org.apache.lucene.search.Explanation;
+import org.opensearch.common.Nullable;
 
 /**
  * Implement this interface to provide a decay function that is executed on a
@@ -45,7 +46,7 @@ public interface DecayFunction {
 
     double evaluate(double value, double scale);
 
-    Explanation explainFunction(String valueString, double value, double scale);
+    Explanation explainFunction(String valueString, double value, double scale, @Nullable String functionName);
 
     /**
      * The final scale parameter is computed from the scale parameter given by

--- a/server/src/main/java/org/opensearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -35,6 +35,7 @@ package org.opensearch.index.query.functionscore;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Explanation;
 import org.opensearch.OpenSearchParseException;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.geo.GeoDistance;
@@ -96,7 +97,28 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
     /**
      * Convenience constructor that converts its parameters into json to parse on the data nodes.
      */
+    protected DecayFunctionBuilder(String fieldName, Object origin, Object scale, Object offset, @Nullable String functionName) {
+        this(fieldName, origin, scale, offset, DEFAULT_DECAY, functionName);
+    }
+
+    /**
+     * Convenience constructor that converts its parameters into json to parse on the data nodes.
+     */
     protected DecayFunctionBuilder(String fieldName, Object origin, Object scale, Object offset, double decay) {
+        this(fieldName, origin, scale, offset, decay, null);
+    }
+
+    /**
+     * Convenience constructor that converts its parameters into json to parse on the data nodes.
+     */
+    protected DecayFunctionBuilder(
+        String fieldName,
+        Object origin,
+        Object scale,
+        Object offset,
+        double decay,
+        @Nullable String functionName
+    ) {
         if (fieldName == null) {
             throw new IllegalArgumentException("decay function: field name must not be null");
         }
@@ -123,6 +145,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
         } catch (IOException e) {
             throw new IllegalArgumentException("unable to build inner function object", e);
         }
+        setFunctionName(functionName);
     }
 
     protected DecayFunctionBuilder(String fieldName, BytesReference functionBytes) {
@@ -285,7 +308,16 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
             );
         }
         IndexNumericFieldData numericFieldData = context.getForField(fieldType);
-        return new NumericFieldDataScoreFunction(origin, scale, decay, offset, getDecayFunction(), numericFieldData, mode);
+        return new NumericFieldDataScoreFunction(
+            origin,
+            scale,
+            decay,
+            offset,
+            getDecayFunction(),
+            numericFieldData,
+            mode,
+            getFunctionName()
+        );
     }
 
     private AbstractDistanceScoreFunction parseGeoVariable(
@@ -325,7 +357,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
         double scale = DistanceUnit.DEFAULT.parse(scaleString, DistanceUnit.DEFAULT);
         double offset = DistanceUnit.DEFAULT.parse(offsetString, DistanceUnit.DEFAULT);
         IndexGeoPointFieldData indexFieldData = context.getForField(fieldType);
-        return new GeoFieldDataScoreFunction(origin, scale, decay, offset, getDecayFunction(), indexFieldData, mode);
+        return new GeoFieldDataScoreFunction(origin, scale, decay, offset, getDecayFunction(), indexFieldData, mode, getFunctionName());
 
     }
 
@@ -375,7 +407,16 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
         val = TimeValue.parseTimeValue(offsetString, TimeValue.timeValueHours(24), DecayFunctionParser.class.getSimpleName() + ".offset");
         double offset = val.getMillis();
         IndexNumericFieldData numericFieldData = context.getForField(dateFieldType);
-        return new NumericFieldDataScoreFunction(origin, scale, decay, offset, getDecayFunction(), numericFieldData, mode);
+        return new NumericFieldDataScoreFunction(
+            origin,
+            scale,
+            decay,
+            offset,
+            getDecayFunction(),
+            numericFieldData,
+            mode,
+            getFunctionName()
+        );
     }
 
     static class GeoFieldDataScoreFunction extends AbstractDistanceScoreFunction {
@@ -392,9 +433,10 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
             double offset,
             DecayFunction func,
             IndexGeoPointFieldData fieldData,
-            MultiValueMode mode
+            MultiValueMode mode,
+            @Nullable String functionName
         ) {
-            super(scale, decay, offset, func, mode);
+            super(scale, decay, offset, func, mode, functionName);
             this.origin = origin;
             this.fieldData = fieldData;
         }
@@ -485,9 +527,10 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
             double offset,
             DecayFunction func,
             IndexNumericFieldData fieldData,
-            MultiValueMode mode
+            MultiValueMode mode,
+            @Nullable String functionName
         ) {
-            super(scale, decay, offset, func, mode);
+            super(scale, decay, offset, func, mode, functionName);
             this.fieldData = fieldData;
             this.origin = origin;
         }
@@ -569,13 +612,15 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
         protected final double offset;
         private final DecayFunction func;
         protected final MultiValueMode mode;
+        protected final String functionName;
 
         public AbstractDistanceScoreFunction(
             double userSuppiedScale,
             double decay,
             double offset,
             DecayFunction func,
-            MultiValueMode mode
+            MultiValueMode mode,
+            @Nullable String functionName
         ) {
             super(CombineFunction.MULTIPLY);
             this.mode = mode;
@@ -591,6 +636,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
                 throw new IllegalArgumentException(FunctionScoreQueryBuilder.NAME + " : offset must be > 0.0");
             }
             this.offset = offset;
+            this.functionName = functionName;
         }
 
         /**
@@ -624,7 +670,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
                     return Explanation.match(
                         (float) score(docId, subQueryScore.getValue().floatValue()),
                         "Function for field " + getFieldName() + ":",
-                        func.explainFunction(getDistanceString(ctx, docId), value, scale)
+                        func.explainFunction(getDistanceString(ctx, docId), value, scale, functionName)
                     );
                 }
             };

--- a/server/src/main/java/org/opensearch/index/query/functionscore/ExponentialDecayFunctionBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/ExponentialDecayFunctionBuilder.java
@@ -33,8 +33,10 @@
 package org.opensearch.index.query.functionscore;
 
 import org.apache.lucene.search.Explanation;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.lucene.search.function.Functions;
 
 import java.io.IOException;
 
@@ -45,12 +47,27 @@ public class ExponentialDecayFunctionBuilder extends DecayFunctionBuilder<Expone
     );
     public static final DecayFunction EXP_DECAY_FUNCTION = new ExponentialDecayScoreFunction();
 
+    public ExponentialDecayFunctionBuilder(String fieldName, Object origin, Object scale, Object offset, @Nullable String functionName) {
+        super(fieldName, origin, scale, offset, functionName);
+    }
+
     public ExponentialDecayFunctionBuilder(String fieldName, Object origin, Object scale, Object offset) {
         super(fieldName, origin, scale, offset);
     }
 
     public ExponentialDecayFunctionBuilder(String fieldName, Object origin, Object scale, Object offset, double decay) {
         super(fieldName, origin, scale, offset, decay);
+    }
+
+    public ExponentialDecayFunctionBuilder(
+        String fieldName,
+        Object origin,
+        Object scale,
+        Object offset,
+        double decay,
+        @Nullable String functionName
+    ) {
+        super(fieldName, origin, scale, offset, decay, functionName);
     }
 
     ExponentialDecayFunctionBuilder(String fieldName, BytesReference functionBytes) {
@@ -82,8 +99,11 @@ public class ExponentialDecayFunctionBuilder extends DecayFunctionBuilder<Expone
         }
 
         @Override
-        public Explanation explainFunction(String valueExpl, double value, double scale) {
-            return Explanation.match((float) evaluate(value, scale), "exp(- " + valueExpl + " * " + -1 * scale + ")");
+        public Explanation explainFunction(String valueExpl, double value, double scale, @Nullable String functionName) {
+            return Explanation.match(
+                (float) evaluate(value, scale),
+                "exp(- " + valueExpl + " * " + -1 * scale + Functions.nameOrEmptyArg(functionName) + ")"
+            );
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/index/query/functionscore/LinearDecayFunctionBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/LinearDecayFunctionBuilder.java
@@ -33,8 +33,10 @@
 package org.opensearch.index.query.functionscore;
 
 import org.apache.lucene.search.Explanation;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.lucene.search.function.Functions;
 
 import java.io.IOException;
 
@@ -47,8 +49,23 @@ public class LinearDecayFunctionBuilder extends DecayFunctionBuilder<LinearDecay
         super(fieldName, origin, scale, offset);
     }
 
+    public LinearDecayFunctionBuilder(String fieldName, Object origin, Object scale, Object offset, @Nullable String functionName) {
+        super(fieldName, origin, scale, offset, functionName);
+    }
+
     public LinearDecayFunctionBuilder(String fieldName, Object origin, Object scale, Object offset, double decay) {
         super(fieldName, origin, scale, offset, decay);
+    }
+
+    public LinearDecayFunctionBuilder(
+        String fieldName,
+        Object origin,
+        Object scale,
+        Object offset,
+        double decay,
+        @Nullable String functionName
+    ) {
+        super(fieldName, origin, scale, offset, decay, functionName);
     }
 
     LinearDecayFunctionBuilder(String fieldName, BytesReference functionBytes) {
@@ -80,8 +97,11 @@ public class LinearDecayFunctionBuilder extends DecayFunctionBuilder<LinearDecay
         }
 
         @Override
-        public Explanation explainFunction(String valueExpl, double value, double scale) {
-            return Explanation.match((float) evaluate(value, scale), "max(0.0, ((" + scale + " - " + valueExpl + ")/" + scale + ")");
+        public Explanation explainFunction(String valueExpl, double value, double scale, @Nullable String functionName) {
+            return Explanation.match(
+                (float) evaluate(value, scale),
+                "max(0.0, ((" + scale + " - " + valueExpl + ")/" + scale + Functions.nameOrEmptyArg(functionName) + ")"
+            );
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/index/query/functionscore/RandomScoreFunctionBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/RandomScoreFunctionBuilder.java
@@ -32,6 +32,7 @@
 package org.opensearch.index.query.functionscore;
 
 import org.opensearch.LegacyESVersion;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -58,6 +59,10 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
     private Integer seed;
 
     public RandomScoreFunctionBuilder() {}
+
+    public RandomScoreFunctionBuilder(@Nullable String functionName) {
+        setFunctionName(functionName);
+    }
 
     /**
      * Read from a stream.
@@ -171,7 +176,7 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
         final int salt = (context.index().getName().hashCode() << 10) | context.getShardId();
         if (seed == null) {
             // DocID-based random score generation
-            return new RandomScoreFunction(hash(context.nowInMillis()), salt, null);
+            return new RandomScoreFunction(hash(context.nowInMillis()), salt, null, getFunctionName());
         } else {
             final MappedFieldType fieldType;
             if (field != null) {
@@ -186,7 +191,7 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
             if (fieldType == null) {
                 if (context.getMapperService().documentMapper() == null) {
                     // no mappings: the index is empty anyway
-                    return new RandomScoreFunction(hash(context.nowInMillis()), salt, null);
+                    return new RandomScoreFunction(hash(context.nowInMillis()), salt, null, getFunctionName());
                 }
                 throw new IllegalArgumentException(
                     "Field [" + field + "] is not mapped on [" + context.index() + "] and cannot be used as a source of random numbers."
@@ -198,7 +203,7 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
             } else {
                 seed = hash(context.nowInMillis());
             }
-            return new RandomScoreFunction(seed, salt, context.getForField(fieldType));
+            return new RandomScoreFunction(seed, salt, context.getForField(fieldType), getFunctionName());
         }
     }
 
@@ -236,6 +241,8 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
                     }
                 } else if ("field".equals(currentFieldName)) {
                     randomScoreFunctionBuilder.setField(parser.text());
+                } else if (FunctionScoreQueryBuilder.NAME_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    randomScoreFunctionBuilder.setFunctionName(parser.text());
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), NAME + " query does not support [" + currentFieldName + "]");
                 }

--- a/server/src/main/java/org/opensearch/index/query/functionscore/ScoreFunctionBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/ScoreFunctionBuilder.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.index.query.functionscore;
 
+import org.opensearch.Version;
 import org.opensearch.common.io.stream.NamedWriteable;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -47,6 +48,7 @@ import java.util.Objects;
 public abstract class ScoreFunctionBuilder<FB extends ScoreFunctionBuilder<FB>> implements ToXContentFragment, NamedWriteable {
 
     private Float weight;
+    private String functionName;
 
     /**
      * Standard empty constructor.
@@ -58,11 +60,17 @@ public abstract class ScoreFunctionBuilder<FB extends ScoreFunctionBuilder<FB>> 
      */
     public ScoreFunctionBuilder(StreamInput in) throws IOException {
         weight = checkWeight(in.readOptionalFloat());
+        if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
+            functionName = in.readOptionalString();
+        }
     }
 
     @Override
     public final void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalFloat(weight);
+        if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
+            out.writeOptionalString(functionName);
+        }
         doWriteTo(out);
     }
 
@@ -99,11 +107,30 @@ public abstract class ScoreFunctionBuilder<FB extends ScoreFunctionBuilder<FB>> 
         return weight;
     }
 
+    /**
+     * The name of this function
+     */
+    public String getFunctionName() {
+        return functionName;
+    }
+
+    /**
+     * Set the name of this function
+     */
+    public void setFunctionName(String functionName) {
+        this.functionName = functionName;
+    }
+
     @Override
     public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         if (weight != null) {
             builder.field(FunctionScoreQueryBuilder.WEIGHT_FIELD.getPreferredName(), weight);
         }
+
+        if (functionName != null) {
+            builder.field(FunctionScoreQueryBuilder.NAME_FIELD.getPreferredName(), functionName);
+        }
+
         doXContent(builder, params);
         return builder;
     }
@@ -128,7 +155,7 @@ public abstract class ScoreFunctionBuilder<FB extends ScoreFunctionBuilder<FB>> 
         }
         @SuppressWarnings("unchecked")
         FB other = (FB) obj;
-        return Objects.equals(weight, other.getWeight()) && doEquals(other);
+        return Objects.equals(weight, other.getWeight()) && Objects.equals(functionName, other.getFunctionName()) && doEquals(other);
     }
 
     /**
@@ -139,7 +166,7 @@ public abstract class ScoreFunctionBuilder<FB extends ScoreFunctionBuilder<FB>> 
 
     @Override
     public final int hashCode() {
-        return Objects.hash(getClass(), weight, doHashCode());
+        return Objects.hash(getClass(), weight, functionName, doHashCode());
     }
 
     /**
@@ -156,7 +183,7 @@ public abstract class ScoreFunctionBuilder<FB extends ScoreFunctionBuilder<FB>> 
         if (weight == null) {
             return scoreFunction;
         }
-        return new WeightFactorFunction(weight, scoreFunction);
+        return new WeightFactorFunction(weight, scoreFunction, getFunctionName());
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/query/functionscore/ScoreFunctionBuilders.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/ScoreFunctionBuilders.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.index.query.functionscore;
 
+import org.opensearch.common.Nullable;
 import org.opensearch.script.Script;
 import org.opensearch.script.ScriptType;
 
@@ -46,8 +47,27 @@ public class ScoreFunctionBuilders {
         return new ExponentialDecayFunctionBuilder(fieldName, origin, scale, null);
     }
 
+    public static ExponentialDecayFunctionBuilder exponentialDecayFunction(
+        String fieldName,
+        Object origin,
+        Object scale,
+        @Nullable String functionName
+    ) {
+        return new ExponentialDecayFunctionBuilder(fieldName, origin, scale, null, functionName);
+    }
+
     public static ExponentialDecayFunctionBuilder exponentialDecayFunction(String fieldName, Object origin, Object scale, Object offset) {
         return new ExponentialDecayFunctionBuilder(fieldName, origin, scale, offset);
+    }
+
+    public static ExponentialDecayFunctionBuilder exponentialDecayFunction(
+        String fieldName,
+        Object origin,
+        Object scale,
+        Object offset,
+        @Nullable String functionName
+    ) {
+        return new ExponentialDecayFunctionBuilder(fieldName, origin, scale, offset, functionName);
     }
 
     public static ExponentialDecayFunctionBuilder exponentialDecayFunction(
@@ -60,8 +80,28 @@ public class ScoreFunctionBuilders {
         return new ExponentialDecayFunctionBuilder(fieldName, origin, scale, offset, decay);
     }
 
+    public static ExponentialDecayFunctionBuilder exponentialDecayFunction(
+        String fieldName,
+        Object origin,
+        Object scale,
+        Object offset,
+        double decay,
+        @Nullable String functionName
+    ) {
+        return new ExponentialDecayFunctionBuilder(fieldName, origin, scale, offset, decay, functionName);
+    }
+
     public static GaussDecayFunctionBuilder gaussDecayFunction(String fieldName, Object origin, Object scale) {
         return new GaussDecayFunctionBuilder(fieldName, origin, scale, null);
+    }
+
+    public static GaussDecayFunctionBuilder gaussDecayFunction(
+        String fieldName,
+        Object origin,
+        Object scale,
+        @Nullable String functionName
+    ) {
+        return new GaussDecayFunctionBuilder(fieldName, origin, scale, null, functionName);
     }
 
     public static GaussDecayFunctionBuilder gaussDecayFunction(String fieldName, Object origin, Object scale, Object offset) {
@@ -70,6 +110,26 @@ public class ScoreFunctionBuilders {
 
     public static GaussDecayFunctionBuilder gaussDecayFunction(String fieldName, Object origin, Object scale, Object offset, double decay) {
         return new GaussDecayFunctionBuilder(fieldName, origin, scale, offset, decay);
+    }
+
+    public static GaussDecayFunctionBuilder gaussDecayFunction(
+        String fieldName,
+        Object origin,
+        Object scale,
+        Object offset,
+        double decay,
+        @Nullable String functionName
+    ) {
+        return new GaussDecayFunctionBuilder(fieldName, origin, scale, offset, decay, functionName);
+    }
+
+    public static LinearDecayFunctionBuilder linearDecayFunction(
+        String fieldName,
+        Object origin,
+        Object scale,
+        @Nullable String functionName
+    ) {
+        return new LinearDecayFunctionBuilder(fieldName, origin, scale, null, functionName);
     }
 
     public static LinearDecayFunctionBuilder linearDecayFunction(String fieldName, Object origin, Object scale) {
@@ -85,28 +145,69 @@ public class ScoreFunctionBuilders {
         Object origin,
         Object scale,
         Object offset,
+        @Nullable String functionName
+    ) {
+        return new LinearDecayFunctionBuilder(fieldName, origin, scale, offset, functionName);
+    }
+
+    public static LinearDecayFunctionBuilder linearDecayFunction(
+        String fieldName,
+        Object origin,
+        Object scale,
+        Object offset,
         double decay
     ) {
         return new LinearDecayFunctionBuilder(fieldName, origin, scale, offset, decay);
     }
 
+    public static LinearDecayFunctionBuilder linearDecayFunction(
+        String fieldName,
+        Object origin,
+        Object scale,
+        Object offset,
+        double decay,
+        @Nullable String functionName
+    ) {
+        return new LinearDecayFunctionBuilder(fieldName, origin, scale, offset, decay, functionName);
+    }
+
     public static ScriptScoreFunctionBuilder scriptFunction(Script script) {
-        return (new ScriptScoreFunctionBuilder(script));
+        return scriptFunction(script, null);
     }
 
     public static ScriptScoreFunctionBuilder scriptFunction(String script) {
-        return (new ScriptScoreFunctionBuilder(new Script(ScriptType.INLINE, Script.DEFAULT_SCRIPT_LANG, script, emptyMap())));
+        return scriptFunction(script, null);
     }
 
     public static RandomScoreFunctionBuilder randomFunction() {
-        return new RandomScoreFunctionBuilder();
+        return randomFunction(null);
     }
 
     public static WeightBuilder weightFactorFunction(float weight) {
-        return (WeightBuilder) (new WeightBuilder().setWeight(weight));
+        return weightFactorFunction(weight, null);
     }
 
     public static FieldValueFactorFunctionBuilder fieldValueFactorFunction(String fieldName) {
-        return new FieldValueFactorFunctionBuilder(fieldName);
+        return fieldValueFactorFunction(fieldName, null);
+    }
+
+    public static ScriptScoreFunctionBuilder scriptFunction(Script script, @Nullable String functionName) {
+        return new ScriptScoreFunctionBuilder(script, functionName);
+    }
+
+    public static ScriptScoreFunctionBuilder scriptFunction(String script, @Nullable String functionName) {
+        return new ScriptScoreFunctionBuilder(new Script(ScriptType.INLINE, Script.DEFAULT_SCRIPT_LANG, script, emptyMap()), functionName);
+    }
+
+    public static RandomScoreFunctionBuilder randomFunction(@Nullable String functionName) {
+        return new RandomScoreFunctionBuilder(functionName);
+    }
+
+    public static WeightBuilder weightFactorFunction(float weight, @Nullable String functionName) {
+        return (WeightBuilder) (new WeightBuilder(functionName).setWeight(weight));
+    }
+
+    public static FieldValueFactorFunctionBuilder fieldValueFactorFunction(String fieldName, @Nullable String functionName) {
+        return new FieldValueFactorFunctionBuilder(fieldName, functionName);
     }
 }

--- a/server/src/main/java/org/opensearch/index/query/functionscore/ScriptScoreFunctionBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/ScriptScoreFunctionBuilder.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.index.query.functionscore;
 
+import org.opensearch.common.Nullable;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -57,10 +58,15 @@ public class ScriptScoreFunctionBuilder extends ScoreFunctionBuilder<ScriptScore
     private final Script script;
 
     public ScriptScoreFunctionBuilder(Script script) {
+        this(script, null);
+    }
+
+    public ScriptScoreFunctionBuilder(Script script, @Nullable String functionName) {
         if (script == null) {
             throw new IllegalArgumentException("script must not be null");
         }
         this.script = script;
+        setFunctionName(functionName);
     }
 
     /**
@@ -112,7 +118,8 @@ public class ScriptScoreFunctionBuilder extends ScoreFunctionBuilder<ScriptScore
                 searchScript,
                 context.index().getName(),
                 context.getShardId(),
-                context.indexVersionCreated()
+                context.indexVersionCreated(),
+                getFunctionName()
             );
         } catch (Exception e) {
             throw new QueryShardException(context, "script_score: the script could not be loaded", e);

--- a/server/src/main/java/org/opensearch/index/query/functionscore/ScriptScoreQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/ScriptScoreQueryBuilder.java
@@ -195,9 +195,11 @@ public class ScriptScoreQueryBuilder extends AbstractQueryBuilder<ScriptScoreQue
         }
         ScoreScript.Factory factory = context.compile(script, ScoreScript.CONTEXT);
         ScoreScript.LeafFactory scoreScriptFactory = factory.newFactory(script.getParams(), context.lookup());
-        Query query = this.query.toQuery(context);
+        final QueryBuilder queryBuilder = this.query;
+        Query query = queryBuilder.toQuery(context);
         return new ScriptScoreQuery(
             query,
+            queryBuilder.queryName(),
             script,
             scoreScriptFactory,
             minScore,

--- a/server/src/main/java/org/opensearch/index/query/functionscore/WeightBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/WeightBuilder.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.index.query.functionscore;
 
+import org.opensearch.common.Nullable;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.lucene.search.function.ScoreFunction;
@@ -50,6 +51,13 @@ public class WeightBuilder extends ScoreFunctionBuilder<WeightBuilder> {
      * Standard constructor.
      */
     public WeightBuilder() {}
+
+    /**
+     * Standard constructor.
+     */
+    public WeightBuilder(@Nullable String functionName) {
+        setFunctionName(functionName);
+    }
 
     /**
      * Read from a stream.

--- a/server/src/main/java/org/opensearch/script/ExplainableScoreScript.java
+++ b/server/src/main/java/org/opensearch/script/ExplainableScoreScript.java
@@ -33,6 +33,7 @@
 package org.opensearch.script;
 
 import org.apache.lucene.search.Explanation;
+import org.opensearch.common.Nullable;
 
 import java.io.IOException;
 
@@ -49,7 +50,21 @@ public interface ExplainableScoreScript {
      * want to explain how that was computed.
      *
      * @param subQueryScore the Explanation for _score
+     * @deprecated please use {@code explain(Explanation subQueryScore, @Nullable String scriptName)}
      */
+    @Deprecated
     Explanation explain(Explanation subQueryScore) throws IOException;
+
+    /**
+     * Build the explanation of the current document being scored
+     * The script score needs the Explanation of the sub query score because it might use _score and
+     * want to explain how that was computed.
+     *
+     * @param subQueryScore the Explanation for _score
+     * @param scriptName the script name
+     */
+    default Explanation explain(Explanation subQueryScore, @Nullable String scriptName) throws IOException {
+        return explain(subQueryScore);
+    }
 
 }


### PR DESCRIPTION
### Description
Backport of https://github.com/opensearch-project/OpenSearch/pull/2244 to `1.x`
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/1711
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
