### PR TITLE
Adds the replication type index setting, alongside a formal notion of feature flags

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -260,6 +260,17 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         Property.IndexScope
     );
 
+    public static final String SETTING_SEGMENT_REPLICATION = "index.replication.segment_replication";
+    /**
+     * Used to specify if the index should use segment replication. If false, document replication is used.
+     */
+    public static final Setting<Boolean> INDEX_SEGMENT_REPLICATION_SETTING = Setting.boolSetting(
+        SETTING_SEGMENT_REPLICATION,
+        false,
+        Property.IndexScope,
+        Property.Final
+    );
+
     public static final String SETTING_AUTO_EXPAND_REPLICAS = "index.auto_expand_replicas";
     public static final Setting<AutoExpandReplicas> INDEX_AUTO_EXPAND_REPLICAS_SETTING = AutoExpandReplicas.SETTING;
 

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -70,6 +70,7 @@ import org.opensearch.index.Index;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.shard.ShardId;
+import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.rest.RestStatus;
 
 import java.io.IOException;
@@ -260,13 +261,14 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         Property.IndexScope
     );
 
-    public static final String SETTING_SEGMENT_REPLICATION = "index.replication.segment_replication";
     /**
-     * Used to specify if the index should use segment replication. If false, document replication is used.
+     * Used to specify the replication type for the index. By default, document replication is used.
      */
-    public static final Setting<Boolean> INDEX_SEGMENT_REPLICATION_SETTING = Setting.boolSetting(
-        SETTING_SEGMENT_REPLICATION,
-        false,
+    public static final String SETTING_REPLICATION_TYPE = "index.replication.type";
+    public static final Setting<ReplicationType> INDEX_REPLICATION_TYPE_SETTING = new Setting<>(
+        SETTING_REPLICATION_TYPE,
+        ReplicationType.DOCUMENT.toString(),
+        ReplicationType::parseString,
         Property.IndexScope,
         Property.Final
     );

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -214,8 +214,8 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
      * setting should be moved to {@link #BUILT_IN_INDEX_SETTINGS}.
      */
     public static final Map<String, Setting> FEATURE_FLAGGED_INDEX_SETTINGS = Map.of(
-        FeatureFlags.SEGREP_FEATURE_FLAG,
-        IndexMetadata.INDEX_SEGMENT_REPLICATION_SETTING
+        FeatureFlags.REPLICATION_TYPE,
+        IndexMetadata.INDEX_REPLICATION_TYPE_SETTING
     );
 
     public static final IndexScopedSettings DEFAULT_SCOPED_SETTINGS = new IndexScopedSettings(Settings.EMPTY, BUILT_IN_INDEX_SETTINGS);

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -40,6 +40,7 @@ import org.opensearch.cluster.routing.allocation.decider.MaxRetryAllocationDecid
 import org.opensearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.settings.Setting.Property;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.IndexSortConfig;
@@ -205,6 +206,16 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
 
             )
         )
+    );
+
+    /**
+     * Map of feature flag name to feature-flagged index setting. Once each feature
+     * is ready for production release, the feature flag can be removed, and the
+     * setting should be moved to {@link #BUILT_IN_INDEX_SETTINGS}.
+     */
+    public static final Map<String, Setting> FEATURE_FLAGGED_INDEX_SETTINGS = Map.of(
+        FeatureFlags.SEGREP_FEATURE_FLAG,
+        IndexMetadata.INDEX_SEGMENT_REPLICATION_SETTING
     );
 
     public static final IndexScopedSettings DEFAULT_SCOPED_SETTINGS = new IndexScopedSettings(Settings.EMPTY, BUILT_IN_INDEX_SETTINGS);

--- a/server/src/main/java/org/opensearch/common/settings/SettingsModule.java
+++ b/server/src/main/java/org/opensearch/common/settings/SettingsModule.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.Strings;
 import org.opensearch.common.inject.Binder;
 import org.opensearch.common.inject.Module;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentType;
