### PR TITLE
[Backport 2.x] Remove endpoint_suffix dependency on account key

### DIFF
--- a/plugins/repository-azure/src/main/java/org/opensearch/repositories/azure/AzureStorageSettings.java
+++ b/plugins/repository-azure/src/main/java/org/opensearch/repositories/azure/AzureStorageSettings.java
@@ -91,8 +91,7 @@ final class AzureStorageSettings {
         AZURE_CLIENT_PREFIX_KEY,
         "endpoint_suffix",
         key -> Setting.simpleString(key, Property.NodeScope),
-        () -> ACCOUNT_SETTING,
-        () -> KEY_SETTING
+        () -> ACCOUNT_SETTING
     );
 
     // The overall operation timeout


### PR DESCRIPTION
Backport https://github.com/opensearch-project/OpenSearch/commit/365e07ce4be444a2f12938f442698f50782e80dc from https://github.com/opensearch-project/OpenSearch/pull/2485