### PR TITLE
Gradle plugin `opensearch.pluginzip` Add implicit dependency.

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/PublishPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/PublishPlugin.java
@@ -135,11 +135,11 @@ public class PublishPlugin implements Plugin<Project> {
                     publication.artifact(project.getTasks().getByName("sourcesJar"));
                     publication.artifact(project.getTasks().getByName("javadocJar"));
                 }
-
-                generatePomTask.configure(
-                    t -> t.dependsOn(String.format("generatePomFileFor%sPublication", Util.capitalize(publication.getName())))
-                );
             }
+
+            generatePomTask.configure(
+                t -> t.dependsOn(String.format("generatePomFileFor%sPublication", Util.capitalize(publication.getName())))
+            );
         });
 
     }

--- a/buildSrc/src/main/java/org/opensearch/gradle/pluginzip/Publish.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/pluginzip/Publish.java
@@ -14,6 +14,7 @@ import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
 import java.nio.file.Path;
+import org.gradle.api.Task;
 
 public class Publish implements Plugin<Project> {
     private Project project;
@@ -63,12 +64,19 @@ public class Publish implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         this.project = project;
-        project.afterEvaluate(evaluatedProject -> { configMaven(project); });
-        project.getGradle().getTaskGraph().whenReady(graph -> {
-            if (graph.hasTask(LOCALMAVEN)) {
-                project.getTasks().getByName(PLUGIN_ZIP_PUBLISH_POM_TASK).setEnabled(false);
+        project.afterEvaluate(evaluatedProject -> {
+            configMaven(project);
+            Task validatePluginZipPom = project.getTasks().findByName("validatePluginZipPom");
+            if (validatePluginZipPom != null) {
+                project.getTasks().getByName("validatePluginZipPom").mustRunAfter("generatePomFileForNebulaPublication");
             }
-
+            Task publishPluginZipPublicationToZipStagingRepository = project.getTasks()
+                .findByName("publishPluginZipPublicationToZipStagingRepository");
+            if (validatePluginZipPom != null) {
+                project.getTasks()
+                    .getByName("publishPluginZipPublicationToZipStagingRepository")
+                    .mustRunAfter("generatePomFileForNebulaPublication");
+            }
         });
     }
 }

--- a/buildSrc/src/main/java/org/opensearch/gradle/pluginzip/Publish.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/pluginzip/Publish.java
@@ -68,14 +68,14 @@ public class Publish implements Plugin<Project> {
             configMaven(project);
             Task validatePluginZipPom = project.getTasks().findByName("validatePluginZipPom");
             if (validatePluginZipPom != null) {
-                project.getTasks().getByName("validatePluginZipPom").mustRunAfter("generatePomFileForNebulaPublication");
+                project.getTasks().getByName("validatePluginZipPom").dependsOn("generatePomFileForNebulaPublication");
             }
             Task publishPluginZipPublicationToZipStagingRepository = project.getTasks()
                 .findByName("publishPluginZipPublicationToZipStagingRepository");
             if (validatePluginZipPom != null) {
                 project.getTasks()
                     .getByName("publishPluginZipPublicationToZipStagingRepository")
-                    .mustRunAfter("generatePomFileForNebulaPublication");
+                    .dependsOn("generatePomFileForNebulaPublication");
             }
         });
     }

