### PR TITLE
[Remove] Type mapping end-points from RestMultiSearchTemplateAction

### DIFF
--- a/modules/lang-mustache/src/main/java/org/opensearch/script/mustache/RestMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/opensearch/script/mustache/RestMultiSearchTemplateAction.java
@@ -75,10 +75,7 @@ public class RestMultiSearchTemplateAction extends BaseRestHandler {
                 new Route(GET, "/_msearch/template"),
                 new Route(POST, "/_msearch/template"),
                 new Route(GET, "/{index}/_msearch/template"),
-                new Route(POST, "/{index}/_msearch/template"),
-                // Deprecated typed endpoints.
-                new Route(GET, "/{index}/{type}/_msearch/template"),
-                new Route(POST, "/{index}/{type}/_msearch/template")
+                new Route(POST, "/{index}/_msearch/template")
             )
         );
     }


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Type mapping end-points from RestMultiSearchTemplateAction. This change escaped in https://github.com/opensearch-project/OpenSearch/pull/2263

Related to #1940 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
