### PR TITLE
Support Java 8 for opensearch-rest-client

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchJavaPlugin.java
@@ -34,6 +34,7 @@ package org.opensearch.gradle;
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar;
 import nebula.plugin.info.InfoBrokerPlugin;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.opensearch.gradle.info.BuildParams;
 import org.opensearch.gradle.info.GlobalBuildInfoPlugin;
 import org.opensearch.gradle.precommit.PrecommitTaskPlugin;
@@ -174,7 +175,8 @@ public class OpenSearchJavaPlugin implements Plugin<Project> {
                 compileTask.getConventionMapping().map("sourceCompatibility", () -> java.getSourceCompatibility().toString());
                 compileTask.getConventionMapping().map("targetCompatibility", () -> java.getTargetCompatibility().toString());
                 // The '--release is available from JDK-9 and above
-                if (BuildParams.getRuntimeJavaVersion().compareTo(JavaVersion.VERSION_1_8) > 0) {
+                if (BuildParams.getRuntimeJavaVersion().compareTo(JavaVersion.VERSION_1_8) > 0
+                    && getCompilerLanguageVersionOrDefault(compileTask).compareTo(JavaLanguageVersion.of(8)) > 0) {
                     compileOptions.getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
                 }
             });
@@ -184,6 +186,10 @@ public class OpenSearchJavaPlugin implements Plugin<Project> {
                 compileTask.getOptions().getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
             });
         });
+    }
+
+    private static JavaLanguageVersion getCompilerLanguageVersionOrDefault(JavaCompile compileTask) {
+        return compileTask.getJavaCompiler().map(c -> c.getMetadata().getLanguageVersion()).getOrElse(JavaLanguageVersion.of(11));
     }
 
     private static Provider<Integer> releaseVersionProviderFromCompileTask(Project project, AbstractCompile compileTask) {

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -33,8 +33,8 @@ import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
 apply plugin: 'opensearch.build'
 apply plugin: 'opensearch.publish'
 
-targetCompatibility = JavaVersion.VERSION_11
-sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_1_8
 
 group = 'org.opensearch.client'
 archivesBaseName = 'opensearch-rest-client'

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -33,11 +33,22 @@ import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
 apply plugin: 'opensearch.build'
 apply plugin: 'opensearch.publish'
 
-targetCompatibility = JavaVersion.VERSION_1_8
-sourceCompatibility = JavaVersion.VERSION_1_8
-
 group = 'org.opensearch.client'
 archivesBaseName = 'opensearch-rest-client'
+
+tasks.withType(JavaCompile).getByName('compileJava').configure {
+  javaCompiler = javaToolchains.compilerFor {
+    languageVersion = JavaLanguageVersion.of(8)
+  }
+
+  options.compilerArgs -= '-Xlint:exports'
+  options.compilerArgs -= '-Xlint:module'
+  options.compilerArgs -= '-Xlint:opens'
+  options.compilerArgs -= '-Xlint:removal'
+  options.compilerArgs -= '-Xlint:requires-automatic'
+  options.compilerArgs -= '-Xlint:requires-transitive-automatic'
+  options.compilerArgs -= '-Xlint:preview'
+}
 
 dependencies {
   api "org.apache.httpcomponents:httpclient:${versions.httpclient}"
@@ -57,7 +68,7 @@ dependencies {
 }
 
 tasks.withType(CheckForbiddenApis).configureEach {
-  //client does not depend on server, so only jdk and http signatures should be checked
+  //client does not depend on shamcreerver, so only jdk and http signatures should be checked
   replaceSignatureFiles('jdk-signatures', 'http-signatures')
 }
 

--- a/client/test/build.gradle
+++ b/client/test/build.gradle
@@ -29,8 +29,8 @@
  */
 apply plugin: 'opensearch.build'
 
-targetCompatibility = JavaVersion.VERSION_11
-sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_1_8
 
 group = "${group}.client.test"
 

--- a/client/test/build.gradle
+++ b/client/test/build.gradle
@@ -29,10 +29,21 @@
  */
 apply plugin: 'opensearch.build'
 
-targetCompatibility = JavaVersion.VERSION_1_8
-sourceCompatibility = JavaVersion.VERSION_1_8
-
 group = "${group}.client.test"
+
+tasks.withType(JavaCompile).getByName('compileJava').configure {
+  javaCompiler = javaToolchains.compilerFor {
+    languageVersion = JavaLanguageVersion.of(8)
+  }
+
+  options.compilerArgs -= '-Xlint:exports'
+  options.compilerArgs -= '-Xlint:module'
+  options.compilerArgs -= '-Xlint:opens'
+  options.compilerArgs -= '-Xlint:removal'
+  options.compilerArgs -= '-Xlint:requires-automatic'
+  options.compilerArgs -= '-Xlint:requires-transitive-automatic'
+  options.compilerArgs -= '-Xlint:preview'
+}
 
 dependencies {
   api "org.apache.httpcomponents:httpcore:${versions.httpcore}"


### PR DESCRIPTION
### Description

This PR sets the source and target compatibility to Java 8 for the `opensearch-rest-client`. Additionally, it sets the client-test project to use Java 8 since `opensearch-rest-client` depends on it.

This should ensure that only Java 8 language features compile for these projects. However, it cannot verify that only Java 8 APIs are in use. I believe OpenSearch would need to use Gradle toolkits and run on a machine with both Java 11 and Java 8 for this.
 
### Issues Resolved

This addresses:
opensearch-project/opensearch-java#156
 
### Verification

1) Download the 2.0.0-rc1 `opensearch-rest-client`:

```
wget https://repo1.maven.org/maven2/org/opensearch/client/opensearch-rest-client/2.0.0-rc1/opensearch-rest-client-2.0.0-rc1.module
```

2) Examine the Gradle module file. It requires Java 11.

```
grep jvm opensearch-rest-client-2.0.0-rc1.module
        "org.gradle.jvm.version": 11,
        "org.gradle.jvm.version": 11,
```

3) Build OpenSearch locally with the change.

```
./gradlew clean assemble
./gradlew publishToMavenLocal
```

4) Verify Java 8 in the Gradle module file

```
grep jvm ~/.m2/repository/org/opensearch/client/opensearch-rest-client/3.0.0-SNAPSHOT/opensearch-rest-client-3.0.0-SNAPSHOT.module
        "org.gradle.jvm.version": 8,
        "org.gradle.jvm.version": 8,
```

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
