### PR TITLE
Delete Operations on Replicas when Segment Replication is enabled

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -229,4 +229,45 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
             }
         });
     }
+
+    public void testDelOps()throws Exception{
+        final String nodeA = internalCluster().startNode();
+        final String nodeB = internalCluster().startNode();
+
+        createIndex(
+            INDEX_NAME,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, SHARD_COUNT)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, REPLICA_COUNT)
+                .put(IndexMetadata.SETTING_SEGMENT_REPLICATION, true)
+                .build()
+        );
+        ensureGreen(INDEX_NAME);
+        client().prepareIndex(INDEX_NAME)
+            .setId("1")
+            .setSource("foo", "bar")
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL)
+            .get();
+
+        assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 1);
+        assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 1);
+
+        client().prepareIndex(INDEX_NAME)
+            .setId("2")
+            .setSource("fooo", "baar")
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL)
+            .get();
+
+        assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 2);
+        assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 2);
+
+        // Now delete with blockUntilRefresh
+        client().prepareDelete(INDEX_NAME, "1").setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL).get();
+        assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 1);
+        assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 1);
+
+        client().prepareDelete(INDEX_NAME, "2").setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL).get();
+        assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 0);
+        assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 0);
+    }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -8,6 +8,9 @@
 
 package org.opensearch.indices.replication;
 
+import org.opensearch.action.DocWriteResponse;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
@@ -122,5 +125,45 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
         ensureGreen(INDEX_NAME);
         assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 2);
         assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 2);
