### PR TITLE
Change deprecation message for REST API parameter 'master_timeout' to specify the version of removal

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.clone/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.clone/10_basic.yml
@@ -48,7 +48,7 @@ setup:
   # now we do the actual clone
   - do:
       allowed_warnings:
-        - "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version."
+        - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
       indices.clone:
         index: "source"
         target: "target"
@@ -102,7 +102,7 @@ setup:
   - do:
       catch: /illegal_argument_exception/
       allowed_warnings:
-        - "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version."
+        - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
       indices.clone:
         index: "source"
         target: "target"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.clone/20_source_mapping.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.clone/20_source_mapping.yml
@@ -52,7 +52,7 @@
   # now we do the actual clone
   - do:
       allowed_warnings:
-        - "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version."
+        - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
       indices.clone:
         index: "source"
         target: "target"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.clone/30_copy_settings.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.clone/30_copy_settings.yml
@@ -37,7 +37,7 @@
   # now we do an actual clone and copy settings
   - do:
       allowed_warnings:
-        - "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version."
+        - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
       indices.clone:
         index: "source"
         target: "copy-settings-target"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yml
@@ -57,7 +57,7 @@
   # now we do the actual shrink
   - do:
       allowed_warnings:
-        - "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version."
+        - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
       indices.shrink:
         index: "source"
         target: "target"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/20_source_mapping.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/20_source_mapping.yml
@@ -61,7 +61,7 @@
     # now we do the actual shrink
     - do:
         allowed_warnings:
-          - "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version."
+          - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
         indices.shrink:
           index: "source"
           target: "target"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/30_copy_settings.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/30_copy_settings.yml
@@ -47,7 +47,7 @@
             index.merge.scheduler.max_thread_count: 2
       allowed_warnings:
         - "parameter [copy_settings] is deprecated and will be removed in 8.0.0"
-        - "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version."
+        - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
 
   - do:
       cluster.health:
@@ -66,7 +66,7 @@
   # now we do a actual shrink and copy settings (by default)
   - do:
       allowed_warnings:
-        - "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version."
+        - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
       indices.shrink:
         index: "source"
         target: "default-copy-settings-target"
@@ -95,7 +95,7 @@
   - do:
       catch: /illegal_argument_exception/
       allowed_warnings:
-        - "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version."
+        - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
       indices.shrink:
         index: "source"
         target: "explicit-no-copy-settings-target"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/10_basic.yml
@@ -48,7 +48,7 @@ setup:
   # now we do the actual split
   - do:
       allowed_warnings:
-        - "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version."
+        - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
       indices.split:
         index: "source"
         target: "target"
@@ -139,7 +139,7 @@ setup:
   # now we do the actual split from 1 to 5
   - do:
       allowed_warnings:
-        - "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version."
+        - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
       indices.split:
         index: "source_one_shard"
         target: "target"
@@ -192,7 +192,7 @@ setup:
   - do:
       catch: /illegal_argument_exception/
       allowed_warnings:
-        - "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version."
+        - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
       indices.split:
         index: "source"
         target: "target"
@@ -208,7 +208,7 @@ setup:
   - do:
       catch: /illegal_state_exception/
       allowed_warnings:
-        - "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version."
+        - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
       indices.split:
         index: "source"
         target: "target"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/20_source_mapping.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/20_source_mapping.yml
@@ -52,7 +52,7 @@
   # now we do the actual split
   - do:
       allowed_warnings:
-        - "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version."
+        - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
       indices.split:
         index: "source"
         target: "target"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
@@ -49,7 +49,7 @@
             index.merge.scheduler.max_thread_count: 2
       allowed_warnings:
         - "parameter [copy_settings] is deprecated and will be removed in 8.0.0"
-        - "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version."
+        - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
 
   - do:
       cluster.health:
@@ -68,7 +68,7 @@
   # now we do a actual shrink and copy settings (by default)
   - do:
       allowed_warnings:
-        - "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version."
+        - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
       indices.split:
         index: "source"
         target: "default-copy-settings-target"
@@ -97,7 +97,7 @@
   - do:
       catch: /illegal_argument_exception/
       allowed_warnings:
-        - "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version."
+        - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
       indices.split:
         index: "source"
         target: "explicit-no-copy-settings-target"

--- a/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
@@ -219,7 +219,7 @@ public abstract class BaseRestHandler implements RestHandler {
         String logMsgKeyPrefix
     ) {
         final String MASTER_TIMEOUT_DEPRECATED_MESSAGE =
-            "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version.";
+            "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead.";
         final String DUPLICATE_PARAMETER_ERROR_MESSAGE =
             "Please only use one of the request parameters [master_timeout, cluster_manager_timeout].";
         if (request.hasParam("master_timeout")) {

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestGetMappingAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestGetMappingAction.java
@@ -63,7 +63,7 @@ public class RestGetMappingAction extends BaseRestHandler {
 
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestGetMappingAction.class);
     private static final String MASTER_TIMEOUT_DEPRECATED_MESSAGE =
-        "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version.";
+        "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead.";
     private static final String DUPLICATE_PARAMETER_ERROR_MESSAGE =
         "Please only use one of the request parameters [master_timeout, cluster_manager_timeout].";
 

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestIndicesAction.java
@@ -86,7 +86,7 @@ public class RestIndicesAction extends AbstractCatAction {
     private static final DateFormatter STRICT_DATE_TIME_FORMATTER = DateFormatter.forPattern("strict_date_time");
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestIndicesAction.class);
     private static final String MASTER_TIMEOUT_DEPRECATED_MESSAGE =
-        "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version.";
+        "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead.";
     private static final String DUPLICATE_PARAMETER_ERROR_MESSAGE =
         "Please only use one of the request parameters [master_timeout, cluster_manager_timeout].";
 

--- a/server/src/test/java/org/opensearch/action/RenamedTimeoutRequestParameterTests.java
+++ b/server/src/test/java/org/opensearch/action/RenamedTimeoutRequestParameterTests.java
@@ -78,7 +78,7 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
     private static final String DUPLICATE_PARAMETER_ERROR_MESSAGE =
         "Please only use one of the request parameters [master_timeout, cluster_manager_timeout].";
     private static final String MASTER_TIMEOUT_DEPRECATED_MESSAGE =
-        "Deprecated parameter [master_timeout] used. To promote inclusive language, please use [cluster_manager_timeout] instead. It will be unsupported in a future major version.";
+        "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead.";
 
     @After
     public void terminateThreadPool() {


### PR DESCRIPTION
### Description
According to the comments, change the deprecation message of REST API parameter `master_timeout`:
https://github.com/opensearch-project/OpenSearch/pull/2678#discussion_r847640803 
https://github.com/opensearch-project/OpenSearch/pull/2682#discussion_r847636915
- Specify the version (3.0) to remove the deprecated parameter.
- Change the word `promote` to `support`.
 
### Issues Resolved
Related to #2511 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
