### PR TITLE
Custom plugin backport to main branch

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/PublishPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/PublishPlugin.java
@@ -125,18 +125,21 @@ public class PublishPlugin implements Plugin<Project> {
             // Add git origin info to generated POM files
             publication.getPom().withXml(PublishPlugin::addScmInfo);
 
-            // have to defer this until archivesBaseName is set
-            project.afterEvaluate(p -> publication.setArtifactId(getArchivesBaseName(project)));
+            if (!publication.getName().toLowerCase().contains("zip")) {
 
-            // publish sources and javadoc for Java projects.
-            if (project.getPluginManager().hasPlugin("opensearch.java")) {
-                publication.artifact(project.getTasks().getByName("sourcesJar"));
-                publication.artifact(project.getTasks().getByName("javadocJar"));
+                // have to defer this until archivesBaseName is set
+                project.afterEvaluate(p -> publication.setArtifactId(getArchivesBaseName(project)));
+
+                // publish sources and javadoc for Java projects.
+                if (project.getPluginManager().hasPlugin("opensearch.java")) {
+                    publication.artifact(project.getTasks().getByName("sourcesJar"));
+                    publication.artifact(project.getTasks().getByName("javadocJar"));
+                }
+
+                generatePomTask.configure(
+                    t -> t.dependsOn(String.format("generatePomFileFor%sPublication", Util.capitalize(publication.getName())))
+                );
             }
-
-            generatePomTask.configure(
-                t -> t.dependsOn(String.format("generatePomFileFor%sPublication", Util.capitalize(publication.getName())))
-            );
         });
 
     }

