### PR TITLE
[Backport 2.x] Removed binary file from linelint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ testfixtures_shared/
 
 # These are generated from .ci/jobs.t
 .ci/jobs/
+
+# build files generated
+doc-tools/missing-doclet/bin/

--- a/.linelint.yml
+++ b/.linelint.yml
@@ -12,7 +12,6 @@ ignore:
   - 'buildSrc/src/testKit/opensearch.build/NOTICE'
   - 'server/licenses/apache-log4j-extras-DEPENDENCIES'
   # Empty files
-  - 'doc-tools/missing-doclet/bin/main/org/opensearch/missingdoclet/MissingDoclet.class'
   - 'buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/build.gradle'
   - 'buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/archives/oss-darwin-tar/build.gradle'
   - 'buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/bwc/bugfix/build.gradle'


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Backport of https://github.com/opensearch-project/OpenSearch/pull/3015
 
### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/2857
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
