### PR TITLE
[Javadocs] add to o.o.monitor,persistance,plugins,repo,script,threapool,usage,watcher

### DIFF
--- a/server/src/main/java/org/opensearch/Assertions.java
+++ b/server/src/main/java/org/opensearch/Assertions.java
@@ -36,6 +36,8 @@ package org.opensearch;
  * Provides a static final field that can be used to check if assertions are enabled. Since this field might be used elsewhere to check if
  * assertions are enabled, if you are running with assertions enabled for specific packages or classes, you should enable assertions on this
  * class too (e.g., {@code -ea org.opensearch.Assertions -ea org.opensearch.cluster.service.MasterService}).
+ *
+ * @opensearch.internal
  */
 public final class Assertions {
 

--- a/server/src/main/java/org/opensearch/Build.java
+++ b/server/src/main/java/org/opensearch/Build.java
@@ -46,6 +46,8 @@ import java.util.jar.Manifest;
 
 /**
  * Information about a build of OpenSearch.
+ *
+ * @opensearch.internal
  */
 public class Build {
     /**

--- a/server/src/main/java/org/opensearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/opensearch/ExceptionsHelper.java
@@ -61,6 +61,11 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+/**
+ * Helper class for OpenSearch Exceptions
+ *
+ * @opensearch.internal
+ */
 public final class ExceptionsHelper {
 
     private static final Logger logger = LogManager.getLogger(ExceptionsHelper.class);

--- a/server/src/main/java/org/opensearch/LegacyESVersion.java
+++ b/server/src/main/java/org/opensearch/LegacyESVersion.java
@@ -43,6 +43,8 @@ import java.lang.reflect.Field;
  *
  * This class keeps all the supported OpenSearch predecessor versions for
  * backward compatibility purpose.
+ *
+ * @opensearch.internal
  */
 public class LegacyESVersion extends Version {
 

--- a/server/src/main/java/org/opensearch/OpenSearchCorruptionException.java
+++ b/server/src/main/java/org/opensearch/OpenSearchCorruptionException.java
@@ -36,6 +36,8 @@ import java.io.IOException;
 /**
  * This exception is thrown when OpenSearch detects
  * an inconsistency in one of it's persistent files.
+ *
+ * @opensearch.internal
  */
 public class OpenSearchCorruptionException extends IOException {
 

--- a/server/src/main/java/org/opensearch/OpenSearchException.java
+++ b/server/src/main/java/org/opensearch/OpenSearchException.java
@@ -73,6 +73,8 @@ import static org.opensearch.common.xcontent.XContentParserUtils.ensureFieldName
 
 /**
  * A base class for all opensearch exceptions.
+ *
+ * @opensearch.internal
  */
 public class OpenSearchException extends RuntimeException implements ToXContentFragment, Writeable {
 

--- a/server/src/main/java/org/opensearch/OpenSearchGenerationException.java
+++ b/server/src/main/java/org/opensearch/OpenSearchGenerationException.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 /**
  * A generic exception indicating failure to generate.
  *
- *
+ * @opensearch.internal
  */
 public class OpenSearchGenerationException extends OpenSearchException {
 

--- a/server/src/main/java/org/opensearch/OpenSearchParseException.java
+++ b/server/src/main/java/org/opensearch/OpenSearchParseException.java
@@ -39,6 +39,8 @@ import java.io.IOException;
 
 /**
  * Unchecked exception that is translated into a {@code 400 BAD REQUEST} error when it bubbles out over HTTP.
+ *
+ * @opensearch.internal
  */
 public class OpenSearchParseException extends OpenSearchException {
 

--- a/server/src/main/java/org/opensearch/OpenSearchSecurityException.java
+++ b/server/src/main/java/org/opensearch/OpenSearchSecurityException.java
@@ -38,6 +38,8 @@ import java.io.IOException;
 
 /**
  * Generic security exception
+ *
+ * @opensearch.internal
  */
 public class OpenSearchSecurityException extends OpenSearchStatusException {
     /**

--- a/server/src/main/java/org/opensearch/OpenSearchStatusException.java
+++ b/server/src/main/java/org/opensearch/OpenSearchStatusException.java
@@ -41,6 +41,8 @@ import java.io.IOException;
 /**
  * Exception who's {@link RestStatus} is arbitrary rather than derived. Used, for example, by reindex-from-remote to wrap remote exceptions
  * that contain a status.
+ *
+ * @opensearch.internal
  */
 public class OpenSearchStatusException extends OpenSearchException {
     private final RestStatus status;

--- a/server/src/main/java/org/opensearch/OpenSearchTimeoutException.java
+++ b/server/src/main/java/org/opensearch/OpenSearchTimeoutException.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 /**
  * The same as {@link java.util.concurrent.TimeoutException} simply a runtime one.
  *
- *
+ * @opensearch.internal
  */
 public class OpenSearchTimeoutException extends OpenSearchException {
     public OpenSearchTimeoutException(StreamInput in) throws IOException {

--- a/server/src/main/java/org/opensearch/OpenSearchWrapperException.java
+++ b/server/src/main/java/org/opensearch/OpenSearchWrapperException.java
@@ -36,6 +36,8 @@ package org.opensearch;
  * An exception that is meant to be "unwrapped" when sent back to the user
  * as an error because its is {@link #getCause() cause}, if non-null is
  * <strong>always</strong> more useful to the user than the exception itself.
+ *
+ * @opensearch.internal
  */
 public interface OpenSearchWrapperException {
     Throwable getCause();

--- a/server/src/main/java/org/opensearch/ResourceAlreadyExistsException.java
+++ b/server/src/main/java/org/opensearch/ResourceAlreadyExistsException.java
@@ -38,6 +38,11 @@ import org.opensearch.rest.RestStatus;
 
 import java.io.IOException;
 
+/**
+ * Exception when Resources already exists
+ *
+ * @opensearch.internal
+ */
 public class ResourceAlreadyExistsException extends OpenSearchException {
 
     public ResourceAlreadyExistsException(Index index) {

--- a/server/src/main/java/org/opensearch/ResourceNotFoundException.java
+++ b/server/src/main/java/org/opensearch/ResourceNotFoundException.java
@@ -38,6 +38,8 @@ import java.io.IOException;
 
 /**
  * Generic ResourceNotFoundException corresponding to the {@link RestStatus#NOT_FOUND} status code
+ *
+ * @opensearch.internal
  */
 public class ResourceNotFoundException extends OpenSearchException {
 

--- a/server/src/main/java/org/opensearch/SpecialPermission.java
+++ b/server/src/main/java/org/opensearch/SpecialPermission.java
@@ -68,6 +68,8 @@ import java.security.BasicPermission;
  *    ...
  *   );
  * </code></pre>
+ *
+ * @opensearch.internal
  */
 public final class SpecialPermission extends BasicPermission {
 

--- a/server/src/main/java/org/opensearch/Version.java
+++ b/server/src/main/java/org/opensearch/Version.java
@@ -51,6 +51,11 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
+/**
+ * OpenSearch Version Class
+ *
+ * @opensearch.api
+ */
 public class Version implements Comparable<Version>, ToXContentFragment {
     /*
      * The logic for ID is: XXYYZZAA, where XX is major version, YY is minor version, ZZ is revision, and AA is alpha/beta/rc indicator AA

--- a/server/src/main/java/org/opensearch/monitor/MonitorService.java
+++ b/server/src/main/java/org/opensearch/monitor/MonitorService.java
@@ -44,6 +44,11 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 
+/**
+ * The resource monitoring service
+ *
+ * @opensearch.internal
+ */
 public class MonitorService extends AbstractLifecycleComponent {
 
     private final JvmGcMonitorService jvmGcMonitorService;

--- a/server/src/main/java/org/opensearch/monitor/NodeHealthService.java
+++ b/server/src/main/java/org/opensearch/monitor/NodeHealthService.java
@@ -32,6 +32,11 @@
 
 package org.opensearch.monitor;
 
+/**
+ * The service for monitoring node health
+ *
+ * @opensearch.internal
+ */
 @FunctionalInterface
 public interface NodeHealthService {
 

--- a/server/src/main/java/org/opensearch/monitor/Probes.java
+++ b/server/src/main/java/org/opensearch/monitor/Probes.java
@@ -35,6 +35,11 @@ package org.opensearch.monitor;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Method;
 
+/**
+ * Probes the various resources
+ *
+ * @opensearch.internal
+ */
 public class Probes {
     public static short getLoadAndScaleToPercent(Method method, OperatingSystemMXBean osMxBean) {
         if (method != null) {

--- a/server/src/main/java/org/opensearch/monitor/StatusInfo.java
+++ b/server/src/main/java/org/opensearch/monitor/StatusInfo.java
@@ -35,6 +35,8 @@ package org.opensearch.monitor;
 /**
  * Class that represents the Health status for a node as determined by {@link NodeHealthService} and provides additional
  * info explaining the reasons
+ *
+ * @opensearch.internal
  */
 public class StatusInfo {
 

--- a/server/src/main/java/org/opensearch/monitor/fs/FsHealthService.java
+++ b/server/src/main/java/org/opensearch/monitor/fs/FsHealthService.java
@@ -68,6 +68,8 @@ import static org.opensearch.monitor.StatusInfo.Status.UNHEALTHY;
 /**
  * Runs periodically and attempts to create a temp file to see if the filesystem is writable. If not then it marks the
  * path as unhealthy.
+ *
+ * @opensearch.internal
  */
 public class FsHealthService extends AbstractLifecycleComponent implements NodeHealthService {
 

--- a/server/src/main/java/org/opensearch/monitor/fs/FsInfo.java
+++ b/server/src/main/java/org/opensearch/monitor/fs/FsInfo.java
@@ -49,6 +49,11 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
+/**
+ * FileSystem information
+ *
+ * @opensearch.internal
+ */
 public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragment {
 
     public static class Path implements Writeable, ToXContentObject {

--- a/server/src/main/java/org/opensearch/monitor/fs/FsProbe.java
+++ b/server/src/main/java/org/opensearch/monitor/fs/FsProbe.java
@@ -51,6 +51,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * FileSystem probe
+ *
+ * @opensearch.internal
+ */
 public class FsProbe {
 
     private static final Logger logger = LogManager.getLogger(FsProbe.class);

--- a/server/src/main/java/org/opensearch/monitor/fs/FsService.java
+++ b/server/src/main/java/org/opensearch/monitor/fs/FsService.java
@@ -44,6 +44,11 @@ import org.opensearch.env.NodeEnvironment;
 import java.io.IOException;
 import java.util.function.Supplier;
 
+/**
+ * FileSystem service
+ *
+ * @opensearch.internal
+ */
 public class FsService {
 
     private static final Logger logger = LogManager.getLogger(FsService.class);

--- a/server/src/main/java/org/opensearch/monitor/jvm/DeadlockAnalyzer.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/DeadlockAnalyzer.java
@@ -45,6 +45,11 @@ import java.util.Set;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
 
+/**
+ * Analyzes Operating System deadlocks
+ *
+ * @opensearch.internal
+ */
 public class DeadlockAnalyzer {
 
     private static final Deadlock NULL_RESULT[] = new Deadlock[0];

--- a/server/src/main/java/org/opensearch/monitor/jvm/GcNames.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/GcNames.java
@@ -32,6 +32,11 @@
 
 package org.opensearch.monitor.jvm;
 
+/**
+ * Simple utility class for human readable GC names
+ *
+ * @opensearch.internal
+ */
 public class GcNames {
 
     public static final String YOUNG = "young";

--- a/server/src/main/java/org/opensearch/monitor/jvm/HotThreads.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/HotThreads.java
@@ -51,6 +51,11 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.ToLongFunction;
 
+/**
+ * Monitors hot threads
+ *
+ * @opensearch.internal
+ */
 public class HotThreads {
 
     private static final Object mutex = new Object();

--- a/server/src/main/java/org/opensearch/monitor/jvm/JvmGcMonitorService.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/JvmGcMonitorService.java
@@ -54,6 +54,11 @@ import java.util.function.BiFunction;
 
 import static java.util.Collections.unmodifiableMap;
 
+/**
+ * Service to monitor garbage collection
+ *
+ * @opensearch.internal
+ */
 public class JvmGcMonitorService extends AbstractLifecycleComponent {
     private static final Logger logger = LogManager.getLogger(JvmGcMonitorService.class);
 

--- a/server/src/main/java/org/opensearch/monitor/jvm/JvmInfo.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/JvmInfo.java
@@ -57,6 +57,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Holds information about the JVM
+ *
+ * @opensearch.internal
+ */
 public class JvmInfo implements ReportingService.Info {
 
     private static JvmInfo INSTANCE;

--- a/server/src/main/java/org/opensearch/monitor/jvm/JvmPid.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/JvmPid.java
@@ -32,6 +32,11 @@
 
 package org.opensearch.monitor.jvm;
 
+/**
+ * JVM Process ID
+ *
+ * @opensearch.internal
+ */
 class JvmPid {
 
     static long getPid() {

--- a/server/src/main/java/org/opensearch/monitor/jvm/JvmService.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/JvmService.java
@@ -40,6 +40,11 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.node.ReportingService;
 
+/**
+ * Service for monitoring the JVM
+ *
+ * @opensearch.internal
+ */
 public class JvmService implements ReportingService<JvmInfo> {
 
     private static final Logger logger = LogManager.getLogger(JvmService.class);

--- a/server/src/main/java/org/opensearch/monitor/jvm/JvmStats.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/JvmStats.java
@@ -58,6 +58,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Holds JVM statistics
+ *
+ * @opensearch.internal
+ */
 public class JvmStats implements Writeable, ToXContentFragment {
 
     private static final RuntimeMXBean runtimeMXBean;

--- a/server/src/main/java/org/opensearch/monitor/os/OsInfo.java
+++ b/server/src/main/java/org/opensearch/monitor/os/OsInfo.java
@@ -40,6 +40,11 @@ import org.opensearch.node.ReportingService;
 
 import java.io.IOException;
 
+/**
+ * Holds Operating System Information
+ *
+ * @opensearch.internal
+ */
 public class OsInfo implements ReportingService.Info {
 
     private final long refreshInterval;

--- a/server/src/main/java/org/opensearch/monitor/os/OsProbe.java
+++ b/server/src/main/java/org/opensearch/monitor/os/OsProbe.java
@@ -74,6 +74,8 @@ import java.util.stream.Collectors;
  * - An error case retrieving these values from a linux kernel
  * - A non-standard libc implementation not implementing the required values
  * For a more exhaustive explanation, see https://github.com/elastic/elasticsearch/pull/42725
+ *
+ * @opensearch.internal
  */
 public class OsProbe {
 

--- a/server/src/main/java/org/opensearch/monitor/os/OsService.java
+++ b/server/src/main/java/org/opensearch/monitor/os/OsService.java
@@ -44,6 +44,11 @@ import org.opensearch.node.ReportingService;
 
 import java.io.IOException;
 
+/**
+ * Service for the Operating System
+ *
+ * @opensearch.internal
+ */
 public class OsService implements ReportingService<OsInfo> {
 
     private static final Logger logger = LogManager.getLogger(OsService.class);

--- a/server/src/main/java/org/opensearch/monitor/os/OsStats.java
+++ b/server/src/main/java/org/opensearch/monitor/os/OsStats.java
@@ -45,6 +45,11 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 
+/**
+ * Holds stats for the Operating System
+ *
+ * @opensearch.internal
+ */
 public class OsStats implements Writeable, ToXContentFragment {
 
     private final long timestamp;

--- a/server/src/main/java/org/opensearch/monitor/process/ProcessInfo.java
+++ b/server/src/main/java/org/opensearch/monitor/process/ProcessInfo.java
@@ -40,6 +40,11 @@ import org.opensearch.node.ReportingService;
 
 import java.io.IOException;
 
+/**
+ * Holds information for monitoring the process
+ *
+ * @opensearch.internal
+ */
 public class ProcessInfo implements ReportingService.Info {
 
     private final long refreshInterval;

--- a/server/src/main/java/org/opensearch/monitor/process/ProcessProbe.java
+++ b/server/src/main/java/org/opensearch/monitor/process/ProcessProbe.java
@@ -41,6 +41,11 @@ import java.lang.reflect.Method;
 
 import static org.opensearch.monitor.jvm.JvmInfo.jvmInfo;
 
+/**
+ * Probes the process
+ *
+ * @opensearch.internal
+ */
 public class ProcessProbe {
 
     private static final OperatingSystemMXBean osMxBean = ManagementFactory.getOperatingSystemMXBean();

--- a/server/src/main/java/org/opensearch/monitor/process/ProcessService.java
+++ b/server/src/main/java/org/opensearch/monitor/process/ProcessService.java
@@ -41,6 +41,11 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.SingleObjectCache;
 import org.opensearch.node.ReportingService;
 
+/**
+ * The service for the process
+ *
+ * @opensearch.internal
+ */
 public final class ProcessService implements ReportingService<ProcessInfo> {
 
     private static final Logger logger = LogManager.getLogger(ProcessService.class);

--- a/server/src/main/java/org/opensearch/monitor/process/ProcessStats.java
+++ b/server/src/main/java/org/opensearch/monitor/process/ProcessStats.java
@@ -43,6 +43,11 @@ import org.opensearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
+/**
+ * Holds stats for the process
+ *
+ * @opensearch.internal
+ */
 public class ProcessStats implements Writeable, ToXContentFragment {
 
     private final long timestamp;

--- a/server/src/main/java/org/opensearch/persistent/AllocatedPersistentTask.java
+++ b/server/src/main/java/org/opensearch/persistent/AllocatedPersistentTask.java
@@ -48,6 +48,8 @@ import java.util.function.Predicate;
 
 /**
  * Represents a executor node operation that corresponds to a persistent task
+ *
+ * @opensearch.internal
  */
 public class AllocatedPersistentTask extends CancellableTask {
 

--- a/server/src/main/java/org/opensearch/persistent/CompletionPersistentTaskAction.java
+++ b/server/src/main/java/org/opensearch/persistent/CompletionPersistentTaskAction.java
@@ -58,6 +58,8 @@ import static org.opensearch.action.ValidateActions.addValidationError;
 /**
  * ActionType that is used by executor node to indicate that the persistent action finished or failed on the node and needs to be
  * removed from the cluster state in case of successful completion or restarted on some other node in case of failure.
+ *
+ * @opensearch.internal
  */
 public class CompletionPersistentTaskAction extends ActionType<PersistentTaskResponse> {
 

--- a/server/src/main/java/org/opensearch/persistent/NodePersistentTasksExecutor.java
+++ b/server/src/main/java/org/opensearch/persistent/NodePersistentTasksExecutor.java
@@ -39,6 +39,8 @@ import org.opensearch.threadpool.ThreadPool;
  * This component is responsible for execution of persistent tasks.
  *
  * It abstracts away the execution of tasks and greatly simplifies testing of PersistentTasksNodeService
+ *
+ * @opensearch.internal
  */
 public class NodePersistentTasksExecutor {
 

--- a/server/src/main/java/org/opensearch/persistent/PersistentTaskParams.java
+++ b/server/src/main/java/org/opensearch/persistent/PersistentTaskParams.java
@@ -38,6 +38,8 @@ import org.opensearch.common.xcontent.ToXContentObject;
 
 /**
  * Parameters used to start persistent task
+ *
+ * @opensearch.internal
  */
 public interface PersistentTaskParams extends VersionedNamedWriteable, ToXContentObject, ClusterState.FeatureAware {
 

--- a/server/src/main/java/org/opensearch/persistent/PersistentTaskResponse.java
+++ b/server/src/main/java/org/opensearch/persistent/PersistentTaskResponse.java
@@ -41,6 +41,8 @@ import java.util.Objects;
 
 /**
  * Response upon a successful start or an persistent task
+ *
+ * @opensearch.internal
  */
 public class PersistentTaskResponse extends ActionResponse {
     private PersistentTask<?> task;

--- a/server/src/main/java/org/opensearch/persistent/PersistentTaskState.java
+++ b/server/src/main/java/org/opensearch/persistent/PersistentTaskState.java
@@ -37,5 +37,7 @@ import org.opensearch.common.xcontent.ToXContentObject;
 /**
  * {@link PersistentTaskState} represents the state of the persistent tasks, as it
  * is persisted in the cluster state.
+ *
+ * @opensearch.internal
  */
 public interface PersistentTaskState extends ToXContentObject, NamedWriteable {}

--- a/server/src/main/java/org/opensearch/persistent/PersistentTasksClusterService.java
+++ b/server/src/main/java/org/opensearch/persistent/PersistentTasksClusterService.java
@@ -61,6 +61,8 @@ import java.util.Objects;
 
 /**
  * Component that runs only on the cluster-manager node and is responsible for assigning running tasks to nodes
+ *
+ * @opensearch.internal
  */
 public class PersistentTasksClusterService implements ClusterStateListener, Closeable {
 

--- a/server/src/main/java/org/opensearch/persistent/PersistentTasksCustomMetadata.java
+++ b/server/src/main/java/org/opensearch/persistent/PersistentTasksCustomMetadata.java
@@ -71,6 +71,8 @@ import static org.opensearch.common.xcontent.ConstructingObjectParser.constructo
 
 /**
  * A cluster state record that contains a list of all running persistent tasks
+ *
+ * @opensearch.internal
  */
 public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<Metadata.Custom> implements Metadata.Custom {
 

--- a/server/src/main/java/org/opensearch/persistent/PersistentTasksExecutor.java
+++ b/server/src/main/java/org/opensearch/persistent/PersistentTasksExecutor.java
@@ -45,6 +45,8 @@ import java.util.function.Predicate;
 /**
  * An executor of tasks that can survive restart of requesting or executing node.
  * These tasks are using cluster state rather than only transport service to send requests and responses.
+ *
+ * @opensearch.internal
  */
 public abstract class PersistentTasksExecutor<Params extends PersistentTaskParams> {
 

--- a/server/src/main/java/org/opensearch/persistent/PersistentTasksExecutorRegistry.java
+++ b/server/src/main/java/org/opensearch/persistent/PersistentTasksExecutorRegistry.java
@@ -38,6 +38,8 @@ import java.util.Map;
 
 /**
  * Components that registers all persistent task executors
+ *
+ * @opensearch.internal
  */
 public class PersistentTasksExecutorRegistry {
 

--- a/server/src/main/java/org/opensearch/persistent/PersistentTasksNodeService.java
+++ b/server/src/main/java/org/opensearch/persistent/PersistentTasksNodeService.java
@@ -61,6 +61,8 @@ import static java.util.Objects.requireNonNull;
 /**
  * This component is responsible for coordination of execution of persistent tasks on individual nodes. It runs on all
  * nodes in the cluster and monitors cluster state changes to detect started commands.
+ *
+ * @opensearch.internal
  */
 public class PersistentTasksNodeService implements ClusterStateListener {
 

--- a/server/src/main/java/org/opensearch/persistent/PersistentTasksService.java
+++ b/server/src/main/java/org/opensearch/persistent/PersistentTasksService.java
@@ -56,6 +56,8 @@ import java.util.function.Predicate;
  * This service is used by persistent tasks and allocated persistent tasks to communicate changes
  * to the cluster-manager node so that the cluster-manager can update the cluster state and can track of the states
  * of the persistent tasks.
+ *
+ * @opensearch.internal
  */
 public class PersistentTasksService {
 

--- a/server/src/main/java/org/opensearch/persistent/RemovePersistentTaskAction.java
+++ b/server/src/main/java/org/opensearch/persistent/RemovePersistentTaskAction.java
@@ -53,6 +53,11 @@ import org.opensearch.transport.TransportService;
 import java.io.IOException;
 import java.util.Objects;
 
+/**
+ * Transport action to remove a persistent task
+ *
+ * @opensearch.internal
+ */
 public class RemovePersistentTaskAction extends ActionType<PersistentTaskResponse> {
 
     public static final RemovePersistentTaskAction INSTANCE = new RemovePersistentTaskAction();

--- a/server/src/main/java/org/opensearch/persistent/StartPersistentTaskAction.java
+++ b/server/src/main/java/org/opensearch/persistent/StartPersistentTaskAction.java
@@ -58,6 +58,8 @@ import static org.opensearch.action.ValidateActions.addValidationError;
 
 /**
  *  This action can be used to add the record for the persistent action to the cluster state.
+ *
+ *  @opensearch.internal
  */
 public class StartPersistentTaskAction extends ActionType<PersistentTaskResponse> {
 

--- a/server/src/main/java/org/opensearch/persistent/UpdatePersistentTaskStatusAction.java
+++ b/server/src/main/java/org/opensearch/persistent/UpdatePersistentTaskStatusAction.java
@@ -55,6 +55,11 @@ import java.util.Objects;
 
 import static org.opensearch.action.ValidateActions.addValidationError;
 
+/**
+ * Transport action for updating persistent tasks
+ *
+ * @opensearch.internal
+ */
 public class UpdatePersistentTaskStatusAction extends ActionType<PersistentTaskResponse> {
 
     public static final UpdatePersistentTaskStatusAction INSTANCE = new UpdatePersistentTaskStatusAction();

--- a/server/src/main/java/org/opensearch/persistent/decider/AssignmentDecision.java
+++ b/server/src/main/java/org/opensearch/persistent/decider/AssignmentDecision.java
@@ -39,6 +39,8 @@ import java.util.Objects;
  * assigning a persistent task to a node of the cluster.
  *
  * @see EnableAssignmentDecider
+ *
+ * @opensearch.internal
  */
 public final class AssignmentDecision {
 

--- a/server/src/main/java/org/opensearch/persistent/decider/EnableAssignmentDecider.java
+++ b/server/src/main/java/org/opensearch/persistent/decider/EnableAssignmentDecider.java
@@ -51,6 +51,8 @@ import static org.opensearch.common.settings.Setting.Property.NodeScope;
  * </ul>
  *
  * @see Allocation
+ *
+ * @opensearch.internal
  */
 public class EnableAssignmentDecider {
 

--- a/server/src/main/java/org/opensearch/plugins/ActionPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/ActionPlugin.java
@@ -72,6 +72,8 @@ import java.util.stream.Collectors;
  *               new ActionHandler<>(RethrottleAction.INSTANCE, TransportRethrottleAction.class));
  *   }
  * }</pre>
+ *
+ * @opensearch.api
  */
 public interface ActionPlugin {
     /**

--- a/server/src/main/java/org/opensearch/plugins/AnalysisPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/AnalysisPlugin.java
@@ -72,6 +72,8 @@ import static java.util.Collections.emptyMap;
  * OpenSearch doesn't have any automatic mechanism to share these components between indexes. If any component is heavy enough to warrant
  * such sharing then it is the Plugin's responsibility to do it in their {@link AnalysisProvider} implementation. We recommend against doing
  * this unless absolutely necessary because it can be difficult to get the caching right given things like behavior changes across versions.
+ *
+ * @opensearch.api
  */
 public interface AnalysisPlugin {
     /**

--- a/server/src/main/java/org/opensearch/plugins/CircuitBreakerPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/CircuitBreakerPlugin.java
@@ -39,6 +39,8 @@ import org.opensearch.indices.breaker.CircuitBreakerService;
 
 /**
  * An extension point for {@link Plugin} implementations to add custom circuit breakers
+ *
+ * @opensearch.api
  */
 public interface CircuitBreakerPlugin {
 

--- a/server/src/main/java/org/opensearch/plugins/ClusterPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/ClusterPlugin.java
@@ -45,6 +45,8 @@ import java.util.function.Supplier;
 
 /**
  * An extension point for {@link Plugin} implementations to customer behavior of cluster management.
+ *
+ * @opensearch.api
  */
 public interface ClusterPlugin {
 

--- a/server/src/main/java/org/opensearch/plugins/DiscoveryPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/DiscoveryPlugin.java
@@ -57,6 +57,8 @@ import java.util.function.Supplier;
  *     }
  * }
  * </pre>
+ *
+ * @opensearch.api
  */
 public interface DiscoveryPlugin {
 

--- a/server/src/main/java/org/opensearch/plugins/EnginePlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/EnginePlugin.java
@@ -45,6 +45,8 @@ import java.util.function.Supplier;
 
 /**
  * A plugin that provides alternative engine implementations.
+ *
+ * @opensearch.api
  */
 public interface EnginePlugin {
 

--- a/server/src/main/java/org/opensearch/plugins/ExtensiblePlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/ExtensiblePlugin.java
@@ -39,6 +39,8 @@ import java.util.List;
  *
  * This class provides a callback for extensible plugins to be informed of other plugins
  * which extend them.
+ *
+ * @opensearch.api
  */
 public interface ExtensiblePlugin {
 

--- a/server/src/main/java/org/opensearch/plugins/IndexStorePlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/IndexStorePlugin.java
@@ -46,6 +46,8 @@ import java.util.Map;
 
 /**
  * A plugin that provides alternative directory implementations.
+ *
+ * @opensearch.api
  */
 public interface IndexStorePlugin {
 

--- a/server/src/main/java/org/opensearch/plugins/IngestPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/IngestPlugin.java
@@ -39,6 +39,8 @@ import org.opensearch.ingest.Processor;
 
 /**
  * An extension point for {@link Plugin} implementations to add custom ingest processors
+ *
+ * @opensearch.api
  */
 public interface IngestPlugin {
 

--- a/server/src/main/java/org/opensearch/plugins/MapperPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/MapperPlugin.java
@@ -42,6 +42,8 @@ import java.util.function.Predicate;
 
 /**
  * An extension point for {@link Plugin} implementations to add custom mappers
+ *
+ * @opensearch.api
  */
 public interface MapperPlugin {
 

--- a/server/src/main/java/org/opensearch/plugins/MetadataUpgrader.java
+++ b/server/src/main/java/org/opensearch/plugins/MetadataUpgrader.java
@@ -42,6 +42,8 @@ import java.util.function.UnaryOperator;
 
 /**
  * Upgrades {@link Metadata} on startup on behalf of installed {@link Plugin}s
+ *
+ * @opensearch.api
  */
 public class MetadataUpgrader {
     public final UnaryOperator<Map<String, IndexTemplateMetadata>> indexTemplateMetadataUpgraders;

--- a/server/src/main/java/org/opensearch/plugins/NetworkPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/NetworkPlugin.java
@@ -52,6 +52,8 @@ import org.opensearch.transport.TransportInterceptor;
 
 /**
  * Plugin for extending network and transport related classes
+ *
+ * @opensearch.api
  */
 public interface NetworkPlugin {
 

--- a/server/src/main/java/org/opensearch/plugins/PersistentTaskPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/PersistentTaskPlugin.java
@@ -43,6 +43,8 @@ import java.util.List;
 
 /**
  * Plugin for registering persistent tasks executors.
+ *
+ * @opensearch.api
  */
 public interface PersistentTaskPlugin {
 

--- a/server/src/main/java/org/opensearch/plugins/Platforms.java
+++ b/server/src/main/java/org/opensearch/plugins/Platforms.java
@@ -39,6 +39,8 @@ import java.util.Locale;
 
 /**
  * Encapsulates platform-dependent methods for handling native components of plugins.
+ *
+ * @opensearch.api
  */
 public class Platforms {
 

--- a/server/src/main/java/org/opensearch/plugins/Plugin.java
+++ b/server/src/main/java/org/opensearch/plugins/Plugin.java
@@ -86,6 +86,8 @@ import java.util.function.UnaryOperator;
  * <li>{@link SearchPlugin}
  * <li>{@link ReloadablePlugin}
  * </ul>
+ *
+ * @opensearch.api
  */
 public abstract class Plugin implements Closeable {
 

--- a/server/src/main/java/org/opensearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginInfo.java
@@ -56,6 +56,8 @@ import java.util.stream.Collectors;
 
 /**
  * An in-memory representation of the plugin descriptor.
+ *
+ * @opensearch.api
  */
 public class PluginInfo implements Writeable, ToXContentObject {
 

--- a/server/src/main/java/org/opensearch/plugins/PluginLoaderIndirection.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginLoaderIndirection.java
@@ -37,6 +37,8 @@ import java.util.List;
 /**
  * This class exists solely as an intermediate layer to avoid causing PluginsService
  * to load ExtendedPluginsClassLoader when used in the transport client.
+ *
+ * @opensearch.api
  */
 class PluginLoaderIndirection {
 

--- a/server/src/main/java/org/opensearch/plugins/PluginSecurity.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginSecurity.java
@@ -54,6 +54,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Security Policy for Plugins
+ *
+ * @opensearch.api
+ */
 class PluginSecurity {
 
     /**

--- a/server/src/main/java/org/opensearch/plugins/ReloadablePlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/ReloadablePlugin.java
@@ -40,6 +40,8 @@ import org.opensearch.common.settings.Settings;
  * is reloaded it might rebuild any internal members. Plugins usually implement
  * this interface in order to reread the values of {@code SecureSetting}s and
  * then rebuild any dependent internal members.
+ *
+ * @opensearch.api
  */
 public interface ReloadablePlugin {
     /**

--- a/server/src/main/java/org/opensearch/plugins/RepositoryPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/RepositoryPlugin.java
@@ -43,6 +43,8 @@ import java.util.Map;
 
 /**
  * An extension point for {@link Plugin} implementations to add custom snapshot repositories.
+ *
+ * @opensearch.api
  */
 public interface RepositoryPlugin {
 

--- a/server/src/main/java/org/opensearch/plugins/ScriptPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/ScriptPlugin.java
@@ -42,6 +42,8 @@ import org.opensearch.script.ScriptEngine;
 
 /**
  * An additional extension point for {@link Plugin}s that extends OpenSearch's scripting functionality.
+ *
+ * @opensearch.api
  */
 public interface ScriptPlugin {
 

--- a/server/src/main/java/org/opensearch/plugins/SearchPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/SearchPlugin.java
@@ -87,6 +87,8 @@ import static java.util.Collections.emptyMap;
 
 /**
  * Plugin for extending search time behavior.
+ *
+ * @opensearch.api
  */
 public interface SearchPlugin {
     /**

--- a/server/src/main/java/org/opensearch/plugins/SystemIndexPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/SystemIndexPlugin.java
@@ -41,6 +41,8 @@ import java.util.Collections;
 /**
  * Plugin for defining system indices. Extends {@link ActionPlugin} because system indices must be accessed via APIs
  * added by the plugin that owns the system index, rather than standard APIs.
+ *
+ * @opensearch.api
  */
 public interface SystemIndexPlugin extends ActionPlugin {
 

--- a/server/src/main/java/org/opensearch/plugins/spi/NamedXContentProvider.java
+++ b/server/src/main/java/org/opensearch/plugins/spi/NamedXContentProvider.java
@@ -38,6 +38,8 @@ import java.util.List;
 
 /**
  * Provides named XContent parsers.
+ *
+ * @opensearch.api
  */
 public interface NamedXContentProvider {
 

--- a/server/src/main/java/org/opensearch/repositories/FilterRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/FilterRepository.java
@@ -57,6 +57,11 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+/**
+ * Repository that is filtered
+ *
+ * @opensearch.internal
+ */
 public class FilterRepository implements Repository {
 
     private final Repository in;

--- a/server/src/main/java/org/opensearch/repositories/IndexId.java
+++ b/server/src/main/java/org/opensearch/repositories/IndexId.java
@@ -45,6 +45,8 @@ import java.util.Objects;
 
 /**
  * Represents a single snapshotted index in the repository.
+ *
+ * @opensearch.internal
  */
 public final class IndexId implements Writeable, ToXContentObject {
     protected static final String NAME = "name";

--- a/server/src/main/java/org/opensearch/repositories/IndexMetaDataGenerations.java
+++ b/server/src/main/java/org/opensearch/repositories/IndexMetaDataGenerations.java
@@ -49,6 +49,8 @@ import java.util.stream.Collectors;
  * {@link org.opensearch.repositories.blobstore.BlobStoreRepository#finalizeSnapshot} the identifier for an instance of
  * {@link IndexMetadata} should be computed and then used to check if it already exists in the repository via
  * {@link #getIndexMetaBlobId(String)}.
+ *
+ * @opensearch.internal
  */
 public final class IndexMetaDataGenerations {
 

--- a/server/src/main/java/org/opensearch/repositories/RepositoriesModule.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoriesModule.java
@@ -49,6 +49,8 @@ import java.util.Map;
 
 /**
  * Sets up classes for Snapshot/Restore.
+ *
+ * @opensearch.internal
  */
 public final class RepositoriesModule {
 

--- a/server/src/main/java/org/opensearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoriesService.java
@@ -79,6 +79,8 @@ import java.util.stream.Stream;
 
 /**
  * Service responsible for maintaining and providing access to snapshot repositories on nodes.
+ *
+ * @opensearch.internal
  */
 public class RepositoriesService extends AbstractLifecycleComponent implements ClusterStateApplier {
 

--- a/server/src/main/java/org/opensearch/repositories/RepositoriesStatsArchive.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoriesStatsArchive.java
@@ -44,6 +44,11 @@ import java.util.List;
 import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 
+/**
+ * Archive of repository stats
+ *
+ * @opensearch.internal
+ */
 public final class RepositoriesStatsArchive {
     private static final Logger logger = LogManager.getLogger(RepositoriesStatsArchive.class);
 

--- a/server/src/main/java/org/opensearch/repositories/Repository.java
+++ b/server/src/main/java/org/opensearch/repositories/Repository.java
@@ -70,6 +70,8 @@ import java.util.function.Function;
  * for each shard</li>
  * <li>When all shard calls return cluster-manager calls {@link #finalizeSnapshot} with possible list of failures</li>
  * </ul>
+ *
+ * @opensearch.internal
  */
 public interface Repository extends LifecycleComponent {
 

--- a/server/src/main/java/org/opensearch/repositories/RepositoryCleanupResult.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoryCleanupResult.java
@@ -43,6 +43,11 @@ import org.opensearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
+/**
+ * Result of a repository cleanup action
+ *
+ * @opensearch.internal
+ */
 public final class RepositoryCleanupResult implements Writeable, ToXContentObject {
 
     public static final ObjectParser<RepositoryCleanupResult, Void> PARSER = new ObjectParser<>(

--- a/server/src/main/java/org/opensearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoryData.java
@@ -60,6 +60,8 @@ import java.util.stream.Collectors;
 /**
  * A class that represents the data in a repository, as captured in the
  * repository's index blob.
+ *
+ * @opensearch.internal
  */
 public final class RepositoryData {
 

--- a/server/src/main/java/org/opensearch/repositories/RepositoryException.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoryException.java
@@ -40,6 +40,8 @@ import java.io.IOException;
 
 /**
  * Generic repository exception
+ *
+ * @opensearch.internal
  */
 public class RepositoryException extends OpenSearchException {
     private final String repository;

--- a/server/src/main/java/org/opensearch/repositories/RepositoryInfo.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoryInfo.java
@@ -44,6 +44,11 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * Information about a repository
+ *
+ * @opensearch.internal
+ */
 public final class RepositoryInfo implements Writeable, ToXContentFragment {
     public final String ephemeralId;
     public final String name;

--- a/server/src/main/java/org/opensearch/repositories/RepositoryMissingException.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoryMissingException.java
@@ -39,6 +39,8 @@ import java.io.IOException;
 
 /**
  * Repository missing exception
+ *
+ * @opensearch.internal
  */
 public class RepositoryMissingException extends RepositoryException {
 

--- a/server/src/main/java/org/opensearch/repositories/RepositoryOperation.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoryOperation.java
@@ -33,6 +33,8 @@ package org.opensearch.repositories;
 
 /**
  * Coordinates of an operation that modifies a repository, assuming that repository at a specific generation.
+ *
+ * @opensearch.internal
  */
 public interface RepositoryOperation {
 

--- a/server/src/main/java/org/opensearch/repositories/RepositoryShardId.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoryShardId.java
@@ -41,6 +41,8 @@ import java.util.Objects;
 
 /**
  * Represents a shard snapshot in a repository.
+ *
+ * @opensearch.internal
  */
 public final class RepositoryShardId implements Writeable {
 

--- a/server/src/main/java/org/opensearch/repositories/RepositoryStats.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoryStats.java
@@ -42,6 +42,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * Stats about a repository
+ *
+ * @opensearch.internal
+ */
 public class RepositoryStats implements Writeable {
 
     public static final RepositoryStats EMPTY_STATS = new RepositoryStats(Collections.emptyMap());

--- a/server/src/main/java/org/opensearch/repositories/RepositoryStatsSnapshot.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoryStatsSnapshot.java
@@ -42,6 +42,11 @@ import org.opensearch.common.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Objects;
 
+/**
+ * Stats snapshot about a repository
+ *
+ * @opensearch.internal
+ */
 public final class RepositoryStatsSnapshot implements Writeable, ToXContentObject {
     public static final long UNKNOWN_CLUSTER_VERSION = -1;
     private final RepositoryInfo repositoryInfo;

--- a/server/src/main/java/org/opensearch/repositories/RepositoryVerificationException.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoryVerificationException.java
@@ -39,6 +39,8 @@ import java.io.IOException;
 
 /**
  * Repository verification exception
+ *
+ * @opensearch.internal
  */
 public class RepositoryVerificationException extends RepositoryException {
 

--- a/server/src/main/java/org/opensearch/repositories/ShardGenerations.java
+++ b/server/src/main/java/org/opensearch/repositories/ShardGenerations.java
@@ -47,6 +47,11 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+/**
+ * Generations of shards for snapshots
+ *
+ * @opensearch.internal
+ */
 public final class ShardGenerations {
 
     public static final ShardGenerations EMPTY = new ShardGenerations(Collections.emptyMap());

--- a/server/src/main/java/org/opensearch/repositories/VerificationFailure.java
+++ b/server/src/main/java/org/opensearch/repositories/VerificationFailure.java
@@ -32,6 +32,11 @@
 
 package org.opensearch.repositories;
 
+/**
+ * Exception thrown when a repository fails verification
+ *
+ * @opensearch.internal
+ */
 public class VerificationFailure {
 
     private String nodeId;

--- a/server/src/main/java/org/opensearch/repositories/VerifyNodeRepositoryAction.java
+++ b/server/src/main/java/org/opensearch/repositories/VerifyNodeRepositoryAction.java
@@ -59,6 +59,11 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Action to verify a node repository
+ *
+ * @opensearch.internal
+ */
 public class VerifyNodeRepositoryAction {
 
     private static final Logger logger = LogManager.getLogger(VerifyNodeRepositoryAction.class);

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -166,6 +166,8 @@ import static org.opensearch.index.snapshots.blobstore.BlobStoreIndexShardSnapsh
  * </p>
  * For in depth documentation on how exactly implementations of this class interact with the snapshot functionality please refer to the
  * documentation of the package {@link org.opensearch.repositories.blobstore}.
+ *
+ * @opensearch.internal
  */
 public abstract class BlobStoreRepository extends AbstractLifecycleComponent implements Repository {
     private static final Logger logger = LogManager.getLogger(BlobStoreRepository.class);

--- a/server/src/main/java/org/opensearch/repositories/blobstore/ChecksumBlobStoreFormat.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/ChecksumBlobStoreFormat.java
@@ -69,6 +69,8 @@ import java.util.Map;
 
 /**
  * Snapshot metadata file format used in v2.0 and above
+ *
+ * @opensearch.internal
  */
 public final class ChecksumBlobStoreFormat<T extends ToXContent> {
 

--- a/server/src/main/java/org/opensearch/repositories/blobstore/FileRestoreContext.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/FileRestoreContext.java
@@ -61,6 +61,8 @@ import static java.util.Collections.unmodifiableMap;
  * restore from some form of a snapshot. It will setup a new store, identify files that need to be copied
  * for the source, and perform the copies. Implementers must implement the functionality of opening the
  * underlying file streams for snapshotted lucene file.
+ *
+ * @opensearch.internal
  */
 public abstract class FileRestoreContext {
 

--- a/server/src/main/java/org/opensearch/repositories/blobstore/MeteredBlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/MeteredBlobStoreRepository.java
@@ -43,6 +43,11 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.util.Map;
 
+/**
+ * A blob store repository that is metered
+ *
+ * @opensearch.internal
+ */
 public abstract class MeteredBlobStoreRepository extends BlobStoreRepository {
     private final RepositoryInfo repositoryInfo;
 

--- a/server/src/main/java/org/opensearch/repositories/fs/FsRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/fs/FsRepository.java
@@ -62,6 +62,8 @@ import java.util.function.Function;
  *      Defaults to not chucked.</dd>
  * <dt>{@code compress}</dt><dd>If set to true metadata files will be stored compressed. Defaults to false.</dd>
  * </dl>
+ *
+ * @opensearch.internal
  */
 public class FsRepository extends BlobStoreRepository {
     private static final Logger logger = LogManager.getLogger(FsRepository.class);

--- a/server/src/main/java/org/opensearch/script/AggregationScript.java
+++ b/server/src/main/java/org/opensearch/script/AggregationScript.java
@@ -46,6 +46,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+/**
+ * Scripts for aggregations
+ *
+ * @opensearch.internal
+ */
 public abstract class AggregationScript implements ScorerAware {
 
     public static final String[] PARAMETERS = {};

--- a/server/src/main/java/org/opensearch/script/BucketAggregationScript.java
+++ b/server/src/main/java/org/opensearch/script/BucketAggregationScript.java
@@ -36,6 +36,8 @@ import java.util.Map;
 
 /**
  * A script used in bucket aggregations that returns a {@code double} value.
+ *
+ * @opensearch.internal
  */
 public abstract class BucketAggregationScript {
 

--- a/server/src/main/java/org/opensearch/script/BucketAggregationSelectorScript.java
+++ b/server/src/main/java/org/opensearch/script/BucketAggregationSelectorScript.java
@@ -36,6 +36,8 @@ import java.util.Map;
 
 /**
  * A script used in bucket aggregations that returns a {@code boolean} value.
+ *
+ * @opensearch.internal
  */
 public abstract class BucketAggregationSelectorScript {
 

--- a/server/src/main/java/org/opensearch/script/ClassPermission.java
+++ b/server/src/main/java/org/opensearch/script/ClassPermission.java
@@ -85,6 +85,8 @@ import java.util.Set;
  *   <li>{@link org.joda.time.ReadableDateTime}</li>
  *   <li>{@link org.joda.time.ReadableInstant}</li>
  * </ul>
+ *
+ * @opensearch.internal
  */
 public final class ClassPermission extends BasicPermission {
     public static final String STANDARD = "<<STANDARD>>";

--- a/server/src/main/java/org/opensearch/script/DynamicMap.java
+++ b/server/src/main/java/org/opensearch/script/DynamicMap.java
@@ -42,6 +42,8 @@ import java.util.function.Function;
  * functions is provided for the overridden values where the function
  * is applied to the existing value when one exists for the
  * corresponding key.
+ *
+ * @opensearch.internal
  */
 public final class DynamicMap implements Map<String, Object> {
 

--- a/server/src/main/java/org/opensearch/script/ExplainableScoreScript.java
+++ b/server/src/main/java/org/opensearch/script/ExplainableScoreScript.java
@@ -41,6 +41,8 @@ import java.io.IOException;
  * To be implemented by {@link ScoreScript} which can provided an {@link Explanation} of the score
  * This is currently not used inside opensearch but it is used, see for example here:
  * https://github.com/elastic/elasticsearch/issues/8561
+ *
+ * @opensearch.internal
  */
 public interface ExplainableScoreScript {
 

--- a/server/src/main/java/org/opensearch/script/FieldScript.java
+++ b/server/src/main/java/org/opensearch/script/FieldScript.java
@@ -46,6 +46,8 @@ import java.util.function.Function;
 
 /**
  * A script to produce dynamic values for return fields.
+ *
+ * @opensearch.internal
  */
 public abstract class FieldScript {
 

--- a/server/src/main/java/org/opensearch/script/FilterScript.java
+++ b/server/src/main/java/org/opensearch/script/FilterScript.java
@@ -42,6 +42,8 @@ import java.util.Map;
 /**
  * A script implementation of a query filter.
  * See {@link org.opensearch.index.query.ScriptQueryBuilder}.
+ *
+ * @opensearch.internal
  */
 public abstract class FilterScript {
 

--- a/server/src/main/java/org/opensearch/script/GeneralScriptException.java
+++ b/server/src/main/java/org/opensearch/script/GeneralScriptException.java
@@ -47,6 +47,8 @@ import java.io.IOException;
  * @deprecated Use ScriptException for exceptions from the scripting engine,
  *             otherwise use a more appropriate exception (e.g. if thrown
  *             from various abstractions)
+ *
+ * @opensearch.internal
  */
 @Deprecated
 public class GeneralScriptException extends OpenSearchException implements OpenSearchWrapperException {

--- a/server/src/main/java/org/opensearch/script/IngestConditionalScript.java
+++ b/server/src/main/java/org/opensearch/script/IngestConditionalScript.java
@@ -38,6 +38,8 @@ import java.util.Map;
 
 /**
  * A script used by {@link org.opensearch.ingest.ConditionalProcessor}.
+ *
+ * @opensearch.internal
  */
 public abstract class IngestConditionalScript {
 

--- a/server/src/main/java/org/opensearch/script/IngestScript.java
+++ b/server/src/main/java/org/opensearch/script/IngestScript.java
@@ -38,6 +38,8 @@ import java.util.Map;
 
 /**
  * A script used by the Ingest Script Processor.
+ *
+ * @opensearch.internal
  */
 public abstract class IngestScript {
 

--- a/server/src/main/java/org/opensearch/script/JodaCompatibleZonedDateTime.java
+++ b/server/src/main/java/org/opensearch/script/JodaCompatibleZonedDateTime.java
@@ -69,6 +69,8 @@ import java.util.Objects;
 
 /**
  * A wrapper around ZonedDateTime that exposes joda methods for backcompat.
+ *
+ * @opensearch.internal
  */
 public class JodaCompatibleZonedDateTime
     implements

--- a/server/src/main/java/org/opensearch/script/NumberSortScript.java
+++ b/server/src/main/java/org/opensearch/script/NumberSortScript.java
@@ -36,6 +36,11 @@ import java.util.Map;
 import org.apache.lucene.index.LeafReaderContext;
 import org.opensearch.search.lookup.SearchLookup;
 
+/**
+ * Script for number sorts
+ *
+ * @opensearch.internal
+ */
 public abstract class NumberSortScript extends AbstractSortScript {
 
     public static final String[] PARAMETERS = {};

--- a/server/src/main/java/org/opensearch/script/ScoreScript.java
+++ b/server/src/main/java/org/opensearch/script/ScoreScript.java
@@ -50,6 +50,8 @@ import java.util.function.Function;
 
 /**
  * A script used for adjusting the score on a per document basis.
+ *
+ * @opensearch.internal
  */
 public abstract class ScoreScript {
 

--- a/server/src/main/java/org/opensearch/script/ScoreScriptUtils.java
+++ b/server/src/main/java/org/opensearch/script/ScoreScriptUtils.java
@@ -48,6 +48,11 @@ import java.time.ZoneId;
 
 import static com.carrotsearch.hppc.BitMixer.mix32;
 
+/**
+ * Utilities for scoring scripts
+ *
+ * @opensearch.internal
+ */
 public final class ScoreScriptUtils {
 
     /****** STATIC FUNCTIONS that can be used by users for score calculations **/

--- a/server/src/main/java/org/opensearch/script/Script.java
+++ b/server/src/main/java/org/opensearch/script/Script.java
@@ -95,6 +95,8 @@ import java.util.function.BiConsumer;
  *                                use an empty {@link Map} to specify no params
  * </ul>
  * </ul>
+ *
+ * @opensearch.internal
  */
 public final class Script implements ToXContentObject, Writeable {
 

--- a/server/src/main/java/org/opensearch/script/ScriptCache.java
+++ b/server/src/main/java/org/opensearch/script/ScriptCache.java
@@ -50,6 +50,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Script cache and compilation rate limiter.
+ *
+ * @opensearch.internal
  */
 public class ScriptCache {
 

--- a/server/src/main/java/org/opensearch/script/ScriptCacheStats.java
+++ b/server/src/main/java/org/opensearch/script/ScriptCacheStats.java
@@ -45,7 +45,14 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-// This class is deprecated in favor of ScriptStats and ScriptContextStats.  It is removed in 8.
+/**
+ * Stats for script caching
+ *
+ * @opensearch.internal
+ *
+ * @deprecated This class is deprecated in favor of ScriptStats and ScriptContextStats.  It is removed in OpenSearch 2.0.
+ */
+@Deprecated
 public class ScriptCacheStats implements Writeable, ToXContentFragment {
     private final Map<String, ScriptStats> context;
     private final ScriptStats general;

--- a/server/src/main/java/org/opensearch/script/ScriptContext.java
+++ b/server/src/main/java/org/opensearch/script/ScriptContext.java
@@ -69,6 +69,8 @@ import java.lang.reflect.Method;
  * For example, to check if a variable {@code doc} is used, a method {@code boolean needsDoc()} should be added.
  * If the variable name starts with an underscore, for example, {@code _score}, the needs method would
  * be {@code boolean needs_score()}.
+ *
+ * @opensearch.internal
  */
 public final class ScriptContext<FactoryType> {
 

--- a/server/src/main/java/org/opensearch/script/ScriptContextInfo.java
+++ b/server/src/main/java/org/opensearch/script/ScriptContextInfo.java
@@ -57,6 +57,11 @@ import java.util.stream.Collectors;
 
 import static org.opensearch.common.xcontent.ConstructingObjectParser.constructorArg;
 
+/**
+ * Information about a script context
+ *
+ * @opensearch.internal
+ */
 public class ScriptContextInfo implements ToXContentObject, Writeable {
     public final String name;
     public final ScriptMethodInfo execute;

--- a/server/src/main/java/org/opensearch/script/ScriptContextStats.java
+++ b/server/src/main/java/org/opensearch/script/ScriptContextStats.java
@@ -41,6 +41,11 @@ import org.opensearch.common.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Objects;
 
+/**
+ * Stats for a script context
+ *
+ * @opensearch.internal
+ */
 public class ScriptContextStats implements Writeable, ToXContentFragment, Comparable<ScriptContextStats> {
     private final String context;
     private final long compilations;

--- a/server/src/main/java/org/opensearch/script/ScriptEngine.java
+++ b/server/src/main/java/org/opensearch/script/ScriptEngine.java
@@ -39,6 +39,8 @@ import java.util.Set;
 
 /**
  * A script language implementation.
+ *
+ * @opensearch.internal
  */
 public interface ScriptEngine extends Closeable {
 

--- a/server/src/main/java/org/opensearch/script/ScriptException.java
+++ b/server/src/main/java/org/opensearch/script/ScriptException.java
@@ -59,6 +59,8 @@ import java.util.Objects;
  *   <li>{@code script}: Identifier for which script failed.
  *   <li>{@code lang}: Scripting engine language, such as "painless"
  * </ul>
+ *
+ * @opensearch.internal
  */
 @SuppressWarnings("serial")
 public class ScriptException extends OpenSearchException {

--- a/server/src/main/java/org/opensearch/script/ScriptFactory.java
+++ b/server/src/main/java/org/opensearch/script/ScriptFactory.java
@@ -34,6 +34,8 @@ package org.opensearch.script;
 
 /**
  * Contains utility methods for compiled scripts without impacting concrete script signatures
+ *
+ * @opensearch.internal
  */
 public interface ScriptFactory {
     /** Returns {@code true} if the result of the script will be deterministic, {@code false} otherwise. */

--- a/server/src/main/java/org/opensearch/script/ScriptLanguagesInfo.java
+++ b/server/src/main/java/org/opensearch/script/ScriptLanguagesInfo.java
@@ -90,6 +90,8 @@ import static org.opensearch.common.xcontent.ConstructingObjectParser.constructo
  *   ]
  * }
  * </code>
+ *
+ * @opensearch.internal
  */
 public class ScriptLanguagesInfo implements ToXContentObject, Writeable {
     private static final ParseField TYPES_ALLOWED = new ParseField("types_allowed");

--- a/server/src/main/java/org/opensearch/script/ScriptMetadata.java
+++ b/server/src/main/java/org/opensearch/script/ScriptMetadata.java
@@ -57,6 +57,8 @@ import java.util.Map;
 /**
  * {@link ScriptMetadata} is used to store user-defined scripts
  * as part of the {@link ClusterState} using only an id as the key.
+ *
+ * @opensearch.internal
  */
 public final class ScriptMetadata implements Metadata.Custom, Writeable, ToXContentFragment {
 

--- a/server/src/main/java/org/opensearch/script/ScriptMetrics.java
+++ b/server/src/main/java/org/opensearch/script/ScriptMetrics.java
@@ -34,6 +34,11 @@ package org.opensearch.script;
 
 import org.opensearch.common.metrics.CounterMetric;
 
+/**
+ * Metrics for scripts
+ *
+ * @opensearch.internal
+ */
 public class ScriptMetrics {
     final CounterMetric compilationsMetric = new CounterMetric();
     final CounterMetric cacheEvictionsMetric = new CounterMetric();

--- a/server/src/main/java/org/opensearch/script/ScriptModule.java
+++ b/server/src/main/java/org/opensearch/script/ScriptModule.java
@@ -48,6 +48,8 @@ import java.util.stream.Stream;
 
 /**
  * Manages building {@link ScriptService}.
+ *
+ * @opensearch.internal
  */
 public class ScriptModule {
 

--- a/server/src/main/java/org/opensearch/script/ScriptService.java
+++ b/server/src/main/java/org/opensearch/script/ScriptService.java
@@ -71,6 +71,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+/**
+ * Service for scripting
+ *
+ * @opensearch.internal
+ */
 public class ScriptService implements Closeable, ClusterStateApplier {
 
     private static final Logger logger = LogManager.getLogger(ScriptService.class);

--- a/server/src/main/java/org/opensearch/script/ScriptStats.java
+++ b/server/src/main/java/org/opensearch/script/ScriptStats.java
@@ -46,6 +46,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Stats for scripts
+ *
+ * @opensearch.internal
+ */
 public class ScriptStats implements Writeable, ToXContentFragment {
     private final List<ScriptContextStats> contextStats;
     private final long compilations;

--- a/server/src/main/java/org/opensearch/script/ScriptType.java
+++ b/server/src/main/java/org/opensearch/script/ScriptType.java
@@ -44,6 +44,8 @@ import java.util.Locale;
  * ScriptType represents the way a script is stored and retrieved from the {@link ScriptService}.
  * It's also used to by {@link ScriptService} to determine whether or not a {@link Script} is
  * allowed to be executed based on both default and user-defined settings.
+ *
+ * @opensearch.internal
  */
 public enum ScriptType implements Writeable {
 

--- a/server/src/main/java/org/opensearch/script/ScriptedMetricAggContexts.java
+++ b/server/src/main/java/org/opensearch/script/ScriptedMetricAggContexts.java
@@ -47,6 +47,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+/**
+ * Contexts for scripted metric aggregations
+ *
+ * @opensearch.internal
+ */
 public class ScriptedMetricAggContexts {
 
     public abstract static class InitScript {

--- a/server/src/main/java/org/opensearch/script/SignificantTermsHeuristicScoreScript.java
+++ b/server/src/main/java/org/opensearch/script/SignificantTermsHeuristicScoreScript.java
@@ -36,6 +36,8 @@ import java.util.Map;
 
 /**
  * A script used in significant terms heuristic scoring.
+ *
+ * @opensearch.internal
  */
 public abstract class SignificantTermsHeuristicScoreScript {
 

--- a/server/src/main/java/org/opensearch/script/SimilarityScript.java
+++ b/server/src/main/java/org/opensearch/script/SimilarityScript.java
@@ -34,7 +34,11 @@ package org.opensearch.script;
 
 import org.opensearch.index.similarity.ScriptedSimilarity;
 
-/** A script that is used to build {@link ScriptedSimilarity} instances. */
+/**
+ * A script that is used to build {@link ScriptedSimilarity} instances.
+ *
+ * @opensearch.internal
+ */
 public abstract class SimilarityScript {
 
     /** Compute the score.

--- a/server/src/main/java/org/opensearch/script/SimilarityWeightScript.java
+++ b/server/src/main/java/org/opensearch/script/SimilarityWeightScript.java
@@ -34,7 +34,11 @@ package org.opensearch.script;
 
 import org.opensearch.index.similarity.ScriptedSimilarity;
 
-/** A script that is used to compute scoring factors that are the same for all documents. */
+/**
+ * A script that is used to compute scoring factors that are the same for all documents.
+ *
+ * @opensearch.internal
+ */
 public abstract class SimilarityWeightScript {
 
     /** Compute the weight.

--- a/server/src/main/java/org/opensearch/script/StoredScriptSource.java
+++ b/server/src/main/java/org/opensearch/script/StoredScriptSource.java
@@ -65,6 +65,8 @@ import java.util.Objects;
 /**
  * {@link StoredScriptSource} represents user-defined parameters for a script
  * saved in the {@link ClusterState}.
+ *
+ * @opensearch.internal
  */
 public class StoredScriptSource extends AbstractDiffable<StoredScriptSource> implements Writeable, ToXContentObject {
 

--- a/server/src/main/java/org/opensearch/script/StringSortScript.java
+++ b/server/src/main/java/org/opensearch/script/StringSortScript.java
@@ -36,6 +36,11 @@ import java.util.Map;
 import org.apache.lucene.index.LeafReaderContext;
 import org.opensearch.search.lookup.SearchLookup;
 
+/**
+ * Script for sorting strings
+ *
+ * @opensearch.internal
+ */
 public abstract class StringSortScript extends AbstractSortScript {
 
     public static final String[] PARAMETERS = {};

--- a/server/src/main/java/org/opensearch/script/TemplateScript.java
+++ b/server/src/main/java/org/opensearch/script/TemplateScript.java
@@ -36,6 +36,8 @@ import java.util.Map;
 
 /**
  * A string template rendered as a script.
+ *
+ * @opensearch.internal
  */
 public abstract class TemplateScript {
 

--- a/server/src/main/java/org/opensearch/script/TermsSetQueryScript.java
+++ b/server/src/main/java/org/opensearch/script/TermsSetQueryScript.java
@@ -43,6 +43,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+/**
+ * Script for terms set query
+ *
+ * @opensearch.internal
+ */
 public abstract class TermsSetQueryScript {
 
     public static final String[] PARAMETERS = {};

--- a/server/src/main/java/org/opensearch/script/UpdateScript.java
+++ b/server/src/main/java/org/opensearch/script/UpdateScript.java
@@ -39,6 +39,8 @@ import java.util.function.Function;
 
 /**
  * An update script.
+ *
+ * @opensearch.internal
  */
 public abstract class UpdateScript {
 

--- a/server/src/main/java/org/opensearch/threadpool/AutoQueueAdjustingExecutorBuilder.java
+++ b/server/src/main/java/org/opensearch/threadpool/AutoQueueAdjustingExecutorBuilder.java
@@ -52,6 +52,8 @@ import java.util.concurrent.ThreadFactory;
 /**
  * A builder for executors that automatically adjust the queue length as needed, depending on
  * Little's Law. See https://en.wikipedia.org/wiki/Little's_law for more information.
+ *
+ * @opensearch.internal
  */
 public final class AutoQueueAdjustingExecutorBuilder extends ExecutorBuilder<AutoQueueAdjustingExecutorBuilder.AutoExecutorSettings> {
 

--- a/server/src/main/java/org/opensearch/threadpool/CancellableAdapter.java
+++ b/server/src/main/java/org/opensearch/threadpool/CancellableAdapter.java
@@ -36,6 +36,11 @@ import org.opensearch.common.util.concurrent.FutureUtils;
 
 import java.util.concurrent.Future;
 
+/**
+ * A cancellable adapter
+ *
+ * @opensearch.internal
+ */
 class CancellableAdapter implements Scheduler.Cancellable {
     private Future<?> future;
 

--- a/server/src/main/java/org/opensearch/threadpool/ExecutorBuilder.java
+++ b/server/src/main/java/org/opensearch/threadpool/ExecutorBuilder.java
@@ -43,6 +43,8 @@ import java.util.List;
  * Base class for executor builders.
  *
  * @param <U> the underlying type of the executor settings
+ *
+ *           @opensearch.internal
  */
 public abstract class ExecutorBuilder<U extends ExecutorBuilder.ExecutorSettings> {
 

--- a/server/src/main/java/org/opensearch/threadpool/FixedExecutorBuilder.java
+++ b/server/src/main/java/org/opensearch/threadpool/FixedExecutorBuilder.java
@@ -47,6 +47,8 @@ import java.util.concurrent.ThreadFactory;
 
 /**
  * A builder for fixed executors.
+ *
+ * @opensearch.internal
  */
 public final class FixedExecutorBuilder extends ExecutorBuilder<FixedExecutorBuilder.FixedExecutorSettings> {
 

--- a/server/src/main/java/org/opensearch/threadpool/ScalingExecutorBuilder.java
+++ b/server/src/main/java/org/opensearch/threadpool/ScalingExecutorBuilder.java
@@ -48,6 +48,8 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * A builder for scaling executors.
+ *
+ * @opensearch.internal
  */
 public final class ScalingExecutorBuilder extends ExecutorBuilder<ScalingExecutorBuilder.ScalingExecutorSettings> {
 

--- a/server/src/main/java/org/opensearch/threadpool/ScheduledCancellableAdapter.java
+++ b/server/src/main/java/org/opensearch/threadpool/ScheduledCancellableAdapter.java
@@ -38,6 +38,11 @@ import java.util.concurrent.Delayed;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * A cancellable adapter that is scheduled
+ *
+ * @opensearch.internal
+ */
 class ScheduledCancellableAdapter implements Scheduler.ScheduledCancellable {
     private final ScheduledFuture<?> scheduledFuture;
 

--- a/server/src/main/java/org/opensearch/threadpool/Scheduler.java
+++ b/server/src/main/java/org/opensearch/threadpool/Scheduler.java
@@ -53,6 +53,8 @@ import java.util.function.Consumer;
 
 /**
  * Scheduler that allows to schedule one-shot and periodic commands.
+ *
+ * @opensearch.internal
  */
 public interface Scheduler {
 

--- a/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
@@ -72,6 +72,11 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.unmodifiableMap;
 
+/**
+ * The OpenSearch threadpool class
+ *
+ * @opensearch.internal
+ */
 public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
 
     private static final Logger logger = LogManager.getLogger(ThreadPool.class);

--- a/server/src/main/java/org/opensearch/threadpool/ThreadPoolInfo.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPoolInfo.java
@@ -42,6 +42,11 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+/**
+ * Information about a threadpool
+ *
+ * @opensearch.internal
+ */
 public class ThreadPoolInfo implements ReportingService.Info, Iterable<ThreadPool.Info> {
 
     private final List<ThreadPool.Info> infos;

--- a/server/src/main/java/org/opensearch/threadpool/ThreadPoolStats.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPoolStats.java
@@ -44,6 +44,11 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+/**
+ * Stats for a threadpool
+ *
+ * @opensearch.internal
+ */
 public class ThreadPoolStats implements Writeable, ToXContentFragment, Iterable<ThreadPoolStats.Stats> {
 
     public static class Stats implements Writeable, ToXContentFragment, Comparable<Stats> {

--- a/server/src/main/java/org/opensearch/usage/UsageService.java
+++ b/server/src/main/java/org/opensearch/usage/UsageService.java
@@ -61,6 +61,8 @@ import java.util.Objects;
 
 /**
  * A service to monitor usage of OpenSearch features.
+ *
+ * @opensearch.internal
  */
 public class UsageService {
 

--- a/server/src/main/java/org/opensearch/watcher/AbstractResourceWatcher.java
+++ b/server/src/main/java/org/opensearch/watcher/AbstractResourceWatcher.java
@@ -38,6 +38,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 /**
  * Abstract resource watcher framework, which handles adding and removing listeners
  * and calling resource observer.
+ *
+ * @opensearch.internal
  */
 public abstract class AbstractResourceWatcher<Listener> implements ResourceWatcher {
     private final List<Listener> listeners = new CopyOnWriteArrayList<>();

--- a/server/src/main/java/org/opensearch/watcher/FileChangesListener.java
+++ b/server/src/main/java/org/opensearch/watcher/FileChangesListener.java
@@ -35,6 +35,8 @@ import java.nio.file.Path;
 
 /**
  * Callback interface that file changes File Watcher is using to notify listeners about changes.
+ *
+ * @opensearch.internal
  */
 public interface FileChangesListener {
     /**

--- a/server/src/main/java/org/opensearch/watcher/FileWatcher.java
+++ b/server/src/main/java/org/opensearch/watcher/FileWatcher.java
@@ -46,6 +46,8 @@ import java.util.Arrays;
  * File resources watcher
  *
  * The file watcher checks directory and all its subdirectories for file changes and notifies its listeners accordingly
+ *
+ * @opensearch.internal
  */
 public class FileWatcher extends AbstractResourceWatcher<FileChangesListener> {
 

--- a/server/src/main/java/org/opensearch/watcher/ResourceWatcher.java
+++ b/server/src/main/java/org/opensearch/watcher/ResourceWatcher.java
@@ -38,6 +38,8 @@ import java.io.IOException;
  * <p>
  * Different resource watchers can be registered with {@link ResourceWatcherService} to be called
  * periodically in order to check for changes in different external resources.
+ *
+ * @opensearch.internal
  */
 public interface ResourceWatcher {
     /**

--- a/server/src/main/java/org/opensearch/watcher/ResourceWatcherService.java
+++ b/server/src/main/java/org/opensearch/watcher/ResourceWatcherService.java
@@ -53,6 +53,8 @@ import java.util.concurrent.CopyOnWriteArraySet;
  * method. This service will call {@link org.opensearch.watcher.ResourceWatcher#checkAndNotify()} method of all
  * registered watcher periodically. The frequency of checks can be specified using {@code resource.reload.interval} setting, which
  * defaults to {@code 60s}. The service can be disabled by setting {@code resource.reload.enabled} setting to {@code false}.
+ *
+ * @opensearch.internal
  */
 public class ResourceWatcherService implements Closeable {
     private static final Logger logger = LogManager.getLogger(ResourceWatcherService.class);

--- a/server/src/main/java/org/opensearch/watcher/WatcherHandle.java
+++ b/server/src/main/java/org/opensearch/watcher/WatcherHandle.java
@@ -32,6 +32,11 @@
 
 package org.opensearch.watcher;
 
+/**
+ * Handle to a watcher
+ *
+ * @opensearch.internal
+ */
 public class WatcherHandle<W extends ResourceWatcher> {
 
     private final ResourceWatcherService.ResourceMonitor monitor;


### PR DESCRIPTION
Adds javadocs to classes in the org.opensearch.monitor, persistence, plugins,
repository, script, threadpool, usage, and watcher packages.

relates https://github.com/opensearch-project/OpenSearch/issues/221
relates https://github.com/opensearch-project/OpenSearch/issues/2868