### PR TITLE
Correct the skip version, multi_terms aggregation is supported on 2.1

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/370_multi_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/370_multi_terms.yml
@@ -46,8 +46,8 @@ setup:
 ---
 "Basic test":
   - skip:
-      version: "- 2.9.99"
-      reason:  multi_terms aggregation is introduced in 3.0.0
+      version: "- 2.0.99"
+      reason:  multi_terms aggregation is introduced in 2.1.0
 
   - do:
       bulk:
@@ -96,8 +96,8 @@ setup:
 ---
 "IP test":
   - skip:
-      version: "- 2.9.99"
-      reason:  multi_terms aggregation is introduced in 3.0.0
+      version: "- 2.0.99"
+      reason:  multi_terms aggregation is introduced in 2.1.0
 
   - do:
       bulk:
@@ -146,8 +146,8 @@ setup:
 ---
 "Boolean test":
   - skip:
-      version: "- 2.9.99"
-      reason:  multi_terms aggregation is introduced in 3.0.0
+      version: "- 2.0.99"
+      reason:  multi_terms aggregation is introduced in 2.1.0
 
   - do:
       bulk:
@@ -196,8 +196,8 @@ setup:
 ---
 "Double test":
   - skip:
-      version: "- 2.9.99"
-      reason:  multi_terms aggregation is introduced in 3.0.0
+      version: "- 2.0.99"
+      reason:  multi_terms aggregation is introduced in 2.1.0
 
   - do:
       bulk:
@@ -239,8 +239,8 @@ setup:
 ---
 "Date test":
   - skip:
-      version: "- 2.9.99"
-      reason:  multi_terms aggregation is introduced in 3.0.0
+      version: "- 2.0.99"
+      reason:  multi_terms aggregation is introduced in 2.1.0
 
   - do:
       bulk:
@@ -282,8 +282,8 @@ setup:
 ---
 "Unmapped keywords":
   - skip:
-      version: "- 2.9.99"
-      reason:  multi_terms aggregation is introduced in 3.0.0
+      version: "- 2.0.99"
+      reason:  multi_terms aggregation is introduced in 2.1.0
 
   - do:
       bulk:
@@ -322,8 +322,8 @@ setup:
 ---
 "Null value":
   - skip:
-      version: "- 2.9.99"
-      reason:  multi_terms aggregation is introduced in 3.0.0
+      version: "- 2.0.99"
+      reason:  multi_terms aggregation is introduced in 2.1.0
 
   - do:
       bulk:
@@ -357,8 +357,8 @@ setup:
 ---
 "multiple multi_terms bucket":
   - skip:
-      version: "- 2.9.99"
-      reason:  multi_terms aggregation is introduced in 3.0.0
+      version: "- 2.0.99"
+      reason:  multi_terms aggregation is introduced in 2.1.0
 
   - do:
       bulk:
@@ -409,8 +409,8 @@ setup:
 ---
 "ordered by metrics":
   - skip:
-      version: "- 3.0.0"
-      reason:  multi_terms aggregation is introduced in 3.0.0
+      version: "- 2.0.99"
+      reason:  multi_terms aggregation is introduced in 2.1.0
 
   - do:
       bulk:
@@ -457,8 +457,8 @@ setup:
 ---
 "top 1 ordered by metrics ":
   - skip:
-      version: "- 2.9.99"
-      reason:  multi_terms aggregation is introduced in 3.0.0
+      version: "- 2.0.99"
+      reason:  multi_terms aggregation is introduced in 2.1.0
 
   - do:
       bulk:
@@ -502,8 +502,8 @@ setup:
 ---
 "min_doc_count":
   - skip:
-      version: "- 2.9.99"
-      reason:  multi_terms aggregation is introduced in 3.0.0
+      version: "- 2.0.99"
+      reason:  multi_terms aggregation is introduced in 2.1.0
 
   - do:
       bulk:
@@ -574,8 +574,8 @@ setup:
 ---
 "sum_other_doc_count":
   - skip:
-      version: "- 2.9.99"
-      reason:  multi_terms aggregation is introduced in 3.0.0
+      version: "- 2.0.99"
+      reason:  multi_terms aggregation is introduced in 2.1.0
 
   - do:
       bulk:


### PR DESCRIPTION
Signed-off-by: Peng Huo <penghuo@gmail.com>

### To maintainer
This PR need to backport to 2.x branch.

### Description
Correct the skip version in 370_multi_terms.yml as the [multi_terms aggregation feature has been backport to 2.x](https://github.com/opensearch-project/OpenSearch/pull/3022) and will be released in 2.1.
 
### Issues Resolved
#1629 

### Test
#### In Main Branch
PASSED: `./gradlew ':qa:mixed-cluster:v2.1.0#mixedClusterTest' --tests "org.opensearch.backwards.MixedClusterClientYamlTestSuiteIT" -Dtests.method="test {p0=search.aggregation/370_multi_terms/*}"`
#### In 2.x Branch
PASSED, `./gradlew ':qa:mixed-cluster:v2.0.0#mixedClusterTest' --tests "org.opensearch.backwards.MixedClusterClientYamlTestSuiteIT" -Dtests.method="test {p0=search.aggregation/370_multi_terms/*}"`
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
