### PR TITLE
Fix TaskInfo serialization and unmute task_list bwc test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/tasks.list/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/tasks.list/10_basic.yml
@@ -1,8 +1,6 @@
 ---
 "tasks_list test":
   - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/opensearch-project/OpenSearch/issues/2757"
       features: [arbitrary_key]
 
   - do:

--- a/server/src/main/java/org/opensearch/tasks/TaskInfo.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskInfo.java
@@ -142,7 +142,7 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
         }
         parentTaskId = TaskId.readFromStream(in);
         headers = in.readMap(StreamInput::readString, StreamInput::readString);
-        if (in.getVersion().onOrAfter(Version.V_2_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_2_1_0)) {
             resourceStats = in.readOptionalWriteable(TaskResourceStats::new);
         } else {
             resourceStats = null;
@@ -164,7 +164,7 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
         }
         parentTaskId.writeTo(out);
         out.writeMap(headers, StreamOutput::writeString, StreamOutput::writeString);
-        if (out.getVersion().onOrAfter(Version.V_2_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_2_1_0)) {
             out.writeOptionalWriteable(resourceStats);
         }
     }


### PR DESCRIPTION
Fixes the version check around resourceStats serialization and unmutes the
failing bwc test.

closes #2757