### PR TITLE
[2.x] Remove deprecation warning of using REST API request parameter 'master_timeout'

### DIFF
--- a/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
@@ -41,7 +41,6 @@ import org.opensearch.action.support.master.MasterNodeRequest;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.collect.Tuple;
-import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.plugins.ActionPlugin;
@@ -214,10 +213,7 @@ public abstract class BaseRestHandler implements RestHandler {
      * @param mnr the action request
      * @param request the REST request to handle
      */
-    public static void parseDeprecatedMasterTimeoutParameter(
-        MasterNodeRequest mnr,
-        RestRequest request
-    ) {
+    public static void parseDeprecatedMasterTimeoutParameter(MasterNodeRequest mnr, RestRequest request) {
         if (request.hasParam("master_timeout")) {
             if (request.hasParam("cluster_manager_timeout")) {
                 throw new OpenSearchParseException(DUPLICATE_PARAMETER_ERROR_MESSAGE);

--- a/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
@@ -203,10 +203,15 @@ public abstract class BaseRestHandler implements RestHandler {
         return Collections.emptySet();
     }
 
+    /* protected static final String MASTER_TIMEOUT_DEPRECATED_MESSAGE = 
+        "Parameter [master_timeout] is deprecated and will be removed in 4.0. To support inclusive language, please use [cluster_manager_timeout] instead."; */
+    protected static final String DUPLICATE_PARAMETER_ERROR_MESSAGE =
+        "Please only use one of the request parameters [master_timeout, cluster_manager_timeout].";
+
     /**
      * Parse the deprecated request parameter 'master_timeout', and add deprecated log if the parameter is used.
      * It also validates whether the two parameters 'master_timeout' and 'cluster_manager_timeout' are not assigned together.
-     * The method is temporarily added in 2.0 duing applying inclusive language. Remove the method along with MASTER_ROLE.
+     * The method is temporarily added in 2.0 during applying inclusive language. Remove the method along with MASTER_ROLE.
      * @param mnr the action request
      * @param request the REST request to handle
      * @param logger the logger that logs deprecation notices
@@ -218,12 +223,9 @@ public abstract class BaseRestHandler implements RestHandler {
         DeprecationLogger logger,
         String logMsgKeyPrefix
     ) {
-        final String MASTER_TIMEOUT_DEPRECATED_MESSAGE =
-            "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead.";
-        final String DUPLICATE_PARAMETER_ERROR_MESSAGE =
-            "Please only use one of the request parameters [master_timeout, cluster_manager_timeout].";
         if (request.hasParam("master_timeout")) {
-            logger.deprecate(logMsgKeyPrefix + "_master_timeout_parameter", MASTER_TIMEOUT_DEPRECATED_MESSAGE);
+            // TODO: Start emitting deprecation warning in 3.0 (A major version ahead of removal)
+            // logger.deprecate(logMsgKeyPrefix + "_master_timeout_parameter", MASTER_TIMEOUT_DEPRECATED_MESSAGE);
             if (request.hasParam("cluster_manager_timeout")) {
                 throw new OpenSearchParseException(DUPLICATE_PARAMETER_ERROR_MESSAGE);
             }

--- a/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
@@ -203,29 +203,22 @@ public abstract class BaseRestHandler implements RestHandler {
         return Collections.emptySet();
     }
 
-    /* protected static final String MASTER_TIMEOUT_DEPRECATED_MESSAGE = 
-        "Parameter [master_timeout] is deprecated and will be removed in 4.0. To support inclusive language, please use [cluster_manager_timeout] instead."; */
     protected static final String DUPLICATE_PARAMETER_ERROR_MESSAGE =
         "Please only use one of the request parameters [master_timeout, cluster_manager_timeout].";
 
     /**
      * Parse the deprecated request parameter 'master_timeout', and add deprecated log if the parameter is used.
      * It also validates whether the two parameters 'master_timeout' and 'cluster_manager_timeout' are not assigned together.
-     * The method is temporarily added in 2.0 during applying inclusive language. Remove the method along with MASTER_ROLE.
+     * Deprecation log is not emitted intentionally, because 'master_timeout' is remained in High-Level-REST-Client to keep compatibility with server 1.x.
+     * The method is temporarily added in 2.0 during applying inclusive language. Remove the method along with the parameter 'master_timeout'.
      * @param mnr the action request
      * @param request the REST request to handle
-     * @param logger the logger that logs deprecation notices
-     * @param logMsgKeyPrefix the key prefix of a deprecation message to avoid duplicate messages.
      */
     public static void parseDeprecatedMasterTimeoutParameter(
         MasterNodeRequest mnr,
-        RestRequest request,
-        DeprecationLogger logger,
-        String logMsgKeyPrefix
+        RestRequest request
     ) {
         if (request.hasParam("master_timeout")) {
-            // TODO: Start emitting deprecation warning in 3.0 (A major version ahead of removal)
-            // logger.deprecate(logMsgKeyPrefix + "_master_timeout_parameter", MASTER_TIMEOUT_DEPRECATED_MESSAGE);
             if (request.hasParam("cluster_manager_timeout")) {
                 throw new OpenSearchParseException(DUPLICATE_PARAMETER_ERROR_MESSAGE);
             }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestCleanupRepositoryAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestCleanupRepositoryAction.java
@@ -70,7 +70,7 @@ public class RestCleanupRepositoryAction extends BaseRestHandler {
         cleanupRepositoryRequest.masterNodeTimeout(
             request.paramAsTime("cluster_manager_timeout", cleanupRepositoryRequest.masterNodeTimeout())
         );
-        parseDeprecatedMasterTimeoutParameter(cleanupRepositoryRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(cleanupRepositoryRequest, request);
         return channel -> client.admin().cluster().cleanupRepository(cleanupRepositoryRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestCloneSnapshotAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestCloneSnapshotAction.java
@@ -75,7 +75,7 @@ public class RestCloneSnapshotAction extends BaseRestHandler {
             XContentMapValues.nodeStringArrayValue(source.getOrDefault("indices", Collections.emptyList()))
         );
         cloneSnapshotRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", cloneSnapshotRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(cloneSnapshotRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(cloneSnapshotRequest, request);
         cloneSnapshotRequest.indicesOptions(IndicesOptions.fromMap(source, cloneSnapshotRequest.indicesOptions()));
         return channel -> client.admin().cluster().cloneSnapshot(cloneSnapshotRequest, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterGetSettingsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterGetSettingsAction.java
@@ -88,7 +88,7 @@ public class RestClusterGetSettingsAction extends BaseRestHandler {
         final boolean renderDefaults = request.paramAsBoolean("include_defaults", false);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", clusterStateRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request);
         return channel -> client.admin().cluster().state(clusterStateRequest, new RestBuilderListener<ClusterStateResponse>(channel) {
             @Override
             public RestResponse buildResponse(ClusterStateResponse response, XContentBuilder builder) throws Exception {

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterHealthAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterHealthAction.java
@@ -85,7 +85,7 @@ public class RestClusterHealthAction extends BaseRestHandler {
         clusterHealthRequest.indicesOptions(IndicesOptions.fromRequest(request, clusterHealthRequest.indicesOptions()));
         clusterHealthRequest.local(request.paramAsBoolean("local", clusterHealthRequest.local()));
         clusterHealthRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", clusterHealthRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(clusterHealthRequest, request, deprecationLogger, "cluster_health");
+        parseDeprecatedMasterTimeoutParameter(clusterHealthRequest, request);
         clusterHealthRequest.timeout(request.paramAsTime("timeout", clusterHealthRequest.timeout()));
         String waitForStatus = request.param("wait_for_status");
         if (waitForStatus != null) {

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterRerouteAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterRerouteAction.java
@@ -144,7 +144,7 @@ public class RestClusterRerouteAction extends BaseRestHandler {
         clusterRerouteRequest.timeout(request.paramAsTime("timeout", clusterRerouteRequest.timeout()));
         clusterRerouteRequest.setRetryFailed(request.paramAsBoolean("retry_failed", clusterRerouteRequest.isRetryFailed()));
         clusterRerouteRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", clusterRerouteRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(clusterRerouteRequest, request, deprecationLogger, "cluster_reroute");
+        parseDeprecatedMasterTimeoutParameter(clusterRerouteRequest, request);
         request.applyContentParser(parser -> PARSER.parse(parser, clusterRerouteRequest, null));
         return clusterRerouteRequest;
     }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterStateAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterStateAction.java
@@ -105,7 +105,7 @@ public class RestClusterStateAction extends BaseRestHandler {
         clusterStateRequest.indicesOptions(IndicesOptions.fromRequest(request, clusterStateRequest.indicesOptions()));
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", clusterStateRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request);
         if (request.hasParam("wait_for_metadata_version")) {
             clusterStateRequest.waitForMetadataVersion(request.paramAsLong("wait_for_metadata_version", 0));
         }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterUpdateSettingsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterUpdateSettingsAction.java
@@ -74,7 +74,7 @@ public class RestClusterUpdateSettingsAction extends BaseRestHandler {
         clusterUpdateSettingsRequest.masterNodeTimeout(
             request.paramAsTime("cluster_manager_timeout", clusterUpdateSettingsRequest.masterNodeTimeout())
         );
-        parseDeprecatedMasterTimeoutParameter(clusterUpdateSettingsRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(clusterUpdateSettingsRequest, request);
         Map<String, Object> source;
         try (XContentParser parser = request.contentParser()) {
             source = parser.map();

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestCreateSnapshotAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestCreateSnapshotAction.java
@@ -72,7 +72,7 @@ public class RestCreateSnapshotAction extends BaseRestHandler {
         CreateSnapshotRequest createSnapshotRequest = createSnapshotRequest(request.param("repository"), request.param("snapshot"));
         request.applyContentParser(p -> createSnapshotRequest.source(p.mapOrdered()));
         createSnapshotRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", createSnapshotRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(createSnapshotRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(createSnapshotRequest, request);
         createSnapshotRequest.waitForCompletion(request.paramAsBoolean("wait_for_completion", false));
         return channel -> client.admin().cluster().createSnapshot(createSnapshotRequest, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestDeleteRepositoryAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestDeleteRepositoryAction.java
@@ -70,7 +70,7 @@ public class RestDeleteRepositoryAction extends BaseRestHandler {
         deleteRepositoryRequest.masterNodeTimeout(
             request.paramAsTime("cluster_manager_timeout", deleteRepositoryRequest.masterNodeTimeout())
         );
-        parseDeprecatedMasterTimeoutParameter(deleteRepositoryRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(deleteRepositoryRequest, request);
         return channel -> client.admin().cluster().deleteRepository(deleteRepositoryRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestDeleteSnapshotAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestDeleteSnapshotAction.java
@@ -71,7 +71,7 @@ public class RestDeleteSnapshotAction extends BaseRestHandler {
             Strings.splitStringByCommaToArray(request.param("snapshot"))
         );
         deleteSnapshotRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", deleteSnapshotRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(deleteSnapshotRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(deleteSnapshotRequest, request);
         return channel -> client.admin().cluster().deleteSnapshot(deleteSnapshotRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestDeleteStoredScriptAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestDeleteStoredScriptAction.java
@@ -66,7 +66,7 @@ public class RestDeleteStoredScriptAction extends BaseRestHandler {
         deleteStoredScriptRequest.masterNodeTimeout(
             request.paramAsTime("cluster_manager_timeout", deleteStoredScriptRequest.masterNodeTimeout())
         );
-        parseDeprecatedMasterTimeoutParameter(deleteStoredScriptRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(deleteStoredScriptRequest, request);
 
         return channel -> client.admin().cluster().deleteStoredScript(deleteStoredScriptRequest, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestGetRepositoriesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestGetRepositoriesAction.java
@@ -81,7 +81,7 @@ public class RestGetRepositoriesAction extends BaseRestHandler {
         getRepositoriesRequest.masterNodeTimeout(
             request.paramAsTime("cluster_manager_timeout", getRepositoriesRequest.masterNodeTimeout())
         );
-        parseDeprecatedMasterTimeoutParameter(getRepositoriesRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(getRepositoriesRequest, request);
         getRepositoriesRequest.local(request.paramAsBoolean("local", getRepositoriesRequest.local()));
         settingsFilter.addFilterSettingParams(request);
         return channel -> client.admin().cluster().getRepositories(getRepositoriesRequest, new RestToXContentListener<>(channel));

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestGetSnapshotsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestGetSnapshotsAction.java
@@ -73,7 +73,7 @@ public class RestGetSnapshotsAction extends BaseRestHandler {
         getSnapshotsRequest.ignoreUnavailable(request.paramAsBoolean("ignore_unavailable", getSnapshotsRequest.ignoreUnavailable()));
         getSnapshotsRequest.verbose(request.paramAsBoolean("verbose", getSnapshotsRequest.verbose()));
         getSnapshotsRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", getSnapshotsRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(getSnapshotsRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(getSnapshotsRequest, request);
         return channel -> client.admin().cluster().getSnapshots(getSnapshotsRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestGetStoredScriptAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestGetStoredScriptAction.java
@@ -63,7 +63,7 @@ public class RestGetStoredScriptAction extends BaseRestHandler {
         String id = request.param("id");
         GetStoredScriptRequest getRequest = new GetStoredScriptRequest(id);
         getRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", getRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(getRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(getRequest, request);
         return channel -> client.admin().cluster().getStoredScript(getRequest, new RestStatusToXContentListener<>(channel));
     }
 }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestPendingClusterTasksAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestPendingClusterTasksAction.java
@@ -65,7 +65,7 @@ public class RestPendingClusterTasksAction extends BaseRestHandler {
         pendingClusterTasksRequest.masterNodeTimeout(
             request.paramAsTime("cluster_manager_timeout", pendingClusterTasksRequest.masterNodeTimeout())
         );
-        parseDeprecatedMasterTimeoutParameter(pendingClusterTasksRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(pendingClusterTasksRequest, request);
         pendingClusterTasksRequest.local(request.paramAsBoolean("local", pendingClusterTasksRequest.local()));
         return channel -> client.admin().cluster().pendingClusterTasks(pendingClusterTasksRequest, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestPutRepositoryAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestPutRepositoryAction.java
@@ -74,7 +74,7 @@ public class RestPutRepositoryAction extends BaseRestHandler {
         }
         putRepositoryRequest.verify(request.paramAsBoolean("verify", true));
         putRepositoryRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", putRepositoryRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(putRepositoryRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(putRepositoryRequest, request);
         putRepositoryRequest.timeout(request.paramAsTime("timeout", putRepositoryRequest.timeout()));
         return channel -> client.admin().cluster().putRepository(putRepositoryRequest, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestPutStoredScriptAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestPutStoredScriptAction.java
@@ -80,7 +80,7 @@ public class RestPutStoredScriptAction extends BaseRestHandler {
 
         PutStoredScriptRequest putRequest = new PutStoredScriptRequest(id, context, content, request.getXContentType(), source);
         putRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", putRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(putRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(putRequest, request);
         putRequest.timeout(request.paramAsTime("timeout", putRequest.timeout()));
         return channel -> client.admin().cluster().putStoredScript(putRequest, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestRestoreSnapshotAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestRestoreSnapshotAction.java
@@ -69,7 +69,7 @@ public class RestRestoreSnapshotAction extends BaseRestHandler {
         restoreSnapshotRequest.masterNodeTimeout(
             request.paramAsTime("cluster_manager_timeout", restoreSnapshotRequest.masterNodeTimeout())
         );
-        parseDeprecatedMasterTimeoutParameter(restoreSnapshotRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(restoreSnapshotRequest, request);
         restoreSnapshotRequest.waitForCompletion(request.paramAsBoolean("wait_for_completion", false));
         request.applyContentParser(p -> restoreSnapshotRequest.source(p.mapOrdered()));
         return channel -> client.admin().cluster().restoreSnapshot(restoreSnapshotRequest, new RestToXContentListener<>(channel));

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestSnapshotsStatusAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestSnapshotsStatusAction.java
@@ -84,7 +84,7 @@ public class RestSnapshotsStatusAction extends BaseRestHandler {
         snapshotsStatusRequest.masterNodeTimeout(
             request.paramAsTime("cluster_manager_timeout", snapshotsStatusRequest.masterNodeTimeout())
         );
-        parseDeprecatedMasterTimeoutParameter(snapshotsStatusRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(snapshotsStatusRequest, request);
         return channel -> client.admin().cluster().snapshotsStatus(snapshotsStatusRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestVerifyRepositoryAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestVerifyRepositoryAction.java
@@ -66,7 +66,7 @@ public class RestVerifyRepositoryAction extends BaseRestHandler {
         verifyRepositoryRequest.masterNodeTimeout(
             request.paramAsTime("cluster_manager_timeout", verifyRepositoryRequest.masterNodeTimeout())
         );
-        parseDeprecatedMasterTimeoutParameter(verifyRepositoryRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(verifyRepositoryRequest, request);
         verifyRepositoryRequest.timeout(request.paramAsTime("timeout", verifyRepositoryRequest.timeout()));
         return channel -> client.admin().cluster().verifyRepository(verifyRepositoryRequest, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/dangling/RestDeleteDanglingIndexAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/dangling/RestDeleteDanglingIndexAction.java
@@ -71,7 +71,7 @@ public class RestDeleteDanglingIndexAction extends BaseRestHandler {
 
         deleteRequest.timeout(request.paramAsTime("timeout", deleteRequest.timeout()));
         deleteRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", deleteRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(deleteRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(deleteRequest, request);
 
         return channel -> client.admin()
             .cluster()

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/dangling/RestImportDanglingIndexAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/dangling/RestImportDanglingIndexAction.java
@@ -70,7 +70,7 @@ public class RestImportDanglingIndexAction extends BaseRestHandler {
 
         importRequest.timeout(request.paramAsTime("timeout", importRequest.timeout()));
         importRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", importRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(importRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(importRequest, request);
 
         return channel -> client.admin()
             .cluster()

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestAddIndexBlockAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestAddIndexBlockAction.java
@@ -69,7 +69,7 @@ public class RestAddIndexBlockAction extends BaseRestHandler {
             Strings.splitStringByCommaToArray(request.param("index"))
         );
         addIndexBlockRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", addIndexBlockRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(addIndexBlockRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(addIndexBlockRequest, request);
         addIndexBlockRequest.timeout(request.paramAsTime("timeout", addIndexBlockRequest.timeout()));
         addIndexBlockRequest.indicesOptions(IndicesOptions.fromRequest(request, addIndexBlockRequest.indicesOptions()));
         return channel -> client.admin().indices().addBlock(addIndexBlockRequest, new RestToXContentListener<>(channel));

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestCloseIndexAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestCloseIndexAction.java
@@ -67,7 +67,7 @@ public class RestCloseIndexAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         CloseIndexRequest closeIndexRequest = new CloseIndexRequest(Strings.splitStringByCommaToArray(request.param("index")));
         closeIndexRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", closeIndexRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(closeIndexRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(closeIndexRequest, request);
         closeIndexRequest.timeout(request.paramAsTime("timeout", closeIndexRequest.timeout()));
         closeIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, closeIndexRequest.indicesOptions()));
         String waitForActiveShards = request.param("wait_for_active_shards");

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestCreateIndexAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestCreateIndexAction.java
@@ -78,7 +78,7 @@ public class RestCreateIndexAction extends BaseRestHandler {
 
         createIndexRequest.timeout(request.paramAsTime("timeout", createIndexRequest.timeout()));
         createIndexRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", createIndexRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(createIndexRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(createIndexRequest, request);
         createIndexRequest.waitForActiveShards(ActiveShardCount.parseString(request.param("wait_for_active_shards")));
         return channel -> client.admin().indices().create(createIndexRequest, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestDeleteComponentTemplateAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestDeleteComponentTemplateAction.java
@@ -64,7 +64,7 @@ public class RestDeleteComponentTemplateAction extends BaseRestHandler {
 
         DeleteComponentTemplateAction.Request deleteReq = new DeleteComponentTemplateAction.Request(request.param("name"));
         deleteReq.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", deleteReq.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(deleteReq, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(deleteReq, request);
 
         return channel -> client.execute(DeleteComponentTemplateAction.INSTANCE, deleteReq, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestDeleteComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestDeleteComposableIndexTemplateAction.java
@@ -64,7 +64,7 @@ public class RestDeleteComposableIndexTemplateAction extends BaseRestHandler {
 
         DeleteComposableIndexTemplateAction.Request deleteReq = new DeleteComposableIndexTemplateAction.Request(request.param("name"));
         deleteReq.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", deleteReq.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(deleteReq, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(deleteReq, request);
 
         return channel -> client.execute(DeleteComposableIndexTemplateAction.INSTANCE, deleteReq, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestDeleteIndexAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestDeleteIndexAction.java
@@ -67,7 +67,7 @@ public class RestDeleteIndexAction extends BaseRestHandler {
         DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(Strings.splitStringByCommaToArray(request.param("index")));
         deleteIndexRequest.timeout(request.paramAsTime("timeout", deleteIndexRequest.timeout()));
         deleteIndexRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", deleteIndexRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(deleteIndexRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(deleteIndexRequest, request);
         deleteIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, deleteIndexRequest.indicesOptions()));
         return channel -> client.admin().indices().delete(deleteIndexRequest, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestDeleteIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestDeleteIndexTemplateAction.java
@@ -64,7 +64,7 @@ public class RestDeleteIndexTemplateAction extends BaseRestHandler {
         deleteIndexTemplateRequest.masterNodeTimeout(
             request.paramAsTime("cluster_manager_timeout", deleteIndexTemplateRequest.masterNodeTimeout())
         );
-        parseDeprecatedMasterTimeoutParameter(deleteIndexTemplateRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(deleteIndexTemplateRequest, request);
         return channel -> client.admin().indices().deleteTemplate(deleteIndexTemplateRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestGetComponentTemplateAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestGetComponentTemplateAction.java
@@ -76,7 +76,7 @@ public class RestGetComponentTemplateAction extends BaseRestHandler {
 
         getRequest.local(request.paramAsBoolean("local", getRequest.local()));
         getRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", getRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(getRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(getRequest, request);
 
         final boolean implicitAll = getRequest.name() == null;
 

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestGetComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestGetComposableIndexTemplateAction.java
@@ -75,7 +75,7 @@ public class RestGetComposableIndexTemplateAction extends BaseRestHandler {
 
         getRequest.local(request.paramAsBoolean("local", getRequest.local()));
         getRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", getRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(getRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(getRequest, request);
 
         final boolean implicitAll = getRequest.name() == null;
 

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestGetIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestGetIndexTemplateAction.java
@@ -82,7 +82,7 @@ public class RestGetIndexTemplateAction extends BaseRestHandler {
         getIndexTemplatesRequest.masterNodeTimeout(
             request.paramAsTime("cluster_manager_timeout", getIndexTemplatesRequest.masterNodeTimeout())
         );
-        parseDeprecatedMasterTimeoutParameter(getIndexTemplatesRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(getIndexTemplatesRequest, request);
 
         final boolean implicitAll = getIndexTemplatesRequest.names().length == 0;
 

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestGetIndicesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestGetIndicesAction.java
@@ -76,7 +76,7 @@ public class RestGetIndicesAction extends BaseRestHandler {
         getIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, getIndexRequest.indicesOptions()));
         getIndexRequest.local(request.paramAsBoolean("local", getIndexRequest.local()));
         getIndexRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", getIndexRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(getIndexRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(getIndexRequest, request);
         getIndexRequest.humanReadable(request.paramAsBoolean("human", false));
         getIndexRequest.includeDefaults(request.paramAsBoolean("include_defaults", false));
         return channel -> client.admin().indices().getIndex(getIndexRequest, new RestToXContentListener<>(channel));

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestGetMappingAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestGetMappingAction.java
@@ -91,10 +91,8 @@ public class RestGetMappingAction extends BaseRestHandler {
         getMappingsRequest.indices(indices);
         getMappingsRequest.indicesOptions(IndicesOptions.fromRequest(request, getMappingsRequest.indicesOptions()));
         TimeValue clusterManagerTimeout = request.paramAsTime("cluster_manager_timeout", getMappingsRequest.masterNodeTimeout());
-        // TODO: Remove the if condition and statements inside after removing MASTER_ROLE.
+        // TODO: Remove the if condition and statements inside after removing parameter 'master_timeout'.
         if (request.hasParam("master_timeout")) {
-            // TODO: Start emitting deprecation warning in 3.0 (A major version ahead of removal)
-            // deprecationLogger.deprecate("get_mapping_master_timeout_parameter", MASTER_TIMEOUT_DEPRECATED_MESSAGE);
             if (request.hasParam("cluster_manager_timeout")) {
                 throw new OpenSearchParseException(DUPLICATE_PARAMETER_ERROR_MESSAGE);
             }

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestGetMappingAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestGetMappingAction.java
@@ -40,7 +40,6 @@ import org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.Strings;
-import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.rest.BaseRestHandler;
@@ -60,12 +59,6 @@ import static java.util.Collections.unmodifiableList;
 import static org.opensearch.rest.RestRequest.Method.GET;
 
 public class RestGetMappingAction extends BaseRestHandler {
-
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestGetMappingAction.class);
-    private static final String MASTER_TIMEOUT_DEPRECATED_MESSAGE =
-        "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead.";
-    private static final String DUPLICATE_PARAMETER_ERROR_MESSAGE =
-        "Please only use one of the request parameters [master_timeout, cluster_manager_timeout].";
 
     private final ThreadPool threadPool;
 
@@ -100,7 +93,8 @@ public class RestGetMappingAction extends BaseRestHandler {
         TimeValue clusterManagerTimeout = request.paramAsTime("cluster_manager_timeout", getMappingsRequest.masterNodeTimeout());
         // TODO: Remove the if condition and statements inside after removing MASTER_ROLE.
         if (request.hasParam("master_timeout")) {
-            deprecationLogger.deprecate("get_mapping_master_timeout_parameter", MASTER_TIMEOUT_DEPRECATED_MESSAGE);
+            // TODO: Start emitting deprecation warning in 3.0 (A major version ahead of removal)
+            // deprecationLogger.deprecate("get_mapping_master_timeout_parameter", MASTER_TIMEOUT_DEPRECATED_MESSAGE);
             if (request.hasParam("cluster_manager_timeout")) {
                 throw new OpenSearchParseException(DUPLICATE_PARAMETER_ERROR_MESSAGE);
             }

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestGetSettingsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestGetSettingsAction.java
@@ -83,7 +83,7 @@ public class RestGetSettingsAction extends BaseRestHandler {
             .names(names);
         getSettingsRequest.local(request.paramAsBoolean("local", getSettingsRequest.local()));
         getSettingsRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", getSettingsRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(getSettingsRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(getSettingsRequest, request);
         return channel -> client.admin().indices().getSettings(getSettingsRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndexDeleteAliasesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndexDeleteAliasesAction.java
@@ -69,7 +69,7 @@ public class RestIndexDeleteAliasesAction extends BaseRestHandler {
         indicesAliasesRequest.timeout(request.paramAsTime("timeout", indicesAliasesRequest.timeout()));
         indicesAliasesRequest.addAliasAction(AliasActions.remove().indices(indices).aliases(aliases));
         indicesAliasesRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", indicesAliasesRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(indicesAliasesRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(indicesAliasesRequest, request);
 
         return channel -> client.admin().indices().aliases(indicesAliasesRequest, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndexPutAliasAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndexPutAliasAction.java
@@ -128,7 +128,7 @@ public class RestIndexPutAliasAction extends BaseRestHandler {
         IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest();
         indicesAliasesRequest.timeout(request.paramAsTime("timeout", indicesAliasesRequest.timeout()));
         indicesAliasesRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", indicesAliasesRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(indicesAliasesRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(indicesAliasesRequest, request);
 
         IndicesAliasesRequest.AliasActions aliasAction = AliasActions.add().indices(indices).alias(alias);
         if (routing != null) {

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndicesAliasesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndicesAliasesAction.java
@@ -64,7 +64,7 @@ public class RestIndicesAliasesAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest();
         indicesAliasesRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", indicesAliasesRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(indicesAliasesRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(indicesAliasesRequest, request);
         indicesAliasesRequest.timeout(request.paramAsTime("timeout", indicesAliasesRequest.timeout()));
         try (XContentParser parser = request.contentParser()) {
             IndicesAliasesRequest.PARSER.parse(parser, indicesAliasesRequest, null);

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestOpenIndexAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestOpenIndexAction.java
@@ -68,7 +68,7 @@ public class RestOpenIndexAction extends BaseRestHandler {
         OpenIndexRequest openIndexRequest = new OpenIndexRequest(Strings.splitStringByCommaToArray(request.param("index")));
         openIndexRequest.timeout(request.paramAsTime("timeout", openIndexRequest.timeout()));
         openIndexRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", openIndexRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(openIndexRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(openIndexRequest, request);
         openIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, openIndexRequest.indicesOptions()));
         String waitForActiveShards = request.param("wait_for_active_shards");
         if (waitForActiveShards != null) {

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestPutComponentTemplateAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestPutComponentTemplateAction.java
@@ -66,7 +66,7 @@ public class RestPutComponentTemplateAction extends BaseRestHandler {
 
         PutComponentTemplateAction.Request putRequest = new PutComponentTemplateAction.Request(request.param("name"));
         putRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", putRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(putRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(putRequest, request);
         putRequest.create(request.paramAsBoolean("create", false));
         putRequest.cause(request.param("cause", "api"));
         putRequest.componentTemplate(ComponentTemplate.parse(request.contentParser()));

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestPutComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestPutComposableIndexTemplateAction.java
@@ -66,7 +66,7 @@ public class RestPutComposableIndexTemplateAction extends BaseRestHandler {
 
         PutComposableIndexTemplateAction.Request putRequest = new PutComposableIndexTemplateAction.Request(request.param("name"));
         putRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", putRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(putRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(putRequest, request);
         putRequest.create(request.paramAsBoolean("create", false));
         putRequest.cause(request.param("cause", "api"));
         putRequest.indexTemplate(ComposableIndexTemplate.parse(request.contentParser()));

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestPutIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestPutIndexTemplateAction.java
@@ -79,7 +79,7 @@ public class RestPutIndexTemplateAction extends BaseRestHandler {
         }
         putRequest.order(request.paramAsInt("order", putRequest.order()));
         putRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", putRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(putRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(putRequest, request);
         putRequest.create(request.paramAsBoolean("create", false));
         putRequest.cause(request.param("cause", ""));
 

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestPutMappingAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestPutMappingAction.java
@@ -87,7 +87,7 @@ public class RestPutMappingAction extends BaseRestHandler {
         putMappingRequest.source(sourceAsMap);
         putMappingRequest.timeout(request.paramAsTime("timeout", putMappingRequest.timeout()));
         putMappingRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", putMappingRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(putMappingRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(putMappingRequest, request);
         putMappingRequest.indicesOptions(IndicesOptions.fromRequest(request, putMappingRequest.indicesOptions()));
         putMappingRequest.writeIndexOnly(request.paramAsBoolean("write_index_only", false));
         return channel -> client.admin().indices().putMapping(putMappingRequest, new RestToXContentListener<>(channel));

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestResizeHandler.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestResizeHandler.java
@@ -92,7 +92,7 @@ public abstract class RestResizeHandler extends BaseRestHandler {
         request.applyContentParser(resizeRequest::fromXContent);
         resizeRequest.timeout(request.paramAsTime("timeout", resizeRequest.timeout()));
         resizeRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", resizeRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(resizeRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(resizeRequest, request);
         resizeRequest.setWaitForActiveShards(ActiveShardCount.parseString(request.param("wait_for_active_shards")));
         return channel -> client.admin().indices().resizeIndex(resizeRequest, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestRolloverIndexAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestRolloverIndexAction.java
@@ -73,7 +73,7 @@ public class RestRolloverIndexAction extends BaseRestHandler {
         rolloverIndexRequest.dryRun(request.paramAsBoolean("dry_run", false));
         rolloverIndexRequest.timeout(request.paramAsTime("timeout", rolloverIndexRequest.timeout()));
         rolloverIndexRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", rolloverIndexRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(rolloverIndexRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(rolloverIndexRequest, request);
         rolloverIndexRequest.getCreateIndexRequest()
             .waitForActiveShards(ActiveShardCount.parseString(request.param("wait_for_active_shards")));
         return channel -> client.admin().indices().rolloverIndex(rolloverIndexRequest, new RestToXContentListener<>(channel));

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestSimulateIndexTemplateAction.java
@@ -67,7 +67,7 @@ public class RestSimulateIndexTemplateAction extends BaseRestHandler {
         simulateIndexTemplateRequest.masterNodeTimeout(
             request.paramAsTime("cluster_manager_timeout", simulateIndexTemplateRequest.masterNodeTimeout())
         );
-        parseDeprecatedMasterTimeoutParameter(simulateIndexTemplateRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(simulateIndexTemplateRequest, request);
         if (request.hasContent()) {
             PutComposableIndexTemplateAction.Request indexTemplateRequest = new PutComposableIndexTemplateAction.Request(
                 "simulating_template"

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestSimulateTemplateAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestSimulateTemplateAction.java
@@ -75,7 +75,7 @@ public class RestSimulateTemplateAction extends BaseRestHandler {
             simulateRequest.indexTemplateRequest(indexTemplateRequest);
         }
         simulateRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", simulateRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(simulateRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(simulateRequest, request);
 
         return channel -> client.execute(SimulateTemplateAction.INSTANCE, simulateRequest, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestUpdateSettingsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestUpdateSettingsAction.java
@@ -71,7 +71,7 @@ public class RestUpdateSettingsAction extends BaseRestHandler {
         updateSettingsRequest.timeout(request.paramAsTime("timeout", updateSettingsRequest.timeout()));
         updateSettingsRequest.setPreserveExisting(request.paramAsBoolean("preserve_existing", updateSettingsRequest.isPreserveExisting()));
         updateSettingsRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", updateSettingsRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(updateSettingsRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(updateSettingsRequest, request);
         updateSettingsRequest.indicesOptions(IndicesOptions.fromRequest(request, updateSettingsRequest.indicesOptions()));
         updateSettingsRequest.fromXContent(request.contentParser());
 

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestAllocationAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestAllocationAction.java
@@ -83,7 +83,7 @@ public class RestAllocationAction extends AbstractCatAction {
         clusterStateRequest.clear().routingTable(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", clusterStateRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request);
 
         return channel -> client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestIndicesAction.java
@@ -53,7 +53,6 @@ import org.opensearch.cluster.health.ClusterIndexHealth;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.Strings;
 import org.opensearch.common.Table;
-import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.unit.TimeValue;
@@ -84,11 +83,6 @@ import static org.opensearch.rest.RestRequest.Method.GET;
 public class RestIndicesAction extends AbstractCatAction {
 
     private static final DateFormatter STRICT_DATE_TIME_FORMATTER = DateFormatter.forPattern("strict_date_time");
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestIndicesAction.class);
-    private static final String MASTER_TIMEOUT_DEPRECATED_MESSAGE =
-        "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead.";
-    private static final String DUPLICATE_PARAMETER_ERROR_MESSAGE =
-        "Please only use one of the request parameters [master_timeout, cluster_manager_timeout].";
 
     @Override
     public List<Route> routes() {
@@ -119,7 +113,8 @@ public class RestIndicesAction extends AbstractCatAction {
         TimeValue clusterManagerTimeout = request.paramAsTime("cluster_manager_timeout", DEFAULT_MASTER_NODE_TIMEOUT);
         // Remove the if condition and statements inside after removing MASTER_ROLE.
         if (request.hasParam("master_timeout")) {
-            deprecationLogger.deprecate("cat_indices_master_timeout_parameter", MASTER_TIMEOUT_DEPRECATED_MESSAGE);
+            // TODO: Start emitting deprecation warning in 3.0 (A major version ahead of removal)
+            // deprecationLogger.deprecate("cat_indices_master_timeout_parameter", MASTER_TIMEOUT_DEPRECATED_MESSAGE);
             if (request.hasParam("cluster_manager_timeout")) {
                 throw new OpenSearchParseException(DUPLICATE_PARAMETER_ERROR_MESSAGE);
             }

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestIndicesAction.java
@@ -111,10 +111,8 @@ public class RestIndicesAction extends AbstractCatAction {
         final IndicesOptions indicesOptions = IndicesOptions.fromRequest(request, IndicesOptions.strictExpand());
         final boolean local = request.paramAsBoolean("local", false);
         TimeValue clusterManagerTimeout = request.paramAsTime("cluster_manager_timeout", DEFAULT_MASTER_NODE_TIMEOUT);
-        // Remove the if condition and statements inside after removing MASTER_ROLE.
+        // TODO: Remove the if condition and statements inside after removing parameter 'master_timeout'.
         if (request.hasParam("master_timeout")) {
-            // TODO: Start emitting deprecation warning in 3.0 (A major version ahead of removal)
-            // deprecationLogger.deprecate("cat_indices_master_timeout_parameter", MASTER_TIMEOUT_DEPRECATED_MESSAGE);
             if (request.hasParam("cluster_manager_timeout")) {
                 throw new OpenSearchParseException(DUPLICATE_PARAMETER_ERROR_MESSAGE);
             }

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestMasterAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestMasterAction.java
@@ -74,7 +74,7 @@ public class RestMasterAction extends AbstractCatAction {
         clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", clusterStateRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request);
 
         return channel -> client.admin().cluster().state(clusterStateRequest, new RestResponseListener<ClusterStateResponse>(channel) {
             @Override

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestNodeAttrsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestNodeAttrsAction.java
@@ -80,7 +80,7 @@ public class RestNodeAttrsAction extends AbstractCatAction {
         clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", clusterStateRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request);
 
         return channel -> client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestNodesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestNodesAction.java
@@ -111,7 +111,7 @@ public class RestNodesAction extends AbstractCatAction {
         }
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", clusterStateRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request);
         final boolean fullId = request.paramAsBoolean("full_id", false);
         return channel -> client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestPendingClusterTasksAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestPendingClusterTasksAction.java
@@ -72,7 +72,7 @@ public class RestPendingClusterTasksAction extends AbstractCatAction {
         pendingClusterTasksRequest.masterNodeTimeout(
             request.paramAsTime("cluster_manager_timeout", pendingClusterTasksRequest.masterNodeTimeout())
         );
-        parseDeprecatedMasterTimeoutParameter(pendingClusterTasksRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(pendingClusterTasksRequest, request);
         pendingClusterTasksRequest.local(request.paramAsBoolean("local", pendingClusterTasksRequest.local()));
         return channel -> client.admin()
             .cluster()

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestPluginsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestPluginsAction.java
@@ -79,7 +79,7 @@ public class RestPluginsAction extends AbstractCatAction {
         clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", clusterStateRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request);
 
         return channel -> client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestRepositoriesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestRepositoriesAction.java
@@ -66,7 +66,7 @@ public class RestRepositoriesAction extends AbstractCatAction {
         getRepositoriesRequest.masterNodeTimeout(
             request.paramAsTime("cluster_manager_timeout", getRepositoriesRequest.masterNodeTimeout())
         );
-        parseDeprecatedMasterTimeoutParameter(getRepositoriesRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(getRepositoriesRequest, request);
 
         return channel -> client.admin()
             .cluster()

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestSegmentsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestSegmentsAction.java
@@ -83,7 +83,7 @@ public class RestSegmentsAction extends AbstractCatAction {
         final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", clusterStateRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request);
         clusterStateRequest.clear().nodes(true).routingTable(true).indices(indices);
 
         return channel -> client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestShardsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestShardsAction.java
@@ -105,7 +105,7 @@ public class RestShardsAction extends AbstractCatAction {
         final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", clusterStateRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request);
         clusterStateRequest.clear().nodes(true).routingTable(true).indices(indices);
         return channel -> client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestSnapshotAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestSnapshotAction.java
@@ -79,7 +79,7 @@ public class RestSnapshotAction extends AbstractCatAction {
         getSnapshotsRequest.ignoreUnavailable(request.paramAsBoolean("ignore_unavailable", getSnapshotsRequest.ignoreUnavailable()));
 
         getSnapshotsRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", getSnapshotsRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(getSnapshotsRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(getSnapshotsRequest, request);
 
         return channel -> client.admin()
             .cluster()

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestTemplatesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestTemplatesAction.java
@@ -79,7 +79,7 @@ public class RestTemplatesAction extends AbstractCatAction {
         clusterStateRequest.clear().metadata(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", clusterStateRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request);
 
         return channel -> client.admin().cluster().state(clusterStateRequest, new RestResponseListener<ClusterStateResponse>(channel) {
             @Override

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestThreadPoolAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestThreadPoolAction.java
@@ -93,7 +93,7 @@ public class RestThreadPoolAction extends AbstractCatAction {
         clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
         clusterStateRequest.masterNodeTimeout(request.paramAsTime("cluster_manager_timeout", clusterStateRequest.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(clusterStateRequest, request);
 
         return channel -> client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override

--- a/server/src/main/java/org/opensearch/rest/action/ingest/RestDeletePipelineAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/ingest/RestDeletePipelineAction.java
@@ -62,7 +62,7 @@ public class RestDeletePipelineAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         DeletePipelineRequest request = new DeletePipelineRequest(restRequest.param("id"));
         request.masterNodeTimeout(restRequest.paramAsTime("cluster_manager_timeout", request.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(request, restRequest, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(request, restRequest);
         request.timeout(restRequest.paramAsTime("timeout", request.timeout()));
         return channel -> client.admin().cluster().deletePipeline(request, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/opensearch/rest/action/ingest/RestGetPipelineAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/ingest/RestGetPipelineAction.java
@@ -65,7 +65,7 @@ public class RestGetPipelineAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         GetPipelineRequest request = new GetPipelineRequest(Strings.splitStringByCommaToArray(restRequest.param("id")));
         request.masterNodeTimeout(restRequest.paramAsTime("cluster_manager_timeout", request.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(request, restRequest, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(request, restRequest);
         return channel -> client.admin().cluster().getPipeline(request, new RestStatusToXContentListener<>(channel));
     }
 }

--- a/server/src/main/java/org/opensearch/rest/action/ingest/RestPutPipelineAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/ingest/RestPutPipelineAction.java
@@ -67,7 +67,7 @@ public class RestPutPipelineAction extends BaseRestHandler {
         Tuple<XContentType, BytesReference> sourceTuple = restRequest.contentOrSourceParam();
         PutPipelineRequest request = new PutPipelineRequest(restRequest.param("id"), sourceTuple.v2(), sourceTuple.v1());
         request.masterNodeTimeout(restRequest.paramAsTime("cluster_manager_timeout", request.masterNodeTimeout()));
-        parseDeprecatedMasterTimeoutParameter(request, restRequest, deprecationLogger, getName());
+        parseDeprecatedMasterTimeoutParameter(request, restRequest);
         request.timeout(restRequest.paramAsTime("timeout", request.timeout()));
         return channel -> client.admin().cluster().putPipeline(request, new RestToXContentListener<>(channel));
     }

--- a/server/src/test/java/org/opensearch/action/RenamedTimeoutRequestParameterTests.java
+++ b/server/src/test/java/org/opensearch/action/RenamedTimeoutRequestParameterTests.java
@@ -102,12 +102,9 @@ import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_READ_ONLY_SETT
 public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
     private final TestThreadPool threadPool = new TestThreadPool(RenamedTimeoutRequestParameterTests.class.getName());
     private final NodeClient client = new NodeClient(Settings.EMPTY, threadPool);
-    private final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RenamedTimeoutRequestParameterTests.class);
 
     private static final String DUPLICATE_PARAMETER_ERROR_MESSAGE =
         "Please only use one of the request parameters [master_timeout, cluster_manager_timeout].";
-    private static final String MASTER_TIMEOUT_DEPRECATED_MESSAGE =
-        "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead.";
 
     @After
     public void terminateThreadPool() {
@@ -117,21 +114,8 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
     public void testNoWarningsForNewParam() {
         BaseRestHandler.parseDeprecatedMasterTimeoutParameter(
             getMasterNodeRequest(),
-            getRestRequestWithNewParam(),
-            deprecationLogger,
-            "test"
+            getRestRequestWithNewParam()
         );
-    }
-
-    @Ignore("Deprecation warning will start emitting in 3.0")
-    public void testDeprecationWarningForOldParam() {
-        BaseRestHandler.parseDeprecatedMasterTimeoutParameter(
-            getMasterNodeRequest(),
-            getRestRequestWithDeprecatedParam(),
-            deprecationLogger,
-            "test"
-        );
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testBothParamsNotValid() {
@@ -139,9 +123,7 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
             OpenSearchParseException.class,
             () -> BaseRestHandler.parseDeprecatedMasterTimeoutParameter(
                 getMasterNodeRequest(),
-                getRestRequestWithBothParams(),
-                deprecationLogger,
-                "test"
+                getRestRequestWithBothParams()
             )
         );
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));

--- a/server/src/test/java/org/opensearch/action/RenamedTimeoutRequestParameterTests.java
+++ b/server/src/test/java/org/opensearch/action/RenamedTimeoutRequestParameterTests.java
@@ -9,12 +9,10 @@
 package org.opensearch.action;
 
 import org.junit.After;
-import org.junit.Ignore;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.action.support.master.MasterNodeRequest;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.bytes.BytesArray;
-import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsFilter;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
@@ -112,19 +110,13 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
     }
 
     public void testNoWarningsForNewParam() {
-        BaseRestHandler.parseDeprecatedMasterTimeoutParameter(
-            getMasterNodeRequest(),
-            getRestRequestWithNewParam()
-        );
+        BaseRestHandler.parseDeprecatedMasterTimeoutParameter(getMasterNodeRequest(), getRestRequestWithNewParam());
     }
 
     public void testBothParamsNotValid() {
         Exception e = assertThrows(
             OpenSearchParseException.class,
-            () -> BaseRestHandler.parseDeprecatedMasterTimeoutParameter(
-                getMasterNodeRequest(),
-                getRestRequestWithBothParams()
-            )
+            () -> BaseRestHandler.parseDeprecatedMasterTimeoutParameter(getMasterNodeRequest(), getRestRequestWithBothParams())
         );
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
     }

--- a/server/src/test/java/org/opensearch/action/RenamedTimeoutRequestParameterTests.java
+++ b/server/src/test/java/org/opensearch/action/RenamedTimeoutRequestParameterTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.action;
 
 import org.junit.After;
+import org.junit.Ignore;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.action.support.master.MasterNodeRequest;
 import org.opensearch.client.node.NodeClient;
@@ -122,6 +123,7 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
         );
     }
 
+    @Ignore("Deprecation warning will start emitting in 3.0")
     public void testDeprecationWarningForOldParam() {
         BaseRestHandler.parseDeprecatedMasterTimeoutParameter(
             getMasterNodeRequest(),
@@ -143,98 +145,84 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
             )
         );
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCatAllocation() {
         RestAllocationAction action = new RestAllocationAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.doCatRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCatIndices() {
         RestIndicesAction action = new RestIndicesAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.doCatRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCatClusterManager() {
         RestMasterAction action = new RestMasterAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.doCatRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCatNodeattrs() {
         RestNodeAttrsAction action = new RestNodeAttrsAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.doCatRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCatNodes() {
         RestNodesAction action = new RestNodesAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.doCatRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCatPendingTasks() {
         RestPendingClusterTasksAction action = new RestPendingClusterTasksAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.doCatRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCatPlugins() {
         RestPluginsAction action = new RestPluginsAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.doCatRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCatRepositories() {
         RestRepositoriesAction action = new RestRepositoriesAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.doCatRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCatShards() {
         RestShardsAction action = new RestShardsAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.doCatRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCatSnapshots() {
         RestSnapshotAction action = new RestSnapshotAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.doCatRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCatTemplates() {
         RestTemplatesAction action = new RestTemplatesAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.doCatRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCatThreadPool() {
         RestThreadPoolAction action = new RestThreadPoolAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.doCatRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCatSegments() {
         RestSegmentsAction action = new RestSegmentsAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.doCatRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testClusterHealth() {
@@ -243,7 +231,6 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
             () -> RestClusterHealthAction.fromRequest(getRestRequestWithBodyWithBothParams())
         );
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testClusterReroute() throws IOException {
@@ -254,7 +241,6 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
             () -> action.prepareRequest(getRestRequestWithBodyWithBothParams(), client)
         );
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testClusterState() throws IOException {
@@ -265,7 +251,6 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
             () -> action.prepareRequest(getRestRequestWithBodyWithBothParams(), client)
         );
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testClusterGetSettings() throws IOException {
@@ -276,7 +261,6 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
             () -> action.prepareRequest(getRestRequestWithBodyWithBothParams(), client)
         );
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testClusterUpdateSettings() throws IOException {
@@ -286,7 +270,6 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
             () -> action.prepareRequest(getRestRequestWithBodyWithBothParams(), client)
         );
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testClusterPendingTasks() {
@@ -296,7 +279,6 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
             () -> action.prepareRequest(getRestRequestWithBodyWithBothParams(), client)
         );
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testAddIndexBlock() {
@@ -308,49 +290,42 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
         RestAddIndexBlockAction action = new RestAddIndexBlockAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(request, client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCloseIndex() {
         RestCloseIndexAction action = new RestCloseIndexAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCreateIndex() {
         RestCreateIndexAction action = new RestCreateIndexAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testDeleteIndex() {
         RestDeleteIndexAction action = new RestDeleteIndexAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testGetIndices() {
         RestGetIndicesAction action = new RestGetIndicesAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testGetMapping() {
         RestGetMappingAction action = new RestGetMappingAction(threadPool);
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testGetSettings() {
         RestGetSettingsAction action = new RestGetSettingsAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testIndexDeleteAliases() {
@@ -362,28 +337,24 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
         RestIndexDeleteAliasesAction action = new RestIndexDeleteAliasesAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(request, client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testIndexPutAlias() {
         RestIndexPutAliasAction action = new RestIndexPutAliasAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testIndicesAliases() {
         RestIndicesAliasesAction action = new RestIndicesAliasesAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testOpenIndex() {
         RestOpenIndexAction action = new RestOpenIndexAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testPutMapping() {
@@ -393,42 +364,36 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
             () -> action.prepareRequest(getRestRequestWithBodyWithBothParams(), client)
         );
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testShrinkIndex() {
         RestResizeHandler.RestShrinkIndexAction action = new RestResizeHandler.RestShrinkIndexAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testSplitIndex() {
         RestResizeHandler.RestSplitIndexAction action = new RestResizeHandler.RestSplitIndexAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCloneIndex() {
         RestResizeHandler.RestCloneIndexAction action = new RestResizeHandler.RestCloneIndexAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testRolloverIndex() {
         RestRolloverIndexAction action = new RestRolloverIndexAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testUpdateSettings() {
         RestUpdateSettingsAction action = new RestUpdateSettingsAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testDeleteDanglingIndex() {
@@ -439,7 +404,6 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
         RestDeleteDanglingIndexAction action = new RestDeleteDanglingIndexAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(request, client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testImportDanglingIndex() {
@@ -450,70 +414,60 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
         RestImportDanglingIndexAction action = new RestImportDanglingIndexAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(request, client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testDeleteComponentTemplate() {
         RestDeleteComponentTemplateAction action = new RestDeleteComponentTemplateAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testDeleteComposableIndexTemplate() {
         RestDeleteComposableIndexTemplateAction action = new RestDeleteComposableIndexTemplateAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testDeleteIndexTemplate() {
         RestDeleteIndexTemplateAction action = new RestDeleteIndexTemplateAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testGetComponentTemplate() {
         RestGetComponentTemplateAction action = new RestGetComponentTemplateAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testGetComposableIndexTemplate() {
         RestGetComposableIndexTemplateAction action = new RestGetComposableIndexTemplateAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testGetIndexTemplate() {
         RestGetIndexTemplateAction action = new RestGetIndexTemplateAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testPutComponentTemplate() {
         RestPutComponentTemplateAction action = new RestPutComponentTemplateAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testPutComposableIndexTemplate() {
         RestPutComposableIndexTemplateAction action = new RestPutComposableIndexTemplateAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testPutIndexTemplate() {
         RestPutIndexTemplateAction action = new RestPutIndexTemplateAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testSimulateIndexTemplate() {
@@ -524,21 +478,18 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
         RestSimulateIndexTemplateAction action = new RestSimulateIndexTemplateAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(request, client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testSimulateTemplate() {
         RestSimulateTemplateAction action = new RestSimulateTemplateAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCleanupRepository() {
         RestCleanupRepositoryAction action = new RestCleanupRepositoryAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCloneSnapshot() {
@@ -548,28 +499,24 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
             () -> action.prepareRequest(getRestRequestWithBodyWithBothParams(), client)
         );
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testCreateSnapshot() {
         RestCreateSnapshotAction action = new RestCreateSnapshotAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testDeleteRepository() {
         RestDeleteRepositoryAction action = new RestDeleteRepositoryAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testDeleteSnapshot() {
         RestDeleteSnapshotAction action = new RestDeleteSnapshotAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testGetRepositories() {
@@ -577,14 +524,12 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
         RestGetRepositoriesAction action = new RestGetRepositoriesAction(filter);
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testGetSnapshots() {
         RestGetSnapshotsAction action = new RestGetSnapshotsAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testPutRepository() {
@@ -594,28 +539,24 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
             () -> action.prepareRequest(getRestRequestWithBodyWithBothParams(), client)
         );
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testRestoreSnapshot() {
         RestRestoreSnapshotAction action = new RestRestoreSnapshotAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testSnapshotsStatus() {
         RestSnapshotsStatusAction action = new RestSnapshotsStatusAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testVerifyRepository() {
         RestVerifyRepositoryAction action = new RestVerifyRepositoryAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testDeletePipeline() {
@@ -626,14 +567,12 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
         RestDeletePipelineAction action = new RestDeletePipelineAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(request, client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testGetPipeline() {
         RestGetPipelineAction action = new RestGetPipelineAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testPutPipeline() {
@@ -644,21 +583,18 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
         RestPutPipelineAction action = new RestPutPipelineAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(request, client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testDeleteStoredScript() {
         RestDeleteStoredScriptAction action = new RestDeleteStoredScriptAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testGetStoredScript() {
         RestGetStoredScriptAction action = new RestGetStoredScriptAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.prepareRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE);
     }
 
     public void testPutStoredScript() {
@@ -668,7 +604,7 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
             () -> action.prepareRequest(getRestRequestWithBodyWithBothParams(), client)
         );
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
-        assertWarnings(MASTER_TIMEOUT_DEPRECATED_MESSAGE, "empty templates should no longer be used");
+        assertWarnings("empty templates should no longer be used");
     }
 
     private MasterNodeRequest getMasterNodeRequest() {


### PR DESCRIPTION
### Description
The REST API request parameter 'master_timeout' is deprecated in issue #2511.
The PR removes the deprecation warning when assigning value to the parameter 'master_timeout'.

The plan of deprecation parameter "master_timeout" changed to not show deprecation warning of 'master_timeout' parameter in 2.x version, but start to emit warning from version 3.0 . 
For the detailed plan, see issue https://github.com/opensearch-project/OpenSearch/issues/2928.

Reason:
This is a compromise with the High Level REST Client (https://github.com/opensearch-project/OpenSearch/tree/1.3.1/client/rest-high-level).
In High Level REST Client, parameter 'master_timeout' is added to every applicable REST API call,
see org.opensearch.client.RequestConverters.Params.[withMasterTimeout](https://github.com/opensearch-project/OpenSearch/blob/1.3.1/client/rest-high-level/src/main/java/org/opensearch/client/RequestConverters.java#L903)(TimeValue).
To keep the compatibility of Rest Client 2.x with server 1.x, the parameter 'master_timeout' is preserved.
Emitting deprecation warning in log file and HTTP response header in this case will confuse the user, because the deprecated parameter is not actively used by the user.

### Issues Resolved
A part of issue https://github.com/opensearch-project/OpenSearch/issues/2928 and https://github.com/opensearch-project/OpenSearch/pull/2511
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
