### PR TITLE
Replace remaining 'blacklist' with 'denylist' in internal class and method names

### DIFF
--- a/server/src/main/java/org/opensearch/common/inject/BindingProcessor.java
+++ b/server/src/main/java/org/opensearch/common/inject/BindingProcessor.java
@@ -274,7 +274,7 @@ class BindingProcessor extends AbstractProcessor {
         }
 
         // prevent the parent from creating a JIT binding for this key
-        injector.state.parent().blacklist(key);
+        injector.state.parent().denylist(key);
         injector.state.putBinding(key, binding);
     }
 

--- a/server/src/main/java/org/opensearch/common/inject/InheritingState.java
+++ b/server/src/main/java/org/opensearch/common/inject/InheritingState.java
@@ -149,12 +149,12 @@ class InheritingState implements State {
     }
 
     @Override
-    public boolean isBlacklisted(Key<?> key) {
+    public boolean isDenylisted(Key<?> key) {
         return denylistedKeys.contains(key);
     }
 
     @Override
-    public void clearBlacklisted() {
+    public void clearDenylisted() {
         denylistedKeys = new WeakKeySet();
     }
 

--- a/server/src/main/java/org/opensearch/common/inject/InheritingState.java
+++ b/server/src/main/java/org/opensearch/common/inject/InheritingState.java
@@ -143,8 +143,8 @@ class InheritingState implements State {
     }
 
     @Override
-    public void blacklist(Key<?> key) {
-        parent.blacklist(key);
+    public void denylist(Key<?> key) {
+        parent.denylist(key);
         denylistedKeys.add(key);
     }
 

--- a/server/src/main/java/org/opensearch/common/inject/InjectorImpl.java
+++ b/server/src/main/java/org/opensearch/common/inject/InjectorImpl.java
@@ -535,7 +535,7 @@ class InjectorImpl implements Injector, Lookups {
         }
 
         BindingImpl<T> binding = createJustInTimeBinding(key, errors);
-        state.parent().blacklist(key);
+        state.parent().denylist(key);
         jitBindings.put(key, binding);
         return binding;
     }

--- a/server/src/main/java/org/opensearch/common/inject/InjectorImpl.java
+++ b/server/src/main/java/org/opensearch/common/inject/InjectorImpl.java
@@ -530,7 +530,7 @@ class InjectorImpl implements Injector, Lookups {
      * other ancestor injectors until this injector is tried.
      */
     private <T> BindingImpl<T> createJustInTimeBindingRecursive(Key<T> key, Errors errors) throws ErrorsException {
-        if (state.isBlacklisted(key)) {
+        if (state.isDenylisted(key)) {
             throw errors.childBindingAlreadySet(key).toException();
         }
 
@@ -555,7 +555,7 @@ class InjectorImpl implements Injector, Lookups {
      *          if the binding cannot be created.
      */
     <T> BindingImpl<T> createJustInTimeBinding(Key<T> key, Errors errors) throws ErrorsException {
-        if (state.isBlacklisted(key)) {
+        if (state.isDenylisted(key)) {
             throw errors.childBindingAlreadySet(key).toException();
         }
 
@@ -805,7 +805,7 @@ class InjectorImpl implements Injector, Lookups {
 
     // ES_GUICE: clear caches
     public void clearCache() {
-        state.clearBlacklisted();
+        state.clearDenylisted();
         constructors = new ConstructorInjectorStore(this);
         membersInjectorStore = new MembersInjectorStore(this, state.getTypeListenerBindings());
         jitBindings = new HashMap<>();

--- a/server/src/main/java/org/opensearch/common/inject/State.java
+++ b/server/src/main/java/org/opensearch/common/inject/State.java
@@ -109,12 +109,12 @@ interface State {
         public void blacklist(Key<?> key) {}
 
         @Override
-        public boolean isBlacklisted(Key<?> key) {
+        public boolean isDenylisted(Key<?> key) {
             return true;
         }
 
         @Override
-        public void clearBlacklisted() {}
+        public void clearDenylisted() {}
 
         @Override
         public void makeAllBindingsToEagerSingletons(Injector injector) {}
@@ -173,7 +173,7 @@ interface State {
      * Returns true if {@code key} is forbidden from being bound in this injector. This indicates that
      * one of this injector's descendent's has bound the key.
      */
-    boolean isBlacklisted(Key<?> key);
+    boolean isDenylisted(Key<?> key);
 
     /**
      * Returns the shared lock for all injector data. This is a low-granularity, high-contention lock
@@ -182,7 +182,7 @@ interface State {
     Object lock();
 
     // ES_GUICE: clean denylist keys
-    void clearBlacklisted();
+    void clearDenylisted();
 
     void makeAllBindingsToEagerSingletons(Injector injector);
 }

--- a/server/src/main/java/org/opensearch/common/inject/State.java
+++ b/server/src/main/java/org/opensearch/common/inject/State.java
@@ -106,7 +106,7 @@ interface State {
         }
 
         @Override
-        public void blacklist(Key<?> key) {}
+        public void denylist(Key<?> key) {}
 
         @Override
         public boolean isDenylisted(Key<?> key) {
@@ -167,7 +167,7 @@ interface State {
      * denylist their bound keys on their parent injectors to prevent just-in-time bindings on the
      * parent injector that would conflict.
      */
-    void blacklist(Key<?> key);
+    void denylist(Key<?> key);
 
     /**
      * Returns true if {@code key} is forbidden from being bound in this injector. This indicates that

--- a/test/framework/src/main/java/org/opensearch/test/rest/yaml/DenylistedPathPatternMatcher.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/yaml/DenylistedPathPatternMatcher.java
@@ -47,7 +47,7 @@ import java.util.regex.Pattern;
  *
  * Each denylist pattern is a suffix match on the path. Empty patterns are not allowed.
  */
-final class BlacklistedPathPatternMatcher {
+final class DenylistedPathPatternMatcher {
     private final Pattern pattern;
 
     /**
@@ -55,7 +55,7 @@ final class BlacklistedPathPatternMatcher {
      *
      * @param p The suffix pattern. Must be a non-empty string.
      */
-    BlacklistedPathPatternMatcher(String p) {
+    DenylistedPathPatternMatcher(String p) {
         // guard against accidentally matching everything as an empty string lead to the pattern ".*" which matches everything
         if (p == null || p.trim().isEmpty()) {
             throw new IllegalArgumentException("Empty denylist patterns are not supported");

--- a/test/framework/src/main/java/org/opensearch/test/rest/yaml/OpenSearchClientYamlSuiteTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/yaml/OpenSearchClientYamlSuiteTestCase.java
@@ -116,7 +116,7 @@ public abstract class OpenSearchClientYamlSuiteTestCase extends OpenSearchRestTe
      */
     private static final String PATHS_SEPARATOR = "(?<!\\\\),";
 
-    private static List<BlacklistedPathPatternMatcher> denylistPathMatchers;
+    private static List<DenylistedPathPatternMatcher> denylistPathMatchers;
     private static ClientYamlTestExecutionContext restTestExecutionContext;
     private static ClientYamlTestExecutionContext adminExecutionContext;
     private static ClientYamlTestClient clientYamlTestClient;
@@ -157,11 +157,11 @@ public abstract class OpenSearchClientYamlSuiteTestCase extends OpenSearchRestTe
             final String[] denylist = resolvePathsProperty(REST_TESTS_BLACKLIST, null);
             denylistPathMatchers = new ArrayList<>();
             for (final String entry : denylist) {
-                denylistPathMatchers.add(new BlacklistedPathPatternMatcher(entry));
+                denylistPathMatchers.add(new DenylistedPathPatternMatcher(entry));
             }
             final String[] denylistAdditions = resolvePathsProperty(REST_TESTS_BLACKLIST_ADDITIONS, null);
             for (final String entry : denylistAdditions) {
-                denylistPathMatchers.add(new BlacklistedPathPatternMatcher(entry));
+                denylistPathMatchers.add(new DenylistedPathPatternMatcher(entry));
             }
         }
         assert restTestExecutionContext != null;
@@ -368,7 +368,7 @@ public abstract class OpenSearchClientYamlSuiteTestCase extends OpenSearchRestTe
 
     public void test() throws IOException {
         // skip test if it matches one of the denylist globs
-        for (BlacklistedPathPatternMatcher denylistedPathMatcher : denylistPathMatchers) {
+        for (DenylistedPathPatternMatcher denylistedPathMatcher : denylistPathMatchers) {
             String testPath = testCandidate.getSuitePath() + "/" + testCandidate.getTestSection().getName();
             assumeFalse(
                 "[" + testCandidate.getTestPath() + "] skipped, reason: blacklisted",

--- a/test/framework/src/main/java/org/opensearch/test/rest/yaml/OpenSearchClientYamlSuiteTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/yaml/OpenSearchClientYamlSuiteTestCase.java
@@ -371,7 +371,7 @@ public abstract class OpenSearchClientYamlSuiteTestCase extends OpenSearchRestTe
         for (DenylistedPathPatternMatcher denylistedPathMatcher : denylistPathMatchers) {
             String testPath = testCandidate.getSuitePath() + "/" + testCandidate.getTestSection().getName();
             assumeFalse(
-                "[" + testCandidate.getTestPath() + "] skipped, reason: blacklisted",
+                "[" + testCandidate.getTestPath() + "] skipped, reason: denylisted",
                 denylistedPathMatcher.isSuffixMatch(testPath)
             );
         }

--- a/test/framework/src/main/java/org/opensearch/test/rest/yaml/OpenSearchClientYamlSuiteTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/yaml/OpenSearchClientYamlSuiteTestCase.java
@@ -370,10 +370,7 @@ public abstract class OpenSearchClientYamlSuiteTestCase extends OpenSearchRestTe
         // skip test if it matches one of the denylist globs
         for (DenylistedPathPatternMatcher denylistedPathMatcher : denylistPathMatchers) {
             String testPath = testCandidate.getSuitePath() + "/" + testCandidate.getTestSection().getName();
-            assumeFalse(
-                "[" + testCandidate.getTestPath() + "] skipped, reason: denylisted",
-                denylistedPathMatcher.isSuffixMatch(testPath)
-            );
+            assumeFalse("[" + testCandidate.getTestPath() + "] skipped, reason: denylisted", denylistedPathMatcher.isSuffixMatch(testPath));
         }
 
         // skip test if the whole suite (yaml file) is disabled

--- a/test/framework/src/test/java/org/opensearch/test/rest/yaml/DenylistedPathPatternMatcherTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/rest/yaml/DenylistedPathPatternMatcherTests.java
@@ -33,7 +33,7 @@ package org.opensearch.test.rest.yaml;
 
 import org.opensearch.test.OpenSearchTestCase;
 
-public class BlacklistedPathPatternMatcherTests extends OpenSearchTestCase {
+public class DenylistedPathPatternMatcherTests extends OpenSearchTestCase {
 
     public void testMatchesExact() {
         // suffix match
@@ -71,12 +71,12 @@ public class BlacklistedPathPatternMatcherTests extends OpenSearchTestCase {
     }
 
     private void assertMatch(String pattern, String path) {
-        BlacklistedPathPatternMatcher matcher = new BlacklistedPathPatternMatcher(pattern);
+        DenylistedPathPatternMatcher matcher = new DenylistedPathPatternMatcher(pattern);
         assertTrue("Pattern [" + pattern + "] should have matched path [" + path + "]", matcher.isSuffixMatch(path));
     }
 
     private void assertNoMatch(String pattern, String path) {
-        BlacklistedPathPatternMatcher matcher = new BlacklistedPathPatternMatcher(pattern);
+        DenylistedPathPatternMatcher matcher = new DenylistedPathPatternMatcher(pattern);
         assertFalse("Pattern [" + pattern + "] should not have matched path [" + path + "]", matcher.isSuffixMatch(path));
     }
 }


### PR DESCRIPTION
### Description

This is the last PR for replacing non-inclusive terminology `blacklist`. 
Most of the internal usages of non-inclusive terminology `blacklist/whitelist` was replaced by PR https://github.com/opensearch-project/OpenSearch/pull/2178, while there are a few remaining.
- Replace `blacklist` with `denylist` in internal class and method names.

Note:
1. The 2 classes to be renamed are not published to Maven
- class `org.opensearch.test.rest.yaml.BlacklistedPathPatternMatcher`
- interfact `org.opensearch.common.inject.State`, javadoc of the package: https://opensearch.org/javadocs/1.3.1/OpenSearch/server/build/docs/javadoc/org/opensearch/common/inject/package-summary.html
2. The package `org.opensearch.common.inject` is a forked version of `Google Guice` framework 2.0 (https://github.com/elastic/elasticsearch/commit/2a19160ad654e17b4f402b53e09d316fde209a4b), and the `blacklist` terminology in Guice code was also been replaced in the commit https://github.com/google/guice/commit/3d98f869fc47a9e5275a053683742dfb5b3b2ada

### Issues Resolved
resolve https://github.com/opensearch-project/OpenSearch/issues/1484
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
