### PR TITLE
Remove endpoint_suffix dependency on account key

### DIFF
--- a/plugins/repository-azure/src/main/java/org/opensearch/repositories/azure/AzureStorageSettings.java
+++ b/plugins/repository-azure/src/main/java/org/opensearch/repositories/azure/AzureStorageSettings.java
@@ -91,8 +91,7 @@ final class AzureStorageSettings {
         AZURE_CLIENT_PREFIX_KEY,
         "endpoint_suffix",
         key -> Setting.simpleString(key, Property.NodeScope),
-        () -> ACCOUNT_SETTING,
-        () -> KEY_SETTING
+        () -> ACCOUNT_SETTING
     );
 
     // The overall operation timeout


### PR DESCRIPTION
Signed-off-by: Raphael Lopez <raphael.lopez@aiven.io>

### Description
Previously, the `repository-azure` plugin failed to load when a SAS token was provided for authentication rather than an Azure Storage Account key. This was due to a dependency in the `ENDPOINT_SUFFIX_SETTING` - more details in the issue description.

I opted to remove the dependency altogether since the plugin has a check in [buildConnectString()](https://github.com/opensearch-project/OpenSearch/blob/bdcaec5caf4a55afc8a2e5e5f136c2f65d098fd6/plugins/repository-azure/src/main/java/org/opensearch/repositories/azure/AzureStorageSettings.java#L281) to ensure that either a SAS token or a Storage Account key is provided. 
 
### Issues Resolved
Relates to #2462 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
