### PR TITLE
Add whitesource config file to 1.x branch

### DIFF
--- a/whitesource.config
+++ b/whitesource.config
@@ -1,0 +1,80 @@
+###############################################################
+# WhiteSource Unified-Agent configuration file
+###############################################################
+# GENERAL SCAN MODE: Files and Package Managers
+###############################################################
+# Organization vitals
+######################
+
+#apiKey='${wss_apikey}'
+apiKey=
+#userKey is required if WhiteSource administrator has enabled "Enforce user level access" option
+#userKey=
+#requesterEmail=user@provider.com
+
+projectName=
+projectVersion=
+projectToken=
+#projectTag= key:value
+
+productName=
+productVersion=
+productToken=
+
+# Change the below URL to your WhiteSource server.
+# Use the 'WhiteSource Server URL' which can be retrieved
+# from your 'Profile' page on the 'Server URLs' panel.
+# Then, add the '/agent' path to it.
+wss.url=https://saas.whitesourcesoftware.com/agent
+
+############
+# Policies #
+############
+checkPolicies=false
+forceCheckAllDependencies=false
+forceUpdate=false
+forceUpdate.failBuildOnPolicyViolation=false
+
+########################################
+# Package Manager Dependency resolvers #
+########################################
+resolveAllDependencies=false
+#excludeDependenciesFromNodes=.*commons-io.*,.*maven-model
+
+resolveAllDependencies=false
+archiveExtractionDepth=7
+followSymbolicLinks=true
+gradle.resolveDependencies=true
+gradle.aggregateModules=true
+gradle.preferredEnvironment=wrapper
+gradle.excludeModules=./qa/*
+maven.resolveDependencies=true
+maven.runPreStep=true
+maven.aggregateModules=true
+maven.ignoredScopes=None
+html.resolveDependencies=true
+npm.resolveDependencies=true
+npm.runPreStep=true
+npm.yarnProject=true
+go.resolveDependencies=true
+go.collectDependenciesAtRuntime=true
+go.dependencyManager=
+python.resolveDependencies=true
+python.ignoreSourceFiles=true
+python.runPipenvPreStep=true
+python.pipenvDevDependencies=true
+python.requirementsFileIncludes=dev-requirements.txt
+python.installVirtualenv=true
+ruby.resolveDependencies=true
+ruby.ignoreSourceFiles=false
+
+###########################################################################################
+# Includes/Excludes Glob patterns - Please use only one exclude line and one include line #
+###########################################################################################
+includes=**/*.cc **/*.zip **/*.cpp **/*.c **/*.swf **/*.tgz **/*.h **/*.js **/*.hpp **/*.py **/*.gzip **/*.cs **/*.rb **/*.exe **/*.gz **/*.pl **/*.cxx **/*.c++ **/*.hxx **/*.jar **/*.java **/*.go **/*.mod **/*.sum **/*.rb
+
+#Exclude file extensions or specific directories by adding **/*.<extension> or **/<excluded_dir>/**
+excludes=**/*sources.jar **/*javadoc.jar
+
+case.sensitive.glob=false
+followSymbolicLinks=true


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Since the WhiteSource integration on GitHub is not working as expected on OpenSearch repo; from what I heard from WhiteSource support, we will need to have this `whitesource.config` file in the `1.x` repo since the WhiteSource file is targeting on the `1.x` branch right now. https://github.com/opensearch-project/OpenSearch/blob/03fbca3f500d8541b4b32c1456997a8493ebe4f5/.whitesource#L6
The `.whitesource` file should stay in the default branch. 

Let's do as what their support suggested and see if this will resolve the issues on WhiteSource integration scanning OpenSearch repo for CVEs . 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
