### PR TITLE
Remove inclue_type_name parameter from rest api spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
@@ -22,10 +22,6 @@
       ]
     },
     "params":{
-      "include_type_name":{
-        "type":"boolean",
-        "description":"Whether a type should be expected in the body of the mappings."
-      },
       "wait_for_active_shards":{
         "type":"string",
         "description":"Set the number of active shards to wait for before the operation returns."

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
@@ -22,10 +22,6 @@
       ]
     },
     "params":{
-      "include_type_name":{
-        "type":"boolean",
-        "description":"Whether to add the type name to the response (default: false)"
-      },
       "local":{
         "type":"boolean",
         "description":"Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
@@ -38,10 +38,6 @@
       ]
     },
     "params":{
-      "include_type_name":{
-        "type":"boolean",
-        "description":"Whether a type should be returned in the body of the mappings."
-      },
       "include_defaults":{
         "type":"boolean",
         "description":"Whether the default mapping values should be returned as well"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
@@ -28,10 +28,6 @@
       ]
     },
     "params":{
-      "include_type_name":{
-        "type":"boolean",
-        "description":"Whether a type should be returned in the body of the mappings."
-      },
       "flat_settings":{
         "type":"boolean",
         "description":"Return settings in flat format (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
@@ -23,10 +23,6 @@
       ]
     },
     "params":{
-      "include_type_name":{
-        "type":"boolean",
-        "description":"Whether a type should be returned in the body of the mappings."
-      },
       "order":{
         "type":"number",
         "description":"The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
@@ -38,10 +38,6 @@
       ]
     },
     "params":{
-      "include_type_name":{
-        "type":"boolean",
-        "description":"Whether a type should be included in the body of the mappings."
-      },
       "timeout":{
         "type":"time",
         "description":"Explicit operation timeout"

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestGetFieldMappingAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestGetFieldMappingAction.java
@@ -60,7 +60,6 @@ import static org.opensearch.rest.RestStatus.NOT_FOUND;
 import static org.opensearch.rest.RestStatus.OK;
 
 public class RestGetFieldMappingAction extends BaseRestHandler {
-
     private static final Logger logger = LogManager.getLogger(RestGetFieldMappingAction.class);
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(logger.getName());
 
@@ -107,7 +106,7 @@ public class RestGetFieldMappingAction extends BaseRestHandler {
                         status = NOT_FOUND;
                     }
                     response.toXContent(builder, request);
-                    return new BytesRestResponse(RestStatus.OK, builder);
+                    return new BytesRestResponse(status, builder);
                 }
             });
     }


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Removes include_type_name from rest api specs. Removal from rest layer completed in https://github.com/opensearch-project/OpenSearch/pull/2397

Related to meta #1940 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
