### PR TITLE
Rename ClusterBlock description 'no master' to 'no cluster-manager'

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/MinimumMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/MinimumMasterNodesIT.java
@@ -91,7 +91,7 @@ public class MinimumMasterNodesIT extends OpenSearchIntegTestCase {
         logger.info("--> start first node");
         String node1Name = internalCluster().startNode(settings);
 
-        logger.info("--> should be blocked, no master...");
+        logger.info("--> should be blocked, no cluster-manager...");
         ClusterState state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
         assertThat(state.nodes().getSize(), equalTo(1)); // verify that we still see the local node in the cluster state
@@ -155,7 +155,7 @@ public class MinimumMasterNodesIT extends OpenSearchIntegTestCase {
         String otherNode = node1Name.equals(masterNode) ? node2Name : node1Name;
         logger.info("--> add voting config exclusion for non-master node, to be sure it's not elected");
         client().execute(AddVotingConfigExclusionsAction.INSTANCE, new AddVotingConfigExclusionsRequest(otherNode)).get();
-        logger.info("--> stop master node, no master block should appear");
+        logger.info("--> stop master node, no cluster-manager block should appear");
         Settings masterDataPathSettings = internalCluster().dataPathSettings(masterNode);
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(masterNode));
 
@@ -166,7 +166,7 @@ public class MinimumMasterNodesIT extends OpenSearchIntegTestCase {
 
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
-        // verify that both nodes are still in the cluster state but there is no master
+        // verify that both nodes are still in the cluster state but there is no cluster-manager
         assertThat(state.nodes().getSize(), equalTo(2));
         assertThat(state.nodes().getMasterNode(), equalTo(null));
 
@@ -208,7 +208,7 @@ public class MinimumMasterNodesIT extends OpenSearchIntegTestCase {
         otherNode = node1Name.equals(masterNode) ? node2Name : node1Name;
         logger.info("--> add voting config exclusion for master node, to be sure it's not elected");
         client().execute(AddVotingConfigExclusionsAction.INSTANCE, new AddVotingConfigExclusionsRequest(masterNode)).get();
-        logger.info("--> stop non-master node, no master block should appear");
+        logger.info("--> stop non-master node, no cluster-manager block should appear");
         Settings otherNodeDataPathSettings = internalCluster().dataPathSettings(otherNode);
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(otherNode));
 
@@ -317,7 +317,7 @@ public class MinimumMasterNodesIT extends OpenSearchIntegTestCase {
         internalCluster().stopRandomNonMasterNode();
         internalCluster().stopRandomNonMasterNode();
 
-        logger.info("--> verify that there is no master anymore on remaining node");
+        logger.info("--> verify that there is no cluster-manager anymore on remaining node");
         // spin here to wait till the state is set
         assertBusy(() -> {
             ClusterState st = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
@@ -386,7 +386,7 @@ public class MinimumMasterNodesIT extends OpenSearchIntegTestCase {
 
         assertThat(failure.get(), instanceOf(FailedToCommitClusterStateException.class));
 
-        logger.debug("--> check that there is no master in minor partition");
+        logger.debug("--> check that there is no cluster-manager in minor partition");
         assertBusy(() -> assertThat(masterClusterService.state().nodes().getMasterNode(), nullValue()));
 
         // let major partition to elect new master, to ensure that old master is not elected once partition is restored,

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/SpecificMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/SpecificMasterNodesIT.java
@@ -74,7 +74,7 @@ public class SpecificMasterNodesIT extends OpenSearchIntegTestCase {
             );
             fail("should not be able to find master");
         } catch (MasterNotDiscoveredException e) {
-            // all is well, no master elected
+            // all is well, no cluster-manager elected
         }
         logger.info("--> start master node");
         final String masterNodeName = internalCluster().startMasterOnlyNode();
@@ -124,7 +124,7 @@ public class SpecificMasterNodesIT extends OpenSearchIntegTestCase {
             );
             fail("should not be able to find master");
         } catch (MasterNotDiscoveredException e) {
-            // all is well, no master elected
+            // all is well, no cluster-manager elected
         }
 
         logger.info("--> start previous master node again");
@@ -178,7 +178,7 @@ public class SpecificMasterNodesIT extends OpenSearchIntegTestCase {
             );
             fail("should not be able to find master");
         } catch (MasterNotDiscoveredException e) {
-            // all is well, no master elected
+            // all is well, no cluster-manager elected
         }
         logger.info("--> start master node (1)");
         final String masterNodeName = internalCluster().startMasterOnlyNode();

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/DiscoveryDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/DiscoveryDisruptionIT.java
@@ -220,7 +220,7 @@ public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
         logger.info("waiting for [{}] to be removed from cluster", nonMasterNode);
         ensureStableCluster(2, masterNode);
 
-        logger.info("waiting for [{}] to have no master", nonMasterNode);
+        logger.info("waiting for [{}] to have no cluster-manager", nonMasterNode);
         assertNoMaster(nonMasterNode);
 
         logger.info("healing partition and checking cluster reforms");

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/MasterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/MasterDisruptionIT.java
@@ -247,7 +247,11 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
         // Wait until the master node sees al 3 nodes again.
         ensureStableCluster(3, new TimeValue(DISRUPTION_HEALING_OVERHEAD.millis() + networkDisruption.expectedTimeToHeal().millis()));
 
-        logger.info("Verify no cluster-manager block with {} set to {}", NoMasterBlockService.NO_CLUSTER_MANAGER_BLOCK_SETTING.getKey(), "all");
+        logger.info(
+            "Verify no cluster-manager block with {} set to {}",
+            NoMasterBlockService.NO_CLUSTER_MANAGER_BLOCK_SETTING.getKey(),
+            "all"
+        );
         client().admin()
             .cluster()
             .prepareUpdateSettings()

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/MasterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/MasterDisruptionIT.java
@@ -217,7 +217,7 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
         // The unlucky node must report *no* master node, since it can't connect to master and in fact it should
         // continuously ping until network failures have been resolved. However
         // It may a take a bit before the node detects it has been cut off from the elected master
-        logger.info("waiting for isolated node [{}] to have no master", isolatedNode);
+        logger.info("waiting for isolated node [{}] to have no cluster-manager", isolatedNode);
         assertNoMaster(isolatedNode, NoMasterBlockService.NO_MASTER_BLOCK_WRITES, TimeValue.timeValueSeconds(30));
 
         logger.info("wait until elected master has been removed and a new 2 node cluster was from (via [{}])", isolatedNode);
@@ -236,7 +236,7 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
                 fail(
                     "node ["
                         + node
-                        + "] has no master or has blocks, despite of being on the right side of the partition. State dump:\n"
+                        + "] has no cluster-manager or has blocks, despite of being on the right side of the partition. State dump:\n"
                         + nodeState
                 );
             }
@@ -247,7 +247,7 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
         // Wait until the master node sees al 3 nodes again.
         ensureStableCluster(3, new TimeValue(DISRUPTION_HEALING_OVERHEAD.millis() + networkDisruption.expectedTimeToHeal().millis()));
 
-        logger.info("Verify no master block with {} set to {}", NoMasterBlockService.NO_CLUSTER_MANAGER_BLOCK_SETTING.getKey(), "all");
+        logger.info("Verify no cluster-manager block with {} set to {}", NoMasterBlockService.NO_CLUSTER_MANAGER_BLOCK_SETTING.getKey(), "all");
         client().admin()
             .cluster()
             .prepareUpdateSettings()
@@ -259,7 +259,7 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
         // The unlucky node must report *no* master node, since it can't connect to master and in fact it should
         // continuously ping until network failures have been resolved. However
         // It may a take a bit before the node detects it has been cut off from the elected master
-        logger.info("waiting for isolated node [{}] to have no master", isolatedNode);
+        logger.info("waiting for isolated node [{}] to have no cluster-manager", isolatedNode);
         assertNoMaster(isolatedNode, NoMasterBlockService.NO_MASTER_BLOCK_ALL, TimeValue.timeValueSeconds(30));
 
         // make sure we have stable cluster & cross partition recoveries are canceled by the removal of the missing node

--- a/server/src/main/java/org/opensearch/cluster/coordination/NoMasterBlockService.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/NoMasterBlockService.java
@@ -45,7 +45,7 @@ public class NoMasterBlockService {
     public static final int NO_MASTER_BLOCK_ID = 2;
     public static final ClusterBlock NO_MASTER_BLOCK_WRITES = new ClusterBlock(
         NO_MASTER_BLOCK_ID,
-        "no master",
+        "no cluster-manager",
         true,
         false,
         false,
@@ -54,7 +54,7 @@ public class NoMasterBlockService {
     );
     public static final ClusterBlock NO_MASTER_BLOCK_ALL = new ClusterBlock(
         NO_MASTER_BLOCK_ID,
-        "no master",
+        "no cluster-manager",
         true,
         true,
         false,
@@ -63,7 +63,7 @@ public class NoMasterBlockService {
     );
     public static final ClusterBlock NO_MASTER_BLOCK_METADATA_WRITES = new ClusterBlock(
         NO_MASTER_BLOCK_ID,
-        "no master",
+        "no cluster-manager",
         true,
         false,
         false,

--- a/server/src/main/java/org/opensearch/discovery/SeedHostsProvider.java
+++ b/server/src/main/java/org/opensearch/discovery/SeedHostsProvider.java
@@ -42,7 +42,7 @@ import java.util.List;
 public interface SeedHostsProvider {
 
     /**
-     * Returns a list of seed hosts to use for discovery. Called repeatedly while discovery is active (i.e. while there is no master)
+     * Returns a list of seed hosts to use for discovery. Called repeatedly while discovery is active (i.e. while there is no cluster-manager)
      * so that this list may be dynamic.
      */
     List<TransportAddress> getSeedAddresses(HostsResolver hostsResolver);

--- a/server/src/test/java/org/opensearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/opensearch/ExceptionSerializationTests.java
@@ -511,7 +511,7 @@ public class ExceptionSerializationTests extends OpenSearchTestCase {
 
     public void testClusterBlockException() throws IOException {
         ClusterBlockException ex = serialize(new ClusterBlockException(singleton(NoMasterBlockService.NO_MASTER_BLOCK_WRITES)));
-        assertEquals("blocked by: [SERVICE_UNAVAILABLE/2/no master];", ex.getMessage());
+        assertEquals("blocked by: [SERVICE_UNAVAILABLE/2/no cluster-manager];", ex.getMessage());
         assertTrue(ex.blocks().contains(NoMasterBlockService.NO_MASTER_BLOCK_WRITES));
         assertEquals(1, ex.blocks().size());
     }

--- a/server/src/test/java/org/opensearch/OpenSearchExceptionTests.java
+++ b/server/src/test/java/org/opensearch/OpenSearchExceptionTests.java
@@ -499,7 +499,7 @@ public class OpenSearchExceptionTests extends OpenSearchTestCase {
             + "\"reason\":\"baz\","
             + "\"caused_by\":{"
             + "\"type\":\"cluster_block_exception\","
-            + "\"reason\":\"blocked by: [SERVICE_UNAVAILABLE/2/no master];\""
+            + "\"reason\":\"blocked by: [SERVICE_UNAVAILABLE/2/no cluster-manager];\""
             + "}"
             + "}"
             + "},"
@@ -537,7 +537,7 @@ public class OpenSearchExceptionTests extends OpenSearchTestCase {
         cause = (OpenSearchException) cause.getCause();
         assertEquals(
             cause.getMessage(),
-            "OpenSearch exception [type=cluster_block_exception, reason=blocked by: [SERVICE_UNAVAILABLE/2/no master];]"
+            "OpenSearch exception [type=cluster_block_exception, reason=blocked by: [SERVICE_UNAVAILABLE/2/no cluster-manager];]"
         );
     }
 
@@ -1034,7 +1034,7 @@ public class OpenSearchExceptionTests extends OpenSearchTestCase {
             case 0:
                 actual = new ClusterBlockException(singleton(NoMasterBlockService.NO_MASTER_BLOCK_WRITES));
                 expected = new OpenSearchException(
-                    "OpenSearch exception [type=cluster_block_exception, " + "reason=blocked by: [SERVICE_UNAVAILABLE/2/no master];]"
+                    "OpenSearch exception [type=cluster_block_exception, " + "reason=blocked by: [SERVICE_UNAVAILABLE/2/no cluster-manager];]"
                 );
                 break;
             case 1: // Simple opensearch exception with headers (other metadata of type number are not parsed)

--- a/server/src/test/java/org/opensearch/OpenSearchExceptionTests.java
+++ b/server/src/test/java/org/opensearch/OpenSearchExceptionTests.java
@@ -1034,7 +1034,8 @@ public class OpenSearchExceptionTests extends OpenSearchTestCase {
             case 0:
                 actual = new ClusterBlockException(singleton(NoMasterBlockService.NO_MASTER_BLOCK_WRITES));
                 expected = new OpenSearchException(
-                    "OpenSearch exception [type=cluster_block_exception, " + "reason=blocked by: [SERVICE_UNAVAILABLE/2/no cluster-manager];]"
+                    "OpenSearch exception [type=cluster_block_exception, "
+                        + "reason=blocked by: [SERVICE_UNAVAILABLE/2/no cluster-manager];]"
                 );
                 break;
             case 1: // Simple opensearch exception with headers (other metadata of type number are not parsed)

--- a/server/src/test/java/org/opensearch/cluster/ClusterStateTests.java
+++ b/server/src/test/java/org/opensearch/cluster/ClusterStateTests.java
@@ -101,7 +101,7 @@ public class ClusterStateTests extends OpenSearchTestCase {
             .nodes(DiscoveryNodes.builder(nodes).masterNodeId(node2.getId()))
             .build();
 
-        // states with no master should never supersede anything
+        // states with no cluster-manager should never supersede anything
         assertFalse(noMaster1.supersedes(noMaster2));
         assertFalse(noMaster1.supersedes(withMaster1a));
 

--- a/test/framework/src/main/java/org/opensearch/action/support/replication/ClusterStateCreationUtils.java
+++ b/test/framework/src/main/java/org/opensearch/action/support/replication/ClusterStateCreationUtils.java
@@ -429,7 +429,7 @@ public class ClusterStateCreationUtils {
      * Creates a cluster state where local node and master node can be specified
      *
      * @param localNode  node in allNodes that is the local node
-     * @param masterNode node in allNodes that is the master node. Can be null if no master exists
+     * @param masterNode node in allNodes that is the master node. Can be null if no cluster-manager exists
      * @param allNodes   all nodes in the cluster
      * @return cluster state
      */

--- a/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -632,7 +632,11 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                     );
                 } else {
                     assertThat(nodeId + " is not following " + leaderId, clusterNode.coordinator.getMode(), is(CANDIDATE));
-                    assertThat(nodeId + " has no cluster-manager", clusterNode.getLastAppliedClusterState().nodes().getMasterNode(), nullValue());
+                    assertThat(
+                        nodeId + " has no cluster-manager",
+                        clusterNode.getLastAppliedClusterState().nodes().getMasterNode(),
+                        nullValue()
+                    );
                     assertThat(
                         nodeId + " has NO_MASTER_BLOCK",
                         clusterNode.getLastAppliedClusterState().blocks().hasGlobalBlockWithId(NO_MASTER_BLOCK_ID),

--- a/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -632,7 +632,7 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                     );
                 } else {
                     assertThat(nodeId + " is not following " + leaderId, clusterNode.coordinator.getMode(), is(CANDIDATE));
-                    assertThat(nodeId + " has no master", clusterNode.getLastAppliedClusterState().nodes().getMasterNode(), nullValue());
+                    assertThat(nodeId + " has no cluster-manager", clusterNode.getLastAppliedClusterState().nodes().getMasterNode(), nullValue());
                     assertThat(
                         nodeId + " has NO_MASTER_BLOCK",
                         clusterNode.getLastAppliedClusterState().blocks().hasGlobalBlockWithId(NO_MASTER_BLOCK_ID),

--- a/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
@@ -825,7 +825,7 @@ public final class InternalTestCluster extends TestCluster {
         if (randomNodeAndClient != null) {
             return randomNodeAndClient.nodeClient(); // ensure node client master is requested
         }
-        throw new AssertionError("No master client found");
+        throw new AssertionError("No cluster-manager client found");
     }
 
     /**

--- a/test/framework/src/main/java/org/opensearch/test/RandomObjects.java
+++ b/test/framework/src/main/java/org/opensearch/test/RandomObjects.java
@@ -333,7 +333,8 @@ public final class RandomObjects {
             case 0:
                 actualException = new ClusterBlockException(singleton(NoMasterBlockService.NO_MASTER_BLOCK_WRITES));
                 expectedException = new OpenSearchException(
-                    "OpenSearch exception [type=cluster_block_exception, " + "reason=blocked by: [SERVICE_UNAVAILABLE/2/no cluster-manager];]"
+                    "OpenSearch exception [type=cluster_block_exception, "
+                        + "reason=blocked by: [SERVICE_UNAVAILABLE/2/no cluster-manager];]"
                 );
                 break;
             case 1:

--- a/test/framework/src/main/java/org/opensearch/test/RandomObjects.java
+++ b/test/framework/src/main/java/org/opensearch/test/RandomObjects.java
@@ -333,7 +333,7 @@ public final class RandomObjects {
             case 0:
                 actualException = new ClusterBlockException(singleton(NoMasterBlockService.NO_MASTER_BLOCK_WRITES));
                 expectedException = new OpenSearchException(
-                    "OpenSearch exception [type=cluster_block_exception, " + "reason=blocked by: [SERVICE_UNAVAILABLE/2/no master];]"
+                    "OpenSearch exception [type=cluster_block_exception, " + "reason=blocked by: [SERVICE_UNAVAILABLE/2/no cluster-manager];]"
                 );
                 break;
             case 1:

--- a/test/framework/src/test/java/org/opensearch/test/test/InternalTestClusterTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/test/InternalTestClusterTests.java
@@ -404,7 +404,7 @@ public class InternalTestClusterTests extends OpenSearchTestCase {
         List<DiscoveryNodeRole> roles = new ArrayList<>();
         for (int i = 0; i < numNodes; i++) {
             final DiscoveryNodeRole role = i == numNodes - 1 && roles.contains(clusterManagerRole) == false
-                ? clusterManagerRole  // last node and still no master
+                ? clusterManagerRole  // last node and still no cluster-manager
                 : randomFrom(clusterManagerRole, DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.INGEST_ROLE);
             roles.add(role);
         }


### PR DESCRIPTION
### Description
To support inclusive language, replace "master" with "cluster manager".
There is no compatibility concern with this code change.

- Rename the description of ClusterBlock `NO_MASTER_BLOCK_...` from `no master` to `no cluster-manager`
- Modify all other usages of `no master` to `no cluster-manager`
 
### Issues Resolved
A part of #1548

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
