### PR TITLE
[Feature/extensions] Fix a bug where indexing timesout when extensions do not exist

### DIFF
--- a/server/src/main/java/org/opensearch/extensions/ExtensionsOrchestrator.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsOrchestrator.java
@@ -227,6 +227,7 @@ public class ExtensionsOrchestrator implements ReportingService<PluginsAndModule
             @Override
             public void handleException(TransportException exp) {
                 logger.error(new ParameterizedMessage("IndicesModuleRequest failed"), exp);
+                inProgressLatch.countDown();
             }
 
             @Override


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Fix a bug where indexing timesout when extensions do not exist
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
