### PR TITLE
[Remove] Type from PutIndexTemplateRequest and PITRB

### DIFF
--- a/modules/mapper-extras/src/test/java/org/opensearch/index/query/RankFeatureQueryBuilderTests.java
+++ b/modules/mapper-extras/src/test/java/org/opensearch/index/query/RankFeatureQueryBuilderTests.java
@@ -62,7 +62,7 @@ public class RankFeatureQueryBuilderTests extends AbstractQueryTestCase<RankFeat
             "_doc",
             new CompressedXContent(
                 Strings.toString(
-                    PutMappingRequest.buildFromSimplifiedDef(
+                    PutMappingRequest.simpleMapping(
                         "my_feature_field",
                         "type=rank_feature",
                         "my_negative_feature_field",

--- a/modules/percolator/src/internalClusterTest/java/org/opensearch/percolator/PercolatorQuerySearchIT.java
+++ b/modules/percolator/src/internalClusterTest/java/org/opensearch/percolator/PercolatorQuerySearchIT.java
@@ -565,7 +565,7 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("test")
-                .addMapping("type", "id", "type=keyword", "field1", fieldMapping, "query", "type=percolator")
+                .addMapping("type", "id", "type=keyword", "field1", fieldMapping.toString(), "query", "type=percolator")
         );
         client().prepareIndex("test")
             .setId("1")

--- a/modules/percolator/src/test/java/org/opensearch/percolator/PercolateQueryBuilderTests.java
+++ b/modules/percolator/src/test/java/org/opensearch/percolator/PercolateQueryBuilderTests.java
@@ -110,14 +110,14 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
             docType,
             new CompressedXContent(
                 Strings.toString(
-                    PutMappingRequest.buildFromSimplifiedDef(queryField, "type=percolator", aliasField, "type=alias,path=" + queryField)
+                    PutMappingRequest.simpleMapping(queryField, "type=percolator", aliasField, "type=alias,path=" + queryField)
                 )
             ),
             MapperService.MergeReason.MAPPING_UPDATE
         );
         mapperService.merge(
             docType,
-            new CompressedXContent(Strings.toString(PutMappingRequest.buildFromSimplifiedDef(TEXT_FIELD_NAME, "type=text"))),
+            new CompressedXContent(Strings.toString(PutMappingRequest.simpleMapping(TEXT_FIELD_NAME, "type=text"))),
             MapperService.MergeReason.MAPPING_UPDATE
         );
     }

--- a/modules/percolator/src/test/java/org/opensearch/percolator/PercolateWithNestedQueryBuilderTests.java
+++ b/modules/percolator/src/test/java/org/opensearch/percolator/PercolateWithNestedQueryBuilderTests.java
@@ -50,7 +50,7 @@ public class PercolateWithNestedQueryBuilderTests extends PercolateQueryBuilderT
         super.initializeAdditionalMappings(mapperService);
         mapperService.merge(
             "_doc",
-            new CompressedXContent(Strings.toString(PutMappingRequest.buildFromSimplifiedDef("some_nested_object", "type=nested"))),
+            new CompressedXContent(Strings.toString(PutMappingRequest.simpleMapping("some_nested_object", "type=nested"))),
             MapperService.MergeReason.MAPPING_UPDATE
         );
     }

