### PR TITLE
Change deprecation message for API parameter value 'master_node' of parameter 'metric'

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.state/20_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.state/20_filtering.yml
@@ -169,7 +169,7 @@ setup:
       cluster.state:
         metric: [ master_node, version ]
       allowed_warnings:
-        - 'Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead.'
+        - 'Assigning [master_node] to parameter [metric] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_node] instead.'
 
   - match: { cluster_uuid: $cluster_uuid }
   - is_true: master_node

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterRerouteAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterRerouteAction.java
@@ -83,7 +83,7 @@ public class RestClusterRerouteAction extends BaseRestHandler {
     // It's used to log deprecation when request parameter 'metric' contains 'master_node', or request parameter 'master_timeout' is used.
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestClusterRerouteAction.class);
     private static final String DEPRECATED_MESSAGE_MASTER_NODE =
-        "Deprecated value [master_node] used for parameter [metric]. To promote inclusive language, please use [cluster_manager_node] instead. It will be unsupported in a future major version.";
+        "Assigning [master_node] to parameter [metric] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_node] instead.";
 
     @Override
     public List<Route> routes() {

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterStateAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterStateAction.java
@@ -76,7 +76,7 @@ public class RestClusterStateAction extends BaseRestHandler {
     // It's used to log deprecation when request parameter 'metric' contains 'master_node', or request parameter 'master_timeout' is used.
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestClusterStateAction.class);
     private static final String DEPRECATED_MESSAGE_MASTER_NODE =
-        "Deprecated value [master_node] used for parameter [metric]. To promote inclusive language, please use [cluster_manager_node] instead. It will be unsupported in a future major version.";
+        "Assigning [master_node] to parameter [metric] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_node] instead.";
 
     @Override
     public String getName() {


### PR DESCRIPTION
### Description
- Fix REST API test failure caused by the commit https://github.com/opensearch-project/OpenSearch/commit/07fc06d5a69106078d5467993752693a64423fb0#diff-07ee2fae81fcb1a59586494ccd6ec9d44a21bdcb5a57ebf053aa352aa85ba5f7 (of PR https://github.com/opensearch-project/OpenSearch/pull/2678), where the file `cluster.state/20_filtering.yml` is changed by mistake.
- Revise the deprecation message to include the version of removal. A similar PR https://github.com/opensearch-project/OpenSearch/pull/2863 for reference.
 
### Issues Resolved

The test failure of `org.opensearch.test.rest.ClientYamlTestSuiteIT" -Dtests.method="test {p0=cluster.state/20_filtering/Filtering the cluster state returns cluster_uuid at the top level regardless of metric filters}`, see https://github.com/opensearch-project/OpenSearch/pull/2875#issuecomment-1097151711 for detail.
Related to https://github.com/opensearch-project/OpenSearch/issues/2878
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
