### PR TITLE
Add Delete Operations to Translog from Engine

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -360,6 +360,12 @@ public abstract class Engine implements Closeable {
      */
     public abstract DeleteResult delete(Delete delete) throws IOException;
 
+    /**
+     * Add document delete operation to translog
+     * @param delete operation to perform
+     * @return {@link DeleteResult} containing updated translog location, version and
+     * document specific failures
+     */
     public abstract DeleteResult addDeleteOperationToTranslog(Delete delete) throws IOException;
 
     public abstract NoOpResult noOp(NoOp noOp) throws IOException;

--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -360,6 +360,8 @@ public abstract class Engine implements Closeable {
      */
     public abstract DeleteResult delete(Delete delete) throws IOException;
 
+    public abstract DeleteResult addDeleteOperationToTranslog(Delete delete) throws IOException;
+
     public abstract NoOpResult noOp(NoOp noOp) throws IOException;
 
     /**

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -1461,8 +1461,7 @@ public class InternalEngine extends Engine {
                 }
             }
             if (delete.origin().isFromTranslog() == false && deleteResult.getResultType() == Result.Type.SUCCESS) {
-                final Translog.Location location = translog.add(new Translog.Delete(delete, deleteResult));
-                deleteResult.setTranslogLocation(location);
+                addDeleteOperationToTranslog(delete, deleteResult);
             }
             localCheckpointTracker.markSeqNoAsProcessed(deleteResult.getSeqNo());
             if (deleteResult.getTranslogLocation() == null) {
@@ -1484,6 +1483,30 @@ public class InternalEngine extends Engine {
         }
         maybePruneDeletes();
         return deleteResult;
+    }
+
+    @Override
+    public Engine.DeleteResult addDeleteOperationToTranslog(Delete delete) throws IOException {
+        try (Releasable ignored = versionMap.acquireLock(delete.uid().bytes())) {
+            DeletionStrategy plan = deletionStrategyForOperation(delete);
+            DeleteResult deleteResult = new DeleteResult(
+                plan.versionOfDeletion,
+                delete.primaryTerm(),
+                delete.seqNo(),
+                plan.currentlyDeleted == false
+            );
+            addDeleteOperationToTranslog(delete, deleteResult);
+            deleteResult.setTook(System.nanoTime() - delete.startTime());
+            deleteResult.freeze();
+            return deleteResult;
+        }
+    }
+
+    private void addDeleteOperationToTranslog(Delete delete, DeleteResult deleteResult) throws IOException {
+        if (deleteResult.getResultType() == Result.Type.SUCCESS) {
+            final Translog.Location location = translog.add(new Translog.Delete(delete, deleteResult));
+            deleteResult.setTranslogLocation(location);
+        }
     }
 
     private Exception tryAcquireInFlightDocs(Operation operation, int addingDocs) {

--- a/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
@@ -301,6 +301,12 @@ public class ReadOnlyEngine extends Engine {
     }
 
     @Override
+    public DeleteResult addDeleteOperationToTranslog(Delete delete) throws IOException {
+        assert false : "this should not be called";
+        throw new UnsupportedOperationException("Translog operations are not supported on a read-only engine");
+    }
+
+    @Override
     public NoOpResult noOp(NoOp noOp) {
         assert false : "this should not be called";
         throw new UnsupportedOperationException("no-ops are not supported on a read-only engine");

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -1632,6 +1632,17 @@ public class InternalEngineTests extends EngineTestCase {
         }
     }
 
+    public void testAddDeleteOperationToTranslog() throws IOException {
+        try (Store store = createStore(); InternalEngine engine = createEngine(store, createTempDir())) {
+            ParsedDocument doc = createParsedDoc("1", null);
+            Engine.DeleteResult result = engine.addDeleteOperationToTranslog(
+                new Engine.Delete(doc.id(), newUid(doc.id()), primaryTerm.get())
+            );
+            assertEquals(Engine.Operation.TYPE.DELETE, result.getOperationType());
+            assertNotNull(result.getTranslogLocation());
+        }
+    }
+
     public void testUpdateWithFullyDeletedSegments() throws IOException {
         final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         final Set<String> liveDocs = new HashSet<>();


### PR DESCRIPTION
Signed-off-by: Rishikesh1159 <rishireddy1159@gmail.com>

### Description
This PR will allow us to decouple adding Delete operations to Lucene and adding Delete operations to Translog. This would be useful for segment replication, as we will need to just add delete operation to replicas translog instead of performing full delete operation. We will only use this method when segment replication is enabled and when we are on a replica node. The logic for checking if segment replication is enabled and is replica node will be added later in a different PR.

This is a part of the process of merging our feature branch - feature/segment-replication - back into main by re-PRing our changes from the feature branch.
The breakdown of the plan to merge to main is detailed here: https://github.com/opensearch-project/OpenSearch/issues/2926
For added context on segment replication - here's the design proposal https://github.com/opensearch-project/OpenSearch/issues/2229
 
### Issues Resolved
#2926 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
