### PR TITLE
Exclude man page symlink in distribution

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -420,6 +420,7 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
         }
         from project.jdks."bundled_${platform}_${architecture}"
         exclude "demo/**"
+        exclude "man/ja/**"
         /*
          * The Contents/MacOS directory interferes with notarization, and is unused by our distribution, so we exclude
          * it from the build.


### PR DESCRIPTION
This is a short-term solution to unblock the build process for the 1.3
release. A tool used in that process (cpio) is failing on a symlink in
the JDK man pages, so this is a hack to just remove that symlink. See
issue #2517 for more details.

Signed-off-by: Andrew Ross <andrross@amazon.com>

### Issues Resolved
#2517
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
