### PR TITLE
Fix minimum index compatibility error message

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexUpgradeService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexUpgradeService.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.similarities.BM25Similarity;
 import org.apache.lucene.search.similarities.Similarity;
+import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.common.TriFunction;
 import org.opensearch.common.settings.IndexScopedSettings;
@@ -134,20 +135,35 @@ public class MetadataIndexUpgradeService {
     private void checkSupportedVersion(IndexMetadata indexMetadata, Version minimumIndexCompatibilityVersion) {
         if (indexMetadata.getState() == IndexMetadata.State.OPEN
             && isSupportedVersion(indexMetadata, minimumIndexCompatibilityVersion) == false) {
-            throw new IllegalStateException(
-                "The index ["
-                    + indexMetadata.getIndex()
-                    + "] was created with version ["
-                    + indexMetadata.getCreationVersion()
-                    + "] but the minimum compatible version is ["
-
-                    + minimumIndexCompatibilityVersion
-                    + "]. It should be re-indexed in OpenSearch "
-                    + minimumIndexCompatibilityVersion.major
-                    + ".x before upgrading to "
-                    + Version.CURRENT
-                    + "."
-            );
+            if (minimumIndexCompatibilityVersion.equals(LegacyESVersion.V_7_0_0)) {
+                // This branch can be removed when LegacyESVersion is removed
+                throw new IllegalStateException(
+                    "The index ["
+                        + indexMetadata.getIndex()
+                        + "] was created with version ["
+                        + indexMetadata.getCreationVersion()
+                        + "] but the minimum compatible version is "
+                        + "OpenSearch 1.0.0 (or Elasticsearch 7.0.0). "
+                        + "It should be re-indexed in OpenSearch 1.x "
+                        + "(or Elasticsearch 7.x) before upgrading to "
+                        + Version.CURRENT
+                        + "."
+                );
+            } else {
+                throw new IllegalStateException(
+                    "The index ["
+                        + indexMetadata.getIndex()
+                        + "] was created with version ["
+                        + indexMetadata.getCreationVersion()
+                        + "] but the minimum compatible version is ["
+                        + minimumIndexCompatibilityVersion
+                        + "]. It should be re-indexed in OpenSearch "
+                        + minimumIndexCompatibilityVersion.major
+                        + ".x before upgrading to "
+                        + Version.CURRENT
+                        + "."
+                );
+            }
         }
     }
 

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataIndexUpgradeServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataIndexUpgradeServiceTests.java
@@ -139,24 +139,21 @@ public class MetadataIndexUpgradeServiceTests extends OpenSearchTestCase {
                 .put(IndexMetadata.SETTING_VERSION_CREATED, indexCreated)
                 .build()
         );
-        String message = expectThrows(
+        String actualMessage = expectThrows(
             IllegalStateException.class,
             () -> service.upgradeIndexMetadata(metadata, Version.CURRENT.minimumIndexCompatibilityVersion())
         ).getMessage();
-        assertEquals(
-            message,
-            "The index [[foo/BOOM]] was created with version ["
-                + indexCreated
-                + "] "
-                + "but the minimum compatible version is ["
-                + minCompat
-                + "]."
-                + " It should be re-indexed in OpenSearch "
-                + minCompat.major
-                + ".x before upgrading to "
-                + Version.CURRENT.toString()
-                + "."
-        );
+
+        String expectedMessage = "The index [[foo/BOOM]] was created with version ["
+            + indexCreated
+            + "] but the minimum compatible version is "
+            + "OpenSearch 1.0.0 (or Elasticsearch 7.0.0). "
+            + "It should be re-indexed in OpenSearch 1.x "
+            + "(or Elasticsearch 7.x) before upgrading to "
+            + Version.CURRENT
+            + ".";
+
+        assertEquals(expectedMessage, actualMessage);
 
         indexCreated = VersionUtils.randomVersionBetween(random(), minCompat, Version.CURRENT);
         indexUpgraded = VersionUtils.randomVersionBetween(random(), indexCreated, Version.CURRENT);


### PR DESCRIPTION
This is a very simple fix that adds a special case for the backward
compatibility message for OS 1.x/ES 7.x. This basically mirrors a
special case already codified in [Version][1]. I think this is a
reasonable fix because it allows the message to be quite verbose. It
should also only need to exist on the 2.x branch of OpenSearch since it
is a special case that will no longer exist in 3.x when the entire
LegacyESVersion concept can be removed from the code base.

[1]: https://github.com/opensearch-project/OpenSearch/blob/cb238aae616d6a0fd8f82e128a1f94c8e4e8b1f7/server/src/main/java/org/opensearch/Version.java#L398

Signed-off-by: Andrew Ross <andrross@amazon.com>

### Issues Resolved
closes #2936
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
