### PR TITLE
Updating repository commons logging version

### DIFF
--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -68,7 +68,7 @@ dependencies {
   api 'com.google.code.gson:gson:2.9.0'
   runtimeOnly 'com.google.guava:guava:30.1.1-jre'
   api 'com.google.protobuf:protobuf-java:3.19.3'
-  api 'commons-logging:commons-logging:1.1.3'
+  api "commons-logging:commons-logging:${versions.commonslogging}"
   api 'commons-cli:commons-cli:1.2'
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api 'commons-collections:commons-collections:3.2.2'


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Updating repository commons logging version to use central versioning system by OpenSearch.
This also solves the problem of Jar hell when https://github.com/dependabot is trying to upgrade commons-logging.

Ref: https://github.com/opensearch-project/OpenSearch/pull/2388#issuecomment-1073125291
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
