### PR TITLE
[Remove] type from CIR.mapping and CIRB.mapping

### DIFF
--- a/modules/analysis-common/src/test/java/org/opensearch/analysis/common/HighlighterWithAnalyzersTests.java
+++ b/modules/analysis-common/src/test/java/org/opensearch/analysis/common/HighlighterWithAnalyzersTests.java
@@ -70,10 +70,8 @@ public class HighlighterWithAnalyzersTests extends OpenSearchIntegTestCase {
 
     public void testNgramHighlightingWithBrokenPositions() throws IOException {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "test",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("test")
                     .startObject("properties")
                     .startObject("name")
                     .field("type", "text")
@@ -83,7 +81,6 @@ public class HighlighterWithAnalyzersTests extends OpenSearchIntegTestCase {
                     .field("analyzer", "autocomplete")
                     .field("search_analyzer", "search_autocomplete")
                     .field("term_vector", "with_positions_offsets")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -260,7 +257,7 @@ public class HighlighterWithAnalyzersTests extends OpenSearchIntegTestCase {
             .put("index.analysis.filter.synonym.type", "synonym")
             .putList("index.analysis.filter.synonym.synonyms", "quick => fast");
 
-        assertAcked(prepareCreate("first_test_index").setSettings(builder.build()).addMapping("type1", type1TermVectorMapping()));
+        assertAcked(prepareCreate("first_test_index").setSettings(builder.build()).setMapping(type1TermVectorMapping()));
 
         ensureGreen();
 
@@ -421,7 +418,6 @@ public class HighlighterWithAnalyzersTests extends OpenSearchIntegTestCase {
     public static XContentBuilder type1TermVectorMapping() throws IOException {
         return XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("field1")
             .field("type", "text")
@@ -430,7 +426,6 @@ public class HighlighterWithAnalyzersTests extends OpenSearchIntegTestCase {
             .startObject("field2")
             .field("type", "text")
             .field("term_vector", "with_positions_offsets")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();

--- a/modules/lang-expression/src/internalClusterTest/java/org/opensearch/script/expression/MoreExpressionIT.java
+++ b/modules/lang-expression/src/internalClusterTest/java/org/opensearch/script/expression/MoreExpressionIT.java
@@ -646,7 +646,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
             .startObject("location")
             .field("type", "geo_point");
         xContentBuilder.endObject().endObject().endObject().endObject();
-        assertAcked(prepareCreate("test").addMapping("type1", xContentBuilder));
+        assertAcked(prepareCreate("test").setMapping(xContentBuilder));
         ensureGreen();
         client().prepareIndex("test")
             .setId("1")
@@ -692,7 +692,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
             .startObject("vip")
             .field("type", "boolean");
         xContentBuilder.endObject().endObject().endObject().endObject();
-        assertAcked(prepareCreate("test").addMapping("doc", xContentBuilder));
+        assertAcked(prepareCreate("test").setMapping(xContentBuilder));
         ensureGreen();
         indexRandom(
             true,

--- a/modules/lang-expression/src/internalClusterTest/java/org/opensearch/script/expression/MoreExpressionIT.java
+++ b/modules/lang-expression/src/internalClusterTest/java/org/opensearch/script/expression/MoreExpressionIT.java
@@ -641,11 +641,10 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
     public void testGeo() throws Exception {
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("location")
             .field("type", "geo_point");
-        xContentBuilder.endObject().endObject().endObject().endObject();
+        xContentBuilder.endObject().endObject().endObject();
         assertAcked(prepareCreate("test").setMapping(xContentBuilder));
         ensureGreen();
         client().prepareIndex("test")
@@ -687,11 +686,10 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
     public void testBoolean() throws Exception {
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("doc")
             .startObject("properties")
             .startObject("vip")
             .field("type", "boolean");
-        xContentBuilder.endObject().endObject().endObject().endObject();
+        xContentBuilder.endObject().endObject().endObject();
         assertAcked(prepareCreate("test").setMapping(xContentBuilder));
         ensureGreen();
         indexRandom(

--- a/modules/mapper-extras/src/javaRestTest/java/org/opensearch/index/mapper/TokenCountFieldMapperIntegrationIT.java
+++ b/modules/mapper-extras/src/javaRestTest/java/org/opensearch/index/mapper/TokenCountFieldMapperIntegrationIT.java
@@ -130,7 +130,6 @@ public class TokenCountFieldMapperIntegrationIT extends OpenSearchIntegTestCase 
         prepareCreate("test").setSettings(settings)
             .setMapping(
                 jsonBuilder().startObject()
-                    .startObject("test")
                     .startObject("properties")
                     .startObject("foo")
                     .field("type", "text")
@@ -156,7 +155,6 @@ public class TokenCountFieldMapperIntegrationIT extends OpenSearchIntegTestCase 
                     .field("analyzer", "mock_english")
                     .field("enable_position_increments", false)
                     .field("store", true)
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()

--- a/modules/mapper-extras/src/javaRestTest/java/org/opensearch/index/mapper/TokenCountFieldMapperIntegrationIT.java
+++ b/modules/mapper-extras/src/javaRestTest/java/org/opensearch/index/mapper/TokenCountFieldMapperIntegrationIT.java
@@ -128,8 +128,7 @@ public class TokenCountFieldMapperIntegrationIT extends OpenSearchIntegTestCase 
         settings.put("index.analysis.analyzer.mock_english.tokenizer", "standard");
         settings.put("index.analysis.analyzer.mock_english.filter", "stop");
         prepareCreate("test").setSettings(settings)
-            .addMapping(
-                "test",
+            .setMapping(
                 jsonBuilder().startObject()
                     .startObject("test")
                     .startObject("properties")

--- a/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/aggregations/AbstractParentChildTestCase.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/aggregations/AbstractParentChildTestCase.java
@@ -55,8 +55,7 @@ public abstract class AbstractParentChildTestCase extends ParentChildTestCase {
     @Before
     public void setupCluster() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "doc",
+            prepareCreate("test").setMapping(
                 addFieldMappings(
                     buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "article", "comment"),
                     "commenter",

--- a/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/aggregations/ChildrenIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/aggregations/ChildrenIT.java
@@ -174,8 +174,7 @@ public class ChildrenIT extends AbstractParentChildTestCase {
     public void testWithDeletes() throws Exception {
         String indexName = "xyz";
         assertAcked(
-            prepareCreate(indexName).addMapping(
-                "doc",
+            prepareCreate(indexName).setMapping(
                 addFieldMappings(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"), "name", "keyword")
             )
         );
@@ -234,8 +233,7 @@ public class ChildrenIT extends AbstractParentChildTestCase {
             prepareCreate(indexName).setSettings(
                 Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
             )
-                .addMapping(
-                    "doc",
+                .setMapping(
                     addFieldMappings(
                         buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, masterType, childType),
                         "brand",
@@ -309,8 +307,7 @@ public class ChildrenIT extends AbstractParentChildTestCase {
         String parentType = "country";
         String childType = "city";
         assertAcked(
-            prepareCreate(indexName).addMapping(
-                "doc",
+            prepareCreate(indexName).setMapping(
                 addFieldMappings(
                     buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, grandParentType, parentType, parentType, childType),
                     "name",
@@ -352,8 +349,7 @@ public class ChildrenIT extends AbstractParentChildTestCase {
         // Before we only evaluated segments that yielded matches in 'towns' and 'parent_names' aggs, which caused
         // us to miss to evaluate child docs in segments we didn't have parent matches for.
         assertAcked(
-            prepareCreate("index").addMapping(
-                "doc",
+            prepareCreate("index").setMapping(
                 addFieldMappings(
                     buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parentType", "childType"),
                     "name",

--- a/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/query/ChildQuerySearchIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/query/ChildQuerySearchIT.java
@@ -630,13 +630,11 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         assertAcked(
             prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("doc")
                     .startObject("properties")
                     .startObject("join_field")
                     .field("type", "join")
                     .startObject("relations")
                     .field("parent", new String[] { "child", "child1" })
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -1110,14 +1108,12 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         assertAcked(
             prepareCreate("grandissue").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("doc")
                     .startObject("properties")
                     .startObject("join_field")
                     .field("type", "join")
                     .startObject("relations")
                     .field("grandparent", "parent")
                     .field("parent", new String[] { "child_type_one", "child_type_two" })
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()

--- a/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/query/ChildQuerySearchIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/query/ChildQuerySearchIT.java
@@ -102,8 +102,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
 
     public void testMultiLevelChild() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "doc",
+            prepareCreate("test").setMapping(
                 buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child", "child", "grandchild")
             )
         );
@@ -166,9 +165,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
 
     // see #2744
     public void test2744() throws IOException {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "foo", "test"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "foo", "test")));
         ensureGreen();
 
         // index simple data
@@ -185,9 +182,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     }
 
     public void testSimpleChildQuery() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
 
         // index simple data
@@ -251,9 +246,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
 
     // Issue #3290
     public void testCachingBugWithFqueryFilter() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
         List<IndexRequestBuilder> builders = new ArrayList<>();
         // index simple data
@@ -290,9 +283,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     }
 
     public void testHasParentFilter() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
         Map<String, Set<String>> parentToChildren = new HashMap<>();
         // Childless parent
@@ -340,9 +331,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     }
 
     public void testSimpleChildQueryWithFlush() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
 
         // index simple data with flushes, so we have many segments
@@ -408,8 +397,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
 
     public void testScopedFacet() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "doc",
+            prepareCreate("test").setMapping(
                 addFieldMappings(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"), "c_field", "keyword")
             )
         );
@@ -459,9 +447,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     }
 
     public void testDeletedParent() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
         // index simple data
         createIndexRequest("test", "parent", "p1", null, "p_field", "p_value1").get();
@@ -496,9 +482,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     }
 
     public void testDfsSearchType() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
 
         // index simple data
@@ -526,9 +510,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     }
 
     public void testHasChildAndHasParentFailWhenSomeSegmentsDontContainAnyParentOrChildDocs() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
 
         createIndexRequest("test", "parent", "1", null, "p_field", 1).get();
@@ -551,9 +533,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     }
 
     public void testCountApiUsage() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
 
         String parentId = "p1";
@@ -584,9 +564,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     }
 
     public void testExplainUsage() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
 
         String parentId = "p1";
@@ -650,8 +628,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
 
     public void testScoreForParentChildQueriesWithFunctionScore() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "doc",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
                     .startObject("doc")
                     .startObject("properties")
@@ -758,9 +735,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
 
     // Issue #2536
     public void testParentChildQueriesCanHandleNoRelevantTypesInIndex() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
 
         SearchResponse response = client().prepareSearch("test")
@@ -792,9 +767,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     }
 
     public void testHasChildAndHasParentFilter_withFilter() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
 
         createIndexRequest("test", "parent", "1", null, "p_field", 1).get();
@@ -820,9 +793,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     }
 
     public void testHasChildInnerHitsHighlighting() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
 
         createIndexRequest("test", "parent", "1", null, "p_field", 1).get();
@@ -848,9 +819,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     }
 
     public void testHasChildAndHasParentWrappedInAQueryFilter() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
 
         // query filter in case for p/c shouldn't execute per segment, but rather
@@ -884,8 +853,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
 
     public void testSimpleQueryRewrite() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "doc",
+            prepareCreate("test").setMapping(
                 addFieldMappings(
                     buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"),
                     "c_field",
@@ -945,9 +913,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
 
     // Issue #3144
     public void testReIndexingParentAndChildDocuments() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
 
         // index simple data
@@ -1004,9 +970,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
 
     // Issue #3203
     public void testHasChildQueryWithMinimumScore() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
 
         // index simple data
@@ -1031,7 +995,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     public void testParentFieldQuery() throws Exception {
         assertAcked(
             prepareCreate("test").setSettings(Settings.builder().put("index.refresh_interval", -1))
-                .addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
+                .setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
         );
         ensureGreen();
 
@@ -1063,7 +1027,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     public void testParentIdQuery() throws Exception {
         assertAcked(
             prepareCreate("test").setSettings(Settings.builder().put(indexSettings()).put("index.refresh_interval", -1))
-                .addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
+                .setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
         );
         ensureGreen();
 
@@ -1083,9 +1047,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     }
 
     public void testHasChildNotBeingCached() throws IOException {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
 
         // index simple data
@@ -1146,8 +1108,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     // Issue #3818
     public void testHasChildQueryOnlyReturnsSingleChildType() throws Exception {
         assertAcked(
-            prepareCreate("grandissue").addMapping(
-                "doc",
+            prepareCreate("grandissue").setMapping(
                 jsonBuilder().startObject()
                     .startObject("doc")
                     .startObject("properties")
@@ -1203,8 +1164,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
 
     public void testHasChildQueryWithNestedInnerObjects() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "doc",
+            prepareCreate("test").setMapping(
                 addFieldMappings(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"), "objects", "nested")
             )
         );
@@ -1282,9 +1242,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     }
 
     public void testNamedFilters() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
 
         String parentId = "p1";
@@ -1368,7 +1326,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     public void testParentChildCaching() throws Exception {
         assertAcked(
             prepareCreate("test").setSettings(Settings.builder().put("index.refresh_interval", -1))
-                .addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
+                .setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
         );
         ensureGreen();
 
@@ -1413,9 +1371,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     }
 
     public void testParentChildQueriesViaScrollApi() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
         for (int i = 0; i < 10; i++) {
             createIndexRequest("test", "parent", "p" + i, null).get();
@@ -1496,9 +1452,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
     }
 
     public void testMinMaxChildren() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         ensureGreen();
 
         indexRandom(true, createMinMaxDocBuilders().toArray(new IndexRequestBuilder[0]));
@@ -1811,10 +1765,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
 
     public void testHasParentInnerQueryType() {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "doc",
-                buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent-type", "child-type")
-            )
+            prepareCreate("test").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent-type", "child-type"))
         );
         createIndexRequest("test", "child-type", "child-id", "parent-id").get();
         createIndexRequest("test", "parent-type", "parent-id", null).get();
@@ -1834,8 +1785,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
 
     public void testHighlightersIgnoreParentChild() throws IOException {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "doc",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
                     .startObject("properties")
                     .startObject("join_field")
@@ -1888,7 +1838,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
 
     public void testAliasesFilterWithHasChildQuery() throws Exception {
         assertAcked(
-            prepareCreate("my-index").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
+            prepareCreate("my-index").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
         );
         createIndexRequest("my-index", "parent", "1", null).get();
         createIndexRequest("my-index", "child", "2", "1").get();

--- a/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/query/InnerHitsIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/query/InnerHitsIT.java
@@ -103,8 +103,7 @@ public class InnerHitsIT extends ParentChildTestCase {
 
     public void testSimpleParentChild() throws Exception {
         assertAcked(
-            prepareCreate("articles").addMapping(
-                "doc",
+            prepareCreate("articles").setMapping(
                 jsonBuilder().startObject()
                     .startObject("doc")
                     .startObject("properties")
@@ -223,8 +222,7 @@ public class InnerHitsIT extends ParentChildTestCase {
 
     public void testRandomParentChild() throws Exception {
         assertAcked(
-            prepareCreate("idx").addMapping(
-                "doc",
+            prepareCreate("idx").setMapping(
                 jsonBuilder().startObject()
                     .startObject("doc")
                     .startObject("properties")
@@ -323,8 +321,7 @@ public class InnerHitsIT extends ParentChildTestCase {
 
     public void testInnerHitsOnHasParent() throws Exception {
         assertAcked(
-            prepareCreate("stack").addMapping(
-                "doc",
+            prepareCreate("stack").setMapping(
                 addFieldMappings(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "question", "answer"), "body", "text")
             )
         );
@@ -379,8 +376,7 @@ public class InnerHitsIT extends ParentChildTestCase {
 
     public void testParentChildMultipleLayers() throws Exception {
         assertAcked(
-            prepareCreate("articles").addMapping(
-                "doc",
+            prepareCreate("articles").setMapping(
                 addFieldMappings(
                     buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "article", "comment", "comment", "remark"),
                     "title",
@@ -449,8 +445,7 @@ public class InnerHitsIT extends ParentChildTestCase {
 
     public void testRoyals() throws Exception {
         assertAcked(
-            prepareCreate("royals").addMapping(
-                "doc",
+            prepareCreate("royals").setMapping(
                 buildParentJoinFieldMappingFromSimplifiedDef(
                     "join_field",
                     true,
@@ -536,9 +531,7 @@ public class InnerHitsIT extends ParentChildTestCase {
     }
 
     public void testMatchesQueriesParentChildInnerHits() throws Exception {
-        assertAcked(
-            prepareCreate("index").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
-        );
+        assertAcked(prepareCreate("index").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child")));
         List<IndexRequestBuilder> requests = new ArrayList<>();
         requests.add(createIndexRequest("index", "parent", "1", null));
         requests.add(createIndexRequest("index", "child", "3", "1", "field", "value1"));
@@ -577,7 +570,7 @@ public class InnerHitsIT extends ParentChildTestCase {
 
     public void testUseMaxDocInsteadOfSize() throws Exception {
         assertAcked(
-            prepareCreate("index1").addMapping("doc", buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
+            prepareCreate("index1").setMapping(buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent", "child"))
         );
         client().admin()
             .indices()
@@ -599,8 +592,7 @@ public class InnerHitsIT extends ParentChildTestCase {
 
     public void testNestedInnerHitWrappedInParentChildInnerhit() {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "doc",
+            prepareCreate("test").setMapping(
                 addFieldMappings(
                     buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent_type", "child_type"),
                     "nested_type",
@@ -632,8 +624,7 @@ public class InnerHitsIT extends ParentChildTestCase {
 
     public void testInnerHitsWithIgnoreUnmapped() {
         assertAcked(
-            prepareCreate("index1").addMapping(
-                "doc",
+            prepareCreate("index1").setMapping(
                 addFieldMappings(
                     buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent_type", "child_type"),
                     "nested_type",
@@ -662,8 +653,7 @@ public class InnerHitsIT extends ParentChildTestCase {
 
     public void testTooHighResultWindow() {
         assertAcked(
-            prepareCreate("index1").addMapping(
-                "doc",
+            prepareCreate("index1").setMapping(
                 addFieldMappings(
                     buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, "parent_type", "child_type"),
                     "nested_type",

--- a/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/query/InnerHitsIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/query/InnerHitsIT.java
@@ -105,7 +105,6 @@ public class InnerHitsIT extends ParentChildTestCase {
         assertAcked(
             prepareCreate("articles").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("doc")
                     .startObject("properties")
                     .startObject("join_field")
                     .field("type", "join")
@@ -119,7 +118,6 @@ public class InnerHitsIT extends ParentChildTestCase {
                     .startObject("message")
                     .field("type", "text")
                     .field("fielddata", true)
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -224,7 +222,6 @@ public class InnerHitsIT extends ParentChildTestCase {
         assertAcked(
             prepareCreate("idx").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("doc")
                     .startObject("properties")
                     .startObject("id")
                     .field("type", "keyword")
@@ -233,7 +230,6 @@ public class InnerHitsIT extends ParentChildTestCase {
                     .field("type", "join")
                     .startObject("relations")
                     .field("parent", new String[] { "child1", "child2" })
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()

--- a/modules/percolator/src/internalClusterTest/java/org/opensearch/percolator/PercolatorQuerySearchIT.java
+++ b/modules/percolator/src/internalClusterTest/java/org/opensearch/percolator/PercolatorQuerySearchIT.java
@@ -846,7 +846,6 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
                 .prepareCreate("test3")
                 .setMapping(
                     jsonBuilder().startObject()
-                        .startObject("type")
                         .startObject("properties")
                         .startObject("field")
                         .field("type", "keyword")
@@ -856,7 +855,6 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
                         .startObject("properties")
                         .startObject(queryFieldName)
                         .field("type", "percolator")
-                        .endObject()
                         .endObject()
                         .endObject()
                         .endObject()
@@ -877,7 +875,6 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
                 .prepareCreate("test2")
                 .setMapping(
                     jsonBuilder().startObject()
-                        .startObject("type")
                         .startObject("properties")
                         .startObject("field")
                         .field("type", "keyword")
@@ -887,7 +884,6 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
                         .startObject("properties")
                         .startObject(queryFieldName)
                         .field("type", "percolator")
-                        .endObject()
                         .endObject()
                         .endObject()
                         .endObject()

--- a/modules/percolator/src/internalClusterTest/java/org/opensearch/percolator/PercolatorQuerySearchIT.java
+++ b/modules/percolator/src/internalClusterTest/java/org/opensearch/percolator/PercolatorQuerySearchIT.java
@@ -844,8 +844,7 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("test3")
-                .addMapping(
-                    "type",
+                .setMapping(
                     jsonBuilder().startObject()
                         .startObject("type")
                         .startObject("properties")
@@ -876,8 +875,7 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("test2")
-                .addMapping(
-                    "type",
+                .setMapping(
                     jsonBuilder().startObject()
                         .startObject("type")
                         .startObject("properties")
@@ -977,7 +975,7 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject()
             .endObject();
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("employee", mapping));
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping(mapping));
         client().prepareIndex("test")
             .setId("q1")
             .setSource(

--- a/modules/percolator/src/test/java/org/opensearch/percolator/PercolatorQuerySearchTests.java
+++ b/modules/percolator/src/test/java/org/opensearch/percolator/PercolatorQuerySearchTests.java
@@ -150,7 +150,7 @@ public class PercolatorQuerySearchTests extends OpenSearchSingleNodeTestCase {
                 .prepareCreate("test")
                 // to avoid normal document from being cached by BitsetFilterCache
                 .setSettings(Settings.builder().put(BitsetFilterCache.INDEX_LOAD_RANDOM_ACCESS_FILTERS_EAGERLY_SETTING.getKey(), false))
-                .addMapping("employee", mapping)
+                .setMapping(mapping)
         );
         client().prepareIndex("test")
             .setId("q1")
@@ -238,7 +238,7 @@ public class PercolatorQuerySearchTests extends OpenSearchSingleNodeTestCase {
             mapping.endObject();
         }
         mapping.endObject();
-        createIndex("test", client().admin().indices().prepareCreate("test").addMapping("employee", mapping));
+        createIndex("test", client().admin().indices().prepareCreate("test").setMapping(mapping));
         Script script = new Script(ScriptType.INLINE, MockScriptPlugin.NAME, "use_fielddata_please", Collections.emptyMap());
         client().prepareIndex("test")
             .setId("q1")

--- a/plugins/analysis-icu/src/internalClusterTest/java/org/opensearch/index/mapper/ICUCollationKeywordFieldMapperIT.java
+++ b/plugins/analysis-icu/src/internalClusterTest/java/org/opensearch/index/mapper/ICUCollationKeywordFieldMapperIT.java
@@ -71,8 +71,6 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
     */
     public void testBasicUsage() throws Exception {
         String index = "foo";
-        String type = "mytype";
-
         String[] equivalent = { "I WİLL USE TURKİSH CASING", "ı will use turkish casıng" };
 
         XContentBuilder builder = jsonBuilder().startObject()
@@ -88,7 +86,7 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).addMapping(type, builder));
+        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
 
         // both values should collate to same value
         indexRandom(
@@ -114,7 +112,6 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
 
     public void testMultipleValues() throws Exception {
         String index = "foo";
-        String type = "mytype";
 
         String[] equivalent = { "a", "C", "a", "B" };
 
@@ -130,7 +127,7 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).addMapping(type, builder));
+        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
 
         // everything should be indexed fine, no exceptions
         indexRandom(
@@ -177,7 +174,6 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
     */
     public void testNormalization() throws Exception {
         String index = "foo";
-        String type = "mytype";
 
         String[] equivalent = { "I W\u0049\u0307LL USE TURKİSH CASING", "ı will use turkish casıng" };
 
@@ -195,7 +191,7 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).addMapping(type, builder));
+        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
 
         indexRandom(
             true,
@@ -223,7 +219,6 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
     */
     public void testSecondaryStrength() throws Exception {
         String index = "foo";
-        String type = "mytype";
 
         String[] equivalent = { "TESTING", "testing" };
 
@@ -241,7 +236,7 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).addMapping(type, builder));
+        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
 
         indexRandom(
             true,
@@ -269,7 +264,6 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
     */
     public void testIgnorePunctuation() throws Exception {
         String index = "foo";
-        String type = "mytype";
 
         String[] equivalent = { "foo-bar", "foo bar" };
 
@@ -287,7 +281,7 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).addMapping(type, builder));
+        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
 
         indexRandom(
             true,
@@ -315,7 +309,6 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
     */
     public void testIgnoreWhitespace() throws Exception {
         String index = "foo";
-        String type = "mytype";
 
         XContentBuilder builder = jsonBuilder().startObject()
             .startObject("properties")
@@ -333,7 +326,7 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).addMapping(type, builder));
+        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
 
         indexRandom(
             true,
@@ -363,7 +356,6 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
      */
     public void testNumerics() throws Exception {
         String index = "foo";
-        String type = "mytype";
 
         XContentBuilder builder = jsonBuilder().startObject()
             .startObject("properties")
@@ -376,7 +368,7 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).addMapping(type, builder));
+        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
 
         indexRandom(
             true,
@@ -399,7 +391,6 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
     */
     public void testIgnoreAccentsButNotCase() throws Exception {
         String index = "foo";
-        String type = "mytype";
 
         XContentBuilder builder = jsonBuilder().startObject()
             .startObject("properties")
@@ -416,7 +407,7 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).addMapping(type, builder));
+        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
 
         indexRandom(
             true,
@@ -441,7 +432,6 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
     */
     public void testUpperCaseFirst() throws Exception {
         String index = "foo";
-        String type = "mytype";
 
         XContentBuilder builder = jsonBuilder().startObject()
             .startObject("properties")
@@ -455,7 +445,7 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).addMapping(type, builder));
+        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
 
         indexRandom(
             true,
@@ -481,7 +471,6 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
     */
     public void testCustomRules() throws Exception {
         String index = "foo";
-        String type = "mytype";
 
         RuleBasedCollator baseCollator = (RuleBasedCollator) Collator.getInstance(new ULocale("de_DE"));
         String DIN5007_2_tailorings = "& ae , a\u0308 & AE , A\u0308" + "& oe , o\u0308 & OE , O\u0308" + "& ue , u\u0308 & UE , u\u0308";
@@ -504,7 +493,7 @@ public class ICUCollationKeywordFieldMapperIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).addMapping(type, builder));
+        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
 
         indexRandom(
             true,

--- a/plugins/mapper-size/src/internalClusterTest/java/org/opensearch/index/mapper/size/SizeMappingIT.java
+++ b/plugins/mapper-size/src/internalClusterTest/java/org/opensearch/index/mapper/size/SizeMappingIT.java
@@ -63,10 +63,9 @@ public class SizeMappingIT extends OpenSearchIntegTestCase {
     // issue 5053
     public void testThatUpdatingMappingShouldNotRemoveSizeMappingConfiguration() throws Exception {
         String index = "foo";
-        String type = MapperService.SINGLE_MAPPING_NAME;
 
         XContentBuilder builder = jsonBuilder().startObject().startObject("_size").field("enabled", true).endObject().endObject();
-        assertAcked(client().admin().indices().prepareCreate(index).addMapping(type, builder));
+        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
 
         // check mapping again
         assertSizeMappingEnabled(index, true);
@@ -88,10 +87,9 @@ public class SizeMappingIT extends OpenSearchIntegTestCase {
 
     public void testThatSizeCanBeSwitchedOnAndOff() throws Exception {
         String index = "foo";
-        String type = MapperService.SINGLE_MAPPING_NAME;
 
         XContentBuilder builder = jsonBuilder().startObject().startObject("_size").field("enabled", true).endObject().endObject();
-        assertAcked(client().admin().indices().prepareCreate(index).addMapping(type, builder));
+        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
 
         // check mapping again
         assertSizeMappingEnabled(index, true);

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/CreateIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/CreateIndexIT.java
@@ -110,8 +110,7 @@ public class CreateIndexIT extends OpenSearchIntegTestCase {
 
     public void testNonNestedMappings() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "_doc",
+            prepareCreate("test").setMapping(
                 XContentFactory.jsonBuilder()
                     .startObject()
                     .startObject("properties")
@@ -131,7 +130,7 @@ public class CreateIndexIT extends OpenSearchIntegTestCase {
     }
 
     public void testEmptyNestedMappings() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("_doc", XContentFactory.jsonBuilder().startObject().endObject()));
+        assertAcked(prepareCreate("test").setMapping(XContentFactory.jsonBuilder().startObject().endObject()));
 
         GetMappingsResponse response = client().admin().indices().prepareGetMappings("test").get();
 
@@ -144,10 +143,8 @@ public class CreateIndexIT extends OpenSearchIntegTestCase {
     public void testMappingParamAndNestedMismatch() throws Exception {
         MapperParsingException e = expectThrows(
             MapperParsingException.class,
-            () -> prepareCreate("test").addMapping(
-                MapperService.SINGLE_MAPPING_NAME,
-                XContentFactory.jsonBuilder().startObject().startObject("type2").endObject().endObject()
-            ).get()
+            () -> prepareCreate("test").setMapping(XContentFactory.jsonBuilder().startObject().startObject("type2").endObject().endObject())
+                .get()
         );
         assertThat(
             e.getMessage(),
@@ -159,10 +156,7 @@ public class CreateIndexIT extends OpenSearchIntegTestCase {
 
     public void testEmptyMappings() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "_doc",
-                XContentFactory.jsonBuilder().startObject().startObject("_doc").endObject().endObject()
-            )
+            prepareCreate("test").setMapping(XContentFactory.jsonBuilder().startObject().startObject("_doc").endObject().endObject())
         );
 
         GetMappingsResponse response = client().admin().indices().prepareGetMappings("test").get();

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/SimpleClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/SimpleClusterStateIT.java
@@ -261,7 +261,7 @@ public class SimpleClusterStateIT extends OpenSearchIntegTestCase {
             ByteSizeValue.parseBytesSizeValue("10k", "estimatedBytesSize").bytesAsInt(),
             ByteSizeValue.parseBytesSizeValue("256k", "estimatedBytesSize").bytesAsInt()
         );
-        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject().startObject("type").startObject("properties");
+        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject().startObject("properties");
         int counter = 0;
         int numberOfFields = 0;
         while (true) {
@@ -273,7 +273,7 @@ public class SimpleClusterStateIT extends OpenSearchIntegTestCase {
             }
         }
         logger.info("number of fields [{}], estimated bytes [{}]", numberOfFields, estimatedBytesSize);
-        mapping.endObject().endObject().endObject();
+        mapping.endObject().endObject();
 
         int numberOfShards = scaledRandomIntBetween(1, cluster().numDataNodes());
         // if the create index is ack'ed, then all nodes have successfully processed the cluster state
@@ -287,7 +287,7 @@ public class SimpleClusterStateIT extends OpenSearchIntegTestCase {
                         .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
                         .put(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey(), Long.MAX_VALUE)
                 )
-                .addMapping("type", mapping)
+                .setMapping(mapping)
                 .setTimeout("60s")
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/GatewayIndexStateIT.java
@@ -105,10 +105,7 @@ public class GatewayIndexStateIT extends OpenSearchIntegTestCase {
         client().admin()
             .indices()
             .prepareCreate("test")
-            .addMapping(
-                "type1",
-                XContentFactory.jsonBuilder().startObject().startObject("_routing").field("required", true).endObject().endObject()
-            )
+            .setMapping(XContentFactory.jsonBuilder().startObject().startObject("_routing").field("required", true).endObject().endObject())
             .execute()
             .actionGet();
 

--- a/server/src/internalClusterTest/java/org/opensearch/get/GetActionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/get/GetActionIT.java
@@ -541,16 +541,13 @@ public class GetActionIT extends OpenSearchIntegTestCase {
     public void testGetFieldsNonLeafField() throws Exception {
         assertAcked(
             prepareCreate("test").addAlias(new Alias("alias"))
-                .addMapping(
-                    "my-type1",
+                .setMapping(
                     jsonBuilder().startObject()
-                        .startObject("my-type1")
                         .startObject("properties")
                         .startObject("field1")
                         .startObject("properties")
                         .startObject("field2")
                         .field("type", "text")
-                        .endObject()
                         .endObject()
                         .endObject()
                         .endObject()
@@ -582,10 +579,8 @@ public class GetActionIT extends OpenSearchIntegTestCase {
             prepareCreate("my-index")
                 // multi types in 5.6
                 .setSettings(Settings.builder().put("index.refresh_interval", -1))
-                .addMapping(
-                    "my-type",
+                .setMapping(
                     jsonBuilder().startObject()
-                        .startObject("my-type")
                         .startObject("properties")
                         .startObject("field1")
                         .field("type", "object")
@@ -599,7 +594,6 @@ public class GetActionIT extends OpenSearchIntegTestCase {
                         .startObject("field4")
                         .field("type", "text")
                         .field("store", true)
-                        .endObject()
                         .endObject()
                         .endObject()
                         .endObject()

--- a/server/src/internalClusterTest/java/org/opensearch/index/IndexSortIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/IndexSortIT.java
@@ -92,7 +92,7 @@ public class IndexSortIT extends OpenSearchIntegTestCase {
                 .put("index.number_of_shards", "1")
                 .put("index.number_of_replicas", "1")
                 .putList("index.sort.field", "date", "numeric_dv", "keyword_dv")
-        ).addMapping("test", TEST_MAPPING).get();
+        ).setMapping(TEST_MAPPING).get();
         for (int i = 0; i < 20; i++) {
             client().prepareIndex("test")
                 .setId(Integer.toString(i))
@@ -108,7 +108,7 @@ public class IndexSortIT extends OpenSearchIntegTestCase {
         IllegalArgumentException exc = expectThrows(
             IllegalArgumentException.class,
             () -> prepareCreate("test").setSettings(Settings.builder().put(indexSettings()).putList("index.sort.field", "invalid_field"))
-                .addMapping("test", TEST_MAPPING)
+                .setMapping(TEST_MAPPING)
                 .get()
         );
         assertThat(exc.getMessage(), containsString("unknown index sort field:[invalid_field]"));
@@ -116,7 +116,7 @@ public class IndexSortIT extends OpenSearchIntegTestCase {
         exc = expectThrows(
             IllegalArgumentException.class,
             () -> prepareCreate("test").setSettings(Settings.builder().put(indexSettings()).putList("index.sort.field", "numeric"))
-                .addMapping("test", TEST_MAPPING)
+                .setMapping(TEST_MAPPING)
                 .get()
         );
         assertThat(exc.getMessage(), containsString("docvalues not found for index sort field:[numeric]"));
@@ -124,7 +124,7 @@ public class IndexSortIT extends OpenSearchIntegTestCase {
         exc = expectThrows(
             IllegalArgumentException.class,
             () -> prepareCreate("test").setSettings(Settings.builder().put(indexSettings()).putList("index.sort.field", "keyword"))
-                .addMapping("test", TEST_MAPPING)
+                .setMapping(TEST_MAPPING)
                 .get()
         );
         assertThat(exc.getMessage(), containsString("docvalues not found for index sort field:[keyword]"));

--- a/server/src/internalClusterTest/java/org/opensearch/index/fielddata/FieldDataLoadingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/fielddata/FieldDataLoadingIT.java
@@ -43,16 +43,13 @@ public class FieldDataLoadingIT extends OpenSearchIntegTestCase {
 
     public void testEagerGlobalOrdinalsFieldDataLoading() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type")
                     .startObject("properties")
                     .startObject("name")
                     .field("type", "text")
                     .field("fielddata", true)
                     .field("eager_global_ordinals", true)
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()

--- a/server/src/internalClusterTest/java/org/opensearch/index/mapper/CopyToMapperIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/mapper/CopyToMapperIntegrationIT.java
@@ -50,7 +50,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class CopyToMapperIntegrationIT extends OpenSearchIntegTestCase {
     public void testDynamicTemplateCopyTo() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test-idx").addMapping("_doc", createDynamicTemplateMapping()));
+        assertAcked(client().admin().indices().prepareCreate("test-idx").setMapping(createDynamicTemplateMapping()));
 
         int recordCount = between(1, 200);
 
@@ -98,7 +98,6 @@ public class CopyToMapperIntegrationIT extends OpenSearchIntegTestCase {
     private XContentBuilder createDynamicTemplateMapping() throws IOException {
         return XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("_doc")
             .startArray("dynamic_templates")
 
             .startObject()
@@ -124,7 +123,6 @@ public class CopyToMapperIntegrationIT extends OpenSearchIntegTestCase {
             .endObject()
 
             .endArray()
-            .endObject()
             .endObject();
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/index/mapper/ExternalValuesMapperIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/mapper/ExternalValuesMapperIntegrationIT.java
@@ -55,15 +55,12 @@ public class ExternalValuesMapperIntegrationIT extends OpenSearchIntegTestCase {
     }
 
     public void testHighlightingOnCustomString() throws Exception {
-        prepareCreate("test-idx").addMapping(
-            "type",
+        prepareCreate("test-idx").setMapping(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject("field")
                 .field("type", FakeStringFieldMapper.CONTENT_TYPE)
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -118,17 +115,14 @@ public class ExternalValuesMapperIntegrationIT extends OpenSearchIntegTestCase {
     }
 
     public void testExternalValues() throws Exception {
-        prepareCreate("test-idx").addMapping(
-            "type",
+        prepareCreate("test-idx").setMapping(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("type")
                 .startObject(ExternalMetadataMapper.CONTENT_TYPE)
                 .endObject()
                 .startObject("properties")
                 .startObject("field")
                 .field("type", ExternalMapperPlugin.EXTERNAL)
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -166,11 +160,9 @@ public class ExternalValuesMapperIntegrationIT extends OpenSearchIntegTestCase {
     }
 
     public void testExternalValuesWithMultifield() throws Exception {
-        prepareCreate("test-idx").addMapping(
-            "_doc",
+        prepareCreate("test-idx").setMapping(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("_doc")
                 .startObject("properties")
                 .startObject("f")
                 .field("type", ExternalMapperPlugin.EXTERNAL_UPPER)
@@ -182,7 +174,6 @@ public class ExternalValuesMapperIntegrationIT extends OpenSearchIntegTestCase {
                 .startObject("raw")
                 .field("type", "keyword")
                 .field("store", true)
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()

--- a/server/src/internalClusterTest/java/org/opensearch/index/mapper/MultiFieldsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/mapper/MultiFieldsIntegrationIT.java
@@ -58,7 +58,7 @@ import static org.hamcrest.Matchers.nullValue;
 public class MultiFieldsIntegrationIT extends OpenSearchIntegTestCase {
     @SuppressWarnings("unchecked")
     public void testMultiFields() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("my-index").addMapping("my-type", createTypeSource()));
+        assertAcked(client().admin().indices().prepareCreate("my-index").setMapping(createTypeSource()));
 
         GetMappingsResponse getMappingsResponse = client().admin().indices().prepareGetMappings("my-index").get();
         MappingMetadata mappingMetadata = getMappingsResponse.mappings().get("my-index");
@@ -98,7 +98,7 @@ public class MultiFieldsIntegrationIT extends OpenSearchIntegTestCase {
 
     @SuppressWarnings("unchecked")
     public void testGeoPointMultiField() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("my-index").addMapping("my-type", createMappingSource("geo_point")));
+        assertAcked(client().admin().indices().prepareCreate("my-index").setMapping(createMappingSource("geo_point")));
 
         GetMappingsResponse getMappingsResponse = client().admin().indices().prepareGetMappings("my-index").get();
         MappingMetadata mappingMetadata = getMappingsResponse.mappings().get("my-index");
@@ -127,7 +127,7 @@ public class MultiFieldsIntegrationIT extends OpenSearchIntegTestCase {
 
     @SuppressWarnings("unchecked")
     public void testCompletionMultiField() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("my-index").addMapping("my-type", createMappingSource("completion")));
+        assertAcked(client().admin().indices().prepareCreate("my-index").setMapping(createMappingSource("completion")));
 
         GetMappingsResponse getMappingsResponse = client().admin().indices().prepareGetMappings("my-index").get();
         MappingMetadata mappingMetadata = getMappingsResponse.mappings().get("my-index");
@@ -149,7 +149,7 @@ public class MultiFieldsIntegrationIT extends OpenSearchIntegTestCase {
 
     @SuppressWarnings("unchecked")
     public void testIpMultiField() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("my-index").addMapping("my-type", createMappingSource("ip")));
+        assertAcked(client().admin().indices().prepareCreate("my-index").setMapping(createMappingSource("ip")));
 
         GetMappingsResponse getMappingsResponse = client().admin().indices().prepareGetMappings("my-index").get();
         MappingMetadata mappingMetadata = getMappingsResponse.mappings().get("my-index");
@@ -172,7 +172,6 @@ public class MultiFieldsIntegrationIT extends OpenSearchIntegTestCase {
     private XContentBuilder createMappingSource(String fieldType) throws IOException {
         return XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("my-type")
             .startObject("properties")
             .startObject("a")
             .field("type", fieldType)
@@ -183,21 +182,18 @@ public class MultiFieldsIntegrationIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
     }
 
     private XContentBuilder createTypeSource() throws IOException {
         return XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("my-type")
             .startObject("properties")
             .startObject("title")
             .field("type", "text")
             .startObject("fields")
             .startObject("not_analyzed")
             .field("type", "keyword")
-            .endObject()
             .endObject()
             .endObject()
             .endObject()

--- a/server/src/internalClusterTest/java/org/opensearch/indices/analysis/PreBuiltAnalyzerIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/analysis/PreBuiltAnalyzerIntegrationIT.java
@@ -78,18 +78,16 @@ public class PreBuiltAnalyzerIntegrationIT extends OpenSearchIntegTestCase {
             loadedAnalyzers.get(preBuiltAnalyzer).add(randomVersion);
 
             final XContentBuilder mapping = jsonBuilder().startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject("foo")
                 .field("type", "text")
                 .field("analyzer", name)
                 .endObject()
                 .endObject()
-                .endObject()
                 .endObject();
 
             Settings versionSettings = settings(randomVersion).build();
-            client().admin().indices().prepareCreate(indexName).addMapping("type", mapping).setSettings(versionSettings).get();
+            client().admin().indices().prepareCreate(indexName).setMapping(mapping).setSettings(versionSettings).get();
         }
 
         ensureGreen();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/mapping/SimpleGetFieldMappingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/mapping/SimpleGetFieldMappingsIT.java
@@ -80,9 +80,8 @@ public class SimpleGetFieldMappingsIT extends OpenSearchIntegTestCase {
         assertThat(response.fieldMappings("index", "field"), nullValue());
     }
 
-    private XContentBuilder getMappingForType(String type) throws IOException {
+    private XContentBuilder getMappingForType() throws IOException {
         return jsonBuilder().startObject()
-            .startObject(type)
             .startObject("properties")
             .startObject("field1")
             .field("type", "text")
@@ -99,14 +98,13 @@ public class SimpleGetFieldMappingsIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
     }
 
     public void testGetFieldMappings() throws Exception {
 
-        assertAcked(prepareCreate("indexa").addMapping("typeA", getMappingForType("typeA")));
-        assertAcked(client().admin().indices().prepareCreate("indexb").addMapping("typeB", getMappingForType("typeB")));
+        assertAcked(prepareCreate("indexa").setMapping(getMappingForType()));
+        assertAcked(client().admin().indices().prepareCreate("indexb").setMapping(getMappingForType()));
 
         // Get mappings by full name
         GetFieldMappingsResponse response = client().admin()
@@ -136,7 +134,7 @@ public class SimpleGetFieldMappingsIT extends OpenSearchIntegTestCase {
 
     @SuppressWarnings("unchecked")
     public void testSimpleGetFieldMappingsWithDefaults() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type", getMappingForType("type")));
+        assertAcked(prepareCreate("test").setMapping(getMappingForType()));
         client().admin().indices().preparePutMapping("test").setSource("num", "type=long").get();
         client().admin().indices().preparePutMapping("test").setSource("field2", "type=text,index=false").get();
 
@@ -163,7 +161,7 @@ public class SimpleGetFieldMappingsIT extends OpenSearchIntegTestCase {
 
     @SuppressWarnings("unchecked")
     public void testGetFieldMappingsWithFieldAlias() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type", getMappingForType("type")));
+        assertAcked(prepareCreate("test").setMapping(getMappingForType()));
 
         GetFieldMappingsResponse response = client().admin().indices().prepareGetFieldMappings().setFields("alias", "field1").get();
 
@@ -179,7 +177,7 @@ public class SimpleGetFieldMappingsIT extends OpenSearchIntegTestCase {
 
     // fix #6552
     public void testSimpleGetFieldMappingsWithPretty() throws Exception {
-        assertAcked(prepareCreate("index").addMapping("type", getMappingForType("type")));
+        assertAcked(prepareCreate("index").setMapping(getMappingForType()));
         Map<String, String> params = new HashMap<>();
         params.put("pretty", "true");
         GetFieldMappingsResponse response = client().admin()
@@ -209,7 +207,7 @@ public class SimpleGetFieldMappingsIT extends OpenSearchIntegTestCase {
     }
 
     public void testGetFieldMappingsWithBlocks() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("_doc", getMappingForType("_doc")));
+        assertAcked(prepareCreate("test").setMapping(getMappingForType()));
 
         for (String block : Arrays.asList(SETTING_BLOCKS_READ, SETTING_BLOCKS_WRITE, SETTING_READ_ONLY)) {
             try {

--- a/server/src/internalClusterTest/java/org/opensearch/indices/mapping/SimpleGetMappingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/mapping/SimpleGetMappingsIT.java
@@ -70,21 +70,19 @@ public class SimpleGetMappingsIT extends OpenSearchIntegTestCase {
         assertEquals(MappingMetadata.EMPTY_MAPPINGS, response.mappings().get("index"));
     }
 
-    private XContentBuilder getMappingForType(String type) throws IOException {
+    private XContentBuilder getMappingForType() throws IOException {
         return jsonBuilder().startObject()
-            .startObject(type)
             .startObject("properties")
             .startObject("field1")
             .field("type", "text")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();
     }
 
     public void testSimpleGetMappings() throws Exception {
-        client().admin().indices().prepareCreate("indexa").addMapping("typeA", getMappingForType("typeA")).execute().actionGet();
-        client().admin().indices().prepareCreate("indexb").addMapping("typeA", getMappingForType("typeA")).execute().actionGet();
+        client().admin().indices().prepareCreate("indexa").setMapping(getMappingForType()).execute().actionGet();
+        client().admin().indices().prepareCreate("indexb").setMapping(getMappingForType()).execute().actionGet();
 
         ClusterHealthResponse clusterHealth = client().admin()
             .cluster()
@@ -114,7 +112,7 @@ public class SimpleGetMappingsIT extends OpenSearchIntegTestCase {
     }
 
     public void testGetMappingsWithBlocks() throws IOException {
-        client().admin().indices().prepareCreate("test").addMapping("_doc", getMappingForType("_doc")).execute().actionGet();
+        client().admin().indices().prepareCreate("test").setMapping(getMappingForType()).execute().actionGet();
         ensureGreen();
 
         for (String block : Arrays.asList(SETTING_BLOCKS_READ, SETTING_BLOCKS_WRITE, SETTING_READ_ONLY)) {

--- a/server/src/internalClusterTest/java/org/opensearch/mget/SimpleMgetIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/mget/SimpleMgetIT.java
@@ -129,16 +129,7 @@ public class SimpleMgetIT extends OpenSearchIntegTestCase {
     public void testThatMgetShouldWorkWithAliasRouting() throws IOException {
         assertAcked(
             prepareCreate("test").addAlias(new Alias("alias1").routing("abc"))
-                .addMapping(
-                    "test",
-                    jsonBuilder().startObject()
-                        .startObject("test")
-                        .startObject("_routing")
-                        .field("required", true)
-                        .endObject()
-                        .endObject()
-                        .endObject()
-                )
+                .setMapping(jsonBuilder().startObject().startObject("_routing").field("required", true).endObject().endObject())
         );
 
         client().prepareIndex("alias1")

--- a/server/src/internalClusterTest/java/org/opensearch/routing/SimpleRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/routing/SimpleRoutingIT.java
@@ -351,17 +351,7 @@ public class SimpleRoutingIT extends OpenSearchIntegTestCase {
             .indices()
             .prepareCreate("test")
             .addAlias(new Alias("alias"))
-            .addMapping(
-                "type1",
-                XContentFactory.jsonBuilder()
-                    .startObject()
-                    .startObject("type1")
-                    .startObject("_routing")
-                    .field("required", true)
-                    .endObject()
-                    .endObject()
-                    .endObject()
-            )
+            .setMapping(XContentFactory.jsonBuilder().startObject().startObject("_routing").field("required", true).endObject().endObject())
             .execute()
             .actionGet();
         ensureGreen();
@@ -450,17 +440,7 @@ public class SimpleRoutingIT extends OpenSearchIntegTestCase {
             .indices()
             .prepareCreate("test")
             .addAlias(new Alias("alias"))
-            .addMapping(
-                "type1",
-                XContentFactory.jsonBuilder()
-                    .startObject()
-                    .startObject("type1")
-                    .startObject("_routing")
-                    .field("required", true)
-                    .endObject()
-                    .endObject()
-                    .endObject()
-            )
+            .setMapping(XContentFactory.jsonBuilder().startObject().startObject("_routing").field("required", true).endObject().endObject())
             .execute()
             .actionGet();
         ensureGreen();
@@ -544,14 +524,12 @@ public class SimpleRoutingIT extends OpenSearchIntegTestCase {
             .indices()
             .prepareCreate("test")
             .addAlias(new Alias("alias"))
-            .addMapping(
-                "type1",
+            .setMapping(
                 XContentFactory.jsonBuilder()
                     .startObject()
                     .startObject("type1")
                     .startObject("_routing")
                     .field("required", true)
-                    .endObject()
                     .endObject()
                     .endObject()
             )

--- a/server/src/internalClusterTest/java/org/opensearch/routing/SimpleRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/routing/SimpleRoutingIT.java
@@ -524,15 +524,7 @@ public class SimpleRoutingIT extends OpenSearchIntegTestCase {
             .indices()
             .prepareCreate("test")
             .addAlias(new Alias("alias"))
-            .setMapping(
-                XContentFactory.jsonBuilder()
-                    .startObject()
-                    .startObject("type1")
-                    .startObject("_routing")
-                    .field("required", true)
-                    .endObject()
-                    .endObject()
-            )
+            .setMapping(XContentFactory.jsonBuilder().startObject().startObject("_routing").field("required", true).endObject().endObject())
             .execute()
             .actionGet();
         ensureGreen();

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/CombiIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/CombiIT.java
@@ -115,17 +115,14 @@ public class CombiIT extends OpenSearchIntegTestCase {
      */
     public void testSubAggregationForTopAggregationOnUnmappedField() throws Exception {
 
-        prepareCreate("idx").addMapping(
-            "type",
+        prepareCreate("idx").setMapping(
             jsonBuilder().startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject("name")
                 .field("type", "keyword")
                 .endObject()
                 .startObject("value")
                 .field("type", "integer")
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/EquivalenceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/EquivalenceIT.java
@@ -133,14 +133,11 @@ public class EquivalenceIT extends OpenSearchIntegTestCase {
             }
         }
 
-        prepareCreate("idx").addMapping(
-            "type",
+        prepareCreate("idx").setMapping(
             jsonBuilder().startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject("values")
                 .field("type", "double")
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -235,10 +232,8 @@ public class EquivalenceIT extends OpenSearchIntegTestCase {
 
         final IntHashSet valuesSet = new IntHashSet();
         cluster().wipeIndices("idx");
-        prepareCreate("idx").addMapping(
-            "type",
+        prepareCreate("idx").setMapping(
             jsonBuilder().startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject("num")
                 .field("type", "double")
@@ -257,7 +252,6 @@ public class EquivalenceIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .startObject("double_values")
                 .field("type", "double")
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -358,14 +352,11 @@ public class EquivalenceIT extends OpenSearchIntegTestCase {
 
     // Duel between histograms and scripted terms
     public void testDuelTermsHistogram() throws Exception {
-        prepareCreate("idx").addMapping(
-            "type",
+        prepareCreate("idx").setMapping(
             jsonBuilder().startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject("num")
                 .field("type", "double")
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -422,14 +413,11 @@ public class EquivalenceIT extends OpenSearchIntegTestCase {
 
     public void testLargeNumbersOfPercentileBuckets() throws Exception {
         // test high numbers of percentile buckets to make sure paging and release work correctly
-        prepareCreate("idx").addMapping(
-            "type",
+        prepareCreate("idx").setMapping(
             jsonBuilder().startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject("double_value")
                 .field("type", "double")
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/NestedIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/NestedIT.java
@@ -158,17 +158,14 @@ public class NestedIT extends OpenSearchIntegTestCase {
         }
 
         assertAcked(
-            prepareCreate("idx_nested_nested_aggs").addMapping(
-                "type",
+            prepareCreate("idx_nested_nested_aggs").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type")
                     .startObject("properties")
                     .startObject("nested1")
                     .field("type", "nested")
                     .startObject("properties")
                     .startObject("nested2")
                     .field("type", "nested")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -400,7 +397,6 @@ public class NestedIT extends OpenSearchIntegTestCase {
     // Test based on: https://github.com/elastic/elasticsearch/issues/9280
     public void testParentFilterResolvedCorrectly() throws Exception {
         XContentBuilder mapping = jsonBuilder().startObject()
-            .startObject("provider")
             .startObject("properties")
             .startObject("comments")
             .field("type", "nested")
@@ -450,11 +446,10 @@ public class NestedIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
         assertAcked(
             prepareCreate("idx2").setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0))
-                .addMapping("provider", mapping)
+                .setMapping(mapping)
         );
         ensureGreen("idx2");
 
@@ -649,10 +644,8 @@ public class NestedIT extends OpenSearchIntegTestCase {
 
     public void testFilterAggInsideNestedAgg() throws Exception {
         assertAcked(
-            prepareCreate("classes").addMapping(
-                "class",
+            prepareCreate("classes").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("class")
                     .startObject("properties")
                     .startObject("name")
                     .field("type", "text")
@@ -674,7 +667,6 @@ public class NestedIT extends OpenSearchIntegTestCase {
                     .endObject()
                     .startObject("type")
                     .field("type", "keyword")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/ReverseNestedIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/ReverseNestedIT.java
@@ -75,8 +75,7 @@ public class ReverseNestedIT extends OpenSearchIntegTestCase {
     @Override
     public void setupSuiteScopeCluster() throws Exception {
         assertAcked(
-            prepareCreate("idx1").addMapping(
-                "type",
+            prepareCreate("idx1").setMapping(
                 jsonBuilder().startObject()
                     .startObject("properties")
                     .startObject("field1")
@@ -99,8 +98,7 @@ public class ReverseNestedIT extends OpenSearchIntegTestCase {
             )
         );
         assertAcked(
-            prepareCreate("idx2").addMapping(
-                "type",
+            prepareCreate("idx2").setMapping(
                 jsonBuilder().startObject()
                     .startObject("properties")
                     .startObject("nested1")
@@ -531,7 +529,6 @@ public class ReverseNestedIT extends OpenSearchIntegTestCase {
 
     public void testSameParentDocHavingMultipleBuckets() throws Exception {
         XContentBuilder mapping = jsonBuilder().startObject()
-            .startObject("product")
             .field("dynamic", "strict")
             .startObject("properties")
             .startObject("id")
@@ -562,11 +559,10 @@ public class ReverseNestedIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
         assertAcked(
             prepareCreate("idx3").setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0))
-                .addMapping("product", mapping)
+                .setMapping(mapping)
         );
 
         client().prepareIndex("idx3")

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/CardinalityIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/CardinalityIT.java
@@ -128,10 +128,8 @@ public class CardinalityIT extends OpenSearchIntegTestCase {
     @Override
     public void setupSuiteScopeCluster() throws Exception {
 
-        prepareCreate("idx").addMapping(
-            "type",
+        prepareCreate("idx").setMapping(
             jsonBuilder().startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject("str_value")
                 .field("type", "keyword")
@@ -150,7 +148,6 @@ public class CardinalityIT extends OpenSearchIntegTestCase {
                 .endObject()
                 .startObject("d_values")
                 .field("type", "double")
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TopHitsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TopHitsIT.java
@@ -139,10 +139,8 @@ public class TopHitsIT extends OpenSearchIntegTestCase {
         assertAcked(prepareCreate("field-collapsing").addMapping("type", "group", "type=keyword"));
         createIndex("empty");
         assertAcked(
-            prepareCreate("articles").addMapping(
-                "article",
+            prepareCreate("articles").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("article")
                     .startObject("properties")
                     .startObject(TERMS_AGGS_FIELD)
                     .field("type", "keyword")
@@ -167,7 +165,6 @@ public class TopHitsIT extends OpenSearchIntegTestCase {
                     .startObject("properties")
                     .startObject("name")
                     .field("type", "keyword")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MaxBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MaxBucketIT.java
@@ -556,7 +556,7 @@ public class MaxBucketIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject()
             .endObject();
-        assertAcked(client().admin().indices().prepareCreate("foo_2").addMapping("doc", builder).get());
+        assertAcked(client().admin().indices().prepareCreate("foo_2").setMapping(builder).get());
 
         XContentBuilder docBuilder = jsonBuilder().startObject()
             .startObject("license")

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MovAvgIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MovAvgIT.java
@@ -130,15 +130,12 @@ public class MovAvgIT extends OpenSearchIntegTestCase {
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        prepareCreate("idx").addMapping(
-            "type",
+        prepareCreate("idx").setMapping(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject(VALUE_FIELD)
                 .field("type", "double")
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()

--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/FetchSubPhasePluginIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/FetchSubPhasePluginIT.java
@@ -79,15 +79,12 @@ public class FetchSubPhasePluginIT extends OpenSearchIntegTestCase {
         client().admin()
             .indices()
             .prepareCreate("test")
-            .addMapping(
-                "type1",
+            .setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("test")
                     .field("type", "text")
                     .field("term_vector", "yes")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()

--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/InnerHitsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/InnerHitsIT.java
@@ -100,10 +100,8 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
 
     public void testSimpleNested() throws Exception {
         assertAcked(
-            prepareCreate("articles").addMapping(
-                "article",
+            prepareCreate("articles").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("article")
                     .startObject("properties")
                     .startObject("comments")
                     .field("type", "nested")
@@ -116,7 +114,6 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
                     .endObject()
                     .startObject("title")
                     .field("type", "text")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -313,10 +310,8 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
 
     public void testNestedMultipleLayers() throws Exception {
         assertAcked(
-            prepareCreate("articles").addMapping(
-                "article",
+            prepareCreate("articles").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("article")
                     .startObject("properties")
                     .startObject("comments")
                     .field("type", "nested")
@@ -336,7 +331,6 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
                     .endObject()
                     .startObject("title")
                     .field("type", "text")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -583,8 +577,7 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
                 // number_of_shards = 1, because then we catch the expected exception in the same way.
                 // (See expectThrows(...) below)
                 .setSettings(Settings.builder().put("index.number_of_shards", 1))
-                .addMapping(
-                    "article",
+                .setMapping(
                     jsonBuilder().startObject()
                         .startObject("properties")
                         .startObject("comments")
@@ -741,7 +734,6 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
 
     public void testMatchesQueriesNestedInnerHits() throws Exception {
         XContentBuilder builder = jsonBuilder().startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("nested1")
             .field("type", "nested")
@@ -755,9 +747,8 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
             .field("type", "long")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(prepareCreate("test").addMapping("type1", builder));
+        assertAcked(prepareCreate("test").setMapping(builder));
         ensureGreen();
 
         List<IndexRequestBuilder> requests = new ArrayList<>();

--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -139,18 +139,16 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     public void testHighlightingWithKeywordIgnoreBoundaryScanner() throws IOException {
         XContentBuilder mappings = jsonBuilder();
         mappings.startObject();
-        mappings.startObject("type")
-            .startObject("properties")
+        mappings.startObject("properties")
             .startObject("tags")
             .field("type", "keyword")
             .endObject()
             .startObject("sort")
             .field("type", "long")
             .endObject()
-            .endObject()
             .endObject();
         mappings.endObject();
-        assertAcked(prepareCreate("test").addMapping("type", mappings));
+        assertAcked(prepareCreate("test").setMapping(mappings));
         client().prepareIndex("test")
             .setId("1")
             .setSource(jsonBuilder().startObject().array("tags", "foo bar", "foo bar", "foo bar", "foo baz").field("sort", 1).endObject())
@@ -176,16 +174,9 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     public void testHighlightingWithStoredKeyword() throws IOException {
         XContentBuilder mappings = jsonBuilder();
         mappings.startObject();
-        mappings.startObject("type")
-            .startObject("properties")
-            .startObject("text")
-            .field("type", "keyword")
-            .field("store", true)
-            .endObject()
-            .endObject()
-            .endObject();
+        mappings.startObject("properties").startObject("text").field("type", "keyword").field("store", true).endObject().endObject();
         mappings.endObject();
-        assertAcked(prepareCreate("test").addMapping("type", mappings));
+        assertAcked(prepareCreate("test").setMapping(mappings));
         client().prepareIndex("test").setId("1").setSource(jsonBuilder().startObject().field("text", "foo").endObject()).get();
         refresh();
         SearchResponse search = client().prepareSearch()
@@ -199,18 +190,16 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         // test the kibana case with * as fieldname that will try highlight all fields including meta fields
         XContentBuilder mappings = jsonBuilder();
         mappings.startObject();
-        mappings.startObject("type")
-            .startObject("properties")
+        mappings.startObject("properties")
             .startObject("text")
             .field("type", "text")
             .field("analyzer", "keyword")
             .field("index_options", "offsets")
             .field("term_vector", "with_positions_offsets")
             .endObject()
-            .endObject()
             .endObject();
         mappings.endObject();
-        assertAcked(prepareCreate("test").addMapping("type", mappings));
+        assertAcked(prepareCreate("test").setMapping(mappings));
         client().prepareIndex("test").setId("1").setSource(jsonBuilder().startObject().field("text", "text").endObject()).get();
         refresh();
         for (String type : ALL_TYPES) {
@@ -224,7 +213,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testFieldAlias() throws IOException {
         XContentBuilder mappings = jsonBuilder().startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("text")
             .field("type", "text")
@@ -236,9 +224,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .field("path", "text")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(prepareCreate("test").addMapping("type", mappings));
+        assertAcked(prepareCreate("test").setMapping(mappings));
 
         client().prepareIndex("test").setId("1").setSource("text", "foo").get();
         refresh();
@@ -253,7 +240,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testFieldAliasWithSourceLookup() throws IOException {
         XContentBuilder mappings = jsonBuilder().startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("text")
             .field("type", "text")
@@ -266,9 +252,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .field("path", "text")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(prepareCreate("test").addMapping("type", mappings));
+        assertAcked(prepareCreate("test").setMapping(mappings));
 
         client().prepareIndex("test").setId("1").setSource("text", "foo bar").get();
         refresh();
@@ -283,7 +268,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testFieldAliasWithWildcardField() throws IOException {
         XContentBuilder mappings = jsonBuilder().startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("keyword")
             .field("type", "keyword")
@@ -293,9 +277,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .field("path", "keyword")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(prepareCreate("test").addMapping("type", mappings));
+        assertAcked(prepareCreate("test").setMapping(mappings));
 
         client().prepareIndex("test").setId("1").setSource("keyword", "foo").get();
         refresh();
@@ -308,8 +291,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     public void testHighlightingWhenFieldsAreNotStoredThereIsNoSource() throws IOException {
         XContentBuilder mappings = jsonBuilder();
         mappings.startObject();
-        mappings.startObject("type")
-            .startObject("_source")
+        mappings.startObject("_source")
             .field("enabled", false)
             .endObject()
             .startObject("properties")
@@ -325,10 +307,9 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .field("type", "text")
             .field("store", true)
             .endObject()
-            .endObject()
             .endObject();
         mappings.endObject();
-        assertAcked(prepareCreate("test").addMapping("type", mappings));
+        assertAcked(prepareCreate("test").setMapping(mappings));
         client().prepareIndex("test")
             .setId("1")
             .setSource(jsonBuilder().startObject().field("unstored_text", "text").field("text", "text").endObject())
@@ -410,10 +391,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testSourceLookupHighlightingUsingPlainHighlighter() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     // we don't store title and don't use term vector, now lets see if it works...
                     .startObject("title")
@@ -427,7 +406,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
                     .field("type", "text")
                     .field("store", false)
                     .field("term_vector", "no")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -480,10 +458,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testSourceLookupHighlightingUsingFastVectorHighlighter() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     // we don't store title, now lets see if it works...
                     .startObject("title")
@@ -497,7 +473,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
                     .field("type", "text")
                     .field("store", false)
                     .field("term_vector", "with_positions_offsets")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -550,10 +525,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testSourceLookupHighlightingUsingPostingsHighlighter() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     // we don't store title, now lets see if it works...
                     .startObject("title")
@@ -567,7 +540,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
                     .field("type", "text")
                     .field("store", false)
                     .field("index_options", "offsets")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -771,10 +743,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testForceSourceWithSourceDisabled() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("_source")
                     .field("enabled", false)
                     .endObject()
@@ -787,7 +757,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
                     .endObject()
                     .startObject("field2")
                     .field("type", "text")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -852,7 +821,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testFastVectorHighlighter() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1TermVectorMapping()));
         ensureGreen();
 
         indexRandom(
@@ -886,7 +855,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testHighlighterWithSentenceBoundaryScanner() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1TermVectorMapping()));
         ensureGreen();
 
         indexRandom(
@@ -927,7 +896,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testHighlighterWithSentenceBoundaryScannerAndLocale() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1TermVectorMapping()));
         ensureGreen();
 
         indexRandom(
@@ -970,7 +939,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testHighlighterWithWordBoundaryScanner() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1TermVectorMapping()));
         ensureGreen();
 
         indexRandom(true, client().prepareIndex("test").setSource("field1", "some quick and hairy brown:fox jumped over the lazy dog"));
@@ -1000,7 +969,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testHighlighterWithWordBoundaryScannerAndLocale() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1TermVectorMapping()));
         ensureGreen();
 
         indexRandom(true, client().prepareIndex("test").setSource("field1", "some quick and hairy brown:fox jumped over the lazy dog"));
@@ -1034,7 +1003,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
      * phraseLimit is not set. Its default is now reasonably low.
      */
     public void testFVHManyMatches() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1TermVectorMapping()));
         ensureGreen();
 
         // Index one megabyte of "t " over and over and over again
@@ -1085,11 +1054,9 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         settings.put("index.analysis.analyzer.mock_english.filter", "mock_snowball");
         assertAcked(
             prepareCreate("test").setSettings(settings)
-                .addMapping(
-                    "type1",
+                .setMapping(
                     XContentFactory.jsonBuilder()
                         .startObject()
-                        .startObject("type1")
                         .startObject("properties")
                         .startObject("foo")
                         .field("type", "text")
@@ -1114,7 +1081,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
                         .field("type", "text")
                         .field("term_vector", "with_positions_offsets")
                         .field("analyzer", "standard")
-                        .endObject()
                         .endObject()
                         .endObject()
                         .endObject()
@@ -1270,7 +1236,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testFastVectorHighlighterManyDocs() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1TermVectorMapping()));
         ensureGreen();
 
         int COUNT = between(20, 100);
@@ -1297,7 +1263,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     public XContentBuilder type1TermVectorMapping() throws IOException {
         return XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("field1")
             .field("type", "text")
@@ -1306,7 +1271,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .startObject("field2")
             .field("type", "text")
             .field("term_vector", "with_positions_offsets")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();
@@ -1406,10 +1370,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testMultiMapperVectorWithStore() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("title")
                     .field("type", "text")
@@ -1422,7 +1384,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
                     .field("store", true)
                     .field("term_vector", "with_positions_offsets")
                     .field("analyzer", "whitespace")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -1453,10 +1414,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testMultiMapperVectorFromSource() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("title")
                     .field("type", "text")
@@ -1469,7 +1428,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
                     .field("store", false)
                     .field("term_vector", "with_positions_offsets")
                     .field("analyzer", "whitespace")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -1501,10 +1459,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testMultiMapperNoVectorWithStore() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("title")
                     .field("type", "text")
@@ -1517,7 +1473,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
                     .field("store", true)
                     .field("term_vector", "no")
                     .field("analyzer", "whitespace")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -1549,10 +1504,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testMultiMapperNoVectorFromSource() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("title")
                     .field("type", "text")
@@ -1565,7 +1518,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
                     .field("store", false)
                     .field("term_vector", "no")
                     .field("analyzer", "whitespace")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -1739,7 +1691,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testBoostingQueryTermVector() throws IOException {
-        assertAcked(prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1TermVectorMapping()));
         ensureGreen();
         client().prepareIndex("test").setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog").get();
         refresh();
@@ -1770,7 +1722,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testCommonTermsTermVector() throws IOException {
-        assertAcked(prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1TermVectorMapping()));
         ensureGreen();
 
         client().prepareIndex("test").setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog").get();
@@ -2278,7 +2230,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPostingsHighlighter() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test")
@@ -2349,7 +2301,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPostingsHighlighterMultipleFields() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()).get());
+        assertAcked(prepareCreate("test").setMapping(type1PostingsffsetsMapping()).get());
         ensureGreen();
 
         index(
@@ -2371,7 +2323,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPostingsHighlighterNumberOfFragments() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test")
@@ -2457,7 +2409,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     public void testMultiMatchQueryHighlight() throws IOException {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("field1")
             .field("type", "text")
@@ -2470,9 +2421,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .field("term_vector", "with_positions_offsets")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(prepareCreate("test").addMapping("type1", mapping));
+        assertAcked(prepareCreate("test").setMapping(mapping));
         ensureGreen();
         client().prepareIndex("test")
             .setSource("field1", "The quick brown fox jumps over", "field2", "The quick brown fox jumps over")
@@ -2507,7 +2457,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPostingsHighlighterOrderByScore() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test")
@@ -2585,10 +2535,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testPostingsHighlighterMultiMapperWithStore() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("title")
                     .field("type", "text")
@@ -2601,7 +2549,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
                     .field("store", true)
                     .field("index_options", "offsets")
                     .field("analyzer", "whitespace")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -2645,10 +2592,8 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testPostingsHighlighterMultiMapperFromSource() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("title")
                     .field("type", "text")
@@ -2661,7 +2606,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
                     .field("store", false)
                     .field("index_options", "offsets")
                     .field("analyzer", "whitespace")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -2693,16 +2637,13 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testPostingsHighlighterShouldFailIfNoOffsets() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("title")
                     .field("type", "text")
                     .field("store", true)
                     .field("index_options", "docs")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -2726,7 +2667,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPostingsHighlighterBoostingQuery() throws IOException {
-        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1PostingsffsetsMapping()));
         ensureGreen();
         client().prepareIndex("test")
             .setSource("field1", "this is a test", "field2", "The quick brown fox jumps over the lazy dog! Second sentence.")
@@ -2743,7 +2684,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPostingsHighlighterCommonTermsQuery() throws IOException {
-        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test")
@@ -2770,7 +2711,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     private static XContentBuilder type1PostingsffsetsMapping() throws IOException {
         return XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("field1")
             .field("type", "text")
@@ -2781,12 +2721,11 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .field("index_options", "offsets")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
     }
 
     public void testPostingsHighlighterPrefixQuery() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test")
@@ -2808,7 +2747,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPostingsHighlighterFuzzyQuery() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test")
@@ -2831,7 +2770,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPostingsHighlighterRegexpQuery() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test")
@@ -2854,7 +2793,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPostingsHighlighterWildcardQuery() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test")
@@ -2890,7 +2829,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPostingsHighlighterTermRangeQuery() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test").setSource("field1", "this is a test", "field2", "aaab").get();
@@ -2905,7 +2844,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPostingsHighlighterQueryString() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test")
@@ -2928,7 +2867,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPostingsHighlighterRegexpQueryWithinConstantScoreQuery() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test").setSource("field1", "The photography word will get highlighted").get();
@@ -2942,7 +2881,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPostingsHighlighterMultiTermQueryMultipleLevels() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test").setSource("field1", "The photography word will get highlighted").get();
@@ -2959,7 +2898,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPostingsHighlighterPrefixQueryWithinBooleanQuery() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test").setSource("field1", "The photography word will get highlighted").get();
@@ -2974,7 +2913,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPostingsHighlighterQueryStringWithinFilteredQuery() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1PostingsffsetsMapping()));
         ensureGreen();
 
         client().prepareIndex("test").setSource("field1", "The photography word will get highlighted").get();
@@ -2989,7 +2928,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPostingsHighlighterManyDocs() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1PostingsffsetsMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1PostingsffsetsMapping()));
         ensureGreen();
 
         int COUNT = between(20, 100);
@@ -3035,7 +2974,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject()
             .endObject();
-        assertAcked(prepareCreate("test").addMapping("typename", mapping));
+        assertAcked(prepareCreate("test").setMapping(mapping));
         ensureGreen();
 
         indexRandom(true, client().prepareIndex("test").setSource("foo", "test typename"));
@@ -3062,7 +3001,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject()
             .endObject();
-        assertAcked(prepareCreate("test").addMapping("typename", mapping));
+        assertAcked(prepareCreate("test").setMapping(mapping));
         assertAcked(client().admin().indices().prepareAliases().addAlias("test", "filtered_alias", matchQuery("foo", "japanese")));
         ensureGreen();
 
@@ -3078,7 +3017,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testFastVectorHighlighterPhraseBoost() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", type1TermVectorMapping()));
+        assertAcked(prepareCreate("test").setMapping(type1TermVectorMapping()));
         phraseBoostTestCase("fvh");
     }
 
@@ -3187,7 +3126,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject();
         mappings.endObject();
-        assertAcked(prepareCreate("test").addMapping("type", mappings));
+        assertAcked(prepareCreate("test").setMapping(mappings));
 
         client().prepareIndex("test")
             .setId("1")
@@ -3227,7 +3166,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject();
         mappings.endObject();
-        assertAcked(prepareCreate("test").addMapping("jobs", mappings));
+        assertAcked(prepareCreate("test").setMapping(mappings));
         ensureYellow();
 
         client().prepareIndex("test")
@@ -3267,7 +3206,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject();
         mappings.endObject();
-        assertAcked(prepareCreate("test").addMapping("type", mappings));
+        assertAcked(prepareCreate("test").setMapping(mappings));
 
         client().prepareIndex("test")
             .setId("1")

--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -2964,13 +2964,11 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     public void testDoesNotHighlightTypeName() throws Exception {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("typename")
             .startObject("properties")
             .startObject("foo")
             .field("type", "text")
             .field("index_options", "offsets")
             .field("term_vector", "with_positions_offsets")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();
@@ -2991,13 +2989,11 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     public void testDoesNotHighlightAliasFilters() throws Exception {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("typename")
             .startObject("properties")
             .startObject("foo")
             .field("type", "text")
             .field("index_options", "offsets")
             .field("term_vector", "with_positions_offsets")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();
@@ -3113,8 +3109,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         // see https://github.com/elastic/elasticsearch/issues/17537
         XContentBuilder mappings = jsonBuilder();
         mappings.startObject();
-        mappings.startObject("type")
-            .startObject("properties")
+        mappings.startObject("properties")
             .startObject("geo_point")
             .field("type", "geo_point")
             .endObject()
@@ -3122,7 +3117,6 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             .field("type", "text")
             .field("term_vector", "with_positions_offsets_payloads")
             .field("index_options", "offsets")
-            .endObject()
             .endObject()
             .endObject();
         mappings.endObject();
@@ -3155,14 +3149,12 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         // see https://github.com/elastic/elasticsearch/issues/17537#issuecomment-244939633
         XContentBuilder mappings = jsonBuilder();
         mappings.startObject();
-        mappings.startObject("jobs")
-            .startObject("properties")
+        mappings.startObject("properties")
             .startObject("loc")
             .field("type", "geo_point")
             .endObject()
             .startObject("jd")
             .field("type", "text")
-            .endObject()
             .endObject()
             .endObject();
         mappings.endObject();
@@ -3198,13 +3190,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         // check that keyword highlighting works
         XContentBuilder mappings = jsonBuilder();
         mappings.startObject();
-        mappings.startObject("type")
-            .startObject("properties")
-            .startObject("keyword_field")
-            .field("type", "keyword")
-            .endObject()
-            .endObject()
-            .endObject();
+        mappings.startObject("properties").startObject("keyword_field").field("type", "keyword").endObject().endObject();
         mappings.endObject();
         assertAcked(prepareCreate("test").setMapping(mappings));
 
@@ -3238,7 +3224,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         // If field is not stored, it is looked up in source (but source has only 'foo'
         b.startObject("foo_copy").field("type", "text").field("store", true).endObject();
         b.endObject().endObject();
-        prepareCreate("test").addMapping("type", b).get();
+        prepareCreate("test").setMapping(b).get();
 
         client().prepareIndex("test")
             .setId("1")

--- a/server/src/internalClusterTest/java/org/opensearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -88,7 +88,7 @@ public class FieldCapabilitiesIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject()
             .endObject();
-        assertAcked(prepareCreate("old_index").addMapping("_doc", oldIndexMapping));
+        assertAcked(prepareCreate("old_index").setMapping(oldIndexMapping));
 
         XContentBuilder newIndexMapping = XContentFactory.jsonBuilder()
             .startObject()
@@ -106,7 +106,7 @@ public class FieldCapabilitiesIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject()
             .endObject();
-        assertAcked(prepareCreate("new_index").addMapping("_doc", newIndexMapping));
+        assertAcked(prepareCreate("new_index").setMapping(newIndexMapping));
         assertAcked(client().admin().indices().prepareAliases().addAlias("new_index", "current"));
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/fields/SearchFieldsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fields/SearchFieldsIT.java
@@ -774,10 +774,8 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
             .indices()
             .prepareCreate("my-index")
             .setSettings(Settings.builder().put("index.refresh_interval", -1))
-            .addMapping(
-                MapperService.SINGLE_MAPPING_NAME,
+            .setMapping(
                 jsonBuilder().startObject()
-                    .startObject(MapperService.SINGLE_MAPPING_NAME)
                     .startObject("properties")
                     .startObject("field1")
                     .field("type", "object")
@@ -791,7 +789,6 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
                     .startObject("field4")
                     .field("type", "text")
                     .field("store", true)
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -1181,7 +1178,6 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
     public void testDocValueFieldsWithFieldAlias() throws Exception {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject(MapperService.SINGLE_MAPPING_NAME)
             .startObject("_source")
             .field("enabled", false)
             .endObject()
@@ -1203,9 +1199,8 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
             .field("path", "date_field")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(prepareCreate("test").addMapping(MapperService.SINGLE_MAPPING_NAME, mapping));
+        assertAcked(prepareCreate("test").setMapping(mapping));
         ensureGreen("test");
 
         DateTime date = new DateTime(1990, 12, 29, 0, 0, DateTimeZone.UTC);
@@ -1244,7 +1239,6 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
     public void testWildcardDocValueFieldsWithFieldAlias() throws Exception {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject(MapperService.SINGLE_MAPPING_NAME)
             .startObject("_source")
             .field("enabled", false)
             .endObject()
@@ -1266,9 +1260,8 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
             .field("path", "date_field")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(prepareCreate("test").addMapping(MapperService.SINGLE_MAPPING_NAME, mapping));
+        assertAcked(prepareCreate("test").setMapping(mapping));
         ensureGreen("test");
 
         DateTime date = new DateTime(1990, 12, 29, 0, 0, DateTimeZone.UTC);
@@ -1306,7 +1299,6 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
     public void testStoredFieldsWithFieldAlias() throws Exception {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject(MapperService.SINGLE_MAPPING_NAME)
             .startObject("properties")
             .startObject("field1")
             .field("type", "text")
@@ -1325,9 +1317,8 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
             .field("path", "field2")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(prepareCreate("test").addMapping(MapperService.SINGLE_MAPPING_NAME, mapping));
+        assertAcked(prepareCreate("test").setMapping(mapping));
 
         index("test", MapperService.SINGLE_MAPPING_NAME, "1", "field1", "value1", "field2", "value2");
         refresh("test");
@@ -1350,7 +1341,6 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
     public void testWildcardStoredFieldsWithFieldAlias() throws Exception {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject(MapperService.SINGLE_MAPPING_NAME)
             .startObject("properties")
             .startObject("field1")
             .field("type", "text")
@@ -1369,9 +1359,8 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
             .field("path", "field2")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(prepareCreate("test").addMapping(MapperService.SINGLE_MAPPING_NAME, mapping));
+        assertAcked(prepareCreate("test").setMapping(mapping));
 
         index("test", MapperService.SINGLE_MAPPING_NAME, "1", "field1", "value1", "field2", "value2");
         refresh("test");

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/DecayFunctionScoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/DecayFunctionScoreIT.java
@@ -96,17 +96,14 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
 
     public void testDistanceScoreGeoLinGaussExp() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("test")
                     .field("type", "text")
                     .endObject()
                     .startObject("loc")
                     .field("type", "geo_point")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -223,17 +220,14 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
 
     public void testDistanceScoreGeoLinGaussExpWithOffset() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("test")
                     .field("type", "text")
                     .endObject()
                     .startObject("num")
                     .field("type", "double")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -337,17 +331,14 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
         Settings settings = Settings.builder().put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1).build();
         assertAcked(
             prepareCreate("test").setSettings(settings)
-                .addMapping(
-                    "type1",
+                .setMapping(
                     jsonBuilder().startObject()
-                        .startObject("type1")
                         .startObject("properties")
                         .startObject("test")
                         .field("type", "text")
                         .endObject()
                         .startObject("loc")
                         .field("type", "geo_point")
-                        .endObject()
                         .endObject()
                         .endObject()
                         .endObject()
@@ -436,17 +427,14 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
 
     public void testParseGeoPoint() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("test")
                     .field("type", "text")
                     .endObject()
                     .startObject("loc")
                     .field("type", "geo_point")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -504,17 +492,14 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
 
     public void testCombineModes() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("test")
                     .field("type", "text")
                     .endObject()
                     .startObject("num")
                     .field("type", "double")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -621,17 +606,14 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
 
     public void testCombineModesExplain() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("test")
                     .field("type", "text")
                     .endObject()
                     .startObject("num")
                     .field("type", "double")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -691,17 +673,14 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
 
     public void testExceptionThrownIfScaleLE0() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("test")
                     .field("type", "text")
                     .endObject()
                     .startObject("num1")
                     .field("type", "date")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -731,10 +710,8 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
 
     public void testParseDateMath() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("test")
                     .field("type", "text")
@@ -742,7 +719,6 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
                     .startObject("num1")
                     .field("type", "date")
                     .field("format", "epoch_millis")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -785,10 +761,8 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
 
     public void testValueMissingLin() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("test")
                     .field("type", "text")
@@ -798,7 +772,6 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
                     .endObject()
                     .startObject("num2")
                     .field("type", "double")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -854,17 +827,14 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
         ZonedDateTime dt = ZonedDateTime.now(ZoneOffset.UTC);
 
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("test")
                     .field("type", "text")
                     .endObject()
                     .startObject("num1")
                     .field("type", "date")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -933,7 +903,6 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
         Version version = VersionUtils.randomIndexCompatibleVersion(random());
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
         XContentBuilder xContentBuilder = jsonBuilder().startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("test")
             .field("type", "text")
@@ -949,8 +918,8 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
             .startObject("geo")
             .field("type", "geo_point")
             .field("ignore_malformed", true);
-        xContentBuilder.endObject().endObject().endObject().endObject();
-        assertAcked(prepareCreate("test").setSettings(settings).addMapping("type", xContentBuilder));
+        xContentBuilder.endObject().endObject().endObject();
+        assertAcked(prepareCreate("test").setSettings(settings).setMapping(xContentBuilder));
         int numDocs = 200;
         List<IndexRequestBuilder> indexBuilders = new ArrayList<>();
 
@@ -1013,17 +982,14 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
 
     public void testParsingExceptionIfFieldDoesNotExist() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type")
                     .startObject("properties")
                     .startObject("test")
                     .field("type", "text")
                     .endObject()
                     .startObject("geo")
                     .field("type", "geo_point")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -1066,17 +1032,14 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
 
     public void testParsingExceptionIfFieldTypeDoesNotMatch() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type")
                     .startObject("properties")
                     .startObject("test")
                     .field("type", "text")
                     .endObject()
                     .startObject("num")
                     .field("type", "text")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -1105,17 +1068,14 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
 
     public void testNoQueryGiven() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type")
                     .startObject("properties")
                     .startObject("test")
                     .field("type", "text")
                     .endObject()
                     .startObject("num")
                     .field("type", "double")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -1138,10 +1098,8 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
 
     public void testMultiFieldOptions() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("test")
                     .field("type", "text")
@@ -1151,7 +1109,6 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
                     .endObject()
                     .startObject("num")
                     .field("type", "float")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -1271,17 +1228,14 @@ public class DecayFunctionScoreIT extends OpenSearchIntegTestCase {
 
     public void testDistanceScoreGeoLinGaussExplain() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("test")
                     .field("type", "text")
                     .endObject()
                     .startObject("loc")
                     .field("type", "geo_point")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/FunctionScoreFieldValueIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/FunctionScoreFieldValueIT.java
@@ -57,17 +57,14 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertOrderedSea
 public class FunctionScoreFieldValueIT extends OpenSearchIntegTestCase {
     public void testFieldValueFactor() throws IOException {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("test")
                     .field("type", randomFrom(new String[] { "short", "float", "long", "integer", "double" }))
                     .endObject()
                     .startObject("body")
                     .field("type", "text")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -169,17 +166,14 @@ public class FunctionScoreFieldValueIT extends OpenSearchIntegTestCase {
 
     public void testFieldValueFactorExplain() throws IOException {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("test")
                     .field("type", randomFrom(new String[] { "short", "float", "long", "integer", "double" }))
                     .endObject()
                     .startObject("body")
                     .field("type", "text")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/FunctionScorePluginIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/FunctionScorePluginIT.java
@@ -76,17 +76,14 @@ public class FunctionScorePluginIT extends OpenSearchIntegTestCase {
         client().admin()
             .indices()
             .prepareCreate("test")
-            .addMapping(
-                "type1",
+            .setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("test")
                     .field("type", "text")
                     .endObject()
                     .startObject("num1")
                     .field("type", "date")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/QueryRescorerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/QueryRescorerIT.java
@@ -127,15 +127,12 @@ public class QueryRescorerIT extends OpenSearchIntegTestCase {
 
     public void testRescorePhrase() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("field1")
                     .field("analyzer", "whitespace")
                     .field("type", "text")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -190,22 +187,16 @@ public class QueryRescorerIT extends OpenSearchIntegTestCase {
 
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("field1")
             .field("type", "text")
             .field("analyzer", "whitespace")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
 
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
-                .addMapping("type1", mapping)
-                .setSettings(builder.put("index.number_of_shards", 1))
+            client().admin().indices().prepareCreate("test").setMapping(mapping).setSettings(builder.put("index.number_of_shards", 1))
         );
 
         client().prepareIndex("test").setId("1").setSource("field1", "massachusetts avenue boston massachusetts").get();
@@ -285,22 +276,16 @@ public class QueryRescorerIT extends OpenSearchIntegTestCase {
 
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("field1")
             .field("type", "text")
             .field("analyzer", "whitespace")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
 
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
-                .addMapping("type1", mapping)
-                .setSettings(builder.put("index.number_of_shards", 1))
+            client().admin().indices().prepareCreate("test").setMapping(mapping).setSettings(builder.put("index.number_of_shards", 1))
         );
 
         client().prepareIndex("test").setId("3").setSource("field1", "massachusetts").get();
@@ -371,22 +356,16 @@ public class QueryRescorerIT extends OpenSearchIntegTestCase {
 
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("field1")
             .field("type", "text")
             .field("analyzer", "whitespace")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
 
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
-                .addMapping("type1", mapping)
-                .setSettings(builder.put("index.number_of_shards", 1))
+            client().admin().indices().prepareCreate("test").setMapping(mapping).setSettings(builder.put("index.number_of_shards", 1))
         );
 
         client().prepareIndex("test").setId("3").setSource("field1", "massachusetts").get();
@@ -524,15 +503,12 @@ public class QueryRescorerIT extends OpenSearchIntegTestCase {
 
     public void testExplain() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("field1")
                     .field("analyzer", "whitespace")
                     .field("type", "text")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -785,15 +761,12 @@ public class QueryRescorerIT extends OpenSearchIntegTestCase {
         }
 
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("field1")
                     .field("analyzer", analyzer)
                     .field("type", "text")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoBoundingBoxQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoBoundingBoxQueryIT.java
@@ -64,12 +64,11 @@ public class GeoBoundingBoxQueryIT extends OpenSearchIntegTestCase {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("location")
             .field("type", "geo_point");
-        xContentBuilder.endObject().endObject().endObject().endObject();
-        assertAcked(prepareCreate("test").setSettings(settings).addMapping("type1", xContentBuilder));
+        xContentBuilder.endObject().endObject().endObject();
+        assertAcked(prepareCreate("test").setSettings(settings).setMapping(xContentBuilder));
         ensureGreen();
 
         client().prepareIndex("test")
@@ -195,12 +194,11 @@ public class GeoBoundingBoxQueryIT extends OpenSearchIntegTestCase {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("location")
             .field("type", "geo_point");
-        xContentBuilder.endObject().endObject().endObject().endObject();
-        assertAcked(prepareCreate("test").setSettings(settings).addMapping("type1", xContentBuilder));
+        xContentBuilder.endObject().endObject().endObject();
+        assertAcked(prepareCreate("test").setSettings(settings).setMapping(xContentBuilder));
         ensureGreen();
 
         client().prepareIndex("test")
@@ -275,12 +273,11 @@ public class GeoBoundingBoxQueryIT extends OpenSearchIntegTestCase {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("location")
             .field("type", "geo_point");
-        xContentBuilder.endObject().endObject().endObject().endObject();
-        assertAcked(prepareCreate("test").setSettings(settings).addMapping("type1", xContentBuilder));
+        xContentBuilder.endObject().endObject().endObject();
+        assertAcked(prepareCreate("test").setSettings(settings).setMapping(xContentBuilder));
         ensureGreen();
 
         client().prepareIndex("test")

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoDistanceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoDistanceIT.java
@@ -124,12 +124,11 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("location")
             .field("type", "geo_point");
-        xContentBuilder.endObject().endObject().endObject().endObject();
-        assertAcked(prepareCreate("test").setSettings(settings).addMapping("type1", xContentBuilder));
+        xContentBuilder.endObject().endObject().endObject();
+        assertAcked(prepareCreate("test").setSettings(settings).setMapping(xContentBuilder));
         ensureGreen();
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoFilterIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoFilterIT.java
@@ -393,7 +393,6 @@ public class GeoFilterIT extends OpenSearchIntegTestCase {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("country")
             .startObject("properties")
             .startObject("pin")
             .field("type", "geo_point");
@@ -404,10 +403,9 @@ public class GeoFilterIT extends OpenSearchIntegTestCase {
             .field("ignore_malformed", true)
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
 
-        client().admin().indices().prepareCreate("countries").setSettings(settings).addMapping("country", xContentBuilder).get();
+        client().admin().indices().prepareCreate("countries").setSettings(settings).setMapping(xContentBuilder).get();
         BulkResponse bulk = client().prepareBulk().add(bulkAction, 0, bulkAction.length, null, xContentBuilder.contentType()).get();
 
         for (BulkItemResponse item : bulk.getItems()) {

--- a/server/src/internalClusterTest/java/org/opensearch/search/morelikethis/MoreLikeThisIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/morelikethis/MoreLikeThisIT.java
@@ -86,14 +86,11 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
     public void testSimpleMoreLikeThis() throws Exception {
         logger.info("Creating index test");
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("text")
                     .field("type", "text")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -119,14 +116,11 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
     public void testSimpleMoreLikeThisWithTypes() throws Exception {
         logger.info("Creating index test");
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("text")
                     .field("type", "text")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -151,17 +145,14 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
 
     // Issue #30148
     public void testMoreLikeThisForZeroTokensInOneOfTheAnalyzedFields() throws Exception {
-        CreateIndexRequestBuilder createIndexRequestBuilder = prepareCreate("test").addMapping(
-            "type",
+        CreateIndexRequestBuilder createIndexRequestBuilder = prepareCreate("test").setMapping(
             jsonBuilder().startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject("myField")
                 .field("type", "text")
                 .endObject()
                 .startObject("empty")
                 .field("type", "text")
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -214,14 +205,11 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
     public void testMoreLikeThisWithAliases() throws Exception {
         logger.info("Creating index test");
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("text")
                     .field("type", "text")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -370,17 +358,14 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
     // Issue #3252
     public void testNumericField() throws Exception {
         final String[] numericTypes = new String[] { "byte", "short", "integer", "long" };
-        prepareCreate("test").addMapping(
-            "type",
+        prepareCreate("test").setMapping(
             jsonBuilder().startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject("int_value")
                 .field("type", randomFrom(numericTypes))
                 .endObject()
                 .startObject("string_value")
                 .field("type", "text")
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -486,7 +471,6 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
     public void testMoreLikeThisWithFieldAlias() throws Exception {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("_doc")
             .startObject("properties")
             .startObject("text")
             .field("type", "text")
@@ -496,10 +480,9 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
             .field("path", "text")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
 
-        assertAcked(prepareCreate("test").addMapping("_doc", mapping));
+        assertAcked(prepareCreate("test").setMapping(mapping));
         ensureGreen();
 
         index("test", "_doc", "1", "text", "lucene");
@@ -517,14 +500,11 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
     public void testSimpleMoreLikeInclude() throws Exception {
         logger.info("Creating index test");
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("text")
                     .field("type", "text")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -584,14 +564,11 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
     public void testSimpleMoreLikeThisIds() throws Exception {
         logger.info("Creating index test");
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("text")
                     .field("type", "text")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -867,10 +844,8 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
     public void testWithMissingRouting() throws IOException {
         logger.info("Creating index test with routing required for type1");
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("text")
                     .field("type", "text")
@@ -878,7 +853,6 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
                     .endObject()
                     .startObject("_routing")
                     .field("required", true)
-                    .endObject()
                     .endObject()
                     .endObject()
             )

--- a/server/src/internalClusterTest/java/org/opensearch/search/nested/SimpleNestedIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/nested/SimpleNestedIT.java
@@ -213,17 +213,14 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
 
     public void testMultiNested() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("nested1")
                     .field("type", "nested")
                     .startObject("properties")
                     .startObject("nested2")
                     .field("type", "nested")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -371,17 +368,14 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
     public void testDeleteNestedDocsWithAlias() throws Exception {
         assertAcked(
             prepareCreate("test").setSettings(Settings.builder().put(indexSettings()).put("index.refresh_interval", -1).build())
-                .addMapping(
-                    "type1",
+                .setMapping(
                     jsonBuilder().startObject()
-                        .startObject("type1")
                         .startObject("properties")
                         .startObject("field1")
                         .field("type", "text")
                         .endObject()
                         .startObject("nested1")
                         .field("type", "nested")
-                        .endObject()
                         .endObject()
                         .endObject()
                         .endObject()
@@ -437,14 +431,11 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
 
     public void testExplain() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("nested1")
                     .field("type", "nested")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -485,10 +476,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
     public void testSimpleNestedSorting() throws Exception {
         assertAcked(
             prepareCreate("test").setSettings(Settings.builder().put(indexSettings()).put("index.refresh_interval", -1))
-                .addMapping(
-                    "type1",
+                .setMapping(
                     jsonBuilder().startObject()
-                        .startObject("type1")
                         .startObject("properties")
                         .startObject("nested1")
                         .field("type", "nested")
@@ -496,7 +485,6 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
                         .startObject("field1")
                         .field("type", "long")
                         .field("store", true)
-                        .endObject()
                         .endObject()
                         .endObject()
                         .endObject()
@@ -586,10 +574,8 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
     public void testSimpleNestedSortingWithNestedFilterMissing() throws Exception {
         assertAcked(
             prepareCreate("test").setSettings(Settings.builder().put(indexSettings()).put("index.refresh_interval", -1))
-                .addMapping(
-                    "type1",
+                .setMapping(
                     jsonBuilder().startObject()
-                        .startObject("type1")
                         .startObject("properties")
                         .startObject("nested1")
                         .field("type", "nested")
@@ -599,7 +585,6 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
                         .endObject()
                         .startObject("field2")
                         .field("type", "boolean")
-                        .endObject()
                         .endObject()
                         .endObject()
                         .endObject()
@@ -1048,11 +1033,9 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
 
     public void testSortNestedWithNestedFilter() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 XContentFactory.jsonBuilder()
                     .startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("grand_parent_values")
                     .field("type", "long")
@@ -1068,7 +1051,6 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
                     .startObject("properties")
                     .startObject("child_values")
                     .field("type", "long")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -1448,8 +1430,7 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
     // Issue #9305
     public void testNestedSortingWithNestedFilterAsFilter() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
                     .startObject("properties")
                     .startObject("officelocation")

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/ExistsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/ExistsIT.java
@@ -70,7 +70,6 @@ public class ExistsIT extends OpenSearchIntegTestCase {
     public void testExists() throws Exception {
         XContentBuilder mapping = XContentBuilder.builder(JsonXContent.jsonXContent)
             .startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("foo")
             .field("type", "text")
@@ -95,10 +94,9 @@ public class ExistsIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate("idx").addMapping("type", mapping));
+        assertAcked(client().admin().indices().prepareCreate("idx").setMapping(mapping));
         Map<String, Object> barObject = new HashMap<>();
         barObject.put("foo", "bar");
         barObject.put("bar", singletonMap("bar", "foo"));
@@ -176,7 +174,6 @@ public class ExistsIT extends OpenSearchIntegTestCase {
     public void testFieldAlias() throws Exception {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("bar")
             .field("type", "long")
@@ -194,9 +191,8 @@ public class ExistsIT extends OpenSearchIntegTestCase {
             .field("path", "foo.bar")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(prepareCreate("idx").addMapping("type", mapping));
+        assertAcked(prepareCreate("idx").setMapping(mapping));
         ensureGreen("idx");
 
         List<IndexRequestBuilder> indexRequests = new ArrayList<>();
@@ -226,7 +222,6 @@ public class ExistsIT extends OpenSearchIntegTestCase {
     public void testFieldAliasWithNoDocValues() throws Exception {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("foo")
             .field("type", "long")
@@ -237,9 +232,8 @@ public class ExistsIT extends OpenSearchIntegTestCase {
             .field("path", "foo")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(prepareCreate("idx").addMapping("type", mapping));
+        assertAcked(prepareCreate("idx").setMapping(mapping));
         ensureGreen("idx");
 
         List<IndexRequestBuilder> indexRequests = new ArrayList<>();

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/MultiMatchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/MultiMatchQueryIT.java
@@ -109,7 +109,7 @@ public class MultiMatchQueryIT extends OpenSearchIntegTestCase {
                 .put("index.analysis.analyzer.category.tokenizer", "standard")
                 .put("index.analysis.analyzer.category.filter", "lowercase")
         );
-        assertAcked(builder.addMapping("test", createMapping()));
+        assertAcked(builder.setMapping(createMapping()));
         ensureGreen();
         int numDocs = scaledRandomIntBetween(50, 100);
         List<IndexRequestBuilder> builders = new ArrayList<>();
@@ -259,7 +259,6 @@ public class MultiMatchQueryIT extends OpenSearchIntegTestCase {
     private XContentBuilder createMapping() throws IOException {
         return XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("test")
             .startObject("properties")
             .startObject("id")
             .field("type", "keyword")
@@ -285,7 +284,6 @@ public class MultiMatchQueryIT extends OpenSearchIntegTestCase {
             .endObject()
             .startObject("date")
             .field("type", "date")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/QueryStringIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/QueryStringIT.java
@@ -278,16 +278,14 @@ public class QueryStringIT extends OpenSearchIntegTestCase {
     public void testLimitOnExpandedFieldsButIgnoreUnmappedFields() throws Exception {
         XContentBuilder builder = jsonBuilder();
         builder.startObject();
-        builder.startObject("_doc");
         builder.startObject("properties");
         for (int i = 0; i < CLUSTER_MAX_CLAUSE_COUNT; i++) {
             builder.startObject("field" + i).field("type", "text").endObject();
         }
         builder.endObject(); // properties
-        builder.endObject(); // type1
         builder.endObject();
 
-        assertAcked(prepareCreate("ignoreunmappedfields").addMapping("_doc", builder));
+        assertAcked(prepareCreate("ignoreunmappedfields").setMapping(builder));
 
         client().prepareIndex("ignoreunmappedfields").setId("1").setSource("field1", "foo bar baz").get();
         refresh();
@@ -303,25 +301,19 @@ public class QueryStringIT extends OpenSearchIntegTestCase {
         XContentBuilder builder = jsonBuilder();
         builder.startObject();
         {
-            builder.startObject("_doc");
-            {
-                builder.startObject("properties");
-                {
-                    for (int i = 0; i < CLUSTER_MAX_CLAUSE_COUNT; i++) {
-                        builder.startObject("field_A" + i).field("type", "text").endObject();
-                        builder.startObject("field_B" + i).field("type", "text").endObject();
-                    }
-                    builder.endObject();
-                }
-                builder.endObject();
+            builder.startObject("properties");
+            for (int i = 0; i < CLUSTER_MAX_CLAUSE_COUNT; i++) {
+                builder.startObject("field_A" + i).field("type", "text").endObject();
+                builder.startObject("field_B" + i).field("type", "text").endObject();
             }
             builder.endObject();
         }
+        builder.endObject();
 
         assertAcked(
             prepareCreate("testindex").setSettings(
                 Settings.builder().put(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey(), CLUSTER_MAX_CLAUSE_COUNT + 100)
-            ).addMapping("_doc", builder)
+            ).setMapping(builder)
         );
 
         client().prepareIndex("testindex").setId("1").setSource("field_A0", "foo bar baz").get();

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/SearchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/SearchQueryIT.java
@@ -1119,16 +1119,13 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     public void testTermsLookupFilter() throws Exception {
         assertAcked(prepareCreate("lookup").addMapping("type", "terms", "type=text", "other", "type=text"));
         assertAcked(
-            prepareCreate("lookup2").addMapping(
-                "type",
+            prepareCreate("lookup2").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type")
                     .startObject("properties")
                     .startObject("arr")
                     .startObject("properties")
                     .startObject("term")
                     .field("type", "text")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -1600,10 +1597,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
     public void testSimpleDFSQuery() throws IOException {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "_doc",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("_doc")
                     .startObject("_routing")
                     .field("required", true)
                     .endObject()
@@ -1618,7 +1613,6 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
                     .endObject()
                     .startObject("bs")
                     .field("type", "keyword")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -1876,8 +1870,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
         assert ("SPI,COMPAT".equals(System.getProperty("java.locale.providers"))) : "`-Djava.locale.providers=SPI,COMPAT` needs to be set";
 
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
                     .startObject("properties")
                     .startObject("date_field")
@@ -1978,7 +1971,6 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     public void testNestedQueryWithFieldAlias() throws Exception {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("_doc")
             .startObject("properties")
             .startObject("section")
             .field("type", "nested")
@@ -1993,9 +1985,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(prepareCreate("index").addMapping("_doc", mapping));
+        assertAcked(prepareCreate("index").setMapping(mapping));
 
         XContentBuilder source = XContentFactory.jsonBuilder()
             .startObject()
@@ -2019,7 +2010,6 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     public void testFieldAliasesForMetaFields() throws Exception {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("id-alias")
             .field("type", "alias")
@@ -2030,9 +2020,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
             .field("path", "_routing")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(prepareCreate("test").addMapping("type", mapping));
+        assertAcked(prepareCreate("test").setMapping(mapping));
 
         IndexRequestBuilder indexRequest = client().prepareIndex("test").setId("1").setRouting("custom").setSource("field", "value");
         indexRandom(true, false, indexRequest);

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/SimpleQueryStringIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/SimpleQueryStringIT.java
@@ -239,10 +239,8 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
 
     public void testNestedFieldSimpleQueryString() throws IOException {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("body")
                     .field("type", "text")
@@ -253,7 +251,6 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
                     .endObject() // fields
                     .endObject() // body
                     .endObject() // properties
-                    .endObject() // type1
                     .endObject()
             )
         );
@@ -607,19 +604,17 @@ public class SimpleQueryStringIT extends OpenSearchIntegTestCase {
     public void testLimitOnExpandedFields() throws Exception {
         XContentBuilder builder = jsonBuilder();
         builder.startObject();
-        builder.startObject("type1");
         builder.startObject("properties");
         for (int i = 0; i < CLUSTER_MAX_CLAUSE_COUNT + 1; i++) {
             builder.startObject("field" + i).field("type", "text").endObject();
         }
         builder.endObject(); // properties
-        builder.endObject(); // type1
         builder.endObject();
 
         assertAcked(
             prepareCreate("toomanyfields").setSettings(
                 Settings.builder().put(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey(), CLUSTER_MAX_CLAUSE_COUNT + 100)
-            ).addMapping("type1", builder)
+            ).setMapping(builder)
         );
 
         client().prepareIndex("toomanyfields").setId("1").setSource("field1", "foo bar baz").get();

--- a/server/src/internalClusterTest/java/org/opensearch/search/scriptfilter/ScriptQuerySearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/scriptfilter/ScriptQuerySearchIT.java
@@ -127,11 +127,7 @@ public class ScriptQuerySearchIT extends OpenSearchIntegTestCase {
         final byte[] randomBytesDoc2 = getRandomBytes(16);
 
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("my-index")
-                .addMapping("my-type", createMappingSource("binary"))
-                .setSettings(indexSettings())
+            client().admin().indices().prepareCreate("my-index").setMapping(createMappingSource("binary")).setSettings(indexSettings())
         );
         client().prepareIndex("my-index")
             .setId("1")
@@ -170,12 +166,10 @@ public class ScriptQuerySearchIT extends OpenSearchIntegTestCase {
     private XContentBuilder createMappingSource(String fieldType) throws IOException {
         return XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("my-type")
             .startObject("properties")
             .startObject("binaryData")
             .field("type", fieldType)
             .field("doc_values", "true")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();

--- a/server/src/internalClusterTest/java/org/opensearch/search/scroll/DuelScrollIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/scroll/DuelScrollIT.java
@@ -115,10 +115,8 @@ public class DuelScrollIT extends OpenSearchIntegTestCase {
 
     private TestContext create(SearchType... searchTypes) throws Exception {
         assertAcked(
-            prepareCreate("index").addMapping(
-                "type",
+            prepareCreate("index").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type")
                     .startObject("properties")
                     .startObject("field1")
                     .field("type", "long")
@@ -134,7 +132,6 @@ public class DuelScrollIT extends OpenSearchIntegTestCase {
                     .endObject()
                     .startObject("field4")
                     .field("type", "keyword")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/FieldSortIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/FieldSortIT.java
@@ -276,18 +276,15 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
     public void testRandomSorting() throws IOException, InterruptedException, ExecutionException {
         Random random = random();
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type",
+            prepareCreate("test").setMapping(
                 XContentFactory.jsonBuilder()
                     .startObject()
-                    .startObject("type")
                     .startObject("properties")
                     .startObject("sparse_bytes")
                     .field("type", "keyword")
                     .endObject()
                     .startObject("dense_bytes")
                     .field("type", "keyword")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -558,11 +555,9 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
     public void testSimpleSorts() throws Exception {
         Random random = random();
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 XContentFactory.jsonBuilder()
                     .startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("str_value")
                     .field("type", "keyword")
@@ -587,7 +582,6 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
                     .endObject()
                     .startObject("double_value")
                     .field("type", "double")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -801,18 +795,15 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
 
     public void testSortMissingNumbers() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 XContentFactory.jsonBuilder()
                     .startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("i_value")
                     .field("type", "integer")
                     .endObject()
                     .startObject("d_value")
                     .field("type", "float")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -873,15 +864,12 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
 
     public void testSortMissingStrings() throws IOException {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 XContentFactory.jsonBuilder()
                     .startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("value")
                     .field("type", "keyword")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -1009,11 +997,9 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
 
     public void testSortMVField() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 XContentFactory.jsonBuilder()
                     .startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("long_values")
                     .field("type", "long")
@@ -1035,7 +1021,6 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
                     .endObject()
                     .startObject("string_values")
                     .field("type", "keyword")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -1345,15 +1330,12 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
 
     public void testSortOnRareField() throws IOException {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 XContentFactory.jsonBuilder()
                     .startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("string_values")
                     .field("type", "keyword")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -1494,11 +1476,9 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
      */
     public void testNestedSort() throws IOException, InterruptedException, ExecutionException {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type",
+            prepareCreate("test").setMapping(
                 XContentFactory.jsonBuilder()
                     .startObject()
-                    .startObject("type")
                     .startObject("properties")
                     .startObject("nested")
                     .field("type", "nested")
@@ -1521,7 +1501,6 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
                     .startObject("fields")
                     .startObject("sub")
                     .field("type", "keyword")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/GeoDistanceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/GeoDistanceIT.java
@@ -72,12 +72,11 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("locations")
             .field("type", "geo_point");
-        xContentBuilder.field("ignore_malformed", true).endObject().endObject().endObject().endObject();
-        assertAcked(prepareCreate("test").setSettings(settings).addMapping("type1", xContentBuilder));
+        xContentBuilder.field("ignore_malformed", true).endObject().endObject().endObject();
+        assertAcked(prepareCreate("test").setSettings(settings).setMapping(xContentBuilder));
         ensureGreen();
 
         client().prepareIndex("test")
@@ -268,12 +267,11 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("locations")
             .field("type", "geo_point");
-        xContentBuilder.endObject().endObject().endObject().endObject();
-        assertAcked(prepareCreate("test").setSettings(settings).addMapping("type1", xContentBuilder));
+        xContentBuilder.endObject().endObject().endObject();
+        assertAcked(prepareCreate("test").setSettings(settings).setMapping(xContentBuilder));
         ensureGreen();
 
         client().prepareIndex("test")
@@ -333,7 +331,6 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("company")
             .startObject("properties")
             .startObject("name")
             .field("type", "text")
@@ -346,9 +343,9 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
             .endObject()
             .startObject("location")
             .field("type", "geo_point");
-        xContentBuilder.endObject().endObject().endObject().endObject().endObject().endObject();
+        xContentBuilder.endObject().endObject().endObject().endObject().endObject();
 
-        assertAcked(prepareCreate("companies").setSettings(settings).addMapping("company", xContentBuilder));
+        assertAcked(prepareCreate("companies").setSettings(settings).setMapping(xContentBuilder));
         ensureGreen();
 
         indexRandom(
@@ -590,15 +587,14 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
 
         XContentBuilder mapping = JsonXContent.contentBuilder()
             .startObject()
-            .startObject("location")
             .startObject("properties")
             .startObject("pin")
             .field("type", "geo_point");
-        mapping.endObject().endObject().endObject().endObject();
+        mapping.endObject().endObject().endObject();
 
         XContentBuilder source = JsonXContent.contentBuilder().startObject().field("pin", Geohash.stringEncode(lon, lat)).endObject();
 
-        assertAcked(prepareCreate("locations").setSettings(settings).addMapping("location", mapping));
+        assertAcked(prepareCreate("locations").setSettings(settings).setMapping(mapping));
         client().prepareIndex("locations").setId("1").setCreate(true).setSource(source).get();
         refresh();
         client().prepareGet("locations", "1").get();
@@ -614,12 +610,11 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
     public void testDistanceSortingWithUnmappedField() throws Exception {
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("locations")
             .field("type", "geo_point");
-        xContentBuilder.endObject().endObject().endObject().endObject();
-        assertAcked(prepareCreate("test1").addMapping("type1", xContentBuilder));
+        xContentBuilder.endObject().endObject().endObject();
+        assertAcked(prepareCreate("test1").setMapping(xContentBuilder));
         assertAcked(prepareCreate("test2"));
         ensureGreen();
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/SimpleSortIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/SimpleSortIT.java
@@ -134,10 +134,8 @@ public class SimpleSortIT extends OpenSearchIntegTestCase {
     public void testSimpleSorts() throws Exception {
         Random random = random();
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("str_value")
                     .field("type", "keyword")
@@ -162,7 +160,6 @@ public class SimpleSortIT extends OpenSearchIntegTestCase {
                     .endObject()
                     .startObject("double_value")
                     .field("type", "double")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()
@@ -446,14 +443,11 @@ public class SimpleSortIT extends OpenSearchIntegTestCase {
 
     public void test2920() throws IOException {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "test",
+            prepareCreate("test").setMapping(
                 jsonBuilder().startObject()
-                    .startObject("test")
                     .startObject("properties")
                     .startObject("value")
                     .field("type", "keyword")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()

--- a/server/src/internalClusterTest/java/org/opensearch/search/suggest/CompletionSuggestSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/suggest/CompletionSuggestSearchIT.java
@@ -682,15 +682,13 @@ public class CompletionSuggestSearchIT extends OpenSearchIntegTestCase {
 
     public void testThatUpgradeToMultiFieldsWorks() throws Exception {
         final XContentBuilder mapping = jsonBuilder().startObject()
-            .startObject(MapperService.SINGLE_MAPPING_NAME)
             .startObject("properties")
             .startObject(FIELD)
             .field("type", "text")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(prepareCreate(INDEX).addMapping(MapperService.SINGLE_MAPPING_NAME, mapping));
+        assertAcked(prepareCreate(INDEX).setMapping(mapping));
         client().prepareIndex(INDEX)
             .setId("1")
             .setRefreshPolicy(IMMEDIATE)
@@ -1328,7 +1326,7 @@ public class CompletionSuggestSearchIT extends OpenSearchIntegTestCase {
                 .indices()
                 .prepareCreate(INDEX)
                 .setSettings(Settings.builder().put(indexSettings()).put(settings))
-                .addMapping(MapperService.SINGLE_MAPPING_NAME, mapping)
+                .setMapping(mapping)
                 .get()
         );
     }
@@ -1376,14 +1374,11 @@ public class CompletionSuggestSearchIT extends OpenSearchIntegTestCase {
             client().admin()
                 .indices()
                 .prepareCreate(INDEX)
-                .addMapping(
-                    MapperService.SINGLE_MAPPING_NAME,
+                .setMapping(
                     jsonBuilder().startObject()
-                        .startObject(MapperService.SINGLE_MAPPING_NAME)
                         .startObject("properties")
                         .startObject(FIELD)
                         .field("type", "completion")
-                        .endObject()
                         .endObject()
                         .endObject()
                         .endObject()
@@ -1408,14 +1403,11 @@ public class CompletionSuggestSearchIT extends OpenSearchIntegTestCase {
             client().admin()
                 .indices()
                 .prepareCreate(INDEX)
-                .addMapping(
-                    MapperService.SINGLE_MAPPING_NAME,
+                .setMapping(
                     jsonBuilder().startObject()
-                        .startObject(MapperService.SINGLE_MAPPING_NAME)
                         .startObject("properties")
                         .startObject(FIELD)
                         .field("type", "completion")
-                        .endObject()
                         .endObject()
                         .endObject()
                         .endObject()
@@ -1449,14 +1441,11 @@ public class CompletionSuggestSearchIT extends OpenSearchIntegTestCase {
             client().admin()
                 .indices()
                 .prepareCreate(INDEX)
-                .addMapping(
-                    MapperService.SINGLE_MAPPING_NAME,
+                .setMapping(
                     jsonBuilder().startObject()
-                        .startObject(MapperService.SINGLE_MAPPING_NAME)
                         .startObject("properties")
                         .startObject(FIELD)
                         .field("type", "completion")
-                        .endObject()
                         .endObject()
                         .endObject()
                         .endObject()
@@ -1508,7 +1497,6 @@ public class CompletionSuggestSearchIT extends OpenSearchIntegTestCase {
     public void testSuggestWithFieldAlias() throws Exception {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject(MapperService.SINGLE_MAPPING_NAME)
             .startObject("properties")
             .startObject(FIELD)
             .field("type", "completion")
@@ -1518,9 +1506,8 @@ public class CompletionSuggestSearchIT extends OpenSearchIntegTestCase {
             .field("path", FIELD)
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(prepareCreate(INDEX).addMapping(MapperService.SINGLE_MAPPING_NAME, mapping));
+        assertAcked(prepareCreate(INDEX).setMapping(mapping));
 
         List<IndexRequestBuilder> builders = new ArrayList<>();
         builders.add(client().prepareIndex(INDEX).setSource(FIELD, "apple"));

--- a/server/src/internalClusterTest/java/org/opensearch/search/suggest/ContextCompletionSuggestSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/suggest/ContextCompletionSuggestSearchIT.java
@@ -42,7 +42,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.Fuzziness;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.search.suggest.CompletionSuggestSearchIT.CompletionMappingBuilder;
 import org.opensearch.search.suggest.completion.CompletionSuggestionBuilder;
@@ -608,7 +607,7 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
         mapping.endObject();
         mapping.endObject();
 
-        assertAcked(prepareCreate(INDEX).addMapping(MapperService.SINGLE_MAPPING_NAME, mapping));
+        assertAcked(prepareCreate(INDEX).setMapping(mapping));
 
         XContentBuilder source1 = jsonBuilder().startObject()
             .startObject("location")
@@ -754,7 +753,7 @@ public class ContextCompletionSuggestSearchIT extends OpenSearchIntegTestCase {
                 .indices()
                 .prepareCreate(INDEX)
                 .setSettings(Settings.builder().put(indexSettings()).put(settings))
-                .addMapping(MapperService.SINGLE_MAPPING_NAME, mapping)
+                .setMapping(mapping)
                 .get()
         );
     }

--- a/server/src/internalClusterTest/java/org/opensearch/search/suggest/SuggestSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/suggest/SuggestSearchIT.java
@@ -127,16 +127,14 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
 
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("text")
             .field("type", "text")
             .field("analyzer", "keyword")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(prepareCreate("test_2").addMapping("type1", mapping));
+        assertAcked(prepareCreate("test_2").setMapping(mapping));
         ensureGreen();
 
         index("test_2", "type1", "1", "text", "ab cd");
@@ -217,7 +215,6 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
 
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("name")
             .field("type", "text")
@@ -230,9 +227,8 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(builder.addMapping("type1", mapping));
+        assertAcked(builder.setMapping(mapping));
         ensureGreen();
 
         index("test", "type1", "1", "name", "I like iced tea");
@@ -300,7 +296,6 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
         );
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("name")
             .field("type", "text")
@@ -313,9 +308,8 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
             .endObject()
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(builder.addMapping("type1", mapping));
+        assertAcked(builder.setMapping(mapping));
         ensureGreen();
 
         indexRandom(
@@ -558,7 +552,6 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
         );
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("body")
             .field("type", "text")
@@ -569,9 +562,8 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
             .field("analyzer", "bigram")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(builder.addMapping("type1", mapping));
+        assertAcked(builder.setMapping(mapping));
         ensureGreen();
 
         index("test", "type1", "1", "body", "hello world");
@@ -614,7 +606,6 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
         );
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("body")
             .field("type", "text")
@@ -625,9 +616,8 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
             .field("analyzer", "bigram")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(builder.addMapping("type1", mapping));
+        assertAcked(builder.setMapping(mapping));
         ensureGreen();
 
         String[] strings = new String[] {
@@ -758,7 +748,6 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
 
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("body")
             .field("type", "text")
@@ -769,9 +758,8 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
             .field("analyzer", "bigram")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(builder.addMapping("type1", mapping));
+        assertAcked(builder.setMapping(mapping));
         ensureGreen();
 
         String line = "xorr the god jewel";
@@ -833,16 +821,14 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
 
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type2")
             .startObject("properties")
             .startObject("name")
             .field("type", "text")
             .field("analyzer", "suggest")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(builder.addMapping("type2", mapping));
+        assertAcked(builder.setMapping(mapping));
         ensureGreen();
 
         index("test", "type2", "1", "foo", "bar");
@@ -880,12 +866,10 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
     public void testEmptyShards() throws IOException, InterruptedException {
         XContentBuilder mappingBuilder = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("name")
             .field("type", "text")
             .field("analyzer", "suggest")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();
@@ -901,7 +885,7 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
                     .put("index.analysis.filter.shingler.min_shingle_size", 2)
                     .put("index.analysis.filter.shingler.max_shingle_size", 5)
                     .put("index.analysis.filter.shingler.output_unigrams", true)
-            ).addMapping("type1", mappingBuilder)
+            ).setMapping(mappingBuilder)
         );
         ensureGreen();
 
@@ -978,16 +962,14 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
 
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("body")
             .field("type", "text")
             .field("analyzer", "body")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(builder.addMapping("type1", mapping));
+        assertAcked(builder.setMapping(mapping));
         ensureGreen();
 
         NumShards test = getNumShards("test");
@@ -1039,16 +1021,14 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
 
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("title")
             .field("type", "text")
             .field("analyzer", "text")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(builder.addMapping("type1", mapping));
+        assertAcked(builder.setMapping(mapping));
         ensureGreen();
 
         List<String> titles = new ArrayList<>();
@@ -1166,7 +1146,6 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
     public void testSuggestWithFieldAlias() throws Exception {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("text")
             .field("type", "keyword")
@@ -1176,9 +1155,8 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
             .field("path", "text")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(prepareCreate("test").addMapping("type", mapping));
+        assertAcked(prepareCreate("test").setMapping(mapping));
 
         List<IndexRequestBuilder> builders = new ArrayList<>();
         builders.add(client().prepareIndex("test").setSource("text", "apple"));
@@ -1195,17 +1173,13 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
     public void testPhraseSuggestMinDocFreq() throws Exception {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("text")
             .field("type", "keyword")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(
-            prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 1).build()).addMapping("type", mapping)
-        );
+        assertAcked(prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 1).build()).setMapping(mapping));
 
         List<IndexRequestBuilder> builders = new ArrayList<>();
         builders.add(client().prepareIndex("test").setSource("text", "apple"));
@@ -1298,16 +1272,14 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
 
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("title")
             .field("type", "text")
             .field("analyzer", "text")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
-        assertAcked(builder.addMapping("type1", mapping));
+        assertAcked(builder.setMapping(mapping));
         ensureGreen();
 
         List<String> titles = new ArrayList<>();

--- a/server/src/internalClusterTest/java/org/opensearch/similarity/SimilarityIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/similarity/SimilarityIT.java
@@ -53,10 +53,8 @@ public class SimilarityIT extends OpenSearchIntegTestCase {
         client().admin()
             .indices()
             .prepareCreate("test")
-            .addMapping(
-                "type1",
+            .setMapping(
                 jsonBuilder().startObject()
-                    .startObject("type1")
                     .startObject("properties")
                     .startObject("field1")
                     .field("similarity", "custom")
@@ -65,7 +63,6 @@ public class SimilarityIT extends OpenSearchIntegTestCase {
                     .startObject("field2")
                     .field("similarity", "boolean")
                     .field("type", "text")
-                    .endObject()
                     .endObject()
                     .endObject()
                     .endObject()

--- a/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequest.java
@@ -248,16 +248,33 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
     /**
      * Adds mapping that will be added when the index gets created.
      *
-     * @param type   The mapping type
      * @param source The mapping source
      * @param xContentType the content type of the mapping source
      * @deprecated types are being removed
      */
     @Deprecated
-    private CreateIndexRequest mapping(String type, BytesReference source, XContentType xContentType) {
+    private CreateIndexRequest mapping(BytesReference source, XContentType xContentType) {
         Objects.requireNonNull(xContentType);
         Map<String, Object> mappingAsMap = XContentHelper.convertToMap(source, false, xContentType).v2();
-        return mapping(type, mappingAsMap);
+        return mapping(MapperService.SINGLE_MAPPING_NAME, mappingAsMap);
+    }
+
+    /**
+     * Adds mapping that will be added when the index gets created.
+     *
+     * @param source The mapping source
+     */
+    public CreateIndexRequest mapping(XContentBuilder source) {
+        return mapping(BytesReference.bytes(source), source.contentType());
+    }
+
+    /**
+     * Set the mapping for this index
+     *
+     * @param source The mapping source
+     */
+    public CreateIndexRequest mapping(Map<String, ?> source) {
+        return mapping(MapperService.SINGLE_MAPPING_NAME, source);
     }
 
     /**
@@ -268,19 +285,7 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
      * @deprecated types are being removed
      */
     @Deprecated
-    public CreateIndexRequest mapping(String type, XContentBuilder source) {
-        return mapping(type, BytesReference.bytes(source), source.contentType());
-    }
-
-    /**
-     * Adds mapping that will be added when the index gets created.
-     *
-     * @param type   The mapping type
-     * @param source The mapping source
-     * @deprecated types are being removed
-     */
-    @Deprecated
-    public CreateIndexRequest mapping(String type, Map<String, ?> source) {
+    private CreateIndexRequest mapping(String type, Map<String, ?> source) {
         // wrap it in a type map if its not
         if (source.size() != 1 || !source.containsKey(type)) {
             source = Collections.singletonMap(MapperService.SINGLE_MAPPING_NAME, source);
@@ -304,7 +309,7 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
      */
     @Deprecated
     public CreateIndexRequest mapping(String type, Object... source) {
-        mapping(type, PutMappingRequest.buildFromSimplifiedDef(source));
+        mapping(PutMappingRequest.buildFromSimplifiedDef(source));
         return this;
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequestBuilder.java
@@ -113,43 +113,28 @@ public class CreateIndexRequestBuilder extends AcknowledgedRequestBuilder<
      *
      * @param source The mapping source
      */
-    @Deprecated
     public CreateIndexRequestBuilder setMapping(String source) {
         request.mapping(source);
         return this;
     }
 
     /**
-     * The cause for this index creation.
+     * Adds mapping that will be added when the index gets created.
+     *
+     * @param source The mapping source
      */
-    public CreateIndexRequestBuilder setCause(String cause) {
-        request.cause(cause);
+    public CreateIndexRequestBuilder setMapping(XContentBuilder source) {
+        request.mapping(source);
         return this;
     }
 
     /**
      * Adds mapping that will be added when the index gets created.
      *
-     * @param type   The mapping type
      * @param source The mapping source
-     * @deprecated types are being removed
      */
-    @Deprecated
-    public CreateIndexRequestBuilder addMapping(String type, XContentBuilder source) {
-        request.mapping(type, source);
-        return this;
-    }
-
-    /**
-     * Adds mapping that will be added when the index gets created.
-     *
-     * @param type   The mapping type
-     * @param source The mapping source
-     * @deprecated types are being removed
-     */
-    @Deprecated
-    public CreateIndexRequestBuilder addMapping(String type, Map<String, Object> source) {
-        request.mapping(type, source);
+    public CreateIndexRequestBuilder setMapping(Map<String, Object> source) {
+        request.mapping(source);
         return this;
     }
 
@@ -161,6 +146,14 @@ public class CreateIndexRequestBuilder extends AcknowledgedRequestBuilder<
     @Deprecated
     public CreateIndexRequestBuilder addMapping(String type, Object... source) {
         request.mapping(type, source);
+        return this;
+    }
+
+    /**
+     * The cause for this index creation.
+     */
+    public CreateIndexRequestBuilder setCause(String cause) {
+        request.cause(cause);
         return this;
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/rollover/RolloverRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/rollover/RolloverRequest.java
@@ -101,7 +101,7 @@ public class RolloverRequest extends AcknowledgedRequest<RolloverRequest> implem
             if (MapperService.isMappingSourceTyped(MapperService.SINGLE_MAPPING_NAME, mappings)) {
                 throw new IllegalArgumentException("The mapping definition cannot be nested under a type");
             }
-            request.createIndexRequest.mapping(MapperService.SINGLE_MAPPING_NAME, mappings);
+            request.createIndexRequest.mapping(mappings);
         }, CreateIndexRequest.MAPPINGS, ObjectParser.ValueType.OBJECT);
         PARSER.declareField(
             (parser, request, context) -> request.createIndexRequest.aliases(parser.map()),

--- a/server/src/test/java/org/opensearch/action/admin/indices/create/CreateIndexRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/create/CreateIndexRequestTests.java
@@ -116,10 +116,10 @@ public class CreateIndexRequestTests extends OpenSearchTestCase {
                 .endObject()
                 .endObject()
                 .endObject();
-            request1.mapping("type1", builder);
+            request1.mapping(builder);
             builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
             builder.startObject()
-                .startObject("type1")
+                .startObject(MapperService.SINGLE_MAPPING_NAME)
                 .startObject("properties")
                 .startObject("field1")
                 .field("type", "text")
@@ -134,7 +134,7 @@ public class CreateIndexRequestTests extends OpenSearchTestCase {
                 .endObject()
                 .endObject()
                 .endObject();
-            request2.mapping("type1", builder);
+            request2.mapping(builder);
             assertEquals(request1.mappings(), request2.mappings());
         }
     }

--- a/server/src/test/java/org/opensearch/action/admin/indices/mapping/put/PutMappingRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/mapping/put/PutMappingRequestTests.java
@@ -160,7 +160,7 @@ public class PutMappingRequestTests extends OpenSearchTestCase {
         String index = randomAlphaOfLength(5);
 
         PutMappingRequest request = new PutMappingRequest(index);
-        request.source(RandomCreateIndexGenerator.randomMapping("_doc"));
+        request.source(RandomCreateIndexGenerator.randomMapping());
 
         return request;
     }

--- a/server/src/test/java/org/opensearch/action/admin/indices/rollover/RolloverRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/rollover/RolloverRequestTests.java
@@ -218,8 +218,7 @@ public class RolloverRequestTests extends OpenSearchTestCase {
     private static RolloverRequest createTestItem() throws IOException {
         RolloverRequest rolloverRequest = new RolloverRequest();
         if (randomBoolean()) {
-            rolloverRequest.getCreateIndexRequest()
-                .mapping(MapperService.SINGLE_MAPPING_NAME, RandomCreateIndexGenerator.randomMapping(MapperService.SINGLE_MAPPING_NAME));
+            rolloverRequest.getCreateIndexRequest().mapping(RandomCreateIndexGenerator.randomMapping());
         }
         if (randomBoolean()) {
             RandomCreateIndexGenerator.randomAliases(rolloverRequest.getCreateIndexRequest());

--- a/server/src/test/java/org/opensearch/action/admin/indices/stats/IndicesStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/stats/IndicesStatsTests.java
@@ -67,7 +67,6 @@ public class IndicesStatsTests extends OpenSearchSingleNodeTestCase {
         IndexModule.Type storeType = IndexModule.defaultStoreType(true);
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("doc")
             .startObject("properties")
             .startObject("foo")
             .field("type", "keyword")
@@ -82,13 +81,12 @@ public class IndicesStatsTests extends OpenSearchSingleNodeTestCase {
             .field("type", "long")
             .endObject()
             .endObject()
-            .endObject()
             .endObject();
         assertAcked(
             client().admin()
                 .indices()
                 .prepareCreate("test")
-                .addMapping("doc", mapping)
+                .setMapping(mapping)
                 .setSettings(Settings.builder().put("index.store.type", storeType.getSettingsKey()))
         );
         ensureGreen("test");

--- a/server/src/test/java/org/opensearch/action/termvectors/AbstractTermVectorsTestCase.java
+++ b/server/src/test/java/org/opensearch/action/termvectors/AbstractTermVectorsTestCase.java
@@ -219,16 +219,16 @@ public abstract class AbstractTermVectorsTestCase extends OpenSearchIntegTestCas
 
     protected void createIndexBasedOnFieldSettings(String index, String alias, TestFieldSetting[] fieldSettings) throws IOException {
         XContentBuilder mappingBuilder = jsonBuilder();
-        mappingBuilder.startObject().startObject("type1").startObject("properties");
+        mappingBuilder.startObject().startObject("properties");
         for (TestFieldSetting field : fieldSettings) {
             field.addToMappings(mappingBuilder);
         }
-        mappingBuilder.endObject().endObject().endObject();
+        mappingBuilder.endObject().endObject();
         Settings.Builder settings = Settings.builder()
             .put(indexSettings())
             .put("index.analysis.analyzer.tv_test.tokenizer", "standard")
             .putList("index.analysis.analyzer.tv_test.filter", "lowercase");
-        assertAcked(prepareCreate(index).addMapping("type1", mappingBuilder).setSettings(settings).addAlias(new Alias(alias)));
+        assertAcked(prepareCreate(index).setMapping(mappingBuilder).setSettings(settings).addAlias(new Alias(alias)));
     }
 
     /**

--- a/server/src/test/java/org/opensearch/action/termvectors/GetTermVectorsTests.java
+++ b/server/src/test/java/org/opensearch/action/termvectors/GetTermVectorsTests.java
@@ -169,13 +169,11 @@ public class GetTermVectorsTests extends OpenSearchSingleNodeTestCase {
         String queryString = createString(tokens, payloads, encoding, delimiter.charAt(0));
         // create the mapping
         XContentBuilder mapping = jsonBuilder().startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("field")
             .field("type", "text")
             .field("term_vector", "with_positions_offsets_payloads")
             .field("analyzer", "payload_test")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();

--- a/server/src/test/java/org/opensearch/index/analysis/PreBuiltAnalyzerTests.java
+++ b/server/src/test/java/org/opensearch/index/analysis/PreBuiltAnalyzerTests.java
@@ -114,12 +114,10 @@ public class PreBuiltAnalyzerTests extends OpenSearchSingleNodeTestCase {
 
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("field")
             .field("type", "text")
             .field("analyzer", analyzerName)
-            .endObject()
             .endObject()
             .endObject()
             .endObject();

--- a/server/src/test/java/org/opensearch/index/mapper/FieldFilterMapperPluginTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/FieldFilterMapperPluginTests.java
@@ -101,7 +101,7 @@ public class FieldFilterMapperPluginTests extends OpenSearchSingleNodeTestCase {
         // as the one coming from a filtered index with same mappings
         GetMappingsResponse getMappingsResponse = client().admin().indices().prepareGetMappings("filtered").get();
         MappingMetadata filtered = getMappingsResponse.getMappings().get("filtered");
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("_doc", filtered.getSourceAsMap()));
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping(filtered.getSourceAsMap()));
         GetFieldMappingsResponse response = client().admin().indices().prepareGetFieldMappings("test").setFields("*").get();
         assertEquals(1, response.mappings().size());
         assertFieldMappings(response.mappings().get("test"), FILTERED_FLAT_FIELDS);
@@ -128,7 +128,7 @@ public class FieldFilterMapperPluginTests extends OpenSearchSingleNodeTestCase {
         // as the one coming from a filtered index with same mappings
         GetMappingsResponse getMappingsResponse = client().admin().indices().prepareGetMappings("filtered").get();
         MappingMetadata filteredMapping = getMappingsResponse.getMappings().get("filtered");
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("_doc", filteredMapping.getSourceAsMap()));
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping(filteredMapping.getSourceAsMap()));
         FieldCapabilitiesResponse test = client().fieldCaps(new FieldCapabilitiesRequest().fields("*").indices("test")).actionGet();
         // properties.value is an object field in the new mapping
         filteredFields.add("properties.value");
@@ -176,7 +176,7 @@ public class FieldFilterMapperPluginTests extends OpenSearchSingleNodeTestCase {
 
     private void assertMappingsAreValid(Map<String, Object> sourceAsMap) {
         // check that the returned filtered mappings are still valid mappings by submitting them and retrieving them back
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("_doc", sourceAsMap));
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping(sourceAsMap));
         GetMappingsResponse testMappingsResponse = client().admin().indices().prepareGetMappings("test").get();
         assertEquals(1, testMappingsResponse.getMappings().size());
         // the mappings are returned unfiltered for this index, yet they are the same as the previous ones that were returned filtered

--- a/server/src/test/java/org/opensearch/index/search/NestedHelperTests.java
+++ b/server/src/test/java/org/opensearch/index/search/NestedHelperTests.java
@@ -66,7 +66,6 @@ public class NestedHelperTests extends OpenSearchSingleNodeTestCase {
         super.setUp();
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("foo")
             .field("type", "keyword")
@@ -106,7 +105,6 @@ public class NestedHelperTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .startObject("foo2")
             .field("type", "long")
-            .endObject()
             .endObject()
             .endObject()
             .endObject()

--- a/server/src/test/java/org/opensearch/index/similarity/SimilarityTests.java
+++ b/server/src/test/java/org/opensearch/index/similarity/SimilarityTests.java
@@ -100,12 +100,10 @@ public class SimilarityTests extends OpenSearchSingleNodeTestCase {
     public void testResolveSimilaritiesFromMapping_bm25() throws IOException {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("field1")
             .field("type", "text")
             .field("similarity", "my_similarity")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();
@@ -131,12 +129,10 @@ public class SimilarityTests extends OpenSearchSingleNodeTestCase {
     public void testResolveSimilaritiesFromMapping_boolean() throws IOException {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("field1")
             .field("type", "text")
             .field("similarity", "boolean")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();
@@ -148,12 +144,10 @@ public class SimilarityTests extends OpenSearchSingleNodeTestCase {
     public void testResolveSimilaritiesFromMapping_DFR() throws IOException {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("field1")
             .field("type", "text")
             .field("similarity", "my_similarity")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();
@@ -178,12 +172,10 @@ public class SimilarityTests extends OpenSearchSingleNodeTestCase {
     public void testResolveSimilaritiesFromMapping_IB() throws IOException {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("field1")
             .field("type", "text")
             .field("similarity", "my_similarity")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();
@@ -208,12 +200,10 @@ public class SimilarityTests extends OpenSearchSingleNodeTestCase {
     public void testResolveSimilaritiesFromMapping_DFI() throws IOException {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("field1")
             .field("type", "text")
             .field("similarity", "my_similarity")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();
@@ -233,12 +223,10 @@ public class SimilarityTests extends OpenSearchSingleNodeTestCase {
     public void testResolveSimilaritiesFromMapping_LMDirichlet() throws IOException {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("field1")
             .field("type", "text")
             .field("similarity", "my_similarity")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();
@@ -261,12 +249,10 @@ public class SimilarityTests extends OpenSearchSingleNodeTestCase {
     public void testResolveSimilaritiesFromMapping_LMJelinekMercer() throws IOException {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("field1")
             .field("type", "text")
             .field("similarity", "my_similarity")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();
@@ -292,12 +278,10 @@ public class SimilarityTests extends OpenSearchSingleNodeTestCase {
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
-                .startObject("type")
                 .startObject("properties")
                 .startObject("field1")
                 .field("type", "text")
                 .field("similarity", "unknown_similarity")
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()

--- a/server/src/test/java/org/opensearch/index/termvectors/TermVectorsServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/termvectors/TermVectorsServiceTests.java
@@ -60,12 +60,10 @@ public class TermVectorsServiceTests extends OpenSearchSingleNodeTestCase {
 
     public void testTook() throws Exception {
         XContentBuilder mapping = jsonBuilder().startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("field")
             .field("type", "text")
             .field("term_vector", "with_positions_offsets_payloads")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();
@@ -90,12 +88,10 @@ public class TermVectorsServiceTests extends OpenSearchSingleNodeTestCase {
 
     public void testDocFreqs() throws IOException {
         XContentBuilder mapping = jsonBuilder().startObject()
-            .startObject("_doc")
             .startObject("properties")
             .startObject("text")
             .field("type", "text")
             .field("term_vector", "with_positions_offsets_payloads")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();
@@ -130,13 +126,11 @@ public class TermVectorsServiceTests extends OpenSearchSingleNodeTestCase {
 
     public void testWithIndexedPhrases() throws IOException {
         XContentBuilder mapping = jsonBuilder().startObject()
-            .startObject("_doc")
             .startObject("properties")
             .startObject("text")
             .field("type", "text")
             .field("index_phrases", true)
             .field("term_vector", "with_positions_offsets_payloads")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();

--- a/server/src/test/java/org/opensearch/search/geo/GeoPointShapeQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/geo/GeoPointShapeQueryTests.java
@@ -89,7 +89,7 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
 
     public void testProcessRelationSupport() throws Exception {
         XContentBuilder xcb = createDefaultMapping();
-        client().admin().indices().prepareCreate("test").addMapping("_doc", xcb).get();
+        client().admin().indices().prepareCreate("test").setMapping(xcb).get();
         ensureGreen();
 
         Rectangle rectangle = new Rectangle(-35, -25, -25, -35);
@@ -112,7 +112,7 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
 
     public void testQueryLine() throws Exception {
         XContentBuilder xcb = createDefaultMapping();
-        client().admin().indices().prepareCreate("test").addMapping("_doc", xcb).get();
+        client().admin().indices().prepareCreate("test").setMapping(xcb).get();
         ensureGreen();
 
         Line line = new Line(new double[] { -25, -25 }, new double[] { -35, -35 });
@@ -126,7 +126,7 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
 
     public void testQueryLinearRing() throws Exception {
         XContentBuilder xcb = createDefaultMapping();
-        client().admin().indices().prepareCreate("test").addMapping("_doc", xcb).get();
+        client().admin().indices().prepareCreate("test").setMapping(xcb).get();
         ensureGreen();
 
         LinearRing linearRing = new LinearRing(new double[] { -25, -35, -25 }, new double[] { -25, -35, -25 });
@@ -148,7 +148,7 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
 
     public void testQueryMultiLine() throws Exception {
         XContentBuilder xcb = createDefaultMapping();
-        client().admin().indices().prepareCreate("test").addMapping("_doc", xcb).get();
+        client().admin().indices().prepareCreate("test").setMapping(xcb).get();
         ensureGreen();
 
         CoordinatesBuilder coords1 = new CoordinatesBuilder().coordinate(-35, -35).coordinate(-25, -25);
@@ -167,7 +167,7 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
 
     public void testQueryMultiPoint() throws Exception {
         XContentBuilder xcb = createDefaultMapping();
-        client().admin().indices().prepareCreate("test").addMapping("_doc", xcb).get();
+        client().admin().indices().prepareCreate("test").setMapping(xcb).get();
         ensureGreen();
 
         MultiPointBuilder mpb = new MultiPointBuilder().coordinate(-35, -25).coordinate(-15, -5);
@@ -182,7 +182,7 @@ public class GeoPointShapeQueryTests extends GeoQueryTests {
 
     public void testQueryPoint() throws Exception {
         XContentBuilder xcb = createDefaultMapping();
-        client().admin().indices().prepareCreate("test").addMapping("_doc", xcb).get();
+        client().admin().indices().prepareCreate("test").setMapping(xcb).get();
         ensureGreen();
 
         PointBuilder pb = new PointBuilder().coordinate(-35, -25);

--- a/server/src/test/java/org/opensearch/search/geo/GeoQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/geo/GeoQueryTests.java
@@ -82,7 +82,7 @@ public abstract class GeoQueryTests extends OpenSearchSingleNodeTestCase {
 
     public void testNullShape() throws Exception {
         XContentBuilder xcb = createDefaultMapping();
-        client().admin().indices().prepareCreate(defaultIndexName).addMapping("_doc", xcb).get();
+        client().admin().indices().prepareCreate(defaultIndexName).setMapping(xcb).get();
         ensureGreen();
 
         client().prepareIndex(defaultIndexName)
@@ -96,7 +96,7 @@ public abstract class GeoQueryTests extends OpenSearchSingleNodeTestCase {
 
     public void testIndexPointsFilterRectangle() throws Exception {
         XContentBuilder xcb = createDefaultMapping();
-        client().admin().indices().prepareCreate(defaultIndexName).addMapping("_doc", xcb).get();
+        client().admin().indices().prepareCreate(defaultIndexName).setMapping(xcb).get();
         ensureGreen();
 
         client().prepareIndex(defaultIndexName)
@@ -134,7 +134,7 @@ public abstract class GeoQueryTests extends OpenSearchSingleNodeTestCase {
 
     public void testIndexPointsCircle() throws Exception {
         XContentBuilder xcb = createDefaultMapping();
-        client().admin().indices().prepareCreate(defaultIndexName).addMapping("_doc", xcb).get();
+        client().admin().indices().prepareCreate(defaultIndexName).setMapping(xcb).get();
         ensureGreen();
 
         client().prepareIndex(defaultIndexName)
@@ -167,7 +167,7 @@ public abstract class GeoQueryTests extends OpenSearchSingleNodeTestCase {
 
     public void testIndexPointsPolygon() throws Exception {
         XContentBuilder xcb = createDefaultMapping();
-        client().admin().indices().prepareCreate(defaultIndexName).addMapping("_doc", xcb).get();
+        client().admin().indices().prepareCreate(defaultIndexName).setMapping(xcb).get();
         ensureGreen();
 
         client().prepareIndex(defaultIndexName)
@@ -203,7 +203,7 @@ public abstract class GeoQueryTests extends OpenSearchSingleNodeTestCase {
 
     public void testIndexPointsMultiPolygon() throws Exception {
         XContentBuilder xcb = createDefaultMapping();
-        client().admin().indices().prepareCreate(defaultIndexName).addMapping("_doc", xcb).get();
+        client().admin().indices().prepareCreate(defaultIndexName).setMapping(xcb).get();
         ensureGreen();
 
         client().prepareIndex(defaultIndexName)
@@ -257,7 +257,7 @@ public abstract class GeoQueryTests extends OpenSearchSingleNodeTestCase {
 
     public void testIndexPointsRectangle() throws Exception {
         XContentBuilder xcb = createDefaultMapping();
-        client().admin().indices().prepareCreate(defaultIndexName).addMapping("_doc", xcb).get();
+        client().admin().indices().prepareCreate(defaultIndexName).setMapping(xcb).get();
         ensureGreen();
 
         client().prepareIndex(defaultIndexName)
@@ -285,7 +285,7 @@ public abstract class GeoQueryTests extends OpenSearchSingleNodeTestCase {
 
     public void testIndexPointsIndexedRectangle() throws Exception {
         XContentBuilder xcb = createDefaultMapping();
-        client().admin().indices().prepareCreate(defaultIndexName).addMapping(defaultIndexName, xcb).get();
+        client().admin().indices().prepareCreate(defaultIndexName).setMapping(xcb).get();
         ensureGreen();
 
         client().prepareIndex(defaultIndexName)
@@ -310,7 +310,7 @@ public abstract class GeoQueryTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject()
             .endObject();
-        client().admin().indices().prepareCreate(indexedShapeIndex).addMapping(defaultIndexName, xcb).get();
+        client().admin().indices().prepareCreate(indexedShapeIndex).setMapping(xcb).get();
         ensureGreen();
 
         client().prepareIndex(indexedShapeIndex)
@@ -352,7 +352,7 @@ public abstract class GeoQueryTests extends OpenSearchSingleNodeTestCase {
 
     public void testRectangleSpanningDateline() throws Exception {
         XContentBuilder xcb = createDefaultMapping();
-        client().admin().indices().prepareCreate("test").addMapping("_doc", xcb).get();
+        client().admin().indices().prepareCreate("test").setMapping(xcb).get();
         ensureGreen();
 
         client().prepareIndex(defaultIndexName)
@@ -385,7 +385,7 @@ public abstract class GeoQueryTests extends OpenSearchSingleNodeTestCase {
 
     public void testPolygonSpanningDateline() throws Exception {
         XContentBuilder xcb = createDefaultMapping();
-        client().admin().indices().prepareCreate("test").addMapping("_doc", xcb).get();
+        client().admin().indices().prepareCreate("test").setMapping(xcb).get();
         ensureGreen();
 
         client().prepareIndex(defaultIndexName)
@@ -429,7 +429,7 @@ public abstract class GeoQueryTests extends OpenSearchSingleNodeTestCase {
 
     public void testMultiPolygonSpanningDateline() throws Exception {
         XContentBuilder xcb = createDefaultMapping();
-        client().admin().indices().prepareCreate("test").addMapping("_doc", xcb).get();
+        client().admin().indices().prepareCreate("test").setMapping(xcb).get();
         ensureGreen();
 
         client().prepareIndex(defaultIndexName)

--- a/server/src/test/java/org/opensearch/search/geo/GeoShapeQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/geo/GeoShapeQueryTests.java
@@ -748,7 +748,6 @@ public class GeoShapeQueryTests extends GeoQueryTests {
     public void testFieldAlias() throws IOException {
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("type")
             .startObject("properties")
             .startObject("location")
             .field("type", "geo_shape")
@@ -757,7 +756,6 @@ public class GeoShapeQueryTests extends GeoQueryTests {
             .startObject("alias")
             .field("type", "alias")
             .field("path", "location")
-            .endObject()
             .endObject()
             .endObject()
             .endObject();

--- a/server/src/test/java/org/opensearch/search/geo/GeoShapeQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/geo/GeoShapeQueryTests.java
@@ -262,7 +262,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
 
         XContentBuilder mapping = createRandomMapping();
         Settings settings = Settings.builder().put("index.number_of_shards", 1).build();
-        client().admin().indices().prepareCreate("test").addMapping("_doc", mapping).setSettings(settings).get();
+        client().admin().indices().prepareCreate("test").setMapping(mapping).setSettings(settings).get();
         ensureGreen();
 
         XContentBuilder docSource = gcb.toXContent(jsonBuilder().startObject().field("geo"), null).endObject();
@@ -282,7 +282,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
     // Test for issue #34418
     public void testEnvelopeSpanningDateline() throws Exception {
         XContentBuilder mapping = createDefaultMapping();
-        client().admin().indices().prepareCreate("test").addMapping("_doc", mapping).get();
+        client().admin().indices().prepareCreate("test").setMapping(mapping).get();
         ensureGreen();
 
         String doc1 = "{\"geo\": {\r\n"
@@ -488,7 +488,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
 
     public void testIndexedShapeReferenceSourceDisabled() throws Exception {
         XContentBuilder mapping = createDefaultMapping();
-        client().admin().indices().prepareCreate("test").addMapping("type1", mapping).get();
+        client().admin().indices().prepareCreate("test").setMapping(mapping).get();
         createIndex("shapes", Settings.EMPTY, "shape_type", "_source", "enabled=false");
         ensureGreen();
 
@@ -612,7 +612,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
         GeometryCollectionBuilder gcb = RandomShapeGenerator.createGeometryCollection(random());
 
         XContentBuilder builder = createRandomMapping();
-        client().admin().indices().prepareCreate("test").addMapping("type", builder).execute().actionGet();
+        client().admin().indices().prepareCreate("test").setMapping(builder).execute().actionGet();
 
         XContentBuilder docSource = gcb.toXContent(jsonBuilder().startObject().field("geo"), null).endObject();
         client().prepareIndex("test").setId("1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
@@ -786,7 +786,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
         gcb.shape(new PolygonBuilder(cb));
 
         XContentBuilder builder = createRandomMapping();
-        client().admin().indices().prepareCreate("test").addMapping("type", builder).get();
+        client().admin().indices().prepareCreate("test").setMapping(builder).get();
 
         XContentBuilder docSource = gcb.toXContent(jsonBuilder().startObject().field("geo"), null).endObject();
         client().prepareIndex("test").setId("1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();

--- a/server/src/test/java/org/opensearch/search/suggest/completion/CategoryContextMappingTests.java
+++ b/server/src/test/java/org/opensearch/search/suggest/completion/CategoryContextMappingTests.java
@@ -77,7 +77,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
     public void testIndexingWithNoContexts() throws Exception {
         String mapping = Strings.toString(
             jsonBuilder().startObject()
-                .startObject("type1")
                 .startObject("properties")
                 .startObject("completion")
                 .field("type", "completion")
@@ -87,7 +86,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
                 .field("type", "category")
                 .endObject()
                 .endArray()
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -129,7 +127,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
     public void testIndexingWithSimpleContexts() throws Exception {
         String mapping = Strings.toString(
             jsonBuilder().startObject()
-                .startObject("type1")
                 .startObject("properties")
                 .startObject("completion")
                 .field("type", "completion")
@@ -139,7 +136,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
                 .field("type", "category")
                 .endObject()
                 .endArray()
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -176,7 +172,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
     public void testIndexingWithSimpleNumberContexts() throws Exception {
         String mapping = Strings.toString(
             jsonBuilder().startObject()
-                .startObject("type1")
                 .startObject("properties")
                 .startObject("completion")
                 .field("type", "completion")
@@ -186,7 +181,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
                 .field("type", "category")
                 .endObject()
                 .endArray()
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -223,7 +217,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
     public void testIndexingWithSimpleBooleanContexts() throws Exception {
         String mapping = Strings.toString(
             jsonBuilder().startObject()
-                .startObject("type1")
                 .startObject("properties")
                 .startObject("completion")
                 .field("type", "completion")
@@ -233,7 +226,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
                 .field("type", "category")
                 .endObject()
                 .endArray()
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -270,7 +262,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
     public void testIndexingWithSimpleNULLContexts() throws Exception {
         String mapping = Strings.toString(
             jsonBuilder().startObject()
-                .startObject("type1")
                 .startObject("properties")
                 .startObject("completion")
                 .field("type", "completion")
@@ -280,7 +271,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
                 .field("type", "category")
                 .endObject()
                 .endArray()
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -314,7 +304,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
     public void testIndexingWithContextList() throws Exception {
         String mapping = Strings.toString(
             jsonBuilder().startObject()
-                .startObject("type1")
                 .startObject("properties")
                 .startObject("completion")
                 .field("type", "completion")
@@ -324,7 +313,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
                 .field("type", "category")
                 .endObject()
                 .endArray()
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -359,7 +347,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
     public void testIndexingWithMixedTypeContextList() throws Exception {
         String mapping = Strings.toString(
             jsonBuilder().startObject()
-                .startObject("type1")
                 .startObject("properties")
                 .startObject("completion")
                 .field("type", "completion")
@@ -369,7 +356,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
                 .field("type", "category")
                 .endObject()
                 .endArray()
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -404,7 +390,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
     public void testIndexingWithMixedTypeContextListHavingNULL() throws Exception {
         String mapping = Strings.toString(
             jsonBuilder().startObject()
-                .startObject("type1")
                 .startObject("properties")
                 .startObject("completion")
                 .field("type", "completion")
@@ -414,7 +399,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
                 .field("type", "category")
                 .endObject()
                 .endArray()
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -443,7 +427,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
     public void testIndexingWithMultipleContexts() throws Exception {
         String mapping = Strings.toString(
             jsonBuilder().startObject()
-                .startObject("type1")
                 .startObject("properties")
                 .startObject("completion")
                 .field("type", "completion")
@@ -457,7 +440,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
                 .field("type", "category")
                 .endObject()
                 .endArray()
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -798,7 +780,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
 
     public void testUnknownQueryContextParsing() throws Exception {
         XContentBuilder mapping = jsonBuilder().startObject()
-            .startObject("type1")
             .startObject("properties")
             .startObject("completion")
             .field("type", "completion")
@@ -812,7 +793,6 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
             .field("type", "category")
             .endObject()
             .endArray()
-            .endObject()
             .endObject()
             .endObject()
             .endObject();

--- a/server/src/test/java/org/opensearch/search/suggest/completion/GeoContextMappingTests.java
+++ b/server/src/test/java/org/opensearch/search/suggest/completion/GeoContextMappingTests.java
@@ -245,7 +245,6 @@ public class GeoContextMappingTests extends OpenSearchSingleNodeTestCase {
     public void testMalformedGeoField() throws Exception {
         XContentBuilder mapping = jsonBuilder();
         mapping.startObject();
-        mapping.startObject("type1");
         mapping.startObject("properties");
         mapping.startObject("pin");
         String type = randomFrom("text", "keyword", "long");
@@ -268,7 +267,6 @@ public class GeoContextMappingTests extends OpenSearchSingleNodeTestCase {
 
         mapping.endObject();
         mapping.endObject();
-        mapping.endObject();
 
         OpenSearchParseException ex = expectThrows(
             OpenSearchParseException.class,
@@ -281,7 +279,6 @@ public class GeoContextMappingTests extends OpenSearchSingleNodeTestCase {
     public void testMissingGeoField() throws Exception {
         XContentBuilder mapping = jsonBuilder();
         mapping.startObject();
-        mapping.startObject("type1");
         mapping.startObject("properties");
         mapping.startObject("suggestion");
         mapping.field("type", "completion");
@@ -298,7 +295,6 @@ public class GeoContextMappingTests extends OpenSearchSingleNodeTestCase {
 
         mapping.endObject();
 
-        mapping.endObject();
         mapping.endObject();
         mapping.endObject();
 

--- a/test/framework/src/main/java/org/opensearch/index/RandomCreateIndexGenerator.java
+++ b/test/framework/src/main/java/org/opensearch/index/RandomCreateIndexGenerator.java
@@ -93,8 +93,7 @@ public final class RandomCreateIndexGenerator {
     }
 
     /**
-     * Creates a random mapping, with the mapping definition nested
-     * under the given type name.
+     * Creates a random mapping
      */
     public static XContentBuilder randomMapping() throws IOException {
         XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));

--- a/test/framework/src/main/java/org/opensearch/index/RandomCreateIndexGenerator.java
+++ b/test/framework/src/main/java/org/opensearch/index/RandomCreateIndexGenerator.java
@@ -63,8 +63,7 @@ public final class RandomCreateIndexGenerator {
         CreateIndexRequest request = new CreateIndexRequest(index);
         randomAliases(request);
         if (randomBoolean()) {
-            String type = randomAlphaOfLength(5);
-            request.mapping(type, randomMapping(type));
+            request.mapping(randomMapping());
         }
         if (randomBoolean()) {
             request.settings(randomIndexSettings());
@@ -97,13 +96,13 @@ public final class RandomCreateIndexGenerator {
      * Creates a random mapping, with the mapping definition nested
      * under the given type name.
      */
-    public static XContentBuilder randomMapping(String type) throws IOException {
+    public static XContentBuilder randomMapping() throws IOException {
         XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
-        builder.startObject().startObject(type);
+        builder.startObject();
 
         randomMappingFields(builder, true);
 
-        builder.endObject().endObject();
+        builder.endObject();
         return builder;
     }
 

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
@@ -310,7 +310,7 @@ public abstract class OpenSearchSingleNodeTestCase extends OpenSearchTestCase {
     protected IndexService createIndex(String index, Settings settings, String type, XContentBuilder mappings) {
         CreateIndexRequestBuilder createIndexRequestBuilder = client().admin().indices().prepareCreate(index).setSettings(settings);
         if (type != null && mappings != null) {
-            createIndexRequestBuilder.addMapping(type, mappings);
+            createIndexRequestBuilder.setMapping(mappings);
         }
         return createIndex(index, createIndexRequestBuilder);
     }


### PR DESCRIPTION
First pass to remove types from CreateIndexRequest and CreateIndexRequestBuilder
mapping method. This method is overloaded several times so the most widely used
methods in the RequestBuilder are refactored from mapping to setMapping to avoid
confusion, conflicts, and to be consistent with other method names (e.g.,
setSettings, setCause, setAlias).

relates #1940 
