### PR TITLE
fix gradle check failure caused by init of EngineConfig

### DIFF
--- a/server/src/test/java/org/opensearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RefreshListenersTests.java
@@ -171,7 +171,7 @@ public class RefreshListenersTests extends OpenSearchTestCase {
             () -> RetentionLeases.EMPTY,
             () -> primaryTerm,
             EngineTestCase.tombstoneDocSupplier(),
-            true // hard coding to true since primaries drive refreshes
+            false // hard coding to false
         );
         engine = new InternalEngine(config);
         engine.recoverFromTranslog((e, s) -> 0, Long.MAX_VALUE);

--- a/test/framework/src/main/java/org/opensearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/EngineTestCase.java
@@ -875,7 +875,7 @@ public abstract class EngineTestCase extends OpenSearchTestCase {
             retentionLeasesSupplier,
             primaryTerm,
             tombstoneDocSupplier(),
-            true // defaulting isPrimary to true
+            false // defaulting isReadOnly to false
         );
     }
 


### PR DESCRIPTION

Signed-off-by: Poojita Raj <poojiraj@amazon.com>

### Description
Fixes the failing tests caused by incorrect initialization of engineConfig in - 
1. EngineTestCase 
2. RefreshListenerTests
 
### Issues Resolved
Failure mentioned in issue #2414 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
