### PR TITLE
Support for geo_bounding_box queries on geo_shape fields

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoBoundingBoxQueryGeoPointsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoBoundingBoxQueryGeoPointsIT.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.geo;
+
+import org.opensearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+public class GeoBoundingBoxQueryGeoPointsIT extends AbstractGeoBoundingBoxQueryIT {
+
+    @Override
+    public XContentBuilder addGeoMapping(XContentBuilder parentMapping) throws IOException {
+        return parentMapping.startObject("location").field("type", "geo_point").endObject();
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoBoundingBoxQueryGeoShapesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoBoundingBoxQueryGeoShapesIT.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.geo;
+
+import org.opensearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+public class GeoBoundingBoxQueryGeoShapesIT extends AbstractGeoBoundingBoxQueryIT {
+
+    @Override
+    public XContentBuilder addGeoMapping(XContentBuilder parentMapping) throws IOException {
+        parentMapping = parentMapping.startObject("location").field("type", "geo_shape");
+        if (randomBoolean()) {
+            parentMapping.field("strategy", "recursive");
+        }
+        return parentMapping.endObject();
+    }
+}


### PR DESCRIPTION
Adds support for using `geo_bounding_box` queries on `geo_shape` field types by
lifting the `geo_point` restriction in the QueryBuilder. Bounding Box query
integration tests are abstracted to test both `geo_point` and `geo_shape` types.

closes #2505