--- a/buildSrc/src/test/java/org/opensearch/gradle/pluginzip/PublishTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/pluginzip/PublishTests.java
@@ -58,6 +58,7 @@ public class PublishTests extends GradleUnitTestCase {
         writeString(new File(projectDir, "settings.gradle"), "");
         // Generate the build.gradle file
         String buildFileContent = "apply plugin: 'maven-publish' \n"
+            + "apply plugin: 'java' \n"
             + "publishing {\n"
             + "  repositories {\n"
             + "       maven {\n"

--- a/buildSrc/src/test/java/org/opensearch/gradle/pluginzip/PublishTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/pluginzip/PublishTests.java
@@ -74,10 +74,14 @@ public class PublishTests extends GradleUnitTestCase {
             + "}";
         writeString(new File(projectDir, "build.gradle"), buildFileContent);
         // Execute the task publishPluginZipPublicationToZipStagingRepository
+        List<String> allArguments = new ArrayList<String>();
+        allArguments.add("build");
+        allArguments.add(zipPublishTask);
+        allArguments.addAll(Arrays.asList(arguments));
         GradleRunner runner = GradleRunner.create();
         runner.forwardOutput();
         runner.withPluginClasspath();
-        runner.withArguments("clean", "build", zipPublishTask);
+        runner.withArguments(allArguments);
         runner.withProjectDir(projectDir);
         BuildResult result = runner.build();
         // Check if task publishMavenzipPublicationToZipstagingRepository has ran well

--- a/buildSrc/src/test/java/org/opensearch/gradle/pluginzip/PublishTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/pluginzip/PublishTests.java
@@ -78,7 +78,6 @@ public class PublishTests extends GradleUnitTestCase {
         List<String> allArguments = new ArrayList<String>();
         allArguments.add("build");
         allArguments.add(zipPublishTask);
-        allArguments.addAll(Arrays.asList(arguments));
         GradleRunner runner = GradleRunner.create();
         runner.forwardOutput();
         runner.withPluginClasspath();

--- a/buildSrc/src/test/java/org/opensearch/gradle/pluginzip/PublishTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/pluginzip/PublishTests.java
@@ -28,6 +28,7 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import java.io.FileReader;
 import org.gradle.api.tasks.bundling.Zip;
+import java.util.List;
 
 public class PublishTests extends GradleUnitTestCase {
 

--- a/buildSrc/src/test/java/org/opensearch/gradle/pluginzip/PublishTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/pluginzip/PublishTests.java
@@ -29,6 +29,7 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import java.io.FileReader;
 import org.gradle.api.tasks.bundling.Zip;
 import java.util.List;
+import java.util.ArrayList;
 
 public class PublishTests extends GradleUnitTestCase {
 

--- a/buildSrc/src/test/java/org/opensearch/gradle/pluginzip/PublishTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/pluginzip/PublishTests.java
@@ -77,7 +77,7 @@ public class PublishTests extends GradleUnitTestCase {
         GradleRunner runner = GradleRunner.create();
         runner.forwardOutput();
         runner.withPluginClasspath();
-        runner.withArguments(zipPublishTask);
+        runner.withArguments("clean", "build", zipPublishTask);
         runner.withProjectDir(projectDir);
         BuildResult result = runner.build();
         // Check if task publishMavenzipPublicationToZipstagingRepository has ran well
@@ -87,6 +87,7 @@ public class PublishTests extends GradleUnitTestCase {
             new File("build/functionalTest/local-staging-repo/org/opensearch/plugin/sample-plugin/2.0.0.0/sample-plugin-2.0.0.0.zip")
                 .exists()
         );
+        assertEquals(SUCCESS, result.task(":" + "build").getOutcome());
         // Parse the maven file and validate the groupID to org.opensearch.plugin
         MavenXpp3Reader reader = new MavenXpp3Reader();
         Model model = reader.read(


### PR DESCRIPTION
Signed-off-by: pgodithi <pgodithi@amazon.com>

### Description
This fix will remove the following warning's during runtime
```
Execution optimizations have been disabled for task ':publishPluginZipPublicationToZipStagingRepository' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: 'opensearch-plugin-template-java/build/distributions/rename-unspecified.pom'. Reason: Task ':publishPluginZipPublicationToZipStagingRepository' uses this output of task ':generatePomFileForNebulaPublication' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```
```
> Task :validatePluginZipPom FAILED
Execution optimizations have been disabled for task ':validatePluginZipPom' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/usr/share/opensearch/git/opensearch-plugin-template-java/build/distributions/rename-unspecified.pom'. Reason: Task ':validatePluginZipPom' uses this output of task ':generatePomFileForNebulaPublication' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
name is missing in [/usr/share/opensearch/git/opensearch-plugin-template-java/build/distributions/rename-unspecified.pom]
description is missing in [/usr/share/opensearch/git/opensearch-plugin-template-java/build/distributions/rename-unspecified.pom]
licenses is empty in [/usr/share/opensearch/git/opensearch-plugin-template-java/build/distributions/rename-unspecified.pom]
developers is empty in [/usr/share/opensearch/git/opensearch-plugin-template-java/build/distributions/rename-unspecified.pom]
Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
```
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/pull/3183
https://github.com/opensearch-project/opensearch-plugin-template-java/pull/31
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
