### PR TITLE
Fixing PluginsServiceTests (post Lucene 9 update)

### DIFF
--- a/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
@@ -648,7 +648,6 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         assertThat(deps, containsInAnyOrder(pluginJar.toUri().toURL(), dep1Jar.toUri().toURL(), dep2Jar.toUri().toURL()));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/2063")
     public void testNonExtensibleDep() throws Exception {
         // This test opens a child classloader, reading a jar under the test temp
         // dir (a dummy plugin). Classloaders are closed by GC, so when test teardown
@@ -791,7 +790,6 @@ public class PluginsServiceTests extends OpenSearchTestCase {
 
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/2063")
     public void testExistingMandatoryInstalledPlugin() throws IOException {
         // This test opens a child classloader, reading a jar under the test temp
         // dir (a dummy plugin). Classloaders are closed by GC, so when test teardown
@@ -825,7 +823,6 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         newPluginsService(settings);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/2063")
     public void testPluginFromParentClassLoader() throws IOException {
         final Path pathHome = createTempDir();
         final Path plugins = pathHome.resolve("plugins");
@@ -863,7 +860,6 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/2063")
     public void testPluginLoadFailure() throws IOException {
         final Path pathHome = createTempDir();
         final Path plugins = pathHome.resolve("plugins");


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Fixing PluginsServiceTests
 
### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/2063
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
