### PR TITLE
Fix Segment Replication integ tests

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -8,13 +8,29 @@
 
 package org.opensearch.indices.replication;
 
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import org.junit.Assert;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.admin.indices.segments.IndexSegments;
+import org.opensearch.action.admin.indices.segments.IndexShardSegments;
+import org.opensearch.action.admin.indices.segments.IndicesSegmentResponse;
+import org.opensearch.action.admin.indices.segments.IndicesSegmentsRequest;
+import org.opensearch.action.admin.indices.segments.ShardSegments;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexModule;
+import org.opensearch.index.engine.Segment;
 import org.opensearch.test.BackgroundIndexer;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
@@ -44,24 +60,84 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
         ensureGreen(INDEX_NAME);
 
         final int initialDocCount = scaledRandomIntBetween(0, 200);
-        try (BackgroundIndexer indexer = new BackgroundIndexer(INDEX_NAME, "_doc", client(), initialDocCount)) {
+        try (BackgroundIndexer indexer = new BackgroundIndexer(INDEX_NAME, "_doc", client(), -1, RandomizedTest.scaledRandomIntBetween(2, 5), false, random())) {
+            indexer.start(initialDocCount);
             waitForDocs(initialDocCount, indexer);
-        }
-        refresh(INDEX_NAME);
-        // wait a short amount of time to give replication a chance to complete.
-        Thread.sleep(1000);
-        assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
-        assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
+            refresh(INDEX_NAME);
+            ensureGreen(INDEX_NAME);
 
-        final int additionalDocCount = scaledRandomIntBetween(0, 200);
-        final int totalDocs = initialDocCount + additionalDocCount;
-        try (BackgroundIndexer indexer = new BackgroundIndexer(INDEX_NAME, "_doc", client(), additionalDocCount)) {
-            waitForDocs(additionalDocCount, indexer);
+            // wait a short amount of time to give replication a chance to complete.
+            Thread.sleep(1000);
+            assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
+            assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
+
+            final int additionalDocCount = scaledRandomIntBetween(0, 200);
+            final int expectedHitCount = initialDocCount + additionalDocCount;
+            indexer.start(additionalDocCount);
+            waitForDocs(expectedHitCount, indexer);
+            ensureGreen(INDEX_NAME);
+
+            flush(INDEX_NAME);
+            Thread.sleep(1000);
+            assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount);
+            assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount);
         }
