### PR TITLE
Add Gradle 7.4 Aggregated Test Reports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ plugins {
   id 'opensearch.global-build-info'
   id "com.diffplug.spotless" version "6.4.2" apply false
   id "org.gradle.test-retry" version "1.3.2" apply false
+  id "test-report-aggregation"
+  id 'jacoco-report-aggregation'
 }
 
 apply from: 'gradle/build-complete.gradle'
@@ -385,6 +387,15 @@ gradle.projectsEvaluated {
       }
     }
   }
+  
+  dependencies {
+    subprojects.findAll { it.pluginManager.hasPlugin('java') }.forEach {
+      testReportAggregation it
+    }
+    subprojects.findAll { it.pluginManager.hasPlugin('jacoco') }.forEach {
+     jacocoAggregation it
+    }
+  }
 }
 
 // test retry configuration
@@ -402,6 +413,7 @@ subprojects {
 // eclipse configuration
 allprojects {
   apply plugin: 'eclipse'
+  
   // Name all the non-root projects after their path so that paths get grouped together when imported into eclipse.
   if (path != ':') {
     eclipse.project.name = path
@@ -557,4 +569,16 @@ subprojects {
       project.tasks.named(taskname).configure { onlyIf { false } }
     }
   }
+}
+
+reporting {
+  reports {
+    testAggregateTestReport(AggregateTestReport) { 
+      testType = TestSuiteType.UNIT_TEST
+    }
+  }
+}
+
+tasks.named(JavaBasePlugin.CHECK_TASK_NAME) {
+  dependsOn tasks.named('testAggregateTestReport', TestReport) 
 }

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -10,92 +10,37 @@ apply plugin: 'jacoco'
 
 repositories {
   mavenCentral()
+  gradlePluginPortal()
 }
 
 allprojects {
   plugins.withId('jacoco') {
-    // The default JaCoCo version in Gradle 6.6.1 is 0.8.5, but at least version 0.8.6 officially supports Java 14
-    jacoco.toolVersion = '0.8.7'
+    jacoco.toolVersion = '0.8.8'
   }
-}
-
-def codeCoverageReportTask = tasks.register("codeCoverageReport", JacocoReport) {
-  description = 'Generates aggregate report from all subprojects.'
-  executionData.setFrom fileTree(dir: '.', include: '**/build/jacoco/*.exec')
-  dependsOn subprojects.findAll(s -> s.tasks.findByName('check') != null).check
-}
-
-tasks.register("codeCoverageReportForUnitTest", JacocoReport) {
-  description = 'Generates aggregate report from all subprojects for unit test.'
-  executionData.setFrom fileTree(dir: '.', include: '**/build/jacoco/test.exec')
-}
-
-tasks.register("codeCoverageReportForIntegrationTest", JacocoReport) {
-  description = 'Generates aggregate report from all subprojects for integration test.'
-  // These kinds of tests are integration test, and the tests can be ran by Gradle tasks with the same name
-  def integrationTestExecPathList = ['**/build/jacoco/integTest.exec',
-                                     '**/build/jacoco/internalClusterTest.exec',
-                                     '**/build/jacoco/javaRestTest.exec',
-                                     '**/build/jacoco/yamlRestTest.exec' ]
-  executionData.setFrom fileTree(dir: '.', include: integrationTestExecPathList)
 }
 
 tasks.withType(JacocoReport).configureEach {
   group = JavaBasePlugin.VERIFICATION_GROUP
 
-  // Select projects with corresponding tests in order to run proper tests and select proper classes to generate the report
-  def projectsWithJavaPlugin = subprojects.findAll { it.pluginManager.hasPlugin('java') }
-  def projectsWithUnitTest = projectsWithJavaPlugin.findAll { it.tasks.findByName('test').enabled }
-  def projectsWithIntegTest = projectsWithJavaPlugin.findAll {it.tasks.findByName('integTest')}
-  def projectsWithAsyncIntegTest = projectsWithJavaPlugin.findAll {it.tasks.findByName('asyncIntegTest')}
-  def projectsWithInternalClusterTest = projectsWithJavaPlugin.findAll {it.tasks.findByName('internalClusterTest')}
-  def projectsWithPooledInternalClusterTest = projectsWithJavaPlugin.findAll {it.tasks.findByName('pooledInternalClusterTest')}
-  def projectsWithJavaRestTest = projectsWithJavaPlugin.findAll {it.tasks.findByName('javaRestTest')}
-  def projectsWithYamlRestTest = projectsWithJavaPlugin.findAll {it.tasks.findByName('yamlRestTest')}
-  def projectsWithIntegrationTest = projectsWithIntegTest + projectsWithAsyncIntegTest + projectsWithInternalClusterTest + projectsWithPooledInternalClusterTest + projectsWithJavaRestTest + projectsWithYamlRestTest
-  def projectsWithTest = projectsWithUnitTest + projectsWithIntegrationTest
-
-  def selectedProjects
-  switch (name) {
-    case "codeCoverageReportForUnitTest":
-      dependsOn projectsWithUnitTest.test
-      selectedProjects = projectsWithUnitTest
-      break
-    case "codeCoverageReportForIntegrationTest":
-      dependsOn projectsWithIntegTest.integTest
-      dependsOn projectsWithAsyncIntegTest.asyncIntegTest
-      dependsOn projectsWithInternalClusterTest.internalClusterTest
-      dependsOn projectsWithPooledInternalClusterTest.pooledInternalClusterTest
-      dependsOn projectsWithJavaRestTest.javaRestTest
-      dependsOn projectsWithYamlRestTest.yamlRestTest
-      selectedProjects = projectsWithIntegrationTest
-      break
-    default:
-      dependsOn projectsWithUnitTest.test
-      dependsOn projectsWithIntegTest.integTest
-      dependsOn projectsWithAsyncIntegTest.asyncIntegTest
-      dependsOn projectsWithInternalClusterTest.internalClusterTest
-      dependsOn projectsWithPooledInternalClusterTest.pooledInternalClusterTest
-      dependsOn projectsWithJavaRestTest.javaRestTest
-      dependsOn projectsWithYamlRestTest.yamlRestTest
-      selectedProjects = projectsWithJavaPlugin
-      break
-  }
-  
-  sourceDirectories.setFrom files(selectedProjects.sourceSets.main.allSource.srcDirs)
-  classDirectories.setFrom files(selectedProjects.sourceSets.main.output)
-
   reports {
     // Code coverage report in HTML and CSV formats are on demand, in case they take extra disk space.
-    xml.getRequired().set(System.getProperty('tests.coverage.report.xml', 'true').toBoolean())
-    html.getRequired().set(System.getProperty('tests.coverage.report.html', 'false').toBoolean())
-    csv.getRequired().set(System.getProperty('tests.coverage.report.csv', 'false').toBoolean())
+    xml.required = System.getProperty('tests.coverage.report.xml', 'true').toBoolean()
+    html.required = System.getProperty('tests.coverage.report.html', 'false').toBoolean()
+    csv.required = System.getProperty('tests.coverage.report.csv', 'false').toBoolean()
   }
 }
 
 if (System.getProperty("tests.coverage")) {
+  reporting {
+    reports {
+      testCodeCoverageReport(JacocoCoverageReport) { 
+        testType = TestSuiteType.UNIT_TEST
+      }
+    }
+  }
+
   // Attach code coverage report task to Gradle check task
   project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME).configure {
-    dependsOn codeCoverageReportTask
+    dependsOn tasks.named('testCodeCoverageReport', JacocoReport) 
   }
 }


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Gradle [released](https://docs.gradle.org/7.4/release-notes.html) version 7.4  tool allows  to create aggregated test and Jacoco coverage HTML reports, see please [1].

Where the reports are located:
 - build/reports/jacoco/testCodeCoverageReport (more details [2])
 - build/reports/tests/unit-tests/aggregated-results (more details [3])

[1] https://docs.gradle.org/7.4/release-notes.html#new-features-and-usability-improvements
[2] https://docs.gradle.org/7.4/samples/sample_jvm_multi_project_with_code_coverage_standalone.html
[3] https://docs.gradle.org/7.4/samples/sample_jvm_multi_project_with_test_aggregation_standalone.html
[4] https://docs.gradle.org/current/userguide/test_report_aggregation_plugin.html

### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
