### PR TITLE
Support for geo_distance queries on geo_shape fields

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoDistanceQueryGeoPointsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoDistanceQueryGeoPointsIT.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.geo;
+
+import org.junit.Before;
+import org.opensearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/** Tests geo_distance queries on geo_point field types */
+public class GeoDistanceQueryGeoPointsIT extends AbstractGeoDistanceIT {
+
+    @Before
+    public void setupTestIndex() throws IOException {
+        indexSetup();
+    }
+
+    @Override
+    public XContentBuilder addGeoMapping(XContentBuilder parentMapping) throws IOException {
+        return parentMapping.startObject("location").field("type", "geo_point").endObject();
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoDistanceQueryGeoShapesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/geo/GeoDistanceQueryGeoShapesIT.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.geo;
+
+import org.junit.Before;
+import org.opensearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/** Tests geo_distance queries on geo_shape field types */
+public class GeoDistanceQueryGeoShapesIT extends AbstractGeoDistanceIT {
+
+    @Before
+    public void setupTestIndex() throws IOException {
+        indexSetup();
+    }
+
+    @Override
+    public XContentBuilder addGeoMapping(XContentBuilder parentMapping) throws IOException {
+        parentMapping = parentMapping.startObject("location").field("type", "geo_shape");
+        if (randomBoolean()) {
+            parentMapping.field("strategy", "recursive");
+        }
+        return parentMapping.endObject();
+    }
+
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/2515")
+    @Override
+    public void testDistanceScript() {
+        // no-op; todo script support for distance calculation on shapes cannot be added until GeoShapeDocValues is added
+    }
+
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/2515")
+    @Override
+    public void testGeoDistanceAggregation() {
+        // no-op; todo aggregation support for distance calculation on shapes cannot be added until GeoShapeDocValues is added
+    }
+}


### PR DESCRIPTION
Adds support for using the `geo_distance` query on `geo_shape` field types by
lifting the `geo_point` restriction in the QueryBuilder. Distance query
integration tests are abstracted to test both `geo_point` and `geo_shape` field
types.

closes #2514 