### PR TITLE
Update ThirdPartyAuditTask to check for and list pointless exclusions.

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/precommit/ThirdPartyAuditTask.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/precommit/ThirdPartyAuditTask.java
@@ -237,6 +237,7 @@ public class ThirdPartyAuditTask extends DefaultTask {
         Set<String> jdkJarHellClasses = runJdkJarHellCheck();
 
         if (missingClassExcludes != null) {
+            assertNoPointlessExclusions("are not missing", missingClassExcludes, missingClasses);
             long bogousExcludesCount = Stream.concat(missingClassExcludes.stream(), violationsExcludes.stream())
                 .filter(each -> missingClasses.contains(each) == false)
                 .filter(each -> violationsClasses.contains(each) == false)
@@ -247,7 +248,6 @@ public class ThirdPartyAuditTask extends DefaultTask {
                     "All excluded classes seem to have no issues. " + "This is sometimes an indication that the check silently failed"
                 );
             }
-            assertNoPointlessExclusions("are not missing", missingClassExcludes, missingClasses);
             missingClasses.removeAll(missingClassExcludes);
         }
         assertNoPointlessExclusions("have no violations", violationsExcludes, violationsClasses);


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
This change swaps the order of the task to first check for no pointless exclusions.
If not caught first these will be thrown inside of the bogusExcludesCount block that logs a
useless error message.

This has caused a few dependabot PRs to linger with the error message:
```
"All excluded classes seem to have no issues. This is sometimes an indication that the check silently failed"
```

After this change it will properly list the pointless exclusions:
```
> Task :modules:ingest-geoip:thirdPartyAudit
Unnecessary exclusions, following classes are not missing:
   * org.apache.http.HttpEntity
  * org.apache.http.HttpResponse
  * org.apache.http.StatusLine
  * org.apache.http.client.config.RequestConfig
  * org.apache.http.client.config.RequestConfig$Builder
  * org.apache.http.client.methods.CloseableHttpResponse
  * org.apache.http.client.methods.HttpGet
  * org.apache.http.client.utils.URIBuilder
  * org.apache.http.impl.auth.BasicScheme
  * org.apache.http.impl.client.CloseableHttpClient
  * org.apache.http.impl.client.HttpClientBuilder
  * org.apache.http.util.EntityUtils
```
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/pull/2736
https://github.com/opensearch-project/OpenSearch/pull/2646
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
