### PR TITLE
[2.x] Revert "Make High-Level-Rest-Client tests allow deprecation warning temporarily (#2702)"

### DIFF
--- a/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
@@ -824,8 +824,7 @@ public abstract class OpenSearchRestTestCase extends OpenSearchTestCase {
     protected RestClient buildClient(Settings settings, HttpHost[] hosts) throws IOException {
         RestClientBuilder builder = RestClient.builder(hosts);
         configureClient(builder, settings);
-        // TODO: set the method argument to 'true' after PR https://github.com/opensearch-project/OpenSearch/pull/2683 merged.
-        builder.setStrictDeprecationMode(false);
+        builder.setStrictDeprecationMode(true);
         return builder.build();
     }
 


### PR DESCRIPTION
### Description
The PR can only be merged after PR https://github.com/opensearch-project/OpenSearch/pull/2920 merged. [<- achieved]

This reverts commit 6a2a33d1872850b04562164c39621698cb99d7b8, and will be get into `2.x` branch.
This PR sets the High-Level-Rest-Client tests back to treating warning header as a failure.

During the process of deprecating REST API request parameter `master_timeout` and add alternative parameter `cluster_manager_timeout`, I made High-Level-Rest-Client tests allow deprecation warning temporarily, by changing the argument of `setStrictDeprecationMode()` to `false` when building `RestClient` for tests, in the above commit / PR https://github.com/opensearch-project/OpenSearch/pull/2702.

Now it's decided not to emit deprecation warning for using parameter `master_timeout` in version 2.x, in issue https://github.com/opensearch-project/OpenSearch/issues/2928, so it will be ready to change this testing behavior back after PR https://github.com/opensearch-project/OpenSearch/pull/2920 merged.
 
Testing:
`./gradlew ':client:rest-high-level:asyncIntegTest'` passed.

### Issues Resolved
A part of issue https://github.com/opensearch-project/OpenSearch/issues/2928 and issue #2511
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
