### PR TITLE
Updated JAVA_HOME to jdk-17 in jenkinsfile

### DIFF
--- a/jenkins/jenkinsfile
+++ b/jenkins/jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
          docker {
             label 'AL2-X64'
             /* See  
-            https://github.com/opensearch-project/opensearch-build/blob/main/docker/ci/dockerfiles/build.ubuntu18.opensearch.x64.dockerfile
+            https://hub.docker.com/layers/ci-runner/opensearchstaging/ci-runner/ci-runner-ubuntu1804-build-v1/images/sha256-2c7bb2780bc08cd4e7e3c382ac53db414754dabd52f9b70e1c7e344dfb9a0e5e?context=explore
             for docker image
             */
             image 'opensearchstaging/ci-runner:ci-runner-ubuntu1804-build-v1'
@@ -16,7 +16,7 @@ pipeline {
         JAVA14_HOME="/opt/java/openjdk-14"
         JAVA17_HOME="/opt/java/openjdk-17"
         JAVA8_HOME="/opt/java/openjdk-8"
-        JAVA_HOME="/opt/java/openjdk-14"
+        JAVA_HOME="/opt/java/openjdk-17"
     }
 
     stages {


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Updated jdk version to use 17 for gradle check on `main`, `2.x` and `2.0` after jenkins will go public.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/2644
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
