### PR TITLE
Rename reserved node id '_must_join_elected_master_' to '_must_join_elected_cluster_manager_' that used by in DetachClusterCommand

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/coordination/ClusterFormationFailureHelper.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/ClusterFormationFailureHelper.java
@@ -218,7 +218,7 @@ public class ClusterFormationFailureHelper {
 
             assert clusterState.getLastCommittedConfiguration().isEmpty() == false;
 
-            if (clusterState.getLastCommittedConfiguration().equals(VotingConfiguration.MUST_JOIN_ELECTED_MASTER)) {
+            if (clusterState.getLastCommittedConfiguration().equals(VotingConfiguration.MUST_JOIN_ELECTED_CLUSTER_MANAGER)) {
                 return String.format(
                     Locale.ROOT,
                     "cluster-manager not discovered yet and this node was detached from its previous cluster, have discovered %s; %s",

--- a/server/src/main/java/org/opensearch/cluster/coordination/CoordinationMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/CoordinationMetadata.java
@@ -350,8 +350,8 @@ public class CoordinationMetadata implements Writeable, ToXContentFragment {
     public static class VotingConfiguration implements Writeable, ToXContentFragment {
 
         public static final VotingConfiguration EMPTY_CONFIG = new VotingConfiguration(Collections.emptySet());
-        public static final VotingConfiguration MUST_JOIN_ELECTED_MASTER = new VotingConfiguration(
-            Collections.singleton("_must_join_elected_master_")
+        public static final VotingConfiguration MUST_JOIN_ELECTED_CLUSTER_MANAGER = new VotingConfiguration(
+            Collections.singleton("_must_join_elected_cluster_manager_")
         );
 
         private final Set<String> nodeIds;

--- a/server/src/main/java/org/opensearch/cluster/coordination/DetachClusterCommand.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/DetachClusterCommand.java
@@ -86,8 +86,8 @@ public class DetachClusterCommand extends OpenSearchNodeCommand {
     // package-private for tests
     static Metadata updateMetadata(Metadata oldMetadata) {
         final CoordinationMetadata coordinationMetadata = CoordinationMetadata.builder()
-            .lastAcceptedConfiguration(CoordinationMetadata.VotingConfiguration.MUST_JOIN_ELECTED_MASTER)
-            .lastCommittedConfiguration(CoordinationMetadata.VotingConfiguration.MUST_JOIN_ELECTED_MASTER)
+            .lastAcceptedConfiguration(CoordinationMetadata.VotingConfiguration.MUST_JOIN_ELECTED_CLUSTER_MANAGER)
+            .lastCommittedConfiguration(CoordinationMetadata.VotingConfiguration.MUST_JOIN_ELECTED_CLUSTER_MANAGER)
             .term(0)
             .build();
         return Metadata.builder(oldMetadata).coordinationMetadata(coordinationMetadata).clusterUUIDCommitted(false).build();

--- a/server/src/test/java/org/opensearch/cluster/coordination/ClusterFormationFailureHelperTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/ClusterFormationFailureHelperTests.java
@@ -428,7 +428,7 @@ public class ClusterFormationFailureHelperTests extends OpenSearchTestCase {
 
         final ClusterState clusterState = state(
             localNode,
-            VotingConfiguration.MUST_JOIN_ELECTED_MASTER.getNodeIds().toArray(new String[0])
+            VotingConfiguration.MUST_JOIN_ELECTED_CLUSTER_MANAGER.getNodeIds().toArray(new String[0])
         );
 
         assertThat(

--- a/test/framework/src/main/java/org/opensearch/cluster/coordination/CoordinationStateTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/coordination/CoordinationStateTestCluster.java
@@ -155,7 +155,7 @@ public class CoordinationStateTestCluster {
                     .getLastAcceptedConfiguration()
                     .isEmpty()
                         ? CoordinationMetadata.VotingConfiguration.EMPTY_CONFIG
-                        : CoordinationMetadata.VotingConfiguration.MUST_JOIN_ELECTED_MASTER;
+                        : CoordinationMetadata.VotingConfiguration.MUST_JOIN_ELECTED_CLUSTER_MANAGER;
                 persistedState = new InMemoryPersistedState(
                     0L,
                     clusterState(0L, 0L, localNode, votingConfiguration, votingConfiguration, 0L)


### PR DESCRIPTION
### Description
To support inclusive language, replace "master" with "cluster manager".

- Replace public field `MUST_JOIN_ELECTED_MASTER` with `MUST_JOIN_ELECTED_CLUSTER_MANAGER` in `VotingConfiguration` class
- Rename the preserved node id `_must_join_elected_master_` to `_must_join_elected_cluster_manager_`

The original `_must_join_elected_master_` is only used as a preserved node id for "Detach Cluster Command" (https://github.com/opensearch-project/OpenSearch/blob/1.3.1/server/src/main/java/org/opensearch/cluster/coordination/DetachClusterCommand.java#L89).
"Detach Cluster Command" `./bin/opensearch-node detach-cluster` can detach a node from its cluster by resetting its cluster UUID. The node can then join another cluster with a different UUID. `_must_join_elected_master_` is set as a node id and used as an identifier for the node processed by "Detach Cluster Command".
Reference: https://www.elastic.co/guide/en/elasticsearch/reference/7.10/node-tool.html#node-tool-detach-cluster

### Issues Resolved
A part of #1548 , #1684
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
