### PR TITLE
Allow deprecation warning for API call 'GET _cat/master' in 'ExceptionIT' of mixed cluster BWC test

### DIFF
--- a/qa/mixed-cluster/src/test/java/org/opensearch/backwards/ExceptionIT.java
+++ b/qa/mixed-cluster/src/test/java/org/opensearch/backwards/ExceptionIT.java
@@ -47,8 +47,13 @@ public class ExceptionIT extends OpenSearchRestTestCase {
     private void logClusterNodes() throws IOException {
         ObjectPath objectPath = ObjectPath.createFromResponse(client().performRequest(new Request("GET", "_nodes")));
         Map<String, ?> nodes = objectPath.evaluate("nodes");
-        String master = EntityUtils.toString(client().performRequest(new Request("GET", "_cat/master?h=id")).getEntity()).trim();
-        logger.info("cluster discovered: master id='{}'", master);
+        // As of 2.0, 'GET _cat/master' API is deprecated to promote inclusive language.
+        // Allow the deprecation warning for the node running an older version.
+        // TODO: Replace the API with 'GET _cat/cluster_manager' when dropping compatibility with 1.x versions.
+        Request catRequest = new Request("GET", "_cat/master?h=id");
+        catRequest.setOptions(expectWarningsOnce("[GET /_cat/master] is deprecated! Use [GET /_cat/cluster_manager] instead."));
+        String clusterManager = EntityUtils.toString(client().performRequest(catRequest).getEntity()).trim();
+        logger.info("cluster discovered: cluster-manager id='{}'", clusterManager);
         for (String id : nodes.keySet()) {
             logger.info("{}: id='{}', name='{}', version={}",
                 objectPath.evaluate("nodes." + id + ".http.publish_address"),


### PR DESCRIPTION
### Description
- Allow deprecation warning when calling `GET _cat/master` API in `ExceptionIT` class of mixed cluster BWC test

The test `ExceptionIT.testOpensearchException()` calls API `GET _cat/master` to log the cluster-manager node ID.
Since the REST API is deprecated in version 2.0 and `RestClient` used in the test treats warning as failure, the test breaks when running the BWC test against node version >=2.0

Note:
Mixed cluster BWC test will spin up 4 nodes with the specified old version, and upgrade 2 nodes to the current version to form a mixed version cluster. 

### Issues Resolved
Resolve https://github.com/opensearch-project/OpenSearch/issues/2759
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
