### PR TITLE
Adding @reta to OpenSearch maintainers.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,7 +4,7 @@
 | --------------- | --------- | ----------- |
 | Abbas Hussain | [abbashus](https://github.com/abbashus) | Amazon |
 | Anas Alkouz | [anasalkouz](https://github.com/anasalkouz) | Amazon |
-| Andrew Ross   | [andross](https://github.com/andrross)| Amazon |
+| Andrew Ross   | [andrross](https://github.com/andrross)| Amazon |
 | Andriy Redko | [reta](https://github.com/reta) | Aiven |
 | Charlotte Henkle | [CEHENKLE](https://github.com/CEHENKLE) | Amazon |
 | Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock) | Amazon |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,27 +3,27 @@
 | Maintainer | GitHub ID | Affiliation |
 | --------------- | --------- | ----------- |
 | Abbas Hussain | [abbashus](https://github.com/abbashus) | Amazon |
-| Charlotte Henkle | [CEHENKLE](https://github.com/CEHENKLE) | Amazon |
-| Himanshu Setia | [setiah](https://github.com/setiah) | Amazon |
-| Nick Knize | [nknize](https://github.com/nknize) | Amazon |
-| Rabi Panda | [adnapibar](https://github.com/adnapibar) | Amazon |
-| Sarat Vemulapalli | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon |
-| Tianli Feng | [tlfeng](https://github.com/tlfeng) | Amazon |
-| Gopala Krishna Ambareesh | [krishna-ggk](https://github.com/krishna-ggk) |Amazon |
-| Vengadanathan Srinivasan | [vengadanathan-s](https://github.com/vengadanathan-s) | Amazon |
-| Shweta Thareja |[shwetathareja](https://github.com/shwetathareja) | Amazon |
-| Itiyama Sadana | [itiyamas](https://github.com/itiyamas) | Amazon |
-| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock) | Amazon |
-| Andrew Ross   | [andross](https://github.com/andrross)| Amazon |
-| Vacha Shah | [VachaShah](https://github.com/VachaShah) | Amazon |
 | Anas Alkouz | [anasalkouz](https://github.com/anasalkouz) | Amazon |
-| Megha Sai Kavikondala | [meghasaik](https://github.com/meghasaik) | Amazon |
-| Rishikesh Pasham | [Rishikesh1159](https://github.com/Rishikesh1159) | Amazon|
-| Xue Zhou | [xuezhou25](https://github.com/xuezhou25) | Amazon |
+| Andrew Ross   | [andross](https://github.com/andrross)| Amazon |
+| Andriy Redko | [reta](https://github.com/reta) | Aiven |
+| Charlotte Henkle | [CEHENKLE](https://github.com/CEHENKLE) | Amazon |
+| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock) | Amazon |
+| Gopala Krishna Ambareesh | [krishna-ggk](https://github.com/krishna-ggk) |Amazon |
+| Himanshu Setia | [setiah](https://github.com/setiah) | Amazon |
+| Itiyama Sadana | [itiyamas](https://github.com/itiyamas) | Amazon |
 | Kartik Ganesh | [kartg](https://github.com/kartg) | Amazon |
 | Marc Handalian | [mch2](https://github.com/mch2) | Amazon |
-| Ryan Bogan | [ryanbogan](https://github.com/ryanbogan) | Amazon |
+| Megha Sai Kavikondala | [meghasaik](https://github.com/meghasaik) | Amazon |
+| Nick Knize | [nknize](https://github.com/nknize) | Amazon |
 | Owais Kazi | [owaiskazi19](https://github.com/owaiskazi19) | Amazon |
-
+| Rabi Panda | [adnapibar](https://github.com/adnapibar) | Amazon |
+| Rishikesh Pasham | [Rishikesh1159](https://github.com/Rishikesh1159) | Amazon|
+| Ryan Bogan | [ryanbogan](https://github.com/ryanbogan) | Amazon |
+| Sarat Vemulapalli | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon |
+| Shweta Thareja |[shwetathareja](https://github.com/shwetathareja) | Amazon |
+| Tianli Feng | [tlfeng](https://github.com/tlfeng) | Amazon |
+| Vacha Shah | [VachaShah](https://github.com/VachaShah) | Amazon |
+| Vengadanathan Srinivasan | [vengadanathan-s](https://github.com/vengadanathan-s) | Amazon |
+| Xue Zhou | [xuezhou25](https://github.com/xuezhou25) | Amazon |
 
 [This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Following the process in https://github.com/opensearch-project/.github/pull/59, I had nominated Andriy Redko (@reta) as a co-maintainer. The maintainers have voted and agreed to this nomination.
 
Andriy is the author of [124 PRs](https://github.com/opensearch-project/OpenSearch/pulls?q=is%3Apr+author%3Areta+is%3Aclosed) into OpenSearch, [second](https://github.com/opensearch-project/OpenSearch/graphs/contributors?from=2021-05-27&to=2022-04-04&type=c) in code change volume since the fork.
 
![image](https://user-images.githubusercontent.com/542335/163454988-4980aa44-94ad-4a83-a364-ed93ec9ed14e.png)
 
Some of reta@’s notable early code contributions were in the supporting infrastructure space, and have increasingly been shifting into adding new features:
 
- https://github.com/opensearch-project/OpenSearch/pull/1500: Concurrent searching
- https://github.com/opensearch-project/OpenSearch/pull/1521, [1302](https://github.com/opensearch-project/OpenSearch/pull/1302), [1390](https://github.com/opensearch-project/OpenSearch/pull/1390), [1789](https://github.com/opensearch-project/OpenSearch/pull/1789): Improving/upgrading/fixing repository-azure
- https://github.com/opensearch-project/OpenSearch/pull/1771, [1721](https://github.com/opensearch-project/OpenSearch/pull/1721), …: Upgrading log4j
- https://github.com/opensearch-project/OpenSearch/pull/1609, [1803](https://github.com/opensearch-project/OpenSearch/pull/1803), [2078](https://github.com/opensearch-project/OpenSearch/pull/2078), …: Upgrades to Gradle
- https://github.com/opensearch-project/OpenSearch/pull/1358. [1803](https://github.com/opensearch-project/OpenSearch/pull/1803), [1476](https://github.com/opensearch-project/OpenSearch/pull/1476), [2007](https://github.com/opensearch-project/OpenSearch/pull/2007): Modernizing, consolidating, upgrading JDK
- https://github.com/opensearch-project/OpenSearch/pull/2001: Support for OPENSEARCH_JAVA_HOME
 
Andriy is active almost daily in the project, thoughtfully reviewing and commenting on pull requests ([example](https://github.com/opensearch-project/OpenSearch/pull/2639#discussion_r839909012)). He also has write permissions on https://github.com/opensearch-project/opensearch-plugin-template-java/ already. 

This PR also sorts current maintainers alphabetically.  
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
