### PR TITLE
[Backport-1.x] Added jenkisfile to run gradle check in OpenSearch

### DIFF
--- a/jenkins/jenkinsfile
+++ b/jenkins/jenkinsfile
@@ -1,0 +1,32 @@
+pipeline {
+    agent {
+         docker {
+            label 'AL2-X64'
+            /* See  
+            https://hub.docker.com/layers/ci-runner/opensearchstaging/ci-runner/ci-runner-ubuntu1804-build-v1/images/sha256-2c7bb2780bc08cd4e7e3c382ac53db414754dabd52f9b70e1c7e344dfb9a0e5e?context=explore
+            for docker image
+            */
+            image 'opensearchstaging/ci-runner:ci-runner-ubuntu1804-build-v1'
+            alwaysPull true
+        }
+    }
+
+    environment {
+        JAVA11_HOME="/opt/java/openjdk-11"
+        JAVA14_HOME="/opt/java/openjdk-14"
+        JAVA17_HOME="/opt/java/openjdk-17"
+        JAVA8_HOME="/opt/java/openjdk-8"
+        JAVA_HOME="/opt/java/openjdk-11"
+    }
+
+    stages {
+        stage('gradle-check') {
+            steps {
+                script {
+                    sh 'echo gradle check'
+                    sh './gradlew check --no-daemon --no-scan'
+                }
+            } 
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Backport of https://github.com/opensearch-project/OpenSearch/pull/2166. The only change is pointing JAVA_HOME  to jdk-11 for 1.x for jenkins to pick up once it goes public.
 
### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/2644
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
