### PR TITLE
[Remove] Type metadata from ingest documents

### DIFF
--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/AppendProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/AppendProcessorTests.java
@@ -147,7 +147,7 @@ public class AppendProcessorTests extends OpenSearchTestCase {
     public void testAppendMetadataExceptVersion() throws Exception {
         // here any metadata field value becomes a list, which won't make sense in most of the cases,
         // but support for append is streamlined like for set so we test it
-        Metadata randomMetadata = randomFrom(Metadata.INDEX, Metadata.TYPE, Metadata.ID, Metadata.ROUTING);
+        Metadata randomMetadata = randomFrom(Metadata.INDEX, Metadata.ID, Metadata.ROUTING);
         List<String> values = new ArrayList<>();
         Processor appendProcessor;
         if (randomBoolean()) {

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/SetProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/SetProcessorTests.java
@@ -116,7 +116,7 @@ public class SetProcessorTests extends OpenSearchTestCase {
     }
 
     public void testSetMetadataExceptVersion() throws Exception {
-        Metadata randomMetadata = randomFrom(Metadata.INDEX, Metadata.TYPE, Metadata.ID, Metadata.ROUTING);
+        Metadata randomMetadata = randomFrom(Metadata.INDEX, Metadata.ID, Metadata.ROUTING);
         Processor processor = createSetProcessor(randomMetadata.getFieldName(), "_value", true, false);
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
         processor.execute(ingestDocument);

--- a/server/src/main/java/org/opensearch/action/ingest/SimulatePipelineRequest.java
+++ b/server/src/main/java/org/opensearch/action/ingest/SimulatePipelineRequest.java
@@ -194,12 +194,6 @@ public class SimulatePipelineRequest extends ActionRequest implements ToXContent
             Map<String, Object> dataMap = (Map<String, Object>) object;
             Map<String, Object> document = ConfigurationUtils.readMap(null, null, dataMap, Fields.SOURCE);
             String index = ConfigurationUtils.readStringOrIntProperty(null, null, dataMap, Metadata.INDEX.getFieldName(), "_index");
-            if (dataMap.containsKey(Metadata.TYPE.getFieldName())) {
-                deprecationLogger.deprecate(
-                    "simulate_pipeline_with_types",
-                    "[types removal] specifying _type in pipeline simulation requests is deprecated"
-                );
-            }
             String id = ConfigurationUtils.readStringOrIntProperty(null, null, dataMap, Metadata.ID.getFieldName(), "_id");
             String routing = ConfigurationUtils.readOptionalStringOrIntProperty(null, null, dataMap, Metadata.ROUTING.getFieldName());
             Long version = null;

--- a/server/src/main/java/org/opensearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/opensearch/ingest/IngestDocument.java
@@ -38,7 +38,6 @@ import org.opensearch.index.mapper.IdFieldMapper;
 import org.opensearch.index.mapper.IndexFieldMapper;
 import org.opensearch.index.mapper.RoutingFieldMapper;
 import org.opensearch.index.mapper.SourceFieldMapper;
-import org.opensearch.index.mapper.TypeFieldMapper;
 import org.opensearch.index.mapper.VersionFieldMapper;
 import org.opensearch.script.TemplateScript;
 
@@ -846,7 +845,6 @@ public final class IngestDocument {
 
     public enum Metadata {
         INDEX(IndexFieldMapper.NAME),
-        TYPE(TypeFieldMapper.NAME),
         ID(IdFieldMapper.NAME),
         ROUTING(RoutingFieldMapper.NAME),
         VERSION(VersionFieldMapper.NAME),

--- a/server/src/test/java/org/opensearch/action/ingest/SimulatePipelineRequestParsingTests.java
+++ b/server/src/test/java/org/opensearch/action/ingest/SimulatePipelineRequestParsingTests.java
@@ -57,7 +57,6 @@ import static org.opensearch.action.ingest.SimulatePipelineRequest.SIMULATED_PIP
 import static org.opensearch.ingest.IngestDocument.Metadata.ID;
 import static org.opensearch.ingest.IngestDocument.Metadata.INDEX;
 import static org.opensearch.ingest.IngestDocument.Metadata.ROUTING;
-import static org.opensearch.ingest.IngestDocument.Metadata.TYPE;
 import static org.opensearch.ingest.IngestDocument.Metadata.VERSION;
 import static org.opensearch.ingest.IngestDocument.Metadata.VERSION_TYPE;
 import static org.opensearch.ingest.IngestDocument.Metadata.IF_SEQ_NO;
@@ -132,15 +131,7 @@ public class SimulatePipelineRequestParsingTests extends OpenSearchTestCase {
         assertThat(actualRequest.getPipeline().getProcessors().size(), equalTo(1));
     }
 
-    public void testParseWithProvidedPipelineNoType() throws Exception {
-        innerTestParseWithProvidedPipeline(false);
-    }
-
-    public void testParseWithProvidedPipelineWithType() throws Exception {
-        innerTestParseWithProvidedPipeline(true);
-    }
-
-    private void innerTestParseWithProvidedPipeline(boolean useExplicitType) throws Exception {
+    public void innerTestParseWithProvidedPipeline() throws Exception {
         int numDocs = randomIntBetween(1, 10);
 
         Map<String, Object> requestContent = new HashMap<>();
@@ -150,16 +141,7 @@ public class SimulatePipelineRequestParsingTests extends OpenSearchTestCase {
         for (int i = 0; i < numDocs; i++) {
             Map<String, Object> doc = new HashMap<>();
             Map<String, Object> expectedDoc = new HashMap<>();
-            List<IngestDocument.Metadata> fields = Arrays.asList(
-                INDEX,
-                TYPE,
-                ID,
-                ROUTING,
-                VERSION,
-                VERSION_TYPE,
-                IF_SEQ_NO,
-                IF_PRIMARY_TERM
-            );
+            List<IngestDocument.Metadata> fields = Arrays.asList(INDEX, ID, ROUTING, VERSION, VERSION_TYPE, IF_SEQ_NO, IF_PRIMARY_TERM);
             for (IngestDocument.Metadata field : fields) {
                 if (field == VERSION) {
                     Long value = randomLong();
@@ -173,14 +155,6 @@ public class SimulatePipelineRequestParsingTests extends OpenSearchTestCase {
                     Long value = randomNonNegativeLong();
                     doc.put(field.getFieldName(), value);
                     expectedDoc.put(field.getFieldName(), value);
-                } else if (field == TYPE) {
-                    if (useExplicitType) {
-                        String value = randomAlphaOfLengthBetween(1, 10);
-                        doc.put(field.getFieldName(), value);
-                        expectedDoc.put(field.getFieldName(), value);
-                    } else {
-                        expectedDoc.put(field.getFieldName(), "_doc");
-                    }
                 } else {
                     if (randomBoolean()) {
                         String value = randomAlphaOfLengthBetween(1, 10);
@@ -249,9 +223,6 @@ public class SimulatePipelineRequestParsingTests extends OpenSearchTestCase {
         assertThat(actualRequest.getPipeline().getId(), equalTo(SIMULATED_PIPELINE_ID));
         assertThat(actualRequest.getPipeline().getDescription(), nullValue());
         assertThat(actualRequest.getPipeline().getProcessors().size(), equalTo(numProcessors));
-        if (useExplicitType) {
-            assertWarnings("[types removal] specifying _type in pipeline simulation requests is deprecated");
-        }
     }
 
     public void testNullPipelineId() {


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Remove _type field support in ingest document
 
Related: #1940 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
