### PR TITLE
Revert "Bump gradle-info-plugin from 7.1.3 to 11.3.3 in /buildSrc (#2…

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -107,7 +107,7 @@ dependencies {
   api 'org.apache.ant:ant:1.10.12'
   api 'com.netflix.nebula:gradle-extra-configurations-plugin:7.0.0'
   api 'com.netflix.nebula:nebula-publishing-plugin:4.4.4'
-  api 'com.netflix.nebula:gradle-info-plugin:11.3.3'
+  api 'com.netflix.nebula:gradle-info-plugin:7.1.3'
   api 'org.apache.rat:apache-rat:0.13'
   api 'commons-io:commons-io:2.7'
   api "net.java.dev.jna:jna:5.11.0"


### PR DESCRIPTION
…831) (#2842)"

This reverts commit d5d00eab8d326d7878ba4d80de63a809cc8d1735.

Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Reverting the nebula gradle info plugin since the upgrade is causing issues with applying `opensearch.build` plugin.
 
### Issues Resolved
#2987 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
