### PR TITLE
[Type Removal] Add mapping method referenced in other repos

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequest.java
@@ -249,10 +249,18 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
      * Adds mapping that will be added when the index gets created.
      *
      * @param source The mapping source
-     * @param xContentType the content type of the mapping source
-     * @deprecated types are being removed
+     * @param xContentType The content type of the source
      */
-    @Deprecated
+    public CreateIndexRequest mapping(String source, XContentType xContentType) {
+        return mapping(new BytesArray(source), xContentType);
+    }
+
+    /**
+     * Adds mapping that will be added when the index gets created.
+     *
+     * @param source The mapping source
+     * @param xContentType the content type of the mapping source
+     */
     private CreateIndexRequest mapping(BytesReference source, XContentType xContentType) {
         Objects.requireNonNull(xContentType);
         Map<String, Object> mappingAsMap = XContentHelper.convertToMap(source, false, xContentType).v2();


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Add mapping method back; removed earlier as part of `remove mapping types` effort. The method was removed [here](https://github.com/opensearch-project/OpenSearch/commit/b619a050bf1048d3edc7b80dd05801a89698ccf1#diff-403b4373119da8105496a50962025139b4031c2900205987d4e374c439e0407c). It is used in [dashboard-reports ](https://github.com/opensearch-project/dashboards-reports/blob/main/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/index/ReportDefinitionsIndex.kt#L68) repo and probably others. 

Related: #1940 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
