### PR TITLE
Enable merge on refresh and merge on commit on Opensearch

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -187,7 +187,8 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.FINAL_PIPELINE,
                 MetadataIndexStateService.VERIFIED_BEFORE_CLOSE_SETTING,
                 ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING,
-                IndexSettings.INDEX_MAX_FULL_FLUSH_MERGE,
+                IndexSettings.INDEX_MERGE_ON_FLUSH_ENABLED,
+                IndexSettings.INDEX_MERGE_ON_FLUSH_MAX_FULL_FLUSH_MERGE_WAIT_TIME,
 
                 // validate that built-in similarities don't get redefined
                 Setting.groupSetting("index.similarity.", (s) -> {

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -187,7 +187,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.FINAL_PIPELINE,
                 MetadataIndexStateService.VERIFIED_BEFORE_CLOSE_SETTING,
                 ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING,
-                IndexSettings.INDEX_MAX_FULL_FLASH_MERGE,
+                IndexSettings.INDEX_MAX_FULL_FLUSH_MERGE,
 
                 // validate that built-in similarities don't get redefined
                 Setting.groupSetting("index.similarity.", (s) -> {

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -187,6 +187,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.FINAL_PIPELINE,
                 MetadataIndexStateService.VERIFIED_BEFORE_CLOSE_SETTING,
                 ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING,
+                IndexSettings.INDEX_MAX_FULL_FLASH_MERGE,
 
                 // validate that built-in similarities don't get redefined
                 Setting.groupSetting("index.similarity.", (s) -> {

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -511,7 +511,7 @@ public final class IndexSettings {
      */
     public static final Setting<TimeValue> INDEX_MERGE_ON_FLUSH_MAX_FULL_FLUSH_MERGE_WAIT_TIME = Setting.timeSetting(
         "index.merge_on_flush.max_full_flush_merge_wait_time",
-        new TimeValue(0, TimeUnit.MILLISECONDS),
+        new TimeValue(10, TimeUnit.SECONDS),
         new TimeValue(0, TimeUnit.MILLISECONDS),
         Property.Dynamic,
         Property.IndexScope
@@ -608,7 +608,10 @@ public final class IndexSettings {
     /**
      * The max amount of time to wait for merges
      */
-    private volatile TimeValue maxFullFlushMerge;
+    private volatile TimeValue maxFullFlushMergeWaitTime;
+    /**
+     * Is merge of flush enabled or not
+     */
     private volatile boolean mergeOnFlushEnabled;
 
     /**
@@ -723,7 +726,7 @@ public final class IndexSettings {
         mappingTotalFieldsLimit = scopedSettings.get(INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING);
         mappingDepthLimit = scopedSettings.get(INDEX_MAPPING_DEPTH_LIMIT_SETTING);
         mappingFieldNameLengthLimit = scopedSettings.get(INDEX_MAPPING_FIELD_NAME_LENGTH_LIMIT_SETTING);
-        maxFullFlushMerge = scopedSettings.get(INDEX_MERGE_ON_FLUSH_MAX_FULL_FLUSH_MERGE_WAIT_TIME);
+        maxFullFlushMergeWaitTime = scopedSettings.get(INDEX_MERGE_ON_FLUSH_MAX_FULL_FLUSH_MERGE_WAIT_TIME);
         mergeOnFlushEnabled = scopedSettings.get(INDEX_MERGE_ON_FLUSH_ENABLED);
 
         scopedSettings.addSettingsUpdateConsumer(MergePolicyConfig.INDEX_COMPOUND_FORMAT_SETTING, mergePolicyConfig::setNoCFSRatio);
@@ -794,7 +797,7 @@ public final class IndexSettings {
         scopedSettings.addSettingsUpdateConsumer(INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING, this::setMappingTotalFieldsLimit);
         scopedSettings.addSettingsUpdateConsumer(INDEX_MAPPING_DEPTH_LIMIT_SETTING, this::setMappingDepthLimit);
         scopedSettings.addSettingsUpdateConsumer(INDEX_MAPPING_FIELD_NAME_LENGTH_LIMIT_SETTING, this::setMappingFieldNameLengthLimit);
-        scopedSettings.addSettingsUpdateConsumer(INDEX_MERGE_ON_FLUSH_MAX_FULL_FLUSH_MERGE_WAIT_TIME, this::setMaxFullFlushMerge);
+        scopedSettings.addSettingsUpdateConsumer(INDEX_MERGE_ON_FLUSH_MAX_FULL_FLUSH_MERGE_WAIT_TIME, this::setMaxFullFlushMergeWaitTime);
         scopedSettings.addSettingsUpdateConsumer(INDEX_MERGE_ON_FLUSH_ENABLED, this::setMergeOnFlushEnabled);
     }
 
@@ -1360,16 +1363,16 @@ public final class IndexSettings {
         this.mappingFieldNameLengthLimit = value;
     }
 
-    private void setMaxFullFlushMerge(TimeValue timeValue) {
-        this.maxFullFlushMerge = timeValue;
+    private void setMaxFullFlushMergeWaitTime(TimeValue timeValue) {
+        this.maxFullFlushMergeWaitTime = timeValue;
     }
 
     private void setMergeOnFlushEnabled(boolean enabled) {
         this.mergeOnFlushEnabled = enabled;
     }
 
-    public TimeValue getMaxFullFlushMerge() {
-        return this.maxFullFlushMerge;
+    public TimeValue getMaxFullFlushMergeWaitTime() {
+        return this.maxFullFlushMergeWaitTime;
     }
 
     public boolean isMergeOnFlushEnabled() {

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -509,7 +509,7 @@ public final class IndexSettings {
      * If this time is reached, we proceed with the commit based on segments merged up to that point. The merges are not
      * aborted, and will still run to completion independent of the commit or getReader call, like natural segment merges.
      */
-    public static final Setting<TimeValue> INDEX_MAX_FULL_FLASH_MERGE = Setting.timeSetting(
+    public static final Setting<TimeValue> INDEX_MAX_FULL_FLUSH_MERGE = Setting.timeSetting(
         "index.max_full_flush_merge",
         new TimeValue(0, TimeUnit.MILLISECONDS),
         new TimeValue(0, TimeUnit.MILLISECONDS),
@@ -715,7 +715,7 @@ public final class IndexSettings {
         mappingTotalFieldsLimit = scopedSettings.get(INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING);
         mappingDepthLimit = scopedSettings.get(INDEX_MAPPING_DEPTH_LIMIT_SETTING);
         mappingFieldNameLengthLimit = scopedSettings.get(INDEX_MAPPING_FIELD_NAME_LENGTH_LIMIT_SETTING);
-        maxFullFlushMerge = scopedSettings.get(INDEX_MAX_FULL_FLASH_MERGE);
+        maxFullFlushMerge = scopedSettings.get(INDEX_MAX_FULL_FLUSH_MERGE);
 
         scopedSettings.addSettingsUpdateConsumer(MergePolicyConfig.INDEX_COMPOUND_FORMAT_SETTING, mergePolicyConfig::setNoCFSRatio);
         scopedSettings.addSettingsUpdateConsumer(
@@ -785,7 +785,7 @@ public final class IndexSettings {
         scopedSettings.addSettingsUpdateConsumer(INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING, this::setMappingTotalFieldsLimit);
         scopedSettings.addSettingsUpdateConsumer(INDEX_MAPPING_DEPTH_LIMIT_SETTING, this::setMappingDepthLimit);
         scopedSettings.addSettingsUpdateConsumer(INDEX_MAPPING_FIELD_NAME_LENGTH_LIMIT_SETTING, this::setMappingFieldNameLengthLimit);
-        scopedSettings.addSettingsUpdateConsumer(INDEX_MAX_FULL_FLASH_MERGE, this::setMaxFullFlushMerge);
+        scopedSettings.addSettingsUpdateConsumer(INDEX_MAX_FULL_FLUSH_MERGE, this::setMaxFullFlushMerge);
     }
 
     private void setSearchIdleAfter(TimeValue searchIdleAfter) {

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -2428,7 +2428,7 @@ public class InternalEngine extends Engine {
         }
 
         if (config().getIndexSettings().isMergeOnFlushEnabled()) {
-            final long maxFullFlushMergeWaitMillis = config().getIndexSettings().getMaxFullFlushMerge().millis();
+            final long maxFullFlushMergeWaitMillis = config().getIndexSettings().getMaxFullFlushMergeWaitTime().millis();
             if (maxFullFlushMergeWaitMillis > 0) {
                 iwc.setMaxFullFlushMergeWaitMillis(maxFullFlushMergeWaitMillis);
                 mergePolicy = new MergeOnFlushMergePolicy(mergePolicy);

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -2427,10 +2427,18 @@ public class InternalEngine extends Engine {
             mergePolicy = new ShuffleForcedMergePolicy(mergePolicy);
         }
 
-        final long maxFullFlushMergeWaitMillis = config().getIndexSettings().getMaxFullFlushMerge().millis();
-        if (maxFullFlushMergeWaitMillis > 0) {
-            iwc.setMaxFullFlushMergeWaitMillis(maxFullFlushMergeWaitMillis);
-            mergePolicy = new MergeOnFlushMergePolicy(mergePolicy);
+        if (config().getIndexSettings().isMergeOnFlushEnabled()) {
+            final long maxFullFlushMergeWaitMillis = config().getIndexSettings().getMaxFullFlushMerge().millis();
+            if (maxFullFlushMergeWaitMillis > 0) {
+                iwc.setMaxFullFlushMergeWaitMillis(maxFullFlushMergeWaitMillis);
+                mergePolicy = new MergeOnFlushMergePolicy(mergePolicy);
+            } else {
+                logger.warn(
+                    "The {} is enabled but {} is set to 0, merge on flush will not be activated",
+                    IndexSettings.INDEX_MERGE_ON_FLUSH_ENABLED.getKey(),
+                    IndexSettings.INDEX_MERGE_ON_FLUSH_MAX_FULL_FLUSH_MERGE_WAIT_TIME.getKey()
+                );
+            }
         }
 
         iwc.setMergePolicy(new OpenSearchMergePolicy(mergePolicy));

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -50,6 +50,7 @@ import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.ShuffleForcedMergePolicy;
 import org.apache.lucene.index.SoftDeletesRetentionMergePolicy;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.sandbox.index.MergeOnFlushMergePolicy;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -2425,6 +2426,13 @@ public class InternalEngine extends Engine {
             // to enable it.
             mergePolicy = new ShuffleForcedMergePolicy(mergePolicy);
         }
+
+        final long maxFullFlushMergeWaitMillis = config().getIndexSettings().getMaxFullFlushMerge().millis();
+        if (maxFullFlushMergeWaitMillis > 0) {
+            iwc.setMaxFullFlushMergeWaitMillis(maxFullFlushMergeWaitMillis);
+            mergePolicy = new MergeOnFlushMergePolicy(mergePolicy);
+        }
+
         iwc.setMergePolicy(new OpenSearchMergePolicy(mergePolicy));
         iwc.setSimilarity(engineConfig.getSimilarity());
         iwc.setRAMBufferSizeMB(engineConfig.getIndexingBufferSize().getMbFrac());

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -494,6 +494,138 @@ public class InternalEngineTests extends EngineTestCase {
         }
     }
 
+    public void testMergeSegmentsOnCommit() throws Exception {
+        final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+
+        final Settings.Builder settings = Settings.builder()
+            .put(defaultSettings.getSettings())
+            .put(IndexSettings.INDEX_MAX_FULL_FLASH_MERGE.getKey(), TimeValue.timeValueMillis(5000));
+        final IndexMetadata indexMetadata = IndexMetadata.builder(defaultSettings.getIndexMetadata()).settings(settings).build();
+        final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(indexMetadata);
+
+        try (
+            Store store = createStore();
+            InternalEngine engine = createEngine(
+                config(indexSettings, store, createTempDir(), NoMergePolicy.INSTANCE, null, null, globalCheckpoint::get)
+            )
+        ) {
+            assertThat(engine.segments(false), empty());
+            int numDocsFirstSegment = randomIntBetween(5, 50);
+            Set<String> liveDocsFirstSegment = new HashSet<>();
+            for (int i = 0; i < numDocsFirstSegment; i++) {
+                String id = Integer.toString(i);
+                ParsedDocument doc = testParsedDocument(id, null, testDocument(), B_1, null);
+                engine.index(indexForDoc(doc));
+                liveDocsFirstSegment.add(id);
+            }
+            engine.refresh("test");
+            List<Segment> segments = engine.segments(randomBoolean());
+            assertThat(segments, hasSize(1));
+            assertThat(segments.get(0).getNumDocs(), equalTo(liveDocsFirstSegment.size()));
+            assertThat(segments.get(0).getDeletedDocs(), equalTo(0));
+            assertFalse(segments.get(0).committed);
+            int deletes = 0;
+            int updates = 0;
+            int appends = 0;
+            int iterations = scaledRandomIntBetween(1, 50);
+            for (int i = 0; i < iterations && liveDocsFirstSegment.isEmpty() == false; i++) {
+                String idToUpdate = randomFrom(liveDocsFirstSegment);
+                liveDocsFirstSegment.remove(idToUpdate);
+                ParsedDocument doc = testParsedDocument(idToUpdate, null, testDocument(), B_1, null);
+                if (randomBoolean()) {
+                    engine.delete(new Engine.Delete(doc.id(), newUid(doc), primaryTerm.get()));
+                    deletes++;
+                } else {
+                    engine.index(indexForDoc(doc));
+                    updates++;
+                }
+                if (randomBoolean()) {
+                    engine.index(indexForDoc(testParsedDocument(UUIDs.randomBase64UUID(), null, testDocument(), B_1, null)));
+                    appends++;
+                }
+            }
+
+            boolean committed = randomBoolean();
+            if (committed) {
+                engine.flush();
+            }
+
+            engine.refresh("test");
+            segments = engine.segments(randomBoolean());
+
+            // All segments have to be merged into one
+            assertThat(segments, hasSize(1));
+            assertThat(segments.get(0).getNumDocs(), equalTo(numDocsFirstSegment + appends - deletes));
+            assertThat(segments.get(0).getDeletedDocs(), equalTo(0));
+            assertThat(segments.get(0).committed, equalTo(committed));
+        }
+    }
+
+    // this test writes documents to the engine while concurrently flushing/commit
+    public void testConcurrentMergeSegmentsOnCommit() throws Exception {
+        final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+
+        final Settings.Builder settings = Settings.builder()
+            .put(defaultSettings.getSettings())
+            .put(IndexSettings.INDEX_MAX_FULL_FLASH_MERGE.getKey(), TimeValue.timeValueMillis(5000));
+        final IndexMetadata indexMetadata = IndexMetadata.builder(defaultSettings.getIndexMetadata()).settings(settings).build();
+        final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(indexMetadata);
+
+        try (
+            Store store = createStore();
+            InternalEngine engine = createEngine(
+                config(indexSettings, store, createTempDir(), NoMergePolicy.INSTANCE, null, null, globalCheckpoint::get)
+            )
+        ) {
+            final int numIndexingThreads = scaledRandomIntBetween(3, 8);
+            final int numDocsPerThread = randomIntBetween(500, 1000);
+            final CyclicBarrier barrier = new CyclicBarrier(numIndexingThreads + 1);
+            final List<Thread> indexingThreads = new ArrayList<>();
+            final CountDownLatch doneLatch = new CountDownLatch(numIndexingThreads);
+            // create N indexing threads to index documents simultaneously
+            for (int threadNum = 0; threadNum < numIndexingThreads; threadNum++) {
+                final int threadIdx = threadNum;
+                Thread indexingThread = new Thread(() -> {
+                    try {
+                        barrier.await(); // wait for all threads to start at the same time
+                        // index random number of docs
+                        for (int i = 0; i < numDocsPerThread; i++) {
+                            final String id = "thread" + threadIdx + "#" + i;
+                            ParsedDocument doc = testParsedDocument(id, null, testDocument(), B_1, null);
+                            engine.index(indexForDoc(doc));
+                        }
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    } finally {
+                        doneLatch.countDown();
+                    }
+
+                });
+                indexingThreads.add(indexingThread);
+            }
+
+            // start the indexing threads
+            for (Thread thread : indexingThreads) {
+                thread.start();
+            }
+            barrier.await(); // wait for indexing threads to all be ready to start
+            assertThat(doneLatch.await(10, TimeUnit.SECONDS), is(true));
+
+            boolean committed = randomBoolean();
+            if (committed) {
+                engine.flush();
+            }
+
+            engine.refresh("test");
+            List<Segment> segments = engine.segments(randomBoolean());
+
+            // All segments have to be merged into one
+            assertThat(segments, hasSize(1));
+            assertThat(segments.get(0).getNumDocs(), equalTo(numIndexingThreads * numDocsPerThread));
+            assertThat(segments.get(0).committed, equalTo(committed));
+        }
+    }
+
     public void testCommitStats() throws IOException {
         final AtomicLong maxSeqNo = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         final AtomicLong localCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -499,7 +499,7 @@ public class InternalEngineTests extends EngineTestCase {
 
         final Settings.Builder settings = Settings.builder()
             .put(defaultSettings.getSettings())
-            .put(IndexSettings.INDEX_MAX_FULL_FLASH_MERGE.getKey(), TimeValue.timeValueMillis(5000));
+            .put(IndexSettings.INDEX_MAX_FULL_FLUSH_MERGE.getKey(), TimeValue.timeValueMillis(5000));
         final IndexMetadata indexMetadata = IndexMetadata.builder(defaultSettings.getIndexMetadata()).settings(settings).build();
         final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(indexMetadata);
 
@@ -567,7 +567,7 @@ public class InternalEngineTests extends EngineTestCase {
 
         final Settings.Builder settings = Settings.builder()
             .put(defaultSettings.getSettings())
-            .put(IndexSettings.INDEX_MAX_FULL_FLASH_MERGE.getKey(), TimeValue.timeValueMillis(5000));
+            .put(IndexSettings.INDEX_MAX_FULL_FLUSH_MERGE.getKey(), TimeValue.timeValueMillis(5000));
         final IndexMetadata indexMetadata = IndexMetadata.builder(defaultSettings.getIndexMetadata()).settings(settings).build();
         final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(indexMetadata);
 


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Enable merge on refresh and merge on commit on Opensearch. Luckily, Apache Lucene 9.1 introduces `MergeOnFlushMergePolicy` which we could use from now on, activated by `index.max_full_flush_merge` (expert) index setting. The experiments I have done using [1] and `pmc` track shows significant reduction of the segments for a price of more merges:

```
./rally race    --track pmc      --target-hosts localhost:9200     --pipeline benchmark-only     --kill-running-processes --exclude-tasks="force-merge,refresh-after-force-merge,wait-until-merges-finish"
```

**Baseline**: 2.0.0-SNAPSHOT
**Contender**: 2.0.0-SNAPSHOT +  "index.max_full_flush_merge": "10s"

|                                                        Metric |                          Task |    Baseline |   Contender |     Diff |    Unit |   Diff % |
|--------------------------------------------------------------:|------------------------------:|------------:|------------:|---------:|--------:|---------:|
...
|                       Cumulative merge time of primary shards |                               |     33.7391 |     63.6844 |  29.9452 |     min |  +88.76% |
|                      Cumulative merge count of primary shards |                               |          58 |         180 |      122 |         | +210.34% |
...
|                                                 Segment count |                               |         133 |          43 |      -90 |         |  -67.67% |
...


|                                                        Metric |                          Task |    Baseline |   Contender |     Diff |    Unit |   Diff % |
|--------------------------------------------------------------:|------------------------------:|------------:|------------:|---------:|--------:|---------:|
...
|                       Cumulative merge time of primary shards |                               |     37.8788 |     61.7903 |  23.9114 |     min |  +63.13% |
|                      Cumulative merge count of primary shards |                               |          65 |         175 |      110 |         | +169.23% |
...
|                                                 Segment count |                               |         129 |          42 |      -87 |         |  -67.44% |
...

[1] https://github.com/opensearch-project/opensearch-benchmark
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/1345
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