-        flush(INDEX_NAME);
-        Thread.sleep(1000);
-        assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), totalDocs);
-        assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), totalDocs);
+        assertSegmentStats(REPLICA_COUNT);
+    }
+
+    private void assertSegmentStats(int numberOfReplicas) {
+        client().admin().indices().segments(new IndicesSegmentsRequest(), new ActionListener<>() {
+            @Override
+            public void onResponse(IndicesSegmentResponse indicesSegmentResponse) {
+                final Map<String, IndexSegments> indices = indicesSegmentResponse.getIndices();
+                assertEquals("Test should only have a single index",1, indices.size());
+                for (Map.Entry<String, IndexSegments> entry : indices.entrySet()) {
+                    final IndexSegments value = entry.getValue();
+                    final Map<Integer, IndexShardSegments> shardGroup = value.getShards();
+                    assertEquals("There should only be one replicationGroup", 1, shardGroup.size());
+                    for (IndexShardSegments shardEntry : shardGroup.values()) {
+                        // get a list of segments across the whole group.
+                        final ShardSegments[] shardSegments = shardEntry.getShards();
+
+                        // get the primary shard's segment list.
+                        final ShardSegments primaryShardSegments = Arrays.stream(shardSegments).filter(s -> s.getShardRouting().primary()).findFirst().get();
+                        final Map<String, Segment> primarySegmentsMap = primaryShardSegments.getSegments().stream().collect(Collectors.toMap(Segment::getName, Function.identity()));
+
+                        // compare primary segments with replicas.
+                        assertEquals("There should be a ShardSegment entry for each replica in the replicationGroup", numberOfReplicas, shardSegments.length - 1);
+                        logger.info("Primary segments {}", primaryShardSegments.getSegments());
+                        for (ShardSegments shardSegment : shardSegments) {
+                            if (shardSegment.getShardRouting().primary()) {
+                                continue;
+                            }
+                            final List<Segment> segments = shardSegment.getSegments();
+                            logger.info("wAT {}", primarySegmentsMap.values().size());
+                            logger.info("{}", segments.size());
+                            logger.info("{}", segments.size());
+                            logger.info("Replica segments {}", segments);
+//                            assertEquals("ShardSegment should have the same segment count as the primary", segments.size(), primarySegmentsMap.size());
+                            for (Segment replicaSegment: segments) {
+                                final Segment primarySegment = primarySegmentsMap.get(replicaSegment.getName());
+                                assertNotNull(primarySegment);
+                                assertEqualSegments(replicaSegment, primarySegment);
+                            }
+                        }
+                    }
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                Assert.fail("Error fetching segment stats");
+            }
+        });
+    }
+
+    private void assertEqualSegments(Segment s1, Segment s2) {
+        assertEquals(s1.getGeneration(), s2.getGeneration());
+        assertEquals(s1.docCount, s2.docCount);
+        assertEquals(s1.delDocCount, s2.delDocCount);
+        assertEquals(s1.sizeInBytes, s2.sizeInBytes);
     }
 
     public void testReplicationAfterForceMerge() throws Exception {
@@ -71,29 +147,36 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
         ensureGreen(INDEX_NAME);
 
         final int initialDocCount = scaledRandomIntBetween(0, 200);
-        try (BackgroundIndexer indexer = new BackgroundIndexer(INDEX_NAME, "_doc", client(), initialDocCount)) {
+        try (BackgroundIndexer indexer = new BackgroundIndexer(INDEX_NAME, "_doc", client(), -1, RandomizedTest.scaledRandomIntBetween(2, 5), false, random())) {
+            indexer.start(initialDocCount);
             waitForDocs(initialDocCount, indexer);
-        }
-        flush(INDEX_NAME);
-        // wait a short amount of time to give replication a chance to complete.
-        Thread.sleep(1000);
-        assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
-        assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
+            ensureGreen(INDEX_NAME);
 
-        final int additionalDocCount = scaledRandomIntBetween(0, 200);
-        final int totalDocs = initialDocCount + additionalDocCount;
-        try (BackgroundIndexer indexer = new BackgroundIndexer(INDEX_NAME, "_doc", client(), additionalDocCount)) {
-            waitForDocs(additionalDocCount, indexer);
+            flush(INDEX_NAME);
+            // wait a short amount of time to give replication a chance to complete.
+            Thread.sleep(1000);
+            assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
+            assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
+
+            final int additionalDocCount = scaledRandomIntBetween(0, 200);
+            final int expectedHitCount = initialDocCount + additionalDocCount;
+
+            // Index a second set of docs so we can merge into one segment.
+            indexer.start(additionalDocCount);
+            waitForDocs(expectedHitCount, indexer);
+            ensureGreen(INDEX_NAME);
+
+            // Force a merge here so that the in memory SegmentInfos does not reference old segments on disk.
+            // This case tests that replicas preserve these files so the local store is not corrupt.
+            client().admin().indices().prepareForceMerge(INDEX_NAME).setMaxNumSegments(1).setFlush(false).get();
+            Thread.sleep(1000);
+            assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount);
+            assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount);
         }
-        // Force a merge here so that the in memory SegmentInfos does not reference old segments on disk.
-        // This case tests that replicas preserve these files so the local store is not corrupt.
-        client().admin().indices().prepareForceMerge(INDEX_NAME).setMaxNumSegments(1).setFlush(false).get();
-        Thread.sleep(1000);
-        assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), totalDocs);
-        assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), totalDocs);
+        assertSegmentStats(REPLICA_COUNT);
     }
 
-    public void testReplicaSetupAfterPrimaryIndexesDocs() throws Exception {
+    public void testReplicaSetupAfterPrimaryIndexesDocs() {
         final String nodeA = internalCluster().startNode();
         createIndex(INDEX_NAME, Settings.builder().put(indexSettings()).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).build());
         ensureGreen(INDEX_NAME);
@@ -122,5 +205,6 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
         ensureGreen(INDEX_NAME);
         assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 2);
         assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 2);
+        assertSegmentStats(REPLICA_COUNT);
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -235,7 +235,7 @@ public abstract class Engine implements Closeable {
         }
     }
 
