### PR TITLE
[Backport-2.x] Bump com.diffplug.spotless from 6.4.1 to 6.4.2 (#2827)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ plugins {
   id 'lifecycle-base'
   id 'opensearch.docker-support'
   id 'opensearch.global-build-info'
-  id "com.diffplug.spotless" version "6.3.0" apply false
+  id "com.diffplug.spotless" version "6.4.2" apply false
   id "org.gradle.test-retry" version "1.3.1" apply false
 }
 


### PR DESCRIPTION
Bumps com.diffplug.spotless from 6.4.1 to 6.4.2.

---
updated-dependencies:
- dependency-name: com.diffplug.spotless
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
(cherry picked from commit c876f55294b5636e558e5735cf2f0c629bcda080)

### Description
Backport from #2827 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
