### PR TITLE
Add Index Operations to Translog from Engine

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -350,6 +350,8 @@ public abstract class Engine implements Closeable {
      */
     public abstract IndexResult index(Index index) throws IOException;
 
+    public abstract IndexResult addIndexOperationToTranslog(Index index) throws IOException;
+
     /**
      * Perform document delete operation on the engine
      * @param delete operation to perform

--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -350,6 +350,12 @@ public abstract class Engine implements Closeable {
      */
     public abstract IndexResult index(Index index) throws IOException;
 
+    /**
+     * Add document index operation to Translog
+     * @param index operation to perform
+     * @return {@link IndexResult} containing updated translog location, version and
+     * document specific failures
+     */
     public abstract IndexResult addIndexOperationToTranslog(Index index) throws IOException;
 
     /**

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -1483,7 +1483,6 @@ public class InternalEngine extends Engine {
                 }
             }
             if (delete.origin().isFromTranslog() == false && deleteResult.getResultType() == Result.Type.SUCCESS) {
-                System.out.println("hey i am called now");
                 final Translog.Location location = translog.add(new Translog.Delete(delete, deleteResult));
                 deleteResult.setTranslogLocation(location);
             }

--- a/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
@@ -295,6 +295,12 @@ public class ReadOnlyEngine extends Engine {
     }
 
     @Override
+    public IndexResult addIndexOperationToTranslog(Index index) throws IOException {
+        assert false : "this should not be called";
+        throw new UnsupportedOperationException("Translog operations are not supported on a read-only engine");
+    }
+
+    @Override
     public DeleteResult delete(Delete delete) {
         assert false : "this should not be called";
         throw new UnsupportedOperationException("deletes are not supported on a read-only engine");

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -1656,6 +1656,18 @@ public class InternalEngineTests extends EngineTestCase {
         }
     }
 
+    public void testAddIndexOperationToTranslog() throws IOException {
+        try (
+            Store store = createStore();
+            InternalEngine engine = createEngine(store, createTempDir())
+        ) {
+            ParsedDocument doc = createParsedDoc("1", null);
+            Engine.IndexResult result=engine.addIndexOperationToTranslog(indexForDoc(doc));
+            assertEquals(Engine.Operation.TYPE.INDEX,result.getOperationType());
+            assertNotNull(result.getTranslogLocation());
+        }
+    }
+
     public void testForceMergeWithSoftDeletesRetention() throws Exception {
         final long retainedExtraOps = randomLongBetween(0, 10);
         Settings.Builder settings = Settings.builder()

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -1657,13 +1657,10 @@ public class InternalEngineTests extends EngineTestCase {
     }
 
     public void testAddIndexOperationToTranslog() throws IOException {
-        try (
-            Store store = createStore();
-            InternalEngine engine = createEngine(store, createTempDir())
-        ) {
+        try (Store store = createStore(); InternalEngine engine = createEngine(store, createTempDir())) {
             ParsedDocument doc = createParsedDoc("1", null);
-            Engine.IndexResult result=engine.addIndexOperationToTranslog(indexForDoc(doc));
-            assertEquals(Engine.Operation.TYPE.INDEX,result.getOperationType());
+            Engine.IndexResult result = engine.addIndexOperationToTranslog(indexForDoc(doc));
+            assertEquals(Engine.Operation.TYPE.INDEX, result.getOperationType());
             assertNotNull(result.getTranslogLocation());
         }
     }


### PR DESCRIPTION
### Description
This PR will allow us to decouple adding Index operations to Lucene and adding Index operations to Translog. This would be useful for segment replication, as we will need to just add Index operation to replicas translog instead of performing full index operation. We will only use this method when segment replication is enabled and when we are on a replica node. The logic for checking if segment replication is enabled and is replica node will be added later in a different PR.

This is a part of the process of merging our feature branch - feature/segment-replication - back into main by re-PRing our changes from the feature branch.
The breakdown of the plan to merge to main is detailed here: https://github.com/opensearch-project/OpenSearch/issues/2926
For added context on segment replication - here's the design proposal https://github.com/opensearch-project/OpenSearch/issues/2229
 
### Issues Resolved
#2926 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
