### PR TITLE
Rename BecomeMasterTask to BecomeClusterManagerTask in JoinTaskExecutor

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/coordination/JoinTaskExecutor.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/JoinTaskExecutor.java
@@ -94,14 +94,19 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
         }
 
         public boolean isBecomeMasterTask() {
-            return reason.equals(BECOME_MASTER_TASK_REASON);
+            return reason.equals(BECOME_MASTER_TASK_REASON) || reason.equals(BECOME_CLUSTER_MANAGER_TASK_REASON);
         }
 
         public boolean isFinishElectionTask() {
             return reason.equals(FINISH_ELECTION_TASK_REASON);
         }
 
+        /**
+         * @deprecated As of 2.0, because supporting inclusive language, replaced by {@link #BECOME_CLUSTER_MANAGER_TASK_REASON}
+         */
+        @Deprecated
         private static final String BECOME_MASTER_TASK_REASON = "_BECOME_MASTER_TASK_";
+        private static final String BECOME_CLUSTER_MANAGER_TASK_REASON = "_BECOME_CLUSTER_MANAGER_TASK_";
         private static final String FINISH_ELECTION_TASK_REASON = "_FINISH_ELECTION_";
     }
 
@@ -331,8 +336,20 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
         return false;
     }
 
+    /**
+     * a task indicates that the current node should become master
+     * @deprecated As of 2.0, because supporting inclusive language, replaced by {@link #newBecomeClusterManagerTask()}
+     */
+    @Deprecated
     public static Task newBecomeMasterTask() {
         return new Task(null, Task.BECOME_MASTER_TASK_REASON);
+    }
+
+    /**
+     * a task indicates that the current node should become cluster-manager
+     */
+    public static Task newBecomeClusterManagerTask() {
+        return new Task(null, Task.BECOME_CLUSTER_MANAGER_TASK_REASON);
     }
 
     /**

--- a/server/src/test/java/org/opensearch/cluster/coordination/JoinTaskExecutorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/JoinTaskExecutorTests.java
@@ -50,6 +50,7 @@ import org.opensearch.test.VersionUtils;
 
 import java.util.HashSet;
 
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.test.VersionUtils.allVersions;
 import static org.opensearch.test.VersionUtils.maxCompatibleVersion;
 import static org.opensearch.test.VersionUtils.randomCompatibleVersion;
@@ -197,5 +198,15 @@ public class JoinTaskExecutorTests extends OpenSearchTestCase {
         assertTrue(taskResult.isSuccess());
 
         assertThat(result.resultingState.getNodes().get(actualNode.getId()).getRoles(), equalTo(actualNode.getRoles()));
+    }
+
+    /**
+     * Validate isBecomeMasterTask() can identify "become cluster manager task" properly
+     */
+    public void testIsBecomeClusterManagerTask() {
+        JoinTaskExecutor.Task joinTaskOfMaster = JoinTaskExecutor.newBecomeMasterTask();
+        assertThat(joinTaskOfMaster.isBecomeMasterTask(), is(true));
+        JoinTaskExecutor.Task joinTaskOfClusterManager = JoinTaskExecutor.newBecomeClusterManagerTask();
+        assertThat(joinTaskOfClusterManager.isBecomeMasterTask(), is(true));
     }
 }


### PR DESCRIPTION
### Description
There is a `ClusterStateTask` with identifier `_BECOME_MASTER_TASK_` used to indicate the node to be the cluster manager node when joining the cluster.

To support inclusive language, and finally change the "master" terminology, I made the following plan:

In version 2.0:
- Deprecate the task identifier `_BECOME_MASTER_TASK_`
- Add alternative name `_BECOME_CLUSTER_MANAGER_TASK_`
- Modify the method that identify the task `isBecomeMasterTask()` to accept the 2 names

In version 3.0:
- Remove the current task identifier `_BECOME_MASTER_TASK_`

The reason not change the name in-place:
The related methods are public methods, in case there are clients that call these method in a mixed version cluster of 1.x and 2.x, this way can keep the compatibility of using these methods with version 1.x cluster.

### Issues Resolved
A part of #1548
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