+    }
+
+    public void testDelOps()throws Exception{
+        final String nodeA = internalCluster().startNode();
+        final String nodeB = internalCluster().startNode();
+
+        createIndex(
+            INDEX_NAME,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, SHARD_COUNT)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, REPLICA_COUNT)
+                .put(IndexMetadata.SETTING_SEGMENT_REPLICATION, true)
+                .build()
+        );
+        ensureGreen(INDEX_NAME);
+        IndexResponse index = client().prepareIndex(INDEX_NAME)
+            .setId("1")
+            .setSource("foo", "bar")
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL)
+            .get();
+//        indexRandom(true, client().prepareIndex(INDEX_NAME).setId("1").setSource("foo", "bar"));
+        assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 1);
+        assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 1);
+
+        IndexResponse index2 = client().prepareIndex(INDEX_NAME)
+            .setId("2")
+            .setSource("fooo", "baar")
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL)
+            .get();
+
+//        indexRandom(true, client().prepareIndex(INDEX_NAME).setId("2").setSource("fooo", "baar"));
+        assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 2);
+        assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 2);
+
+        // Now delete with blockUntilRefresh
+        DeleteResponse delete = client().prepareDelete(INDEX_NAME, "1").setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL).get();
+        assertEquals(DocWriteResponse.Result.DELETED, delete.getResult());
+        assertFalse("request shouldn't have forced a refresh", delete.forcedRefresh());
+        assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 1);
+        assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 1);
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -369,6 +369,8 @@ public abstract class Engine implements Closeable {
      */
     public abstract DeleteResult delete(Delete delete) throws IOException;
 
+    public abstract DeleteResult addDeleteOperationToTranslog(Delete delete) throws IOException;
+
     public abstract NoOpResult noOp(NoOp noOp) throws IOException;
 
     /**

--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -369,8 +369,6 @@ public abstract class Engine implements Closeable {
      */
     public abstract DeleteResult delete(Delete delete) throws IOException;
 
-    public abstract DeleteResult addDeleteOperationToTranslog(Delete delete) throws IOException;
-
     public abstract NoOpResult noOp(NoOp noOp) throws IOException;
 
     /**

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -686,7 +686,7 @@ public class InternalEngine extends Engine {
     private DirectoryReader getDirectoryReader() throws IOException {
         // for segment replication: replicas should create the reader from store, we don't want an open IW on replicas.
         if (engineConfig.isReadOnly()) {
-            return DirectoryReader.open(store.directory());
+            return (SoftDeletesDirectoryReaderWrapper)DirectoryReader.open(store.directory());
         }
         return DirectoryReader.open(indexWriter);
     }

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -36,21 +36,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.NumericDocValuesField;
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexCommit;
-import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.LiveIndexWriterConfig;
-import org.apache.lucene.index.MergePolicy;
-import org.apache.lucene.index.SegmentCommitInfo;
-import org.apache.lucene.index.SegmentInfos;
-import org.apache.lucene.index.ShuffleForcedMergePolicy;
-import org.apache.lucene.index.SoftDeletesRetentionMergePolicy;
-import org.apache.lucene.index.StandardDirectoryReader;
-import org.apache.lucene.index.Term;
+import org.apache.lucene.index.*;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -2291,6 +2277,9 @@ public class InternalEngine extends Engine {
         OpenSearchDirectoryReader reader = null;
         try {
             reader = externalReaderManager.internalReaderManager.acquire();
+            if (engineConfig.isReadOnly()) {
+                return ((StandardDirectoryReader)((SoftDeletesDirectoryReaderWrapper) reader.getDelegate()).getDelegate()).getSegmentInfos();
+            }
             return ((StandardDirectoryReader) reader.getDelegate()).getSegmentInfos();
         } catch (IOException e) {
             throw new EngineException(shardId, e.getMessage(), e);

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -1506,8 +1506,7 @@ public class InternalEngine extends Engine {
                 }
             }
             if (delete.origin().isFromTranslog() == false && deleteResult.getResultType() == Result.Type.SUCCESS) {
-                final Translog.Location location = translog.add(new Translog.Delete(delete, deleteResult));
-                deleteResult.setTranslogLocation(location);
+                addDeleteOperationToTranslog(delete, deleteResult);
             }
             localCheckpointTracker.markSeqNoAsProcessed(deleteResult.getSeqNo());
             if (deleteResult.getTranslogLocation() == null) {
@@ -1529,6 +1528,30 @@ public class InternalEngine extends Engine {
         }
         maybePruneDeletes();
         return deleteResult;
+    }
+
+    @Override
+    public Engine.DeleteResult addDeleteOperationToTranslog(Delete delete) throws IOException{
+        try (Releasable ignored = versionMap.acquireLock(delete.uid().bytes())) {
+            DeletionStrategy plan = deletionStrategyForOperation(delete);
+            DeleteResult deleteResult = new DeleteResult(
+                plan.versionOfDeletion,
+                delete.primaryTerm(),
+                delete.seqNo(),
+                plan.currentlyDeleted == false
+            );
+            addDeleteOperationToTranslog(delete, deleteResult);
+            deleteResult.setTook(System.nanoTime() - delete.startTime());
+            deleteResult.freeze();
+            return deleteResult;
+        }
+    }
+
+    private void addDeleteOperationToTranslog(Delete delete, DeleteResult deleteResult) throws IOException{
+        if(deleteResult.getResultType() == Result.Type.SUCCESS){
+            final Translog.Location location = translog.add(new Translog.Delete(delete, deleteResult));
+            deleteResult.setTranslogLocation(location);
+        }
     }
 
     private Exception tryAcquireInFlightDocs(Operation operation, int addingDocs) {

--- a/server/src/main/java/org/opensearch/index/engine/OpenSearchReaderManager.java
+++ b/server/src/main/java/org/opensearch/index/engine/OpenSearchReaderManager.java
@@ -92,9 +92,6 @@ class OpenSearchReaderManager extends ReferenceManager<OpenSearchDirectoryReader
         // If not using NRT repl.
         if (currentInfos == null) {
             reader = (OpenSearchDirectoryReader) DirectoryReader.openIfChanged(referenceToRefresh);
-            if (reader != null) {
-                logger.info("Num docs primary {}", reader.getDelegate().numDocs());
-            }
         } else {
             // Open a new reader, sharing any common segment readers with the old one:
             DirectoryReader innerReader = StandardDirectoryReader.open(referenceToRefresh.directory(), currentInfos, subs, null);

--- a/server/src/main/java/org/opensearch/index/engine/OpenSearchReaderManager.java
+++ b/server/src/main/java/org/opensearch/index/engine/OpenSearchReaderManager.java
@@ -95,11 +95,15 @@ class OpenSearchReaderManager extends ReferenceManager<OpenSearchDirectoryReader
         // If not using NRT repl.
         if (currentInfos == null) {
             reader = (OpenSearchDirectoryReader) DirectoryReader.openIfChanged(referenceToRefresh);
+            if (reader != null) {
+                logger.info("Num docs primary {}", reader.getDelegate().numDocs());
+            }
         } else {
             // Open a new reader, sharing any common segment readers with the old one:
             DirectoryReader innerReader = StandardDirectoryReader.open(referenceToRefresh.directory(), currentInfos, subs, null);
             reader = OpenSearchDirectoryReader.wrap(innerReader, referenceToRefresh.shardId());
             logger.trace("updated to SegmentInfosVersion=" + currentInfos.getVersion() + " reader=" + innerReader);
+            logger.info("Num docs replica {}", reader.getDelegate().numDocs());
         }
         return reader;
     }

--- a/server/src/main/java/org/opensearch/index/engine/OpenSearchReaderManager.java
+++ b/server/src/main/java/org/opensearch/index/engine/OpenSearchReaderManager.java
@@ -92,6 +92,9 @@ class OpenSearchReaderManager extends ReferenceManager<OpenSearchDirectoryReader
         // If not using NRT repl.
         if (currentInfos == null) {
             reader = (OpenSearchDirectoryReader) DirectoryReader.openIfChanged(referenceToRefresh);
+            if (reader != null) {
+                logger.info("Num docs primary {}", reader.getDelegate().numDocs());
+            }
         } else {
             // Open a new reader, sharing any common segment readers with the old one:
             DirectoryReader innerReader = StandardDirectoryReader.open(referenceToRefresh.directory(), currentInfos, subs, null);

--- a/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
@@ -307,12 +307,6 @@ public class ReadOnlyEngine extends Engine {
     }
 
     @Override
-    public DeleteResult addDeleteOperationToTranslog(Delete delete) throws IOException{
-        assert false : "this should not be called";
-        throw new UnsupportedOperationException("Translog operations are not supported on a read-only engine");
-    }
-
-    @Override
     public NoOpResult noOp(NoOp noOp) {
         assert false : "this should not be called";
         throw new UnsupportedOperationException("no-ops are not supported on a read-only engine");

--- a/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
@@ -307,6 +307,12 @@ public class ReadOnlyEngine extends Engine {
     }
 
     @Override
+    public DeleteResult addDeleteOperationToTranslog(Delete delete) throws IOException{
+        assert false : "this should not be called";
+        throw new UnsupportedOperationException("Translog operations are not supported on a read-only engine");
+    }
+
+    @Override
     public NoOpResult noOp(NoOp noOp) {
         assert false : "this should not be called";
         throw new UnsupportedOperationException("no-ops are not supported on a read-only engine");

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1139,6 +1139,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             + "]";
         ensureWriteAllowed(origin);
         final Engine.Delete delete = prepareDelete(id, seqNo, opPrimaryTerm, version, versionType, origin, ifSeqNo, ifPrimaryTerm);
+        if(origin.equals(Engine.Operation.Origin.REPLICA) && indexSettings.isSegrepEnabled()){
+            return getEngine().addDeleteOperationToTranslog(delete);
+        }
         return delete(engine, delete);
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1139,9 +1139,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             + "]";
         ensureWriteAllowed(origin);
         final Engine.Delete delete = prepareDelete(id, seqNo, opPrimaryTerm, version, versionType, origin, ifSeqNo, ifPrimaryTerm);
-        if(origin.equals(Engine.Operation.Origin.REPLICA) && indexSettings.isSegrepEnabled()){
-            return getEngine().addDeleteOperationToTranslog(delete);
-        }
         return delete(engine, delete);
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1141,6 +1141,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             + "]";
         ensureWriteAllowed(origin);
         final Engine.Delete delete = prepareDelete(id, seqNo, opPrimaryTerm, version, versionType, origin, ifSeqNo, ifPrimaryTerm);
+        if(origin.equals(Engine.Operation.Origin.REPLICA) && indexSettings.isSegrepEnabled()){
+            return getEngine().addDeleteOperationToTranslog(delete);
+        }
         return delete(engine, delete);
     }
 


### PR DESCRIPTION
### Description
This PR fixes delete operations to only write to xlog on replicas. Integration Test for this is also added
 
### Issues Resolved
#2330 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
