### PR TITLE
Rename `file` to `dir` in Environment

### DIFF
--- a/distribution/tools/keystore-cli/src/main/java/org/opensearch/common/settings/AddFileKeyStoreCommand.java
+++ b/distribution/tools/keystore-cli/src/main/java/org/opensearch/common/settings/AddFileKeyStoreCommand.java
@@ -95,7 +95,7 @@ class AddFileKeyStoreCommand extends BaseKeyStoreCommand {
             keyStore.setFile(setting, Files.readAllBytes(file));
         }
 
-        keyStore.save(env.configFile(), getKeyStorePassword().getChars());
+        keyStore.save(env.configDir(), getKeyStorePassword().getChars());
     }
 
     @SuppressForbidden(reason = "file arg for cli")

--- a/distribution/tools/keystore-cli/src/main/java/org/opensearch/common/settings/AddStringKeyStoreCommand.java
+++ b/distribution/tools/keystore-cli/src/main/java/org/opensearch/common/settings/AddStringKeyStoreCommand.java
@@ -121,7 +121,7 @@ class AddStringKeyStoreCommand extends BaseKeyStoreCommand {
             }
         }
 
-        keyStore.save(env.configFile(), getKeyStorePassword().getChars());
+        keyStore.save(env.configDir(), getKeyStorePassword().getChars());
     }
 
 }

--- a/distribution/tools/keystore-cli/src/main/java/org/opensearch/common/settings/CreateKeyStoreCommand.java
+++ b/distribution/tools/keystore-cli/src/main/java/org/opensearch/common/settings/CreateKeyStoreCommand.java
@@ -59,7 +59,7 @@ class CreateKeyStoreCommand extends KeyStoreAwareCommand {
     @Override
     protected void execute(Terminal terminal, OptionSet options, Environment env) throws Exception {
         try (SecureString password = options.has(passwordOption) ? readPassword(terminal, true) : new SecureString(new char[0])) {
-            Path keystoreFile = KeyStoreWrapper.keystorePath(env.configFile());
+            Path keystoreFile = KeyStoreWrapper.keystorePath(env.configDir());
             if (Files.exists(keystoreFile)) {
                 if (terminal.promptYesNo("An opensearch keystore already exists. Overwrite?", false) == false) {
                     terminal.println("Exiting without creating keystore.");
@@ -67,8 +67,8 @@ class CreateKeyStoreCommand extends KeyStoreAwareCommand {
                 }
             }
             KeyStoreWrapper keystore = KeyStoreWrapper.create();
-            keystore.save(env.configFile(), password.getChars());
-            terminal.println("Created opensearch keystore in " + KeyStoreWrapper.keystorePath(env.configFile()));
+            keystore.save(env.configDir(), password.getChars());
+            terminal.println("Created opensearch keystore in " + KeyStoreWrapper.keystorePath(env.configDir()));
         } catch (SecurityException e) {
             throw new UserException(ExitCodes.IO_ERROR, "Error creating the opensearch keystore.");
         }

--- a/distribution/tools/keystore-cli/src/main/java/org/opensearch/common/settings/RemoveSettingKeyStoreCommand.java
+++ b/distribution/tools/keystore-cli/src/main/java/org/opensearch/common/settings/RemoveSettingKeyStoreCommand.java
@@ -66,6 +66,6 @@ class RemoveSettingKeyStoreCommand extends BaseKeyStoreCommand {
             }
             keyStore.remove(setting);
         }
-        keyStore.save(env.configFile(), getKeyStorePassword().getChars());
+        keyStore.save(env.configDir(), getKeyStorePassword().getChars());
     }
 }

