### PR TITLE
[Backport] [1.x] ignore_malformed parameter on ip_range data_type throws mapper_parsing_exception (#2429)

### DIFF
--- a/server/src/test/java/org/opensearch/index/mapper/IpRangeFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/IpRangeFieldMapperTests.java
@@ -33,6 +33,7 @@ package org.opensearch.index.mapper;
 
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
+import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.Strings;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.compress.CompressedXContent;
@@ -40,10 +41,13 @@ import org.opensearch.common.network.InetAddresses;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.index.IndexService;
+import org.opensearch.index.termvectors.TermVectorsService;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 import org.junit.Before;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -76,15 +80,7 @@ public class IpRangeFieldMapperTests extends OpenSearchSingleNodeTestCase {
         cases.put("192.168.0.0/16", "192.168.255.255");
         cases.put("192.168.0.0/17", "192.168.127.255");
         for (final Map.Entry<String, String> entry : cases.entrySet()) {
-            ParsedDocument doc = mapper.parse(
-                new SourceToParse(
-                    "test",
-                    "type",
-                    "1",
-                    BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("field", entry.getKey()).endObject()),
-                    XContentType.JSON
-                )
-            );
+            ParsedDocument doc = mapper.parse(source(b -> b.field("field", entry.getKey())));
             IndexableField[] fields = doc.rootDoc().getFields("field");
             assertEquals(3, fields.length);
             IndexableField dvField = fields[0];
@@ -98,5 +94,88 @@ public class IpRangeFieldMapperTests extends OpenSearchSingleNodeTestCase {
                 + InetAddresses.toAddrString(InetAddresses.forString(entry.getValue()));
             assertThat(storedField.stringValue(), containsString(strVal));
         }
+
+        // Use alternative form to populate the value:
+        //
+        // {
+        // "field": {
+        // "gte": "192.168.1.10",
+        // "lte": "192.168.1.15"
+        // }
+        // }
+        final Map<String, String> params = new HashMap<>();
+        params.put("gte", "192.168.1.1");
+        params.put("lte", "192.168.1.15");
+
+        final ParsedDocument doc = mapper.parse(source(b -> b.field("field", params)));
+        final IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(3, fields.length);
+
+        final IndexableField storedField = fields[2];
+        assertThat(storedField.stringValue(), containsString("192.168.1.1 : 192.168.1.15"));
+    }
+
+    public void testIgnoreMalformed() throws Exception {
+        final DocumentMapper mapper = parser.parse(
+            "type",
+            new CompressedXContent(
+                Strings.toString(
+                    XContentFactory.jsonBuilder()
+                        .startObject()
+                        .startObject("type")
+                        .startObject("properties")
+                        .startObject("field")
+                        .field("type", "ip_range")
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                )
+            )
+        );
+
+        final ThrowingRunnable runnable = () -> mapper.parse(source(b -> b.field("field", ":1")));
+        final MapperParsingException e = expectThrows(MapperParsingException.class, runnable);
+        assertThat(e.getCause().getMessage(), containsString("Expected [ip/prefix] but was [:1]"));
+
+        final DocumentMapper mapper2 = parser.parse(
+            "type",
+            new CompressedXContent(
+                Strings.toString(
+                    XContentFactory.jsonBuilder()
+                        .startObject()
+                        .startObject("type")
+                        .startObject("properties")
+                        .startObject("field")
+                        .field("type", "ip_range")
+                        .field("ignore_malformed", true)
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                )
+            )
+        );
+
+        ParsedDocument doc = mapper2.parse(source(b -> b.field("field", ":1")));
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(0, fields.length);
+        assertArrayEquals(new String[] { "field" }, TermVectorsService.getValues(doc.rootDoc().getFields("_ignored")));
+
+        final Map<String, String> params = new HashMap<>();
+        params.put("gte", "x.x.x.x");
+        params.put("lte", "192.168.1.15");
+
+        doc = mapper2.parse(source(b -> b.field("field", params)));
+        fields = doc.rootDoc().getFields("field");
+        assertEquals(0, fields.length);
+        assertArrayEquals(new String[] { "field" }, TermVectorsService.getValues(doc.rootDoc().getFields("_ignored")));
+    }
+
+    private final SourceToParse source(CheckedConsumer<XContentBuilder, IOException> build) throws IOException {
+        XContentBuilder builder = JsonXContent.contentBuilder().startObject();
+        build.accept(builder);
+        builder.endObject();
+        return new SourceToParse("test", "_doc", "1", BytesReference.bytes(builder), XContentType.JSON);
     }
 }


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Backport of https://github.com/opensearch-project/OpenSearch/pull/2429 to 1.x
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/1873
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
