### PR TITLE
[Type removal] Remove _type support in NOOP bulk indexing from client benchmark

### DIFF
--- a/client/benchmark/README.md
+++ b/client/benchmark/README.md
@@ -29,7 +29,7 @@ Example invocation:
 wget http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/geonames/documents-2.json.bz2
 bzip2 -d documents-2.json.bz2
 mv documents-2.json client/benchmark/build
-gradlew -p client/benchmark run --args ' rest bulk localhost build/documents-2.json geonames type 8647880 5000'
+gradlew -p client/benchmark run --args ' rest bulk localhost build/documents-2.json geonames 8647880 5000'
 ```
 
 The parameters are all in the `'`s and are in order:
@@ -39,7 +39,6 @@ The parameters are all in the `'`s and are in order:
 * Benchmark target host IP (the host where OpenSearch is running)
 * full path to the file that should be bulk indexed
 * name of the index
-* name of the (sole) type in the index
 * number of documents in the file
 * bulk size
 

--- a/client/benchmark/src/main/java/org/opensearch/client/benchmark/AbstractBenchmark.java
+++ b/client/benchmark/src/main/java/org/opensearch/client/benchmark/AbstractBenchmark.java
@@ -49,7 +49,7 @@ public abstract class AbstractBenchmark<T extends Closeable> {
 
     protected abstract T client(String benchmarkTargetHost) throws Exception;
 
-    protected abstract BulkRequestExecutor bulkRequestExecutor(T client, String indexName, String typeName);
+    protected abstract BulkRequestExecutor bulkRequestExecutor(T client, String indexName);
 
     protected abstract SearchRequestExecutor searchRequestExecutor(T client, String indexName);
 
@@ -76,16 +76,15 @@ public abstract class AbstractBenchmark<T extends Closeable> {
 
     @SuppressForbidden(reason = "system out is ok for a command line tool")
     private void runBulkIndexBenchmark(String[] args) throws Exception {
-        if (args.length != 7) {
-            System.err.println("usage: 'bulk' benchmarkTargetHostIp indexFilePath indexName typeName numberOfDocuments bulkSize");
+        if (args.length != 6) {
+            System.err.println("usage: 'bulk' benchmarkTargetHostIp indexFilePath indexName numberOfDocuments bulkSize");
             System.exit(1);
         }
         String benchmarkTargetHost = args[1];
         String indexFilePath = args[2];
         String indexName = args[3];
-        String typeName = args[4];
-        int totalDocs = Integer.valueOf(args[5]);
-        int bulkSize = Integer.valueOf(args[6]);
+        int totalDocs = Integer.valueOf(args[4]);
+        int bulkSize = Integer.valueOf(args[5]);
 
         int totalIterationCount = (int) Math.floor(totalDocs / bulkSize);
         // consider 40% of all iterations as warmup iterations
@@ -97,7 +96,7 @@ public abstract class AbstractBenchmark<T extends Closeable> {
         BenchmarkRunner benchmark = new BenchmarkRunner(
             warmupIterations,
             iterations,
-            new BulkBenchmarkTask(bulkRequestExecutor(client, indexName, typeName), indexFilePath, warmupIterations, iterations, bulkSize)
+            new BulkBenchmarkTask(bulkRequestExecutor(client, indexName), indexFilePath, warmupIterations, iterations, bulkSize)
         );
 
         try {

--- a/client/benchmark/src/main/java/org/opensearch/client/benchmark/rest/RestClientBenchmark.java
+++ b/client/benchmark/src/main/java/org/opensearch/client/benchmark/rest/RestClientBenchmark.java
@@ -65,8 +65,8 @@ public final class RestClientBenchmark extends AbstractBenchmark<RestClient> {
     }
 
     @Override
-    protected BulkRequestExecutor bulkRequestExecutor(RestClient client, String indexName, String typeName) {
-        return new RestBulkRequestExecutor(client, indexName, typeName);
+    protected BulkRequestExecutor bulkRequestExecutor(RestClient client, String indexName) {
+        return new RestBulkRequestExecutor(client, indexName);
     }
 
     @Override
@@ -78,9 +78,9 @@ public final class RestClientBenchmark extends AbstractBenchmark<RestClient> {
         private final RestClient client;
         private final String actionMetadata;
 
-        RestBulkRequestExecutor(RestClient client, String index, String type) {
+        RestBulkRequestExecutor(RestClient client, String index) {
             this.client = client;
-            this.actionMetadata = String.format(Locale.ROOT, "{ \"index\" : { \"_index\" : \"%s\", \"_type\" : \"%s\" } }%n", index, type);
+            this.actionMetadata = String.format(Locale.ROOT, "{ \"index\" : { \"_index\" : \"%s\" } }%n", index);
         }
 
         @Override
@@ -91,7 +91,7 @@ public final class RestClientBenchmark extends AbstractBenchmark<RestClient> {
                 bulkRequestBody.append(bulkItem);
                 bulkRequestBody.append("\n");
             }
-            Request request = new Request("POST", "/geonames/type/_noop_bulk");
+            Request request = new Request("POST", "/geonames/_noop_bulk");
             request.setJsonEntity(bulkRequestBody.toString());
             try {
                 Response response = client.performRequest(request);


### PR DESCRIPTION
### Description
This change removes the `_type` param support in client benchmark bulk indexing actions. 
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/3074
https://github.com/opensearch-project/OpenSearch/issues/2979

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