@@ -83,6 +84,12 @@ public class SettingsModule implements Module {
         }
         for (Setting<?> setting : IndexScopedSettings.BUILT_IN_INDEX_SETTINGS) {
             registerSetting(setting);
+        }
+
+        for (Map.Entry<String, Setting> featureFlaggedSetting : IndexScopedSettings.FEATURE_FLAGGED_INDEX_SETTINGS.entrySet()) {
+            if (FeatureFlags.isEnabled(featureFlaggedSetting.getKey())) {
+                registerSetting(featureFlaggedSetting.getValue());
+            }
         }
 
         for (Setting<?> setting : additionalSettings) {

--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -16,10 +16,10 @@ package org.opensearch.common.util;
 public class FeatureFlags {
 
     /**
-     * Gates the visibility of the index setting that enables segment replication.
+     * Gates the visibility of the index setting that allows changing of replication type.
      * Once the feature is ready for production release, this feature flag can be removed.
      */
-    public static final String SEGREP_FEATURE_FLAG = "opensearch.segment_replication_feature_flag_enabled";
+    public static final String REPLICATION_TYPE = "opensearch.experimental.feature.replication_type.enabled";
 
     /**
      * Used to test feature flags whose values are expected to be booleans.

--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.util;
+
+/**
+ * Utility class to manage feature flags. Feature flags are system properties that must be set on the JVM.
+ * These are used to gate the visibility/availability of incomplete features. Fore more information, see
+ * https://featureflags.io/feature-flag-introduction/
+ */
+public class FeatureFlags {
+
+    /**
+     * Gates the visibility of the index setting that enables segment replication.
+     * Once the feature is ready for production release, this feature flag can be removed.
+     */
+    public static final String SEGREP_FEATURE_FLAG = "opensearch.segment_replication_feature_flag_enabled";
+
+    /**
+     * Used to test feature flags whose values are expected to be booleans.
+     * This method returns true if the value is "true" (case-insensitive),
+     * and false otherwise.
+     */
+    public static boolean isEnabled(String featureFlagName) {
+        return "true".equalsIgnoreCase(System.getProperty(featureFlagName));
+    }
+}

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -531,7 +531,7 @@ public final class IndexSettings {
     private final String nodeName;
     private final Settings nodeSettings;
     private final int numberOfShards;
-    private final Boolean isSegRepEnabled;
+    private final ReplicationType replicationType;
     // volatile fields are updated via #updateIndexMetadata(IndexMetadata) under lock
     private volatile Settings settings;
     private volatile IndexMetadata indexMetadata;
@@ -683,9 +683,7 @@ public final class IndexSettings {
         nodeName = Node.NODE_NAME_SETTING.get(settings);
         this.indexMetadata = indexMetadata;
         numberOfShards = settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, null);
-
-        ReplicationType replicationType = ReplicationType.parseString(settings.get(IndexMetadata.SETTING_REPLICATION_TYPE));
-        isSegRepEnabled = ReplicationType.SEGMENT.equals(replicationType);
+        replicationType = ReplicationType.parseString(settings.get(IndexMetadata.SETTING_REPLICATION_TYPE));
 
         this.searchThrottled = INDEX_SEARCH_THROTTLED.get(settings);
         this.queryStringLenient = QUERY_STRING_LENIENT_SETTING.get(settings);
@@ -924,7 +922,7 @@ public final class IndexSettings {
      * Returns true if segment replication is enabled on the index.
      */
     public boolean isSegrepEnabled() {
-        return Boolean.TRUE.equals(isSegRepEnabled);
+        return ReplicationType.SEGMENT.equals(replicationType);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -46,6 +46,7 @@ import org.opensearch.common.unit.ByteSizeUnit;
 import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.index.translog.Translog;
+import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.ingest.IngestService;
 import org.opensearch.node.Node;
 
@@ -682,7 +683,9 @@ public final class IndexSettings {
         nodeName = Node.NODE_NAME_SETTING.get(settings);
         this.indexMetadata = indexMetadata;
         numberOfShards = settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, null);
-        isSegRepEnabled = settings.getAsBoolean(IndexMetadata.SETTING_SEGMENT_REPLICATION, false);
+
+        ReplicationType replicationType = ReplicationType.parseString(settings.get(IndexMetadata.SETTING_REPLICATION_TYPE));
+        isSegRepEnabled = ReplicationType.SEGMENT.equals(replicationType);
 
         this.searchThrottled = INDEX_SEARCH_THROTTLED.get(settings);
         this.queryStringLenient = QUERY_STRING_LENIENT_SETTING.get(settings);

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -921,7 +921,7 @@ public final class IndexSettings {
     /**
      * Returns true if segment replication is enabled on the index.
      */
-    public boolean isSegrepEnabled() {
+    public boolean isSegRepEnabled() {
         return ReplicationType.SEGMENT.equals(replicationType);
     }
 

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -530,6 +530,7 @@ public final class IndexSettings {
     private final String nodeName;
     private final Settings nodeSettings;
     private final int numberOfShards;
+    private final Boolean isSegRepEnabled;
     // volatile fields are updated via #updateIndexMetadata(IndexMetadata) under lock
     private volatile Settings settings;
     private volatile IndexMetadata indexMetadata;
@@ -681,6 +682,7 @@ public final class IndexSettings {
         nodeName = Node.NODE_NAME_SETTING.get(settings);
         this.indexMetadata = indexMetadata;
         numberOfShards = settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, null);
+        isSegRepEnabled = settings.getAsBoolean(IndexMetadata.SETTING_SEGMENT_REPLICATION, false);
 
         this.searchThrottled = INDEX_SEARCH_THROTTLED.get(settings);
         this.queryStringLenient = QUERY_STRING_LENIENT_SETTING.get(settings);
@@ -913,6 +915,13 @@ public final class IndexSettings {
      */
     public int getNumberOfReplicas() {
         return settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, null);
+    }
+
+    /**
+     * Returns true if segment replication is enabled on the index.
+     */
+    public boolean isSegrepEnabled() {
+        return Boolean.TRUE.equals(isSegRepEnabled);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/indices/replication/common/ReplicationType.java
+++ b/server/src/main/java/org/opensearch/indices/replication/common/ReplicationType.java
@@ -8,17 +8,14 @@
 
 package org.opensearch.indices.replication.common;
 
+/**
+ * Enumerates the types of replication strategies supported by OpenSearch.
+ * For more information, see https://github.com/opensearch-project/OpenSearch/issues/1694
+ */
 public enum ReplicationType {
 
-    DOCUMENT("document"),
-
-    SEGMENT("segment");
-
-    private final String value;
-
-    ReplicationType(String replicationType) {
-        this.value = replicationType;
-    }
+    DOCUMENT,
+    SEGMENT;
 
     public static ReplicationType parseString(String replicationType) {
         try {
@@ -29,10 +26,5 @@ public enum ReplicationType {
             // return a default value for null input
             return DOCUMENT;
         }
-    }
-
-    @Override
-    public String toString() {
-        return value;
     }
 }

--- a/server/src/main/java/org/opensearch/indices/replication/common/ReplicationType.java
+++ b/server/src/main/java/org/opensearch/indices/replication/common/ReplicationType.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication.common;
+
+public enum ReplicationType {
+
+    DOCUMENT("document"),
+
+    SEGMENT("segment");
+
+    private final String value;
+
+    ReplicationType(String replicationType) {
+        this.value = replicationType;
+    }
+
+    public static ReplicationType parseString(String replicationType) {
+        try {
+            return ReplicationType.valueOf(replicationType);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Could not parse ReplicationStrategy for [" + replicationType + "]");
+        } catch (NullPointerException npe) {
+            // return a default value for null input
+            return DOCUMENT;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -256,27 +256,6 @@ public class Node implements Closeable {
     );
 
     /**
-     * Feature flag to gate the visibility of the index setting that enables segment replication.
-     * Once the feature is ready for production release, this feature flag can be removed.
-     */
-    public static final boolean SEGREP_FEATURE_FLAG_ENABLED = "true".equals(
-        System.getProperty("opensearch.segment_replication_feature_flag_enabled")
-    );
-
-    /**
-     * Used to specify if the index should use segment replication. If false, document replication is used.
-     * Currently located here so that it can gated by the {@link #SEGREP_FEATURE_FLAG_ENABLED} feature flag.
-     * Once the feature is ready for production release, the setting can be moved to
-     * {@link org.opensearch.common.settings.IndexScopedSettings#BUILT_IN_INDEX_SETTINGS}.
-     */
-    private static final Setting<Boolean> INDEX_SEGMENT_REPLICATION_SETTING = Setting.boolSetting(
-        "index.replication.segment_replication",
-        false,
-        Property.IndexScope,
-        Property.Final
-    );
-
-    /**
     * controls whether the node is allowed to persist things like metadata to disk
     * Note that this does not control whether the node stores actual indices (see
     * {@link #NODE_DATA_SETTING}). However, if this is false, {@link #NODE_DATA_SETTING}
@@ -477,10 +456,6 @@ public class Node implements Closeable {
             final List<String> additionalSettingsFilter = new ArrayList<>(pluginsService.getPluginSettingsFilter());
             for (final ExecutorBuilder<?> builder : threadPool.builders()) {
                 additionalSettings.addAll(builder.getRegisteredSettings());
-            }
-            // Add segment replication setting gated by feature flag
-            if (SEGREP_FEATURE_FLAG_ENABLED) {
-                additionalSettings.add(INDEX_SEGMENT_REPLICATION_SETTING);
             }
             client = new NodeClient(settings, threadPool);
 

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -256,6 +256,27 @@ public class Node implements Closeable {
     );
 
     /**
+     * Feature flag to gate the visibility of the index setting that enables segment replication.
+     * Once the feature is ready for production release, this feature flag can be removed.
+     */
+    public static final boolean SEGREP_FEATURE_FLAG_ENABLED = "true".equals(
+        System.getProperty("opensearch.segment_replication_feature_flag_enabled")
+    );
+
+    /**
+     * Used to specify if the index should use segment replication. If false, document replication is used.
+     * Currently located here so that it can gated by the {@link #SEGREP_FEATURE_FLAG_ENABLED} feature flag.
+     * Once the feature is ready for production release, the setting can be moved to
+     * {@link org.opensearch.common.settings.IndexScopedSettings#BUILT_IN_INDEX_SETTINGS}.
+     */
+    private static final Setting<Boolean> INDEX_SEGMENT_REPLICATION_SETTING = Setting.boolSetting(
+        "index.replication.segment_replication",
+        false,
+        Property.IndexScope,
+        Property.Final
+    );
+
+    /**
     * controls whether the node is allowed to persist things like metadata to disk
     * Note that this does not control whether the node stores actual indices (see
     * {@link #NODE_DATA_SETTING}). However, if this is false, {@link #NODE_DATA_SETTING}
@@ -456,6 +477,10 @@ public class Node implements Closeable {
             final List<String> additionalSettingsFilter = new ArrayList<>(pluginsService.getPluginSettingsFilter());
             for (final ExecutorBuilder<?> builder : threadPool.builders()) {
                 additionalSettings.addAll(builder.getRegisteredSettings());
+            }
+            // Add segment replication setting gated by feature flag
+            if (SEGREP_FEATURE_FLAG_ENABLED) {
+                additionalSettings.add(INDEX_SEGMENT_REPLICATION_SETTING);
             }
             client = new NodeClient(settings, threadPool);
 

--- a/server/src/main/resources/org/opensearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/security.policy
@@ -120,6 +120,9 @@ grant {
   // TODO: set this with gradle or some other way that repros with seed?
   permission java.util.PropertyPermission "processors.override", "write";
 
+  // needed for feature flags
+  permission java.util.PropertyPermission "opensearch.experimental.feature.*", "write";
+
   // TODO: these simply trigger a noisy warning if its unable to clear the properties
   // fix that in randomizedtesting
   permission java.util.PropertyPermission "junit4.childvm.count", "write";

--- a/server/src/test/java/org/opensearch/common/util/FeatureFlagTests.java
+++ b/server/src/test/java/org/opensearch/common/util/FeatureFlagTests.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.util;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class FeatureFlagTests extends OpenSearchTestCase {
+
+    public void testMissingFeatureFlag() {
+        String testFlag = "missingFeatureFlag";
+        assertNull(System.getProperty(testFlag));
+        assertFalse(FeatureFlags.isEnabled(testFlag));
+    }
+
+    public void testNonBooleanFeatureFlag() {
+        String javaVersionProperty = "java.version";
+        assertNotNull(System.getProperty(javaVersionProperty));
+        assertFalse(FeatureFlags.isEnabled(javaVersionProperty));
+    }
+}

--- a/server/src/test/java/org/opensearch/common/util/FeatureFlagTests.java
+++ b/server/src/test/java/org/opensearch/common/util/FeatureFlagTests.java
@@ -8,9 +8,26 @@
 
 package org.opensearch.common.util;
 
+import org.junit.BeforeClass;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
 public class FeatureFlagTests extends OpenSearchTestCase {
+
+    @SuppressForbidden(reason = "sets the feature flag")
+    @BeforeClass
+    public static void enableFeature() {
+        AccessController.doPrivileged((PrivilegedAction<String>) () -> System.setProperty(FeatureFlags.REPLICATION_TYPE, "true"));
+    }
+
+    public void testReplicationTypeFeatureFlag() {
+        String replicationTypeFlag = FeatureFlags.REPLICATION_TYPE;
+        assertNotNull(System.getProperty(replicationTypeFlag));
+        assertTrue(FeatureFlags.isEnabled(replicationTypeFlag));
+    }
 
     public void testMissingFeatureFlag() {
         String testFlag = "missingFeatureFlag";


### PR DESCRIPTION
Signed-off-by: Kartik Ganesh <gkart@amazon.com>

### Description
This change formalizes the notion of [feature flags](https://featureflags.io/feature-flag-introduction/), and adds a "replication type" setting that will differentiate between document and [segment replication](https://github.com/opensearch-project/OpenSearch/issues/2229), gated by a feature flag. 

Since seg-rep is currently an incomplete implementation, the feature flag ensures that the setting is not visible to users without explicitly setting a system property. We can then continue to merge seg-rep related changes from the [feature branch](https://github.com/opensearch-project/OpenSearch/tree/feature/segment-replication) to `main` safely hidden behind the feature flag gate.

The ReplicationType setting is represented as an enum. Its default value is `DOCUMENT`. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
