### PR TITLE
fix - replica shards trying to send replica checkpoints

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -3231,7 +3231,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             }
         };
         final List<ReferenceManager.RefreshListener> internalRefreshListener;
-        if (indexSettings.isSegrepEnabled()) {
+        if (indexSettings.isSegrepEnabled() && shardRouting.primary()) {
             internalRefreshListener = Arrays.asList(new RefreshMetricUpdater(refreshMetric), checkpointRefreshListener);
         } else {
             internalRefreshListener = Collections.singletonList(new RefreshMetricUpdater(refreshMetric));


### PR DESCRIPTION
Signed-off-by: Poojita Raj <poojiraj@amazon.com>

### Description
This fix stops the replica shards from incorrectly trying to send checkpoints by avoiding wiring up the replica's internalRefreshListeners with CheckpointRefreshListener.
 
### Issues Resolved
Resolves #2815 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
