### PR TITLE
Fixing the --release flag usage for javac (#2343)

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchJavaPlugin.java
@@ -173,7 +173,10 @@ public class OpenSearchJavaPlugin implements Plugin<Project> {
                 // workaround for https://github.com/gradle/gradle/issues/14141
                 compileTask.getConventionMapping().map("sourceCompatibility", () -> java.getSourceCompatibility().toString());
                 compileTask.getConventionMapping().map("targetCompatibility", () -> java.getTargetCompatibility().toString());
-                compileOptions.getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
+                // The '--release is available from JDK-9 and above
+                if (BuildParams.getRuntimeJavaVersion().compareTo(JavaVersion.VERSION_1_8) > 0) {
+                    compileOptions.getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
+                }
             });
             // also apply release flag to groovy, which is used in build-tools
             project.getTasks().withType(GroovyCompile.class).configureEach(compileTask -> {
@@ -267,7 +270,9 @@ public class OpenSearchJavaPlugin implements Plugin<Project> {
              * that the default will change to html5 in the future.
              */
             CoreJavadocOptions javadocOptions = (CoreJavadocOptions) javadoc.getOptions();
-            javadocOptions.addBooleanOption("html5", true);
+            if (BuildParams.getRuntimeJavaVersion().compareTo(JavaVersion.VERSION_1_8) > 0) {
+                javadocOptions.addBooleanOption("html5", true);
+            }
         });
 
         TaskProvider<Javadoc> javadoc = project.getTasks().withType(Javadoc.class).named("javadoc");

--- a/distribution/tools/java-version-checker/build.gradle
+++ b/distribution/tools/java-version-checker/build.gradle
@@ -11,7 +11,8 @@
 
 apply plugin: 'opensearch.build'
 
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 // targetting very old java versions enables a warning by default on newer JDK: disable it.
 compileJava.options.compilerArgs += '-Xlint:-options'
 


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

* Fixing the --release flag usage for javac
* Fixing the --html5 flag usage for javadoc

### Description
Bringing https://github.com/opensearch-project/OpenSearch/pull/2343 to `main`
 
### Issues Resolved
Part of https://github.com/opensearch-project/job-scheduler/pull/130
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
