### PR TITLE
[Remove] types based addMapping method from CreateIndexRequest and Builder

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -42,8 +42,6 @@ import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.common.Priority;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
-import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.monitor.os.OsStats;
 import org.opensearch.node.NodeRoleSettings;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -276,19 +274,13 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
         assertThat(response.getStatus(), Matchers.equalTo(ClusterHealthStatus.GREEN));
         assertTrue(response.getIndicesStats().getMappings().getFieldTypeStats().isEmpty());
 
-        client().admin()
-            .indices()
-            .prepareCreate("test1")
-            .addMapping(MapperService.SINGLE_MAPPING_NAME, "{\"properties\":{\"foo\":{\"type\": \"keyword\"}}}", XContentType.JSON)
-            .get();
+        client().admin().indices().prepareCreate("test1").setMapping("{\"properties\":{\"foo\":{\"type\": \"keyword\"}}}").get();
         client().admin()
             .indices()
             .prepareCreate("test2")
-            .addMapping(
-                MapperService.SINGLE_MAPPING_NAME,
+            .setMapping(
                 "{\"properties\":{\"foo\":{\"type\": \"keyword\"},\"bar\":{\"properties\":{\"baz\":{\"type\":\"keyword\"},"
-                    + "\"eggplant\":{\"type\":\"integer\"}}}}}",
-                XContentType.JSON
+                    + "\"eggplant\":{\"type\":\"integer\"}}}}}"
             )
             .get();
         response = client().admin().cluster().prepareClusterStats().get();

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/get/GetIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/get/GetIndexIT.java
@@ -40,7 +40,6 @@ import org.opensearch.cluster.metadata.AliasMetadata;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
@@ -64,12 +63,7 @@ import static org.hamcrest.Matchers.notNullValue;
 public class GetIndexIT extends OpenSearchIntegTestCase {
     @Override
     protected void setupSuiteScopeCluster() throws Exception {
-        assertAcked(
-            prepareCreate("idx").addAlias(new Alias("alias_idx"))
-                .addMapping("type1", "{\"type1\":{}}", XContentType.JSON)
-                .setSettings(Settings.builder().put("number_of_shards", 1))
-                .get()
-        );
+        assertAcked(prepareCreate("idx").addAlias(new Alias("alias_idx")).setSettings(Settings.builder().put("number_of_shards", 1)).get());
         ensureSearchable("idx");
         createIndex("empty_idx");
         ensureSearchable("idx", "empty_idx");

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/SpecificMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/SpecificMasterNodesIT.java
@@ -36,7 +36,6 @@ import org.apache.lucene.search.join.ScoreMode;
 import org.opensearch.action.admin.cluster.configuration.AddVotingConfigExclusionsAction;
 import org.opensearch.action.admin.cluster.configuration.AddVotingConfigExclusionsRequest;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.discovery.MasterNotDiscoveredException;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -321,11 +320,9 @@ public class SpecificMasterNodesIT extends OpenSearchIntegTestCase {
         internalCluster().startDataOnlyNode();
 
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
-                "{\"type1\" : {\"properties\" : {\"table_a\" : { \"type\" : \"nested\", "
-                    + "\"properties\" : {\"field_a\" : { \"type\" : \"keyword\" },\"field_b\" :{ \"type\" : \"keyword\" }}}}}}",
-                XContentType.JSON
+            prepareCreate("test").setMapping(
+                "{\"properties\" : {\"table_a\" : { \"type\" : \"nested\", "
+                    + "\"properties\" : {\"field_a\" : { \"type\" : \"keyword\" },\"field_b\" :{ \"type\" : \"keyword\" }}}}}"
             )
         );
         client().admin()

--- a/server/src/internalClusterTest/java/org/opensearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/GatewayIndexStateIT.java
@@ -57,7 +57,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Priority;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.index.mapper.MapperParsingException;
 import org.opensearch.indices.IndexClosedException;
@@ -483,19 +482,15 @@ public class GatewayIndexStateIT extends OpenSearchIntegTestCase {
         prepareCreate("test").setSettings(
             Settings.builder().put("index.analysis.analyzer.test.tokenizer", "standard").put("index.number_of_shards", "1")
         )
-            .addMapping(
-                "type1",
+            .setMapping(
                 "{\n"
-                    + "    \"type1\": {\n"
-                    + "      \"properties\": {\n"
-                    + "        \"field1\": {\n"
-                    + "          \"type\": \"text\",\n"
-                    + "          \"analyzer\": \"test\"\n"
-                    + "        }\n"
+                    + "    \"properties\": {\n"
+                    + "      \"field1\": {\n"
+                    + "        \"type\": \"text\",\n"
+                    + "        \"analyzer\": \"test\"\n"
                     + "      }\n"
                     + "    }\n"
-                    + "  }}",
-                XContentType.JSON
+                    + "  }"
             )
             .get();
         logger.info("--> indexing a simple document");

--- a/server/src/internalClusterTest/java/org/opensearch/gateway/RecoveryFromGatewayIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/RecoveryFromGatewayIT.java
@@ -51,7 +51,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexService;
@@ -115,16 +114,14 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("type1")
                 .startObject("properties")
                 .startObject("appAccountIds")
                 .field("type", "text")
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
-        assertAcked(prepareCreate("test").addMapping("type1", mapping, XContentType.JSON));
+        assertAcked(prepareCreate("test").setMapping(mapping));
 
         client().prepareIndex("test")
             .setId("10990239")
@@ -212,7 +209,6 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("type1")
                 .startObject("properties")
                 .startObject("field")
                 .field("type", "text")
@@ -222,14 +218,13 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
         // note: default replica settings are tied to #data nodes-1 which is 0 here. We can do with 1 in this test.
         int numberOfShards = numberOfShards();
         assertAcked(
             prepareCreate("test").setSettings(
                 Settings.builder().put(SETTING_NUMBER_OF_SHARDS, numberOfShards()).put(SETTING_NUMBER_OF_REPLICAS, randomIntBetween(0, 1))
-            ).addMapping("type1", mapping, XContentType.JSON)
+            ).setMapping(mapping)
         );
 
         int value1Docs;

--- a/server/src/internalClusterTest/java/org/opensearch/get/GetActionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/get/GetActionIT.java
@@ -291,7 +291,6 @@ public class GetActionIT extends OpenSearchIntegTestCase {
         String mapping1 = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("type1")
                 .startObject("properties")
                 .startObject("field")
                 .field("type", "text")
@@ -299,9 +298,8 @@ public class GetActionIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
-        assertAcked(prepareCreate("test").addMapping("type1", mapping1, XContentType.JSON));
+        assertAcked(prepareCreate("test").setMapping(mapping1));
         ensureGreen();
 
         GetResponse response = client().prepareGet("test", "1").get();

--- a/server/src/internalClusterTest/java/org/opensearch/index/mapper/CopyToMapperIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/mapper/CopyToMapperIntegrationIT.java
@@ -36,7 +36,6 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.Strings;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.Aggregator.SubAggCollectionMode;
@@ -81,7 +80,6 @@ public class CopyToMapperIntegrationIT extends OpenSearchIntegTestCase {
     public void testDynamicObjectCopyTo() throws Exception {
         String mapping = Strings.toString(
             jsonBuilder().startObject()
-                .startObject("_doc")
                 .startObject("properties")
                 .startObject("foo")
                 .field("type", "text")
@@ -89,9 +87,8 @@ public class CopyToMapperIntegrationIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
-        assertAcked(client().admin().indices().prepareCreate("test-idx").addMapping("_doc", mapping, XContentType.JSON));
+        assertAcked(client().admin().indices().prepareCreate("test-idx").setMapping(mapping));
         client().prepareIndex("test-idx").setId("1").setSource("foo", "bar").get();
         client().admin().indices().prepareRefresh("test-idx").execute().actionGet();
         SearchResponse response = client().prepareSearch("test-idx").setQuery(QueryBuilders.termQuery("root.top.child", "bar")).get();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/mapping/ConcurrentDynamicTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/mapping/ConcurrentDynamicTemplateIT.java
@@ -34,7 +34,6 @@ package org.opensearch.indices.mapping;
 
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.index.IndexResponse;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
@@ -49,14 +48,10 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.emptyIterable;
 
 public class ConcurrentDynamicTemplateIT extends OpenSearchIntegTestCase {
-    private final String mappingType = "test-mapping";
-
     // see #3544
     public void testConcurrentDynamicMapping() throws Exception {
         final String fieldName = "field";
-        final String mapping = "{ \""
-            + mappingType
-            + "\": {"
+        final String mapping = "{ "
             + "\"dynamic_templates\": ["
             + "{ \""
             + fieldName
@@ -65,14 +60,14 @@ public class ConcurrentDynamicTemplateIT extends OpenSearchIntegTestCase {
             + "\"mapping\": {"
             + "\"type\": \"text\","
             + "\"store\": true,"
-            + "\"analyzer\": \"whitespace\" } } } ] } }";
+            + "\"analyzer\": \"whitespace\" } } } ] }";
         // The 'fieldNames' array is used to help with retrieval of index terms
         // after testing
 
         int iters = scaledRandomIntBetween(5, 15);
         for (int i = 0; i < iters; i++) {
             cluster().wipeIndices("test");
-            assertAcked(prepareCreate("test").addMapping(mappingType, mapping, XContentType.JSON));
+            assertAcked(prepareCreate("test").setMapping(mapping));
             int numDocs = scaledRandomIntBetween(10, 100);
             final CountDownLatch latch = new CountDownLatch(numDocs);
             final List<Throwable> throwable = new CopyOnWriteArrayList<>();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/mapping/UpdateMappingIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/mapping/UpdateMappingIntegrationIT.java
@@ -145,7 +145,7 @@ public class UpdateMappingIntegrationIT extends OpenSearchIntegTestCase {
             .indices()
             .prepareCreate("test")
             .setSettings(Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
-            .addMapping("_doc", "{\"_doc\":{\"properties\":{\"body\":{\"type\":\"text\"}}}}", XContentType.JSON)
+            .setMapping("{\"properties\":{\"body\":{\"type\":\"text\"}}}")
             .execute()
             .actionGet();
         client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
@@ -196,7 +196,7 @@ public class UpdateMappingIntegrationIT extends OpenSearchIntegTestCase {
             .indices()
             .prepareCreate("test")
             .setSettings(Settings.builder().put("index.number_of_shards", 2).put("index.number_of_replicas", 0))
-            .addMapping("type", "{\"type\":{\"properties\":{\"body\":{\"type\":\"text\"}}}}", XContentType.JSON)
+            .setMapping("{\"properties\":{\"body\":{\"type\":\"text\"}}}")
             .execute()
             .actionGet();
         client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
@@ -221,7 +221,7 @@ public class UpdateMappingIntegrationIT extends OpenSearchIntegTestCase {
         client().admin()
             .indices()
             .prepareCreate("test")
-            .addMapping("type", "{\"type\":{\"properties\":{\"body\":{\"type\":\"text\", \"norms\": false }}}}", XContentType.JSON)
+            .setMapping("{\"properties\":{\"body\":{\"type\":\"text\", \"norms\": false }}}")
             .execute()
             .actionGet();
         try {
@@ -248,11 +248,7 @@ public class UpdateMappingIntegrationIT extends OpenSearchIntegTestCase {
             .indices()
             .prepareCreate("test")
             .setSettings(Settings.builder().put("index.number_of_shards", 2).put("index.number_of_replicas", 0))
-            .addMapping(
-                MapperService.SINGLE_MAPPING_NAME,
-                "{\"" + MapperService.SINGLE_MAPPING_NAME + "\":{\"properties\":{\"body\":{\"type\":\"text\"}}}}",
-                XContentType.JSON
-            )
+            .setMapping("{\"properties\":{\"body\":{\"type\":\"text\"}}}")
             .execute()
             .actionGet();
         client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
@@ -50,7 +50,6 @@ import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.MockEngineFactoryPlugin;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.indices.IndicesService;
@@ -104,7 +103,6 @@ public class RandomExceptionCircuitBreakerIT extends OpenSearchIntegTestCase {
             .toString(
                 XContentFactory.jsonBuilder()
                     .startObject()
-                    .startObject("type")
                     .startObject("properties")
                     .startObject("test-str")
                     .field("type", "keyword")
@@ -115,7 +113,6 @@ public class RandomExceptionCircuitBreakerIT extends OpenSearchIntegTestCase {
                     .field("type", randomFrom(Arrays.asList("float", "long", "double", "short", "integer")))
                     .endObject() // test-num
                     .endObject() // properties
-                    .endObject() // type
                     .endObject()
             );
         final double topLevelRate;
@@ -149,7 +146,7 @@ public class RandomExceptionCircuitBreakerIT extends OpenSearchIntegTestCase {
             .indices()
             .prepareCreate("test")
             .setSettings(settings)
-            .addMapping("type", mapping, XContentType.JSON)
+            .setMapping(mapping)
             .execute()
             .actionGet();
         final int numDocs;

--- a/server/src/internalClusterTest/java/org/opensearch/indices/state/OpenCloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/state/OpenCloseIndexIT.java
@@ -47,7 +47,6 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.rest.RestStatus;
@@ -305,17 +304,15 @@ public class OpenCloseIndexIT extends OpenSearchIntegTestCase {
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject("test")
                 .field("type", "keyword")
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
 
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type", mapping, XContentType.JSON));
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping(mapping));
         ensureGreen();
         int docs = between(10, 100);
         IndexRequestBuilder[] builder = new IndexRequestBuilder[docs];

--- a/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
@@ -1004,11 +1004,9 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
 
     public void testCompletionFieldsParam() throws Exception {
         assertAcked(
-            prepareCreate("test1").addMapping(
-                "_doc",
+            prepareCreate("test1").setMapping(
                 "{ \"properties\": { \"bar\": { \"type\": \"text\", \"fields\": { \"completion\": { \"type\": \"completion\" }}}"
-                    + ",\"baz\": { \"type\": \"text\", \"fields\": { \"completion\": { \"type\": \"completion\" }}}}}",
-                XContentType.JSON
+                    + ",\"baz\": { \"type\": \"text\", \"fields\": { \"completion\": { \"type\": \"completion\" }}}}}"
             )
         );
         ensureGreen();

--- a/server/src/internalClusterTest/java/org/opensearch/routing/PartitionedRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/routing/PartitionedRoutingIT.java
@@ -36,8 +36,6 @@ import org.apache.lucene.util.Constants;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.mockito.internal.util.collections.Sets;
@@ -63,11 +61,7 @@ public class PartitionedRoutingIT extends OpenSearchIntegTestCase {
                             .put("index.number_of_routing_shards", shards)
                             .put("index.routing_partition_size", partitionSize)
                     )
-                    .addMapping(
-                        MapperService.SINGLE_MAPPING_NAME,
-                        "{\"" + MapperService.SINGLE_MAPPING_NAME + "\":{\"_routing\":{\"required\":true}}}",
-                        XContentType.JSON
-                    )
+                    .setMapping("{\"_routing\":{\"required\":true}}")
                     .execute()
                     .actionGet();
                 ensureGreen();
@@ -101,11 +95,7 @@ public class PartitionedRoutingIT extends OpenSearchIntegTestCase {
                     .put("index.number_of_replicas", numberOfReplicas())
                     .put("index.routing_partition_size", partitionSize)
             )
-            .addMapping(
-                MapperService.SINGLE_MAPPING_NAME,
-                "{\"" + MapperService.SINGLE_MAPPING_NAME + "\":{\"_routing\":{\"required\":true}}}",
-                XContentType.JSON
-            )
+            .setMapping("{\"_routing\":{\"required\":true}}}")
             .execute()
             .actionGet();
         ensureGreen();

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramIT.java
@@ -41,7 +41,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.time.DateFormatters;
 import org.opensearch.common.time.DateMathParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.mapper.DateFieldMapper;
 import org.opensearch.index.query.MatchNoneQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
@@ -1316,7 +1315,6 @@ public class DateHistogramIT extends OpenSearchIntegTestCase {
     public void testSingleValueWithMultipleDateFormatsFromMapping() throws Exception {
         String mappingJson = Strings.toString(
             jsonBuilder().startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject("date")
                 .field("type", "date")
@@ -1324,9 +1322,8 @@ public class DateHistogramIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
-        prepareCreate("idx2").addMapping("type", mappingJson, XContentType.JSON).get();
+        prepareCreate("idx2").setMapping(mappingJson).get();
         IndexRequestBuilder[] reqs = new IndexRequestBuilder[5];
         for (int i = 0; i < reqs.length; i++) {
             reqs[i] = client().prepareIndex("idx2")

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsDocCountErrorIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsDocCountErrorIT.java
@@ -36,7 +36,6 @@ import org.opensearch.action.index.IndexRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.aggregations.bucket.terms.Terms.Bucket;
@@ -110,13 +109,7 @@ public class TermsDocCountErrorIT extends OpenSearchIntegTestCase {
             );
         }
         numRoutingValues = between(1, 40);
-        assertAcked(
-            prepareCreate("idx_with_routing").addMapping(
-                "type",
-                "{ \"type\" : { \"_routing\" : { \"required\" : true } } }",
-                XContentType.JSON
-            )
-        );
+        assertAcked(prepareCreate("idx_with_routing").setMapping("{ \"_routing\" : { \"required\" : true } }"));
         for (int i = 0; i < numDocs; i++) {
             builders.add(
                 client().prepareIndex("idx_single_shard")

--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWithRandomExceptionsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWithRandomExceptionsIT.java
@@ -50,7 +50,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.Settings.Builder;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.MockEngineFactoryPlugin;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.plugins.Plugin;
@@ -85,11 +84,9 @@ public class SearchWithRandomExceptionsIT extends OpenSearchIntegTestCase {
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject("test")
                 .field("type", "keyword")
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -121,7 +118,7 @@ public class SearchWithRandomExceptionsIT extends OpenSearchIntegTestCase {
             .put(EXCEPTION_LOW_LEVEL_RATIO_KEY, lowLevelRate)
             .put(MockEngineSupport.WRAP_READER_RATIO.getKey(), 1.0d);
         logger.info("creating index: [test] using settings: [{}]", settings.build());
-        assertAcked(prepareCreate("test").setSettings(settings).addMapping("type", mapping, XContentType.JSON));
+        assertAcked(prepareCreate("test").setSettings(settings).setMapping(mapping));
         ensureSearchable();
         final int numDocs = between(10, 100);
         int numCreated = 0;

--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWithRandomIOExceptionsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWithRandomIOExceptionsIT.java
@@ -46,7 +46,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.search.sort.SortOrder;
@@ -73,11 +72,9 @@ public class SearchWithRandomIOExceptionsIT extends OpenSearchIntegTestCase {
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject("test")
                 .field("type", "keyword")
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -108,7 +105,7 @@ public class SearchWithRandomIOExceptionsIT extends OpenSearchIntegTestCase {
         if (createIndexWithoutErrors) {
             Settings.Builder settings = Settings.builder().put("index.number_of_replicas", numberOfReplicas());
             logger.info("creating index: [test] using settings: [{}]", settings.build());
-            client().admin().indices().prepareCreate("test").setSettings(settings).addMapping("type", mapping, XContentType.JSON).get();
+            client().admin().indices().prepareCreate("test").setSettings(settings).setMapping(mapping).get();
             numInitialDocs = between(10, 100);
             ensureGreen();
             for (int i = 0; i < numInitialDocs; i++) {
@@ -134,7 +131,7 @@ public class SearchWithRandomIOExceptionsIT extends OpenSearchIntegTestCase {
                 // we cannot expect that the index will be valid
                 .put(MockFSDirectoryFactory.RANDOM_IO_EXCEPTION_RATE_ON_OPEN_SETTING.getKey(), exceptionOnOpenRate);
             logger.info("creating index: [test] using settings: [{}]", settings.build());
-            client().admin().indices().prepareCreate("test").setSettings(settings).addMapping("type", mapping, XContentType.JSON).get();
+            client().admin().indices().prepareCreate("test").setSettings(settings).setMapping(mapping).get();
         }
         ClusterHealthResponse clusterHealthResponse = client().admin()
             .cluster()

--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -51,7 +51,6 @@ import org.opensearch.common.settings.Settings.Builder;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.analysis.AbstractIndexAnalyzerProvider;
 import org.opensearch.index.analysis.AnalyzerProvider;
 import org.opensearch.index.analysis.PreConfiguredTokenFilter;
@@ -3292,7 +3291,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     public void testACopyFieldWithNestedQuery() throws Exception {
         String mapping = Strings.toString(
             jsonBuilder().startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject("foo")
                 .field("type", "nested")
@@ -3310,9 +3308,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
-        prepareCreate("test").addMapping("type", mapping, XContentType.JSON).get();
+        prepareCreate("test").setMapping(mapping).get();
 
         client().prepareIndex("test")
             .setId("1")
@@ -3424,7 +3421,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     public void testWithNestedQuery() throws Exception {
         String mapping = Strings.toString(
             jsonBuilder().startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject("text")
                 .field("type", "text")
@@ -3441,9 +3437,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
-        prepareCreate("test").addMapping("type", mapping, XContentType.JSON).get();
+        prepareCreate("test").setMapping(mapping).get();
 
         client().prepareIndex("test")
             .setId("1")

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoFilterIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoFilterIT.java
@@ -214,7 +214,6 @@ public class GeoFilterIT extends OpenSearchIntegTestCase {
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("polygon")
                 .startObject("properties")
                 .startObject("area")
                 .field("type", "geo_shape")
@@ -222,13 +221,9 @@ public class GeoFilterIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
 
-        CreateIndexRequestBuilder mappingRequest = client().admin()
-            .indices()
-            .prepareCreate("shapes")
-            .addMapping("polygon", mapping, XContentType.JSON);
+        CreateIndexRequestBuilder mappingRequest = client().admin().indices().prepareCreate("shapes").setMapping(mapping);
         mappingRequest.get();
         client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoShapeIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoShapeIntegrationIT.java
@@ -76,7 +76,6 @@ public class GeoShapeIntegrationIT extends OpenSearchIntegTestCase {
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("shape")
                 .startObject("properties")
                 .startObject("location")
                 .field("type", "geo_shape")
@@ -84,16 +83,14 @@ public class GeoShapeIntegrationIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
 
         // create index
-        assertAcked(prepareCreate(idxName).addMapping("shape", mapping, XContentType.JSON));
+        assertAcked(prepareCreate(idxName).setMapping(mapping));
 
         mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("shape")
                 .startObject("properties")
                 .startObject("location")
                 .field("type", "geo_shape")
@@ -101,10 +98,9 @@ public class GeoShapeIntegrationIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
 
-        assertAcked(prepareCreate(idxName + "2").addMapping("shape", mapping, XContentType.JSON));
+        assertAcked(prepareCreate(idxName + "2").setMapping(mapping));
         ensureGreen(idxName, idxName + "2");
 
         internalCluster().fullRestart();
@@ -227,7 +223,7 @@ public class GeoShapeIntegrationIT extends OpenSearchIntegTestCase {
             + "  }";
 
         // create index
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("doc", mapping, XContentType.JSON).get());
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping(mapping).get());
         ensureGreen();
 
         String source = "{\n"
@@ -265,10 +261,10 @@ public class GeoShapeIntegrationIT extends OpenSearchIntegTestCase {
             + "  }";
 
         // create index
-        assertAcked(client().admin().indices().prepareCreate("vector").addMapping("doc", mappingVector, XContentType.JSON).get());
+        assertAcked(client().admin().indices().prepareCreate("vector").setMapping(mappingVector).get());
         ensureGreen();
 
-        assertAcked(client().admin().indices().prepareCreate("quad").addMapping("doc", mappingQuad, XContentType.JSON).get());
+        assertAcked(client().admin().indices().prepareCreate("quad").setMapping(mappingQuad).get());
         ensureGreen();
 
         String source = "{\n" + "    \"shape\" : \"POLYGON((179 0, -179 0, -179 2, 179 2, 179 0))\"" + "}";

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/LegacyGeoShapeIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/LegacyGeoShapeIntegrationIT.java
@@ -68,7 +68,6 @@ public class LegacyGeoShapeIntegrationIT extends OpenSearchIntegTestCase {
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("shape")
                 .startObject("properties")
                 .startObject("location")
                 .field("type", "geo_shape")
@@ -77,16 +76,14 @@ public class LegacyGeoShapeIntegrationIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
 
         // create index
-        assertAcked(prepareCreate(idxName).addMapping("shape", mapping, XContentType.JSON));
+        assertAcked(prepareCreate(idxName).setMapping(mapping));
 
         mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("shape")
                 .startObject("properties")
                 .startObject("location")
                 .field("type", "geo_shape")
@@ -95,10 +92,9 @@ public class LegacyGeoShapeIntegrationIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
 
-        assertAcked(prepareCreate(idxName + "2").addMapping("shape", mapping, XContentType.JSON));
+        assertAcked(prepareCreate(idxName + "2").setMapping(mapping));
         ensureGreen(idxName, idxName + "2");
 
         internalCluster().fullRestart();
@@ -205,7 +201,7 @@ public class LegacyGeoShapeIntegrationIT extends OpenSearchIntegTestCase {
             + "  }";
 
         // create index
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("doc", mapping, XContentType.JSON).get());
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping(mapping).get());
         ensureGreen();
 
         String source = "{\n"

--- a/server/src/internalClusterTest/java/org/opensearch/search/morelikethis/MoreLikeThisIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/morelikethis/MoreLikeThisIT.java
@@ -42,7 +42,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.MoreLikeThisQueryBuilder;
 import org.opensearch.index.query.MoreLikeThisQueryBuilder.Item;
@@ -283,12 +282,9 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
     public void testMoreLikeThisWithAliasesInLikeDocuments() throws Exception {
         String indexName = "foo";
         String aliasName = "foo_name";
-        String typeName = "bar";
 
-        String mapping = Strings.toString(
-            XContentFactory.jsonBuilder().startObject().startObject("bar").startObject("properties").endObject().endObject().endObject()
-        );
-        client().admin().indices().prepareCreate(indexName).addMapping(typeName, mapping, XContentType.JSON).get();
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("properties").endObject().endObject());
+        client().admin().indices().prepareCreate(indexName).setMapping(mapping).get();
         client().admin().indices().prepareAliases().addAlias(indexName, aliasName).get();
 
         assertThat(ensureGreen(), equalTo(ClusterHealthStatus.GREEN));
@@ -309,10 +305,8 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
     }
 
     public void testMoreLikeThisIssue2197() throws Exception {
-        String mapping = Strings.toString(
-            XContentFactory.jsonBuilder().startObject().startObject("bar").startObject("properties").endObject().endObject().endObject()
-        );
-        client().admin().indices().prepareCreate("foo").addMapping("bar", mapping, XContentType.JSON).get();
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("properties").endObject().endObject());
+        client().admin().indices().prepareCreate("foo").setMapping(mapping).get();
         client().prepareIndex("foo")
             .setId("1")
             .setSource(jsonBuilder().startObject().startObject("foo").field("bar", "boz").endObject().endObject())
@@ -332,10 +326,8 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
 
     // Issue #2489
     public void testMoreLikeWithCustomRouting() throws Exception {
-        String mapping = Strings.toString(
-            XContentFactory.jsonBuilder().startObject().startObject("bar").startObject("properties").endObject().endObject().endObject()
-        );
-        client().admin().indices().prepareCreate("foo").addMapping("bar", mapping, XContentType.JSON).get();
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("properties").endObject().endObject());
+        client().admin().indices().prepareCreate("foo").setMapping(mapping).get();
         ensureGreen();
 
         client().prepareIndex("foo")
@@ -354,14 +346,10 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
 
     // Issue #3039
     public void testMoreLikeThisIssueRoutingNotSerialized() throws Exception {
-        String mapping = Strings.toString(
-            XContentFactory.jsonBuilder().startObject().startObject("bar").startObject("properties").endObject().endObject().endObject()
-        );
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("properties").endObject().endObject());
         assertAcked(
-            prepareCreate("foo", 2, Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 2).put(SETTING_NUMBER_OF_REPLICAS, 0)).addMapping(
-                "bar",
-                mapping,
-                XContentType.JSON
+            prepareCreate("foo", 2, Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 2).put(SETTING_NUMBER_OF_REPLICAS, 0)).setMapping(
+                mapping
             )
         );
         ensureGreen();

--- a/server/src/internalClusterTest/java/org/opensearch/search/nested/SimpleNestedIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/nested/SimpleNestedIT.java
@@ -719,25 +719,22 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
 
     public void testNestedSortWithMultiLevelFiltering() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 "{\n"
-                    + "  \"type1\": {\n"
-                    + "    \"properties\": {\n"
-                    + "      \"acl\": {\n"
-                    + "        \"type\": \"nested\",\n"
-                    + "        \"properties\": {\n"
-                    + "          \"access_id\": {\"type\": \"keyword\"},\n"
-                    + "          \"operation\": {\n"
-                    + "            \"type\": \"nested\",\n"
-                    + "            \"properties\": {\n"
-                    + "              \"name\": {\"type\": \"keyword\"},\n"
-                    + "              \"user\": {\n"
-                    + "                \"type\": \"nested\",\n"
-                    + "                \"properties\": {\n"
-                    + "                  \"username\": {\"type\": \"keyword\"},\n"
-                    + "                  \"id\": {\"type\": \"integer\"}\n"
-                    + "                }\n"
+                    + "  \"properties\": {\n"
+                    + "    \"acl\": {\n"
+                    + "      \"type\": \"nested\",\n"
+                    + "      \"properties\": {\n"
+                    + "        \"access_id\": {\"type\": \"keyword\"},\n"
+                    + "        \"operation\": {\n"
+                    + "          \"type\": \"nested\",\n"
+                    + "          \"properties\": {\n"
+                    + "            \"name\": {\"type\": \"keyword\"},\n"
+                    + "            \"user\": {\n"
+                    + "              \"type\": \"nested\",\n"
+                    + "              \"properties\": {\n"
+                    + "                \"username\": {\"type\": \"keyword\"},\n"
+                    + "                \"id\": {\"type\": \"integer\"}\n"
                     + "              }\n"
                     + "            }\n"
                     + "          }\n"
@@ -745,8 +742,7 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
                     + "      }\n"
                     + "    }\n"
                     + "  }\n"
-                    + "}",
-                XContentType.JSON
+                    + "}"
             )
         );
         ensureGreen();
@@ -965,8 +961,7 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
     public void testLeakingSortValues() throws Exception {
         assertAcked(
             prepareCreate("test").setSettings(Settings.builder().put("number_of_shards", 1))
-                .addMapping(
-                    "test-type",
+                .setMapping(
                     "{\n"
                         + "        \"dynamic\": \"strict\",\n"
                         + "        \"properties\": {\n"
@@ -987,8 +982,7 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
                         + "            }\n"
                         + "          }\n"
                         + "        }\n"
-                        + "      }\n",
-                    XContentType.JSON
+                        + "      }\n"
                 )
         );
         ensureGreen();

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/SimpleQueryStringIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/SimpleQueryStringIT.java
@@ -379,7 +379,6 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("type1")
                 .startObject("properties")
                 .startObject("location")
                 .field("type", "text")
@@ -387,13 +386,9 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
 
-        CreateIndexRequestBuilder mappingRequest = client().admin()
-            .indices()
-            .prepareCreate("test1")
-            .addMapping("type1", mapping, XContentType.JSON);
+        CreateIndexRequestBuilder mappingRequest = client().admin().indices().prepareCreate("test1").setMapping(mapping);
         mappingRequest.get();
         indexRandom(true, client().prepareIndex("test1").setId("1").setSource("location", "Köln"));
         refresh();
@@ -431,7 +426,6 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("type1")
                 .startObject("properties")
                 .startObject("body")
                 .field("type", "text")
@@ -439,13 +433,9 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
 
-        CreateIndexRequestBuilder mappingRequest = client().admin()
-            .indices()
-            .prepareCreate("test1")
-            .addMapping("type1", mapping, XContentType.JSON);
+        CreateIndexRequestBuilder mappingRequest = client().admin().indices().prepareCreate("test1").setMapping(mapping);
         mappingRequest.get();
         indexRandom(true, client().prepareIndex("test1").setId("1").setSource("body", "Some Text"));
         refresh();

--- a/server/src/internalClusterTest/java/org/opensearch/search/slice/SearchSliceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/slice/SearchSliceIT.java
@@ -43,7 +43,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.search.Scroll;
 import org.opensearch.search.SearchException;
 import org.opensearch.search.SearchHit;
@@ -67,7 +66,6 @@ public class SearchSliceIT extends OpenSearchIntegTestCase {
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject("invalid_random_kw")
                 .field("type", "keyword")
@@ -83,14 +81,13 @@ public class SearchSliceIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
         assertAcked(
             client().admin()
                 .indices()
                 .prepareCreate("test")
                 .setSettings(Settings.builder().put("number_of_shards", numberOfShards).put("index.max_slices_per_scroll", 10000))
-                .addMapping("type", mapping, XContentType.JSON)
+                .setMapping(mapping)
         );
         ensureGreen();
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/SimpleSortIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/SimpleSortIT.java
@@ -38,7 +38,6 @@ import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.common.Strings;
 import org.opensearch.common.geo.GeoPoint;
 import org.opensearch.common.geo.GeoUtils;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.fielddata.ScriptDocValues;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.script.MockScriptPlugin;
@@ -243,7 +242,6 @@ public class SimpleSortIT extends OpenSearchIntegTestCase {
     public void testSortMinValueScript() throws IOException {
         String mapping = Strings.toString(
             jsonBuilder().startObject()
-                .startObject("type1")
                 .startObject("properties")
                 .startObject("lvalue")
                 .field("type", "long")
@@ -259,10 +257,9 @@ public class SimpleSortIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
 
-        assertAcked(prepareCreate("test").addMapping("type1", mapping, XContentType.JSON));
+        assertAcked(prepareCreate("test").setMapping(mapping));
         ensureGreen();
 
         for (int i = 0; i < 10; i++) {
@@ -359,7 +356,6 @@ public class SimpleSortIT extends OpenSearchIntegTestCase {
         // be propagated to all nodes yet and sort operation fail when the sort field is not defined
         String mapping = Strings.toString(
             jsonBuilder().startObject()
-                .startObject("type1")
                 .startObject("properties")
                 .startObject("id")
                 .field("type", "keyword")
@@ -369,9 +365,8 @@ public class SimpleSortIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
-        assertAcked(prepareCreate("test").addMapping("type1", mapping, XContentType.JSON));
+        assertAcked(prepareCreate("test").setMapping(mapping));
         ensureGreen();
 
         client().prepareIndex("test").setSource(jsonBuilder().startObject().field("id", "1").field("svalue", "aaa").endObject()).get();

--- a/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequest.java
@@ -250,19 +250,6 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
      *
      * @param type   The mapping type
      * @param source The mapping source
-     * @param xContentType The content type of the source
-     * @deprecated types are being removed
-     */
-    @Deprecated
-    public CreateIndexRequest mapping(String type, String source, XContentType xContentType) {
-        return mapping(type, new BytesArray(source), xContentType);
-    }
-
-    /**
-     * Adds mapping that will be added when the index gets created.
-     *
-     * @param type   The mapping type
-     * @param source The mapping source
      * @param xContentType the content type of the mapping source
      * @deprecated types are being removed
      */

--- a/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequestBuilder.java
@@ -111,13 +111,11 @@ public class CreateIndexRequestBuilder extends AcknowledgedRequestBuilder<
     /**
      * Adds mapping that will be added when the index gets created.
      *
-     * @param type   The mapping type
      * @param source The mapping source
-     * @param xContentType The content type of the source
      */
     @Deprecated
-    public CreateIndexRequestBuilder addMapping(String type, String source, XContentType xContentType) {
-        request.mapping(type, source, xContentType);
+    public CreateIndexRequestBuilder setMapping(String source) {
+        request.mapping(source);
         return this;
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/rollover/RolloverRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/rollover/RolloverRequestBuilder.java
@@ -38,7 +38,6 @@ import org.opensearch.client.OpenSearchClient;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.common.xcontent.XContentType;
 
 public class RolloverRequestBuilder extends MasterNodeOperationRequestBuilder<RolloverRequest, RolloverResponse, RolloverRequestBuilder> {
     public RolloverRequestBuilder(OpenSearchClient client, RolloverAction action) {
@@ -87,11 +86,6 @@ public class RolloverRequestBuilder extends MasterNodeOperationRequestBuilder<Ro
 
     public RolloverRequestBuilder mapping(String type, Object... source) {
         this.request.getCreateIndexRequest().mapping(type, source);
-        return this;
-    }
-
-    public RolloverRequestBuilder mapping(String type, String source, XContentType xContentType) {
-        this.request.getCreateIndexRequest().mapping(type, source, xContentType);
         return this;
     }
 

--- a/server/src/test/java/org/opensearch/index/mapper/MapperServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/MapperServiceTests.java
@@ -40,7 +40,6 @@ import org.opensearch.common.compress.CompressedXContent;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.env.Environment;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
@@ -175,7 +174,7 @@ public class MapperServiceTests extends OpenSearchSingleNodeTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("test-index")
-                .addMapping("type", "{\"type\":{}}", XContentType.JSON)
+                .setMapping("{\"" + MapperService.SINGLE_MAPPING_NAME + "\":{}}")
                 .setSettings(Settings.builder().put("index.number_of_shards", 4).put("index.routing_partition_size", 2))
                 .execute()
                 .actionGet();
@@ -187,7 +186,7 @@ public class MapperServiceTests extends OpenSearchSingleNodeTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("test-index")
-                .addMapping("type", "{\"type\":{\"_routing\":{\"required\":true}}}", XContentType.JSON)
+                .setMapping("{\"" + MapperService.SINGLE_MAPPING_NAME + "\":{\"_routing\":{\"required\":true}}}")
                 .setSettings(Settings.builder().put("index.number_of_shards", 4).put("index.routing_partition_size", 2))
                 .execute()
                 .actionGet()

--- a/server/src/test/java/org/opensearch/index/mapper/MapperServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/MapperServiceTests.java
@@ -186,7 +186,7 @@ public class MapperServiceTests extends OpenSearchSingleNodeTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("test-index")
-                .setMapping("{\"" + MapperService.SINGLE_MAPPING_NAME + "\":{\"_routing\":{\"required\":true}}}")
+                .setMapping("{\"_routing\":{\"required\":true}}")
                 .setSettings(Settings.builder().put("index.number_of_shards", 4).put("index.routing_partition_size", 2))
                 .execute()
                 .actionGet()

--- a/server/src/test/java/org/opensearch/search/geo/GeoShapeQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/geo/GeoShapeQueryTests.java
@@ -432,16 +432,14 @@ public class GeoShapeQueryTests extends GeoQueryTests {
     public void testEdgeCases() throws Exception {
         XContentBuilder xcb = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("geo")
             .field("type", "geo_shape")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
         String mapping = Strings.toString(xcb);
-        client().admin().indices().prepareCreate("test").addMapping("type1", mapping, XContentType.JSON).get();
+        client().admin().indices().prepareCreate("test").setMapping(mapping).get();
         ensureGreen();
 
         client().prepareIndex("test")
@@ -629,7 +627,6 @@ public class GeoShapeQueryTests extends GeoQueryTests {
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("type1")
                 .startObject("properties")
                 .startObject("location")
                 .field("type", "geo_shape")
@@ -640,10 +637,9 @@ public class GeoShapeQueryTests extends GeoQueryTests {
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
 
-        client().admin().indices().prepareCreate("geo_points_only").addMapping("type1", mapping, XContentType.JSON).get();
+        client().admin().indices().prepareCreate("geo_points_only").setMapping(mapping).get();
         ensureGreen();
 
         ShapeBuilder shape = RandomShapeGenerator.createShape(random());
@@ -669,7 +665,6 @@ public class GeoShapeQueryTests extends GeoQueryTests {
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("type1")
                 .startObject("properties")
                 .startObject("geo")
                 .field("type", "geo_shape")
@@ -680,10 +675,9 @@ public class GeoShapeQueryTests extends GeoQueryTests {
                 .endObject()
                 .endObject()
                 .endObject()
-                .endObject()
         );
 
-        client().admin().indices().prepareCreate("geo_points_only").addMapping("type1", mapping, XContentType.JSON).get();
+        client().admin().indices().prepareCreate("geo_points_only").setMapping(mapping).get();
         ensureGreen();
 
         // MULTIPOINT
@@ -710,7 +704,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
 
     public void testIndexedShapeReference() throws Exception {
         String mapping = Strings.toString(createDefaultMapping());
-        client().admin().indices().prepareCreate("test").addMapping("type1", mapping, XContentType.JSON).get();
+        client().admin().indices().prepareCreate("test").setMapping(mapping).get();
         createIndex("shapes");
         ensureGreen();
 
@@ -907,7 +901,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
 
     public void testDistanceQuery() throws Exception {
         String mapping = Strings.toString(createRandomMapping());
-        client().admin().indices().prepareCreate("test_distance").addMapping("type1", mapping, XContentType.JSON).get();
+        client().admin().indices().prepareCreate("test_distance").setMapping(mapping).get();
         ensureGreen();
 
         CircleBuilder circleBuilder = new CircleBuilder().center(new Coordinate(1, 0)).radius(350, DistanceUnit.KILOMETERS);
@@ -950,7 +944,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
     public void testIndexRectangleSpanningDateLine() throws Exception {
         String mapping = Strings.toString(createRandomMapping());
 
-        client().admin().indices().prepareCreate("test").addMapping("type1", mapping, XContentType.JSON).get();
+        client().admin().indices().prepareCreate("test").setMapping(mapping).get();
         ensureGreen();
 
         EnvelopeBuilder envelopeBuilder = new EnvelopeBuilder(new Coordinate(178, 10), new Coordinate(-178, -10));


### PR DESCRIPTION
Removes the obsolete types based .addMapping method from CreateIndexRequest and
CreateIndexRequestBuilder. Tests are refactored to use the new source only
setMapping method.

relates #1940
depends on #2469 