### PR TITLE
Add Github Workflow to build and publish lucene snapshots.

### DIFF
--- a/.github/workflows/lucene-snapshots.yml
+++ b/.github/workflows/lucene-snapshots.yml
@@ -1,0 +1,55 @@
+# This workflow will check out, build, and publish snapshots of lucene.
+
+name: OpenSearch Lucene snapshots
+
+on:
+  workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      ref:
+        description:
+        required: false
+        default: 'main'
+
+jobs:
+  publish-snapshots:
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Checkout Lucene
+        uses: actions/checkout@v2
+        with:
+          repository: 'apache/lucene'
+          path: lucene
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Set hash
+        working-directory: ./lucene
+        run: |
+          echo "::set-output name=REVISION::$(git rev-parse --short HEAD)"
+        id: version
+
+      - name: Publish Lucene to local maven repo.
+        working-directory: ./lucene
+        run: ./gradlew publishJarsPublicationToMavenLocal -Pversion.suffix=snapshot-${{ steps.version.outputs.REVISION }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.LUCENE_SNAPSHOTS_ROLE }}
+          aws-region: us-west-2
+
+      - name: Copy files to S3 with the aws CLI.
+        run: |
+          aws s3 cp ~/.m2/repository/org/apache/lucene/ s3://${{ secrets.LUCENE_SNAPSHOTS_BUCKET }}/snapshots/lucene/org/apache/lucene/  --recursive --no-progress

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -49,6 +49,7 @@
   - [Submitting Changes](#submitting-changes)
   - [Backports](#backports)
   - [LineLint](#linelint)
+  - [Lucene Snapshots](#lucene-snapshots)
 
 # Developer Guide
 
@@ -488,3 +489,8 @@ Executing the binary will automatically search the local directory tree for lint
 Pass a list of files or directories to limit your search.
 
     linelint README.md LICENSE
+
+# Lucene Snapshots
+The Github workflow in [lucene-snapshots.yml](.github/workflows/lucene-snapshots.yml) is a Github worfklow executable by maintainers to build a top-down snapshot build of lucene.
+These snapshots are available to test compatibility with upcoming changes to Lucene by updating the version at [version.properties](buildsrc/version.properties) with the `version-snapshot-sha` version.
+Example: `lucene = 10.0.0-snapshot-2e941fc`.

--- a/buildSrc/src/main/java/org/opensearch/gradle/RepositoriesSetupPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/RepositoriesSetupPlugin.java
@@ -92,10 +92,9 @@ public class RepositoriesSetupPlugin implements Plugin<Project> {
                 throw new GradleException("Malformed lucene snapshot version: " + luceneVersion);
             }
             String revision = matcher.group(1);
-            // TODO(cleanup) - Setup own lucene snapshot repo
             MavenArtifactRepository luceneRepo = repos.maven(repo -> {
                 repo.setName("lucene-snapshots");
-                repo.setUrl("https://artifacts.opensearch.org/snapshots/lucene/");
+                repo.setUrl("https://d1nvenhzbhpy0q.cloudfront.net/snapshots/lucene/");
             });
             repos.exclusiveContent(exclusiveRepo -> {
                 exclusiveRepo.filter(


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
This change introduces a github workflow so that maintainers can build and push snapshots of lucene.
The RepositoriesSetupPlugin is also updated with a url from where these snapshots can be retrieved.

This workflow will be initially manually executable by maintainers but will be extended to run periodically and test compatibility with OpenSearch.

I have [tested](https://github.com/mch2/TestActions/actions/workflows/lucene-snapshots.yml) this workflow & the Integration with RepositoriesSetupPlugin from a personal repository.
 
### Issues Resolved
closes #2785 
closes #2786 
closes https://github.com/opensearch-project/opensearch-build/issues/1920
closes https://github.com/opensearch-project/opensearch-build/issues/1778
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
