### PR TITLE
[2.0] Replace 'master' terminology with 'cluster manager' in log messages in 'server/src/main' directory - Part 2

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/MinimumMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/MinimumMasterNodesIT.java
@@ -153,7 +153,7 @@ public class MinimumMasterNodesIT extends OpenSearchIntegTestCase {
 
         String masterNode = internalCluster().getMasterName();
         String otherNode = node1Name.equals(masterNode) ? node2Name : node1Name;
-        logger.info("--> add voting config exclusion for non-cluster-manager node, to be sure it's not elected");
+        logger.info("--> add voting config exclusion for non-master node, to be sure it's not elected");
         client().execute(AddVotingConfigExclusionsAction.INSTANCE, new AddVotingConfigExclusionsRequest(otherNode)).get();
         logger.info("--> stop master node, no master block should appear");
         Settings masterDataPathSettings = internalCluster().dataPathSettings(masterNode);
@@ -208,7 +208,7 @@ public class MinimumMasterNodesIT extends OpenSearchIntegTestCase {
         otherNode = node1Name.equals(masterNode) ? node2Name : node1Name;
         logger.info("--> add voting config exclusion for master node, to be sure it's not elected");
         client().execute(AddVotingConfigExclusionsAction.INSTANCE, new AddVotingConfigExclusionsRequest(masterNode)).get();
-        logger.info("--> stop non-cluster-manager node, no master block should appear");
+        logger.info("--> stop non-master node, no master block should appear");
         Settings otherNodeDataPathSettings = internalCluster().dataPathSettings(otherNode);
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(otherNode));
 

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/MinimumMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/MinimumMasterNodesIT.java
@@ -153,7 +153,7 @@ public class MinimumMasterNodesIT extends OpenSearchIntegTestCase {
 
         String masterNode = internalCluster().getMasterName();
         String otherNode = node1Name.equals(masterNode) ? node2Name : node1Name;
-        logger.info("--> add voting config exclusion for non-master node, to be sure it's not elected");
+        logger.info("--> add voting config exclusion for non-cluster-manager node, to be sure it's not elected");
         client().execute(AddVotingConfigExclusionsAction.INSTANCE, new AddVotingConfigExclusionsRequest(otherNode)).get();
         logger.info("--> stop master node, no master block should appear");
         Settings masterDataPathSettings = internalCluster().dataPathSettings(masterNode);
@@ -208,7 +208,7 @@ public class MinimumMasterNodesIT extends OpenSearchIntegTestCase {
         otherNode = node1Name.equals(masterNode) ? node2Name : node1Name;
         logger.info("--> add voting config exclusion for master node, to be sure it's not elected");
         client().execute(AddVotingConfigExclusionsAction.INSTANCE, new AddVotingConfigExclusionsRequest(masterNode)).get();
-        logger.info("--> stop non-master node, no master block should appear");
+        logger.info("--> stop non-cluster-manager node, no master block should appear");
         Settings otherNodeDataPathSettings = internalCluster().dataPathSettings(otherNode);
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(otherNode));
 

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/SnapshotDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/SnapshotDisruptionIT.java
@@ -158,7 +158,7 @@ public class SnapshotDisruptionIT extends AbstractSnapshotIntegTestCase {
             assertNotNull(sne);
             assertThat(
                 sne.getMessage(),
-                either(endsWith(" Failed to update cluster state during snapshot finalization")).or(endsWith(" no longer master"))
+                either(endsWith(" Failed to update cluster state during snapshot finalization")).or(endsWith(" no longer cluster-manager"))
             );
             assertThat(sne.getSnapshotName(), is(snapshot));
         }
@@ -248,7 +248,7 @@ public class SnapshotDisruptionIT extends AbstractSnapshotIntegTestCase {
 
         blockDataNode(repoName, dataNode);
 
-        logger.info("--> create snapshot via master node client");
+        logger.info("--> create snapshot via cluster-manager node client");
         final ActionFuture<CreateSnapshotResponse> snapshotResponse = internalCluster().masterClient()
             .admin()
             .cluster()
@@ -272,7 +272,7 @@ public class SnapshotDisruptionIT extends AbstractSnapshotIntegTestCase {
             SnapshotException.class,
             () -> snapshotResponse.actionGet(TimeValue.timeValueSeconds(30L))
         );
-        assertThat(sne.getMessage(), endsWith("no longer master"));
+        assertThat(sne.getMessage(), endsWith("no longer cluster-manager"));
     }
 
     private void assertSnapshotExists(String repository, String snapshot) {

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/SnapshotDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/SnapshotDisruptionIT.java
@@ -248,7 +248,7 @@ public class SnapshotDisruptionIT extends AbstractSnapshotIntegTestCase {
 
         blockDataNode(repoName, dataNode);
 
-        logger.info("--> create snapshot via cluster-manager node client");
+        logger.info("--> create snapshot via master node client");
         final ActionFuture<CreateSnapshotResponse> snapshotResponse = internalCluster().masterClient()
             .admin()
             .cluster()

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -218,11 +218,11 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
                     @Override
                     public void onNoLongerMaster(String source) {
                         logger.trace(
-                            "stopped being master while waiting for events with priority [{}]. retrying.",
+                            "stopped being cluster-manager while waiting for events with priority [{}]. retrying.",
                             request.waitForEvents()
                         );
                         // TransportMasterNodeAction implements the retry logic, which is triggered by passing a NotMasterException
-                        listener.onFailure(new NotMasterException("no longer master. source: [" + source + "]"));
+                        listener.onFailure(new NotMasterException("no longer cluster-manager. source: [" + source + "]"));
                     }
 
                     @Override

--- a/server/src/main/java/org/opensearch/action/admin/cluster/repositories/cleanup/TransportCleanupRepositoryAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/repositories/cleanup/TransportCleanupRepositoryAction.java
@@ -136,7 +136,7 @@ public final class TransportCleanupRepositoryAction extends TransportMasterNodeA
                     return;
                 }
                 clusterService.submitStateUpdateTask(
-                    "clean up repository cleanup task after master failover",
+                    "clean up repository cleanup task after cluster-manager failover",
                     new ClusterStateUpdateTask() {
                         @Override
                         public ClusterState execute(ClusterState currentState) {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -159,7 +159,7 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
                     // For example the minimum_master_node could have been breached and we're no longer elected master,
                     // so we should *not* execute the reroute.
                     if (!clusterService.state().nodes().isLocalNodeElectedMaster()) {
-                        logger.debug("Skipping reroute after cluster update settings, because node is no longer master");
+                        logger.debug("Skipping reroute after cluster update settings, because node is no longer cluster-manager");
                         listener.onResponse(
                             new ClusterUpdateSettingsResponse(
                                 updateSettingsAcked,
@@ -198,7 +198,7 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
                             @Override
                             public void onNoLongerMaster(String source) {
                                 logger.debug(
-                                    "failed to preform reroute after cluster settings were updated - current node is no longer a master"
+                                    "failed to preform reroute after cluster settings were updated - current node is no longer a cluster-manager"
                                 );
                                 listener.onResponse(
                                     new ClusterUpdateSettingsResponse(

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -138,7 +138,7 @@ public class TransportClusterStateAction extends TransportMasterNodeReadAction<C
                         } else {
                             listener.onFailure(
                                 new NotMasterException(
-                                    "master stepped down waiting for metadata version " + request.waitForMetadataVersion()
+                                    "cluster-manager stepped down waiting for metadata version " + request.waitForMetadataVersion()
                                 )
                             );
                         }

--- a/server/src/main/java/org/opensearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/master/TransportMasterNodeAction.java
@@ -198,7 +198,7 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
                     }
                 } else {
                     if (nodes.getMasterNode() == null) {
-                        logger.debug("no known master node, scheduling a retry");
+                        logger.debug("no known cluster-manager node, scheduling a retry");
                         retryOnMasterChange(clusterState, null);
                     } else {
                         DiscoveryNode masterNode = nodes.getMasterNode();

--- a/server/src/main/java/org/opensearch/cluster/ClusterStateTaskListener.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterStateTaskListener.java
@@ -47,7 +47,7 @@ public interface ClusterStateTaskListener {
      * Used only for tasks submitted to {@link MasterService}.
      */
     default void onNoLongerMaster(String source) {
-        onFailure(source, new NotMasterException("no longer master. source: [" + source + "]"));
+        onFailure(source, new NotMasterException("no longer cluster-manager. source: [" + source + "]"));
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/action/index/NodeMappingRefreshAction.java
+++ b/server/src/main/java/org/opensearch/cluster/action/index/NodeMappingRefreshAction.java
@@ -76,7 +76,7 @@ public class NodeMappingRefreshAction {
 
     public void nodeMappingRefresh(final DiscoveryNode masterNode, final NodeMappingRefreshRequest request) {
         if (masterNode == null) {
-            logger.warn("can't send mapping refresh for [{}], no master known.", request.index());
+            logger.warn("can't send mapping refresh for [{}], no cluster-manager known.", request.index());
             return;
         }
         transportService.sendRequest(masterNode, ACTION_NAME, request, EmptyTransportResponseHandler.INSTANCE_SAME);

--- a/server/src/main/java/org/opensearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/opensearch/cluster/action/shard/ShardStateAction.java
@@ -180,7 +180,7 @@ public class ShardStateAction {
         DiscoveryNode masterNode = currentState.nodes().getMasterNode();
         Predicate<ClusterState> changePredicate = MasterNodeChangePredicate.build(currentState);
         if (masterNode == null) {
-            logger.warn("no master known for action [{}] for shard entry [{}]", actionName, request);
+            logger.warn("no cluster-manager known for action [{}] for shard entry [{}]", actionName, request);
             waitForNewMasterAndRetry(actionName, observer, request, listener, changePredicate);
         } else {
             logger.debug("sending [{}] to [{}] for shard entry [{}]", actionName, masterNode.getId(), request);
@@ -305,7 +305,7 @@ public class ShardStateAction {
             @Override
             public void onNewClusterState(ClusterState state) {
                 if (logger.isTraceEnabled()) {
-                    logger.trace("new cluster state [{}] after waiting for master election for shard entry [{}]", state, request);
+                    logger.trace("new cluster state [{}] after waiting for cluster-manager election for shard entry [{}]", state, request);
                 }
                 sendShardAction(actionName, state, request, listener);
             }
@@ -376,13 +376,13 @@ public class ShardStateAction {
 
                     @Override
                     public void onNoLongerMaster(String source) {
-                        logger.error("{} no longer master while failing shard [{}]", request.shardId, request);
+                        logger.error("{} no longer cluster-manager while failing shard [{}]", request.shardId, request);
                         try {
                             channel.sendResponse(new NotMasterException(source));
                         } catch (Exception channelException) {
                             logger.warn(
                                 () -> new ParameterizedMessage(
-                                    "{} failed to send no longer master while failing shard [{}]",
+                                    "{} failed to send no longer cluster-manager while failing shard [{}]",
                                     request.shardId,
                                     request
                                 ),

--- a/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java
@@ -1233,14 +1233,16 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 if (mode != Mode.LEADER || getCurrentTerm() != clusterChangedEvent.state().term()) {
                     logger.debug(
                         () -> new ParameterizedMessage(
-                            "[{}] failed publication as node is no longer master for term {}",
+                            "[{}] failed publication as node is no longer cluster-manager for term {}",
                             clusterChangedEvent.source(),
                             clusterChangedEvent.state().term()
                         )
                     );
                     publishListener.onFailure(
                         new FailedToCommitClusterStateException(
-                            "node is no longer master for term " + clusterChangedEvent.state().term() + " while handling publication"
+                            "node is no longer cluster-manager for term "
+                                + clusterChangedEvent.state().term()
+                                + " while handling publication"
                         )
                     );
                     return;

--- a/server/src/main/java/org/opensearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/JoinHelper.java
@@ -142,19 +142,23 @@ public class JoinHelper {
                 // Stop processing the current cluster state update, as there's no point in continuing to compute it as
                 // it will later be rejected by Coordinator.publish(...) anyhow
                 if (currentState.term() > term) {
-                    logger.trace("encountered higher term {} than current {}, there is a newer master", currentState.term(), term);
+                    logger.trace("encountered higher term {} than current {}, there is a newer cluster-manager", currentState.term(), term);
                     throw new NotMasterException(
-                        "Higher term encountered (current: " + currentState.term() + " > used: " + term + "), there is a newer master"
+                        "Higher term encountered (current: "
+                            + currentState.term()
+                            + " > used: "
+                            + term
+                            + "), there is a newer cluster-manager"
                     );
                 } else if (currentState.nodes().getMasterNodeId() == null && joiningTasks.stream().anyMatch(Task::isBecomeMasterTask)) {
-                    assert currentState.term() < term : "there should be at most one become master task per election (= by term)";
+                    assert currentState.term() < term : "there should be at most one become cluster-manager task per election (= by term)";
                     final CoordinationMetadata coordinationMetadata = CoordinationMetadata.builder(currentState.coordinationMetadata())
                         .term(term)
                         .build();
                     final Metadata metadata = Metadata.builder(currentState.metadata()).coordinationMetadata(coordinationMetadata).build();
                     currentState = ClusterState.builder(currentState).metadata(metadata).build();
                 } else if (currentState.nodes().isLocalNodeElectedMaster()) {
-                    assert currentState.term() == term : "term should be stable for the same master";
+                    assert currentState.term() == term : "term should be stable for the same cluster-manager";
                 }
                 return super.execute(currentState, joiningTasks);
             }
@@ -297,7 +301,7 @@ public class JoinHelper {
     }
 
     public void sendJoinRequest(DiscoveryNode destination, long term, Optional<Join> optionalJoin, Runnable onCompletion) {
-        assert destination.isMasterNode() : "trying to join master-ineligible " + destination;
+        assert destination.isMasterNode() : "trying to join cluster-manager-ineligible " + destination;
         final StatusInfo statusInfo = nodeHealthService.getHealth();
         if (statusInfo.getStatus() == UNHEALTHY) {
             logger.debug("dropping join request to [{}]: [{}]", destination, statusInfo.getInfo());
@@ -348,7 +352,7 @@ public class JoinHelper {
     }
 
     public void sendStartJoinRequest(final StartJoinRequest startJoinRequest, final DiscoveryNode destination) {
-        assert startJoinRequest.getSourceNode().isMasterNode() : "sending start-join request for master-ineligible "
+        assert startJoinRequest.getSourceNode().isMasterNode() : "sending start-join request for cluster-manager-ineligible "
             + startJoinRequest.getSourceNode();
         transportService.sendRequest(destination, START_JOIN_ACTION_NAME, startJoinRequest, new TransportResponseHandler<Empty>() {
             @Override

--- a/server/src/main/java/org/opensearch/cluster/coordination/JoinTaskExecutor.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/JoinTaskExecutor.java
@@ -129,7 +129,7 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
         if (joiningNodes.size() == 1 && joiningNodes.get(0).isFinishElectionTask()) {
             return results.successes(joiningNodes).build(currentState);
         } else if (currentNodes.getMasterNode() == null && joiningNodes.stream().anyMatch(Task::isBecomeMasterTask)) {
-            assert joiningNodes.stream().anyMatch(Task::isFinishElectionTask) : "becoming a master but election is not finished "
+            assert joiningNodes.stream().anyMatch(Task::isFinishElectionTask) : "becoming a cluster-manager but election is not finished "
                 + joiningNodes;
             // use these joins to try and become the master.
             // Note that we don't have to do any validation of the amount of joining nodes - the commit
@@ -137,8 +137,11 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
             newState = becomeMasterAndTrimConflictingNodes(currentState, joiningNodes);
             nodesChanged = true;
         } else if (currentNodes.isLocalNodeElectedMaster() == false) {
-            logger.trace("processing node joins, but we are not the master. current master: {}", currentNodes.getMasterNode());
-            throw new NotMasterException("Node [" + currentNodes.getLocalNode() + "] not master for join request");
+            logger.trace(
+                "processing node joins, but we are not the cluster-manager. current cluster-manager: {}",
+                currentNodes.getMasterNode()
+            );
+            throw new NotMasterException("Node [" + currentNodes.getLocalNode() + "] not cluster-manager for join request");
         } else {
             newState = ClusterState.builder(currentState);
         }

--- a/server/src/main/java/org/opensearch/cluster/coordination/LeaderChecker.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/LeaderChecker.java
@@ -208,7 +208,7 @@ public class LeaderChecker {
             logger.debug(message);
             throw new NodeHealthCheckFailureException(message);
         } else if (discoveryNodes.isLocalNodeElectedMaster() == false) {
-            logger.debug("rejecting leader check on non-master {}", request);
+            logger.debug("rejecting leader check on non-cluster-manager {}", request);
             throw new CoordinationStateRejectedException(
                 "rejecting leader check from [" + request.getSender() + "] sent to a node that is no longer the master"
             );

--- a/server/src/main/java/org/opensearch/cluster/coordination/NoMasterBlockService.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/NoMasterBlockService.java
@@ -105,7 +105,9 @@ public class NoMasterBlockService {
             case "metadata_write":
                 return NO_MASTER_BLOCK_METADATA_WRITES;
             default:
-                throw new IllegalArgumentException("invalid no-master block [" + value + "], must be one of [all, write, metadata_write]");
+                throw new IllegalArgumentException(
+                    "invalid no-cluster-manager block [" + value + "], must be one of [all, write, metadata_write]"
+                );
         }
     }
 

--- a/server/src/main/java/org/opensearch/cluster/coordination/NodeRemovalClusterStateTaskExecutor.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/NodeRemovalClusterStateTaskExecutor.java
@@ -127,7 +127,7 @@ public class NodeRemovalClusterStateTaskExecutor
 
     @Override
     public void onNoLongerMaster(String source) {
-        logger.debug("no longer master while processing node removal [{}]", source);
+        logger.debug("no longer cluster-manager while processing node removal [{}]", source);
     }
 
 }

--- a/server/src/main/java/org/opensearch/cluster/coordination/Reconfigurator.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/Reconfigurator.java
@@ -114,7 +114,7 @@ public class Reconfigurator {
     ) {
         assert liveNodes.contains(currentMaster) : "liveNodes = " + liveNodes + " master = " + currentMaster;
         logger.trace(
-            "{} reconfiguring {} based on liveNodes={}, retiredNodeIds={}, currentMaster={}",
+            "{} reconfiguring {} based on liveNodes={}, retiredNodeIds={}, currentClusterManager={}",
             this,
             currentConfig,
             liveNodes,

--- a/server/src/main/java/org/opensearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/opensearch/cluster/service/MasterService.java
@@ -228,14 +228,14 @@ public class MasterService extends AbstractLifecycleComponent {
     }
 
     public static boolean assertMasterUpdateThread() {
-        assert isMasterUpdateThread() : "not called from the master service thread";
+        assert isMasterUpdateThread() : "not called from the cluster-manager service thread";
         return true;
     }
 
     public static boolean assertNotMasterUpdateThread(String reason) {
         assert isMasterUpdateThread() == false : "Expected current thread ["
             + Thread.currentThread()
-            + "] to not be the master service thread. Reason: ["
+            + "] to not be the cluster-manager service thread. Reason: ["
             + reason
             + "]";
         return true;
@@ -244,7 +244,7 @@ public class MasterService extends AbstractLifecycleComponent {
     private void runTasks(TaskInputs taskInputs) {
         final String summary = taskInputs.summary;
         if (!lifecycle.started()) {
-            logger.debug("processing [{}]: ignoring, master service not started", summary);
+            logger.debug("processing [{}]: ignoring, cluster-manager service not started", summary);
             return;
         }
 
@@ -252,7 +252,7 @@ public class MasterService extends AbstractLifecycleComponent {
         final ClusterState previousClusterState = state();
 
         if (!previousClusterState.nodes().isLocalNodeElectedMaster() && taskInputs.runOnlyWhenMaster()) {
-            logger.debug("failing [{}]: local node is no longer master", summary);
+            logger.debug("failing [{}]: local node is no longer cluster-manager", summary);
             taskInputs.onNoLongerMaster();
             return;
         }
@@ -616,7 +616,10 @@ public class MasterService extends AbstractLifecycleComponent {
                 listener.onNoLongerMaster(source);
             } catch (Exception e) {
                 logger.error(
-                    () -> new ParameterizedMessage("exception thrown by listener while notifying no longer master from [{}]", source),
+                    () -> new ParameterizedMessage(
+                        "exception thrown by listener while notifying no longer cluster-manager from [{}]",
+                        source
+                    ),
                     e
                 );
             }

--- a/server/src/main/java/org/opensearch/common/settings/ConsistentSettingsService.java
+++ b/server/src/main/java/org/opensearch/common/settings/ConsistentSettingsService.java
@@ -283,7 +283,7 @@ public final class ConsistentSettingsService {
 
         @Override
         public void offMaster() {
-            logger.trace("I am no longer master, nothing to do");
+            logger.trace("I am no longer cluster-manager, nothing to do");
         }
     }
 

--- a/server/src/main/java/org/opensearch/gateway/GatewayService.java
+++ b/server/src/main/java/org/opensearch/gateway/GatewayService.java
@@ -216,7 +216,7 @@ public class GatewayService extends AbstractLifecycleComponent implements Cluste
 
         final DiscoveryNodes nodes = state.nodes();
         if (state.nodes().getMasterNodeId() == null) {
-            logger.debug("not recovering from gateway, no master elected yet");
+            logger.debug("not recovering from gateway, no cluster-manager elected yet");
         } else if (recoverAfterNodes != -1 && (nodes.getMasterAndDataNodes().size()) < recoverAfterNodes) {
             logger.debug(
                 "not recovering from gateway, nodes_size (data+master) [{}] < recover_after_nodes [{}]",
@@ -333,7 +333,7 @@ public class GatewayService extends AbstractLifecycleComponent implements Cluste
 
         @Override
         public void onNoLongerMaster(String source) {
-            logger.debug("stepped down as master before recovering state [{}]", source);
+            logger.debug("stepped down as cluster-manager before recovering state [{}]", source);
             resetRecoveredFlags();
         }
 

--- a/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
@@ -1179,7 +1179,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
             // check that the master does not fabricate new in-sync entries out of thin air once we are in primary mode
             assert !primaryMode
                 || inSyncAllocationIds.stream().allMatch(inSyncId -> checkpoints.containsKey(inSyncId) && checkpoints.get(inSyncId).inSync)
-                : "update from master in primary mode contains in-sync ids "
+                : "update from cluster-manager in primary mode contains in-sync ids "
                     + inSyncAllocationIds
                     + " that have no matching entries in "
                     + checkpoints;
@@ -1197,7 +1197,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
                 for (String initializingId : initializingAllocationIds) {
                     if (checkpoints.containsKey(initializingId) == false) {
                         final boolean inSync = inSyncAllocationIds.contains(initializingId);
-                        assert inSync == false : "update from master in primary mode has "
+                        assert inSync == false : "update from cluster-manager in primary mode has "
                             + initializingId
                             + " as in-sync but it does not exist locally";
                         final long localCheckpoint = SequenceNumbers.UNASSIGNED_SEQ_NO;

--- a/server/src/main/java/org/opensearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/opensearch/indices/cluster/IndicesClusterStateService.java
@@ -669,7 +669,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             // we managed to tell the master we started), mark us as started
             if (logger.isTraceEnabled()) {
                 logger.trace(
-                    "{} master marked shard as initializing, but shard has state [{}], resending shard started to {}",
+                    "{} cluster-manager marked shard as initializing, but shard has state [{}], resending shard started to {}",
                     shardRouting.shardId(),
                     state,
                     nodes.getMasterNode()
@@ -679,7 +679,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                 shardStateAction.shardStarted(
                     shardRouting,
                     primaryTerm,
-                    "master "
+                    "cluster-manager "
                         + nodes.getMasterNode()
                         + " marked shard as initializing, but shard state is ["
                         + state

--- a/server/src/main/java/org/opensearch/repositories/fs/FsRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/fs/FsRepository.java
@@ -118,7 +118,7 @@ public class FsRepository extends BlobStoreRepository {
         if (location.isEmpty()) {
             logger.warn(
                 "the repository location is missing, it should point to a shared file system location"
-                    + " that is available on all master and data nodes"
+                    + " that is available on all cluster-manager and data nodes"
             );
             throw new RepositoryException(metadata.name(), "missing location");
         }

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -954,7 +954,7 @@ public class RestoreService implements ClusterStateApplier {
 
         @Override
         public void onNoLongerMaster(String source) {
-            logger.debug("no longer master while processing restore state update [{}]", source);
+            logger.debug("no longer cluster-manager while processing restore state update [{}]", source);
         }
 
     }

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotShardsService.java
@@ -450,8 +450,8 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                             if (stage == Stage.DONE) {
                                 // but we think the shard is done - we need to make new master know that the shard is done
                                 logger.debug(
-                                    "[{}] new master thinks the shard [{}] is not completed but the shard is done locally, "
-                                        + "updating status on the master",
+                                    "[{}] new cluster-manager thinks the shard [{}] is not completed but the shard is done locally, "
+                                        + "updating status on the cluster-manager",
                                     snapshot.snapshot(),
                                     shardId
                                 );
@@ -460,8 +460,8 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                             } else if (stage == Stage.FAILURE) {
                                 // but we think the shard failed - we need to make new master know that the shard failed
                                 logger.debug(
-                                    "[{}] new master thinks the shard [{}] is not completed but the shard failed locally, "
-                                        + "updating status on master",
+                                    "[{}] new cluster-manager thinks the shard [{}] is not completed but the shard failed locally, "
+                                        + "updating status on cluster-manager",
                                     snapshot.snapshot(),
                                     shardId
                                 );

--- a/server/src/test/java/org/opensearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/service/MasterServiceTests.java
@@ -167,7 +167,7 @@ public class MasterServiceTests extends OpenSearchTestCase {
         });
 
         latch1.await();
-        assertTrue("cluster state update task was executed on a non-master", taskFailed[0]);
+        assertTrue("cluster state update task was executed on a non-cluster-manager", taskFailed[0]);
 
         final CountDownLatch latch2 = new CountDownLatch(1);
         nonMaster.submitStateUpdateTask("test", new LocalClusterUpdateTask() {
@@ -185,7 +185,7 @@ public class MasterServiceTests extends OpenSearchTestCase {
             }
         });
         latch2.await();
-        assertFalse("non-master cluster state update task was not executed", taskFailed[0]);
+        assertFalse("non-cluster-manager cluster state update task was not executed", taskFailed[0]);
 
         nonMaster.close();
     }

--- a/server/src/test/java/org/opensearch/discovery/PeerFinderTests.java
+++ b/server/src/test/java/org/opensearch/discovery/PeerFinderTests.java
@@ -147,7 +147,7 @@ public class PeerFinderTests extends OpenSearchTestCase {
                                 listener.onResponse(discoveryNode);
                                 return;
                             } else {
-                                listener.onFailure(new OpenSearchException("non-master node " + discoveryNode));
+                                listener.onFailure(new OpenSearchException("non-cluster-manager node " + discoveryNode));
                                 return;
                             }
                         }

--- a/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -1343,7 +1343,7 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
 
                         @Override
                         public void onNoLongerMaster(String source) {
-                            logger.trace("no longer master: [{}]", source);
+                            logger.trace("no longer cluster-manager: [{}]", source);
                             taskListener.onNoLongerMaster(source);
                         }
 

--- a/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
@@ -836,7 +836,7 @@ public final class InternalTestCluster extends TestCluster {
         if (randomNodeAndClient != null) {
             return randomNodeAndClient.nodeClient(); // ensure node client non-master is requested
         }
-        throw new AssertionError("No non-master client found");
+        throw new AssertionError("No non-cluster-manager client found");
     }
 
     /**


### PR DESCRIPTION
### Description
In PR https://github.com/opensearch-project/OpenSearch/pull/2575, most of the `master` terminology in log messages is replaced by `cluster-manager`, but there are a few remaining.
This PR replaces more `master` word with `cluster-manager` in `server/src/main` directory that used in log messages.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/2539
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
