### PR TITLE
[Rename] ESTestCase stragglers to OpenSearchTestCase

### DIFF
--- a/buildSrc/src/main/resources/forbidden/opensearch-test-signatures.txt
+++ b/buildSrc/src/main/resources/forbidden/opensearch-test-signatures.txt
@@ -26,4 +26,4 @@ com.carrotsearch.randomizedtesting.annotations.Nightly @ We don't run nightly te
 
 org.junit.Test @defaultMessage Just name your test method testFooBar
 
-java.lang.Math#random() @ Use one of the various randomization methods from LuceneTestCase or ESTestCase for reproducibility
+java.lang.Math#random() @ Use one of the various randomization methods from LuceneTestCase or OpenSearchTestCase for reproducibility

--- a/server/src/main/resources/org/opensearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/security.policy
@@ -116,7 +116,7 @@ grant {
   permission java.util.PropertyPermission "solr.data.dir", "write";
   permission java.util.PropertyPermission "solr.directoryFactory", "write";
 
-  // set by ESTestCase to improve test reproducibility
+  // set by OpenSearchTestCase to improve test reproducibility
   // TODO: set this with gradle or some other way that repros with seed?
   permission java.util.PropertyPermission "processors.override", "write";
 


### PR DESCRIPTION
A few places still referenced legacy ESTestCase naming. This refactors those
instances to OpenSearchTestCase.