### PR TITLE
[Type removal] Remove _type deprecation from script and conditional processor

### DIFF
--- a/modules/ingest-common/src/main/java/org/opensearch/ingest/common/ScriptProcessor.java
+++ b/modules/ingest-common/src/main/java/org/opensearch/ingest/common/ScriptProcessor.java
@@ -64,12 +64,6 @@ import static org.opensearch.ingest.ConfigurationUtils.newConfigurationException
  */
 public final class ScriptProcessor extends AbstractProcessor {
 
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(DynamicMap.class);
-    private static final Map<String, Function<Object, Object>> PARAMS_FUNCTIONS = org.opensearch.common.collect.Map.of("_type", value -> {
-        deprecationLogger.deprecate("script_processor", "[types removal] Looking up doc types [_type] in scripts is deprecated.");
-        return value;
-    });
-
     public static final String TYPE = "script";
 
     private final Script script;
@@ -111,7 +105,7 @@ public final class ScriptProcessor extends AbstractProcessor {
         } else {
             ingestScript = precompiledIngestScript;
         }
-        ingestScript.execute(new DynamicMap(document.getSourceAndMetadata(), PARAMS_FUNCTIONS));
+        ingestScript.execute(document.getSourceAndMetadata());
         CollectionUtils.ensureNoSelfReferences(document.getSourceAndMetadata(), "ingest script");
         return document;
     }

--- a/modules/ingest-common/src/main/java/org/opensearch/ingest/common/ScriptProcessor.java
+++ b/modules/ingest-common/src/main/java/org/opensearch/ingest/common/ScriptProcessor.java
@@ -34,7 +34,6 @@ package org.opensearch.ingest.common;
 
 import org.opensearch.common.Nullable;
 import org.opensearch.common.bytes.BytesReference;
-import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.util.CollectionUtils;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
@@ -45,7 +44,6 @@ import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.ingest.AbstractProcessor;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.Processor;
-import org.opensearch.script.DynamicMap;
 import org.opensearch.script.IngestScript;
 import org.opensearch.script.Script;
 import org.opensearch.script.ScriptException;
@@ -55,7 +53,6 @@ import org.opensearch.script.ScriptType;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.opensearch.ingest.ConfigurationUtils.newConfigurationException;
 

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/ScriptProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/ScriptProcessorTests.java
@@ -105,24 +105,4 @@ public class ScriptProcessorTests extends OpenSearchTestCase {
         int bytesTotal = ingestDocument.getFieldValue("bytes_in", Integer.class) + ingestDocument.getFieldValue("bytes_out", Integer.class);
         assertThat(ingestDocument.getSourceAndMetadata().get("bytes_total"), is(bytesTotal));
     }
-
-    public void testTypeDeprecation() throws Exception {
-        String scriptName = "script";
-        ScriptService scriptService = new ScriptService(
-            Settings.builder().build(),
-            Collections.singletonMap(
-                Script.DEFAULT_SCRIPT_LANG,
-                new MockScriptEngine(Script.DEFAULT_SCRIPT_LANG, Collections.singletonMap(scriptName, ctx -> {
-                    ctx.get("_type");
-                    return null;
-                }), Collections.emptyMap())
-            ),
-            new HashMap<>(ScriptModule.CORE_CONTEXTS)
-        );
-        Script script = new Script(ScriptType.INLINE, Script.DEFAULT_SCRIPT_LANG, scriptName, Collections.emptyMap());
-        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
-        ScriptProcessor processor = new ScriptProcessor(randomAlphaOfLength(10), null, script, null, scriptService);
-        processor.execute(ingestDocument);
-        assertWarnings("[types removal] Looking up doc types [_type] in scripts is deprecated.");
-    }
 }

--- a/server/src/main/java/org/opensearch/ingest/ConditionalProcessor.java
+++ b/server/src/main/java/org/opensearch/ingest/ConditionalProcessor.java
@@ -64,15 +64,6 @@ import static org.opensearch.ingest.ConfigurationUtils.newConfigurationException
  */
 public class ConditionalProcessor extends AbstractProcessor implements WrappingProcessor {
 
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(DynamicMap.class);
-    private static final Map<String, Function<Object, Object>> FUNCTIONS = org.opensearch.common.collect.Map.of("_type", value -> {
-        deprecationLogger.deprecate(
-            "conditional-processor__type",
-            "[types removal] Looking up doc types [_type] in scripts is deprecated."
-        );
-        return value;
-    });
-
     static final String TYPE = "conditional";
 
     private final Script condition;
@@ -153,7 +144,7 @@ public class ConditionalProcessor extends AbstractProcessor implements WrappingP
             IngestConditionalScript.Factory factory = scriptService.compile(condition, IngestConditionalScript.CONTEXT);
             script = factory.newInstance(condition.getParams());
         }
-        return script.execute(new UnmodifiableIngestData(new DynamicMap(ingestDocument.getSourceAndMetadata(), FUNCTIONS)));
+        return script.execute(new UnmodifiableIngestData(ingestDocument.getSourceAndMetadata()));
     }
 
     public Processor getInnerProcessor() {

--- a/server/src/main/java/org/opensearch/ingest/ConditionalProcessor.java
+++ b/server/src/main/java/org/opensearch/ingest/ConditionalProcessor.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.ingest;
 
-import org.opensearch.common.logging.DeprecationLogger;
-import org.opensearch.script.DynamicMap;
 import org.opensearch.script.IngestConditionalScript;
 import org.opensearch.script.Script;
 import org.opensearch.script.ScriptException;
@@ -51,7 +49,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 

--- a/server/src/main/java/org/opensearch/script/UpdateScript.java
+++ b/server/src/main/java/org/opensearch/script/UpdateScript.java
@@ -44,12 +44,6 @@ import java.util.function.Function;
  */
 public abstract class UpdateScript {
 
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(DynamicMap.class);
-    private static final Map<String, Function<Object, Object>> PARAMS_FUNCTIONS = org.opensearch.common.collect.Map.of("_type", value -> {
-        deprecationLogger.deprecate("update-script", "[types removal] Looking up doc types [_type] in scripts is deprecated.");
-        return value;
-    });
-
     public static final String[] PARAMETERS = {};
 
     /** The context used to compile {@link UpdateScript} factories. */
@@ -63,7 +57,7 @@ public abstract class UpdateScript {
 
     public UpdateScript(Map<String, Object> params, Map<String, Object> ctx) {
         this.params = params;
-        this.ctx = new DynamicMap(ctx, PARAMS_FUNCTIONS);
+        this.ctx = ctx;
     }
 
     /** Return the parameters for this script. */

--- a/server/src/main/java/org/opensearch/script/UpdateScript.java
+++ b/server/src/main/java/org/opensearch/script/UpdateScript.java
@@ -32,10 +32,7 @@
 
 package org.opensearch.script;
 
-import org.opensearch.common.logging.DeprecationLogger;
-
 import java.util.Map;
-import java.util.function.Function;
 
 /**
  * An update script.


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
With removal of type in `2.0`, _type deprecation messages processor scripts is not required

Related with 
https://github.com/opensearch-project/OpenSearch/issues/2979
https://github.com/opensearch-project/OpenSearch/issues/3131


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
