### PR TITLE
[1.3 backport] Fix opensearch-env always sources the environment from hardcoded file in #875

### DIFF
--- a/distribution/src/bin/opensearch-env
+++ b/distribution/src/bin/opensearch-env
@@ -81,7 +81,9 @@ fi
 
 export HOSTNAME=$HOSTNAME
 
-${source.path.env}
+if [ -z "$OPENSEARCH_PATH_CONF" ]; then
+  ${source.path.env}
+fi
 
 if [ -z "$OPENSEARCH_PATH_CONF" ]; then
   echo "OPENSEARCH_PATH_CONF must be set to the configuration path"


### PR DESCRIPTION
distribution/bin/opensearch-env always sources the environment from the default environment file /etc/default/opensearch. This is an issue if we want to run multiple instances of OpenSearch on the same host. This change lets users override the default behavior by not sourcing the default environment file in case OPENSEARCH_PATH_CONF  is set.

Signed-off-by: xuezhou25 <85715413+xuezhou25@users.noreply.github.com>
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>



### Description
[1.x backport] Fix opensearch-env always sources the environment from hardcoded file in #875
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/1545#issuecomment-1092408321
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
