### PR TITLE
fix _cat/shards api replica output

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -2379,7 +2379,11 @@ public class InternalEngine extends Engine {
     @Override
     protected final void writerSegmentStats(SegmentsStats stats) {
         stats.addVersionMapMemoryInBytes(versionMap.ramBytesUsed());
-        stats.addIndexWriterMemoryInBytes(indexWriter.ramBytesUsed());
+        long indexWriterMemoryInBytes = 0;
+        if (!(engineConfig.getIndexSettings().isSegrepEnabled() && engineConfig.isReadOnly())) {
+            indexWriterMemoryInBytes = indexWriter.ramBytesUsed();
+        }
+        stats.addIndexWriterMemoryInBytes(indexWriterMemoryInBytes);
         stats.updateMaxUnsafeAutoIdTimestamp(maxUnsafeAutoIdTimestamp.get());
     }
 


### PR DESCRIPTION
Signed-off-by: Poojita Raj <poojiraj@amazon.com>

### Description
The cat shards api output now includes the store size for the replica.
 
### Issues Resolved
Resolves #2431 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
