### PR TITLE
Remove type end-points from count action

### DIFF
--- a/server/src/main/java/org/opensearch/rest/action/search/RestCountAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/search/RestCountAction.java
@@ -66,10 +66,7 @@ public class RestCountAction extends BaseRestHandler {
                 new Route(GET, "/_count"),
                 new Route(POST, "/_count"),
                 new Route(GET, "/{index}/_count"),
-                new Route(POST, "/{index}/_count"),
-                // Deprecated typed endpoints.
-                new Route(GET, "/{index}/{type}/_count"),
-                new Route(POST, "/{index}/{type}/_count")
+                new Route(POST, "/{index}/_count")
             )
         );
     }


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Removes type endpoint from count action. Internal reference removal were done as part of https://github.com/opensearch-project/OpenSearch/pull/2109

Related #1940 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
