### PR TITLE
[Unmute] IndexPrimaryRelocationIT.testPrimaryRelocationWhileIndexing

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/recovery/IndexPrimaryRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/recovery/IndexPrimaryRelocationIT.java
@@ -56,7 +56,6 @@ public class IndexPrimaryRelocationIT extends OpenSearchIntegTestCase {
 
     private static final int RELOCATION_COUNT = 15;
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/2063")
     public void testPrimaryRelocationWhileIndexing() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(randomIntBetween(2, 3));
         client().admin()


### PR DESCRIPTION
Unmutes IndexPrimaryRelocationIT.testPrimaryRelocationWhileIndexing which was
fixed by LuceneChangesSnapshot using accurate ops history.

relates #2063