### PR TITLE
Fix build-tools/reaper source/target compatibility to be JDK-11

### DIFF
--- a/buildSrc/reaper/build.gradle
+++ b/buildSrc/reaper/build.gradle
@@ -11,6 +11,9 @@
 
 apply plugin: 'java'
 
+targetCompatibility = JavaVersion.VERSION_11
+sourceCompatibility = JavaVersion.VERSION_11
+
 jar {
   archiveFileName = "${project.name}.jar"
   manifest {


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Fix build-tools/reaper source/target compatibility to be JDK-11
 
### Issues Resolved
Fixes https://github.com/opensearch-project/OpenSearch/issues/2581
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
