### PR TITLE
Fixing publishZip publication by adding the dependency to generatePomFileForNebulaPublication

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/pluginzip/Publish.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/pluginzip/Publish.java
@@ -7,17 +7,17 @@
  */
 package org.opensearch.gradle.pluginzip;
 
-import java.util.*;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
+import org.gradle.api.publish.maven.tasks.PublishToMavenRepository;
+
 import java.nio.file.Path;
 
 public class Publish implements Plugin<Project> {
-    private Project project;
-
     public final static String EXTENSION_NAME = "zipmavensettings";
     public final static String PUBLICATION_NAME = "pluginZip";
     public final static String STAGING_REPO = "zipStaging";
@@ -48,6 +48,15 @@ public class Publish implements Plugin<Project> {
                 });
             });
         });
+
+        final Task pomFileTask = project.getTasks().findByName​("generatePomFileForNebulaPublication");
+        if (pomFileTask != null) {
+            project.getTasks().withType(PublishToMavenRepository.class).configureEach(t -> {
+                if (t.getPublication().getName().equals(PUBLICATION_NAME)) {
+                    t.dependsOn(pomFileTask);
+                }
+            });
+        }
     }
 
     static String getProperty(String name, Project project) {
@@ -62,7 +71,6 @@ public class Publish implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        this.project = project;
         project.afterEvaluate(evaluatedProject -> { configMaven(project); });
         project.getGradle().getTaskGraph().whenReady(graph -> {
             if (graph.hasTask(LOCALMAVEN)) {


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Fixing `publishZip` publication by adding the dependency to `generatePomFileForNebulaPublication`, the issue manifested in https://github.com/opensearch-project/opensearch-plugin-template-java/pull/31:

```
> Task :publishPluginZipPublicationToZipStagingRepository
Execution optimizations have been disabled for task ':publishPluginZipPublicationToZipStagingRepository' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: 'opensearch-plugin-template-java/build/distributions/rename-unspecified.pom'. Reason: Task ':publishPluginZipPublicationToZipStagingRepository' uses this output of task ':generatePomFileForNebulaPublication' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
```
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
