### PR TITLE
Sync maintainers with actual permissions.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,7 @@
-## Maintainers
+- [Current Maintainers](#current-maintainers)
+- [Emeritus](#emeritus)
+  
+## Current Maintainers
 
 | Maintainer | GitHub ID | Affiliation |
 | --------------- | --------- | ----------- |
@@ -8,12 +11,10 @@
 | Andriy Redko | [reta](https://github.com/reta) | Aiven |
 | Charlotte Henkle | [CEHENKLE](https://github.com/CEHENKLE) | Amazon |
 | Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock) | Amazon |
-| Gopala Krishna Ambareesh | [krishna-ggk](https://github.com/krishna-ggk) |Amazon |
 | Himanshu Setia | [setiah](https://github.com/setiah) | Amazon |
-| Itiyama Sadana | [itiyamas](https://github.com/itiyamas) | Amazon |
 | Kartik Ganesh | [kartg](https://github.com/kartg) | Amazon |
+| Kunal Kotwani | [kotwanikunal](https://github.com/kotwanikunal) | Amazon |
 | Marc Handalian | [mch2](https://github.com/mch2) | Amazon |
-| Megha Sai Kavikondala | [meghasaik](https://github.com/meghasaik) | Amazon |
 | Nick Knize | [nknize](https://github.com/nknize) | Amazon |
 | Owais Kazi | [owaiskazi19](https://github.com/owaiskazi19) | Amazon |
 | Rabi Panda | [adnapibar](https://github.com/adnapibar) | Amazon |
@@ -23,7 +24,11 @@
 | Shweta Thareja |[shwetathareja](https://github.com/shwetathareja) | Amazon |
 | Tianli Feng | [tlfeng](https://github.com/tlfeng) | Amazon |
 | Vacha Shah | [VachaShah](https://github.com/VachaShah) | Amazon |
-| Vengadanathan Srinivasan | [vengadanathan-s](https://github.com/vengadanathan-s) | Amazon |
 | Xue Zhou | [xuezhou25](https://github.com/xuezhou25) | Amazon |
+
+## Emeritus
+
+| Maintainer | GitHub ID | Affiliation |
+| Megha Sai Kavikondala | [meghasaik](https://github.com/meghasaik) | Amazon |
 
 [This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Fixing some discrepancies between names in this list and actual permissions that were introduced prior to us adding the external maintainers process.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
