### PR TITLE
Set term vector flags to false for ._index_prefix field (#1901).

### DIFF
--- a/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/SearchAsYouTypeFieldMapper.java
@@ -207,6 +207,9 @@ public class SearchAsYouTypeFieldMapper extends ParametrizedFieldMapper {
             // set up the prefix field
             FieldType prefixft = new FieldType(fieldType);
             prefixft.setStoreTermVectors(false);
+            prefixft.setStoreTermVectorPositions(false);
+            prefixft.setStoreTermVectorOffsets(false);
+            prefixft.setStoreTermVectorPayloads(false);
             prefixft.setOmitNorms(true);
             prefixft.setStored(false);
             final String fullName = buildFullName(context);

--- a/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/SearchAsYouTypeFieldMapper.java
@@ -205,11 +205,8 @@ public class SearchAsYouTypeFieldMapper extends ParametrizedFieldMapper {
             ft.setIndexAnalyzer(analyzers.getIndexAnalyzer());
 
             // set up the prefix field
-            FieldType prefixft = new FieldType(fieldType);
-            prefixft.setStoreTermVectors(false);
-            prefixft.setStoreTermVectorPositions(false);
-            prefixft.setStoreTermVectorOffsets(false);
-            prefixft.setStoreTermVectorPayloads(false);
+            FieldType prefixft = new FieldType();
+            prefixft.setIndexOptions(fieldType.indexOptions());
             prefixft.setOmitNorms(true);
             prefixft.setStored(false);
             final String fullName = buildFullName(context);

--- a/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
@@ -352,18 +352,30 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
     }
 
     public void testTermVectors() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "search_as_you_type").field("term_vector", "yes")));
+        String[] termVectors = {
+            "yes",
+            "with_positions",
+            "with_offsets",
+            "with_positions_offsets",
+            "with_positions_payloads",
+            "with_positions_offsets_payloads" };
 
-        assertTrue(getRootFieldMapper(mapper, "field").fieldType().fieldType.storeTermVectors());
+        for (String termVector : termVectors) {
+            DocumentMapper mapper = createDocumentMapper(
+                    fieldMapping(b -> b.field("type", "search_as_you_type").field("term_vector", termVector))
+            );
 
-        Stream.of(getShingleFieldMapper(mapper, "field._2gram"), getShingleFieldMapper(mapper, "field._3gram"))
-            .forEach(m -> assertTrue("for " + m.name(), m.fieldType.storeTermVectors()));
+            assertTrue(getRootFieldMapper(mapper, "field").fieldType().fieldType.storeTermVectors());
 
-        PrefixFieldMapper prefixFieldMapper = getPrefixFieldMapper(mapper, "field._index_prefix");
-        assertFalse(prefixFieldMapper.fieldType.storeTermVectors());
-        assertFalse(prefixFieldMapper.fieldType.storeTermVectorOffsets());
-        assertFalse(prefixFieldMapper.fieldType.storeTermVectorPositions());
-        assertFalse(prefixFieldMapper.fieldType.storeTermVectorPayloads());
+            Stream.of(getShingleFieldMapper(mapper, "field._2gram"), getShingleFieldMapper(mapper, "field._3gram"))
+                    .forEach(m -> assertTrue("for " + m.name(), m.fieldType.storeTermVectors()));
+
+            PrefixFieldMapper prefixFieldMapper = getPrefixFieldMapper(mapper, "field._index_prefix");
+            assertFalse(prefixFieldMapper.fieldType.storeTermVectors());
+            assertFalse(prefixFieldMapper.fieldType.storeTermVectorOffsets());
+            assertFalse(prefixFieldMapper.fieldType.storeTermVectorPositions());
+            assertFalse(prefixFieldMapper.fieldType.storeTermVectorPayloads());
+       }
     }
 
     public void testNorms() throws IOException {

--- a/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
@@ -362,20 +362,20 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
 
         for (String termVector : termVectors) {
             DocumentMapper mapper = createDocumentMapper(
-                    fieldMapping(b -> b.field("type", "search_as_you_type").field("term_vector", termVector))
+                fieldMapping(b -> b.field("type", "search_as_you_type").field("term_vector", termVector))
             );
 
             assertTrue(getRootFieldMapper(mapper, "field").fieldType().fieldType.storeTermVectors());
 
             Stream.of(getShingleFieldMapper(mapper, "field._2gram"), getShingleFieldMapper(mapper, "field._3gram"))
-                    .forEach(m -> assertTrue("for " + m.name(), m.fieldType.storeTermVectors()));
+                .forEach(m -> assertTrue("for " + m.name(), m.fieldType.storeTermVectors()));
 
             PrefixFieldMapper prefixFieldMapper = getPrefixFieldMapper(mapper, "field._index_prefix");
             assertFalse(prefixFieldMapper.fieldType.storeTermVectors());
             assertFalse(prefixFieldMapper.fieldType.storeTermVectorOffsets());
             assertFalse(prefixFieldMapper.fieldType.storeTermVectorPositions());
             assertFalse(prefixFieldMapper.fieldType.storeTermVectorPayloads());
-       }
+        }
     }
 
     public void testNorms() throws IOException {

--- a/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
@@ -361,6 +361,9 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
 
         PrefixFieldMapper prefixFieldMapper = getPrefixFieldMapper(mapper, "field._index_prefix");
         assertFalse(prefixFieldMapper.fieldType.storeTermVectors());
+        assertFalse(prefixFieldMapper.fieldType.storeTermVectorOffsets());
+        assertFalse(prefixFieldMapper.fieldType.storeTermVectorPositions());
+        assertFalse(prefixFieldMapper.fieldType.storeTermVectorPayloads());
     }
 
     public void testNorms() throws IOException {


### PR DESCRIPTION
Signed-off-by: Vesa Pehkonen <vesa.pehkonen@intel.com>

### Description
This fix the issue #1901
 
### Issues Resolved
This fix the issue #1901
 
### Check List
- [x ] New functionality includes testing.
  - [x ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
