### PR TITLE
Added explicit 'null' check for response listener to prevent obscure NullPointerException issues

### DIFF
--- a/client/rest-high-level/src/main/java/org/opensearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/RestHighLevelClient.java
@@ -1917,6 +1917,10 @@ public class RestHighLevelClient implements Closeable {
         ActionListener<Resp> listener,
         Set<Integer> ignores
     ) {
+        if (listener == null) {
+            throw new IllegalArgumentException("The listener is required and cannot be null");
+        }
+
         Request req;
         try {
             req = requestConverter.apply(request);

--- a/client/rest-high-level/src/test/java/org/opensearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/RestHighLevelClientTests.java
@@ -284,6 +284,20 @@ public class RestHighLevelClientTests extends OpenSearchTestCase {
         }
     }
 
+    public void testNullableActionListener() {
+        ActionRequest request = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+        };
+
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> restHighLevelClient.performRequestAsync(request, null, RequestOptions.DEFAULT, null, null, null)
+        );
+    }
+
     public void testParseEntity() throws IOException {
         {
             IllegalStateException ise = expectThrows(IllegalStateException.class, () -> restHighLevelClient.parseEntity(null, null));


### PR DESCRIPTION

Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
See please https://github.com/opensearch-project/OpenSearch/issues/2436#issuecomment-1105614010
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/2436
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
