### PR TITLE
Fixing plugin installation URL to consume build qualifier

### DIFF
--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/InstallPluginCommand.java
@@ -374,7 +374,7 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
                 stagingHash
             );
         } else {
-            baseUrl = String.format(Locale.ROOT, "https://artifacts.opensearch.org/releases/plugins/%s/%s", pluginId, version);
+            baseUrl = String.format(Locale.ROOT, "https://artifacts.opensearch.org/releases/plugins/%s/%s", pluginId, Build.CURRENT.getQualifiedVersion());
         }
         final String platformUrl = String.format(
             Locale.ROOT,

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/InstallPluginCommand.java
@@ -374,7 +374,12 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
                 stagingHash
             );
         } else {
-            baseUrl = String.format(Locale.ROOT, "https://artifacts.opensearch.org/releases/plugins/%s/%s", pluginId, Build.CURRENT.getQualifiedVersion());
+            baseUrl = String.format(
+                Locale.ROOT,
+                "https://artifacts.opensearch.org/releases/plugins/%s/%s",
+                pluginId,
+                Build.CURRENT.getQualifiedVersion()
+            );
         }
         final String platformUrl = String.format(
             Locale.ROOT,

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
@@ -1049,7 +1049,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
 
     public void testOfficialPlugin() throws Exception {
         String url = "https://artifacts.opensearch.org/releases/plugins/analysis-icu/"
-            + Version.CURRENT
+            + Build.CURRENT.getQualifiedVersion()
             + "/analysis-icu-"
             + Build.CURRENT.getQualifiedVersion()
             + ".zip";
@@ -1093,7 +1093,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
 
     public void testOfficialPlatformPlugin() throws Exception {
         String url = "https://artifacts.opensearch.org/releases/plugins/analysis-icu/"
-            + Version.CURRENT
+            + Build.CURRENT.getQualifiedVersion()
             + "/analysis-icu-"
             + Platforms.PLATFORM_NAME
             + "-"
@@ -1159,7 +1159,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
 
     public void testOfficialChecksumWithoutFilename() throws Exception {
         String url = "https://artifacts.opensearch.org/releases/plugins/analysis-icu/"
-            + Version.CURRENT
+            + Build.CURRENT.getQualifiedVersion()
             + "/analysis-icu-"
             + Build.CURRENT.getQualifiedVersion()
             + ".zip";
@@ -1184,7 +1184,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
 
     public void testOfficialShaMissing() throws Exception {
         String url = "https://artifacts.opensearch.org/releases/plugins/analysis-icu/"
-            + Version.CURRENT
+            + Build.CURRENT.getQualifiedVersion()
             + "/analysis-icu-"
             + Build.CURRENT.getQualifiedVersion()
             + ".zip";
@@ -1229,7 +1229,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
 
     public void testInvalidShaFileMissingFilename() throws Exception {
         String url = "https://artifacts.opensearch.org/releases/plugins/analysis-icu/"
-            + Version.CURRENT
+            + Build.CURRENT.getQualifiedVersion()
             + "/analysis-icu-"
             + Build.CURRENT.getQualifiedVersion()
             + ".zip";
@@ -1254,7 +1254,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
 
     public void testInvalidShaFileMismatchFilename() throws Exception {
         String url = "https://artifacts.opensearch.org/releases/plugins/analysis-icu/"
-            + Version.CURRENT
+            + Build.CURRENT.getQualifiedVersion()
             + "/analysis-icu-"
             + Build.CURRENT.getQualifiedVersion()
             + ".zip";
@@ -1279,7 +1279,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
 
     public void testInvalidShaFileContainingExtraLine() throws Exception {
         String url = "https://artifacts.opensearch.org/releases/plugins/analysis-icu/"
-            + Version.CURRENT
+            + Build.CURRENT.getQualifiedVersion()
             + "/analysis-icu-"
             + Build.CURRENT.getQualifiedVersion()
             + ".zip";
@@ -1304,7 +1304,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
 
     public void testSha512Mismatch() throws Exception {
         String url = "https://artifacts.opensearch.org/releases/plugins/analysis-icu/"
-            + Version.CURRENT
+            + Build.CURRENT.getQualifiedVersion()
             + "/analysis-icu-"
             + Build.CURRENT.getQualifiedVersion()
             + ".zip";
@@ -1349,7 +1349,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
     public void testPublicKeyIdMismatchToExpectedPublicKeyId() throws Exception {
         final String icu = "analysis-icu";
         final String url = "https://artifacts.opensearch.org/releases/plugins/analysis-icu/"
-            + Version.CURRENT
+            + Build.CURRENT.getQualifiedVersion()
             + "/"
             + icu
             + "-"
@@ -1386,7 +1386,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
     public void testFailedSignatureVerification() throws Exception {
         final String icu = "analysis-icu";
         final String url = "https://artifacts.opensearch.org/releases/plugins/analysis-icu/"
-            + Version.CURRENT
+            + Build.CURRENT.getQualifiedVersion()
             + "/"
             + icu
             + "-"


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Plugin installation URL for official plugins do not consume build qualifier, causing problems with the folder structure we expose for `artifacts.opensearch.org`. 
This PR fixes it and consumes the build qualifier while populating the URL for native plugins.

Unit tests already cover this, but added manual testing into PR for readability. 

Before the fix:
```
opensearch-3.0.0-rc1 % ./bin/opensearch-plugin install repository-s3
-> Installing repository-s3
-> Downloading repository-s3 from opensearch
-> Failed installing repository-s3
-> Rolling back repository-s3
-> Rolled back repository-s3
Exception in thread "main" java.io.IOException: Server returned HTTP response code: 403 for URL: https://artifacts.opensearch.org/releases/plugins/repository-s3/3.0.0/repository-s3-3.0.0-rc1.zip
```

After the fix:
```
opensearch-3.0.0-rc1 % ./bin/opensearch-plugin install repository-s3
-> Installing repository-s3
-> Downloading repository-s3 from opensearch
-> Failed installing repository-s3
-> Rolling back repository-s3
-> Rolled back repository-s3
Exception in thread "main" java.io.IOException: Server returned HTTP response code: 403 for URL: https://artifacts.opensearch.org/releases/plugins/repository-s3/3.0.0-rc1/repository-s3-3.0.0-rc1.zip
```
 
### Issues Resolved
Closes #3168 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
