### PR TITLE
Make discovered_master field optional on the client to support compat…

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponse.java
@@ -90,7 +90,7 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
             // ClusterStateHealth fields
             int numberOfNodes = (int) parsedObjects[i++];
             int numberOfDataNodes = (int) parsedObjects[i++];
-            boolean hasDiscoveredMaster = (boolean) parsedObjects[i++];
+            boolean hasDiscoveredMaster = Boolean.TRUE.equals(parsedObjects[i++]);
             int activeShards = (int) parsedObjects[i++];
             int relocatingShards = (int) parsedObjects[i++];
             int activePrimaryShards = (int) parsedObjects[i++];
@@ -151,7 +151,7 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
         // ClusterStateHealth fields
         PARSER.declareInt(constructorArg(), new ParseField(NUMBER_OF_NODES));
         PARSER.declareInt(constructorArg(), new ParseField(NUMBER_OF_DATA_NODES));
-        PARSER.declareBoolean(constructorArg(), new ParseField(DISCOVERED_MASTER));
+        PARSER.declareBoolean(optionalConstructorArg(), new ParseField(DISCOVERED_MASTER));
         PARSER.declareInt(constructorArg(), new ParseField(ACTIVE_SHARDS));
         PARSER.declareInt(constructorArg(), new ParseField(RELOCATING_SHARDS));
         PARSER.declareInt(constructorArg(), new ParseField(ACTIVE_PRIMARY_SHARDS));

--- a/server/src/test/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponsesTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponsesTests.java
@@ -228,7 +228,7 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
                 NamedXContentRegistry.EMPTY,
                 DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
                 "{\"cluster_name\":\"535799904437:7-1-3-node\",\"status\":\"green\","
-                    + "\"timed_out\":false,\"number_of_nodes\":6,\"number_of_data_nodes\":3,\"discovered_master\":false,"
+                    + "\"timed_out\":false,\"number_of_nodes\":6,\"number_of_data_nodes\":3,\"discovered_master\":true,"
                     + "\"active_primary_shards\":4,\"active_shards\":5,\"relocating_shards\":0,\"initializing_shards\":0,"
                     + "\"unassigned_shards\":0,\"delayed_unassigned_shards\":0,\"number_of_pending_tasks\":0,"
                     + "\"number_of_in_flight_fetch\":0,\"task_max_waiting_in_queue_millis\":0,"
@@ -236,6 +236,27 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
             )
         ) {
 
+            ClusterHealthResponse clusterHealth = ClusterHealthResponse.fromXContent(parser);
+            assertNotNull(clusterHealth);
+            assertThat(clusterHealth.getClusterName(), Matchers.equalTo("535799904437:7-1-3-node"));
+            assertThat(clusterHealth.getNumberOfNodes(), Matchers.equalTo(6));
+            assertThat(clusterHealth.hasDiscoveredMaster(), Matchers.equalTo(true));
+        }
+    }
+
+    public void testParseFromXContentWithoutDiscoveredMasterField() throws IOException {
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                "{\"cluster_name\":\"535799904437:7-1-3-node\",\"status\":\"green\","
+                    + "\"timed_out\":false,\"number_of_nodes\":6,\"number_of_data_nodes\":3,"
+                    + "\"active_primary_shards\":4,\"active_shards\":5,\"relocating_shards\":0,\"initializing_shards\":0,"
+                    + "\"unassigned_shards\":0,\"delayed_unassigned_shards\":0,\"number_of_pending_tasks\":0,"
+                    + "\"number_of_in_flight_fetch\":0,\"task_max_waiting_in_queue_millis\":0,"
+                    + "\"active_shards_percent_as_number\":100}"
+            )
+        ) {
             ClusterHealthResponse clusterHealth = ClusterHealthResponse.fromXContent(parser);
             assertNotNull(clusterHealth);
             assertThat(clusterHealth.getClusterName(), Matchers.equalTo("535799904437:7-1-3-node"));


### PR DESCRIPTION
…ibility for opensearch client with odfe

Signed-off-by: Mohit Godwani <mgodwan@amazon.com>

### Description
Make the discovered_master field in ClusterHealthResponse optional
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/1965
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