--- a/distribution/tools/keystore-cli/src/test/java/org/opensearch/bootstrap/BootstrapTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/opensearch/bootstrap/BootstrapTests.java
@@ -71,7 +71,7 @@ public class BootstrapTests extends OpenSearchTestCase {
     }
 
     public void testLoadSecureSettings() throws Exception {
-        final Path configPath = env.configFile();
+        final Path configPath = env.configDir();
         final SecureString seed;
         try (KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.create()) {
             seed = KeyStoreWrapper.SEED_SETTING.get(Settings.builder().setSecureSettings(keyStoreWrapper).build());

--- a/distribution/tools/keystore-cli/src/test/java/org/opensearch/common/settings/AddFileKeyStoreCommandTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/opensearch/common/settings/AddFileKeyStoreCommandTests.java
@@ -66,14 +66,14 @@ public class AddFileKeyStoreCommandTests extends KeyStoreCommandTestCase {
         for (int i = 0; i < length; ++i) {
             bytes[i] = randomByte();
         }
-        Path file = env.configFile().resolve(randomAlphaOfLength(16));
+        Path file = env.configDir().resolve(randomAlphaOfLength(16));
         Files.write(file, bytes);
         return file;
     }
 
     private void addFile(KeyStoreWrapper keystore, String setting, Path file, String password) throws Exception {
         keystore.setFile(setting, Files.readAllBytes(file));
-        keystore.save(env.configFile(), password.toCharArray());
+        keystore.save(env.configDir(), password.toCharArray());
     }
 
     public void testMissingCreateWithEmptyPasswordWhenPrompted() throws Exception {
@@ -95,7 +95,7 @@ public class AddFileKeyStoreCommandTests extends KeyStoreCommandTestCase {
         terminal.addSecretInput(randomFrom("", "keystorepassword"));
         terminal.addTextInput("n"); // explicit no
         execute("foo");
-        assertNull(KeyStoreWrapper.load(env.configFile()));
+        assertNull(KeyStoreWrapper.load(env.configDir()));
     }
 
     public void testOverwritePromptDefault() throws Exception {

--- a/distribution/tools/keystore-cli/src/test/java/org/opensearch/common/settings/AddStringKeyStoreCommandTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/opensearch/common/settings/AddStringKeyStoreCommandTests.java
@@ -101,7 +101,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
     public void testMissingNoCreate() throws Exception {
         terminal.addTextInput("n"); // explicit no
         execute("foo");
-        assertNull(KeyStoreWrapper.load(env.configFile()));
+        assertNull(KeyStoreWrapper.load(env.configDir()));
     }
 
     public void testOverwritePromptDefault() throws Exception {
@@ -161,7 +161,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testPromptForValue() throws Exception {
         String password = "keystorepassword";
-        KeyStoreWrapper.create().save(env.configFile(), password.toCharArray());
+        KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
         terminal.addSecretInput("secret value");
         execute("foo");
@@ -170,7 +170,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testPromptForMultipleValues() throws Exception {
         final String password = "keystorepassword";
-        KeyStoreWrapper.create().save(env.configFile(), password.toCharArray());
+        KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
         terminal.addSecretInput("bar1");
         terminal.addSecretInput("bar2");
@@ -183,7 +183,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testStdinShort() throws Exception {
         String password = "keystorepassword";
-        KeyStoreWrapper.create().save(env.configFile(), password.toCharArray());
+        KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
         setInput("secret value 1");
         execute("-x", "foo");
@@ -192,7 +192,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testStdinLong() throws Exception {
         String password = "keystorepassword";
-        KeyStoreWrapper.create().save(env.configFile(), password.toCharArray());
+        KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
         setInput("secret value 2");
         execute("--stdin", "foo");
@@ -201,7 +201,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testStdinNoInput() throws Exception {
         String password = "keystorepassword";
-        KeyStoreWrapper.create().save(env.configFile(), password.toCharArray());
+        KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
         setInput("");
         execute("-x", "foo");
@@ -210,7 +210,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testStdinInputWithLineBreaks() throws Exception {
         String password = "keystorepassword";
-        KeyStoreWrapper.create().save(env.configFile(), password.toCharArray());
+        KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
         setInput("Typedthisandhitenter\n");
         execute("-x", "foo");
@@ -219,7 +219,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testStdinInputWithCarriageReturn() throws Exception {
         String password = "keystorepassword";
-        KeyStoreWrapper.create().save(env.configFile(), password.toCharArray());
+        KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
         setInput("Typedthisandhitenter\r");
         execute("-x", "foo");
@@ -228,7 +228,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testStdinWithMultipleValues() throws Exception {
         final String password = "keystorepassword";
-        KeyStoreWrapper.create().save(env.configFile(), password.toCharArray());
+        KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
         setInput("bar1\nbar2\nbar3");
         execute(randomFrom("-x", "--stdin"), "foo1", "foo2", "foo3");
@@ -239,7 +239,7 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testAddUtf8String() throws Exception {
         String password = "keystorepassword";
-        KeyStoreWrapper.create().save(env.configFile(), password.toCharArray());
+        KeyStoreWrapper.create().save(env.configDir(), password.toCharArray());
         terminal.addSecretInput(password);
         final int stringSize = randomIntBetween(8, 16);
         try (CharArrayWriter secretChars = new CharArrayWriter(stringSize)) {

--- a/distribution/tools/keystore-cli/src/test/java/org/opensearch/common/settings/CreateKeyStoreCommandTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/opensearch/common/settings/CreateKeyStoreCommandTests.java
@@ -67,7 +67,7 @@ public class CreateKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testDefaultNotPromptForPassword() throws Exception {
         execute();
-        Path configDir = env.configFile();
+        Path configDir = env.configDir();
         assertNotNull(KeyStoreWrapper.load(configDir));
     }
 
@@ -76,7 +76,7 @@ public class CreateKeyStoreCommandTests extends KeyStoreCommandTestCase {
         terminal.addSecretInput(password);
         terminal.addSecretInput(password);
         execute();
-        Path configDir = env.configFile();
+        Path configDir = env.configDir();
         assertNotNull(KeyStoreWrapper.load(configDir));
     }
 
@@ -86,13 +86,13 @@ public class CreateKeyStoreCommandTests extends KeyStoreCommandTestCase {
         terminal.addSecretInput(password);
         env = setupEnv(false, fileSystems);
         execute();
-        Path configDir = env.configFile();
+        Path configDir = env.configDir();
         assertNotNull(KeyStoreWrapper.load(configDir));
     }
 
     public void testOverwrite() throws Exception {
         String password = randomFrom("", "keystorepassword");
-        Path keystoreFile = KeyStoreWrapper.keystorePath(env.configFile());
+        Path keystoreFile = KeyStoreWrapper.keystorePath(env.configDir());
         byte[] content = "not a keystore".getBytes(StandardCharsets.UTF_8);
         Files.write(keystoreFile, content);
 
@@ -108,6 +108,6 @@ public class CreateKeyStoreCommandTests extends KeyStoreCommandTestCase {
         terminal.addSecretInput(password);
         terminal.addSecretInput(password);
         execute();
-        assertNotNull(KeyStoreWrapper.load(env.configFile()));
+        assertNotNull(KeyStoreWrapper.load(env.configDir()));
     }
 }

--- a/distribution/tools/keystore-cli/src/test/java/org/opensearch/common/settings/KeyStoreCommandTestCase.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/opensearch/common/settings/KeyStoreCommandTestCase.java
@@ -92,12 +92,12 @@ public abstract class KeyStoreCommandTestCase extends CommandTestCase {
         for (int i = 0; i < settings.length; i += 2) {
             keystore.setString(settings[i], settings[i + 1].toCharArray());
         }
-        keystore.save(env.configFile(), password.toCharArray());
+        keystore.save(env.configDir(), password.toCharArray());
         return keystore;
     }
 
     KeyStoreWrapper loadKeystore(String password) throws Exception {
-        KeyStoreWrapper keystore = KeyStoreWrapper.load(env.configFile());
+        KeyStoreWrapper keystore = KeyStoreWrapper.load(env.configDir());
         keystore.decrypt(password.toCharArray());
         return keystore;
     }

--- a/distribution/tools/keystore-cli/src/test/java/org/opensearch/common/settings/UpgradeKeyStoreCommandTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/opensearch/common/settings/UpgradeKeyStoreCommandTests.java
@@ -63,7 +63,7 @@ public class UpgradeKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/468")
     public void testKeystoreUpgrade() throws Exception {
-        final Path keystore = KeyStoreWrapper.keystorePath(env.configFile());
+        final Path keystore = KeyStoreWrapper.keystorePath(env.configDir());
         try (
             InputStream is = KeyStoreWrapperTests.class.getResourceAsStream("/format-v3-opensearch.keystore");
             OutputStream os = Files.newOutputStream(keystore)
@@ -74,12 +74,12 @@ public class UpgradeKeyStoreCommandTests extends KeyStoreCommandTestCase {
                 os.write(buffer, 0, read);
             }
         }
-        try (KeyStoreWrapper beforeUpgrade = KeyStoreWrapper.load(env.configFile())) {
+        try (KeyStoreWrapper beforeUpgrade = KeyStoreWrapper.load(env.configDir())) {
             assertNotNull(beforeUpgrade);
             assertThat(beforeUpgrade.getFormatVersion(), equalTo(3));
         }
         execute();
-        try (KeyStoreWrapper afterUpgrade = KeyStoreWrapper.load(env.configFile())) {
+        try (KeyStoreWrapper afterUpgrade = KeyStoreWrapper.load(env.configDir())) {
             assertNotNull(afterUpgrade);
             assertThat(afterUpgrade.getFormatVersion(), equalTo(KeyStoreWrapper.FORMAT_VERSION));
             afterUpgrade.decrypt(new char[0]);
@@ -89,7 +89,7 @@ public class UpgradeKeyStoreCommandTests extends KeyStoreCommandTestCase {
 
     public void testKeystoreDoesNotExist() {
         final UserException e = expectThrows(UserException.class, this::execute);
-        assertThat(e, hasToString(containsString("keystore not found at [" + KeyStoreWrapper.keystorePath(env.configFile()) + "]")));
+        assertThat(e, hasToString(containsString("keystore not found at [" + KeyStoreWrapper.keystorePath(env.configDir()) + "]")));
     }
 
 }

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/InstallPluginCommand.java
@@ -269,8 +269,8 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
                 final List<Path> deleteOnFailure = new ArrayList<>();
                 deleteOnFailures.put(pluginId, deleteOnFailure);
 
-                final Path pluginZip = download(terminal, pluginId, env.tmpFile(), isBatch);
-                final Path extractedZip = unzip(pluginZip, env.pluginsFile());
+                final Path pluginZip = download(terminal, pluginId, env.tmpDir(), isBatch);
+                final Path extractedZip = unzip(pluginZip, env.pluginsDir());
                 deleteOnFailure.add(extractedZip);
                 final PluginInfo pluginInfo = installPlugin(terminal, isBatch, extractedZip, env, deleteOnFailure);
                 terminal.println("-> Installed " + pluginInfo.getName() + " with folder name " + pluginInfo.getTargetFolderName());
@@ -815,14 +815,14 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
         PluginsService.verifyCompatibility(info);
 
         // checking for existing version of the plugin
-        verifyPluginName(env.pluginsFile(), info.getName());
+        verifyPluginName(env.pluginsDir(), info.getName());
 
-        PluginsService.checkForFailedPluginRemovals(env.pluginsFile());
+        PluginsService.checkForFailedPluginRemovals(env.pluginsDir());
 
         terminal.println(VERBOSE, info.toString());
 
         // check for jar hell before any copying
-        jarHellCheck(info, pluginRoot, env.pluginsFile(), env.modulesFile());
+        jarHellCheck(info, pluginRoot, env.pluginsDir(), env.modulesDir());
 
         return info;
     }
@@ -872,21 +872,21 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
         Path policy = tmpRoot.resolve(PluginInfo.OPENSEARCH_PLUGIN_POLICY);
         final Set<String> permissions;
         if (Files.exists(policy)) {
-            permissions = PluginSecurity.parsePermissions(policy, env.tmpFile());
+            permissions = PluginSecurity.parsePermissions(policy, env.tmpDir());
         } else {
             permissions = Collections.emptySet();
         }
         PluginSecurity.confirmPolicyExceptions(terminal, permissions, isBatch);
 
         String targetFolderName = info.getTargetFolderName();
-        final Path destination = env.pluginsFile().resolve(targetFolderName);
+        final Path destination = env.pluginsDir().resolve(targetFolderName);
         deleteOnFailure.add(destination);
 
         installPluginSupportFiles(
             info,
             tmpRoot,
-            env.binFile().resolve(targetFolderName),
-            env.configFile().resolve(targetFolderName),
+            env.binDir().resolve(targetFolderName),
+            env.configDir().resolve(targetFolderName),
             deleteOnFailure
         );
         movePlugin(tmpRoot, destination);

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/ListPluginsCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/ListPluginsCommand.java
@@ -57,13 +57,13 @@ class ListPluginsCommand extends EnvironmentAwareCommand {
 
     @Override
     protected void execute(Terminal terminal, OptionSet options, Environment env) throws Exception {
-        if (Files.exists(env.pluginsFile()) == false) {
-            throw new IOException("Plugins directory missing: " + env.pluginsFile());
+        if (Files.exists(env.pluginsDir()) == false) {
+            throw new IOException("Plugins directory missing: " + env.pluginsDir());
         }
 
-        terminal.println(Terminal.Verbosity.VERBOSE, "Plugins directory: " + env.pluginsFile());
+        terminal.println(Terminal.Verbosity.VERBOSE, "Plugins directory: " + env.pluginsDir());
         final List<Path> plugins = new ArrayList<>();
-        try (DirectoryStream<Path> paths = Files.newDirectoryStream(env.pluginsFile())) {
+        try (DirectoryStream<Path> paths = Files.newDirectoryStream(env.pluginsDir())) {
             for (Path plugin : paths) {
                 plugins.add(plugin);
             }
@@ -75,7 +75,7 @@ class ListPluginsCommand extends EnvironmentAwareCommand {
     }
 
     private void printPlugin(Environment env, Terminal terminal, Path plugin, String prefix) throws IOException {
-        PluginInfo info = PluginInfo.readFromProperties(env.pluginsFile().resolve(plugin));
+        PluginInfo info = PluginInfo.readFromProperties(env.pluginsDir().resolve(plugin));
         terminal.println(Terminal.Verbosity.SILENT, prefix + info.getName());
         terminal.println(Terminal.Verbosity.VERBOSE, info.toString(prefix));
         if (info.getOpenSearchVersion().equals(Version.CURRENT) == false) {

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/RemovePluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/RemovePluginCommand.java
@@ -99,7 +99,7 @@ class RemovePluginCommand extends EnvironmentAwareCommand {
 
         // first make sure nothing extends this plugin
         List<String> usedBy = new ArrayList<>();
-        Set<PluginsService.Bundle> bundles = PluginsService.getPluginBundles(env.pluginsFile());
+        Set<PluginsService.Bundle> bundles = PluginsService.getPluginBundles(env.pluginsDir());
         for (PluginsService.Bundle bundle : bundles) {
             for (String extendedPlugin : bundle.plugin.getExtendedPlugins()) {
                 if (extendedPlugin.equals(pluginName)) {
@@ -114,9 +114,9 @@ class RemovePluginCommand extends EnvironmentAwareCommand {
             );
         }
 
-        Path pluginDir = env.pluginsFile().resolve(pluginName);
-        Path pluginConfigDir = env.configFile().resolve(pluginName);
-        Path removing = env.pluginsFile().resolve(".removing-" + pluginName);
+        Path pluginDir = env.pluginsDir().resolve(pluginName);
+        Path pluginConfigDir = env.configDir().resolve(pluginName);
+        Path removing = env.pluginsDir().resolve(".removing-" + pluginName);
 
         /*
          * If the plugin directory is not found with the plugin name, scan the list of all installed plugins
@@ -124,9 +124,9 @@ class RemovePluginCommand extends EnvironmentAwareCommand {
          */
         if (!Files.exists(pluginDir)) {
             terminal.println("searching in other folders to find if plugin exists with custom folder name");
-            pluginDir = PluginHelper.verifyIfPluginExists(env.pluginsFile(), pluginName);
-            pluginConfigDir = env.configFile().resolve(pluginDir.getFileName());
-            removing = env.pluginsFile().resolve(".removing-" + pluginDir.getFileName());
+            pluginDir = PluginHelper.verifyIfPluginExists(env.pluginsDir(), pluginName);
+            pluginConfigDir = env.configDir().resolve(pluginDir.getFileName());
+            removing = env.pluginsDir().resolve(".removing-" + pluginDir.getFileName());
         }
 
         terminal.println("-> removing [" + pluginName + "]...");
@@ -158,7 +158,7 @@ class RemovePluginCommand extends EnvironmentAwareCommand {
             terminal.println(VERBOSE, "removing [" + pluginDir + "]");
         }
 
-        final Path pluginBinDir = env.binFile().resolve(pluginName);
+        final Path pluginBinDir = env.binDir().resolve(pluginName);
         if (Files.exists(pluginBinDir)) {
             if (!Files.isDirectory(pluginBinDir)) {
                 throw new UserException(ExitCodes.IO_ERROR, "bin dir for " + pluginName + " is not a directory");

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/ListPluginsCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/ListPluginsCommandTests.java
@@ -111,7 +111,7 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
         final boolean hasNativeController
     ) throws IOException {
         PluginTestUtil.writePluginProperties(
-            env.pluginsFile().resolve(name),
+            env.pluginsDir().resolve(name),
             "description",
             description,
             "name",
@@ -132,9 +132,9 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
     }
 
     public void testPluginsDirMissing() throws Exception {
-        Files.delete(env.pluginsFile());
+        Files.delete(env.pluginsDir());
         IOException e = expectThrows(IOException.class, () -> listPlugins(home));
-        assertEquals("Plugins directory missing: " + env.pluginsFile(), e.getMessage());
+        assertEquals("Plugins directory missing: " + env.pluginsDir(), e.getMessage());
     }
 
     public void testNoPlugins() throws Exception {
@@ -161,7 +161,7 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
         MockTerminal terminal = listPlugins(home, params);
         assertEquals(
             buildMultiline(
-                "Plugins directory: " + env.pluginsFile(),
+                "Plugins directory: " + env.pluginsDir(),
                 "fake_plugin",
                 "- Plugin information:",
                 "Name: fake_plugin",
@@ -184,7 +184,7 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
         MockTerminal terminal = listPlugins(home, params);
         assertEquals(
             buildMultiline(
-                "Plugins directory: " + env.pluginsFile(),
+                "Plugins directory: " + env.pluginsDir(),
                 "fake_plugin1",
                 "- Plugin information:",
                 "Name: fake_plugin1",
@@ -208,7 +208,7 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
         MockTerminal terminal = listPlugins(home, params);
         assertEquals(
             buildMultiline(
-                "Plugins directory: " + env.pluginsFile(),
+                "Plugins directory: " + env.pluginsDir(),
                 "fake_plugin1",
                 "- Plugin information:",
                 "Name: fake_plugin1",
@@ -245,14 +245,14 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
     }
 
     public void testPluginWithoutDescriptorFile() throws Exception {
-        final Path pluginDir = env.pluginsFile().resolve("fake1");
+        final Path pluginDir = env.pluginsDir().resolve("fake1");
         Files.createDirectories(pluginDir);
         NoSuchFileException e = expectThrows(NoSuchFileException.class, () -> listPlugins(home));
         assertEquals(pluginDir.resolve(PluginInfo.OPENSEARCH_PLUGIN_PROPERTIES).toString(), e.getFile());
     }
 
     public void testPluginWithWrongDescriptorFile() throws Exception {
-        final Path pluginDir = env.pluginsFile().resolve("fake1");
+        final Path pluginDir = env.pluginsDir().resolve("fake1");
         PluginTestUtil.writePluginProperties(pluginDir, "description", "fake desc");
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> listPlugins(home));
         final Path descriptorPath = pluginDir.resolve(PluginInfo.OPENSEARCH_PLUGIN_PROPERTIES);
@@ -261,7 +261,7 @@ public class ListPluginsCommandTests extends OpenSearchTestCase {
 
     public void testExistingIncompatiblePlugin() throws Exception {
         PluginTestUtil.writePluginProperties(
-            env.pluginsFile().resolve("fake_plugin1"),
+            env.pluginsDir().resolve("fake_plugin1"),
             "description",
             "fake desc 1",
             "name",

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/RemovePluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/RemovePluginCommandTests.java
@@ -93,11 +93,11 @@ public class RemovePluginCommandTests extends OpenSearchTestCase {
     }
 
     void createPlugin(String name, String... additionalProps) throws IOException {
-        createPlugin(env.pluginsFile(), name, Version.CURRENT, additionalProps);
+        createPlugin(env.pluginsDir(), name, Version.CURRENT, additionalProps);
     }
 
     void createPlugin(String name, Version version) throws IOException {
-        createPlugin(env.pluginsFile(), name, version);
+        createPlugin(env.pluginsDir(), name, version);
     }
 
     void createPlugin(Path path, String name, Version version, String... additionalProps) throws IOException {
@@ -130,7 +130,7 @@ public class RemovePluginCommandTests extends OpenSearchTestCase {
     }
 
     static void assertRemoveCleaned(Environment env) throws IOException {
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(env.pluginsFile())) {
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(env.pluginsDir())) {
             for (Path file : stream) {
                 if (file.getFileName().toString().startsWith(".removing")) {
                     fail("Removal dir still exists, " + file);
@@ -147,23 +147,23 @@ public class RemovePluginCommandTests extends OpenSearchTestCase {
 
     public void testBasic() throws Exception {
         createPlugin("fake");
-        Files.createFile(env.pluginsFile().resolve("fake").resolve("plugin.jar"));
-        Files.createDirectory(env.pluginsFile().resolve("fake").resolve("subdir"));
+        Files.createFile(env.pluginsDir().resolve("fake").resolve("plugin.jar"));
+        Files.createDirectory(env.pluginsDir().resolve("fake").resolve("subdir"));
         createPlugin("other");
         removePlugin("fake", home, randomBoolean());
-        assertFalse(Files.exists(env.pluginsFile().resolve("fake")));
-        assertTrue(Files.exists(env.pluginsFile().resolve("other")));
+        assertFalse(Files.exists(env.pluginsDir().resolve("fake")));
+        assertTrue(Files.exists(env.pluginsDir().resolve("other")));
         assertRemoveCleaned(env);
     }
 
     public void testRemovePluginWithCustomFolderName() throws Exception {
         createPlugin("fake", "custom.foldername", "custom-folder");
-        Files.createFile(env.pluginsFile().resolve("custom-folder").resolve("plugin.jar"));
-        Files.createDirectory(env.pluginsFile().resolve("custom-folder").resolve("subdir"));
+        Files.createFile(env.pluginsDir().resolve("custom-folder").resolve("plugin.jar"));
+        Files.createDirectory(env.pluginsDir().resolve("custom-folder").resolve("subdir"));
         createPlugin("other");
         removePlugin("fake", home, randomBoolean());
-        assertFalse(Files.exists(env.pluginsFile().resolve("custom-folder")));
-        assertTrue(Files.exists(env.pluginsFile().resolve("other")));
+        assertFalse(Files.exists(env.pluginsDir().resolve("custom-folder")));
+        assertTrue(Files.exists(env.pluginsDir().resolve("other")));
         assertRemoveCleaned(env);
     }
 
@@ -177,62 +177,62 @@ public class RemovePluginCommandTests extends OpenSearchTestCase {
             )
         );
         removePlugin("fake", home, randomBoolean());
-        assertThat(Files.exists(env.pluginsFile().resolve("fake")), equalTo(false));
+        assertThat(Files.exists(env.pluginsDir().resolve("fake")), equalTo(false));
         assertRemoveCleaned(env);
     }
 
     public void testBin() throws Exception {
         createPlugin("fake");
-        Path binDir = env.binFile().resolve("fake");
+        Path binDir = env.binDir().resolve("fake");
         Files.createDirectories(binDir);
         Files.createFile(binDir.resolve("somescript"));
         removePlugin("fake", home, randomBoolean());
-        assertFalse(Files.exists(env.pluginsFile().resolve("fake")));
-        assertTrue(Files.exists(env.binFile().resolve("opensearch")));
+        assertFalse(Files.exists(env.pluginsDir().resolve("fake")));
+        assertTrue(Files.exists(env.binDir().resolve("opensearch")));
         assertFalse(Files.exists(binDir));
         assertRemoveCleaned(env);
     }
 
     public void testBinNotDir() throws Exception {
         createPlugin("fake");
-        Files.createFile(env.binFile().resolve("fake"));
+        Files.createFile(env.binDir().resolve("fake"));
         UserException e = expectThrows(UserException.class, () -> removePlugin("fake", home, randomBoolean()));
         assertTrue(e.getMessage(), e.getMessage().contains("not a directory"));
-        assertTrue(Files.exists(env.pluginsFile().resolve("fake"))); // did not remove
-        assertTrue(Files.exists(env.binFile().resolve("fake")));
+        assertTrue(Files.exists(env.pluginsDir().resolve("fake"))); // did not remove
+        assertTrue(Files.exists(env.binDir().resolve("fake")));
         assertRemoveCleaned(env);
     }
 
     public void testConfigDirPreserved() throws Exception {
         createPlugin("fake");
-        final Path configDir = env.configFile().resolve("fake");
+        final Path configDir = env.configDir().resolve("fake");
         Files.createDirectories(configDir);
         Files.createFile(configDir.resolve("fake.yml"));
         final MockTerminal terminal = removePlugin("fake", home, false);
-        assertTrue(Files.exists(env.configFile().resolve("fake")));
+        assertTrue(Files.exists(env.configDir().resolve("fake")));
         assertThat(terminal.getOutput(), containsString(expectedConfigDirPreservedMessage(configDir)));
         assertRemoveCleaned(env);
     }
 
     public void testPurgePluginExists() throws Exception {
         createPlugin("fake");
-        final Path configDir = env.configFile().resolve("fake");
+        final Path configDir = env.configDir().resolve("fake");
         if (randomBoolean()) {
             Files.createDirectories(configDir);
             Files.createFile(configDir.resolve("fake.yml"));
         }
         final MockTerminal terminal = removePlugin("fake", home, true);
-        assertFalse(Files.exists(env.configFile().resolve("fake")));
+        assertFalse(Files.exists(env.configDir().resolve("fake")));
         assertThat(terminal.getOutput(), not(containsString(expectedConfigDirPreservedMessage(configDir))));
         assertRemoveCleaned(env);
     }
 
     public void testPurgePluginDoesNotExist() throws Exception {
-        final Path configDir = env.configFile().resolve("fake");
+        final Path configDir = env.configDir().resolve("fake");
         Files.createDirectories(configDir);
         Files.createFile(configDir.resolve("fake.yml"));
         final MockTerminal terminal = removePlugin("fake", home, true);
-        assertFalse(Files.exists(env.configFile().resolve("fake")));
+        assertFalse(Files.exists(env.configDir().resolve("fake")));
         assertThat(terminal.getOutput(), not(containsString(expectedConfigDirPreservedMessage(configDir))));
         assertRemoveCleaned(env);
     }
@@ -243,8 +243,8 @@ public class RemovePluginCommandTests extends OpenSearchTestCase {
     }
 
     public void testPurgeOnlyMarkerFileExists() throws Exception {
-        final Path configDir = env.configFile().resolve("fake");
-        final Path removing = env.pluginsFile().resolve(".removing-fake");
+        final Path configDir = env.configDir().resolve("fake");
+        final Path removing = env.pluginsDir().resolve(".removing-fake");
         Files.createFile(removing);
         final MockTerminal terminal = removePlugin("fake", home, randomBoolean());
         assertFalse(Files.exists(removing));
@@ -253,7 +253,7 @@ public class RemovePluginCommandTests extends OpenSearchTestCase {
 
     public void testNoConfigDirPreserved() throws Exception {
         createPlugin("fake");
-        final Path configDir = env.configFile().resolve("fake");
+        final Path configDir = env.configDir().resolve("fake");
         final MockTerminal terminal = removePlugin("fake", home, randomBoolean());
         assertThat(terminal.getOutput(), not(containsString(expectedConfigDirPreservedMessage(configDir))));
     }
@@ -293,8 +293,8 @@ public class RemovePluginCommandTests extends OpenSearchTestCase {
 
     public void testRemoveWhenRemovingMarker() throws Exception {
         createPlugin("fake");
-        Files.createFile(env.pluginsFile().resolve("fake").resolve("plugin.jar"));
-        Files.createFile(env.pluginsFile().resolve(".removing-fake"));
+        Files.createFile(env.pluginsDir().resolve("fake").resolve("plugin.jar"));
+        Files.createFile(env.pluginsDir().resolve(".removing-fake"));
         removePlugin("fake", home, randomBoolean());
     }
 

--- a/distribution/tools/upgrade-cli/src/main/java/org/opensearch/upgrade/TaskInput.java
+++ b/distribution/tools/upgrade-cli/src/main/java/org/opensearch/upgrade/TaskInput.java
@@ -83,11 +83,11 @@ class TaskInput {
     }
 
     public Path getOpenSearchConfig() {
-        return openSearchEnv.configFile();
+        return openSearchEnv.configDir();
     }
 
     public Path getOpenSearchBin() {
-        return openSearchEnv.binFile();
+        return openSearchEnv.binDir();
     }
 
     public boolean isRunning() {

--- a/distribution/tools/upgrade-cli/src/test/java/org/opensearch/upgrade/UpgradeCliTests.java
+++ b/distribution/tools/upgrade-cli/src/test/java/org/opensearch/upgrade/UpgradeCliTests.java
@@ -121,7 +121,7 @@ public class UpgradeCliTests extends CommandTestCase {
                 "path.logs: \"/var/log/eslogs\""
             )
         );
-        List<String> actualSettings = Files.readAllLines(env.configFile().resolve("opensearch.yml"))
+        List<String> actualSettings = Files.readAllLines(env.configDir().resolve("opensearch.yml"))
             .stream()
             .filter(Objects::nonNull)
             .filter(line -> !line.isEmpty())
@@ -132,7 +132,7 @@ public class UpgradeCliTests extends CommandTestCase {
 
     private void assertKeystoreImported(String passwd) throws IOException, GeneralSecurityException {
         // assert keystore is created
-        KeyStoreWrapper keystore = KeyStoreWrapper.load(env.configFile());
+        KeyStoreWrapper keystore = KeyStoreWrapper.load(env.configDir());
         assertNotNull(keystore);
 
         // assert all keystore settings are imported
@@ -148,13 +148,13 @@ public class UpgradeCliTests extends CommandTestCase {
     }
 
     private void assertJvmOptionsImported() throws IOException, GeneralSecurityException {
-        Path path = env.configFile().resolve("jvm.options.d");
+        Path path = env.configDir().resolve("jvm.options.d");
         assertThat(Files.exists(path), is(true));
         assertThat(Files.isDirectory(path), is(true));
         assertThat(Files.exists(path.resolve("test.options")), is(true));
     }
 
     private void assertLog4jPropertiesImported() throws IOException, GeneralSecurityException {
-        assertThat(Files.exists(env.configFile().resolve("log4j2.properties")), is(true));
+        assertThat(Files.exists(env.configDir().resolve("log4j2.properties")), is(true));
     }
 }

--- a/distribution/tools/upgrade-cli/src/test/java/org/opensearch/upgrade/ValidateInputTaskTests.java
+++ b/distribution/tools/upgrade-cli/src/test/java/org/opensearch/upgrade/ValidateInputTaskTests.java
@@ -64,6 +64,6 @@ public class ValidateInputTaskTests extends OpenSearchTestCase {
         assertThat(summary.get("Elasticsearch Version"), is("7.10.2"));
         assertThat(summary.get("Elasticsearch Plugins"), is("[plugin-1, plugin-2]"));
         assertThat(summary.get("Elasticsearch Config"), is("es_home"));
-        assertThat(summary.get("OpenSearch Config"), is(env.configFile().toString()));
+        assertThat(summary.get("OpenSearch Config"), is(env.configDir().toString()));
     }
 }

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/HyphenationCompoundWordTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/HyphenationCompoundWordTokenFilterFactory.java
@@ -61,7 +61,7 @@ public class HyphenationCompoundWordTokenFilterFactory extends AbstractCompoundW
             throw new IllegalArgumentException("hyphenation_patterns_path is a required setting.");
         }
 
-        Path hyphenationPatternsFile = env.configFile().resolve(hyphenationPatternsPath);
+        Path hyphenationPatternsFile = env.configDir().resolve(hyphenationPatternsPath);
 
         try {
             InputStream in = Files.newInputStream(hyphenationPatternsFile);

--- a/modules/ingest-geoip/src/main/java/org/opensearch/ingest/geoip/IngestGeoIpPlugin.java
+++ b/modules/ingest-geoip/src/main/java/org/opensearch/ingest/geoip/IngestGeoIpPlugin.java
@@ -102,7 +102,7 @@ public class IngestGeoIpPlugin extends Plugin implements IngestPlugin, Closeable
     private Path getGeoIpDirectory(Processor.Parameters parameters) {
         final Path geoIpDirectory;
         if (parameters.env.settings().get("ingest.geoip.database_path") == null) {
-            geoIpDirectory = parameters.env.modulesFile().resolve("ingest-geoip");
+            geoIpDirectory = parameters.env.modulesDir().resolve("ingest-geoip");
         } else {
             geoIpDirectory = PathUtils.get(parameters.env.settings().get("ingest.geoip.database_path"));
         }

--- a/modules/ingest-geoip/src/main/java/org/opensearch/ingest/geoip/IngestGeoIpPlugin.java
+++ b/modules/ingest-geoip/src/main/java/org/opensearch/ingest/geoip/IngestGeoIpPlugin.java
@@ -82,7 +82,7 @@ public class IngestGeoIpPlugin extends Plugin implements IngestPlugin, Closeable
             throw new IllegalStateException("getProcessors called twice for geoip plugin!!");
         }
         final Path geoIpDirectory = getGeoIpDirectory(parameters);
-        final Path geoIpConfigDirectory = parameters.env.configFile().resolve("ingest-geoip");
+        final Path geoIpConfigDirectory = parameters.env.configDir().resolve("ingest-geoip");
         long cacheSize = CACHE_SIZE.get(parameters.env.settings());
         try {
             databaseReaders = loadDatabaseReaders(geoIpDirectory, geoIpConfigDirectory);

--- a/modules/ingest-user-agent/src/main/java/org/opensearch/ingest/useragent/IngestUserAgentPlugin.java
+++ b/modules/ingest-user-agent/src/main/java/org/opensearch/ingest/useragent/IngestUserAgentPlugin.java
@@ -62,7 +62,7 @@ public class IngestUserAgentPlugin extends Plugin implements IngestPlugin {
 
     @Override
     public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
-        Path userAgentConfigDirectory = parameters.env.configFile().resolve("ingest-user-agent");
+        Path userAgentConfigDirectory = parameters.env.configDir().resolve("ingest-user-agent");
 
         if (Files.exists(userAgentConfigDirectory) == false && Files.isDirectory(userAgentConfigDirectory)) {
             throw new IllegalStateException(

--- a/modules/reindex/src/main/java/org/opensearch/index/reindex/ReindexSslConfig.java
+++ b/modules/reindex/src/main/java/org/opensearch/index/reindex/ReindexSslConfig.java
@@ -126,7 +126,7 @@ class ReindexSslConfig {
                 return settings.getAsList(key);
             }
         };
-        configuration = loader.load(environment.configFile());
+        configuration = loader.load(environment.configDir());
         reload();
 
         final FileChangesListener listener = new FileChangesListener() {

--- a/plugins/analysis-icu/src/main/java/org/opensearch/index/analysis/IcuCollationTokenFilterFactory.java
+++ b/plugins/analysis-icu/src/main/java/org/opensearch/index/analysis/IcuCollationTokenFilterFactory.java
@@ -33,7 +33,7 @@
 package org.opensearch.index.analysis;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 
@@ -72,7 +72,7 @@ public class IcuCollationTokenFilterFactory extends AbstractTokenFilterFactory {
         if (rules != null) {
             Exception failureToResolve = null;
             try {
-                rules = Streams.copyToString(Files.newBufferedReader(environment.configFile().resolve(rules), Charset.forName("UTF-8")));
+                rules = Streams.copyToString(Files.newBufferedReader(environment.configDir().resolve(rules), StandardCharsets.UTF_8));
             } catch (IOException | SecurityException | InvalidPathException e) {
                 failureToResolve = e;
             }

--- a/plugins/analysis-icu/src/main/java/org/opensearch/index/analysis/IcuTokenizerFactory.java
+++ b/plugins/analysis-icu/src/main/java/org/opensearch/index/analysis/IcuTokenizerFactory.java
@@ -120,7 +120,7 @@ public class IcuTokenizerFactory extends AbstractTokenizerFactory {
     // parse a single RBBi rule file
     private BreakIterator parseRules(String filename, Environment env) throws IOException {
 
-        final Path path = env.configFile().resolve(filename);
+        final Path path = env.configDir().resolve(filename);
         String rules = Files.readAllLines(path).stream().filter((v) -> v.startsWith("#") == false).collect(Collectors.joining("\n"));
 
         return new RuleBasedBreakIterator(rules.toString());

--- a/plugins/examples/custom-settings/src/main/java/org/opensearch/example/customsettings/ExampleCustomSettingsConfig.java
+++ b/plugins/examples/custom-settings/src/main/java/org/opensearch/example/customsettings/ExampleCustomSettingsConfig.java
@@ -96,7 +96,7 @@ public class ExampleCustomSettingsConfig {
 
     public ExampleCustomSettingsConfig(final Environment environment) {
         // Elasticsearch config directory
-        final Path configDir = environment.configFile();
+        final Path configDir = environment.configDir();
 
         // Resolve the plugin's custom settings file
         final Path customSettingsYamlFile = configDir.resolve("custom-settings/custom.yml");

--- a/plugins/repository-hdfs/src/main/java/org/opensearch/repositories/hdfs/HdfsSecurityContext.java
+++ b/plugins/repository-hdfs/src/main/java/org/opensearch/repositories/hdfs/HdfsSecurityContext.java
@@ -102,7 +102,7 @@ class HdfsSecurityContext {
      * Expects keytab file to exist at {@code $CONFIG_DIR$/repository-hdfs/krb5.keytab}
      */
     static Path locateKeytabFile(Environment environment) {
-        Path keytabPath = environment.configFile().resolve("repository-hdfs").resolve("krb5.keytab");
+        Path keytabPath = environment.configDir().resolve("repository-hdfs").resolve("krb5.keytab");
         try {
             if (Files.exists(keytabPath) == false) {
                 throw new RuntimeException("Could not locate keytab at [" + keytabPath + "].");

--- a/qa/evil-tests/src/test/java/org/opensearch/bootstrap/EvilSecurityTests.java
+++ b/qa/evil-tests/src/test/java/org/opensearch/bootstrap/EvilSecurityTests.java
@@ -125,23 +125,23 @@ public class EvilSecurityTests extends OpenSearchTestCase {
         // check that all directories got permissions:
 
         // bin file: ro
-        assertExactPermissions(new FilePermission(environment.binFile().toString(), "read,readlink"), permissions);
+        assertExactPermissions(new FilePermission(environment.binDir().toString(), "read,readlink"), permissions);
         // lib file: ro
-        assertExactPermissions(new FilePermission(environment.libFile().toString(), "read,readlink"), permissions);
+        assertExactPermissions(new FilePermission(environment.libDir().toString(), "read,readlink"), permissions);
         // modules file: ro
-        assertExactPermissions(new FilePermission(environment.modulesFile().toString(), "read,readlink"), permissions);
+        assertExactPermissions(new FilePermission(environment.modulesDir().toString(), "read,readlink"), permissions);
         // config file: ro
-        assertExactPermissions(new FilePermission(environment.configFile().toString(), "read,readlink"), permissions);
+        assertExactPermissions(new FilePermission(environment.configDir().toString(), "read,readlink"), permissions);
         // plugins: ro
-        assertExactPermissions(new FilePermission(environment.pluginsFile().toString(), "read,readlink"), permissions);
+        assertExactPermissions(new FilePermission(environment.pluginsDir().toString(), "read,readlink"), permissions);
 
         // data paths: r/w
         for (Path dataPath : environment.dataFiles()) {
             assertExactPermissions(new FilePermission(dataPath.toString(), "read,readlink,write,delete"), permissions);
         }
-        assertExactPermissions(new FilePermission(environment.sharedDataFile().toString(), "read,readlink,write,delete"), permissions);
+        assertExactPermissions(new FilePermission(environment.sharedDataDir().toString(), "read,readlink,write,delete"), permissions);
         // logs: r/w
-        assertExactPermissions(new FilePermission(environment.logsFile().toString(), "read,readlink,write,delete"), permissions);
+        assertExactPermissions(new FilePermission(environment.logsDir().toString(), "read,readlink,write,delete"), permissions);
         // temp dir: r/w
         assertExactPermissions(new FilePermission(fakeTmpDir.toString(), "read,readlink,write,delete"), permissions);
         // PID file: delete only (for the shutdown hook)

--- a/qa/no-bootstrap-tests/src/test/java/org/opensearch/bootstrap/SpawnerNoBootstrapTests.java
+++ b/qa/no-bootstrap-tests/src/test/java/org/opensearch/bootstrap/SpawnerNoBootstrapTests.java
@@ -90,8 +90,8 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
         Environment environment = TestEnvironment.newEnvironment(settings);
 
         // This plugin will NOT have a controller daemon
-        Path plugin = environment.modulesFile().resolve("a_plugin");
-        Files.createDirectories(environment.modulesFile());
+        Path plugin = environment.modulesDir().resolve("a_plugin");
+        Files.createDirectories(environment.modulesDir());
         Files.createDirectories(plugin);
         PluginTestUtil.writePluginProperties(
                 plugin,
@@ -113,8 +113,8 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
      * Two plugins - one with a controller daemon and one without.
      */
     public void testControllerSpawn() throws Exception {
-        assertControllerSpawns(Environment::pluginsFile, false);
-        assertControllerSpawns(Environment::modulesFile, true);
+        assertControllerSpawns(Environment::pluginsDir, false);
+        assertControllerSpawns(Environment::modulesDir, true);
     }
 
     private void assertControllerSpawns(final Function<Environment, Path> pluginsDirFinder, boolean expectSpawn) throws Exception {
@@ -133,8 +133,8 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
 
         // this plugin will have a controller daemon
         Path plugin = pluginsDirFinder.apply(environment).resolve("test_plugin");
-        Files.createDirectories(environment.modulesFile());
-        Files.createDirectories(environment.pluginsFile());
+        Files.createDirectories(environment.modulesDir());
+        Files.createDirectories(environment.pluginsDir());
         Files.createDirectories(plugin);
         PluginTestUtil.writePluginProperties(
             plugin,
@@ -192,7 +192,7 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
 
         Environment environment = TestEnvironment.newEnvironment(settings);
 
-        Path plugin = environment.modulesFile().resolve("test_plugin");
+        Path plugin = environment.modulesDir().resolve("test_plugin");
         Files.createDirectories(plugin);
         PluginTestUtil.writePluginProperties(
                 plugin,

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/ReloadSecureSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/ReloadSecureSettingsIT.java
@@ -77,7 +77,7 @@ public class ReloadSecureSettingsIT extends OpenSearchIntegTestCase {
         final Environment environment = internalCluster().getInstance(Environment.class);
         final AtomicReference<AssertionError> reloadSettingsError = new AtomicReference<>();
         // keystore file should be missing for this test case
-        Files.deleteIfExists(KeyStoreWrapper.keystorePath(environment.configFile()));
+        Files.deleteIfExists(KeyStoreWrapper.keystorePath(environment.configDir()));
         final int initialReloadCount = mockReloadablePlugin.getReloadCount();
         final CountDownLatch latch = new CountDownLatch(1);
         final SecureString emptyPassword = randomBoolean() ? new SecureString(new char[0]) : null;
@@ -130,10 +130,10 @@ public class ReloadSecureSettingsIT extends OpenSearchIntegTestCase {
         final int initialReloadCount = mockReloadablePlugin.getReloadCount();
         // invalid "keystore" file should be present in the config dir
         try (InputStream keystore = ReloadSecureSettingsIT.class.getResourceAsStream("invalid.txt.keystore")) {
-            if (Files.exists(environment.configFile()) == false) {
-                Files.createDirectory(environment.configFile());
+            if (Files.exists(environment.configDir()) == false) {
+                Files.createDirectory(environment.configDir());
             }
-            Files.copy(keystore, KeyStoreWrapper.keystorePath(environment.configFile()), StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(keystore, KeyStoreWrapper.keystorePath(environment.configDir()), StandardCopyOption.REPLACE_EXISTING);
         }
         final CountDownLatch latch = new CountDownLatch(1);
         final SecureString emptyPassword = randomBoolean() ? new SecureString(new char[0]) : null;
@@ -452,7 +452,7 @@ public class ReloadSecureSettingsIT extends OpenSearchIntegTestCase {
     private SecureSettings writeEmptyKeystore(Environment environment, char[] password) throws Exception {
         final KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.create();
         try {
-            keyStoreWrapper.save(environment.configFile(), password);
+            keyStoreWrapper.save(environment.configDir(), password);
         } catch (final AccessControlException e) {
             if (e.getPermission() instanceof RuntimePermission && e.getPermission().getName().equals("accessUserInformation")) {
                 // this is expected: the save method is extra diligent and wants to make sure

--- a/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
@@ -247,7 +247,7 @@ public class IndexShardIT extends OpenSearchSingleNodeTestCase {
 
     public void testIndexDirIsDeletedWhenShardRemoved() throws Exception {
         Environment env = getInstanceFromNode(Environment.class);
-        Path idxPath = env.sharedDataFile().resolve(randomAlphaOfLength(10));
+        Path idxPath = env.sharedDataDir().resolve(randomAlphaOfLength(10));
         logger.info("--> idxPath: [{}]", idxPath);
         Settings idxSettings = Settings.builder().put(IndexMetadata.SETTING_DATA_PATH, idxPath).build();
         createIndex("test", idxSettings);
@@ -282,7 +282,7 @@ public class IndexShardIT extends OpenSearchSingleNodeTestCase {
 
     public void testIndexCanChangeCustomDataPath() throws Exception {
         final String index = "test-custom-data-path";
-        final Path sharedDataPath = getInstanceFromNode(Environment.class).sharedDataFile().resolve(randomAsciiLettersOfLength(10));
+        final Path sharedDataPath = getInstanceFromNode(Environment.class).sharedDataDir().resolve(randomAsciiLettersOfLength(10));
         final Path indexDataPath = sharedDataPath.resolve("start-" + randomAsciiLettersOfLength(10));
 
         logger.info("--> creating index [{}] with data_path [{}]", index, indexDataPath);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/reload/TransportNodesReloadSecureSettingsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/reload/TransportNodesReloadSecureSettingsAction.java
@@ -144,7 +144,7 @@ public class TransportNodesReloadSecureSettingsAction extends TransportNodesActi
         final SecureString secureSettingsPassword = request.hasPassword()
             ? request.getSecureSettingsPassword()
             : new SecureString(new char[0]);
-        try (KeyStoreWrapper keystore = KeyStoreWrapper.load(environment.configFile())) {
+        try (KeyStoreWrapper keystore = KeyStoreWrapper.load(environment.configDir())) {
             // reread keystore from config file
             if (keystore == null) {
                 return new NodesReloadSecureSettingsResponse.NodeResponse(

--- a/server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
+++ b/server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
@@ -189,7 +189,7 @@ final class Bootstrap {
         }
 
         initializeNatives(
-            environment.tmpFile(),
+            environment.tmpDir(),
             BootstrapSettings.MEMORY_LOCK_SETTING.get(settings),
             BootstrapSettings.SYSTEM_CALL_FILTER_SETTING.get(settings),
             BootstrapSettings.CTRLHANDLER_SETTING.get(settings)
@@ -254,7 +254,7 @@ final class Bootstrap {
     static SecureSettings loadSecureSettings(Environment initialEnv) throws BootstrapException {
         final KeyStoreWrapper keystore;
         try {
-            keystore = KeyStoreWrapper.load(initialEnv.configFile());
+            keystore = KeyStoreWrapper.load(initialEnv.configDir());
         } catch (IOException e) {
             throw new BootstrapException(e);
         }
@@ -273,11 +273,11 @@ final class Bootstrap {
         try {
             if (keystore == null) {
                 final KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.create();
-                keyStoreWrapper.save(initialEnv.configFile(), new char[0]);
+                keyStoreWrapper.save(initialEnv.configDir(), new char[0]);
                 return keyStoreWrapper;
             } else {
                 keystore.decrypt(password.getChars());
-                KeyStoreWrapper.upgrade(keystore, initialEnv.configFile(), password.getChars());
+                KeyStoreWrapper.upgrade(keystore, initialEnv.configDir(), password.getChars());
             }
         } catch (Exception e) {
             throw new BootstrapException(e);
@@ -366,7 +366,7 @@ final class Bootstrap {
         INSTANCE = new Bootstrap();
 
         final SecureSettings keystore = loadSecureSettings(initialEnv);
-        final Environment environment = createEnvironment(pidFile, keystore, initialEnv.settings(), initialEnv.configFile());
+        final Environment environment = createEnvironment(pidFile, keystore, initialEnv.settings(), initialEnv.configDir());
 
         LogConfigurator.setNodeName(Node.NODE_NAME_SETTING.get(environment.settings()));
         try {

--- a/server/src/main/java/org/opensearch/bootstrap/OpenSearch.java
+++ b/server/src/main/java/org/opensearch/bootstrap/OpenSearch.java
@@ -160,7 +160,7 @@ class OpenSearch extends EnvironmentAwareCommand {
 
         // a misconfigured java.io.tmpdir can cause hard-to-diagnose problems later, so reject it immediately
         try {
-            env.validateTmpFile();
+            env.validateTmpDir();
         } catch (IOException e) {
             throw new UserException(ExitCodes.CONFIG, e.getMessage());
         }

--- a/server/src/main/java/org/opensearch/bootstrap/Security.java
+++ b/server/src/main/java/org/opensearch/bootstrap/Security.java
@@ -178,11 +178,11 @@ final class Security {
      * we look for matching plugins and set URLs to fit
      */
     @SuppressForbidden(reason = "proper use of URL")
-    static Map<String, Policy> getPluginPermissions(Environment environment) throws IOException, NoSuchAlgorithmException {
+    static Map<String, Policy> getPluginPermissions(Environment environment) throws IOException {
         Map<String, Policy> map = new HashMap<>();
         // collect up set of plugins and modules by listing directories.
-        Set<Path> pluginsAndModules = new LinkedHashSet<>(PluginsService.findPluginDirs(environment.pluginsFile()));
-        pluginsAndModules.addAll(PluginsService.findPluginDirs(environment.modulesFile()));
+        Set<Path> pluginsAndModules = new LinkedHashSet<>(PluginsService.findPluginDirs(environment.pluginsDir()));
+        pluginsAndModules.addAll(PluginsService.findPluginDirs(environment.modulesDir()));
 
         // now process each one
         for (Path plugin : pluginsAndModules) {
@@ -310,19 +310,19 @@ final class Security {
      */
     static void addFilePermissions(Permissions policy, Environment environment) throws IOException {
         // read-only dirs
-        addDirectoryPath(policy, Environment.PATH_HOME_SETTING.getKey(), environment.binFile(), "read,readlink", false);
-        addDirectoryPath(policy, Environment.PATH_HOME_SETTING.getKey(), environment.libFile(), "read,readlink", false);
-        addDirectoryPath(policy, Environment.PATH_HOME_SETTING.getKey(), environment.modulesFile(), "read,readlink", false);
-        addDirectoryPath(policy, Environment.PATH_HOME_SETTING.getKey(), environment.pluginsFile(), "read,readlink", false);
-        addDirectoryPath(policy, "path.conf'", environment.configFile(), "read,readlink", false);
+        addDirectoryPath(policy, Environment.PATH_HOME_SETTING.getKey(), environment.binDir(), "read,readlink", false);
+        addDirectoryPath(policy, Environment.PATH_HOME_SETTING.getKey(), environment.libDir(), "read,readlink", false);
+        addDirectoryPath(policy, Environment.PATH_HOME_SETTING.getKey(), environment.modulesDir(), "read,readlink", false);
+        addDirectoryPath(policy, Environment.PATH_HOME_SETTING.getKey(), environment.pluginsDir(), "read,readlink", false);
+        addDirectoryPath(policy, "path.conf'", environment.configDir(), "read,readlink", false);
         // read-write dirs
-        addDirectoryPath(policy, "java.io.tmpdir", environment.tmpFile(), "read,readlink,write,delete", false);
-        addDirectoryPath(policy, Environment.PATH_LOGS_SETTING.getKey(), environment.logsFile(), "read,readlink,write,delete", false);
-        if (environment.sharedDataFile() != null) {
+        addDirectoryPath(policy, "java.io.tmpdir", environment.tmpDir(), "read,readlink,write,delete", false);
+        addDirectoryPath(policy, Environment.PATH_LOGS_SETTING.getKey(), environment.logsDir(), "read,readlink,write,delete", false);
+        if (environment.sharedDataDir() != null) {
             addDirectoryPath(
                 policy,
                 Environment.PATH_SHARED_DATA_SETTING.getKey(),
-                environment.sharedDataFile(),
+                environment.sharedDataDir(),
                 "read,readlink,write,delete",
                 false
             );

--- a/server/src/main/java/org/opensearch/bootstrap/Spawner.java
+++ b/server/src/main/java/org/opensearch/bootstrap/Spawner.java
@@ -77,14 +77,14 @@ final class Spawner implements Closeable {
         if (!spawned.compareAndSet(false, true)) {
             throw new IllegalStateException("native controllers already spawned");
         }
-        if (!Files.exists(environment.modulesFile())) {
-            throw new IllegalStateException("modules directory [" + environment.modulesFile() + "] not found");
+        if (!Files.exists(environment.modulesDir())) {
+            throw new IllegalStateException("modules directory [" + environment.modulesDir() + "] not found");
         }
         /*
          * For each module, attempt to spawn the controller daemon. Silently ignore any module that doesn't include a controller for the
          * correct platform.
          */
-        List<Path> paths = PluginsService.findPluginDirs(environment.modulesFile());
+        List<Path> paths = PluginsService.findPluginDirs(environment.modulesDir());
         for (final Path modules : paths) {
             final PluginInfo info = PluginInfo.readFromProperties(modules);
             final Path spawnPath = Platforms.nativeControllerPath(modules);
@@ -99,7 +99,7 @@ final class Spawner implements Closeable {
                 );
                 throw new IllegalArgumentException(message);
             }
-            final Process process = spawnNativeController(spawnPath, environment.tmpFile(), inheritIo);
+            final Process process = spawnNativeController(spawnPath, environment.tmpDir(), inheritIo);
             processes.add(process);
         }
     }

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1188,7 +1188,7 @@ public class MetadataCreateIndexService {
     }
 
     List<String> getIndexSettingsValidationErrors(final Settings settings, final boolean forbidPrivateIndexSettings) {
-        List<String> validationErrors = validateIndexCustomPath(settings, env.sharedDataFile());
+        List<String> validationErrors = validateIndexCustomPath(settings, env.sharedDataDir());
         if (forbidPrivateIndexSettings) {
             validationErrors.addAll(validatePrivateSettingsNotExplicitlySet(settings, indexScopedSettings));
         }

--- a/server/src/main/java/org/opensearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/opensearch/common/logging/LogConfigurator.java
@@ -139,7 +139,7 @@ public class LogConfigurator {
             // whether or not the error listener check failed we can remove the listener now
             StatusLogger.getLogger().removeListener(ERROR_LISTENER);
         }
-        configure(environment.settings(), environment.configFile(), environment.logsFile());
+        configure(environment.settings(), environment.configDir(), environment.logsDir());
     }
 
     /**

--- a/server/src/main/java/org/opensearch/common/settings/BaseKeyStoreCommand.java
+++ b/server/src/main/java/org/opensearch/common/settings/BaseKeyStoreCommand.java
@@ -57,14 +57,14 @@ public abstract class BaseKeyStoreCommand extends KeyStoreAwareCommand {
     @Override
     protected final void execute(Terminal terminal, OptionSet options, Environment env) throws Exception {
         try {
-            final Path configFile = env.configFile();
+            final Path configFile = env.configDir();
             keyStore = KeyStoreWrapper.load(configFile);
             if (keyStore == null) {
                 if (keyStoreMustExist) {
                     throw new UserException(
                         ExitCodes.DATA_ERROR,
                         "OpenSearch keystore not found at ["
-                            + KeyStoreWrapper.keystorePath(env.configFile())
+                            + KeyStoreWrapper.keystorePath(env.configDir())
                             + "]. Use 'create' command to create one."
                     );
                 } else if (options.has(forceOption) == false) {

--- a/server/src/main/java/org/opensearch/common/settings/ChangeKeyStorePasswordCommand.java
+++ b/server/src/main/java/org/opensearch/common/settings/ChangeKeyStorePasswordCommand.java
@@ -51,7 +51,7 @@ class ChangeKeyStorePasswordCommand extends BaseKeyStoreCommand {
     protected void executeCommand(Terminal terminal, OptionSet options, Environment env) throws Exception {
         try (SecureString newPassword = readPassword(terminal, true)) {
             final KeyStoreWrapper keyStore = getKeyStore();
-            keyStore.save(env.configFile(), newPassword.getChars());
+            keyStore.save(env.configDir(), newPassword.getChars());
             terminal.println("OpenSearch keystore password changed successfully.");
         } catch (SecurityException e) {
             throw new UserException(ExitCodes.DATA_ERROR, e.getMessage());

--- a/server/src/main/java/org/opensearch/common/settings/HasPasswordKeyStoreCommand.java
+++ b/server/src/main/java/org/opensearch/common/settings/HasPasswordKeyStoreCommand.java
@@ -52,7 +52,7 @@ public class HasPasswordKeyStoreCommand extends KeyStoreAwareCommand {
 
     @Override
     protected void execute(Terminal terminal, OptionSet options, Environment env) throws Exception {
-        final Path configFile = env.configFile();
+        final Path configFile = env.configDir();
         final KeyStoreWrapper keyStore = KeyStoreWrapper.load(configFile);
 
         // We handle error printing here so we can respect the "--silent" flag

--- a/server/src/main/java/org/opensearch/common/settings/UpgradeKeyStoreCommand.java
+++ b/server/src/main/java/org/opensearch/common/settings/UpgradeKeyStoreCommand.java
@@ -47,7 +47,7 @@ public class UpgradeKeyStoreCommand extends BaseKeyStoreCommand {
 
     @Override
     protected void executeCommand(final Terminal terminal, final OptionSet options, final Environment env) throws Exception {
-        KeyStoreWrapper.upgrade(getKeyStore(), env.configFile(), getKeyStorePassword().getChars());
+        KeyStoreWrapper.upgrade(getKeyStore(), env.configDir(), getKeyStorePassword().getChars());
     }
 
 }

--- a/server/src/main/java/org/opensearch/env/Environment.java
+++ b/server/src/main/java/org/opensearch/env/Environment.java
@@ -87,27 +87,27 @@ public class Environment {
 
     private final Path[] repoFiles;
 
-    private final Path configFile;
+    private final Path configDir;
 
-    private final Path pluginsFile;
+    private final Path pluginsDir;
 
-    private final Path modulesFile;
+    private final Path modulesDir;
 
-    private final Path sharedDataFile;
+    private final Path sharedDataDir;
 
     /** location of bin/, used by plugin manager */
-    private final Path binFile;
+    private final Path binDir;
 
     /** location of lib/, */
-    private final Path libFile;
+    private final Path libDir;
 
-    private final Path logsFile;
+    private final Path logsDir;
 
     /** Path to the PID file (can be null if no PID file is configured) **/
     private final Path pidFile;
 
     /** Path to the temporary file directory used by the JDK */
-    private final Path tmpFile;
+    private final Path tmpDir;
 
     public Environment(final Settings settings, final Path configPath) {
         this(settings, configPath, true);
@@ -127,14 +127,14 @@ public class Environment {
         }
 
         if (configPath != null) {
-            configFile = configPath.toAbsolutePath().normalize();
+            configDir = configPath.toAbsolutePath().normalize();
         } else {
-            configFile = homeFile.resolve("config");
+            configDir = homeFile.resolve("config");
         }
 
-        tmpFile = Objects.requireNonNull(tmpPath);
+        tmpDir = Objects.requireNonNull(tmpPath);
 
-        pluginsFile = homeFile.resolve("plugins");
+        pluginsDir = homeFile.resolve("plugins");
 
         List<String> dataPaths = PATH_DATA_SETTING.get(settings);
         if (nodeLocalStorage) {
@@ -155,9 +155,9 @@ public class Environment {
             }
         }
         if (PATH_SHARED_DATA_SETTING.exists(settings)) {
-            sharedDataFile = PathUtils.get(PATH_SHARED_DATA_SETTING.get(settings)).toAbsolutePath().normalize();
+            sharedDataDir = PathUtils.get(PATH_SHARED_DATA_SETTING.get(settings)).toAbsolutePath().normalize();
         } else {
-            sharedDataFile = null;
+            sharedDataDir = null;
         }
         List<String> repoPaths = PATH_REPO_SETTING.get(settings);
         if (repoPaths.isEmpty()) {
@@ -171,9 +171,9 @@ public class Environment {
 
         // this is trappy, Setting#get(Settings) will get a fallback setting yet return false for Settings#exists(Settings)
         if (PATH_LOGS_SETTING.exists(settings)) {
-            logsFile = PathUtils.get(PATH_LOGS_SETTING.get(settings)).toAbsolutePath().normalize();
+            logsDir = PathUtils.get(PATH_LOGS_SETTING.get(settings)).toAbsolutePath().normalize();
         } else {
-            logsFile = homeFile.resolve("logs");
+            logsDir = homeFile.resolve("logs");
         }
 
         if (NODE_PIDFILE_SETTING.exists(settings) || PIDFILE_SETTING.exists(settings)) {
@@ -182,16 +182,16 @@ public class Environment {
             pidFile = null;
         }
 
-        binFile = homeFile.resolve("bin");
-        libFile = homeFile.resolve("lib");
-        modulesFile = homeFile.resolve("modules");
+        binDir = homeFile.resolve("bin");
+        libDir = homeFile.resolve("lib");
+        modulesDir = homeFile.resolve("modules");
 
         final Settings.Builder finalSettings = Settings.builder().put(settings);
         if (PATH_DATA_SETTING.exists(settings)) {
             finalSettings.putList(PATH_DATA_SETTING.getKey(), Arrays.stream(dataFiles).map(Path::toString).collect(Collectors.toList()));
         }
         finalSettings.put(PATH_HOME_SETTING.getKey(), homeFile);
-        finalSettings.put(PATH_LOGS_SETTING.getKey(), logsFile.toString());
+        finalSettings.put(PATH_LOGS_SETTING.getKey(), logsDir.toString());
         if (PATH_REPO_SETTING.exists(settings)) {
             finalSettings.putList(
                 Environment.PATH_REPO_SETTING.getKey(),
@@ -199,8 +199,8 @@ public class Environment {
             );
         }
         if (PATH_SHARED_DATA_SETTING.exists(settings)) {
-            assert sharedDataFile != null;
-            finalSettings.put(Environment.PATH_SHARED_DATA_SETTING.getKey(), sharedDataFile.toString());
+            assert sharedDataDir != null;
+            finalSettings.put(Environment.PATH_SHARED_DATA_SETTING.getKey(), sharedDataDir.toString());
         }
         if (NODE_PIDFILE_SETTING.exists(settings)) {
             assert pidFile != null;
@@ -229,8 +229,8 @@ public class Environment {
     /**
      * The shared data location
      */
-    public Path sharedDataFile() {
-        return sharedDataFile;
+    public Path sharedDataDir() {
+        return sharedDataDir;
     }
 
     /**
@@ -295,32 +295,31 @@ public class Environment {
         }
     }
 
-    // TODO: rename all these "file" methods to "dir"
     /**
      * The config directory.
      */
-    public Path configFile() {
-        return configFile;
+    public Path configDir() {
+        return configDir;
     }
 
-    public Path pluginsFile() {
-        return pluginsFile;
+    public Path pluginsDir() {
+        return pluginsDir;
     }
 
-    public Path binFile() {
-        return binFile;
+    public Path binDir() {
+        return binDir;
     }
 
-    public Path libFile() {
-        return libFile;
+    public Path libDir() {
+        return libDir;
     }
 
-    public Path modulesFile() {
-        return modulesFile;
+    public Path modulesDir() {
+        return modulesDir;
     }
 
-    public Path logsFile() {
-        return logsFile;
+    public Path logsDir() {
+        return logsDir;
     }
 
     /**
@@ -331,17 +330,17 @@ public class Environment {
     }
 
     /** Path to the default temp directory used by the JDK */
-    public Path tmpFile() {
-        return tmpFile;
+    public Path tmpDir() {
+        return tmpDir;
     }
 
     /** Ensure the configured temp directory is a valid directory */
-    public void validateTmpFile() throws IOException {
-        if (Files.exists(tmpFile) == false) {
-            throw new FileNotFoundException("Temporary file directory [" + tmpFile + "] does not exist or is not accessible");
+    public void validateTmpDir() throws IOException {
+        if (Files.exists(tmpDir) == false) {
+            throw new FileNotFoundException("Temporary file directory [" + tmpDir + "] does not exist or is not accessible");
         }
-        if (Files.isDirectory(tmpFile) == false) {
-            throw new IOException("Configured temporary file directory [" + tmpFile + "] is not a directory");
+        if (Files.isDirectory(tmpDir) == false) {
+            throw new IOException("Configured temporary file directory [" + tmpDir + "] is not a directory");
         }
     }
 
@@ -356,14 +355,14 @@ public class Environment {
     public static void assertEquivalent(Environment actual, Environment expected) {
         assertEquals(actual.dataFiles(), expected.dataFiles(), "dataFiles");
         assertEquals(actual.repoFiles(), expected.repoFiles(), "repoFiles");
-        assertEquals(actual.configFile(), expected.configFile(), "configFile");
-        assertEquals(actual.pluginsFile(), expected.pluginsFile(), "pluginsFile");
-        assertEquals(actual.binFile(), expected.binFile(), "binFile");
-        assertEquals(actual.libFile(), expected.libFile(), "libFile");
-        assertEquals(actual.modulesFile(), expected.modulesFile(), "modulesFile");
-        assertEquals(actual.logsFile(), expected.logsFile(), "logsFile");
+        assertEquals(actual.configDir(), expected.configDir(), "configDir");
+        assertEquals(actual.pluginsDir(), expected.pluginsDir(), "pluginsDir");
+        assertEquals(actual.binDir(), expected.binDir(), "binDir");
+        assertEquals(actual.libDir(), expected.libDir(), "libDir");
+        assertEquals(actual.modulesDir(), expected.modulesDir(), "modulesDir");
+        assertEquals(actual.logsDir(), expected.logsDir(), "logsDir");
         assertEquals(actual.pidFile(), expected.pidFile(), "pidFile");
-        assertEquals(actual.tmpFile(), expected.tmpFile(), "tmpFile");
+        assertEquals(actual.tmpDir(), expected.tmpDir(), "tmpDir");
     }
 
     private static void assertEquals(Object actual, Object expected, String name) {

--- a/server/src/main/java/org/opensearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/opensearch/env/NodeEnvironment.java
@@ -289,7 +289,7 @@ public final class NodeEnvironment implements Closeable {
         NodeLock nodeLock = null;
 
         try {
-            sharedDataPath = environment.sharedDataFile();
+            sharedDataPath = environment.sharedDataDir();
             IOException lastException = null;
             int maxLocalStorageNodes = MAX_LOCAL_STORAGE_NODES_SETTING.get(settings);
 

--- a/server/src/main/java/org/opensearch/index/analysis/Analysis.java
+++ b/server/src/main/java/org/opensearch/index/analysis/Analysis.java
@@ -246,7 +246,7 @@ public class Analysis {
             }
         }
 
-        final Path path = env.configFile().resolve(wordListPath);
+        final Path path = env.configDir().resolve(wordListPath);
 
         try {
             return loadWordList(path, removeComments);
@@ -291,7 +291,7 @@ public class Analysis {
         if (filePath == null) {
             return null;
         }
-        final Path path = env.configFile().resolve(filePath);
+        final Path path = env.configDir().resolve(filePath);
         try {
             return Files.newBufferedReader(path, StandardCharsets.UTF_8);
         } catch (CharacterCodingException ex) {

--- a/server/src/main/java/org/opensearch/indices/analysis/HunspellService.java
+++ b/server/src/main/java/org/opensearch/indices/analysis/HunspellService.java
@@ -144,7 +144,7 @@ public class HunspellService {
     }
 
     private Path resolveHunspellDirectory(Environment env) {
-        return env.configFile().resolve("hunspell");
+        return env.configDir().resolve("hunspell");
     }
 
     /**
@@ -218,7 +218,7 @@ public class HunspellService {
 
             affixStream = Files.newInputStream(affixFiles[0]);
 
-            try (Directory tmp = new NIOFSDirectory(env.tmpFile())) {
+            try (Directory tmp = new NIOFSDirectory(env.tmpDir())) {
                 return new Dictionary(tmp, "hunspell", affixStream, dicStreams, ignoreCase);
             }
 

--- a/server/src/main/java/org/opensearch/node/InternalSettingsPreparer.java
+++ b/server/src/main/java/org/opensearch/node/InternalSettingsPreparer.java
@@ -85,7 +85,7 @@ public class InternalSettingsPreparer {
         Environment environment = new Environment(output.build(), configPath);
 
         output = Settings.builder(); // start with a fresh output
-        Path path = environment.configFile().resolve("opensearch.yml");
+        Path path = environment.configDir().resolve("opensearch.yml");
         if (Files.exists(path)) {
             try {
                 output.loadFromPath(path);

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -197,7 +197,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -392,18 +392,18 @@ public class Node implements Closeable {
             if (logger.isDebugEnabled()) {
                 logger.debug(
                     "using config [{}], data [{}], logs [{}], plugins [{}]",
-                    initialEnvironment.configFile(),
+                    initialEnvironment.configDir(),
                     Arrays.toString(initialEnvironment.dataFiles()),
-                    initialEnvironment.logsFile(),
-                    initialEnvironment.pluginsFile()
+                    initialEnvironment.logsDir(),
+                    initialEnvironment.pluginsDir()
                 );
             }
 
             this.pluginsService = new PluginsService(
                 tmpSettings,
-                initialEnvironment.configFile(),
-                initialEnvironment.modulesFile(),
-                initialEnvironment.pluginsFile(),
+                initialEnvironment.configDir(),
+                initialEnvironment.modulesDir(),
+                initialEnvironment.pluginsDir(),
                 classpathPlugins
             );
             final Settings settings = pluginsService.updatedSettings();
@@ -419,7 +419,7 @@ public class Node implements Closeable {
              * Create the environment based on the finalized view of the settings. This is to ensure that components get the same setting
              * values, no matter they ask for them from.
              */
-            this.environment = new Environment(settings, initialEnvironment.configFile(), Node.NODE_LOCAL_STORAGE_SETTING.get(settings));
+            this.environment = new Environment(settings, initialEnvironment.configDir(), Node.NODE_LOCAL_STORAGE_SETTING.get(settings));
             Environment.assertEquivalent(initialEnvironment, this.environment);
             nodeEnvironment = new NodeEnvironment(tmpSettings, environment);
             logger.info(
@@ -820,7 +820,7 @@ public class Node implements Closeable {
                 clusterService.getClusterSettings(),
                 pluginsService.filterPlugins(DiscoveryPlugin.class),
                 clusterModule.getAllocationService(),
-                environment.configFile(),
+                environment.configDir(),
                 gatewayMetaState,
                 rerouteService,
                 fsHealthService
@@ -1343,8 +1343,8 @@ public class Node implements Closeable {
 
     /** Writes a file to the logs dir containing the ports for the given transport type */
     private void writePortsFile(String type, BoundTransportAddress boundAddress) {
-        Path tmpPortsFile = environment.logsFile().resolve(type + ".ports.tmp");
-        try (BufferedWriter writer = Files.newBufferedWriter(tmpPortsFile, Charset.forName("UTF-8"))) {
+        Path tmpPortsFile = environment.logsDir().resolve(type + ".ports.tmp");
+        try (BufferedWriter writer = Files.newBufferedWriter(tmpPortsFile, StandardCharsets.UTF_8)) {
             for (TransportAddress address : boundAddress.boundAddresses()) {
                 InetAddress inetAddress = InetAddress.getByName(address.getAddress());
                 writer.write(NetworkAddress.format(new InetSocketAddress(inetAddress, address.getPort())) + "\n");
@@ -1352,7 +1352,7 @@ public class Node implements Closeable {
         } catch (IOException e) {
             throw new RuntimeException("Failed to write ports file", e);
         }
-        Path portsFile = environment.logsFile().resolve(type + ".ports");
+        Path portsFile = environment.logsDir().resolve(type + ".ports");
         try {
             Files.move(tmpPortsFile, portsFile, StandardCopyOption.ATOMIC_MOVE);
         } catch (IOException e) {

--- a/server/src/test/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
@@ -596,7 +596,7 @@ public class MetadataRolloverServiceTests extends OpenSearchTestCase {
         try {
             ClusterService clusterService = ClusterServiceUtils.createClusterService(testThreadPool);
             Environment env = mock(Environment.class);
-            when(env.sharedDataFile()).thenReturn(null);
+            when(env.sharedDataDir()).thenReturn(null);
             AllocationService allocationService = mock(AllocationService.class);
             when(allocationService.reroute(any(ClusterState.class), any(String.class))).then(i -> i.getArguments()[0]);
             IndicesService indicesService = mockIndicesServices();
@@ -722,7 +722,7 @@ public class MetadataRolloverServiceTests extends OpenSearchTestCase {
 
             ClusterService clusterService = ClusterServiceUtils.createClusterService(testThreadPool);
             Environment env = mock(Environment.class);
-            when(env.sharedDataFile()).thenReturn(null);
+            when(env.sharedDataDir()).thenReturn(null);
             AllocationService allocationService = mock(AllocationService.class);
             when(allocationService.reroute(any(ClusterState.class), any(String.class))).then(i -> i.getArguments()[0]);
             DocumentMapper documentMapper = mock(DocumentMapper.class);

--- a/server/src/test/java/org/opensearch/env/EnvironmentTests.java
+++ b/server/src/test/java/org/opensearch/env/EnvironmentTests.java
@@ -117,28 +117,28 @@ public class EnvironmentTests extends OpenSearchTestCase {
         final Path pathHome = createTempDir().toAbsolutePath();
         final Settings settings = Settings.builder().put("path.home", pathHome).build();
         final Environment environment = new Environment(settings, null);
-        assertThat(environment.logsFile(), equalTo(pathHome.resolve("logs")));
+        assertThat(environment.logsDir(), equalTo(pathHome.resolve("logs")));
     }
 
     public void testDefaultConfigPath() {
         final Path path = createTempDir().toAbsolutePath();
         final Settings settings = Settings.builder().put("path.home", path).build();
         final Environment environment = new Environment(settings, null);
-        assertThat(environment.configFile(), equalTo(path.resolve("config")));
+        assertThat(environment.configDir(), equalTo(path.resolve("config")));
     }
 
     public void testConfigPath() {
         final Path configPath = createTempDir().toAbsolutePath();
         final Settings settings = Settings.builder().put("path.home", createTempDir().toAbsolutePath()).build();
         final Environment environment = new Environment(settings, configPath);
-        assertThat(environment.configFile(), equalTo(configPath));
+        assertThat(environment.configDir(), equalTo(configPath));
     }
 
     public void testConfigPathWhenNotSet() {
         final Path pathHome = createTempDir().toAbsolutePath();
         final Settings settings = Settings.builder().put("path.home", pathHome).build();
         final Environment environment = new Environment(settings, null);
-        assertThat(environment.configFile(), equalTo(pathHome.resolve("config")));
+        assertThat(environment.configDir(), equalTo(pathHome.resolve("config")));
     }
 
     public void testNodeDoesNotRequireLocalStorage() {
@@ -164,7 +164,7 @@ public class EnvironmentTests extends OpenSearchTestCase {
     public void testNonExistentTempPathValidation() {
         Settings build = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir()).build();
         Environment environment = new Environment(build, null, true, createTempDir().resolve("this_does_not_exist"));
-        FileNotFoundException e = expectThrows(FileNotFoundException.class, environment::validateTmpFile);
+        FileNotFoundException e = expectThrows(FileNotFoundException.class, environment::validateTmpDir);
         assertThat(e.getMessage(), startsWith("Temporary file directory ["));
         assertThat(e.getMessage(), endsWith("this_does_not_exist] does not exist or is not accessible"));
     }
@@ -172,7 +172,7 @@ public class EnvironmentTests extends OpenSearchTestCase {
     public void testTempPathValidationWhenRegularFile() throws IOException {
         Settings build = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir()).build();
         Environment environment = new Environment(build, null, true, createTempFile("something", ".test"));
-        IOException e = expectThrows(IOException.class, environment::validateTmpFile);
+        IOException e = expectThrows(IOException.class, environment::validateTmpDir);
         assertThat(e.getMessage(), startsWith("Configured temporary file directory ["));
         assertThat(e.getMessage(), endsWith(".test] is not a directory"));
     }

--- a/server/src/test/java/org/opensearch/indices/analysis/AnalysisModuleTests.java
+++ b/server/src/test/java/org/opensearch/indices/analysis/AnalysisModuleTests.java
@@ -473,7 +473,7 @@ public class AnalysisModuleTests extends OpenSearchTestCase {
         InputStream aff = getClass().getResourceAsStream("/indices/analyze/conf_dir/hunspell/en_US/en_US.aff");
         InputStream dic = getClass().getResourceAsStream("/indices/analyze/conf_dir/hunspell/en_US/en_US.dic");
         Dictionary dictionary;
-        try (Directory tmp = new NIOFSDirectory(environment.tmpFile())) {
+        try (Directory tmp = new NIOFSDirectory(environment.tmpDir())) {
             dictionary = new Dictionary(tmp, "hunspell", aff, dic);
         }
         AnalysisModule module = new AnalysisModule(environment, singletonList(new AnalysisPlugin() {

--- a/server/src/test/java/org/opensearch/node/InternalSettingsPreparerTests.java
+++ b/server/src/test/java/org/opensearch/node/InternalSettingsPreparerTests.java
@@ -85,7 +85,7 @@ public class InternalSettingsPreparerTests extends OpenSearchTestCase {
         assertNotNull(settings.get(ClusterName.CLUSTER_NAME_SETTING.getKey())); // a cluster name was set
         assertEquals(settings.toString(), size + 1 /* path.home is in the base settings */, settings.names().size());
         String home = Environment.PATH_HOME_SETTING.get(baseEnvSettings);
-        String configDir = env.configFile().toString();
+        String configDir = env.configDir().toString();
         assertTrue(configDir, configDir.startsWith(home));
     }
 

--- a/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
@@ -102,7 +102,7 @@ public class PluginsServiceTests extends OpenSearchTestCase {
             settings,
             null,
             null,
-            TestEnvironment.newEnvironment(settings).pluginsFile(),
+            TestEnvironment.newEnvironment(settings).pluginsDir(),
             Arrays.asList(classpathPlugins)
         );
     }

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -262,7 +262,7 @@ public class BlobStoreRepositoryTests extends OpenSearchSingleNodeTestCase {
             .put(node().getEnvironment().settings())
             .put(FsRepository.REPOSITORIES_COMPRESS_SETTING.getKey(), true)
             .build();
-        Environment useCompressEnvironment = new Environment(useCompressSettings, node().getEnvironment().configFile());
+        Environment useCompressEnvironment = new Environment(useCompressSettings, node().getEnvironment().configDir());
 
         new FsRepository(metadata, useCompressEnvironment, null, BlobStoreTestUtil.mockClusterService(), null);
 

--- a/test/framework/src/main/java/org/opensearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/AbstractBuilderTestCase.java
@@ -376,7 +376,7 @@ public abstract class AbstractBuilderTestCase extends OpenSearchTestCase {
                 () -> { throw new AssertionError("node.name must be set"); }
             );
             PluginsService pluginsService;
-            pluginsService = new PluginsService(nodeSettings, null, env.modulesFile(), env.pluginsFile(), plugins);
+            pluginsService = new PluginsService(nodeSettings, null, env.modulesDir(), env.pluginsDir(), plugins);
 
             client = (Client) Proxy.newProxyInstance(Client.class.getClassLoader(), new Class[] { Client.class }, clientInvocationHandler);
             ScriptModule scriptModule = createScriptModule(pluginsService.filterPlugins(ScriptPlugin.class));

--- a/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
@@ -1740,7 +1740,7 @@ public final class InternalTestCluster extends TestCluster {
                     .distinct()
                     .collect(Collectors.toList());
                 Set<Path> configPaths = Stream.concat(currentNodes.stream(), newNodes.stream())
-                    .map(nac -> nac.node.getEnvironment().configFile())
+                    .map(nac -> nac.node.getEnvironment().configDir())
                     .collect(Collectors.toSet());
                 logger.debug("configuring discovery with {} at {}", discoveryFileContents, configPaths);
                 for (final Path configPath : configPaths) {


### PR DESCRIPTION


### Description
I find a `TODO` in `Environment`, this pr is used to fix this `TODO`.
 
### Issues Resolved
Rename some method ended with `file` to `dir`, e.g.  `configFile` to `configDir`.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
