### PR TITLE
Updates to segrep classes to mirror refactoring in main

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -1122,9 +1122,10 @@ public abstract class Engine implements Closeable {
     /**
      * Fetch a snapshot of the latest SegmentInfos from the engine and ensure that segment files are retained in the directory
      * until closed.
-     * @return {@link SegmentInfosRef} - A ref to segmentInfos that must be closed for segment files to be deleted.
+     * @return {@link GatedCloseable} - A wrapper around a {@link SegmentInfos} instance that must be closed for segment files
+     * to be deleted.
      */
-    public SegmentInfosRef getLatestSegmentInfosSafe() {
+    public GatedCloseable<SegmentInfos> getLatestSegmentInfosSafe() {
         return null;
     };
 

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -2269,7 +2269,7 @@ public class InternalEngine extends Engine {
     }
 
     @Override
-    public SegmentInfosRef getLatestSegmentInfosSafe() {
+    public GatedCloseable<SegmentInfos> getLatestSegmentInfosSafe() {
         assert (engineConfig.isReadOnly() == false);
         final SegmentInfos segmentInfos = getLatestSegmentInfos();
         try {
@@ -2277,7 +2277,7 @@ public class InternalEngine extends Engine {
         } catch (IOException e) {
             throw new EngineException(shardId, e.getMessage(), e);
         }
-        return new Engine.SegmentInfosRef(segmentInfos, () -> indexWriter.decRefDeleter(segmentInfos));
+        return new GatedCloseable<>(segmentInfos, () -> indexWriter.decRefDeleter(segmentInfos));
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1498,10 +1498,10 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     /**
      * Fetch a ref to the latest SegmentInfos held by the engine.  This ensures the files will not be deleted until
      * the ref is closed.
-     * @return {@link Engine.SegmentInfosRef}
+     * @return a {@link GatedCloseable} wrapper around a {@link SegmentInfos} instance
      * @throws EngineException - When infos cannot be retrieved from the Engine.
      */
-    public Engine.SegmentInfosRef getLatestSegmentInfosSafe() throws EngineException {
+    public GatedCloseable<SegmentInfos> getLatestSegmentInfosSafe() throws EngineException {
         return getEngine().getLatestSegmentInfosSafe();
     }
 

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationReplicaService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationReplicaService.java
@@ -178,7 +178,7 @@ public class SegmentReplicationReplicaService implements IndexEventListener {
                 logger.trace("not running replication with id [{}] - can not find it (probably finished)", replicationId);
                 return;
             }
-            final ReplicationTarget replicationTarget = replicationRef.target();
+            final ReplicationTarget replicationTarget = replicationRef.get();
             timer = replicationTarget.state().getTimer();
             final IndexShard indexShard = replicationTarget.getIndexShard();
 
@@ -217,7 +217,7 @@ public class SegmentReplicationReplicaService implements IndexEventListener {
                     );
                     onGoingReplications.failReplication(
                         replicationId,
-                        new ReplicationFailedException(replicationRef.target().getIndexShard(), "unexpected error", e),
+                        new ReplicationFailedException(replicationRef.get().getIndexShard(), "unexpected error", e),
                         true // be safe
                     );
                 } else {

--- a/server/src/main/java/org/opensearch/indices/replication/copy/CopyState.java
+++ b/server/src/main/java/org/opensearch/indices/replication/copy/CopyState.java
@@ -11,8 +11,8 @@ package org.opensearch.indices.replication.copy;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.store.ByteBuffersIndexOutput;
+import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.util.concurrent.AbstractRefCounted;
-import org.opensearch.index.engine.Engine;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.store.Store;
 
@@ -21,7 +21,7 @@ import java.io.UncheckedIOException;
 
 public class CopyState extends AbstractRefCounted {
 
-    private final Engine.SegmentInfosRef segmentInfosRef;
+    private final GatedCloseable<SegmentInfos> segmentInfosRef;
     private final ReplicationCheckpoint checkpoint;
     private final Store.MetadataSnapshot metadataSnapshot;
     private final byte[] infosBytes;
@@ -29,7 +29,7 @@ public class CopyState extends AbstractRefCounted {
     CopyState(IndexShard shard) throws IOException {
         super("replication-nrt-state");
         this.segmentInfosRef = shard.getLatestSegmentInfosSafe();
-        final SegmentInfos segmentInfos = segmentInfosRef.getSegmentInfos();
+        final SegmentInfos segmentInfos = segmentInfosRef.get();
         this.checkpoint = new ReplicationCheckpoint(
             shard.shardId(),
             shard.getOperationPrimaryTerm(),

--- a/server/src/main/java/org/opensearch/indices/replication/copy/PrimaryShardReplicationSource.java
+++ b/server/src/main/java/org/opensearch/indices/replication/copy/PrimaryShardReplicationSource.java
@@ -231,7 +231,7 @@ public class PrimaryShardReplicationSource {
                 ReplicationCollection.ReplicationRef replicationRef = segmentReplicationReplicaService.getOnGoingReplications()
                     .getReplicationSafe(request.getReplicationId(), request.shardId())
             ) {
-                final ReplicationTarget replicationTarget = replicationRef.target();
+                final ReplicationTarget replicationTarget = replicationRef.get();
                 final ActionListener<Void> listener = createOrFinishListener(replicationRef, channel, Actions.FILE_CHUNK, request);
                 if (listener == null) {
                     return;
@@ -274,7 +274,7 @@ public class PrimaryShardReplicationSource {
         final ReplicationFileChunkRequest request,
         final CheckedFunction<Void, TransportResponse, Exception> responseFn
     ) {
-        final ReplicationTarget replicationTarget = replicationRef.target();
+        final ReplicationTarget replicationTarget = replicationRef.get();
         final ActionListener<TransportResponse> channelListener = new ChannelActionListener<>(channel, action, request);
         final ActionListener<Void> voidListener = ActionListener.map(channelListener, responseFn);
 


### PR DESCRIPTION
### Description
This PR comprises two changes:
1. The first updates the `ReplicationRef` class to mirror `RecoveryRef` and simply be an extension of `GatedAutoCloseable`.
2. The second change removes the SegmentInfosRef class and replaces it with GatedCloseable wrapper. This is similar to the removal of the IndexCommitRef class.
 
### Issues Resolved
closes #2202 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
