### PR TITLE
[Bug] Fix InboundDecoder version compat check

### DIFF
--- a/server/src/main/java/org/opensearch/transport/InboundDecoder.java
+++ b/server/src/main/java/org/opensearch/transport/InboundDecoder.java
@@ -217,7 +217,7 @@ public class InboundDecoder implements Releasable {
         // handshake. This looks odd but it's required to establish the connection correctly we check for real compatibility
         // once the connection is established
         final Version compatibilityVersion = isHandshake ? currentVersion.minimumCompatibilityVersion() : currentVersion;
-        if ((currentVersion.equals(Version.V_2_0_0) && remoteVersion.equals(Version.fromId(6079999))) == false
+        if ((currentVersion.onOrAfter(Version.V_2_0_0) && remoteVersion.equals(Version.fromId(6079999))) == false
             && remoteVersion.isCompatible(compatibilityVersion) == false) {
             final Version minCompatibilityVersion = isHandshake ? compatibilityVersion : compatibilityVersion.minimumCompatibilityVersion();
             String msg = "Received " + (isHandshake ? "handshake " : "") + "message from unsupported version: [";


### PR DESCRIPTION
Change InboundDecoder `ensureVersionCompatibility` check for `onOrAfter`
`V_2_0_0` instead of explicit 2.0 check. This way bug fix and minor
versions will correctly handshake in a mixed 1.x Cluster.
