### PR TITLE
Override toString for usable logs

### DIFF
--- a/client/rest-high-level/src/main/java/org/opensearch/client/cluster/ProxyModeInfo.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/cluster/ProxyModeInfo.java
@@ -94,4 +94,20 @@ public class ProxyModeInfo implements RemoteConnectionInfo.ModeInfo {
     public int hashCode() {
         return Objects.hash(address, serverName, maxSocketConnections, numSocketsConnected);
     }
+
+    @Override
+    public String toString() {
+        return "ProxyModeInfo{"
+            + "address='"
+            + address
+            + '\''
+            + ", serverName='"
+            + serverName
+            + '\''
+            + ", maxSocketConnections="
+            + maxSocketConnections
+            + ", numSocketsConnected="
+            + numSocketsConnected
+            + '}';
+    }
 }

--- a/client/rest-high-level/src/main/java/org/opensearch/client/cluster/RemoteConnectionInfo.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/cluster/RemoteConnectionInfo.java
@@ -142,6 +142,22 @@ public final class RemoteConnectionInfo {
         return Objects.hash(modeInfo, initialConnectionTimeoutString, clusterAlias, skipUnavailable);
     }
 
+    @Override
+    public String toString() {
+        return "RemoteConnectionInfo{"
+            + "modeInfo="
+            + modeInfo
+            + ", initialConnectionTimeoutString='"
+            + initialConnectionTimeoutString
+            + '\''
+            + ", clusterAlias='"
+            + clusterAlias
+            + '\''
+            + ", skipUnavailable="
+            + skipUnavailable
+            + '}';
+    }
+
     public interface ModeInfo {
 
         boolean isConnected();

--- a/client/rest-high-level/src/main/java/org/opensearch/client/cluster/SniffModeInfo.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/cluster/SniffModeInfo.java
@@ -86,4 +86,16 @@ public class SniffModeInfo implements RemoteConnectionInfo.ModeInfo {
     public int hashCode() {
         return Objects.hash(seedNodes, maxConnectionsPerCluster, numNodesConnected);
     }
+
+    @Override
+    public String toString() {
+        return "SniffModeInfo{"
+            + "seedNodes="
+            + seedNodes
+            + ", maxConnectionsPerCluster="
+            + maxConnectionsPerCluster
+            + ", numNodesConnected="
+            + numNodesConnected
+            + '}';
+    }
 }


### PR DESCRIPTION
Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>

### Description
- The logs for the flakey test have the generic Java object hash representation
- Adding in `toString` overrides for corresponding classes for usable logs
 
### Issues Resolved
- https://github.com/opensearch-project/OpenSearch/issues/1703
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