--- a/server/src/internalClusterTest/java/org/opensearch/document/AliasedIndexDocumentActionsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/document/AliasedIndexDocumentActionsIT.java
@@ -49,7 +49,7 @@ public class AliasedIndexDocumentActionsIT extends DocumentActionsIT {
         logger.info("--> creating index test");
         client().admin()
             .indices()
-            .create(createIndexRequest("test1").mapping("type1", "name", "type=keyword,store=true").alias(new Alias("test")))
+            .create(createIndexRequest("test1").simpleMapping("name", "type=keyword,store=true").alias(new Alias("test")))
             .actionGet();
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/index/HiddenIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/HiddenIndexIT.java
@@ -122,7 +122,7 @@ public class HiddenIndexIT extends OpenSearchIntegTestCase {
                 .indices()
                 .preparePutTemplate("a_global_template")
                 .setPatterns(Collections.singletonList("*"))
-                .setMapping("_doc", "foo", "type=text")
+                .setMapping("foo", "type=text")
                 .get()
         );
         assertAcked(
@@ -130,7 +130,7 @@ public class HiddenIndexIT extends OpenSearchIntegTestCase {
                 .indices()
                 .preparePutTemplate("not_global_template")
                 .setPatterns(Collections.singletonList("a*"))
-                .setMapping("_doc", "bar", "type=text")
+                .setMapping("bar", "type=text")
                 .get()
         );
         assertAcked(
@@ -138,7 +138,7 @@ public class HiddenIndexIT extends OpenSearchIntegTestCase {
                 .indices()
                 .preparePutTemplate("specific_template")
                 .setPatterns(Collections.singletonList("a_hidden_index"))
-                .setMapping("_doc", "baz", "type=text")
+                .setMapping("baz", "type=text")
                 .get()
         );
         assertAcked(
@@ -146,7 +146,7 @@ public class HiddenIndexIT extends OpenSearchIntegTestCase {
                 .indices()
                 .preparePutTemplate("unused_template")
                 .setPatterns(Collections.singletonList("not_used"))
-                .setMapping("_doc", "foobar", "type=text")
+                .setMapping("foobar", "type=text")
                 .get()
         );
 
@@ -192,7 +192,7 @@ public class HiddenIndexIT extends OpenSearchIntegTestCase {
                 .indices()
                 .preparePutTemplate("a_global_template")
                 .setPatterns(Collections.singletonList("my_hidden_pattern*"))
-                .setMapping("_doc", "foo", "type=text")
+                .setMapping("foo", "type=text")
                 .setSettings(Settings.builder().put("index.hidden", true).build())
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/index/HiddenIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/HiddenIndexIT.java
@@ -122,7 +122,7 @@ public class HiddenIndexIT extends OpenSearchIntegTestCase {
                 .indices()
                 .preparePutTemplate("a_global_template")
                 .setPatterns(Collections.singletonList("*"))
-                .addMapping("_doc", "foo", "type=text")
+                .setMapping("_doc", "foo", "type=text")
                 .get()
         );
         assertAcked(
@@ -130,7 +130,7 @@ public class HiddenIndexIT extends OpenSearchIntegTestCase {
                 .indices()
                 .preparePutTemplate("not_global_template")
                 .setPatterns(Collections.singletonList("a*"))
-                .addMapping("_doc", "bar", "type=text")
+                .setMapping("_doc", "bar", "type=text")
                 .get()
         );
         assertAcked(
@@ -138,7 +138,7 @@ public class HiddenIndexIT extends OpenSearchIntegTestCase {
                 .indices()
                 .preparePutTemplate("specific_template")
                 .setPatterns(Collections.singletonList("a_hidden_index"))
-                .addMapping("_doc", "baz", "type=text")
+                .setMapping("_doc", "baz", "type=text")
                 .get()
         );
         assertAcked(
@@ -146,7 +146,7 @@ public class HiddenIndexIT extends OpenSearchIntegTestCase {
                 .indices()
                 .preparePutTemplate("unused_template")
                 .setPatterns(Collections.singletonList("not_used"))
-                .addMapping("_doc", "foobar", "type=text")
+                .setMapping("_doc", "foobar", "type=text")
                 .get()
         );
 
@@ -192,7 +192,7 @@ public class HiddenIndexIT extends OpenSearchIntegTestCase {
                 .indices()
                 .preparePutTemplate("a_global_template")
                 .setPatterns(Collections.singletonList("my_hidden_pattern*"))
-                .addMapping("_doc", "foo", "type=text")
+                .setMapping("_doc", "foo", "type=text")
                 .setSettings(Settings.builder().put("index.hidden", true).build())
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/indices/template/SimpleIndexTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/template/SimpleIndexTemplateIT.java
@@ -554,7 +554,7 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
             .indices()
             .preparePutTemplate("template_with_aliases")
             .setPatterns(Collections.singletonList("te*"))
-            .setMapping("_doc", "type", "type=keyword", "field", "type=text")
+            .setMapping("type", "type=keyword", "field", "type=text")
             .addAlias(new Alias("simple_alias"))
             .addAlias(new Alias("templated_alias-{index}"))
             .addAlias(new Alias("filtered_alias").filter("{\"term\":{\"type\":\"type2\"}}"))
@@ -820,7 +820,7 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
             .preparePutTemplate("template1")
             .setPatterns(Collections.singletonList("a*"))
             .setOrder(0)
-            .setMapping("test", "field", "type=text")
+            .setMapping("field", "type=text")
             .addAlias(new Alias("alias1").filter(termQuery("field", "value")))
             .get();
         // Indexing into b index should fail, since there is field with name 'field' in the mapping
@@ -930,7 +930,7 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
                 .setPatterns(Collections.singletonList("te*"))
                 .setVersion(version)
                 .setOrder(order)
-                .setMapping("test", "field", "type=text")
+                .setMapping("field", "type=text")
                 .get()
         );
 

--- a/server/src/internalClusterTest/java/org/opensearch/indices/template/SimpleIndexTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/template/SimpleIndexTemplateIT.java
@@ -554,7 +554,7 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
             .indices()
             .preparePutTemplate("template_with_aliases")
             .setPatterns(Collections.singletonList("te*"))
-            .addMapping("_doc", "type", "type=keyword", "field", "type=text")
+            .setMapping("_doc", "type", "type=keyword", "field", "type=text")
             .addAlias(new Alias("simple_alias"))
             .addAlias(new Alias("templated_alias-{index}"))
             .addAlias(new Alias("filtered_alias").filter("{\"term\":{\"type\":\"type2\"}}"))
@@ -820,7 +820,7 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
             .preparePutTemplate("template1")
             .setPatterns(Collections.singletonList("a*"))
             .setOrder(0)
-            .addMapping("test", "field", "type=text")
+            .setMapping("test", "field", "type=text")
             .addAlias(new Alias("alias1").filter(termQuery("field", "value")))
             .get();
         // Indexing into b index should fail, since there is field with name 'field' in the mapping
@@ -930,7 +930,7 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
                 .setPatterns(Collections.singletonList("te*"))
                 .setVersion(version)
                 .setOrder(order)
-                .addMapping("test", "field", "type=text")
+                .setMapping("test", "field", "type=text")
                 .get()
         );
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/TransportTwoNodesSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/TransportTwoNodesSearchIT.java
@@ -96,7 +96,7 @@ public class TransportTwoNodesSearchIT extends OpenSearchIntegTestCase {
 
         client().admin()
             .indices()
-            .create(createIndexRequest("test").settings(settingsBuilder).mapping("type", "foo", "type=geo_point"))
+            .create(createIndexRequest("test").settings(settingsBuilder).simpleMapping("foo", "type=geo_point"))
             .actionGet();
 
         ensureGreen();

--- a/server/src/internalClusterTest/java/org/opensearch/search/searchafter/SearchAfterIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/searchafter/SearchAfterIT.java
@@ -323,7 +323,7 @@ public class SearchAfterIT extends OpenSearchIntegTestCase {
                 fail("Can't match type [" + type + "]");
             }
         }
-        indexRequestBuilder.addMapping(typeName, mappings.toArray()).get();
+        indexRequestBuilder.addMapping(typeName, mappings.toArray(new String[0])).get();
         ensureGreen();
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequest.java
@@ -305,11 +305,9 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
     /**
      * A specialized simplified mapping source method, takes the form of simple properties definition:
      * ("field1", "type=string,store=true").
-     * @deprecated types are being removed
      */
-    @Deprecated
-    public CreateIndexRequest mapping(String type, Object... source) {
-        mapping(PutMappingRequest.buildFromSimplifiedDef(source));
+    public CreateIndexRequest simpleMapping(String... source) {
+        mapping(PutMappingRequest.simpleMapping(source));
         return this;
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequestBuilder.java
@@ -144,8 +144,8 @@ public class CreateIndexRequestBuilder extends AcknowledgedRequestBuilder<
      * @deprecated types are being removed
      */
     @Deprecated
-    public CreateIndexRequestBuilder addMapping(String type, Object... source) {
-        request.mapping(type, source);
+    public CreateIndexRequestBuilder addMapping(String type, String... source) {
+        request.simpleMapping(source);
         return this;
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/mapping/put/PutMappingRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/mapping/put/PutMappingRequest.java
@@ -217,8 +217,8 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
      * Also supports metadata mapping fields such as `_all` and `_parent` as property definition, these metadata
      * mapping fields will automatically be put on the top level mapping object.
      */
-    public PutMappingRequest source(Object... source) {
-        return source(buildFromSimplifiedDef(source));
+    public PutMappingRequest source(String... source) {
+        return source(simpleMapping(source));
     }
 
     public String origin() {
@@ -239,7 +239,7 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
      *             if the number of the source arguments is not divisible by two
      * @return the mappings definition
      */
-    public static XContentBuilder buildFromSimplifiedDef(Object... source) {
+    public static XContentBuilder simpleMapping(String... source) {
         if (source.length % 2 != 0) {
             throw new IllegalArgumentException("mapping source must be pairs of fieldnames and properties definition.");
         }
@@ -248,10 +248,10 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
             builder.startObject();
 
             for (int i = 0; i < source.length; i++) {
-                String fieldName = source[i++].toString();
+                String fieldName = source[i++];
                 if (RESERVED_FIELDS.contains(fieldName)) {
                     builder.startObject(fieldName);
-                    String[] s1 = Strings.splitStringByCommaToArray(source[i].toString());
+                    String[] s1 = Strings.splitStringByCommaToArray(source[i]);
                     for (String s : s1) {
                         String[] s2 = Strings.split(s, "=");
                         if (s2.length != 2) {
@@ -265,13 +265,13 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
 
             builder.startObject("properties");
             for (int i = 0; i < source.length; i++) {
-                String fieldName = source[i++].toString();
+                String fieldName = source[i++];
                 if (RESERVED_FIELDS.contains(fieldName)) {
                     continue;
                 }
 
                 builder.startObject(fieldName);
-                String[] s1 = Strings.splitStringByCommaToArray(source[i].toString());
+                String[] s1 = Strings.splitStringByCommaToArray(source[i]);
                 for (String s : s1) {
                     String[] s2 = Strings.split(s, "=");
                     if (s2.length != 2) {

--- a/server/src/main/java/org/opensearch/action/admin/indices/mapping/put/PutMappingRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/mapping/put/PutMappingRequestBuilder.java
@@ -102,7 +102,7 @@ public class PutMappingRequestBuilder extends AcknowledgedRequestBuilder<
      * A specialized simplified mapping source method, takes the form of simple properties definition:
      * ("field1", "type=string,store=true").
      */
-    public PutMappingRequestBuilder setSource(Object... source) {
+    public PutMappingRequestBuilder setSource(String... source) {
         request.source(source);
         return this;
     }

--- a/server/src/main/java/org/opensearch/action/admin/indices/rollover/RolloverRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/rollover/RolloverRequestBuilder.java
@@ -84,8 +84,8 @@ public class RolloverRequestBuilder extends MasterNodeOperationRequestBuilder<Ro
         return this;
     }
 
-    public RolloverRequestBuilder mapping(String type, Object... source) {
-        this.request.getCreateIndexRequest().mapping(type, source);
+    public RolloverRequestBuilder simpleMapping(String... source) {
+        this.request.getCreateIndexRequest().simpleMapping(source);
         return this;
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -58,6 +58,7 @@ import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.common.xcontent.support.XContentMapValues;
+import org.opensearch.index.mapper.MapperService;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -303,8 +304,8 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
      * A specialized simplified mapping source method, takes the form of simple properties definition:
      * ("field1", "type=string,store=true").
      */
-    public PutIndexTemplateRequest mapping(String type, Object... source) {
-        mapping(type, PutMappingRequest.buildFromSimplifiedDef(source));
+    public PutIndexTemplateRequest mapping(String... source) {
+        mapping(MapperService.SINGLE_MAPPING_NAME, PutMappingRequest.simpleMapping(source));
         return this;
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/put/PutIndexTemplateRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/put/PutIndexTemplateRequestBuilder.java
@@ -137,8 +137,8 @@ public class PutIndexTemplateRequestBuilder extends MasterNodeOperationRequestBu
      * A specialized simplified mapping source method, takes the form of simple properties definition:
      * ("field1", "type=string,store=true").
      */
-    public PutIndexTemplateRequestBuilder addMapping(String type, Object... source) {
-        request.mapping(type, source);
+    public PutIndexTemplateRequestBuilder setMapping(String... source) {
+        request.mapping(source);
         return this;
     }
 

--- a/server/src/test/java/org/opensearch/action/admin/indices/mapping/put/PutMappingRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/mapping/put/PutMappingRequestTests.java
@@ -92,15 +92,12 @@ public class PutMappingRequestTests extends OpenSearchTestCase {
     }
 
     /**
-     * Test that {@link PutMappingRequest#buildFromSimplifiedDef(Object...)}
+     * Test that {@link PutMappingRequest#simpleMapping(String...)}
      * rejects inputs where the {@code Object...} varargs of field name and properties are not
      * paired correctly
      */
     public void testBuildFromSimplifiedDef() {
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> PutMappingRequest.buildFromSimplifiedDef("only_field")
-        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PutMappingRequest.simpleMapping("only_field"));
         assertEquals("mapping source must be pairs of fieldnames and properties definition.", e.getMessage());
     }
 

--- a/server/src/test/java/org/opensearch/index/mapper/RangeFieldQueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/RangeFieldQueryStringQueryBuilderTests.java
@@ -73,7 +73,7 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
             "_doc",
             new CompressedXContent(
                 Strings.toString(
-                    PutMappingRequest.buildFromSimplifiedDef(
+                    PutMappingRequest.simpleMapping(
                         INTEGER_RANGE_FIELD_NAME,
                         "type=integer_range",
                         LONG_RANGE_FIELD_NAME,

--- a/server/src/test/java/org/opensearch/index/query/MatchQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/MatchQueryBuilderTests.java
@@ -390,7 +390,7 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
             "_doc",
             new CompressedXContent(
                 Strings.toString(
-                    PutMappingRequest.buildFromSimplifiedDef("string_boost", "type=text", "string_no_pos", "type=text,index_options=docs")
+                    PutMappingRequest.simpleMapping("string_boost", "type=text", "string_no_pos", "type=text,index_options=docs")
                 )
             ),
             MapperService.MergeReason.MAPPING_UPDATE

--- a/server/src/test/java/org/opensearch/index/query/NestedQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/NestedQueryBuilderTests.java
@@ -77,7 +77,7 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
             "_doc",
             new CompressedXContent(
                 Strings.toString(
-                    PutMappingRequest.buildFromSimplifiedDef(
+                    PutMappingRequest.simpleMapping(
                         TEXT_FIELD_NAME,
                         "type=text",
                         INT_FIELD_NAME,

--- a/server/src/test/java/org/opensearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/QueryStringQueryBuilderTests.java
@@ -1096,7 +1096,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             .merge(
                 "_doc",
                 new CompressedXContent(
-                    Strings.toString(PutMappingRequest.buildFromSimplifiedDef("foo", "type=text", "_field_names", "enabled=false"))
+                    Strings.toString(PutMappingRequest.simpleMapping("foo", "type=text", "_field_names", "enabled=false"))
                 ),
                 MapperService.MergeReason.MAPPING_UPDATE
             );
@@ -1112,7 +1112,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
                 .merge(
                     "_doc",
                     new CompressedXContent(
-                        Strings.toString(PutMappingRequest.buildFromSimplifiedDef("foo", "type=text", "_field_names", "enabled=true"))
+                        Strings.toString(PutMappingRequest.simpleMapping("foo", "type=text", "_field_names", "enabled=true"))
                     ),
                     MapperService.MergeReason.MAPPING_UPDATE
                 );

--- a/server/src/test/java/org/opensearch/index/query/TermsSetQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/TermsSetQueryBuilderTests.java
@@ -93,7 +93,7 @@ public class TermsSetQueryBuilderTests extends AbstractQueryTestCase<TermsSetQue
         String docType = "_doc";
         mapperService.merge(
             docType,
-            new CompressedXContent(Strings.toString(PutMappingRequest.buildFromSimplifiedDef("m_s_m", "type=long"))),
+            new CompressedXContent(Strings.toString(PutMappingRequest.simpleMapping("m_s_m", "type=long"))),
             MapperService.MergeReason.MAPPING_UPDATE
         );
     }

--- a/test/framework/src/main/java/org/opensearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/AbstractBuilderTestCase.java
@@ -438,7 +438,7 @@ public abstract class AbstractBuilderTestCase extends OpenSearchTestCase {
                     "_doc",
                     new CompressedXContent(
                         Strings.toString(
-                            PutMappingRequest.buildFromSimplifiedDef(
+                            PutMappingRequest.simpleMapping(
                                 TEXT_FIELD_NAME,
                                 "type=text",
                                 KEYWORD_FIELD_NAME,

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
@@ -320,7 +320,7 @@ public abstract class OpenSearchSingleNodeTestCase extends OpenSearchTestCase {
      * @deprecated types are being removed
      */
     @Deprecated
-    protected IndexService createIndex(String index, Settings settings, String type, Object... mappings) {
+    protected IndexService createIndex(String index, Settings settings, String type, String... mappings) {
         CreateIndexRequestBuilder createIndexRequestBuilder = client().admin().indices().prepareCreate(index).setSettings(settings);
         if (type != null) {
             createIndexRequestBuilder.addMapping(type, mappings);


### PR DESCRIPTION
Continues removal of types from PutIndexTemplateRequest and
PutIndexTemplateRequestBuilder.mapping. Delegated mapping method in
PutIndexTemplateRequestBuilder is refactored to setMapping for consistency with
similar methods (e.g., setSettings, setAliases).

relates #1940