--- a/buildSrc/src/main/java/org/opensearch/gradle/pluginzip/Publish.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/pluginzip/Publish.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.gradle.pluginzip;
+
+import java.util.*;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.maven.MavenPublication;
+import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
+import java.nio.file.Path;
+
+public class Publish implements Plugin<Project> {
+    private Project project;
+
+    public final static String EXTENSION_NAME = "zipmavensettings";
+    public final static String PUBLICATION_NAME = "pluginZip";
+    public final static String STAGING_REPO = "zipStaging";
+    public final static String PLUGIN_ZIP_PUBLISH_POM_TASK = "generatePomFileForPluginZipPublication";
+    public final static String LOCALMAVEN = "publishToMavenLocal";
+    public final static String LOCAL_STAGING_REPO_PATH = "/build/local-staging-repo";
+    public String zipDistributionLocation = "/build/distributions/";
+
+    public static void configMaven(Project project) {
+        final Path buildDirectory = project.getRootDir().toPath();
+        project.getPluginManager().apply(MavenPublishPlugin.class);
+        project.getExtensions().configure(PublishingExtension.class, publishing -> {
+            publishing.repositories(repositories -> {
+                repositories.maven(maven -> {
+                    maven.setName(STAGING_REPO);
+                    maven.setUrl(buildDirectory.toString() + LOCAL_STAGING_REPO_PATH);
+                });
+            });
+            publishing.publications(publications -> {
+                publications.create(PUBLICATION_NAME, MavenPublication.class, mavenZip -> {
+                    String zipGroup = "org.opensearch.plugin";
+                    String zipArtifact = project.getName();
+                    String zipVersion = getProperty("version", project);
+                    mavenZip.artifact(project.getTasks().named("bundlePlugin"));
+                    mavenZip.setGroupId(zipGroup);
+                    mavenZip.setArtifactId(zipArtifact);
+                    mavenZip.setVersion(zipVersion);
+                });
+            });
+        });
+    }
+
+    static String getProperty(String name, Project project) {
+        if (project.hasProperty(name)) {
+            Object property = project.property(name);
+            if (property != null) {
+                return property.toString();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void apply(Project project) {
+        this.project = project;
+        project.afterEvaluate(evaluatedProject -> { configMaven(project); });
+        project.getGradle().getTaskGraph().whenReady(graph -> {
+            if (graph.hasTask(LOCALMAVEN)) {
+                project.getTasks().getByName(PLUGIN_ZIP_PUBLISH_POM_TASK).setEnabled(false);
+            }
+
+        });
+    }
+}

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/opensearch.pluginzip.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/opensearch.pluginzip.properties
@@ -1,0 +1,1 @@
+implementation-class=org.opensearch.gradle.pluginzip.Publish

--- a/buildSrc/src/test/java/org/opensearch/gradle/pluginzip/PublishTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/pluginzip/PublishTests.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gradle.pluginzip;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.gradle.api.Project;
+import org.opensearch.gradle.test.GradleUnitTestCase;
+import org.junit.Test;
+import java.io.IOException;
+import org.gradle.api.publish.maven.tasks.PublishToMavenRepository;
+import java.io.File;
+import org.gradle.testkit.runner.BuildResult;
+import java.io.FileWriter;
+import java.io.Writer;
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import java.nio.file.Files;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import java.io.FileReader;
+import org.gradle.api.tasks.bundling.Zip;
+
+public class PublishTests extends GradleUnitTestCase {
+
+    @Test
+    public void testZipPublish() throws IOException, XmlPullParserException {
+        Project project = ProjectBuilder.builder().build();
+        String zipPublishTask = "publishPluginZipPublicationToZipStagingRepository";
+        // Apply the opensearch.pluginzip plugin
+        project.getPluginManager().apply("opensearch.pluginzip");
+        // Check if the plugin has been applied to the project
+        assertTrue(project.getPluginManager().hasPlugin("opensearch.pluginzip"));
+        // Check if the project has the task from class PublishToMavenRepository after plugin apply
+        assertNotNull(project.getTasks().withType(PublishToMavenRepository.class));
+        // Create a mock bundlePlugin task
+        Zip task = project.getTasks().create("bundlePlugin", Zip.class);
+        Publish.configMaven(project);
+        // Check if the main task publishPluginZipPublicationToZipStagingRepository exists after plugin apply
+        assertTrue(project.getTasks().getNames().contains(zipPublishTask));
+        assertNotNull("Task to generate: ", project.getTasks().getByName(zipPublishTask));
+        // Run Gradle functional tests, but calling a build.gradle file, that resembles the plugin publish behavior
+        File projectDir = new File("build/functionalTest");
+        // Create a sample plugin zip file
+        File sampleZip = new File("build/functionalTest/sample-plugin.zip");
+        Files.createDirectories(projectDir.toPath());
+        Files.createFile(sampleZip.toPath());
+        writeString(new File(projectDir, "settings.gradle"), "");
+        // Generate the build.gradle file
+        String buildFileContent = "apply plugin: 'maven-publish' \n"
+            + "publishing {\n"
+            + "  repositories {\n"
+            + "       maven {\n"
+            + "          url = 'local-staging-repo/'\n"
+            + "          name = 'zipStaging'\n"
+            + "        }\n"
+            + "  }\n"
+            + "   publications {\n"
+            + "         pluginZip(MavenPublication) {\n"
+            + "             groupId = 'org.opensearch.plugin' \n"
+            + "             artifactId = 'sample-plugin' \n"
+            + "             version = '2.0.0.0' \n"
+            + "             artifact('sample-plugin.zip') \n"
+            + "         }\n"
+            + "   }\n"
+            + "}";
+        writeString(new File(projectDir, "build.gradle"), buildFileContent);
+        // Execute the task publishPluginZipPublicationToZipStagingRepository
+        GradleRunner runner = GradleRunner.create();
+        runner.forwardOutput();
+        runner.withPluginClasspath();
+        runner.withArguments(zipPublishTask);
+        runner.withProjectDir(projectDir);
+        BuildResult result = runner.build();
+        // Check if task publishMavenzipPublicationToZipstagingRepository has ran well
+        assertEquals(SUCCESS, result.task(":" + zipPublishTask).getOutcome());
+        // check if the zip has been published to local staging repo
+        assertTrue(
+            new File("build/functionalTest/local-staging-repo/org/opensearch/plugin/sample-plugin/2.0.0.0/sample-plugin-2.0.0.0.zip")
+                .exists()
+        );
+        // Parse the maven file and validate the groupID to org.opensearch.plugin
+        MavenXpp3Reader reader = new MavenXpp3Reader();
+        Model model = reader.read(
+            new FileReader("build/functionalTest/local-staging-repo/org/opensearch/plugin/sample-plugin/2.0.0.0/sample-plugin-2.0.0.0.pom")
+        );
+        assertEquals(model.getGroupId(), "org.opensearch.plugin");
+    }
+
+    private void writeString(File file, String string) throws IOException {
+        try (Writer writer = new FileWriter(file)) {
+            writer.write(string);
+        }
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: pgodithi <pgodithi@amazon.com>

### Description
This change will add custom zippublish plugin, that can publish plugin zips to maven repo.
(This is a BackPort PR, merging to main branch, There is already a [PR](https://github.com/opensearch-project/OpenSearch/pull/2988) that was merged to 2.0)
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/1916
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