-    public void updateCurrentInfos(SegmentInfos infos, long seqNo) throws IOException {}
+    public void finalizeReplication(SegmentInfos infos, Store.MetadataSnapshot expectedMetadata, long seqNo) throws IOException {}
 
     public long getProcessedLocalCheckpoint() {
         return 0L;

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -104,6 +104,7 @@ import org.opensearch.index.seqno.SeqNoStats;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.shard.OpenSearchMergePolicy;
 import org.opensearch.index.shard.ShardId;
+import org.opensearch.index.store.Store;
 import org.opensearch.index.translog.DefaultTranslogDeletionPolicy;
 import org.opensearch.index.translog.Translog;
 import org.opensearch.index.translog.TranslogConfig;
@@ -336,11 +337,28 @@ public class InternalEngine extends Engine {
     }
 
     @Override
-    public void updateCurrentInfos(SegmentInfos infos, long seqNo) throws IOException {
+    public synchronized void finalizeReplication(SegmentInfos infos, Store.MetadataSnapshot expectedMetadata, long seqNo)
+        throws IOException {
         assert engineConfig.isReadOnly() : "Only replicas should update Infos";
+
+        store.incRef();
+        try {
+            refreshLastCommittedSegmentInfos();
+            // clean up the local store of old segment files
+            // and validate the latest segment infos against the snapshot sent from the primary shard.
+            store.cleanupAndVerify(
+                "finalize - clean with in memory infos",
+                expectedMetadata,
+                store.getMetadata(infos),
+                store.getMetadata(lastCommittedSegmentInfos)
+            );
+        } finally {
+            store.decRef();
+        }
+        // Update the current infos reference on the Engine's reader.
         externalReaderManager.internalReaderManager.updateSegments(infos);
-        externalReaderManager.maybeRefresh();
         localCheckpointTracker.fastForwardProcessedSeqNo(seqNo);
+        externalReaderManager.maybeRefresh();
     }
 
     private LocalCheckpointTracker createLocalCheckpointTracker(

--- a/server/src/main/java/org/opensearch/index/engine/Segment.java
+++ b/server/src/main/java/org/opensearch/index/engine/Segment.java
@@ -178,8 +178,17 @@ public class Segment implements Writeable {
 
         Segment segment = (Segment) o;
 
-        return Objects.equals(name, segment.name);
-
+        return Objects.equals(name, segment.name)
+            && Objects.equals(docCount, segment.docCount)
+            && Objects.equals(delDocCount, segment.delDocCount)
+            && Objects.equals(sizeInBytes, segment.sizeInBytes)
+            && Objects.equals(search, segment.search)
+            && Objects.equals(committed, segment.committed)
+            && Objects.equals(attributes, segment.attributes)
+            && Objects.equals(version, segment.version)
+            && Objects.equals(compound, segment.compound)
+            && Objects.equals(mergeId, segment.mergeId)
+            && Objects.equals(generation, segment.generation);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/store/Store.java
+++ b/server/src/main/java/org/opensearch/index/store/Store.java
@@ -691,12 +691,16 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
      * @param localSnapshot  The local snapshot from in memory SegmentInfos.
      * @throws IllegalStateException if the latest snapshot in this store differs from the given one after the cleanup.
      */
-    public void cleanupAndVerify(String reason, MetadataSnapshot remoteSnapshot, MetadataSnapshot localSnapshot) throws IOException {
+    public void cleanupAndVerify(
+        String reason,
+        MetadataSnapshot remoteSnapshot,
+        MetadataSnapshot localSnapshot,
+        MetadataSnapshot latestCommitPointMetadata
+    ) throws IOException {
         // fetch a snapshot from the latest on disk Segments_N file. This can be behind
         // the passed in local in memory snapshot, so we want to ensure files it references are not removed.
         metadataLock.writeLock().lock();
         try (Lock writeLock = directory.obtainLock(IndexWriter.WRITE_LOCK_NAME)) {
-            final Store.MetadataSnapshot latestCommitPointMetadata = getMetadata((IndexCommit) null);
             cleanupFiles(reason, remoteSnapshot, latestCommitPointMetadata);
             verifyAfterCleanup(remoteSnapshot, localSnapshot);
         } finally {

--- a/server/src/main/java/org/opensearch/indices/replication/copy/CopyState.java
+++ b/server/src/main/java/org/opensearch/indices/replication/copy/CopyState.java
@@ -43,7 +43,8 @@ public class CopyState extends AbstractRefCounted {
             shardId,
             shard.getOperationPrimaryTerm(),
             segmentInfos.getGeneration(),
-            shard.getProcessedLocalCheckpoint()
+            shard.getProcessedLocalCheckpoint(),
+            segmentInfos.getVersion()
         );
 
         // Send files that are merged away in the latest SegmentInfos but not in the latest on disk Segments_N.

--- a/server/src/main/java/org/opensearch/indices/replication/copy/ReplicationCheckpoint.java
+++ b/server/src/main/java/org/opensearch/indices/replication/copy/ReplicationCheckpoint.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.indices.replication.copy;
 
+import org.opensearch.common.Nullable;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -22,12 +23,14 @@ public class ReplicationCheckpoint implements Writeable {
     private final long primaryTerm;
     private final long segmentsGen;
     private final long seqNo;
+    private final long version;
 
-    public ReplicationCheckpoint(ShardId shardId, long primaryTerm, long segments_gen, long seqNo) {
+    public ReplicationCheckpoint(ShardId shardId, long primaryTerm, long segmentsGen, long seqNo, long version) {
         this.shardId = shardId;
         this.primaryTerm = primaryTerm;
-        this.segmentsGen = segments_gen;
+        this.segmentsGen = segmentsGen;
         this.seqNo = seqNo;
+        this.version = version;
     }
 
     public ReplicationCheckpoint(StreamInput in) throws IOException {
@@ -35,6 +38,7 @@ public class ReplicationCheckpoint implements Writeable {
         primaryTerm = in.readLong();
         segmentsGen = in.readLong();
         seqNo = in.readLong();
+        version = in.readLong();
     }
 
     public long getPrimaryTerm() {
@@ -43,6 +47,10 @@ public class ReplicationCheckpoint implements Writeable {
 
     public long getSegmentsGen() {
         return segmentsGen;
+    }
+
+    public long getVersion() {
+        return version;
     }
 
     public long getSeqNo() {
@@ -59,6 +67,7 @@ public class ReplicationCheckpoint implements Writeable {
         out.writeLong(primaryTerm);
         out.writeLong(segmentsGen);
         out.writeLong(seqNo);
+        out.writeLong(version);
     }
 
     @Override
@@ -69,12 +78,17 @@ public class ReplicationCheckpoint implements Writeable {
         return primaryTerm == that.primaryTerm
             && segmentsGen == that.segmentsGen
             && seqNo == that.seqNo
+            && version == that.version
             && Objects.equals(shardId, that.shardId);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(shardId, primaryTerm, segmentsGen, seqNo);
+    }
+
+    public boolean isAheadOf(@Nullable ReplicationCheckpoint other) {
+        return other == null || version > other.getVersion();
     }
 
     @Override
@@ -88,6 +102,8 @@ public class ReplicationCheckpoint implements Writeable {
             + segmentsGen
             + ", seqNo="
             + seqNo
+            + ", version="
+            + version
             + '}';
     }
 }


### PR DESCRIPTION
### Description
This PR is a combination of three changes that gets Segrep integ tests to reliably pass.
 
Fixes:
1. Updates the tests to use a single BackgroundIndexer.  This ensures we correctly index the expected amount of documents. BackgroundIndexers start indexing with docId of 0, so using multiple indexers creates conflicts.
2. Fix Index shards to correctly compare checkpoint version instead of segment gen when determining
    if a received checkpoint should be processed. Without this change replicas will ignore checkpoints for merges.
3. Store the latest checkpoint received and process it after a copy event completes.  This ensures we are always processing the latest checkpoint if it is received during an active copy.

Improvements:
- Update tests to compare result of segments() API.  This will compare the segments on all replicas to the primary's version.
- Renamed UpdateCurrentInfos to `FinalizeReplication` inside of InternalEngine and moved cleanup logic there instead of ReplicationTarget.  This method will now also refresh the InternalEngine's latestCommittedSegmentInfos reference that is required to accurately update the committed & searchable properties on the segment data returned from Segments API.

### Issues Resolved
#2285
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
