### PR TITLE
[Remove] types from CreateIndexRequest and companion Builder's mapping method

### DIFF
--- a/modules/analysis-common/src/internalClusterTest/java/org/opensearch/analysis/common/QueryStringWithAnalyzersIT.java
+++ b/modules/analysis-common/src/internalClusterTest/java/org/opensearch/analysis/common/QueryStringWithAnalyzersIT.java
@@ -73,7 +73,7 @@ public class QueryStringWithAnalyzersIT extends OpenSearchIntegTestCase {
                         .put("analysis.filter.custom_word_delimiter.split_on_numerics", "false")
                         .put("analysis.filter.custom_word_delimiter.stem_english_possessive", "false")
                 )
-                .addMapping("type1", "field1", "type=text,analyzer=my_analyzer", "field2", "type=text,analyzer=my_analyzer")
+                .setMapping("field1", "type=text,analyzer=my_analyzer", "field2", "type=text,analyzer=my_analyzer")
         );
 
         client().prepareIndex("test").setId("1").setSource("field1", "foo bar baz", "field2", "not needed").get();

--- a/modules/analysis-common/src/test/java/org/opensearch/analysis/common/HighlighterWithAnalyzersTests.java
+++ b/modules/analysis-common/src/test/java/org/opensearch/analysis/common/HighlighterWithAnalyzersTests.java
@@ -149,8 +149,7 @@ public class HighlighterWithAnalyzersTests extends OpenSearchIntegTestCase {
          * query. We cut off and extract terms if there are more than 16 terms in the query
          */
         assertAcked(
-            prepareCreate("test").addMapping(
-                "test",
+            prepareCreate("test").setMapping(
                 "body",
                 "type=text,analyzer=custom_analyzer," + "search_analyzer=custom_analyzer,term_vector=with_positions_offsets"
             )
@@ -225,8 +224,7 @@ public class HighlighterWithAnalyzersTests extends OpenSearchIntegTestCase {
 
         assertAcked(
             prepareCreate("test").setSettings(builder.build())
-                .addMapping(
-                    "type1",
+                .setMapping(
                     "field1",
                     "type=text,term_vector=with_positions_offsets,search_analyzer=synonym," + "analyzer=standard,index_options=offsets"
                 )
@@ -335,8 +333,7 @@ public class HighlighterWithAnalyzersTests extends OpenSearchIntegTestCase {
 
         assertAcked(
             prepareCreate("second_test_index").setSettings(builder.build())
-                .addMapping(
-                    "doc",
+                .setMapping(
                     "field4",
                     "type=text,term_vector=with_positions_offsets,analyzer=synonym",
                     "field3",

--- a/modules/lang-expression/src/internalClusterTest/java/org/opensearch/script/expression/MoreExpressionIT.java
+++ b/modules/lang-expression/src/internalClusterTest/java/org/opensearch/script/expression/MoreExpressionIT.java
@@ -158,7 +158,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
     }
 
     public void testDateMethods() throws Exception {
-        OpenSearchAssertions.assertAcked(prepareCreate("test").addMapping("doc", "date0", "type=date", "date1", "type=date"));
+        OpenSearchAssertions.assertAcked(prepareCreate("test").setMapping("date0", "type=date", "date1", "type=date"));
         ensureGreen("test");
         indexRandom(
             true,
@@ -188,7 +188,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
     }
 
     public void testDateObjectMethods() throws Exception {
-        OpenSearchAssertions.assertAcked(prepareCreate("test").addMapping("doc", "date0", "type=date", "date1", "type=date"));
+        OpenSearchAssertions.assertAcked(prepareCreate("test").setMapping("date0", "type=date", "date1", "type=date"));
         ensureGreen("test");
         indexRandom(
             true,
@@ -219,7 +219,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
 
     public void testMultiValueMethods() throws Exception {
         OpenSearchAssertions.assertAcked(
-            prepareCreate("test").addMapping("doc", "double0", "type=double", "double1", "type=double", "double2", "type=double")
+            prepareCreate("test").setMapping("double0", "type=double", "double1", "type=double", "double2", "type=double")
         );
         ensureGreen("test");
 
@@ -322,7 +322,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
     }
 
     public void testInvalidDateMethodCall() throws Exception {
-        OpenSearchAssertions.assertAcked(prepareCreate("test").addMapping("doc", "double", "type=double"));
+        OpenSearchAssertions.assertAcked(prepareCreate("test").setMapping("double", "type=double"));
         ensureGreen("test");
         indexRandom(true, client().prepareIndex("test").setId("1").setSource("double", "178000000.0"));
         try {
@@ -343,7 +343,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
     }
 
     public void testSparseField() throws Exception {
-        OpenSearchAssertions.assertAcked(prepareCreate("test").addMapping("doc", "x", "type=long", "y", "type=long"));
+        OpenSearchAssertions.assertAcked(prepareCreate("test").setMapping("x", "type=long", "y", "type=long"));
         ensureGreen("test");
         indexRandom(
             true,
@@ -528,7 +528,7 @@ public class MoreExpressionIT extends OpenSearchIntegTestCase {
 
     public void testStringSpecialValueVariable() throws Exception {
         // i.e. expression script for term aggregations, which is not allowed
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("doc", "text", "type=keyword").get());
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping("text", "type=keyword").get());
         ensureGreen("test");
         indexRandom(
             true,

--- a/modules/percolator/src/internalClusterTest/java/org/opensearch/percolator/PercolatorQuerySearchIT.java
+++ b/modules/percolator/src/internalClusterTest/java/org/opensearch/percolator/PercolatorQuerySearchIT.java
@@ -101,7 +101,7 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("test")
-                .addMapping("type", "id", "type=keyword", "field1", "type=keyword", "field2", "type=keyword", "query", "type=percolator")
+                .setMapping("id", "type=keyword", "field1", "type=keyword", "field2", "type=keyword", "query", "type=percolator")
         );
 
         client().prepareIndex("test")
@@ -183,8 +183,7 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("test")
-                .addMapping(
-                    "type",
+                .setMapping(
                     "field1",
                     "type=long",
                     "field2",
@@ -315,17 +314,7 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("test")
-                .addMapping(
-                    "type",
-                    "id",
-                    "type=keyword",
-                    "field1",
-                    "type=geo_point",
-                    "field2",
-                    "type=geo_shape",
-                    "query",
-                    "type=percolator"
-                )
+                .setMapping("id", "type=keyword", "field1", "type=geo_point", "field2", "type=geo_shape", "query", "type=percolator")
         );
 
         client().prepareIndex("test")
@@ -380,7 +369,7 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("test")
-                .addMapping("type", "id", "type=keyword", "field1", "type=keyword", "field2", "type=keyword", "query", "type=percolator")
+                .setMapping("id", "type=keyword", "field1", "type=keyword", "field2", "type=keyword", "query", "type=percolator")
         );
 
         client().prepareIndex("test")
@@ -438,7 +427,7 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("test")
-                .addMapping("type", "_source", "enabled=false", "field1", "type=keyword", "query", "type=percolator")
+                .setMapping("_source", "enabled=false", "field1", "type=keyword", "query", "type=percolator")
         );
 
         client().prepareIndex("test").setId("1").setSource(jsonBuilder().startObject().field("query", matchAllQuery()).endObject()).get();
@@ -459,7 +448,7 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("test")
-                .addMapping("type", "id", "type=keyword", "field1", "type=text", "field2", "type=text", "query", "type=percolator")
+                .setMapping("id", "type=keyword", "field1", "type=text", "field2", "type=text", "query", "type=percolator")
         );
 
         client().prepareIndex("test")
@@ -565,7 +554,7 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("test")
-                .addMapping("type", "id", "type=keyword", "field1", fieldMapping.toString(), "query", "type=percolator")
+                .setMapping("id", "type=keyword", "field1", fieldMapping.toString(), "query", "type=percolator")
         );
         client().prepareIndex("test")
             .setId("1")
@@ -810,7 +799,7 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("test")
-                .addMapping("type", "field", "type=text,position_increment_gap=5", "query", "type=percolator")
+                .setMapping("field", "type=text,position_increment_gap=5", "query", "type=percolator")
         );
         client().prepareIndex("test")
             .setId("1")
@@ -832,13 +821,13 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
     public void testManyPercolatorFields() throws Exception {
         String queryFieldName = randomAlphaOfLength(8);
         assertAcked(
-            client().admin().indices().prepareCreate("test1").addMapping("type", queryFieldName, "type=percolator", "field", "type=keyword")
+            client().admin().indices().prepareCreate("test1").setMapping(queryFieldName, "type=percolator", "field", "type=keyword")
         );
         assertAcked(
             client().admin()
                 .indices()
                 .prepareCreate("test2")
-                .addMapping("type", queryFieldName, "type=percolator", "second_query_field", "type=percolator", "field", "type=keyword")
+                .setMapping(queryFieldName, "type=percolator", "second_query_field", "type=percolator", "field", "type=keyword")
         );
         assertAcked(
             client().admin()
@@ -867,7 +856,7 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
     public void testWithMultiplePercolatorFields() throws Exception {
         String queryFieldName = randomAlphaOfLength(8);
         assertAcked(
-            client().admin().indices().prepareCreate("test1").addMapping("type", queryFieldName, "type=percolator", "field", "type=keyword")
+            client().admin().indices().prepareCreate("test1").setMapping(queryFieldName, "type=percolator", "field", "type=keyword")
         );
         assertAcked(
             client().admin()
@@ -1130,7 +1119,7 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPercolatorQueryViaMultiSearch() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type", "field1", "type=text", "query", "type=percolator"));
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "query", "type=percolator"));
 
         client().prepareIndex("test")
             .setId("1")
@@ -1248,7 +1237,7 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
                 client().admin()
                     .indices()
                     .prepareCreate("test")
-                    .addMapping("_doc", "id", "type=keyword", "field1", "type=keyword", "query", "type=percolator")
+                    .setMapping("id", "type=keyword", "field1", "type=keyword", "query", "type=percolator")
             );
 
             client().prepareIndex("test")
@@ -1298,7 +1287,7 @@ public class PercolatorQuerySearchIT extends OpenSearchIntegTestCase {
 
     public void testWrappedWithConstantScore() throws Exception {
 
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("_doc", "d", "type=date", "q", "type=percolator"));
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping("d", "type=date", "q", "type=percolator"));
 
         client().prepareIndex("test")
             .setId("1")

--- a/modules/percolator/src/test/java/org/opensearch/percolator/PercolatorQuerySearchTests.java
+++ b/modules/percolator/src/test/java/org/opensearch/percolator/PercolatorQuerySearchTests.java
@@ -96,7 +96,7 @@ public class PercolatorQuerySearchTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testPercolateScriptQuery() throws IOException {
-        client().admin().indices().prepareCreate("index").addMapping("type", "query", "type=percolator").get();
+        client().admin().indices().prepareCreate("index").setMapping("query", "type=percolator").get();
         client().prepareIndex("index")
             .setId("1")
             .setSource(

--- a/plugins/mapper-size/src/internalClusterTest/java/org/opensearch/index/mapper/size/SizeMappingIT.java
+++ b/plugins/mapper-size/src/internalClusterTest/java/org/opensearch/index/mapper/size/SizeMappingIT.java
@@ -36,7 +36,6 @@ import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.plugin.mapper.MapperSizePlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -122,7 +121,7 @@ public class SizeMappingIT extends OpenSearchIntegTestCase {
     }
 
     public void testBasic() throws Exception {
-        assertAcked(prepareCreate("test").addMapping(MapperService.SINGLE_MAPPING_NAME, "_size", "enabled=true"));
+        assertAcked(prepareCreate("test").setMapping("_size", "enabled=true"));
         final String source = "{\"f\":10}";
         indexRandom(true, client().prepareIndex("test").setId("1").setSource(source, XContentType.JSON));
         GetResponse getResponse = client().prepareGet("test", "1").setStoredFields("_size").get();

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/ShrinkIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/ShrinkIndexIT.java
@@ -71,7 +71,6 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.engine.SegmentsStats;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.TermsQueryBuilder;
 import org.opensearch.index.seqno.SeqNoStats;
 import org.opensearch.index.shard.IndexShard;
@@ -527,7 +526,7 @@ public class ShrinkIndexIT extends OpenSearchIntegTestCase {
                 .put("sort.order", "desc")
                 .put("number_of_shards", 8)
                 .put("number_of_replicas", 0)
-        ).addMapping(MapperService.SINGLE_MAPPING_NAME, "id", "type=keyword,doc_values=true").get();
+        ).setMapping("id", "type=keyword,doc_values=true").get();
         for (int i = 0; i < 20; i++) {
             client().prepareIndex("source")
                 .setId(Integer.toString(i))

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/SplitIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/SplitIndexIT.java
@@ -65,7 +65,6 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.engine.SegmentsStats;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.TermsQueryBuilder;
 import org.opensearch.index.seqno.SeqNoStats;
 import org.opensearch.index.shard.IndexShard;
@@ -136,12 +135,12 @@ public class SplitIndexIT extends OpenSearchIntegTestCase {
             int numRoutingShards = MetadataCreateIndexService.calculateNumRoutingShards(secondSplitShards, Version.CURRENT) - 1;
             settings.put("index.routing_partition_size", randomIntBetween(1, numRoutingShards));
             if (useNested) {
-                createInitialIndex.addMapping(MapperService.SINGLE_MAPPING_NAME, "_routing", "required=true", "nested1", "type=nested");
+                createInitialIndex.setMapping("_routing", "required=true", "nested1", "type=nested");
             } else {
-                createInitialIndex.addMapping(MapperService.SINGLE_MAPPING_NAME, "_routing", "required=true");
+                createInitialIndex.setMapping("_routing", "required=true");
             }
         } else if (useNested) {
-            createInitialIndex.addMapping(MapperService.SINGLE_MAPPING_NAME, "nested1", "type=nested");
+            createInitialIndex.setMapping("nested1", "type=nested");
         }
         logger.info("use routing {} use mixed routing {} use nested {}", useRouting, useMixedRouting, useNested);
         createInitialIndex.setSettings(settings).get();
@@ -523,7 +522,7 @@ public class SplitIndexIT extends OpenSearchIntegTestCase {
                 .put("sort.order", "desc")
                 .put("number_of_shards", 2)
                 .put("number_of_replicas", 0)
-        ).addMapping(MapperService.SINGLE_MAPPING_NAME, "id", "type=keyword,doc_values=true").get();
+        ).setMapping("id", "type=keyword,doc_values=true").get();
         for (int i = 0; i < 20; i++) {
             client().prepareIndex("source")
                 .setId(Integer.toString(i))

--- a/server/src/internalClusterTest/java/org/opensearch/action/search/TransportSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/search/TransportSearchIT.java
@@ -348,7 +348,7 @@ public class TransportSearchIT extends OpenSearchIntegTestCase {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 5))
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numOfReplicas)
             .put(IndexSettings.INDEX_SEARCH_IDLE_AFTER.getKey(), TimeValue.timeValueMillis(randomIntBetween(50, 500)));
-        assertAcked(prepareCreate("test").setSettings(settings).addMapping("_doc", "created_date", "type=date,format=yyyy-MM-dd"));
+        assertAcked(prepareCreate("test").setSettings(settings).setMapping("created_date", "type=date,format=yyyy-MM-dd"));
         ensureGreen("test");
         assertBusy(() -> {
             for (String node : internalCluster().nodesInclude("test")) {

--- a/server/src/internalClusterTest/java/org/opensearch/action/termvectors/GetTermVectorsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/termvectors/GetTermVectorsIT.java
@@ -161,8 +161,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         // must be of type string and indexed.
         assertAcked(
             prepareCreate("test").addAlias(new Alias("alias"))
-                .addMapping(
-                    "type1",
+                .setMapping(
                     "field0",
                     "type=integer,", // no tvs
                     "field1",
@@ -548,10 +547,8 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
     public void testDuelWithAndWithoutTermVectors() throws IOException, ExecutionException, InterruptedException {
         // setup indices
         String[] indexNames = new String[] { "with_tv", "without_tv" };
-        assertAcked(
-            prepareCreate(indexNames[0]).addMapping("type1", "field1", "type=text,term_vector=with_positions_offsets,analyzer=keyword")
-        );
-        assertAcked(prepareCreate(indexNames[1]).addMapping("type1", "field1", "type=text,term_vector=no,analyzer=keyword"));
+        assertAcked(prepareCreate(indexNames[0]).setMapping("field1", "type=text,term_vector=with_positions_offsets,analyzer=keyword"));
+        assertAcked(prepareCreate(indexNames[1]).setMapping("field1", "type=text,term_vector=no,analyzer=keyword"));
         ensureGreen();
 
         // index documents with and without term vectors
@@ -656,9 +653,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
     public void testArtificialVsExisting() throws ExecutionException, InterruptedException, IOException {
         // setup indices
         Settings.Builder settings = Settings.builder().put(indexSettings()).put("index.analysis.analyzer", "standard");
-        assertAcked(
-            prepareCreate("test").setSettings(settings).addMapping("type1", "field1", "type=text,term_vector=with_positions_offsets")
-        );
+        assertAcked(prepareCreate("test").setSettings(settings).setMapping("field1", "type=text,term_vector=with_positions_offsets"));
         ensureGreen();
 
         // index documents existing document
@@ -704,7 +699,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
     public void testArtificialNoDoc() throws IOException {
         // setup indices
         Settings.Builder settings = Settings.builder().put(indexSettings()).put("index.analysis.analyzer", "standard");
-        assertAcked(prepareCreate("test").setSettings(settings).addMapping("type1", "field1", "type=text"));
+        assertAcked(prepareCreate("test").setSettings(settings).setMapping("field1", "type=text"));
         ensureGreen();
 
         // request tvs from artificial document
@@ -929,7 +924,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
     public void testFilterLength() throws ExecutionException, InterruptedException, IOException {
         logger.info("Setting up the index ...");
         Settings.Builder settings = Settings.builder().put(indexSettings()).put("index.analysis.analyzer", "keyword");
-        assertAcked(prepareCreate("test").setSettings(settings).addMapping("type1", "tags", "type=text"));
+        assertAcked(prepareCreate("test").setSettings(settings).setMapping("tags", "type=text"));
 
         int numTerms = scaledRandomIntBetween(10, 50);
         logger.info("Indexing one document with tags of increasing length ...");
@@ -962,7 +957,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
     public void testFilterTermFreq() throws ExecutionException, InterruptedException, IOException {
         logger.info("Setting up the index ...");
         Settings.Builder settings = Settings.builder().put(indexSettings()).put("index.analysis.analyzer", "keyword");
-        assertAcked(prepareCreate("test").setSettings(settings).addMapping("type1", "tags", "type=text"));
+        assertAcked(prepareCreate("test").setSettings(settings).setMapping("tags", "type=text"));
 
         logger.info("Indexing one document with tags of increasing frequencies ...");
         int numTerms = scaledRandomIntBetween(10, 50);
@@ -1000,7 +995,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
             .put(indexSettings())
             .put("index.analysis.analyzer", "keyword")
             .put("index.number_of_shards", 1); // no dfs
-        assertAcked(prepareCreate("test").setSettings(settings).addMapping("type1", "tags", "type=text"));
+        assertAcked(prepareCreate("test").setSettings(settings).setMapping("tags", "type=text"));
 
         int numDocs = scaledRandomIntBetween(10, 50); // as many terms as there are docs
         logger.info("Indexing {} documents with tags of increasing dfs ...", numDocs);
@@ -1030,9 +1025,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
     public void testArtificialDocWithPreference() throws InterruptedException, IOException {
         // setup indices
         Settings.Builder settings = Settings.builder().put(indexSettings()).put("index.analysis.analyzer", "standard");
-        assertAcked(
-            prepareCreate("test").setSettings(settings).addMapping("type1", "field1", "type=text,term_vector=with_positions_offsets")
-        );
+        assertAcked(prepareCreate("test").setSettings(settings).setMapping("field1", "type=text,term_vector=with_positions_offsets"));
         ensureGreen();
 
         // index document
@@ -1076,8 +1069,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
             .putList("index.analysis.normalizer.my_normalizer.filter", "lowercase");
         assertAcked(
             prepareCreate(indexNames[0]).setSettings(builder.build())
-                .addMapping(
-                    "type1",
+                .setMapping(
                     "field1",
                     "type=text,term_vector=with_positions_offsets,analyzer=my_analyzer",
                     "field2",
@@ -1086,7 +1078,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         );
         assertAcked(
             prepareCreate(indexNames[1]).setSettings(builder.build())
-                .addMapping("type1", "field1", "type=keyword,normalizer=my_normalizer", "field2", "type=keyword")
+                .setMapping("field1", "type=keyword,normalizer=my_normalizer", "field2", "type=keyword")
         );
         ensureGreen();
 

--- a/server/src/internalClusterTest/java/org/opensearch/aliases/IndexAliasesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/aliases/IndexAliasesIT.java
@@ -226,7 +226,7 @@ public class IndexAliasesIT extends OpenSearchIntegTestCase {
 
     public void testFilteringAliases() throws Exception {
         logger.info("--> creating index [test]");
-        assertAcked(prepareCreate("test").addMapping("type", "user", "type=text"));
+        assertAcked(prepareCreate("test").setMapping("user", "type=text"));
 
         ensureGreen();
 
@@ -260,7 +260,7 @@ public class IndexAliasesIT extends OpenSearchIntegTestCase {
 
     public void testSearchingFilteringAliasesSingleIndex() throws Exception {
         logger.info("--> creating index [test]");
-        assertAcked(prepareCreate("test").addMapping("type1", "id", "type=text", "name", "type=text,fielddata=true"));
+        assertAcked(prepareCreate("test").setMapping("id", "type=text", "name", "type=text,fielddata=true"));
 
         ensureGreen();
 
@@ -363,9 +363,9 @@ public class IndexAliasesIT extends OpenSearchIntegTestCase {
 
     public void testSearchingFilteringAliasesTwoIndices() throws Exception {
         logger.info("--> creating index [test1]");
-        assertAcked(prepareCreate("test1").addMapping("type1", "name", "type=text"));
+        assertAcked(prepareCreate("test1").setMapping("name", "type=text"));
         logger.info("--> creating index [test2]");
-        assertAcked(prepareCreate("test2").addMapping("type1", "name", "type=text"));
+        assertAcked(prepareCreate("test2").setMapping("name", "type=text"));
         ensureGreen();
 
         logger.info("--> adding filtering aliases to index [test1]");
@@ -593,8 +593,8 @@ public class IndexAliasesIT extends OpenSearchIntegTestCase {
 
     public void testDeletingByQueryFilteringAliases() throws Exception {
         logger.info("--> creating index [test1] and [test2");
-        assertAcked(prepareCreate("test1").addMapping("type1", "name", "type=text"));
-        assertAcked(prepareCreate("test2").addMapping("type1", "name", "type=text"));
+        assertAcked(prepareCreate("test1").setMapping("name", "type=text"));
+        assertAcked(prepareCreate("test2").setMapping("name", "type=text"));
         ensureGreen();
 
         logger.info("--> adding filtering aliases to index [test1]");
@@ -648,8 +648,8 @@ public class IndexAliasesIT extends OpenSearchIntegTestCase {
 
     public void testDeleteAliases() throws Exception {
         logger.info("--> creating index [test1] and [test2]");
-        assertAcked(prepareCreate("test1").addMapping("type", "name", "type=text"));
-        assertAcked(prepareCreate("test2").addMapping("type", "name", "type=text"));
+        assertAcked(prepareCreate("test1").setMapping("name", "type=text"));
+        assertAcked(prepareCreate("test2").setMapping("name", "type=text"));
         ensureGreen();
 
         logger.info("--> adding filtering aliases to index [test1]");
@@ -780,7 +780,7 @@ public class IndexAliasesIT extends OpenSearchIntegTestCase {
 
     public void testSameAlias() throws Exception {
         logger.info("--> creating index [test]");
-        assertAcked(prepareCreate("test").addMapping("type", "name", "type=text"));
+        assertAcked(prepareCreate("test").setMapping("name", "type=text"));
         ensureGreen();
 
         logger.info("--> creating alias1 ");
@@ -1073,7 +1073,7 @@ public class IndexAliasesIT extends OpenSearchIntegTestCase {
 
     public void testCreateIndexWithAliases() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping("type", "field", "type=text")
+            prepareCreate("test").setMapping("field", "type=text")
                 .addAlias(new Alias("alias1"))
                 .addAlias(new Alias("alias2").filter(QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery("field"))))
                 .addAlias(new Alias("alias3").indexRouting("index").searchRouting("search"))
@@ -1103,7 +1103,7 @@ public class IndexAliasesIT extends OpenSearchIntegTestCase {
 
     public void testCreateIndexWithAliasesSource() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping("type", "field", "type=text")
+            prepareCreate("test").setMapping("field", "type=text")
                 .setAliases(
                     "{\n"
                         + "        \"alias1\" : {},\n"
@@ -1180,7 +1180,7 @@ public class IndexAliasesIT extends OpenSearchIntegTestCase {
     }
 
     public void testAliasFilterWithNowInRangeFilterAndQuery() throws Exception {
-        assertAcked(prepareCreate("my-index").addMapping("my-type", "timestamp", "type=date"));
+        assertAcked(prepareCreate("my-index").setMapping("timestamp", "type=date"));
         assertAliasesVersionIncreases(
             "my-index",
             () -> assertAcked(

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/RareClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/RareClusterStateIT.java
@@ -176,9 +176,7 @@ public class RareClusterStateIT extends OpenSearchIntegTestCase {
         internalCluster().startMasterOnlyNode();
         String dataNode = internalCluster().startDataOnlyNode();
         assertFalse(client().admin().cluster().prepareHealth().setWaitForNodes("2").get().isTimedOut());
-        prepareCreate("test").setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0))
-            .addMapping(MapperService.SINGLE_MAPPING_NAME)
-            .get();
+        prepareCreate("test").setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)).get();
         ensureGreen("test");
 
         // block none master node.

--- a/server/src/internalClusterTest/java/org/opensearch/document/DocumentActionsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/document/DocumentActionsIT.java
@@ -69,7 +69,7 @@ import static org.hamcrest.Matchers.nullValue;
  */
 public class DocumentActionsIT extends OpenSearchIntegTestCase {
     protected void createIndex() {
-        OpenSearchAssertions.assertAcked(prepareCreate(getConcreteIndexName()).addMapping("type1", "name", "type=keyword,store=true"));
+        OpenSearchAssertions.assertAcked(prepareCreate(getConcreteIndexName()).setMapping("name", "type=keyword,store=true"));
     }
 
     protected String getConcreteIndexName() {

--- a/server/src/internalClusterTest/java/org/opensearch/document/ShardInfoIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/document/ShardInfoIT.java
@@ -125,7 +125,7 @@ public class ShardInfoIT extends OpenSearchIntegTestCase {
                 Settings.builder()
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numberOfPrimaryShards)
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numCopies - 1)
-            ).addMapping("type", "_routing", "required=" + routingRequired).get()
+            ).setMapping("_routing", "required=" + routingRequired).get()
         );
         for (int i = 0; i < numberOfPrimaryShards; i++) {
             ensureActiveShardCopies(i, numNodes);

--- a/server/src/internalClusterTest/java/org/opensearch/explain/ExplainActionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/explain/ExplainActionIT.java
@@ -115,7 +115,7 @@ public class ExplainActionIT extends OpenSearchIntegTestCase {
 
     public void testExplainWithFields() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping("test", "obj1.field1", "type=keyword,store=true", "obj1.field2", "type=keyword,store=true")
+            prepareCreate("test").setMapping("obj1.field1", "type=keyword,store=true", "obj1.field2", "type=keyword,store=true")
                 .addAlias(new Alias("alias"))
         );
         ensureGreen("test");
@@ -212,7 +212,7 @@ public class ExplainActionIT extends OpenSearchIntegTestCase {
 
     public void testExplainWithFilteredAlias() {
         assertAcked(
-            prepareCreate("test").addMapping("test", "field2", "type=text")
+            prepareCreate("test").setMapping("field2", "type=text")
                 .addAlias(new Alias("alias1").filter(QueryBuilders.termQuery("field2", "value2")))
         );
         ensureGreen("test");
@@ -231,7 +231,7 @@ public class ExplainActionIT extends OpenSearchIntegTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("test")
-                .addMapping("test", "field2", "type=text")
+                .setMapping("field2", "type=text")
                 .addAlias(new Alias("alias1").filter(QueryBuilders.termQuery("field2", "value2")))
         );
         ensureGreen("test");

--- a/server/src/internalClusterTest/java/org/opensearch/get/GetActionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/get/GetActionIT.java
@@ -84,7 +84,7 @@ public class GetActionIT extends OpenSearchIntegTestCase {
 
     public void testSimpleGet() {
         assertAcked(
-            prepareCreate("test").addMapping("type1", "field1", "type=keyword,store=true", "field2", "type=keyword,store=true")
+            prepareCreate("test").setMapping("field1", "type=keyword,store=true", "field2", "type=keyword,store=true")
                 .setSettings(Settings.builder().put("index.refresh_interval", -1))
                 .addAlias(new Alias("alias").writeIndex(randomFrom(true, false, null)))
         );
@@ -234,7 +234,7 @@ public class GetActionIT extends OpenSearchIntegTestCase {
     public void testSimpleMultiGet() throws Exception {
         assertAcked(
             prepareCreate("test").addAlias(new Alias("alias").writeIndex(randomFrom(true, false, null)))
-                .addMapping("type1", "field", "type=keyword,store=true")
+                .setMapping("field", "type=keyword,store=true")
                 .setSettings(Settings.builder().put("index.refresh_interval", -1))
         );
         ensureGreen();

--- a/server/src/internalClusterTest/java/org/opensearch/index/suggest/stats/SuggestStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/suggest/stats/SuggestStatsIT.java
@@ -79,12 +79,12 @@ public class SuggestStatsIT extends OpenSearchIntegTestCase {
         assertAcked(
             prepareCreate("test1").setSettings(
                 Settings.builder().put(SETTING_NUMBER_OF_SHARDS, shardsIdx1).put(SETTING_NUMBER_OF_REPLICAS, 0)
-            ).addMapping("type", "f", "type=text")
+            ).setMapping("f", "type=text")
         );
         assertAcked(
             prepareCreate("test2").setSettings(
                 Settings.builder().put(SETTING_NUMBER_OF_SHARDS, shardsIdx2).put(SETTING_NUMBER_OF_REPLICAS, 0)
-            ).addMapping("type", "f", "type=text")
+            ).setMapping("f", "type=text")
         );
         assertThat(shardsIdx1 + shardsIdx2, equalTo(numAssignedShards("test1", "test2")));
         assertThat(numAssignedShards("test1", "test2"), greaterThanOrEqualTo(2));

--- a/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
@@ -73,7 +73,7 @@ public class IndicesRequestCacheIT extends OpenSearchIntegTestCase {
             client.admin()
                 .indices()
                 .prepareCreate("index")
-                .addMapping("type", "f", "type=date")
+                .setMapping("f", "type=date")
                 .setSettings(Settings.builder().put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true))
                 .get()
         );
@@ -137,7 +137,7 @@ public class IndicesRequestCacheIT extends OpenSearchIntegTestCase {
             client.admin()
                 .indices()
                 .prepareCreate("index")
-                .addMapping("type", "s", "type=date")
+                .setMapping("s", "type=date")
                 .setSettings(
                     Settings.builder()
                         .put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true)
@@ -208,7 +208,7 @@ public class IndicesRequestCacheIT extends OpenSearchIntegTestCase {
             client.admin()
                 .indices()
                 .prepareCreate("index")
-                .addMapping("type", "s", "type=date")
+                .setMapping("s", "type=date")
                 .setSettings(
                     Settings.builder()
                         .put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true)
@@ -274,7 +274,7 @@ public class IndicesRequestCacheIT extends OpenSearchIntegTestCase {
             client.admin()
                 .indices()
                 .prepareCreate("index")
-                .addMapping("type", "d", "type=date")
+                .setMapping("d", "type=date")
                 .setSettings(
                     Settings.builder()
                         .put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true)
@@ -345,9 +345,9 @@ public class IndicesRequestCacheIT extends OpenSearchIntegTestCase {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
             .build();
-        assertAcked(client.admin().indices().prepareCreate("index-1").addMapping("type", "d", "type=date").setSettings(settings).get());
-        assertAcked(client.admin().indices().prepareCreate("index-2").addMapping("type", "d", "type=date").setSettings(settings).get());
-        assertAcked(client.admin().indices().prepareCreate("index-3").addMapping("type", "d", "type=date").setSettings(settings).get());
+        assertAcked(client.admin().indices().prepareCreate("index-1").setMapping("d", "type=date").setSettings(settings).get());
+        assertAcked(client.admin().indices().prepareCreate("index-2").setMapping("d", "type=date").setSettings(settings).get());
+        assertAcked(client.admin().indices().prepareCreate("index-3").setMapping("d", "type=date").setSettings(settings).get());
         ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
         DateFormatter formatter = DateFormatter.forPattern("strict_date_optional_time");
         indexRandom(
@@ -426,7 +426,7 @@ public class IndicesRequestCacheIT extends OpenSearchIntegTestCase {
             .put("index.number_of_routing_shards", 2)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
             .build();
-        assertAcked(client.admin().indices().prepareCreate("index").addMapping("type", "s", "type=date").setSettings(settings).get());
+        assertAcked(client.admin().indices().prepareCreate("index").setMapping("s", "type=date").setSettings(settings).get());
         indexRandom(
             true,
             client.prepareIndex("index").setId("1").setRouting("1").setSource("s", "2016-03-19"),
@@ -529,7 +529,7 @@ public class IndicesRequestCacheIT extends OpenSearchIntegTestCase {
             client.admin()
                 .indices()
                 .prepareCreate("index")
-                .addMapping("type", "created_at", "type=date")
+                .setMapping("created_at", "type=date")
                 .setSettings(settings)
                 .addAlias(new Alias("last_week").filter(QueryBuilders.rangeQuery("created_at").gte("now-7d/d")))
                 .get()
@@ -578,7 +578,7 @@ public class IndicesRequestCacheIT extends OpenSearchIntegTestCase {
             client.admin()
                 .indices()
                 .prepareCreate("index")
-                .addMapping("_doc", "k", "type=keyword")
+                .setMapping("k", "type=keyword")
                 .setSettings(
                     Settings.builder()
                         .put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true)

--- a/server/src/internalClusterTest/java/org/opensearch/indices/analyze/AnalyzeActionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/analyze/AnalyzeActionIT.java
@@ -99,7 +99,7 @@ public class AnalyzeActionIT extends OpenSearchIntegTestCase {
     }
 
     public void testAnalyzeNumericField() throws IOException {
-        assertAcked(prepareCreate("test").addAlias(new Alias("alias")).addMapping("test", "long", "type=long", "double", "type=double"));
+        assertAcked(prepareCreate("test").addAlias(new Alias("alias")).setMapping("long", "type=long", "double", "type=double"));
         ensureGreen("test");
 
         expectThrows(
@@ -413,7 +413,7 @@ public class AnalyzeActionIT extends OpenSearchIntegTestCase {
     }
 
     public void testAnalyzeKeywordField() throws IOException {
-        assertAcked(prepareCreate("test").addAlias(new Alias("alias")).addMapping("test", "keyword", "type=keyword"));
+        assertAcked(prepareCreate("test").addAlias(new Alias("alias")).setMapping("keyword", "type=keyword"));
         ensureGreen("test");
 
         AnalyzeAction.Response analyzeResponse = client().admin().indices().prepareAnalyze(indexOrAlias(), "ABC").setField("keyword").get();
@@ -435,7 +435,7 @@ public class AnalyzeActionIT extends OpenSearchIntegTestCase {
                         .put("index.analysis.normalizer.my_normalizer.type", "custom")
                         .putList("index.analysis.normalizer.my_normalizer.filter", "lowercase")
                 )
-                .addMapping("test", "keyword", "type=keyword,normalizer=my_normalizer")
+                .setMapping("keyword", "type=keyword,normalizer=my_normalizer")
         );
         ensureGreen("test");
 

--- a/server/src/internalClusterTest/java/org/opensearch/indices/memory/breaker/CircuitBreakerServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/memory/breaker/CircuitBreakerServiceIT.java
@@ -142,8 +142,7 @@ public class CircuitBreakerServiceIT extends OpenSearchIntegTestCase {
             return;
         }
         assertAcked(
-            prepareCreate("cb-test", 1, Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, between(0, 1))).addMapping(
-                "type",
+            prepareCreate("cb-test", 1, Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, between(0, 1))).setMapping(
                 "test",
                 "type=text,fielddata=true"
             )

--- a/server/src/internalClusterTest/java/org/opensearch/indices/recovery/IndexPrimaryRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/recovery/IndexPrimaryRelocationIT.java
@@ -62,7 +62,7 @@ public class IndexPrimaryRelocationIT extends OpenSearchIntegTestCase {
             .indices()
             .prepareCreate("test")
             .setSettings(Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
-            .addMapping("type", "field", "type=text")
+            .setMapping("field", "type=text")
             .get();
         ensureGreen("test");
         AtomicInteger numAutoGenDocs = new AtomicInteger();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
@@ -148,7 +148,7 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
                 .indices()
                 .prepareCreate("test")
                 .setSettings(settingsBuilder().put("index.number_of_shards", 2))
-                .addMapping("type", "field", "type=text,fielddata=true", "field2", "type=text,fielddata=true")
+                .setMapping("field", "type=text,fielddata=true", "field2", "type=text,fielddata=true")
                 .get()
         );
         ensureGreen();
@@ -270,7 +270,7 @@ public class IndexStatsIT extends OpenSearchIntegTestCase {
                 .indices()
                 .prepareCreate("test")
                 .setSettings(settingsBuilder().put("index.number_of_replicas", 0).put("index.number_of_shards", 2))
-                .addMapping("type", "field", "type=text,fielddata=true")
+                .setMapping("field", "type=text,fielddata=true")
                 .get()
         );
         ensureGreen();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/template/SimpleIndexTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/template/SimpleIndexTemplateIT.java
@@ -624,7 +624,7 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
             )
             .get();
 
-        assertAcked(prepareCreate("test_index").addMapping("_doc"));
+        assertAcked(prepareCreate("test_index"));
         ensureGreen();
 
         GetAliasesResponse getAliasesResponse = client().admin().indices().prepareGetAliases().setIndices("test_index").get();
@@ -663,7 +663,7 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
             )
             .get();
 
-        assertAcked(prepareCreate("test_index").addMapping("_doc"));
+        assertAcked(prepareCreate("test_index"));
         ensureGreen();
 
         GetAliasesResponse getAliasesResponse = client().admin().indices().prepareGetAliases().setIndices("test_index").get();

--- a/server/src/internalClusterTest/java/org/opensearch/recovery/TruncatedRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/recovery/TruncatedRecoveryIT.java
@@ -108,7 +108,7 @@ public class TruncatedRecoveryIT extends OpenSearchIntegTestCase {
         // create the index and prevent allocation on any other nodes than the lucky one
         // we have no replicas so far and make sure that we allocate the primary on the lucky node
         assertAcked(
-            prepareCreate("test").addMapping("type1", "field1", "type=text", "the_id", "type=text")
+            prepareCreate("test").setMapping("field1", "type=text", "the_id", "type=text")
                 .setSettings(
                     Settings.builder()
                         .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/AggregationsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/AggregationsIntegrationIT.java
@@ -52,7 +52,7 @@ public class AggregationsIntegrationIT extends OpenSearchIntegTestCase {
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        assertAcked(prepareCreate("index").addMapping("type", "f", "type=keyword").get());
+        assertAcked(prepareCreate("index").setMapping("f", "type=keyword").get());
         numDocs = randomIntBetween(1, 20);
         List<IndexRequestBuilder> docs = new ArrayList<>();
         for (int i = 0; i < numDocs; ++i) {

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/MetadataIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/MetadataIT.java
@@ -53,7 +53,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResp
 public class MetadataIT extends OpenSearchIntegTestCase {
 
     public void testMetadataSetOnAggregationResult() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("idx").addMapping("type", "name", "type=keyword").get());
+        assertAcked(client().admin().indices().prepareCreate("idx").setMapping("name", "type=keyword").get());
         IndexRequestBuilder[] builders = new IndexRequestBuilder[randomInt(30)];
         for (int i = 0; i < builders.length; i++) {
             String name = "name_" + randomIntBetween(1, 10);

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/MissingValueIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/MissingValueIT.java
@@ -67,9 +67,7 @@ public class MissingValueIT extends OpenSearchIntegTestCase {
 
     @Override
     protected void setupSuiteScopeCluster() throws Exception {
-        assertAcked(
-            prepareCreate("idx").addMapping("type", "date", "type=date", "location", "type=geo_point", "str", "type=keyword").get()
-        );
+        assertAcked(prepareCreate("idx").setMapping("date", "type=date", "location", "type=geo_point", "str", "type=keyword").get());
         indexRandom(
             true,
             client().prepareIndex("idx").setId("1").setSource(),

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/AdjacencyMatrixIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/AdjacencyMatrixIT.java
@@ -117,7 +117,7 @@ public class AdjacencyMatrixIT extends OpenSearchIntegTestCase {
                 builders.add(client().prepareIndex("idx").setId("" + i).setSource(source));
             }
         }
-        prepareCreate("empty_bucket_idx").addMapping("type", "value", "type=integer").get();
+        prepareCreate("empty_bucket_idx").setMapping("value", "type=integer").get();
         for (int i = 0; i < 2; i++) {
             builders.add(
                 client().prepareIndex("empty_bucket_idx")

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramIT.java
@@ -144,7 +144,7 @@ public class DateHistogramIT extends OpenSearchIntegTestCase {
     public void setupSuiteScopeCluster() throws Exception {
         createIndex("idx", "idx_unmapped");
         // TODO: would be nice to have more random data here
-        assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", "value", "type=integer"));
+        assertAcked(prepareCreate("empty_bucket_idx").setMapping("value", "type=integer"));
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
             builders.add(
@@ -188,7 +188,7 @@ public class DateHistogramIT extends OpenSearchIntegTestCase {
         addExpectedBucket(date(1, 6), 1, 5, 1);
         addExpectedBucket(date(1, 7), 1, 5, 1);
 
-        assertAcked(client().admin().indices().prepareCreate("sort_idx").addMapping("type", "date", "type=date").get());
+        assertAcked(client().admin().indices().prepareCreate("sort_idx").setMapping("date", "type=date").get());
         for (int i = 1; i <= 3; i++) {
             builders.add(
                 client().prepareIndex("sort_idx")
@@ -1038,7 +1038,7 @@ public class DateHistogramIT extends OpenSearchIntegTestCase {
     }
 
     public void testSingleValueWithTimeZone() throws Exception {
-        prepareCreate("idx2").addMapping("type", "date", "type=date").get();
+        prepareCreate("idx2").setMapping("date", "type=date").get();
         IndexRequestBuilder[] reqs = new IndexRequestBuilder[5];
         ZonedDateTime date = date("2014-03-11T00:00:00+00:00");
         for (int i = 0; i < reqs.length; i++) {
@@ -1394,7 +1394,7 @@ public class DateHistogramIT extends OpenSearchIntegTestCase {
     }
 
     public void testDSTBoundaryIssue9491() throws InterruptedException, ExecutionException {
-        assertAcked(client().admin().indices().prepareCreate("test9491").addMapping("type", "d", "type=date").get());
+        assertAcked(client().admin().indices().prepareCreate("test9491").setMapping("d", "type=date").get());
         indexRandom(
             true,
             client().prepareIndex("test9491").setSource("d", "2014-10-08T13:00:00Z"),
@@ -1417,7 +1417,7 @@ public class DateHistogramIT extends OpenSearchIntegTestCase {
     }
 
     public void testIssue8209() throws InterruptedException, ExecutionException {
-        assertAcked(client().admin().indices().prepareCreate("test8209").addMapping("type", "d", "type=date").get());
+        assertAcked(client().admin().indices().prepareCreate("test8209").setMapping("d", "type=date").get());
         indexRandom(
             true,
             client().prepareIndex("test8209").setSource("d", "2014-01-01T00:00:00Z"),
@@ -1498,7 +1498,7 @@ public class DateHistogramIT extends OpenSearchIntegTestCase {
      */
     public void testRewriteTimeZone_EpochMillisFormat() throws InterruptedException, ExecutionException {
         String index = "test31392";
-        assertAcked(client().admin().indices().prepareCreate(index).addMapping("type", "d", "type=date,format=epoch_millis").get());
+        assertAcked(client().admin().indices().prepareCreate(index).setMapping("d", "type=date,format=epoch_millis").get());
         indexRandom(true, client().prepareIndex(index).setSource("d", "1477954800000"));
         ensureSearchable(index);
         SearchResponse response = client().prepareSearch(index)
@@ -1608,7 +1608,7 @@ public class DateHistogramIT extends OpenSearchIntegTestCase {
      */
     public void testScriptCaching() throws Exception {
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "d", "type=date")
+            prepareCreate("cache_test_idx").setMapping("d", "type=date")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );
@@ -1828,7 +1828,7 @@ public class DateHistogramIT extends OpenSearchIntegTestCase {
      * timeZones.
      */
     public void testDateNanosHistogram() throws Exception {
-        assertAcked(prepareCreate("nanos").addMapping("_doc", "date", "type=date_nanos").get());
+        assertAcked(prepareCreate("nanos").setMapping("date", "type=date_nanos").get());
         indexRandom(true, client().prepareIndex("nanos").setId("1").setSource("date", "2000-01-01"));
         indexRandom(true, client().prepareIndex("nanos").setId("2").setSource("date", "2000-01-02"));
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramOffsetIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateHistogramOffsetIT.java
@@ -72,7 +72,7 @@ public class DateHistogramOffsetIT extends OpenSearchIntegTestCase {
 
     @Before
     public void beforeEachTest() throws IOException {
-        prepareCreate("idx2").addMapping("type", "date", "type=date").get();
+        prepareCreate("idx2").setMapping("date", "type=date").get();
     }
 
     @After

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateRangeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DateRangeIT.java
@@ -125,7 +125,7 @@ public class DateRangeIT extends OpenSearchIntegTestCase {
         for (int i = docs.size(); i < numDocs; ++i) {
             docs.add(indexDoc(randomIntBetween(6, 10), randomIntBetween(1, 20), randomInt(100)));
         }
-        assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", "value", "type=integer"));
+        assertAcked(prepareCreate("empty_bucket_idx").setMapping("value", "type=integer"));
         for (int i = 0; i < 2; i++) {
             docs.add(
                 client().prepareIndex("empty_bucket_idx")
@@ -913,7 +913,7 @@ public class DateRangeIT extends OpenSearchIntegTestCase {
      */
     public void testScriptCaching() throws Exception {
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "date", "type=date")
+            prepareCreate("cache_test_idx").setMapping("date", "type=date")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );
@@ -1070,7 +1070,7 @@ public class DateRangeIT extends OpenSearchIntegTestCase {
      */
     public void testRangeWithFormatStringValue() throws Exception {
         String indexName = "dateformat_test_idx";
-        assertAcked(prepareCreate(indexName).addMapping("type", "date", "type=date,format=strict_hour_minute_second"));
+        assertAcked(prepareCreate(indexName).setMapping("date", "type=date,format=strict_hour_minute_second"));
         indexRandom(
             true,
             client().prepareIndex(indexName).setId("1").setSource(jsonBuilder().startObject().field("date", "00:16:40").endObject()),
@@ -1132,7 +1132,7 @@ public class DateRangeIT extends OpenSearchIntegTestCase {
      */
     public void testRangeWithFormatNumericValue() throws Exception {
         String indexName = "dateformat_numeric_test_idx";
-        assertAcked(prepareCreate(indexName).addMapping("type", "date", "type=date,format=epoch_second"));
+        assertAcked(prepareCreate(indexName).setMapping("date", "type=date,format=epoch_second"));
         indexRandom(
             true,
             client().prepareIndex(indexName).setId("1").setSource(jsonBuilder().startObject().field("date", 1002).endObject()),

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DiversifiedSamplerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DiversifiedSamplerIT.java
@@ -78,14 +78,14 @@ public class DiversifiedSamplerIT extends OpenSearchIntegTestCase {
         assertAcked(
             prepareCreate("test").setSettings(
                 Settings.builder().put(SETTING_NUMBER_OF_SHARDS, NUM_SHARDS).put(SETTING_NUMBER_OF_REPLICAS, 0)
-            ).addMapping("book", "author", "type=keyword", "name", "type=keyword", "genre", "type=keyword", "price", "type=float")
+            ).setMapping("author", "type=keyword", "name", "type=keyword", "genre", "type=keyword", "price", "type=float")
         );
         createIndex("idx_unmapped");
         // idx_unmapped_author is same as main index but missing author field
         assertAcked(
             prepareCreate("idx_unmapped_author").setSettings(
                 Settings.builder().put(SETTING_NUMBER_OF_SHARDS, NUM_SHARDS).put(SETTING_NUMBER_OF_REPLICAS, 0)
-            ).addMapping("book", "name", "type=keyword", "genre", "type=keyword", "price", "type=float")
+            ).setMapping("name", "type=keyword", "genre", "type=keyword", "price", "type=float")
         );
 
         ensureGreen();

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DoubleTermsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/DoubleTermsIT.java
@@ -178,7 +178,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
         }
 
         createIndex("idx_unmapped");
-        assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
+        assertAcked(prepareCreate("empty_bucket_idx").setMapping(SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < 2; i++) {
             builders.add(
                 client().prepareIndex("empty_bucket_idx")
@@ -238,7 +238,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
         bucketProps.put("sum_d", 1d);
         expectedMultiSortBuckets.put((Double) bucketProps.get("_term"), bucketProps);
 
-        assertAcked(prepareCreate("sort_idx").addMapping("multi_sort_type", SINGLE_VALUED_FIELD_NAME, "type=double"));
+        assertAcked(prepareCreate("sort_idx").setMapping(SINGLE_VALUED_FIELD_NAME, "type=double"));
         for (int i = 1; i <= 3; i++) {
             builders.add(
                 client().prepareIndex("sort_idx")
@@ -980,7 +980,7 @@ public class DoubleTermsIT extends AbstractTermsTestCase {
      */
     public void testScriptCaching() throws Exception {
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "d", "type=float")
+            prepareCreate("cache_test_idx").setMapping("d", "type=float")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/FilterIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/FilterIT.java
@@ -90,7 +90,7 @@ public class FilterIT extends OpenSearchIntegTestCase {
                 builders.add(client().prepareIndex("idx").setId("" + i).setSource(source));
             }
         }
-        prepareCreate("empty_bucket_idx").addMapping("type", "value", "type=integer").get();
+        prepareCreate("empty_bucket_idx").setMapping("value", "type=integer").get();
         for (int i = 0; i < 2; i++) {
             builders.add(
                 client().prepareIndex("empty_bucket_idx")

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/FiltersIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/FiltersIT.java
@@ -109,7 +109,7 @@ public class FiltersIT extends OpenSearchIntegTestCase {
                 builders.add(client().prepareIndex("idx").setId("" + i).setSource(source));
             }
         }
-        prepareCreate("empty_bucket_idx").addMapping("type", "value", "type=integer").get();
+        prepareCreate("empty_bucket_idx").setMapping("value", "type=integer").get();
         for (int i = 0; i < 2; i++) {
             builders.add(
                 client().prepareIndex("empty_bucket_idx")

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/GeoDistanceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/GeoDistanceIT.java
@@ -93,9 +93,9 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
     @Override
     public void setupSuiteScopeCluster() throws Exception {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
-        prepareCreate("idx").setSettings(settings).addMapping("type", "location", "type=geo_point", "city", "type=keyword").get();
+        prepareCreate("idx").setSettings(settings).setMapping("location", "type=geo_point", "city", "type=keyword").get();
 
-        prepareCreate("idx-multi").addMapping("type", "location", "type=geo_point", "city", "type=keyword").get();
+        prepareCreate("idx-multi").setMapping("location", "type=geo_point", "city", "type=keyword").get();
 
         createIndex("idx_unmapped");
 
@@ -138,7 +138,7 @@ public class GeoDistanceIT extends OpenSearchIntegTestCase {
             cities.add(indexCity("idx-multi", cityName));
         }
         indexRandom(true, cities);
-        prepareCreate("empty_bucket_idx").addMapping("type", "value", "type=integer", "location", "type=geo_point").get();
+        prepareCreate("empty_bucket_idx").setMapping("value", "type=integer", "location", "type=geo_point").get();
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
             builders.add(

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/GeoHashGridIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/GeoHashGridIT.java
@@ -101,7 +101,7 @@ public class GeoHashGridIT extends OpenSearchIntegTestCase {
 
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
 
-        assertAcked(prepareCreate("idx").setSettings(settings).addMapping("type", "location", "type=geo_point", "city", "type=keyword"));
+        assertAcked(prepareCreate("idx").setSettings(settings).setMapping("location", "type=geo_point", "city", "type=keyword"));
 
         List<IndexRequestBuilder> cities = new ArrayList<>();
         Random random = random();
@@ -126,7 +126,7 @@ public class GeoHashGridIT extends OpenSearchIntegTestCase {
         indexRandom(true, cities);
 
         assertAcked(
-            prepareCreate("multi_valued_idx").setSettings(settings).addMapping("type", "location", "type=geo_point", "city", "type=keyword")
+            prepareCreate("multi_valued_idx").setSettings(settings).setMapping("location", "type=geo_point", "city", "type=keyword")
         );
 
         cities = new ArrayList<>();

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/HistogramIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/HistogramIT.java
@@ -180,7 +180,7 @@ public class HistogramIT extends OpenSearchIntegTestCase {
 
         getMultiSortDocs(builders);
 
-        assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
+        assertAcked(prepareCreate("empty_bucket_idx").setMapping(SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < 2; i++) {
             builders.add(
                 client().prepareIndex("empty_bucket_idx")
@@ -211,7 +211,7 @@ public class HistogramIT extends OpenSearchIntegTestCase {
         addExpectedBucket(6, 1, 5, 1);
         addExpectedBucket(7, 1, 5, 1);
 
-        assertAcked(client().admin().indices().prepareCreate("sort_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=double").get());
+        assertAcked(client().admin().indices().prepareCreate("sort_idx").setMapping(SINGLE_VALUED_FIELD_NAME, "type=double").get());
         for (int i = 1; i <= 3; i++) {
             builders.add(
                 client().prepareIndex("sort_idx")
@@ -1124,7 +1124,7 @@ public class HistogramIT extends OpenSearchIntegTestCase {
     }
 
     public void testDecimalIntervalAndOffset() throws Exception {
-        assertAcked(prepareCreate("decimal_values").addMapping("type", "d", "type=float").get());
+        assertAcked(prepareCreate("decimal_values").setMapping("d", "type=float").get());
         indexRandom(
             true,
             client().prepareIndex("decimal_values").setId("1").setSource("d", -0.6),
@@ -1151,7 +1151,7 @@ public class HistogramIT extends OpenSearchIntegTestCase {
      */
     public void testScriptCaching() throws Exception {
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "d", "type=float")
+            prepareCreate("cache_test_idx").setMapping("d", "type=float")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );
@@ -1349,7 +1349,7 @@ public class HistogramIT extends OpenSearchIntegTestCase {
     }
 
     public void testHardBounds() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type", "d", "type=double").get());
+        assertAcked(prepareCreate("test").setMapping("d", "type=double").get());
         indexRandom(
             true,
             client().prepareIndex("test").setId("1").setSource("d", -0.6),

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/IpRangeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/IpRangeIT.java
@@ -70,7 +70,7 @@ public class IpRangeIT extends OpenSearchIntegTestCase {
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        assertAcked(prepareCreate("idx").addMapping("type", "ip", "type=ip", "ips", "type=ip"));
+        assertAcked(prepareCreate("idx").setMapping("ip", "type=ip", "ips", "type=ip"));
         waitForRelocation(ClusterHealthStatus.GREEN);
 
         indexRandom(

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/IpTermsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/IpTermsIT.java
@@ -76,7 +76,7 @@ public class IpTermsIT extends AbstractTermsTestCase {
     }
 
     public void testScriptValue() throws Exception {
-        assertAcked(prepareCreate("index").addMapping("type", "ip", "type=ip"));
+        assertAcked(prepareCreate("index").setMapping("ip", "type=ip"));
         indexRandom(
             true,
             client().prepareIndex("index").setId("1").setSource("ip", "192.168.1.7"),
@@ -104,7 +104,7 @@ public class IpTermsIT extends AbstractTermsTestCase {
     }
 
     public void testScriptValues() throws Exception {
-        assertAcked(prepareCreate("index").addMapping("type", "ip", "type=ip"));
+        assertAcked(prepareCreate("index").setMapping("ip", "type=ip"));
         indexRandom(
             true,
             client().prepareIndex("index").setId("1").setSource("ip", "192.168.1.7"),
@@ -132,7 +132,7 @@ public class IpTermsIT extends AbstractTermsTestCase {
     }
 
     public void testMissingValue() throws Exception {
-        assertAcked(prepareCreate("index").addMapping("type", "ip", "type=ip"));
+        assertAcked(prepareCreate("index").setMapping("ip", "type=ip"));
         indexRandom(
             true,
             client().prepareIndex("index").setId("1").setSource("ip", "192.168.1.7"),

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/LongTermsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/LongTermsIT.java
@@ -164,7 +164,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
         indexRandom(true, highCardBuilders);
         createIndex("idx_unmapped");
 
-        assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
+        assertAcked(prepareCreate("empty_bucket_idx").setMapping(SINGLE_VALUED_FIELD_NAME, "type=integer"));
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
             builders.add(
@@ -928,7 +928,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
      */
     public void testScriptCaching() throws Exception {
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "d", "type=long")
+            prepareCreate("cache_test_idx").setMapping("d", "type=long")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/MinDocCountIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/MinDocCountIT.java
@@ -117,7 +117,7 @@ public class MinDocCountIT extends AbstractTermsTestCase {
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("idx").addMapping("type", "s", "type=keyword").get());
+        assertAcked(client().admin().indices().prepareCreate("idx").setMapping("s", "type=keyword").get());
 
         cardinality = randomIntBetween(8, 30);
         final List<IndexRequestBuilder> indexRequests = new ArrayList<>();

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/NaNSortingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/NaNSortingIT.java
@@ -132,7 +132,7 @@ public class NaNSortingIT extends OpenSearchIntegTestCase {
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("idx").addMapping("type", "string_value", "type=keyword").get());
+        assertAcked(client().admin().indices().prepareCreate("idx").setMapping("string_value", "type=keyword").get());
         final int numDocs = randomIntBetween(2, 10);
         for (int i = 0; i < numDocs; ++i) {
             final long value = randomInt(5);

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/NestedIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/NestedIT.java
@@ -96,7 +96,7 @@ public class NestedIT extends OpenSearchIntegTestCase {
     @Override
     public void setupSuiteScopeCluster() throws Exception {
 
-        assertAcked(prepareCreate("idx").addMapping("type", "nested", "type=nested", "incorrect", "type=object"));
+        assertAcked(prepareCreate("idx").setMapping("nested", "type=nested", "incorrect", "type=object"));
         ensureGreen("idx");
 
         List<IndexRequestBuilder> builders = new ArrayList<>();
@@ -126,7 +126,7 @@ public class NestedIT extends OpenSearchIntegTestCase {
             builders.add(client().prepareIndex("idx").setId("" + i + 1).setSource(source));
         }
 
-        prepareCreate("empty_bucket_idx").addMapping("type", "value", "type=integer", "nested", "type=nested").get();
+        prepareCreate("empty_bucket_idx").setMapping("value", "type=integer", "nested", "type=nested").get();
         ensureGreen("empty_bucket_idx");
         for (int i = 0; i < 2; i++) {
             builders.add(
@@ -539,7 +539,7 @@ public class NestedIT extends OpenSearchIntegTestCase {
     public void testNestedSameDocIdProcessedMultipleTime() throws Exception {
         assertAcked(
             prepareCreate("idx4").setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0))
-                .addMapping("product", "categories", "type=keyword", "name", "type=text", "property", "type=nested")
+                .setMapping("categories", "type=keyword", "name", "type=text", "property", "type=nested")
         );
         ensureGreen("idx4");
 
@@ -808,7 +808,7 @@ public class NestedIT extends OpenSearchIntegTestCase {
         assertAcked(
             prepareCreate("idxduplicatehitnames").setSettings(
                 Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0)
-            ).addMapping("product", "categories", "type=keyword", "name", "type=text", "property", "type=nested")
+            ).setMapping("categories", "type=keyword", "name", "type=text", "property", "type=nested")
         );
         ensureGreen("idxduplicatehitnames");
 
@@ -832,7 +832,7 @@ public class NestedIT extends OpenSearchIntegTestCase {
         assertAcked(
             prepareCreate("idxnullhitnames").setSettings(
                 Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0)
-            ).addMapping("product", "categories", "type=keyword", "name", "type=text", "property", "type=nested")
+            ).setMapping("categories", "type=keyword", "name", "type=text", "property", "type=nested")
         );
         ensureGreen("idxnullhitnames");
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/RangeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/RangeIT.java
@@ -136,7 +136,7 @@ public class RangeIT extends OpenSearchIntegTestCase {
             );
         }
         createIndex("idx_unmapped");
-        prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer").get();
+        prepareCreate("empty_bucket_idx").setMapping(SINGLE_VALUED_FIELD_NAME, "type=integer").get();
         for (int i = 0; i < 2; i++) {
             builders.add(
                 client().prepareIndex("empty_bucket_idx")
@@ -152,8 +152,8 @@ public class RangeIT extends OpenSearchIntegTestCase {
 
         // Create two indices and add the field 'route_length_miles' as an alias in
         // one, and a concrete field in the other.
-        prepareCreate("old_index").addMapping("_doc", "distance", "type=double", "route_length_miles", "type=alias,path=distance").get();
-        prepareCreate("new_index").addMapping("_doc", "route_length_miles", "type=double").get();
+        prepareCreate("old_index").setMapping("distance", "type=double", "route_length_miles", "type=alias,path=distance").get();
+        prepareCreate("new_index").setMapping("route_length_miles", "type=double").get();
 
         builders.add(client().prepareIndex("old_index").setSource("distance", 42.0));
         builders.add(client().prepareIndex("old_index").setSource("distance", 50.5));
@@ -931,7 +931,7 @@ public class RangeIT extends OpenSearchIntegTestCase {
      */
     public void testScriptCaching() throws Exception {
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "i", "type=integer")
+            prepareCreate("cache_test_idx").setMapping("i", "type=integer")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/SamplerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/SamplerIT.java
@@ -77,14 +77,14 @@ public class SamplerIT extends OpenSearchIntegTestCase {
         assertAcked(
             prepareCreate("test").setSettings(
                 Settings.builder().put(SETTING_NUMBER_OF_SHARDS, NUM_SHARDS).put(SETTING_NUMBER_OF_REPLICAS, 0)
-            ).addMapping("book", "author", "type=keyword", "name", "type=text", "genre", "type=keyword", "price", "type=float")
+            ).setMapping("author", "type=keyword", "name", "type=text", "genre", "type=keyword", "price", "type=float")
         );
         createIndex("idx_unmapped");
         // idx_unmapped_author is same as main index but missing author field
         assertAcked(
             prepareCreate("idx_unmapped_author").setSettings(
                 Settings.builder().put(SETTING_NUMBER_OF_SHARDS, NUM_SHARDS).put(SETTING_NUMBER_OF_REPLICAS, 0)
-            ).addMapping("book", "name", "type=text", "genre", "type=keyword", "price", "type=float")
+            ).setMapping("name", "type=text", "genre", "type=keyword", "price", "type=float")
         );
 
         ensureGreen();

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/ShardReduceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/ShardReduceIT.java
@@ -94,8 +94,7 @@ public class ShardReduceIT extends OpenSearchIntegTestCase {
     @Override
     public void setupSuiteScopeCluster() throws Exception {
         assertAcked(
-            prepareCreate("idx").addMapping(
-                "type",
+            prepareCreate("idx").setMapping(
                 "nested",
                 "type=nested",
                 "ip",

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
@@ -40,7 +40,6 @@ import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.plugins.Plugin;
@@ -215,7 +214,7 @@ public class SignificantTermsSignificanceScoreIT extends OpenSearchIntegTestCase
         String settings = "{\"index.number_of_shards\": 1, \"index.number_of_replicas\": 0}";
         assertAcked(
             prepareCreate(INDEX_NAME).setSettings(settings, XContentType.JSON)
-                .addMapping("_doc", "text", "type=keyword", CLASS_FIELD, "type=keyword")
+                .setMapping("text", "type=keyword", CLASS_FIELD, "type=keyword")
         );
         String[] cat1v1 = { "constant", "one" };
         String[] cat1v2 = { "constant", "uno" };
@@ -453,7 +452,7 @@ public class SignificantTermsSignificanceScoreIT extends OpenSearchIntegTestCase
     private void indexEqualTestData() throws ExecutionException, InterruptedException {
         assertAcked(
             prepareCreate("test").setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0))
-                .addMapping("_doc", "text", "type=text,fielddata=true", "class", "type=keyword")
+                .setMapping("text", "type=text,fielddata=true", "class", "type=keyword")
         );
         createIndex("idx_unmapped");
 
@@ -545,9 +544,7 @@ public class SignificantTermsSignificanceScoreIT extends OpenSearchIntegTestCase
         if (type.equals("text")) {
             textMappings += ",fielddata=true";
         }
-        assertAcked(
-            prepareCreate(INDEX_NAME).addMapping(MapperService.SINGLE_MAPPING_NAME, TEXT_FIELD, textMappings, CLASS_FIELD, "type=keyword")
-        );
+        assertAcked(prepareCreate(INDEX_NAME).setMapping(TEXT_FIELD, textMappings, CLASS_FIELD, "type=keyword"));
         String[] gb = { "0", "1" };
         List<IndexRequestBuilder> indexRequestBuilderList = new ArrayList<>();
         for (int i = 0; i < randomInt(20); i++) {
@@ -575,7 +572,7 @@ public class SignificantTermsSignificanceScoreIT extends OpenSearchIntegTestCase
      */
     public void testScriptCaching() throws Exception {
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "d", "type=long")
+            prepareCreate("cache_test_idx").setMapping("d", "type=long")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsDocCountErrorIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsDocCountErrorIT.java
@@ -74,7 +74,7 @@ public class TermsDocCountErrorIT extends OpenSearchIntegTestCase {
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("idx").addMapping("type", STRING_FIELD_NAME, "type=keyword").get());
+        assertAcked(client().admin().indices().prepareCreate("idx").setMapping(STRING_FIELD_NAME, "type=keyword").get());
         List<IndexRequestBuilder> builders = new ArrayList<>();
         int numDocs = between(10, 200);
         int numUniqueTerms = between(2, numDocs / 2);
@@ -92,7 +92,7 @@ public class TermsDocCountErrorIT extends OpenSearchIntegTestCase {
             );
         }
         assertAcked(
-            prepareCreate("idx_single_shard").addMapping("type", STRING_FIELD_NAME, "type=keyword")
+            prepareCreate("idx_single_shard").setMapping(STRING_FIELD_NAME, "type=keyword")
                 .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1))
         );
         for (int i = 0; i < numDocs; i++) {
@@ -125,7 +125,7 @@ public class TermsDocCountErrorIT extends OpenSearchIntegTestCase {
             );
         }
         assertAcked(
-            prepareCreate("idx_fixed_docs_0").addMapping("type", STRING_FIELD_NAME, "type=keyword")
+            prepareCreate("idx_fixed_docs_0").setMapping(STRING_FIELD_NAME, "type=keyword")
                 .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1))
         );
         Map<String, Integer> shard0DocsPerTerm = new HashMap<>();
@@ -151,7 +151,7 @@ public class TermsDocCountErrorIT extends OpenSearchIntegTestCase {
         }
 
         assertAcked(
-            prepareCreate("idx_fixed_docs_1").addMapping("type", STRING_FIELD_NAME, "type=keyword")
+            prepareCreate("idx_fixed_docs_1").setMapping(STRING_FIELD_NAME, "type=keyword")
                 .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1))
         );
         Map<String, Integer> shard1DocsPerTerm = new HashMap<>();
@@ -177,7 +177,7 @@ public class TermsDocCountErrorIT extends OpenSearchIntegTestCase {
         }
 
         assertAcked(
-            prepareCreate("idx_fixed_docs_2").addMapping("type", STRING_FIELD_NAME, "type=keyword")
+            prepareCreate("idx_fixed_docs_2").setMapping(STRING_FIELD_NAME, "type=keyword")
                 .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1))
         );
         Map<String, Integer> shard2DocsPerTerm = new HashMap<>();

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsShardMinDocCountIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsShardMinDocCountIT.java
@@ -35,7 +35,6 @@ import org.opensearch.action.index.IndexRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.aggregations.BucketOrder;
 import org.opensearch.search.aggregations.bucket.filter.InternalFilter;
@@ -73,7 +72,7 @@ public class TermsShardMinDocCountIT extends OpenSearchIntegTestCase {
         }
         assertAcked(
             prepareCreate(index).setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0))
-                .addMapping(MapperService.SINGLE_MAPPING_NAME, "text", textMappings)
+                .setMapping("text", textMappings)
         );
         List<IndexRequestBuilder> indexBuilders = new ArrayList<>();
 
@@ -142,7 +141,7 @@ public class TermsShardMinDocCountIT extends OpenSearchIntegTestCase {
         }
         assertAcked(
             prepareCreate(index).setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0))
-                .addMapping(MapperService.SINGLE_MAPPING_NAME, "text", termMappings)
+                .setMapping("text", termMappings)
         );
         List<IndexRequestBuilder> indexBuilders = new ArrayList<>();
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/terms/StringTermsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/terms/StringTermsIT.java
@@ -157,15 +157,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("idx")
-                .addMapping(
-                    "type",
-                    SINGLE_VALUED_FIELD_NAME,
-                    "type=keyword",
-                    MULTI_VALUED_FIELD_NAME,
-                    "type=keyword",
-                    "tag",
-                    "type=keyword"
-                )
+                .setMapping(SINGLE_VALUED_FIELD_NAME, "type=keyword", MULTI_VALUED_FIELD_NAME, "type=keyword", "tag", "type=keyword")
                 .get()
         );
         List<IndexRequestBuilder> builders = new ArrayList<>();
@@ -193,15 +185,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("high_card_idx")
-                .addMapping(
-                    "type",
-                    SINGLE_VALUED_FIELD_NAME,
-                    "type=keyword",
-                    MULTI_VALUED_FIELD_NAME,
-                    "type=keyword",
-                    "tag",
-                    "type=keyword"
-                )
+                .setMapping(SINGLE_VALUED_FIELD_NAME, "type=keyword", MULTI_VALUED_FIELD_NAME, "type=keyword", "tag", "type=keyword")
                 .get()
         );
         for (int i = 0; i < 100; i++) {
@@ -218,7 +202,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
                     )
             );
         }
-        prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer").get();
+        prepareCreate("empty_bucket_idx").setMapping(SINGLE_VALUED_FIELD_NAME, "type=integer").get();
 
         for (int i = 0; i < 2; i++) {
             builders.add(
@@ -281,15 +265,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("sort_idx")
-                .addMapping(
-                    "type",
-                    SINGLE_VALUED_FIELD_NAME,
-                    "type=keyword",
-                    MULTI_VALUED_FIELD_NAME,
-                    "type=keyword",
-                    "tag",
-                    "type=keyword"
-                )
+                .setMapping(SINGLE_VALUED_FIELD_NAME, "type=keyword", MULTI_VALUED_FIELD_NAME, "type=keyword", "tag", "type=keyword")
                 .get()
         );
         for (int i = 1; i <= 3; i++) {
@@ -1262,7 +1238,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
      */
     public void testScriptCaching() throws Exception {
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "d", "type=keyword")
+            prepareCreate("cache_test_idx").setMapping("d", "type=keyword")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/CardinalityIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/CardinalityIT.java
@@ -491,7 +491,7 @@ public class CardinalityIT extends OpenSearchIntegTestCase {
      */
     public void testScriptCaching() throws Exception {
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "d", "type=long")
+            prepareCreate("cache_test_idx").setMapping("d", "type=long")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/ExtendedStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/ExtendedStatsIT.java
@@ -869,7 +869,7 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
      */
     public void testScriptCaching() throws Exception {
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "d", "type=long")
+            prepareCreate("cache_test_idx").setMapping("d", "type=long")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/HDRPercentileRanksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/HDRPercentileRanksIT.java
@@ -585,7 +585,7 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
      */
     public void testScriptCaching() throws Exception {
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "d", "type=long")
+            prepareCreate("cache_test_idx").setMapping("d", "type=long")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/HDRPercentilesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/HDRPercentilesIT.java
@@ -554,7 +554,7 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
      */
     public void testScriptCaching() throws Exception {
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "d", "type=long")
+            prepareCreate("cache_test_idx").setMapping("d", "type=long")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
@@ -137,7 +137,7 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
 
         indexRandom(true, builders);
 
-        prepareCreate("empty_bucket_idx").addMapping("type", "value", "type=integer").get();
+        prepareCreate("empty_bucket_idx").setMapping("value", "type=integer").get();
 
         builders = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
@@ -516,7 +516,7 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
      */
     public void testScriptCaching() throws Exception {
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "d", "type=long")
+            prepareCreate("cache_test_idx").setMapping("d", "type=long")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/ScriptedMetricIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/ScriptedMetricIT.java
@@ -310,7 +310,7 @@ public class ScriptedMetricIT extends OpenSearchIntegTestCase {
         // "1". then each test will have
         // to check that this bucket exists with the appropriate sub
         // aggregations.
-        prepareCreate("empty_bucket_idx").addMapping("type", "value", "type=integer").get();
+        prepareCreate("empty_bucket_idx").setMapping("value", "type=integer").get();
         builders = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
             builders.add(
@@ -1183,7 +1183,7 @@ public class ScriptedMetricIT extends OpenSearchIntegTestCase {
         Script ndRandom = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "return Math.random()", Collections.emptyMap());
 
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "d", "type=long")
+            prepareCreate("cache_test_idx").setMapping("d", "type=long")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/StatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/StatsIT.java
@@ -258,7 +258,7 @@ public class StatsIT extends AbstractNumericTestCase {
      */
     public void testScriptCaching() throws Exception {
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "d", "type=long")
+            prepareCreate("cache_test_idx").setMapping("d", "type=long")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/SumIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/SumIT.java
@@ -79,8 +79,7 @@ public class SumIT extends AbstractNumericTestCase {
 
         // Create two indices and add the field 'route_length_miles' as an alias in
         // one, and a concrete field in the other.
-        prepareCreate("old_index").addMapping(
-            "_doc",
+        prepareCreate("old_index").setMapping(
             "transit_mode",
             "type=keyword",
             "distance",
@@ -88,7 +87,7 @@ public class SumIT extends AbstractNumericTestCase {
             "route_length_miles",
             "type=alias,path=distance"
         ).get();
-        prepareCreate("new_index").addMapping("_doc", "transit_mode", "type=keyword", "route_length_miles", "type=double").get();
+        prepareCreate("new_index").setMapping("transit_mode", "type=keyword", "route_length_miles", "type=double").get();
 
         List<IndexRequestBuilder> builders = new ArrayList<>();
         builders.add(client().prepareIndex("old_index").setSource("transit_mode", "train", "distance", 42.0));
@@ -236,7 +235,7 @@ public class SumIT extends AbstractNumericTestCase {
      */
     public void testScriptCaching() throws Exception {
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "d", "type=long")
+            prepareCreate("cache_test_idx").setMapping("d", "type=long")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TDigestPercentileRanksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TDigestPercentileRanksIT.java
@@ -497,7 +497,7 @@ public class TDigestPercentileRanksIT extends AbstractNumericTestCase {
      */
     public void testScriptCaching() throws Exception {
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "d", "type=long")
+            prepareCreate("cache_test_idx").setMapping("d", "type=long")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TDigestPercentilesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TDigestPercentilesIT.java
@@ -469,7 +469,7 @@ public class TDigestPercentilesIT extends AbstractNumericTestCase {
      */
     public void testScriptCaching() throws Exception {
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "d", "type=long")
+            prepareCreate("cache_test_idx").setMapping("d", "type=long")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TopHitsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/TopHitsIT.java
@@ -135,8 +135,8 @@ public class TopHitsIT extends OpenSearchIntegTestCase {
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        assertAcked(prepareCreate("idx").addMapping("type", TERMS_AGGS_FIELD, "type=keyword"));
-        assertAcked(prepareCreate("field-collapsing").addMapping("type", "group", "type=keyword"));
+        assertAcked(prepareCreate("idx").setMapping(TERMS_AGGS_FIELD, "type=keyword"));
+        assertAcked(prepareCreate("field-collapsing").setMapping("group", "type=keyword"));
         createIndex("empty");
         assertAcked(
             prepareCreate("articles").setMapping(
@@ -1143,7 +1143,7 @@ public class TopHitsIT extends OpenSearchIntegTestCase {
     public void testScriptCaching() throws Exception {
         try {
             assertAcked(
-                prepareCreate("cache_test_idx").addMapping("type", "d", "type=long")
+                prepareCreate("cache_test_idx").setMapping("d", "type=long")
                     .setSettings(
                         Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1)
                     )

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/ValueCountIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/ValueCountIT.java
@@ -238,7 +238,7 @@ public class ValueCountIT extends OpenSearchIntegTestCase {
      */
     public void testScriptCaching() throws Exception {
         assertAcked(
-            prepareCreate("cache_test_idx").addMapping("type", "d", "type=long")
+            prepareCreate("cache_test_idx").setMapping("d", "type=long")
                 .setSettings(Settings.builder().put("requests.cache.enable", true).put("number_of_shards", 1).put("number_of_replicas", 1))
                 .get()
         );

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/AvgBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/AvgBucketIT.java
@@ -71,7 +71,7 @@ public class AvgBucketIT extends OpenSearchIntegTestCase {
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("idx").addMapping("type", "tag", "type=keyword").get());
+        assertAcked(client().admin().indices().prepareCreate("idx").setMapping("tag", "type=keyword").get());
         createIndex("idx_unmapped");
 
         numDocs = randomIntBetween(6, 20);
@@ -100,7 +100,7 @@ public class AvgBucketIT extends OpenSearchIntegTestCase {
             valueCounts[bucket]++;
         }
 
-        assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
+        assertAcked(prepareCreate("empty_bucket_idx").setMapping(SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < 2; i++) {
             builders.add(
                 client().prepareIndex("empty_bucket_idx")

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/DateDerivativeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/DateDerivativeIT.java
@@ -103,7 +103,7 @@ public class DateDerivativeIT extends OpenSearchIntegTestCase {
         createIndex("idx");
         createIndex("idx_unmapped");
         // TODO: would be nice to have more random data here
-        prepareCreate("empty_bucket_idx").addMapping("type", "value", "type=integer").get();
+        prepareCreate("empty_bucket_idx").setMapping("value", "type=integer").get();
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
             builders.add(

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/DerivativeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/DerivativeIT.java
@@ -140,7 +140,7 @@ public class DerivativeIT extends OpenSearchIntegTestCase {
         valueCounts_empty = new Long[] { 1L, 1L, 2L, 0L, 2L, 2L, 0L, 0L, 0L, 3L, 2L, 1L };
         firstDerivValueCounts_empty = new Double[] { null, 0d, 1d, -2d, 2d, 0d, -2d, 0d, 0d, 3d, -1d, -1d };
 
-        assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
+        assertAcked(prepareCreate("empty_bucket_idx").setMapping(SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < valueCounts_empty.length; i++) {
             for (int docs = 0; docs < valueCounts_empty[i]; docs++) {
                 builders.add(client().prepareIndex("empty_bucket_idx").setSource(newDocBuilder(i)));
@@ -154,7 +154,7 @@ public class DerivativeIT extends OpenSearchIntegTestCase {
         firstDerivValueCounts_empty_rnd = new Double[numBuckets_empty_rnd];
         firstDerivValueCounts_empty_rnd[0] = null;
 
-        assertAcked(prepareCreate("empty_bucket_idx_rnd").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
+        assertAcked(prepareCreate("empty_bucket_idx_rnd").setMapping(SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < numBuckets_empty_rnd; i++) {
             valueCounts_empty_rnd[i] = (long) randomIntBetween(1, 10);
             // make approximately half of the buckets empty

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/ExtendedStatsBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/ExtendedStatsBucketIT.java
@@ -74,7 +74,7 @@ public class ExtendedStatsBucketIT extends OpenSearchIntegTestCase {
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("idx").addMapping("type", "tag", "type=keyword").get());
+        assertAcked(client().admin().indices().prepareCreate("idx").setMapping("tag", "type=keyword").get());
         createIndex("idx_unmapped", "idx_gappy");
 
         numDocs = randomIntBetween(6, 20);
@@ -113,7 +113,7 @@ public class ExtendedStatsBucketIT extends OpenSearchIntegTestCase {
             );
         }
 
-        assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
+        assertAcked(prepareCreate("empty_bucket_idx").setMapping(SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < 2; i++) {
             builders.add(
                 client().prepareIndex("empty_bucket_idx")

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MaxBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MaxBucketIT.java
@@ -85,7 +85,7 @@ public class MaxBucketIT extends OpenSearchIntegTestCase {
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("idx").addMapping("type", "tag", "type=keyword").get());
+        assertAcked(client().admin().indices().prepareCreate("idx").setMapping("tag", "type=keyword").get());
         createIndex("idx_unmapped");
 
         numDocs = randomIntBetween(6, 20);
@@ -114,7 +114,7 @@ public class MaxBucketIT extends OpenSearchIntegTestCase {
             valueCounts[bucket]++;
         }
 
-        assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
+        assertAcked(prepareCreate("empty_bucket_idx").setMapping(SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < 2; i++) {
             builders.add(
                 client().prepareIndex("empty_bucket_idx")

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MinBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MinBucketIT.java
@@ -71,7 +71,7 @@ public class MinBucketIT extends OpenSearchIntegTestCase {
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("idx").addMapping("type", "tag", "type=keyword").get());
+        assertAcked(client().admin().indices().prepareCreate("idx").setMapping("tag", "type=keyword").get());
         createIndex("idx_unmapped");
 
         numDocs = randomIntBetween(6, 20);
@@ -100,7 +100,7 @@ public class MinBucketIT extends OpenSearchIntegTestCase {
             valueCounts[bucket]++;
         }
 
-        assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
+        assertAcked(prepareCreate("empty_bucket_idx").setMapping(SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < 2; i++) {
             builders.add(
                 client().prepareIndex("empty_bucket_idx")

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/PercentilesBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/PercentilesBucketIT.java
@@ -75,7 +75,7 @@ public class PercentilesBucketIT extends OpenSearchIntegTestCase {
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("idx").addMapping("type", "tag", "type=keyword").get());
+        assertAcked(client().admin().indices().prepareCreate("idx").setMapping("tag", "type=keyword").get());
         createIndex("idx_unmapped");
 
         numDocs = randomIntBetween(6, 20);
@@ -104,7 +104,7 @@ public class PercentilesBucketIT extends OpenSearchIntegTestCase {
             valueCounts[bucket]++;
         }
 
-        assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
+        assertAcked(prepareCreate("empty_bucket_idx").setMapping(SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < 2; i++) {
             builders.add(
                 client().prepareIndex("empty_bucket_idx")

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/StatsBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/StatsBucketIT.java
@@ -71,7 +71,7 @@ public class StatsBucketIT extends OpenSearchIntegTestCase {
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("idx").addMapping("type", "tag", "type=keyword").get());
+        assertAcked(client().admin().indices().prepareCreate("idx").setMapping("tag", "type=keyword").get());
         createIndex("idx_unmapped");
 
         numDocs = randomIntBetween(6, 20);
@@ -100,7 +100,7 @@ public class StatsBucketIT extends OpenSearchIntegTestCase {
             valueCounts[bucket]++;
         }
 
-        assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
+        assertAcked(prepareCreate("empty_bucket_idx").setMapping(SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < 2; i++) {
             builders.add(
                 client().prepareIndex("empty_bucket_idx")

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/SumBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/SumBucketIT.java
@@ -71,7 +71,7 @@ public class SumBucketIT extends OpenSearchIntegTestCase {
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("idx").addMapping("type", "tag", "type=keyword").get());
+        assertAcked(client().admin().indices().prepareCreate("idx").setMapping("tag", "type=keyword").get());
         createIndex("idx_unmapped");
 
         numDocs = randomIntBetween(6, 20);
@@ -100,7 +100,7 @@ public class SumBucketIT extends OpenSearchIntegTestCase {
             valueCounts[bucket]++;
         }
 
-        assertAcked(prepareCreate("empty_bucket_idx").addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=integer"));
+        assertAcked(prepareCreate("empty_bucket_idx").setMapping(SINGLE_VALUED_FIELD_NAME, "type=integer"));
         for (int i = 0; i < 2; i++) {
             builders.add(
                 client().prepareIndex("empty_bucket_idx")

--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWhileRelocatingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWhileRelocatingIT.java
@@ -65,7 +65,7 @@ public class SearchWhileRelocatingIT extends OpenSearchIntegTestCase {
             .indices()
             .prepareCreate("test")
             .setSettings(Settings.builder().put("index.number_of_shards", numShards).put("index.number_of_replicas", numberOfReplicas))
-            .addMapping("type", "loc", "type=geo_point", "test", "type=text")
+            .setMapping("loc", "type=geo_point", "test", "type=text")
             .get();
         ensureGreen();
         List<IndexRequestBuilder> indexBuilders = new ArrayList<>();

--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/TransportSearchFailuresIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/TransportSearchFailuresIT.java
@@ -65,7 +65,7 @@ public class TransportSearchFailuresIT extends OpenSearchIntegTestCase {
 
     public void testFailedSearchWithWrongQuery() throws Exception {
         logger.info("Start Testing failed search with wrong query");
-        assertAcked(prepareCreate("test", 1).addMapping("type", "foo", "type=geo_point"));
+        assertAcked(prepareCreate("test", 1).setMapping("foo", "type=geo_point"));
 
         NumShards test = getNumShards("test");
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/InnerHitsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/InnerHitsIT.java
@@ -242,7 +242,7 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
     }
 
     public void testRandomNested() throws Exception {
-        assertAcked(prepareCreate("idx").addMapping("type", "field1", "type=nested", "field2", "type=nested"));
+        assertAcked(prepareCreate("idx").setMapping("field1", "type=nested", "field2", "type=nested"));
         int numDocs = scaledRandomIntBetween(25, 100);
         List<IndexRequestBuilder> requestBuilders = new ArrayList<>();
 
@@ -538,7 +538,7 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
 
     // Issue #9723
     public void testNestedDefinedAsObject() throws Exception {
-        assertAcked(prepareCreate("articles").addMapping("article", "comments", "type=nested", "title", "type=text"));
+        assertAcked(prepareCreate("articles").setMapping("comments", "type=nested", "title", "type=text"));
 
         List<IndexRequestBuilder> requests = new ArrayList<>();
         requests.add(
@@ -852,7 +852,7 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
     }
 
     public void testNestedSource() throws Exception {
-        assertAcked(prepareCreate("index1").addMapping("message", "comments", "type=nested"));
+        assertAcked(prepareCreate("index1").setMapping("comments", "type=nested"));
         client().prepareIndex("index1")
             .setId("1")
             .setSource(
@@ -947,7 +947,7 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
     }
 
     public void testInnerHitsWithIgnoreUnmapped() throws Exception {
-        assertAcked(prepareCreate("index1").addMapping("_doc", "nested_type", "type=nested"));
+        assertAcked(prepareCreate("index1").setMapping("nested_type", "type=nested"));
         createIndex("index2");
         client().prepareIndex("index1").setId("1").setSource("nested_type", Collections.singletonMap("key", "value")).get();
         client().prepareIndex("index2").setId("3").setSource("key", "value").get();
@@ -967,7 +967,7 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
     }
 
     public void testUseMaxDocInsteadOfSize() throws Exception {
-        assertAcked(prepareCreate("index2").addMapping("type", "nested", "type=nested"));
+        assertAcked(prepareCreate("index2").setMapping("nested", "type=nested"));
         client().admin()
             .indices()
             .prepareUpdateSettings("index2")
@@ -990,7 +990,7 @@ public class InnerHitsIT extends OpenSearchIntegTestCase {
     }
 
     public void testTooHighResultWindow() throws Exception {
-        assertAcked(prepareCreate("index2").addMapping("type", "nested", "type=nested"));
+        assertAcked(prepareCreate("index2").setMapping("nested", "type=nested"));
         client().prepareIndex("index2")
             .setId("1")
             .setSource(

--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -332,9 +332,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     // see #3486
     public void testHighTermFrequencyDoc() throws IOException {
-        assertAcked(
-            prepareCreate("test").addMapping("test", "name", "type=text,term_vector=with_positions_offsets,store=" + randomBoolean())
-        );
+        assertAcked(prepareCreate("test").setMapping("name", "type=text,term_vector=with_positions_offsets,store=" + randomBoolean()));
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < 6000; i++) {
             builder.append("abc").append(" ");
@@ -350,8 +348,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testEnsureNoNegativeOffsets() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 "no_long_term",
                 "type=text,term_vector=with_positions_offsets",
                 "long_term",
@@ -620,8 +617,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testHighlightIssue1994() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 "title",
                 "type=text,store=false",
                 "titleTV",
@@ -697,8 +693,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     // Issue #5175
     public void testHighlightingOnWildcardFields() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 "field-postings",
                 "type=text,index_options=offsets",
                 "field-fvh",
@@ -1277,7 +1272,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testSameContent() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", "title", "type=text,store=true,term_vector=with_positions_offsets"));
+        assertAcked(prepareCreate("test").setMapping("title", "type=text,store=true,term_vector=with_positions_offsets"));
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < 5; i++) {
@@ -1305,7 +1300,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testFastVectorHighlighterOffsetParameter() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", "title", "type=text,store=true,term_vector=with_positions_offsets").get());
+        assertAcked(prepareCreate("test").setMapping("title", "type=text,store=true,term_vector=with_positions_offsets").get());
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < 5; i++) {
@@ -1327,7 +1322,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testEscapeHtml() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", "title", "type=text,store=true"));
+        assertAcked(prepareCreate("test").setMapping("title", "type=text,store=true"));
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < indexRequestBuilders.length; i++) {
@@ -1348,7 +1343,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testEscapeHtmlVector() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", "title", "type=text,store=true,term_vector=with_positions_offsets"));
+        assertAcked(prepareCreate("test").setMapping("title", "type=text,store=true,term_vector=with_positions_offsets"));
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < 5; i++) {
@@ -1547,7 +1542,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testFastVectorHighlighterShouldFailIfNoTermVectors() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", "title", "type=text,store=true,term_vector=no"));
+        assertAcked(prepareCreate("test").setMapping("title", "type=text,store=true,term_vector=no"));
         ensureGreen();
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
@@ -1584,9 +1579,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testDisableFastVectorHighlighter() throws Exception {
-        assertAcked(
-            prepareCreate("test").addMapping("type1", "title", "type=text,store=true,term_vector=with_positions_offsets,analyzer=classic")
-        );
+        assertAcked(prepareCreate("test").setMapping("title", "type=text,store=true,term_vector=with_positions_offsets,analyzer=classic"));
         ensureGreen();
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
@@ -1645,7 +1638,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testFSHHighlightAllMvFragments() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", "tags", "type=text,term_vector=with_positions_offsets"));
+        assertAcked(prepareCreate("test").setMapping("tags", "type=text,term_vector=with_positions_offsets"));
         ensureGreen();
         client().prepareIndex("test")
             .setId("1")
@@ -1737,7 +1730,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPlainHighlightDifferentFragmenter() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", "tags", "type=text"));
+        assertAcked(prepareCreate("test").setMapping("tags", "type=text"));
         ensureGreen();
         client().prepareIndex("test")
             .setId("1")
@@ -1824,8 +1817,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testFastVectorHighlighterMultipleFields() {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 "field1",
                 "type=text,term_vector=with_positions_offsets",
                 "field2",
@@ -1849,7 +1841,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testMissingStoredField() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", "highlight_field", "type=text,store=true"));
+        assertAcked(prepareCreate("test").setMapping("highlight_field", "type=text,store=true"));
         ensureGreen();
         client().prepareIndex("test").setId("1").setSource(jsonBuilder().startObject().field("field", "highlight").endObject()).get();
         refresh();
@@ -1869,8 +1861,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     // Issue #3211
     public void testNumericHighlighting() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "test",
+            prepareCreate("test").setMapping(
                 "text",
                 "type=text",
                 "byte",
@@ -1911,7 +1902,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
         assertAcked(
             prepareCreate("test").setSettings(
                 Settings.builder().put(indexSettings()).put("analysis.analyzer.my_analyzer.type", "mock_whitespace").build()
-            ).addMapping("type", "text", "type=text,analyzer=my_analyzer")
+            ).setMapping("text", "type=text,analyzer=my_analyzer")
         );
         ensureGreen();
         client().prepareIndex("test").setId("1").setSource("text", "opensearch test").get();
@@ -1927,8 +1918,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testHighlightUsesHighlightQuery() throws IOException {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 "text",
                 "type=text," + randomStoreField() + "term_vector=with_positions_offsets,index_options=offsets"
             )
@@ -1974,8 +1964,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testHighlightNoMatchSize() throws IOException {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 "text",
                 "type=text," + randomStoreField() + "term_vector=with_positions_offsets,index_options=offsets"
             )
@@ -2085,8 +2074,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testHighlightNoMatchSizeWithMultivaluedFields() throws IOException {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 "text",
                 "type=text," + randomStoreField() + "term_vector=with_positions_offsets,index_options=offsets"
             )
@@ -2181,8 +2169,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
 
     public void testHighlightNoMatchSizeNumberOfFragments() throws IOException {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 "text",
                 "type=text," + randomStoreField() + "term_vector=with_positions_offsets,index_options=offsets"
             )
@@ -2506,7 +2493,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testPostingsHighlighterEscapeHtml() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", "title", "type=text," + randomStoreField() + "index_options=offsets"));
+        assertAcked(prepareCreate("test").setMapping("title", "type=text," + randomStoreField() + "index_options=offsets"));
 
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[5];
         for (int i = 0; i < 5; i++) {
@@ -3342,7 +3329,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
             client().admin()
                 .indices()
                 .prepareCreate("index-1")
-                .addMapping("type", "d", "type=date", "field", "type=text,store=true,term_vector=with_positions_offsets")
+                .setMapping("d", "type=date", "field", "type=text,store=true,term_vector=with_positions_offsets")
                 .setSettings(Settings.builder().put("index.number_of_replicas", 0).put("index.number_of_shards", 2))
                 .get()
         );
@@ -3461,9 +3448,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     public void testWithNormalizer() throws Exception {
         Builder builder = Settings.builder().put(indexSettings()).putList("index.analysis.normalizer.my_normalizer.filter", "lowercase");
 
-        assertAcked(
-            prepareCreate("test").setSettings(builder.build()).addMapping("doc", "keyword", "type=keyword,normalizer=my_normalizer")
-        );
+        assertAcked(prepareCreate("test").setSettings(builder.build()).setMapping("keyword", "type=keyword,normalizer=my_normalizer"));
         ensureGreen();
 
         client().prepareIndex("test")
@@ -3485,7 +3470,7 @@ public class HighlighterSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testDisableHighlightIdField() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("doc", "keyword", "type=keyword"));
+        assertAcked(prepareCreate("test").setMapping("keyword", "type=keyword"));
         ensureGreen();
 
         client().prepareIndex("test")

--- a/server/src/internalClusterTest/java/org/opensearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -222,8 +222,8 @@ public class FieldCapabilitiesIT extends OpenSearchIntegTestCase {
     }
 
     public void testWithIndexFilter() throws InterruptedException {
-        assertAcked(prepareCreate("index-1").addMapping("_doc", "timestamp", "type=date", "field1", "type=keyword"));
-        assertAcked(prepareCreate("index-2").addMapping("_doc", "timestamp", "type=date", "field1", "type=long"));
+        assertAcked(prepareCreate("index-1").setMapping("timestamp", "type=date", "field1", "type=keyword"));
+        assertAcked(prepareCreate("index-2").setMapping("timestamp", "type=date", "field1", "type=long"));
 
         List<IndexRequestBuilder> reqs = new ArrayList<>();
         reqs.add(client().prepareIndex("index-1").setSource("timestamp", "2015-07-08"));

--- a/server/src/internalClusterTest/java/org/opensearch/search/fields/SearchFieldsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fields/SearchFieldsIT.java
@@ -444,7 +444,7 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
     }
 
     public void testIdBasedScriptFields() throws Exception {
-        prepareCreate("test").addMapping("type1", "num1", "type=long").get();
+        prepareCreate("test").setMapping("num1", "type=long").get();
 
         int numDocs = randomIntBetween(1, 30);
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[numDocs];
@@ -839,7 +839,7 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
 
     // see #8203
     public void testSingleValueFieldDatatField() throws ExecutionException, InterruptedException {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type", "test_field", "type=keyword").get());
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping("test_field", "type=keyword").get());
         indexRandom(true, client().prepareIndex("test").setId("1").setSource("test_field", "foobar"));
         refresh();
         SearchResponse searchResponse = client().prepareSearch("test")
@@ -1114,8 +1114,7 @@ public class SearchFieldsIT extends OpenSearchIntegTestCase {
 
     public void testScriptFields() throws Exception {
         assertAcked(
-            prepareCreate("index").addMapping(
-                "type",
+            prepareCreate("index").setMapping(
                 "s",
                 "type=keyword",
                 "l",

--- a/server/src/internalClusterTest/java/org/opensearch/search/functionscore/RandomScoreFunctionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/functionscore/RandomScoreFunctionIT.java
@@ -168,8 +168,7 @@ public class RandomScoreFunctionIT extends OpenSearchIntegTestCase {
 
     public void testScoreAccessWithinScript() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type",
+            prepareCreate("test").setMapping(
                 "body",
                 "type=text",
                 "index",

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoPolygonIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoPolygonIT.java
@@ -66,8 +66,7 @@ public class GeoPolygonIT extends OpenSearchIntegTestCase {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
 
         assertAcked(
-            prepareCreate("test").setSettings(settings)
-                .addMapping("type1", "location", "type=geo_point", "alias", "type=alias,path=location")
+            prepareCreate("test").setSettings(settings).setMapping("location", "type=geo_point", "alias", "type=alias,path=location")
         );
         ensureGreen();
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoShapeIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoShapeIntegrationIT.java
@@ -136,9 +136,7 @@ public class GeoShapeIntegrationIT extends OpenSearchIntegTestCase {
      */
     public void testIgnoreMalformed() throws Exception {
         // create index
-        assertAcked(
-            client().admin().indices().prepareCreate("test").addMapping("geometry", "shape", "type=geo_shape,ignore_malformed=true").get()
-        );
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping("shape", "type=geo_shape,ignore_malformed=true").get());
         ensureGreen();
 
         // test self crossing ccw poly not crossing dateline
@@ -188,7 +186,7 @@ public class GeoShapeIntegrationIT extends OpenSearchIntegTestCase {
 
     public void testMappingUpdate() throws Exception {
         // create index
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("geometry", "shape", "type=geo_shape").get());
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping("shape", "type=geo_shape").get());
         ensureGreen();
 
         String update = "{\n"

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/LegacyGeoShapeIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/LegacyGeoShapeIntegrationIT.java
@@ -131,11 +131,7 @@ public class LegacyGeoShapeIntegrationIT extends OpenSearchIntegTestCase {
     public void testIgnoreMalformed() throws Exception {
         // create index
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
-                .addMapping("geometry", "shape", "type=geo_shape,tree=quadtree,ignore_malformed=true")
-                .get()
+            client().admin().indices().prepareCreate("test").setMapping("shape", "type=geo_shape,tree=quadtree,ignore_malformed=true").get()
         );
         ensureGreen();
 
@@ -226,11 +222,7 @@ public class LegacyGeoShapeIntegrationIT extends OpenSearchIntegTestCase {
     public void testLegacyCircle() throws Exception {
         // create index
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
-                .addMapping("geometry", "shape", "type=geo_shape,strategy=recursive,tree=geohash")
-                .get()
+            client().admin().indices().prepareCreate("test").setMapping("shape", "type=geo_shape,strategy=recursive,tree=geohash").get()
         );
         ensureGreen();
 
@@ -255,11 +247,7 @@ public class LegacyGeoShapeIntegrationIT extends OpenSearchIntegTestCase {
         try {
             // create index
             assertAcked(
-                client().admin()
-                    .indices()
-                    .prepareCreate("test")
-                    .addMapping("_doc", "shape", "type=geo_shape,strategy=recursive,tree=geohash")
-                    .get()
+                client().admin().indices().prepareCreate("test").setMapping("shape", "type=geo_shape,strategy=recursive,tree=geohash").get()
             );
             ensureGreen();
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/morelikethis/MoreLikeThisIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/morelikethis/MoreLikeThisIT.java
@@ -42,7 +42,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.MoreLikeThisQueryBuilder;
 import org.opensearch.index.query.MoreLikeThisQueryBuilder.Item;
 import org.opensearch.index.query.QueryBuilder;
@@ -183,7 +182,7 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
 
     public void testSimpleMoreLikeOnLongField() throws Exception {
         logger.info("Creating index test");
-        assertAcked(prepareCreate("test").addMapping("type1", "some_long", "type=long"));
+        assertAcked(prepareCreate("test").setMapping("some_long", "type=long"));
         logger.info("Running Cluster Health");
         assertThat(ensureGreen(), equalTo(ClusterHealthStatus.GREEN));
 
@@ -598,7 +597,7 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
     public void testMoreLikeThisMultiValueFields() throws Exception {
         logger.info("Creating the index ...");
         assertAcked(
-            prepareCreate("test").addMapping("type1", "text", "type=text,analyzer=keyword")
+            prepareCreate("test").setMapping("text", "type=text,analyzer=keyword")
                 .setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1))
         );
         ensureGreen();
@@ -632,7 +631,7 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
     public void testMinimumShouldMatch() throws ExecutionException, InterruptedException {
         logger.info("Creating the index ...");
         assertAcked(
-            prepareCreate("test").addMapping("type1", "text", "type=text,analyzer=whitespace")
+            prepareCreate("test").setMapping("text", "type=text,analyzer=whitespace")
                 .setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1))
         );
         ensureGreen();
@@ -693,15 +692,7 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
 
     public void testMoreLikeThisMalformedArtificialDocs() throws Exception {
         logger.info("Creating the index ...");
-        assertAcked(
-            prepareCreate("test").addMapping(
-                MapperService.SINGLE_MAPPING_NAME,
-                "text",
-                "type=text,analyzer=whitespace",
-                "date",
-                "type=date"
-            )
-        );
+        assertAcked(prepareCreate("test").setMapping("text", "type=text,analyzer=whitespace", "date", "type=date"));
         ensureGreen("test");
 
         logger.info("Creating an index with a single document ...");
@@ -790,9 +781,7 @@ public class MoreLikeThisIT extends OpenSearchIntegTestCase {
     }
 
     public void testSelectFields() throws IOException, ExecutionException, InterruptedException {
-        assertAcked(
-            prepareCreate("test").addMapping("type1", "text", "type=text,analyzer=whitespace", "text1", "type=text,analyzer=whitespace")
-        );
+        assertAcked(prepareCreate("test").setMapping("text", "type=text,analyzer=whitespace", "text1", "type=text,analyzer=whitespace"));
         ensureGreen("test");
 
         indexRandom(

--- a/server/src/internalClusterTest/java/org/opensearch/search/nested/SimpleNestedIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/nested/SimpleNestedIT.java
@@ -73,7 +73,7 @@ import static org.hamcrest.Matchers.startsWith;
 
 public class SimpleNestedIT extends OpenSearchIntegTestCase {
     public void testSimpleNested() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", "nested1", "type=nested"));
+        assertAcked(prepareCreate("test").setMapping("nested1", "type=nested"));
         ensureGreen();
 
         // check on no data, see it works
@@ -1597,7 +1597,7 @@ public class SimpleNestedIT extends OpenSearchIntegTestCase {
         if (loadFixedBitSeLazily) {
             settingsBuilder.put("index.load_fixed_bitset_filters_eagerly", false);
         }
-        assertAcked(prepareCreate("test").setSettings(settingsBuilder).addMapping("type"));
+        assertAcked(prepareCreate("test").setSettings(settingsBuilder));
 
         client().prepareIndex("test").setId("0").setSource("field", "value").get();
         client().prepareIndex("test").setId("1").setSource("field", "value").get();

--- a/server/src/internalClusterTest/java/org/opensearch/search/profile/aggregation/AggregationProfilerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/profile/aggregation/AggregationProfilerIT.java
@@ -108,7 +108,7 @@ public class AggregationProfilerIT extends OpenSearchIntegTestCase {
                 .indices()
                 .prepareCreate("idx")
                 .setSettings(org.opensearch.common.collect.Map.of("number_of_shards", 1, "number_of_replicas", 0))
-                .addMapping("type", STRING_FIELD, "type=keyword", NUMBER_FIELD, "type=integer", TAG_FIELD, "type=keyword")
+                .setMapping(STRING_FIELD, "type=keyword", NUMBER_FIELD, "type=integer", TAG_FIELD, "type=keyword")
                 .get()
         );
         List<IndexRequestBuilder> builders = new ArrayList<>();

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/MultiMatchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/MultiMatchQueryIT.java
@@ -1015,7 +1015,7 @@ public class MultiMatchQueryIT extends OpenSearchIntegTestCase {
         CreateIndexRequestBuilder builder = prepareCreate(idx).setSettings(
             Settings.builder().put(indexSettings()).put(SETTING_NUMBER_OF_SHARDS, 3).put(SETTING_NUMBER_OF_REPLICAS, 0)
         );
-        assertAcked(builder.addMapping("type", "title", "type=text", "body", "type=text"));
+        assertAcked(builder.setMapping("title", "type=text", "body", "type=text"));
         ensureGreen();
         List<IndexRequestBuilder> builders = new ArrayList<>();
         builders.add(client().prepareIndex(idx).setId("1").setSource("title", "foo", "body", "bar"));

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/ScriptScoreQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/ScriptScoreQueryIT.java
@@ -88,7 +88,7 @@ public class ScriptScoreQueryIT extends OpenSearchIntegTestCase {
     // 2) score is calculated based on a script with params
     // 3) min score applied
     public void testScriptScore() {
-        assertAcked(prepareCreate("test-index").addMapping("_doc", "field1", "type=text", "field2", "type=double"));
+        assertAcked(prepareCreate("test-index").setMapping("field1", "type=text", "field2", "type=double"));
         int docCount = 10;
         for (int i = 1; i <= docCount; i++) {
             client().prepareIndex("test-index").setId("" + i).setSource("field1", "text" + (i % 2), "field2", i).get();
@@ -114,7 +114,7 @@ public class ScriptScoreQueryIT extends OpenSearchIntegTestCase {
     }
 
     public void testScriptScoreBoolQuery() {
-        assertAcked(prepareCreate("test-index").addMapping("_doc", "field1", "type=text", "field2", "type=double"));
+        assertAcked(prepareCreate("test-index").setMapping("field1", "type=text", "field2", "type=double"));
         int docCount = 10;
         for (int i = 1; i <= docCount; i++) {
             client().prepareIndex("test-index").setId("" + i).setSource("field1", "text" + i, "field2", i).get();
@@ -136,7 +136,7 @@ public class ScriptScoreQueryIT extends OpenSearchIntegTestCase {
     public void testRewrittenQuery() {
         assertAcked(
             prepareCreate("test-index2").setSettings(Settings.builder().put("index.number_of_shards", 1))
-                .addMapping("_doc", "field1", "type=date", "field2", "type=double")
+                .setMapping("field1", "type=date", "field2", "type=double")
         );
         client().prepareIndex("test-index2").setId("1").setSource("field1", "2019-09-01", "field2", 1).get();
         client().prepareIndex("test-index2").setId("2").setSource("field1", "2019-10-01", "field2", 2).get();
@@ -154,7 +154,7 @@ public class ScriptScoreQueryIT extends OpenSearchIntegTestCase {
 
     public void testDisallowExpensiveQueries() {
         try {
-            assertAcked(prepareCreate("test-index").addMapping("_doc", "field1", "type=text", "field2", "type=double"));
+            assertAcked(prepareCreate("test-index").setMapping("field1", "type=text", "field2", "type=double"));
             int docCount = 10;
             for (int i = 1; i <= docCount; i++) {
                 client().prepareIndex("test-index").setId("" + i).setSource("field1", "text" + (i % 2), "field2", i).get();

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/SearchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/SearchQueryIT.java
@@ -211,7 +211,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     }
 
     public void testIndexOptions() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", "field1", "type=text,index_options=docs"));
+        assertAcked(prepareCreate("test").setMapping("field1", "type=text,index_options=docs"));
         indexRandom(
             true,
             client().prepareIndex("test").setId("1").setSource("field1", "quick brown fox", "field2", "quick brown fox"),
@@ -337,7 +337,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
         client().admin()
             .indices()
             .prepareCreate("test")
-            .addMapping("type1", "field1", "type=text,analyzer=whitespace")
+            .setMapping("field1", "type=text,analyzer=whitespace")
             .setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1))
             .get();
         indexRandom(
@@ -479,7 +479,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     public void testDateRangeInQueryString() {
         // the mapping needs to be provided upfront otherwise we are not sure how many failures we get back
         // as with dynamic mappings some shards might be lacking behind and parse a different query
-        assertAcked(prepareCreate("test").addMapping("type", "past", "type=date", "future", "type=date"));
+        assertAcked(prepareCreate("test").setMapping("past", "type=date", "future", "type=date"));
 
         ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
         String aMonthAgo = DateTimeFormatter.ISO_LOCAL_DATE.format(now.minusMonths(1));
@@ -505,7 +505,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     public void testDateRangeInQueryStringWithTimeZone_7880() {
         // the mapping needs to be provided upfront otherwise we are not sure how many failures we get back
         // as with dynamic mappings some shards might be lacking behind and parse a different query
-        assertAcked(prepareCreate("test").addMapping("type", "past", "type=date"));
+        assertAcked(prepareCreate("test").setMapping("past", "type=date"));
 
         ZoneId timeZone = randomZone();
         String now = DateFormatter.forPattern("strict_date_optional_time").format(Instant.now().atZone(timeZone));
@@ -523,7 +523,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     public void testDateRangeInQueryStringWithTimeZone_10477() {
         // the mapping needs to be provided upfront otherwise we are not sure how many failures we get back
         // as with dynamic mappings some shards might be lacking behind and parse a different query
-        assertAcked(prepareCreate("test").addMapping("type", "past", "type=date"));
+        assertAcked(prepareCreate("test").setMapping("past", "type=date"));
 
         client().prepareIndex("test").setId("1").setSource("past", "2015-04-05T23:00:00+0000").get();
         client().prepareIndex("test").setId("2").setSource("past", "2015-04-06T00:00:00+0000").get();
@@ -732,7 +732,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     }
 
     public void testMatchQueryNumeric() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", "long", "type=long", "double", "type=double"));
+        assertAcked(prepareCreate("test").setMapping("long", "type=long", "double", "type=double"));
 
         indexRandom(
             true,
@@ -752,7 +752,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     }
 
     public void testMatchQueryFuzzy() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("_doc", "text", "type=text"));
+        assertAcked(prepareCreate("test").setMapping("text", "type=text"));
 
         indexRandom(
             true,
@@ -846,9 +846,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     }
 
     public void testMatchQueryZeroTermsQuery() {
-        assertAcked(
-            prepareCreate("test").addMapping("type1", "field1", "type=text,analyzer=classic", "field2", "type=text,analyzer=classic")
-        );
+        assertAcked(prepareCreate("test").setMapping("field1", "type=text,analyzer=classic", "field2", "type=text,analyzer=classic"));
         client().prepareIndex("test").setId("1").setSource("field1", "value1").get();
         client().prepareIndex("test").setId("2").setSource("field1", "value2").get();
         refresh();
@@ -869,9 +867,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     }
 
     public void testMultiMatchQueryZeroTermsQuery() {
-        assertAcked(
-            prepareCreate("test").addMapping("type1", "field1", "type=text,analyzer=classic", "field2", "type=text,analyzer=classic")
-        );
+        assertAcked(prepareCreate("test").setMapping("field1", "type=text,analyzer=classic", "field2", "type=text,analyzer=classic"));
         client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value2").get();
         client().prepareIndex("test").setId("2").setSource("field1", "value3", "field2", "value4").get();
         refresh();
@@ -1039,7 +1035,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     }
 
     public void testEmptytermsQuery() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type", "term", "type=text"));
+        assertAcked(prepareCreate("test").setMapping("term", "type=text"));
 
         indexRandom(
             true,
@@ -1059,7 +1055,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     }
 
     public void testTermsQuery() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type", "str", "type=text", "lng", "type=long", "dbl", "type=double"));
+        assertAcked(prepareCreate("test").setMapping("str", "type=text", "lng", "type=long", "dbl", "type=double"));
 
         indexRandom(
             true,
@@ -1117,7 +1113,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     }
 
     public void testTermsLookupFilter() throws Exception {
-        assertAcked(prepareCreate("lookup").addMapping("type", "terms", "type=text", "other", "type=text"));
+        assertAcked(prepareCreate("lookup").setMapping("terms", "type=text", "other", "type=text"));
         assertAcked(
             prepareCreate("lookup2").setMapping(
                 jsonBuilder().startObject()
@@ -1133,8 +1129,8 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
                     .endObject()
             )
         );
-        assertAcked(prepareCreate("lookup3").addMapping("type", "_source", "enabled=false", "terms", "type=text"));
-        assertAcked(prepareCreate("test").addMapping("type", "term", "type=text"));
+        assertAcked(prepareCreate("lookup3").setMapping("_source", "enabled=false", "terms", "type=text"));
+        assertAcked(prepareCreate("test").setMapping("term", "type=text"));
 
         indexRandom(
             true,
@@ -1283,8 +1279,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
     public void testNumericTermsAndRanges() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 "num_byte",
                 "type=byte",
                 "num_short",
@@ -1400,8 +1395,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
 
     public void testNumericRangeFilter_2826() throws Exception {
         assertAcked(
-            prepareCreate("test").addMapping(
-                "type1",
+            prepareCreate("test").setMapping(
                 "num_byte",
                 "type=byte",
                 "num_short",
@@ -1780,7 +1774,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     }
 
     public void testRangeQueryWithTimeZone() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", "date", "type=date", "num", "type=integer"));
+        assertAcked(prepareCreate("test").setMapping("date", "type=date", "num", "type=integer"));
 
         indexRandom(
             true,
@@ -1955,7 +1949,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
     }
 
     public void testRangeQueryRangeFields_24744() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", "int_range", "type=integer_range"));
+        assertAcked(prepareCreate("test").setMapping("int_range", "type=integer_range"));
 
         client().prepareIndex("test")
             .setId("1")
@@ -2064,7 +2058,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
                     .put("index.analysis.normalizer.lowercase_normalizer.type", "custom")
                     .putList("index.analysis.normalizer.lowercase_normalizer.filter", "lowercase")
                     .build()
-            ).addMapping("_doc", "field1", "type=keyword,normalizer=lowercase_normalizer")
+            ).setMapping("field1", "type=keyword,normalizer=lowercase_normalizer")
         );
         client().prepareIndex("test").setId("1").setSource("field1", "Bbb Aaa").get();
         refresh();
@@ -2091,7 +2085,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
                     .put("index.analysis.analyzer.lowercase_analyzer.tokenizer", "standard")
                     .putList("index.analysis.analyzer.lowercase_analyzer.filter", "lowercase")
                     .build()
-            ).addMapping("_doc", "field1", "type=text,analyzer=lowercase_analyzer")
+            ).setMapping("field1", "type=text,analyzer=lowercase_analyzer")
         );
         client().prepareIndex("test").setId("1").setSource("field1", "Bbb Aaa").get();
         refresh();
@@ -2119,7 +2113,7 @@ public class SearchQueryIT extends OpenSearchIntegTestCase {
                     .put("index.analysis.normalizer.no_wildcard.type", "custom")
                     .put("index.analysis.normalizer.no_wildcard.char_filter", "no_wildcard")
                     .build()
-            ).addMapping("_doc", "field", "type=keyword,normalizer=no_wildcard")
+            ).setMapping("field", "type=keyword,normalizer=no_wildcard")
         );
         client().prepareIndex("test").setId("1").setSource("field", "label-1").get();
         refresh();

--- a/server/src/internalClusterTest/java/org/opensearch/search/scriptfilter/ScriptQuerySearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/scriptfilter/ScriptQuerySearchIT.java
@@ -240,7 +240,7 @@ public class ScriptQuerySearchIT extends OpenSearchIntegTestCase {
 
     public void testDisallowExpensiveQueries() {
         try {
-            assertAcked(prepareCreate("test-index").addMapping("_doc", "num1", "type=double"));
+            assertAcked(prepareCreate("test-index").setMapping("num1", "type=double"));
             int docCount = 10;
             for (int i = 1; i <= docCount; i++) {
                 client().prepareIndex("test-index").setId("" + i).setSource("num1", i).get();

--- a/server/src/internalClusterTest/java/org/opensearch/search/scroll/SearchScrollIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/scroll/SearchScrollIT.java
@@ -541,7 +541,7 @@ public class SearchScrollIT extends OpenSearchIntegTestCase {
         assertAcked(
             prepareCreate("test").setSettings(
                 Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-            ).addMapping("test", "no_field", "type=keyword", "some_field", "type=keyword")
+            ).setMapping("no_field", "type=keyword", "some_field", "type=keyword")
         );
         client().prepareIndex("test").setId("1").setSource("some_field", "test").get();
         refresh();
@@ -718,7 +718,7 @@ public class SearchScrollIT extends OpenSearchIntegTestCase {
                 .indices()
                 .prepareCreate("test")
                 .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards))
-                .addMapping("_doc", "created_date", "type=date,format=yyyy-MM-dd")
+                .setMapping("created_date", "type=date,format=yyyy-MM-dd")
         );
         client().prepareIndex("test").setId("1").setSource("created_date", "2020-01-01").get();
         client().prepareIndex("test").setId("2").setSource("created_date", "2020-01-02").get();

--- a/server/src/internalClusterTest/java/org/opensearch/search/searchafter/SearchAfterIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/searchafter/SearchAfterIT.java
@@ -59,13 +59,10 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class SearchAfterIT extends OpenSearchIntegTestCase {
     private static final String INDEX_NAME = "test";
-    private static final String TYPE_NAME = "type1";
     private static final int NUM_DOCS = 100;
 
     public void testsShouldFail() throws Exception {
-        assertAcked(
-            client().admin().indices().prepareCreate("test").addMapping("type1", "field1", "type=long", "field2", "type=keyword").get()
-        );
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field1", "type=long", "field2", "type=keyword").get());
         ensureGreen();
         indexRandom(true, client().prepareIndex("test").setId("0").setSource("field1", 0, "field2", "toto"));
         {
@@ -159,7 +156,7 @@ public class SearchAfterIT extends OpenSearchIntegTestCase {
     }
 
     public void testWithNullStrings() throws InterruptedException {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", "field2", "type=keyword").get());
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field2", "type=keyword").get());
         ensureGreen();
         indexRandom(
             true,
@@ -219,7 +216,7 @@ public class SearchAfterIT extends OpenSearchIntegTestCase {
         if (reqSize == 0) {
             reqSize = 1;
         }
-        assertSearchFromWithSortValues(INDEX_NAME, TYPE_NAME, documents, reqSize);
+        assertSearchFromWithSortValues(INDEX_NAME, documents, reqSize);
     }
 
     private static class ListComparator implements Comparator<List> {
@@ -250,10 +247,10 @@ public class SearchAfterIT extends OpenSearchIntegTestCase {
 
     private ListComparator LST_COMPARATOR = new ListComparator();
 
-    private void assertSearchFromWithSortValues(String indexName, String typeName, List<List> documents, int reqSize) throws Exception {
+    private void assertSearchFromWithSortValues(String indexName, List<List> documents, int reqSize) throws Exception {
         int numFields = documents.get(0).size();
         {
-            createIndexMappingsFromObjectType(indexName, typeName, documents.get(0));
+            createIndexMappingsFromObjectType(indexName, documents.get(0));
             List<IndexRequestBuilder> requests = new ArrayList<>();
             for (int i = 0; i < documents.size(); i++) {
                 XContentBuilder builder = jsonBuilder();
@@ -289,7 +286,7 @@ public class SearchAfterIT extends OpenSearchIntegTestCase {
         }
     }
 
-    private void createIndexMappingsFromObjectType(String indexName, String typeName, List<Object> types) {
+    private void createIndexMappingsFromObjectType(String indexName, List<Object> types) {
         CreateIndexRequestBuilder indexRequestBuilder = client().admin().indices().prepareCreate(indexName);
         List<String> mappings = new ArrayList<>();
         int numFields = types.size();
@@ -323,7 +320,7 @@ public class SearchAfterIT extends OpenSearchIntegTestCase {
                 fail("Can't match type [" + type + "]");
             }
         }
-        indexRequestBuilder.addMapping(typeName, mappings.toArray(new String[0])).get();
+        indexRequestBuilder.setMapping(mappings.toArray(new String[0])).get();
         ensureGreen();
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
@@ -295,7 +295,7 @@ public class SimpleSearchIT extends OpenSearchIntegTestCase {
     public void testSimpleIndexSortEarlyTerminate() throws Exception {
         prepareCreate("test").setSettings(
             Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0).put("index.sort.field", "rank")
-        ).addMapping(MapperService.SINGLE_MAPPING_NAME, "rank", "type=integer").get();
+        ).setMapping("rank", "type=integer").get();
         ensureGreen();
         int max = randomIntBetween(3, 29);
         List<IndexRequestBuilder> docbuilders = new ArrayList<>(max);
@@ -498,7 +498,7 @@ public class SimpleSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testQueryNumericFieldWithRegex() throws Exception {
-        assertAcked(prepareCreate("idx").addMapping("type", "num", "type=integer"));
+        assertAcked(prepareCreate("idx").setMapping("num", "type=integer"));
         ensureGreen("idx");
 
         try {
@@ -510,7 +510,7 @@ public class SimpleSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testTermQueryBigInt() throws Exception {
-        prepareCreate("idx").addMapping("type", "field", "type=keyword").get();
+        prepareCreate("idx").setMapping("field", "type=keyword").get();
         ensureGreen("idx");
 
         client().prepareIndex("idx")

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/FieldSortIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/FieldSortIT.java
@@ -137,7 +137,7 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
         final boolean useMapping = randomBoolean();
         for (int i = 0; i < numIndices; i++) {
             if (useMapping) {
-                assertAcked(prepareCreate("test_" + i).addAlias(new Alias("test")).addMapping("foo", "entry", "type=long"));
+                assertAcked(prepareCreate("test_" + i).addAlias(new Alias("test")).setMapping("entry", "type=long"));
             } else {
                 assertAcked(prepareCreate("test_" + i).addAlias(new Alias("test")));
             }
@@ -243,7 +243,7 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
     }
 
     public void testTrackScores() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type1", "svalue", "type=keyword").get());
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping("svalue", "type=keyword").get());
         ensureGreen();
         index(
             "test",
@@ -354,7 +354,7 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
     }
 
     public void test3078() {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type", "field", "type=keyword").get());
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field", "type=keyword").get());
         ensureGreen();
 
         for (int i = 1; i < 101; i++) {
@@ -492,7 +492,7 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
     }
 
     public void testIssue2986() {
-        assertAcked(client().admin().indices().prepareCreate("test").addMapping("post", "field1", "type=keyword").get());
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field1", "type=keyword").get());
 
         client().prepareIndex("test").setId("1").setSource("{\"field1\":\"value1\"}", XContentType.JSON).get();
         client().prepareIndex("test").setId("2").setSource("{\"field1\":\"value2\"}", XContentType.JSON).get();
@@ -516,7 +516,7 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
             } catch (Exception e) {
                 // ignore
             }
-            assertAcked(client().admin().indices().prepareCreate("test").addMapping("type", "tag", "type=keyword").get());
+            assertAcked(client().admin().indices().prepareCreate("test").setMapping("tag", "type=keyword").get());
             ensureGreen();
             client().prepareIndex("test").setId("1").setSource("tag", "alpha").get();
             refresh();
@@ -1610,11 +1610,11 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
         assertAcked(
             prepareCreate("test1").setSettings(
                 Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, between(2, maximumNumberOfShards()))
-            ).addMapping("type", sortField, "type=long").get()
+            ).setMapping(sortField, "type=long").get()
         );
         assertAcked(
             prepareCreate("test2").setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1))
-                .addMapping("type", sortField, "type=long")
+                .setMapping(sortField, "type=long")
                 .get()
         );
 
@@ -1650,7 +1650,7 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
         // Use an ip field, which uses different internal/external
         // representations of values, to make sure values are both correctly
         // rendered and parsed (search_after)
-        assertAcked(prepareCreate("test").addMapping("type", "ip", "type=ip"));
+        assertAcked(prepareCreate("test").setMapping("ip", "type=ip"));
         indexRandom(
             true,
             client().prepareIndex("test").setId("1").setSource("ip", "192.168.1.7"),
@@ -1671,7 +1671,7 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
     }
 
     public void testScriptFieldSort() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("t", "keyword", "type=keyword", "number", "type=integer"));
+        assertAcked(prepareCreate("test").setMapping("keyword", "type=keyword", "number", "type=integer"));
         ensureGreen();
         final int numDocs = randomIntBetween(10, 20);
         IndexRequestBuilder[] indexReqs = new IndexRequestBuilder[numDocs];
@@ -1721,10 +1721,8 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
     public void testFieldAlias() throws Exception {
         // Create two indices and add the field 'route_length_miles' as an alias in
         // one, and a concrete field in the other.
-        assertAcked(
-            prepareCreate("old_index").addMapping("_doc", "distance", "type=double", "route_length_miles", "type=alias,path=distance")
-        );
-        assertAcked(prepareCreate("new_index").addMapping("_doc", "route_length_miles", "type=double"));
+        assertAcked(prepareCreate("old_index").setMapping("distance", "type=double", "route_length_miles", "type=alias,path=distance"));
+        assertAcked(prepareCreate("new_index").setMapping("route_length_miles", "type=double"));
         ensureGreen("old_index", "new_index");
 
         List<IndexRequestBuilder> builders = new ArrayList<>();
@@ -1749,10 +1747,8 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
     public void testFieldAliasesWithMissingValues() throws Exception {
         // Create two indices and add the field 'route_length_miles' as an alias in
         // one, and a concrete field in the other.
-        assertAcked(
-            prepareCreate("old_index").addMapping("_doc", "distance", "type=double", "route_length_miles", "type=alias,path=distance")
-        );
-        assertAcked(prepareCreate("new_index").addMapping("_doc", "route_length_miles", "type=double"));
+        assertAcked(prepareCreate("old_index").setMapping("distance", "type=double", "route_length_miles", "type=alias,path=distance"));
+        assertAcked(prepareCreate("new_index").setMapping("route_length_miles", "type=double"));
         ensureGreen("old_index", "new_index");
 
         List<IndexRequestBuilder> builders = new ArrayList<>();
@@ -1775,9 +1771,9 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
     }
 
     public void testCastNumericType() throws Exception {
-        assertAcked(prepareCreate("index_double").addMapping("_doc", "field", "type=double"));
-        assertAcked(prepareCreate("index_long").addMapping("_doc", "field", "type=long"));
-        assertAcked(prepareCreate("index_float").addMapping("_doc", "field", "type=float"));
+        assertAcked(prepareCreate("index_double").setMapping("field", "type=double"));
+        assertAcked(prepareCreate("index_long").setMapping("field", "type=long"));
+        assertAcked(prepareCreate("index_float").setMapping("field", "type=float"));
         ensureGreen("index_double", "index_long", "index_float");
 
         List<IndexRequestBuilder> builders = new ArrayList<>();
@@ -1821,8 +1817,8 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
     }
 
     public void testCastDate() throws Exception {
-        assertAcked(prepareCreate("index_date").addMapping("_doc", "field", "type=date"));
-        assertAcked(prepareCreate("index_date_nanos").addMapping("_doc", "field", "type=date_nanos"));
+        assertAcked(prepareCreate("index_date").setMapping("field", "type=date"));
+        assertAcked(prepareCreate("index_date_nanos").setMapping("field", "type=date_nanos"));
         ensureGreen("index_date", "index_date_nanos");
 
         List<IndexRequestBuilder> builders = new ArrayList<>();
@@ -1937,7 +1933,7 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
     }
 
     public void testCastNumericTypeExceptions() throws Exception {
-        assertAcked(prepareCreate("index").addMapping("_doc", "keyword", "type=keyword", "ip", "type=ip"));
+        assertAcked(prepareCreate("index").setMapping("keyword", "type=keyword", "ip", "type=ip"));
         ensureGreen("index");
         for (String invalidField : new String[] { "keyword", "ip" }) {
             for (String numericType : new String[] { "long", "double", "date", "date_nanos" }) {
@@ -1957,7 +1953,7 @@ public class FieldSortIT extends OpenSearchIntegTestCase {
     public void testLongSortOptimizationCorrectResults() {
         assertAcked(
             prepareCreate("test1").setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 2))
-                .addMapping("_doc", "long_field", "type=long")
+                .setMapping("long_field", "type=long")
                 .get()
         );
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/GeoDistanceSortBuilderIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/GeoDistanceSortBuilderIT.java
@@ -83,7 +83,7 @@ public class GeoDistanceSortBuilderIT extends OpenSearchIntegTestCase {
          */
         Version version = randomBoolean() ? Version.CURRENT : VersionUtils.randomIndexCompatibleVersion(random());
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
-        assertAcked(prepareCreate("index").setSettings(settings).addMapping("type", LOCATION_FIELD, "type=geo_point"));
+        assertAcked(prepareCreate("index").setSettings(settings).setMapping(LOCATION_FIELD, "type=geo_point"));
         XContentBuilder d1Builder = jsonBuilder();
         GeoPoint[] d1Points = { new GeoPoint(3, 2), new GeoPoint(4, 1) };
         createShuffeldJSONArray(d1Builder, d1Points);
@@ -174,7 +174,7 @@ public class GeoDistanceSortBuilderIT extends OpenSearchIntegTestCase {
          */
         Version version = randomBoolean() ? Version.CURRENT : VersionUtils.randomIndexCompatibleVersion(random());
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
-        assertAcked(prepareCreate("index").setSettings(settings).addMapping("type", LOCATION_FIELD, "type=geo_point"));
+        assertAcked(prepareCreate("index").setSettings(settings).setMapping(LOCATION_FIELD, "type=geo_point"));
         XContentBuilder d1Builder = jsonBuilder();
         GeoPoint[] d1Points = { new GeoPoint(0, 1), new GeoPoint(0, 4), new GeoPoint(0, 10) };
         createShuffeldJSONArray(d1Builder, d1Points);
@@ -248,7 +248,7 @@ public class GeoDistanceSortBuilderIT extends OpenSearchIntegTestCase {
          */
         Version version = randomBoolean() ? Version.CURRENT : VersionUtils.randomIndexCompatibleVersion(random());
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, version).build();
-        assertAcked(prepareCreate("index").setSettings(settings).addMapping("type", LOCATION_FIELD, "type=geo_point"));
+        assertAcked(prepareCreate("index").setSettings(settings).setMapping(LOCATION_FIELD, "type=geo_point"));
         XContentBuilder d1Builder = jsonBuilder();
         GeoPoint[] d1Points = { new GeoPoint(2.5, 1), new GeoPoint(2.75, 2), new GeoPoint(3, 3), new GeoPoint(3.25, 4) };
         createShuffeldJSONArray(d1Builder, d1Points);
@@ -306,7 +306,7 @@ public class GeoDistanceSortBuilderIT extends OpenSearchIntegTestCase {
     }
 
     public void testSinglePointGeoDistanceSort() throws ExecutionException, InterruptedException, IOException {
-        assertAcked(prepareCreate("index").addMapping("type", LOCATION_FIELD, "type=geo_point"));
+        assertAcked(prepareCreate("index").setMapping(LOCATION_FIELD, "type=geo_point"));
         indexRandom(
             true,
             client().prepareIndex("index")
@@ -382,8 +382,7 @@ public class GeoDistanceSortBuilderIT extends OpenSearchIntegTestCase {
 
     public void testCrossIndexIgnoreUnmapped() throws Exception {
         assertAcked(
-            prepareCreate("test1").addMapping("type", "str_field", "type=keyword", "long_field", "type=long", "double_field", "type=double")
-                .get()
+            prepareCreate("test1").setMapping("str_field", "type=keyword", "long_field", "type=long", "double_field", "type=double").get()
         );
         assertAcked(prepareCreate("test2").get());
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/source/MetadataFetchingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/source/MetadataFetchingIT.java
@@ -69,7 +69,7 @@ public class MetadataFetchingIT extends OpenSearchIntegTestCase {
     }
 
     public void testInnerHits() {
-        assertAcked(prepareCreate("test").addMapping("_doc", "nested", "type=nested"));
+        assertAcked(prepareCreate("test").setMapping("nested", "type=nested"));
         ensureGreen();
         client().prepareIndex("test").setId("1").setSource("field", "value", "nested", Collections.singletonMap("title", "foo")).get();
         refresh();

--- a/server/src/internalClusterTest/java/org/opensearch/search/suggest/SuggestSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/suggest/SuggestSearchIT.java
@@ -97,7 +97,7 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
 
     // see #3196
     public void testSuggestAcrossMultipleIndices() throws IOException {
-        assertAcked(prepareCreate("test").addMapping("type1", "text", "type=text"));
+        assertAcked(prepareCreate("test").setMapping("text", "type=text"));
         ensureGreen();
 
         index("test", "type1", "1", "text", "abcd");
@@ -111,7 +111,7 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
             .text("abcd");
         logger.info("--> run suggestions with one index");
         searchSuggest("test", termSuggest);
-        assertAcked(prepareCreate("test_1").addMapping("type1", "text", "type=text"));
+        assertAcked(prepareCreate("test_1").setMapping("text", "type=text"));
         ensureGreen();
 
         index("test_1", "type1", "1", "text", "ab cd");
@@ -342,7 +342,7 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testSimple() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", "text", "type=text"));
+        assertAcked(prepareCreate("test").setMapping("text", "type=text"));
         ensureGreen();
 
         index("test", "type1", "1", "text", "abcd");
@@ -367,7 +367,7 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testEmpty() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", "text", "type=text"));
+        assertAcked(prepareCreate("test").setMapping("text", "type=text"));
         ensureGreen();
 
         index("test", "type1", "1", "text", "bar");
@@ -386,7 +386,7 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testEmptyIndex() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("type1", "text", "type=text"));
+        assertAcked(prepareCreate("test").setMapping("text", "type=text"));
         ensureGreen();
 
         // use SuggestMode.ALWAYS, otherwise the results can vary between requests.
@@ -412,7 +412,7 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
     }
 
     public void testWithMultipleCommands() throws Exception {
-        assertAcked(prepareCreate("test").addMapping("typ1", "field1", "type=text", "field2", "type=text"));
+        assertAcked(prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
         ensureGreen();
 
         index("test", "typ1", "1", "field1", "prefix_abcd", "field2", "prefix_efgh");
@@ -516,7 +516,7 @@ public class SuggestSearchIT extends OpenSearchIntegTestCase {
     // see #2817
     public void testStopwordsOnlyPhraseSuggest() throws IOException {
         assertAcked(
-            prepareCreate("test").addMapping("typ1", "body", "type=text,analyzer=stopwd")
+            prepareCreate("test").setMapping("body", "type=text,analyzer=stopwd")
                 .setSettings(
                     Settings.builder()
                         .put("index.analysis.analyzer.stopwd.tokenizer", "standard")

--- a/server/src/internalClusterTest/java/org/opensearch/update/UpdateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/update/UpdateIT.java
@@ -542,7 +542,7 @@ public class UpdateIT extends OpenSearchIntegTestCase {
     }
 
     public void testContextVariables() throws Exception {
-        assertAcked(prepareCreate("test").addAlias(new Alias("alias")).addMapping("type1"));
+        assertAcked(prepareCreate("test").addAlias(new Alias("alias")));
         ensureGreen();
 
         // Index some documents

--- a/server/src/internalClusterTest/java/org/opensearch/validate/SimpleValidateQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/validate/SimpleValidateQueryIT.java
@@ -297,7 +297,7 @@ public class SimpleValidateQueryIT extends OpenSearchIntegTestCase {
 
     public void testExplainFilteredAlias() {
         assertAcked(
-            prepareCreate("test").addMapping("test", "field", "type=text")
+            prepareCreate("test").setMapping("field", "type=text")
                 .addAlias(new Alias("alias").filter(QueryBuilders.termQuery("field", "value1")))
         );
         ensureGreen();
@@ -318,7 +318,7 @@ public class SimpleValidateQueryIT extends OpenSearchIntegTestCase {
         client().admin()
             .indices()
             .prepareCreate("test")
-            .addMapping(MapperService.SINGLE_MAPPING_NAME, "field", "type=text,analyzer=whitespace")
+            .setMapping("field", "type=text,analyzer=whitespace")
             .setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1))
             .get();
         client().prepareIndex("test").setId("1").setSource("field", "quick lazy huge brown pidgin").get();
@@ -380,7 +380,7 @@ public class SimpleValidateQueryIT extends OpenSearchIntegTestCase {
         client().admin()
             .indices()
             .prepareCreate("test")
-            .addMapping(MapperService.SINGLE_MAPPING_NAME, "field", "type=text,analyzer=whitespace")
+            .setMapping("field", "type=text,analyzer=whitespace")
             .setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 2).put("index.number_of_routing_shards", 2))
             .get();
         // We are relying on specific routing behaviors for the result to be right, so
@@ -484,7 +484,7 @@ public class SimpleValidateQueryIT extends OpenSearchIntegTestCase {
         client().admin()
             .indices()
             .prepareCreate("twitter")
-            .addMapping("_doc", "user", "type=integer", "followers", "type=integer")
+            .setMapping("user", "type=integer", "followers", "type=integer")
             .setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 2).put("index.number_of_routing_shards", 2))
             .get();
         client().prepareIndex("twitter").setId("1").setSource("followers", new int[] { 1, 2, 3 }).get();

--- a/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequestBuilder.java
@@ -141,10 +141,8 @@ public class CreateIndexRequestBuilder extends AcknowledgedRequestBuilder<
     /**
      * A specialized simplified mapping source method, takes the form of simple properties definition:
      * ("field1", "type=string,store=true").
-     * @deprecated types are being removed
      */
-    @Deprecated
-    public CreateIndexRequestBuilder addMapping(String type, String... source) {
+    public CreateIndexRequestBuilder setMapping(String... source) {
         request.simpleMapping(source);
         return this;
     }

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataMappingServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataMappingServiceTests.java
@@ -57,7 +57,7 @@ public class MetadataMappingServiceTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testMappingClusterStateUpdateDoesntChangeExistingIndices() throws Exception {
-        final IndexService indexService = createIndex("test", client().admin().indices().prepareCreate("test"));
+        final IndexService indexService = createIndex("test", client().admin().indices().prepareCreate("test").setMapping());
         final CompressedXContent currentMapping = indexService.mapperService().documentMapper().mappingSource();
 
         final MetadataMappingService mappingService = getInstanceFromNode(MetadataMappingService.class);
@@ -118,7 +118,7 @@ public class MetadataMappingServiceTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testMappingVersionUnchanged() throws Exception {
-        final IndexService indexService = createIndex("test", client().admin().indices().prepareCreate("test"));
+        final IndexService indexService = createIndex("test", client().admin().indices().prepareCreate("test").setMapping());
         final long previousVersion = indexService.getMetadata().getMappingVersion();
         final MetadataMappingService mappingService = getInstanceFromNode(MetadataMappingService.class);
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataMappingServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataMappingServiceTests.java
@@ -39,7 +39,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.compress.CompressedXContent;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexService;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 import org.opensearch.test.InternalSettingsPlugin;
@@ -58,10 +57,7 @@ public class MetadataMappingServiceTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testMappingClusterStateUpdateDoesntChangeExistingIndices() throws Exception {
-        final IndexService indexService = createIndex(
-            "test",
-            client().admin().indices().prepareCreate("test").addMapping(MapperService.SINGLE_MAPPING_NAME)
-        );
+        final IndexService indexService = createIndex("test", client().admin().indices().prepareCreate("test"));
         final CompressedXContent currentMapping = indexService.mapperService().documentMapper().mappingSource();
 
         final MetadataMappingService mappingService = getInstanceFromNode(MetadataMappingService.class);
@@ -86,7 +82,7 @@ public class MetadataMappingServiceTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testClusterStateIsNotChangedWithIdenticalMappings() throws Exception {
-        createIndex("test", client().admin().indices().prepareCreate("test").addMapping("type"));
+        createIndex("test", client().admin().indices().prepareCreate("test"));
 
         final MetadataMappingService mappingService = getInstanceFromNode(MetadataMappingService.class);
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
@@ -106,7 +102,7 @@ public class MetadataMappingServiceTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testMappingVersion() throws Exception {
-        final IndexService indexService = createIndex("test", client().admin().indices().prepareCreate("test").addMapping("type"));
+        final IndexService indexService = createIndex("test", client().admin().indices().prepareCreate("test"));
         final long previousVersion = indexService.getMetadata().getMappingVersion();
         final MetadataMappingService mappingService = getInstanceFromNode(MetadataMappingService.class);
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
@@ -122,7 +118,7 @@ public class MetadataMappingServiceTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testMappingVersionUnchanged() throws Exception {
-        final IndexService indexService = createIndex("test", client().admin().indices().prepareCreate("test").addMapping("type"));
+        final IndexService indexService = createIndex("test", client().admin().indices().prepareCreate("test"));
         final long previousVersion = indexService.getMetadata().getMappingVersion();
         final MetadataMappingService mappingService = getInstanceFromNode(MetadataMappingService.class);
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);

--- a/server/src/test/java/org/opensearch/index/fieldstats/FieldStatsProviderRefreshTests.java
+++ b/server/src/test/java/org/opensearch/index/fieldstats/FieldStatsProviderRefreshTests.java
@@ -55,7 +55,7 @@ public class FieldStatsProviderRefreshTests extends OpenSearchSingleNodeTestCase
             client().admin()
                 .indices()
                 .prepareCreate("index")
-                .addMapping("type", "s", "type=text")
+                .setMapping("s", "type=text")
                 .setSettings(
                     Settings.builder()
                         .put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true)

--- a/server/src/test/java/org/opensearch/index/mapper/UpdateMappingTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/UpdateMappingTests.java
@@ -259,7 +259,7 @@ public class UpdateMappingTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testMappingVersion() {
-        createIndex("test", client().admin().indices().prepareCreate("test").addMapping(MapperService.SINGLE_MAPPING_NAME));
+        createIndex("test", client().admin().indices().prepareCreate("test"));
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
         {
             final long previousVersion = clusterService.state().metadata().index("test").getMappingVersion();

--- a/server/src/test/java/org/opensearch/index/query/CommonTermsQueryParserTests.java
+++ b/server/src/test/java/org/opensearch/index/query/CommonTermsQueryParserTests.java
@@ -38,8 +38,7 @@ import org.opensearch.test.OpenSearchSingleNodeTestCase;
 public class CommonTermsQueryParserTests extends OpenSearchSingleNodeTestCase {
     public void testWhenParsedQueryIsNullNoNullPointerExceptionIsThrown() {
         final String index = "test-index";
-        final String type = "test-type";
-        client().admin().indices().prepareCreate(index).addMapping(type, "name", "type=text,analyzer=stop").execute().actionGet();
+        client().admin().indices().prepareCreate(index).setMapping("name", "type=text,analyzer=stop").execute().actionGet();
         ensureGreen();
 
         CommonTermsQueryBuilder commonTermsQueryBuilder = new CommonTermsQueryBuilder("name", "the").queryName("query-name");

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/ShardSizeTestCase.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/ShardSizeTestCase.java
@@ -55,7 +55,7 @@ public abstract class ShardSizeTestCase extends OpenSearchIntegTestCase {
     }
 
     protected void createIdx(String keyFieldMapping) {
-        assertAcked(prepareCreate("idx").addMapping("type", "key", keyFieldMapping));
+        assertAcked(prepareCreate("idx").setMapping("key", keyFieldMapping));
     }
 
     protected static String routing1; // routing key to shard 1

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/AbstractGeoTestCase.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/AbstractGeoTestCase.java
@@ -87,8 +87,7 @@ public abstract class AbstractGeoTestCase extends OpenSearchIntegTestCase {
     public void setupSuiteScopeCluster() throws Exception {
         createIndex(UNMAPPED_IDX_NAME);
         assertAcked(
-            prepareCreate(IDX_NAME).addMapping(
-                "type",
+            prepareCreate(IDX_NAME).setMapping(
                 SINGLE_VALUED_FIELD_NAME,
                 "type=geo_point",
                 MULTI_VALUED_FIELD_NAME,
@@ -168,11 +167,10 @@ public abstract class AbstractGeoTestCase extends OpenSearchIntegTestCase {
             );
         }
 
-        assertAcked(prepareCreate(EMPTY_IDX_NAME).addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=geo_point"));
+        assertAcked(prepareCreate(EMPTY_IDX_NAME).setMapping(SINGLE_VALUED_FIELD_NAME, "type=geo_point"));
 
         assertAcked(
-            prepareCreate(DATELINE_IDX_NAME).addMapping(
-                "type",
+            prepareCreate(DATELINE_IDX_NAME).setMapping(
                 SINGLE_VALUED_FIELD_NAME,
                 "type=geo_point",
                 MULTI_VALUED_FIELD_NAME,
@@ -205,8 +203,7 @@ public abstract class AbstractGeoTestCase extends OpenSearchIntegTestCase {
         }
         assertAcked(
             prepareCreate(HIGH_CARD_IDX_NAME).setSettings(Settings.builder().put("number_of_shards", 2))
-                .addMapping(
-                    "type",
+                .setMapping(
                     SINGLE_VALUED_FIELD_NAME,
                     "type=geo_point",
                     MULTI_VALUED_FIELD_NAME,
@@ -247,7 +244,7 @@ public abstract class AbstractGeoTestCase extends OpenSearchIntegTestCase {
             client().prepareIndex(IDX_ZERO_NAME)
                 .setSource(jsonBuilder().startObject().array(SINGLE_VALUED_FIELD_NAME, 0.0, 1.0).endObject())
         );
-        assertAcked(prepareCreate(IDX_ZERO_NAME).addMapping("type", SINGLE_VALUED_FIELD_NAME, "type=geo_point"));
+        assertAcked(prepareCreate(IDX_ZERO_NAME).setMapping(SINGLE_VALUED_FIELD_NAME, "type=geo_point"));
 
         indexRandom(true, builders);
         ensureSearchable();

--- a/server/src/test/java/org/opensearch/search/geo/GeoShapeQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/geo/GeoShapeQueryTests.java
@@ -148,7 +148,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
 
     public void testShapeFetchingPath() throws Exception {
         createIndex("shapes");
-        client().admin().indices().prepareCreate("test").addMapping("type", "geo", "type=geo_shape").get();
+        client().admin().indices().prepareCreate("test").setMapping("geo", "type=geo_shape").get();
 
         String location = "\"geo\" : {\"type\":\"polygon\", \"coordinates\":[[[-10,-10],[10,-10],[10,10],[-10,10],[-10,-10]]]}";
 
@@ -538,14 +538,9 @@ public class GeoShapeQueryTests extends GeoQueryTests {
         PointBuilder pb = new PointBuilder(pt[0], pt[1]);
         gcb.shape(pb);
         if (randomBoolean()) {
-            client().admin().indices().prepareCreate("test").addMapping("type", "geo", "type=geo_shape").execute().actionGet();
+            client().admin().indices().prepareCreate("test").setMapping("geo", "type=geo_shape").execute().actionGet();
         } else {
-            client().admin()
-                .indices()
-                .prepareCreate("test")
-                .addMapping("type", "geo", "type=geo_shape,tree=quadtree")
-                .execute()
-                .actionGet();
+            client().admin().indices().prepareCreate("test").setMapping("geo", "type=geo_shape,tree=quadtree").execute().actionGet();
         }
         XContentBuilder docSource = gcb.toXContent(jsonBuilder().startObject().field("geo"), null).endObject();
         client().prepareIndex("test").setId("1").setSource(docSource).setRefreshPolicy(IMMEDIATE).get();
@@ -578,14 +573,9 @@ public class GeoShapeQueryTests extends GeoQueryTests {
         }
 
         if (usePrefixTrees) {
-            client().admin()
-                .indices()
-                .prepareCreate("test")
-                .addMapping("type", "geo", "type=geo_shape,tree=quadtree")
-                .execute()
-                .actionGet();
+            client().admin().indices().prepareCreate("test").setMapping("geo", "type=geo_shape,tree=quadtree").execute().actionGet();
         } else {
-            client().admin().indices().prepareCreate("test").addMapping("type", "geo", "type=geo_shape").execute().actionGet();
+            client().admin().indices().prepareCreate("test").setMapping("geo", "type=geo_shape").execute().actionGet();
         }
 
         XContentBuilder docSource = gcb.toXContent(jsonBuilder().startObject().field("geo"), null).endObject();
@@ -805,7 +795,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
 
     public void testShapeFilterWithDefinedGeoCollection() throws Exception {
         createIndex("shapes");
-        client().admin().indices().prepareCreate("test").addMapping("type", "geo", "type=geo_shape,tree=quadtree").get();
+        client().admin().indices().prepareCreate("test").setMapping("geo", "type=geo_shape,tree=quadtree").get();
 
         XContentBuilder docSource = jsonBuilder().startObject()
             .startObject("geo")

--- a/server/src/test/java/org/opensearch/test/search/aggregations/bucket/SharedSignificantTermsTestMethods.java
+++ b/server/src/test/java/org/opensearch/test/search/aggregations/bucket/SharedSignificantTermsTestMethods.java
@@ -100,7 +100,7 @@ public class SharedSignificantTermsTestMethods {
         assertAcked(
             testCase.prepareCreate(INDEX_NAME)
                 .setSettings(settings, XContentType.JSON)
-                .addMapping("_doc", "text", textMappings, CLASS_FIELD, "type=keyword")
+                .setMapping("text", textMappings, CLASS_FIELD, "type=keyword")
         );
         String[] gb = { "0", "1" };
         List<IndexRequestBuilder> indexRequestBuilderList = new ArrayList<>();

--- a/test/framework/src/main/java/org/opensearch/search/aggregations/metrics/AbstractNumericTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/search/aggregations/metrics/AbstractNumericTestCase.java
@@ -76,7 +76,7 @@ public abstract class AbstractNumericTestCase extends OpenSearchIntegTestCase {
         // two docs {value: 0} and {value : 2}, then building a histogram agg with interval 1 and with empty
         // buckets computed.. the empty bucket is the one associated with key "1". then each test will have
         // to check that this bucket exists with the appropriate sub aggregations.
-        prepareCreate("empty_bucket_idx").addMapping("type", "value", "type=integer").execute().actionGet();
+        prepareCreate("empty_bucket_idx").setMapping("value", "type=integer").execute().actionGet();
         builders = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
             builders.add(

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
@@ -322,8 +322,8 @@ public abstract class OpenSearchSingleNodeTestCase extends OpenSearchTestCase {
     @Deprecated
     protected IndexService createIndex(String index, Settings settings, String type, String... mappings) {
         CreateIndexRequestBuilder createIndexRequestBuilder = client().admin().indices().prepareCreate(index).setSettings(settings);
-        if (type != null) {
-            createIndexRequestBuilder.addMapping(type, mappings);
+        if (mappings != null) {
+            createIndexRequestBuilder.setMapping(mappings);
         }
         return createIndex(index, createIndexRequestBuilder);
     }


### PR DESCRIPTION
Removes the type variable as input to CreateIndexRequest.mapping(Object...)
along with the CreateIndexRequestBuilder helper class. This also refactors the
method name to setMapping for consistency with other methods (e.g.,
setSettings).

relates #1940