### PR TITLE
Adding a null pointer check to fix index_prefix query

### DIFF
--- a/server/src/main/java/org/opensearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/TextFieldMapper.java
@@ -583,7 +583,9 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
             }
             Automaton automaton = Operations.concatenate(automata);
             AutomatonQuery query = new AutomatonQuery(new Term(name(), value + "*"), automaton);
-            query.setRewriteMethod(method);
+            if (method != null) {
+                query.setRewriteMethod(method);
+            }
             return new BooleanQuery.Builder().add(query, BooleanClause.Occur.SHOULD)
                 .add(new TermQuery(new Term(parentField.name(), value)), BooleanClause.Occur.SHOULD)
                 .build();

--- a/server/src/test/java/org/opensearch/index/mapper/TextFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/TextFieldTypeTests.java
@@ -190,6 +190,17 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
         );
 
         assertThat(q, equalTo(expected));
+
+        q = ft.prefixQuery("g", null, false, randomMockShardContext());
+        automaton = Operations.concatenate(Arrays.asList(Automata.makeChar('g'), Automata.makeAnyChar()));
+
+        expected = new ConstantScoreQuery(
+            new BooleanQuery.Builder().add(new AutomatonQuery(new Term("field._index_prefix", "g*"), automaton), BooleanClause.Occur.SHOULD)
+                .add(new TermQuery(new Term("field", "g")), BooleanClause.Occur.SHOULD)
+                .build()
+        );
+
+        assertThat(q, equalTo(expected));
     }
 
     public void testFetchSourceValue() throws IOException {


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
When the length of the query prefix is = minChars-1, the code follows the path in TextFieldMapper and throws an NPE [here](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/mapper/TextFieldMapper.java#L586). Adding a null check for the method, the query returns a result without an NPE now:

```
curl -XPUT localhost:9200/test --data '{                                                                             
"mappings": {
    "properties": {
      "t": {
        "type": "text",
        "index_prefixes": { "min_chars": "3" }
      }
    }
  }
}' -H "Content-Type:Application/json"
{{"acknowledged":true,"shards_acknowledged":true,"index":"test"}
```
```
curl 'localhost:9200/test/_search?pretty' --data '{"query":{"prefix":{"t": "st"}}}' -H "Content-Type:Application/json"
{
  "took" : 9,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 0,
      "relation" : "eq"
    },
    "max_score" : null,
    "hits" : [ ]
  }
}
```

Tested with various scenarios mentioned in the issue. Adding the details in the comments of this PR.
 
### Issues Resolved
#2826 
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
