### PR TITLE
Replace internal usages of 'master' terminology in server/src/test di…

### DIFF
--- a/server/src/test/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponsesTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponsesTests.java
@@ -112,9 +112,9 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
         assertThat(clusterHealth.getActiveShardsPercent(), is(allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(100.0))));
     }
 
-    public void testClusterHealthVerifyMasterNodeDiscovery() throws IOException {
+    public void testClusterHealthVerifyClusterManagerNodeDiscovery() throws IOException {
         DiscoveryNode localNode = new DiscoveryNode("node", OpenSearchTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
-        // set the node information to verify master_node discovery in ClusterHealthResponse
+        // set the node information to verify cluster_manager_node discovery in ClusterHealthResponse
         ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
             .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()).masterNodeId(localNode.getId()))
             .build();
@@ -150,7 +150,7 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
     }
 
     public void testVersionCompatibleSerialization() throws IOException {
-        boolean hasDiscoveredMaster = false;
+        boolean hasDiscoveredClusterManager = false;
         int indicesSize = randomInt(20);
         Map<String, ClusterIndexHealth> indices = new HashMap<>(indicesSize);
         if ("indices".equals(level) || "shards".equals(level)) {
@@ -167,12 +167,12 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
             randomInt(100),
             randomInt(100),
             randomInt(100),
-            hasDiscoveredMaster,
+            hasDiscoveredClusterManager,
             randomDoubleBetween(0d, 100d, true),
             randomFrom(ClusterHealthStatus.values()),
             indices
         );
-        // Create the Cluster Health Response object with discovered master as false,
+        // Create the Cluster Health Response object with discovered cluster manager as false,
         // to verify serialization puts default value for the field
         ClusterHealthResponse clusterHealth = new ClusterHealthResponse(
             "test-cluster",
@@ -209,7 +209,7 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
         StreamInput in_gt_7_0 = out_gt_1_0.bytes().streamInput();
         in_gt_7_0.setVersion(new_version);
         clusterHealth = ClusterHealthResponse.readResponseFrom(in_gt_7_0);
-        assertThat(clusterHealth.hasDiscoveredMaster(), Matchers.equalTo(hasDiscoveredMaster));
+        assertThat(clusterHealth.hasDiscoveredMaster(), Matchers.equalTo(hasDiscoveredClusterManager));
     }
 
     ClusterHealthResponse maybeSerialize(ClusterHealthResponse clusterHealth) throws IOException {
@@ -222,7 +222,7 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
         return clusterHealth;
     }
 
-    public void testParseFromXContentWithDiscoveredMasterField() throws IOException {
+    public void testParseFromXContentWithDiscoveredClusterManagerField() throws IOException {
         try (
             XContentParser parser = JsonXContent.jsonXContent.createParser(
                 NamedXContentRegistry.EMPTY,

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
@@ -474,12 +474,12 @@ public class CancellableTasksTests extends TaskManagerTestCase {
             for (int i = 1; i < testNodes.length; i++) {
                 discoveryNodes[i - 1] = testNodes[i].discoveryNode();
             }
-            DiscoveryNode master = discoveryNodes[0];
+            DiscoveryNode clusterManager = discoveryNodes[0];
             for (int i = 1; i < testNodes.length; i++) {
                 // Notify only nodes that should remain in the cluster
                 setState(
                     testNodes[i].clusterService,
-                    ClusterStateCreationUtils.state(testNodes[i].discoveryNode(), master, discoveryNodes)
+                    ClusterStateCreationUtils.state(testNodes[i].discoveryNode(), clusterManager, discoveryNodes)
                 );
             }
             if (randomBoolean()) {

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
@@ -257,9 +257,9 @@ public abstract class TaskManagerTestCase extends OpenSearchTestCase {
         for (int i = 0; i < nodes.length; i++) {
             discoveryNodes[i] = nodes[i].discoveryNode();
         }
-        DiscoveryNode master = discoveryNodes[0];
+        DiscoveryNode clusterManager = discoveryNodes[0];
         for (TestNode node : nodes) {
-            setState(node.clusterService, ClusterStateCreationUtils.state(node.discoveryNode(), master, discoveryNodes));
+            setState(node.clusterService, ClusterStateCreationUtils.state(node.discoveryNode(), clusterManager, discoveryNodes));
         }
         for (TestNode nodeA : nodes) {
             for (TestNode nodeB : nodes) {

--- a/server/src/test/java/org/opensearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
@@ -374,9 +374,9 @@ public class TransportBroadcastByNodeActionTests extends OpenSearchTestCase {
         Request request = new Request(new String[] { TEST_INDEX });
         PlainActionFuture<Response> listener = new PlainActionFuture<>();
 
-        DiscoveryNode masterNode = clusterService.state().nodes().getMasterNode();
+        DiscoveryNode clusterManagerNode = clusterService.state().nodes().getMasterNode();
         DiscoveryNodes.Builder builder = DiscoveryNodes.builder(clusterService.state().getNodes());
-        builder.remove(masterNode.getId());
+        builder.remove(clusterManagerNode.getId());
 
         setState(clusterService, ClusterState.builder(clusterService.state()).nodes(builder));
 
@@ -384,11 +384,11 @@ public class TransportBroadcastByNodeActionTests extends OpenSearchTestCase {
 
         Map<String, List<CapturingTransport.CapturedRequest>> capturedRequests = transport.getCapturedRequestsByTargetNodeAndClear();
 
-        // the master should not be in the list of nodes that requests were sent to
+        // the cluster manager should not be in the list of nodes that requests were sent to
         ShardsIterator shardIt = clusterService.state().routingTable().allShards(new String[] { TEST_INDEX });
         Set<String> set = new HashSet<>();
         for (ShardRouting shard : shardIt) {
-            if (!shard.currentNodeId().equals(masterNode.getId())) {
+            if (!shard.currentNodeId().equals(clusterManagerNode.getId())) {
                 set.add(shard.currentNodeId());
             }
         }

--- a/server/src/test/java/org/opensearch/cluster/action/shard/ShardStateActionTests.java
+++ b/server/src/test/java/org/opensearch/cluster/action/shard/ShardStateActionTests.java
@@ -112,16 +112,16 @@ public class ShardStateActionTests extends OpenSearchTestCase {
             super(clusterService, transportService, allocationService, rerouteService, THREAD_POOL);
         }
 
-        private Runnable onBeforeWaitForNewMasterAndRetry;
+        private Runnable onBeforeWaitForNewClusterManagerAndRetry;
 
         public void setOnBeforeWaitForNewMasterAndRetry(Runnable onBeforeWaitForNewMasterAndRetry) {
-            this.onBeforeWaitForNewMasterAndRetry = onBeforeWaitForNewMasterAndRetry;
+            this.onBeforeWaitForNewClusterManagerAndRetry = onBeforeWaitForNewMasterAndRetry;
         }
 
-        private Runnable onAfterWaitForNewMasterAndRetry;
+        private Runnable onAfterWaitForNewClusterManagerAndRetry;
 
         public void setOnAfterWaitForNewMasterAndRetry(Runnable onAfterWaitForNewMasterAndRetry) {
-            this.onAfterWaitForNewMasterAndRetry = onAfterWaitForNewMasterAndRetry;
+            this.onAfterWaitForNewClusterManagerAndRetry = onAfterWaitForNewMasterAndRetry;
         }
 
         @Override
@@ -132,9 +132,9 @@ public class ShardStateActionTests extends OpenSearchTestCase {
             ActionListener<Void> listener,
             Predicate<ClusterState> changePredicate
         ) {
-            onBeforeWaitForNewMasterAndRetry.run();
+            onBeforeWaitForNewClusterManagerAndRetry.run();
             super.waitForNewMasterAndRetry(actionName, observer, request, listener, changePredicate);
-            onAfterWaitForNewMasterAndRetry.run();
+            onAfterWaitForNewClusterManagerAndRetry.run();
         }
     }
 

--- a/server/src/test/java/org/opensearch/cluster/coordination/ClusterFormationFailureHelperTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/ClusterFormationFailureHelperTests.java
@@ -283,7 +283,7 @@ public class ClusterFormationFailureHelperTests extends OpenSearchTestCase {
             is("this node is unhealthy: unhealthy-info")
         );
 
-        final DiscoveryNode masterNode = new DiscoveryNode(
+        final DiscoveryNode clusterManagerNode = new DiscoveryNode(
             "local",
             buildNewFakeTransportAddress(),
             emptyMap(),
@@ -292,7 +292,7 @@ public class ClusterFormationFailureHelperTests extends OpenSearchTestCase {
         );
         clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .version(12L)
-            .nodes(DiscoveryNodes.builder().add(masterNode).localNodeId(masterNode.getId()))
+            .nodes(DiscoveryNodes.builder().add(clusterManagerNode).localNodeId(clusterManagerNode.getId()))
             .build();
 
         assertThat(
@@ -818,8 +818,8 @@ public class ClusterFormationFailureHelperTests extends OpenSearchTestCase {
             )
         );
 
-        final DiscoveryNode otherMasterNode = new DiscoveryNode("other-master", buildNewFakeTransportAddress(), Version.CURRENT);
-        final DiscoveryNode otherNonMasterNode = new DiscoveryNode(
+        final DiscoveryNode otherClusterManagerNode = new DiscoveryNode("other-master", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode otherNonClusterManagerNode = new DiscoveryNode(
             "other-non-master",
             buildNewFakeTransportAddress(),
             emptyMap(),
@@ -833,7 +833,13 @@ public class ClusterFormationFailureHelperTests extends OpenSearchTestCase {
 
         String[] configNodeIds = new String[] { "n1", "n2" };
         final ClusterState stateWithOtherNodes = ClusterState.builder(ClusterName.DEFAULT)
-            .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()).add(otherMasterNode).add(otherNonMasterNode))
+            .nodes(
+                DiscoveryNodes.builder()
+                    .add(localNode)
+                    .localNodeId(localNode.getId())
+                    .add(otherClusterManagerNode)
+                    .add(otherNonClusterManagerNode)
+            )
             .metadata(
                 Metadata.builder()
                     .coordinationMetadata(
@@ -864,13 +870,13 @@ public class ClusterFormationFailureHelperTests extends OpenSearchTestCase {
                         + "discovery will continue using [] from hosts providers and ["
                         + localNode
                         + ", "
-                        + otherMasterNode
+                        + otherClusterManagerNode
                         + "] from last-known cluster state; node term 0, last-accepted version 0 in term 0",
 
                     "master not discovered or elected yet, an election requires two nodes with ids [n1, n2], "
                         + "have discovered [] which is not a quorum; "
                         + "discovery will continue using [] from hosts providers and ["
-                        + otherMasterNode
+                        + otherClusterManagerNode
                         + ", "
                         + localNode
                         + "] from last-known cluster state; node term 0, last-accepted version 0 in term 0"

--- a/server/src/test/java/org/opensearch/cluster/coordination/JoinTaskExecutorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/JoinTaskExecutorTests.java
@@ -168,7 +168,7 @@ public class JoinTaskExecutorTests extends OpenSearchTestCase {
 
         final JoinTaskExecutor joinTaskExecutor = new JoinTaskExecutor(Settings.EMPTY, allocationService, logger, rerouteService, null);
 
-        final DiscoveryNode masterNode = new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode clusterManagerNode = new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
 
         final DiscoveryNode actualNode = new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
         final DiscoveryNode bwcNode = new DiscoveryNode(
@@ -183,7 +183,13 @@ public class JoinTaskExecutorTests extends OpenSearchTestCase {
             actualNode.getVersion()
         );
         final ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
-            .nodes(DiscoveryNodes.builder().add(masterNode).localNodeId(masterNode.getId()).masterNodeId(masterNode.getId()).add(bwcNode))
+            .nodes(
+                DiscoveryNodes.builder()
+                    .add(clusterManagerNode)
+                    .localNodeId(clusterManagerNode.getId())
+                    .masterNodeId(clusterManagerNode.getId())
+                    .add(bwcNode)
+            )
             .build();
 
         final ClusterStateTaskExecutor.ClusterTasksResult<JoinTaskExecutor.Task> result = joinTaskExecutor.execute(

--- a/server/src/test/java/org/opensearch/cluster/coordination/NoMasterBlockServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/NoMasterBlockServiceTests.java
@@ -44,12 +44,12 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class NoMasterBlockServiceTests extends OpenSearchTestCase {
 
-    private NoMasterBlockService noMasterBlockService;
+    private NoMasterBlockService noClusterManagerBlockService;
     private ClusterSettings clusterSettings;
 
     private void createService(Settings settings) {
         clusterSettings = new ClusterSettings(settings, BUILT_IN_CLUSTER_SETTINGS);
-        noMasterBlockService = new NoMasterBlockService(settings, clusterSettings);
+        noClusterManagerBlockService = new NoMasterBlockService(settings, clusterSettings);
     }
 
     private void assertDeprecatedWarningEmitted() {
@@ -61,22 +61,22 @@ public class NoMasterBlockServiceTests extends OpenSearchTestCase {
 
     public void testBlocksWritesByDefault() {
         createService(Settings.EMPTY);
-        assertThat(noMasterBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_WRITES));
+        assertThat(noClusterManagerBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_WRITES));
     }
 
     public void testBlocksWritesIfConfiguredBySetting() {
         createService(Settings.builder().put(NO_CLUSTER_MANAGER_BLOCK_SETTING.getKey(), "write").build());
-        assertThat(noMasterBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_WRITES));
+        assertThat(noClusterManagerBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_WRITES));
     }
 
     public void testBlocksAllIfConfiguredBySetting() {
         createService(Settings.builder().put(NO_CLUSTER_MANAGER_BLOCK_SETTING.getKey(), "all").build());
-        assertThat(noMasterBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_ALL));
+        assertThat(noClusterManagerBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_ALL));
     }
 
     public void testBlocksMetadataWritesIfConfiguredBySetting() {
         createService(Settings.builder().put(NO_CLUSTER_MANAGER_BLOCK_SETTING.getKey(), "metadata_write").build());
-        assertThat(noMasterBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_METADATA_WRITES));
+        assertThat(noClusterManagerBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_METADATA_WRITES));
     }
 
     public void testRejectsInvalidSetting() {
@@ -88,12 +88,12 @@ public class NoMasterBlockServiceTests extends OpenSearchTestCase {
 
     public void testSettingCanBeUpdated() {
         createService(Settings.builder().put(NO_CLUSTER_MANAGER_BLOCK_SETTING.getKey(), "all").build());
-        assertThat(noMasterBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_ALL));
+        assertThat(noClusterManagerBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_ALL));
 
         clusterSettings.applySettings(Settings.builder().put(NO_CLUSTER_MANAGER_BLOCK_SETTING.getKey(), "write").build());
-        assertThat(noMasterBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_WRITES));
+        assertThat(noClusterManagerBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_WRITES));
 
         clusterSettings.applySettings(Settings.builder().put(NO_CLUSTER_MANAGER_BLOCK_SETTING.getKey(), "metadata_write").build());
-        assertThat(noMasterBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_METADATA_WRITES));
+        assertThat(noClusterManagerBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_METADATA_WRITES));
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/coordination/ReconfiguratorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/ReconfiguratorTests.java
@@ -223,8 +223,8 @@ public class ReconfiguratorTests extends OpenSearchTestCase {
         boolean autoShrinkVotingConfiguration,
         VotingConfiguration expectedConfig
     ) {
-        final DiscoveryNode master = liveNodes.stream().sorted(Comparator.comparing(DiscoveryNode::getId)).findFirst().get();
-        check(liveNodes, retired, master.getId(), config, autoShrinkVotingConfiguration, expectedConfig);
+        final DiscoveryNode clusterManager = liveNodes.stream().sorted(Comparator.comparing(DiscoveryNode::getId)).findFirst().get();
+        check(liveNodes, retired, clusterManager.getId(), config, autoShrinkVotingConfiguration, expectedConfig);
     }
 
     private void check(
@@ -239,14 +239,14 @@ public class ReconfiguratorTests extends OpenSearchTestCase {
             Settings.builder().put(CLUSTER_AUTO_SHRINK_VOTING_CONFIGURATION.getKey(), autoShrinkVotingConfiguration).build()
         );
 
-        final DiscoveryNode master = liveNodes.stream().filter(n -> n.getId().equals(masterId)).findFirst().get();
-        final VotingConfiguration adaptedConfig = reconfigurator.reconfigure(liveNodes, retired, master, config);
+        final DiscoveryNode clusterManager = liveNodes.stream().filter(n -> n.getId().equals(masterId)).findFirst().get();
+        final VotingConfiguration adaptedConfig = reconfigurator.reconfigure(liveNodes, retired, clusterManager, config);
         assertEquals(
             new ParameterizedMessage(
                 "[liveNodes={}, retired={}, master={}, config={}, autoShrinkVotingConfiguration={}]",
                 liveNodes,
                 retired,
-                master,
+                clusterManager,
                 config,
                 autoShrinkVotingConfiguration
             ).getFormattedMessage(),

--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodesTests.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodesTests.java
@@ -108,12 +108,12 @@ public class DiscoveryNodesTests extends OpenSearchTestCase {
         assertThat(discoveryNodes.resolveNodes(new String[0]), arrayContainingInAnyOrder(allNodes));
         assertThat(discoveryNodes.resolveNodes("_all"), arrayContainingInAnyOrder(allNodes));
 
-        final String[] nonMasterNodes = StreamSupport.stream(discoveryNodes.getNodes().values().spliterator(), false)
+        final String[] nonClusterManagerNodes = StreamSupport.stream(discoveryNodes.getNodes().values().spliterator(), false)
             .map(n -> n.value)
             .filter(n -> n.isMasterNode() == false)
             .map(DiscoveryNode::getId)
             .toArray(String[]::new);
-        assertThat(discoveryNodes.resolveNodes("_all", "master:false"), arrayContainingInAnyOrder(nonMasterNodes));
+        assertThat(discoveryNodes.resolveNodes("_all", "master:false"), arrayContainingInAnyOrder(nonClusterManagerNodes));
 
         assertThat(discoveryNodes.resolveNodes("master:false", "_all"), arrayContainingInAnyOrder(allNodes));
     }
@@ -254,18 +254,18 @@ public class DiscoveryNodesTests extends OpenSearchTestCase {
             nodesB.add(node);
         }
 
-        DiscoveryNode masterA = randomBoolean() ? null : RandomPicks.randomFrom(random(), nodesA);
-        DiscoveryNode masterB = randomBoolean() ? null : RandomPicks.randomFrom(random(), nodesB);
+        DiscoveryNode clusterManagerA = randomBoolean() ? null : RandomPicks.randomFrom(random(), nodesA);
+        DiscoveryNode clusterManagerB = randomBoolean() ? null : RandomPicks.randomFrom(random(), nodesB);
 
         DiscoveryNodes.Builder builderA = DiscoveryNodes.builder();
         nodesA.stream().forEach(builderA::add);
-        final String masterAId = masterA == null ? null : masterA.getId();
-        builderA.masterNodeId(masterAId);
+        final String clusterManagerAId = clusterManagerA == null ? null : clusterManagerA.getId();
+        builderA.masterNodeId(clusterManagerAId);
         builderA.localNodeId(RandomPicks.randomFrom(random(), nodesA).getId());
 
         DiscoveryNodes.Builder builderB = DiscoveryNodes.builder();
         nodesB.stream().forEach(builderB::add);
-        final String masterBId = masterB == null ? null : masterB.getId();
+        final String masterBId = clusterManagerB == null ? null : clusterManagerB.getId();
         builderB.masterNodeId(masterBId);
         builderB.localNodeId(RandomPicks.randomFrom(random(), nodesB).getId());
 
@@ -276,18 +276,18 @@ public class DiscoveryNodesTests extends OpenSearchTestCase {
 
         DiscoveryNodes.Delta delta = discoNodesB.delta(discoNodesA);
 
-        if (masterA == null) {
+        if (clusterManagerA == null) {
             assertThat(delta.previousMasterNode(), nullValue());
         } else {
-            assertThat(delta.previousMasterNode().getId(), equalTo(masterAId));
+            assertThat(delta.previousMasterNode().getId(), equalTo(clusterManagerAId));
         }
-        if (masterB == null) {
+        if (clusterManagerB == null) {
             assertThat(delta.newMasterNode(), nullValue());
         } else {
             assertThat(delta.newMasterNode().getId(), equalTo(masterBId));
         }
 
-        if (Objects.equals(masterAId, masterBId)) {
+        if (Objects.equals(clusterManagerAId, masterBId)) {
             assertFalse(delta.masterNodeChanged());
         } else {
             assertTrue(delta.masterNodeChanged());

--- a/server/src/test/java/org/opensearch/cluster/routing/OperationRoutingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/OperationRoutingTests.java
@@ -774,14 +774,14 @@ public class OperationRoutingTests extends OpenSearchTestCase {
             );
             allNodes[i++] = node;
         }
-        DiscoveryNode master = new DiscoveryNode(
+        DiscoveryNode clusterManager = new DiscoveryNode(
             "master",
             buildNewFakeTransportAddress(),
             Collections.emptyMap(),
             Collections.singleton(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE),
             Version.CURRENT
         );
-        allNodes[i] = master;
+        allNodes[i] = clusterManager;
         return allNodes;
     }
 

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -1222,7 +1222,7 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
             .build();
         RoutingTable initialRoutingTable = RoutingTable.builder().addAsNew(metadata.index("test")).build();
 
-        DiscoveryNode masterNode = new DiscoveryNode(
+        DiscoveryNode clusterManagerNode = new DiscoveryNode(
             "master",
             "master",
             buildNewFakeTransportAddress(),
@@ -1240,7 +1240,7 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
         );
         DiscoveryNodes.Builder discoveryNodesBuilder = DiscoveryNodes.builder().add(dataNode);
         if (randomBoolean()) {
-            discoveryNodesBuilder.add(masterNode);
+            discoveryNodesBuilder.add(clusterManagerNode);
         }
         DiscoveryNodes discoveryNodes = discoveryNodesBuilder.build();
 

--- a/server/src/test/java/org/opensearch/discovery/HandshakingTransportAddressConnectorTests.java
+++ b/server/src/test/java/org/opensearch/discovery/HandshakingTransportAddressConnectorTests.java
@@ -190,7 +190,7 @@ public class HandshakingTransportAddressConnectorTests extends OpenSearchTestCas
         }
     }
 
-    public void testDoesNotConnectToNonMasterNode() throws InterruptedException {
+    public void testDoesNotConnectToNonClusterManagerNode() throws InterruptedException {
         remoteNode = new DiscoveryNode("remote-node", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT);
         discoveryAddress = getDiscoveryAddress();
         remoteClusterName = "local-cluster";

--- a/server/src/test/java/org/opensearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/opensearch/env/NodeEnvironmentTests.java
@@ -566,10 +566,10 @@ public class NodeEnvironmentTests extends OpenSearchTestCase {
         verifyFailsOnMetadata(noDataNoMasterSettings, indexPath);
 
         // build settings using same path.data as original but without master role
-        Settings noMasterSettings = nonMasterNode(settings);
+        Settings noClusterManagerSettings = nonMasterNode(settings);
 
         // test that we can create master=false env regardless of data.
-        newNodeEnvironment(noMasterSettings).close();
+        newNodeEnvironment(noClusterManagerSettings).close();
 
         // test that we can create data=true, master=true env. Also remove state dir to leave only shard data for following asserts
         try (NodeEnvironment env = newNodeEnvironment(settings)) {

--- a/server/src/test/java/org/opensearch/env/NodeRepurposeCommandTests.java
+++ b/server/src/test/java/org/opensearch/env/NodeRepurposeCommandTests.java
@@ -75,18 +75,18 @@ import static org.hamcrest.Matchers.not;
 public class NodeRepurposeCommandTests extends OpenSearchTestCase {
 
     private static final Index INDEX = new Index("testIndex", "testUUID");
-    private Settings dataMasterSettings;
+    private Settings dataClusterManagerSettings;
     private Environment environment;
     private Path[] nodePaths;
-    private Settings dataNoMasterSettings;
-    private Settings noDataNoMasterSettings;
-    private Settings noDataMasterSettings;
+    private Settings dataNoClusterManagerSettings;
+    private Settings noDataNoClusterManagerSettings;
+    private Settings noDataClusterManagerSettings;
 
     @Before
     public void createNodePaths() throws IOException {
-        dataMasterSettings = buildEnvSettings(Settings.EMPTY);
-        environment = TestEnvironment.newEnvironment(dataMasterSettings);
-        try (NodeEnvironment nodeEnvironment = new NodeEnvironment(dataMasterSettings, environment)) {
+        dataClusterManagerSettings = buildEnvSettings(Settings.EMPTY);
+        environment = TestEnvironment.newEnvironment(dataClusterManagerSettings);
+        try (NodeEnvironment nodeEnvironment = new NodeEnvironment(dataClusterManagerSettings, environment)) {
             nodePaths = nodeEnvironment.nodeDataPaths();
             final String nodeId = randomAlphaOfLength(10);
             try (
@@ -95,36 +95,36 @@ public class NodeRepurposeCommandTests extends OpenSearchTestCase {
                     nodeId,
                     xContentRegistry(),
                     BigArrays.NON_RECYCLING_INSTANCE,
-                    new ClusterSettings(dataMasterSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+                    new ClusterSettings(dataClusterManagerSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
                     () -> 0L
                 ).createWriter()
             ) {
                 writer.writeFullStateAndCommit(1L, ClusterState.EMPTY_STATE);
             }
         }
-        dataNoMasterSettings = nonMasterNode(dataMasterSettings);
-        noDataNoMasterSettings = removeRoles(
-            dataMasterSettings,
+        dataNoClusterManagerSettings = nonMasterNode(dataClusterManagerSettings);
+        noDataNoClusterManagerSettings = removeRoles(
+            dataClusterManagerSettings,
             Collections.unmodifiableSet(new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE)))
         );
 
-        noDataMasterSettings = masterNode(nonDataNode(dataMasterSettings));
+        noDataClusterManagerSettings = masterNode(nonDataNode(dataClusterManagerSettings));
     }
 
     public void testEarlyExitNoCleanup() throws Exception {
-        createIndexDataFiles(dataMasterSettings, randomInt(10), randomBoolean());
+        createIndexDataFiles(dataClusterManagerSettings, randomInt(10), randomBoolean());
 
-        verifyNoQuestions(dataMasterSettings, containsString(NO_CLEANUP));
-        verifyNoQuestions(dataNoMasterSettings, containsString(NO_CLEANUP));
+        verifyNoQuestions(dataClusterManagerSettings, containsString(NO_CLEANUP));
+        verifyNoQuestions(dataNoClusterManagerSettings, containsString(NO_CLEANUP));
     }
 
     public void testNothingToCleanup() throws Exception {
-        verifyNoQuestions(noDataNoMasterSettings, containsString(NO_DATA_TO_CLEAN_UP_FOUND));
-        verifyNoQuestions(noDataMasterSettings, containsString(NO_SHARD_DATA_TO_CLEAN_UP_FOUND));
+        verifyNoQuestions(noDataNoClusterManagerSettings, containsString(NO_DATA_TO_CLEAN_UP_FOUND));
+        verifyNoQuestions(noDataClusterManagerSettings, containsString(NO_SHARD_DATA_TO_CLEAN_UP_FOUND));
 
-        Environment environment = TestEnvironment.newEnvironment(noDataMasterSettings);
+        Environment environment = TestEnvironment.newEnvironment(noDataClusterManagerSettings);
         if (randomBoolean()) {
-            try (NodeEnvironment env = new NodeEnvironment(noDataMasterSettings, environment)) {
+            try (NodeEnvironment env = new NodeEnvironment(noDataClusterManagerSettings, environment)) {
                 try (
                     PersistedClusterStateService.Writer writer = OpenSearchNodeCommand.createPersistedClusterStateService(
                         Settings.EMPTY,
@@ -136,19 +136,24 @@ public class NodeRepurposeCommandTests extends OpenSearchTestCase {
             }
         }
 
-        verifyNoQuestions(noDataNoMasterSettings, containsString(NO_DATA_TO_CLEAN_UP_FOUND));
-        verifyNoQuestions(noDataMasterSettings, containsString(NO_SHARD_DATA_TO_CLEAN_UP_FOUND));
+        verifyNoQuestions(noDataNoClusterManagerSettings, containsString(NO_DATA_TO_CLEAN_UP_FOUND));
+        verifyNoQuestions(noDataClusterManagerSettings, containsString(NO_SHARD_DATA_TO_CLEAN_UP_FOUND));
 
-        createIndexDataFiles(dataMasterSettings, 0, randomBoolean());
+        createIndexDataFiles(dataClusterManagerSettings, 0, randomBoolean());
 
-        verifyNoQuestions(noDataMasterSettings, containsString(NO_SHARD_DATA_TO_CLEAN_UP_FOUND));
+        verifyNoQuestions(noDataClusterManagerSettings, containsString(NO_SHARD_DATA_TO_CLEAN_UP_FOUND));
 
     }
 
     public void testLocked() throws IOException {
-        try (NodeEnvironment env = new NodeEnvironment(dataMasterSettings, TestEnvironment.newEnvironment(dataMasterSettings))) {
+        try (
+            NodeEnvironment env = new NodeEnvironment(
+                dataClusterManagerSettings,
+                TestEnvironment.newEnvironment(dataClusterManagerSettings)
+            )
+        ) {
             assertThat(
-                expectThrows(OpenSearchException.class, () -> verifyNoQuestions(noDataNoMasterSettings, null)).getMessage(),
+                expectThrows(OpenSearchException.class, () -> verifyNoQuestions(noDataNoClusterManagerSettings, null)).getMessage(),
                 containsString(NodeRepurposeCommand.FAILED_TO_OBTAIN_NODE_LOCK_MSG)
             );
         }
@@ -158,7 +163,7 @@ public class NodeRepurposeCommandTests extends OpenSearchTestCase {
         int shardCount = randomIntBetween(1, 10);
         boolean verbose = randomBoolean();
         boolean hasClusterState = randomBoolean();
-        createIndexDataFiles(dataMasterSettings, shardCount, hasClusterState);
+        createIndexDataFiles(dataClusterManagerSettings, shardCount, hasClusterState);
 
         String messageText = NodeRepurposeCommand.noMasterMessage(1, environment.dataFiles().length * shardCount, 0);
 
@@ -168,22 +173,22 @@ public class NodeRepurposeCommandTests extends OpenSearchTestCase {
             conditionalNot(containsString("no name for uuid: testUUID"), verbose == false || hasClusterState)
         );
 
-        verifyUnchangedOnAbort(noDataNoMasterSettings, outputMatcher, verbose);
+        verifyUnchangedOnAbort(noDataNoClusterManagerSettings, outputMatcher, verbose);
 
         // verify test setup
-        expectThrows(IllegalStateException.class, () -> new NodeEnvironment(noDataNoMasterSettings, environment).close());
+        expectThrows(IllegalStateException.class, () -> new NodeEnvironment(noDataNoClusterManagerSettings, environment).close());
 
-        verifySuccess(noDataNoMasterSettings, outputMatcher, verbose);
+        verifySuccess(noDataNoClusterManagerSettings, outputMatcher, verbose);
 
         // verify cleaned.
-        new NodeEnvironment(noDataNoMasterSettings, environment).close();
+        new NodeEnvironment(noDataNoClusterManagerSettings, environment).close();
     }
 
     public void testCleanupShardData() throws Exception {
         int shardCount = randomIntBetween(1, 10);
         boolean verbose = randomBoolean();
         boolean hasClusterState = randomBoolean();
-        createIndexDataFiles(dataMasterSettings, shardCount, hasClusterState);
+        createIndexDataFiles(dataClusterManagerSettings, shardCount, hasClusterState);
 
         Matcher<String> matcher = allOf(
             containsString(NodeRepurposeCommand.shardMessage(environment.dataFiles().length * shardCount, 1)),
@@ -192,15 +197,15 @@ public class NodeRepurposeCommandTests extends OpenSearchTestCase {
             conditionalNot(containsString("no name for uuid: testUUID"), verbose == false || hasClusterState)
         );
 
-        verifyUnchangedOnAbort(noDataMasterSettings, matcher, verbose);
+        verifyUnchangedOnAbort(noDataClusterManagerSettings, matcher, verbose);
 
         // verify test setup
-        expectThrows(IllegalStateException.class, () -> new NodeEnvironment(noDataMasterSettings, environment).close());
+        expectThrows(IllegalStateException.class, () -> new NodeEnvironment(noDataClusterManagerSettings, environment).close());
 
-        verifySuccess(noDataMasterSettings, matcher, verbose);
+        verifySuccess(noDataClusterManagerSettings, matcher, verbose);
 
         // verify clean.
-        new NodeEnvironment(noDataMasterSettings, environment).close();
+        new NodeEnvironment(noDataClusterManagerSettings, environment).close();
     }
 
     static void verifySuccess(Settings settings, Matcher<String> outputMatcher, boolean verbose) throws Exception {

--- a/server/src/test/java/org/opensearch/gateway/GatewayServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/GatewayServiceTests.java
@@ -129,13 +129,13 @@ public class GatewayServiceTests extends OpenSearchTestCase {
         GatewayService service = createService(Settings.builder());
         ClusterStateUpdateTask clusterStateUpdateTask = service.new RecoverStateUpdateTask();
         String nodeId = randomAlphaOfLength(10);
-        DiscoveryNode masterNode = DiscoveryNode.createLocal(
+        DiscoveryNode clusterManagerNode = DiscoveryNode.createLocal(
             settings(Version.CURRENT).put(masterNode()).build(),
             new TransportAddress(TransportAddress.META_ADDRESS, 9300),
             nodeId
         );
         ClusterState stateWithBlock = ClusterState.builder(ClusterName.DEFAULT)
-            .nodes(DiscoveryNodes.builder().localNodeId(nodeId).masterNodeId(nodeId).add(masterNode).build())
+            .nodes(DiscoveryNodes.builder().localNodeId(nodeId).masterNodeId(nodeId).add(clusterManagerNode).build())
             .blocks(ClusterBlocks.builder().addGlobalBlock(STATE_NOT_RECOVERED_BLOCK).build())
             .build();
 

--- a/server/src/test/java/org/opensearch/rest/action/admin/cluster/RestClusterHealthActionTests.java
+++ b/server/src/test/java/org/opensearch/rest/action/admin/cluster/RestClusterHealthActionTests.java
@@ -52,7 +52,7 @@ public class RestClusterHealthActionTests extends OpenSearchTestCase {
         Map<String, String> params = new HashMap<>();
         String index = "index";
         boolean local = randomBoolean();
-        String masterTimeout = randomTimeValue();
+        String clusterManagerTimeout = randomTimeValue();
         String timeout = randomTimeValue();
         ClusterHealthStatus waitForStatus = randomFrom(ClusterHealthStatus.values());
         boolean waitForNoRelocatingShards = randomBoolean();
@@ -63,7 +63,7 @@ public class RestClusterHealthActionTests extends OpenSearchTestCase {
 
         params.put("index", index);
         params.put("local", String.valueOf(local));
-        params.put("master_timeout", masterTimeout);
+        params.put("master_timeout", clusterManagerTimeout);
         params.put("timeout", timeout);
         params.put("wait_for_status", waitForStatus.name());
         if (waitForNoRelocatingShards || randomBoolean()) {
@@ -81,7 +81,7 @@ public class RestClusterHealthActionTests extends OpenSearchTestCase {
         assertThat(clusterHealthRequest.indices().length, equalTo(1));
         assertThat(clusterHealthRequest.indices()[0], equalTo(index));
         assertThat(clusterHealthRequest.local(), equalTo(local));
-        assertThat(clusterHealthRequest.masterNodeTimeout(), equalTo(TimeValue.parseTimeValue(masterTimeout, "test")));
+        assertThat(clusterHealthRequest.masterNodeTimeout(), equalTo(TimeValue.parseTimeValue(clusterManagerTimeout, "test")));
         assertThat(clusterHealthRequest.timeout(), equalTo(TimeValue.parseTimeValue(timeout, "test")));
         assertThat(clusterHealthRequest.waitForStatus(), equalTo(waitForStatus));
         assertThat(clusterHealthRequest.waitForNoRelocatingShards(), equalTo(waitForNoRelocatingShards));

--- a/server/src/test/java/org/opensearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/opensearch/transport/RemoteClusterServiceTests.java
@@ -553,11 +553,11 @@ public class RemoteClusterServiceTests extends OpenSearchTestCase {
         final Settings settings = Settings.EMPTY;
         final List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
         final Settings data = nonMasterNode();
-        final Settings dedicatedMaster = masterOnlyNode();
+        final Settings dedicatedClusterManager = masterOnlyNode();
         try (
-            MockTransportService c1N1 = startTransport("cluster_1_node_1", knownNodes, Version.CURRENT, dedicatedMaster);
+            MockTransportService c1N1 = startTransport("cluster_1_node_1", knownNodes, Version.CURRENT, dedicatedClusterManager);
             MockTransportService c1N2 = startTransport("cluster_1_node_2", knownNodes, Version.CURRENT, data);
-            MockTransportService c2N1 = startTransport("cluster_2_node_1", knownNodes, Version.CURRENT, dedicatedMaster);
+            MockTransportService c2N1 = startTransport("cluster_2_node_1", knownNodes, Version.CURRENT, dedicatedClusterManager);
             MockTransportService c2N2 = startTransport("cluster_2_node_2", knownNodes, Version.CURRENT, data)
         ) {
             final DiscoveryNode c1N1Node = c1N1.getLocalDiscoNode();

--- a/server/src/test/java/org/opensearch/transport/SniffConnectionStrategyTests.java
+++ b/server/src/test/java/org/opensearch/transport/SniffConnectionStrategyTests.java
@@ -773,14 +773,14 @@ public class SniffConnectionStrategyTests extends OpenSearchTestCase {
             assertTrue(nodePredicate.test(dedicatedIngest));
         }
         {
-            DiscoveryNode masterIngest = new DiscoveryNode(
+            DiscoveryNode clusterManagerIngest = new DiscoveryNode(
                 "id",
                 address,
                 Collections.emptyMap(),
                 new HashSet<>(Arrays.asList(DiscoveryNodeRole.INGEST_ROLE, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE)),
                 Version.CURRENT
             );
-            assertTrue(nodePredicate.test(masterIngest));
+            assertTrue(nodePredicate.test(clusterManagerIngest));
         }
         {
             DiscoveryNode dedicatedData = new DiscoveryNode(


### PR DESCRIPTION
### Description
- Replace the non-inclusive terminology "master" with "cluster manager" in code comments, internal variable/method/class names, in `server/src/test` directory.
- Backwards compatibility is not impacted.
- The PR is split from https://github.com/opensearch-project/OpenSearch/pull/2150

Replacement rules:
- `master` -> `cluster_manager` or `clusterManager` (variable name) or `cluster-manager` (code comment)
- `Master` -> `ClusterManager`
 
### Issues Resolved
A part of #1548 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
