### PR TITLE
Build: do not ship jdk when no-jdk option set

### DIFF
--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -355,7 +355,7 @@ tasks.register('buildDeb', Deb) {
 }
 
 tasks.register('buildNoJdkDeb', Deb) {
-  configure(commonDebConfig(true, 'x64'))
+  configure(commonDebConfig(false, 'x64'))
 }
 
 Closure commonRpmConfig(boolean jdk, String architecture) {


### PR DESCRIPTION
### Description

When using package distribution

```
./gradlew :distribution:packages:no-jdk-deb:assemble
```

When `true` this include jdk switch the boolean to the correct value

### Issues Resolved

fix https://github.com/opensearch-project/OpenSearch/issues/3024

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
