### PR TITLE
[Javadocs] add to o.o.search.rescore,searchafter,slice, sort, and suggest

### DIFF
--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -99,6 +99,11 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.function.LongSupplier;
 
+/**
+ * The main search context used during search phase
+ *
+ * @opensearch.internal
+ */
 final class DefaultSearchContext extends SearchContext {
 
     private final ReaderContext readerContext;

--- a/server/src/main/java/org/opensearch/search/DocValueFormat.java
+++ b/server/src/main/java/org/opensearch/search/DocValueFormat.java
@@ -63,7 +63,11 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.function.LongSupplier;
 
-/** A formatter for values as returned by the fielddata/doc-values APIs. */
+/**
+ * A formatter for values as returned by the fielddata/doc-values APIs.
+ *
+ * @opensearch.internal
+ */
 public interface DocValueFormat extends NamedWriteable {
     long MASK_2_63 = 0x8000000000000000L;
     BigInteger BIGINTEGER_2_64_MINUS_ONE = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE); // 2^64 -1

--- a/server/src/main/java/org/opensearch/search/MultiValueMode.java
+++ b/server/src/main/java/org/opensearch/search/MultiValueMode.java
@@ -58,6 +58,8 @@ import java.util.Locale;
 
 /**
  * Defines what values to pick in the case a document contains multiple values for a particular field.
+ *
+ * @opensearch.internal
  */
 public enum MultiValueMode implements Writeable {
     /**

--- a/server/src/main/java/org/opensearch/search/RescoreDocIds.java
+++ b/server/src/main/java/org/opensearch/search/RescoreDocIds.java
@@ -45,6 +45,8 @@ import java.util.Set;
  * Since {@link org.opensearch.search.internal.SearchContext} no longer hold the states of search, the top K results
  * (i.e., documents that will be rescored by query rescorers) need to be serialized/ deserialized between search phases.
  * A {@link RescoreDocIds} encapsulates the top K results for each rescorer by its ordinal index.
+ *
+ * @opensearch.internal
  */
 public final class RescoreDocIds implements Writeable {
     public static final RescoreDocIds EMPTY = new RescoreDocIds(Collections.emptyMap());

--- a/server/src/main/java/org/opensearch/search/Scroll.java
+++ b/server/src/main/java/org/opensearch/search/Scroll.java
@@ -44,7 +44,7 @@ import java.util.Objects;
  * A scroll enables scrolling of search request. It holds a {@link #keepAlive()} time that
  * will control how long to keep the scrolling resources open.
  *
- *
+ * @opensearch.internal
  */
 public final class Scroll implements Writeable {
 

--- a/server/src/main/java/org/opensearch/search/SearchContextMissingException.java
+++ b/server/src/main/java/org/opensearch/search/SearchContextMissingException.java
@@ -40,6 +40,11 @@ import org.opensearch.search.internal.ShardSearchContextId;
 
 import java.io.IOException;
 
+/**
+ * Error thrown if no search context is available
+ *
+ * @opensearch.internal
+ */
 public class SearchContextMissingException extends OpenSearchException {
 
     private final ShardSearchContextId contextId;

--- a/server/src/main/java/org/opensearch/search/SearchContextSourcePrinter.java
+++ b/server/src/main/java/org/opensearch/search/SearchContextSourcePrinter.java
@@ -35,6 +35,11 @@ package org.opensearch.search;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.tasks.Task;
 
+/**
+ * Prints the search context source
+ *
+ * @opensearch.internal
+ */
 public class SearchContextSourcePrinter {
     private final SearchContext searchContext;
 

--- a/server/src/main/java/org/opensearch/search/SearchException.java
+++ b/server/src/main/java/org/opensearch/search/SearchException.java
@@ -39,6 +39,11 @@ import org.opensearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
+/**
+ * Error thrown if there is a problem during search
+ *
+ * @opensearch.internal
+ */
 public class SearchException extends OpenSearchException implements OpenSearchWrapperException {
 
     private final SearchShardTarget shardTarget;

--- a/server/src/main/java/org/opensearch/search/SearchExtBuilder.java
+++ b/server/src/main/java/org/opensearch/search/SearchExtBuilder.java
@@ -55,6 +55,8 @@ import org.opensearch.plugins.SearchPlugin.SearchExtSpec;
  * of the {@link SearchExtSpec}.
  *
  * @see SearchExtSpec
+ *
+ * @opensearch.internal
  */
 public abstract class SearchExtBuilder implements NamedWriteable, ToXContentFragment {
 

--- a/server/src/main/java/org/opensearch/search/SearchHit.java
+++ b/server/src/main/java/org/opensearch/search/SearchHit.java
@@ -90,6 +90,8 @@ import static org.opensearch.common.xcontent.XContentParserUtils.ensureFieldName
  * A single search hit.
  *
  * @see SearchHits
+ *
+ * @opensearch.internal
  */
 public final class SearchHit implements Writeable, ToXContentObject, Iterable<DocumentField> {
 

--- a/server/src/main/java/org/opensearch/search/SearchHits.java
+++ b/server/src/main/java/org/opensearch/search/SearchHits.java
@@ -54,6 +54,11 @@ import java.util.Objects;
 
 import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
+/**
+ * Encapsulates the results of a search operation
+ *
+ * @opensearch.internal
+ */
 public final class SearchHits implements Writeable, ToXContentFragment, Iterable<SearchHit> {
     public static SearchHits empty() {
         return empty(true);

--- a/server/src/main/java/org/opensearch/search/SearchModule.java
+++ b/server/src/main/java/org/opensearch/search/SearchModule.java
@@ -317,6 +317,8 @@ import static org.opensearch.index.query.CommonTermsQueryBuilder.COMMON_TERMS_QU
 
 /**
  * Sets up things that can be done at search time like queries, aggregations, and suggesters.
+ *
+ * @opensearch.internal
  */
 public class SearchModule {
     public static final Setting<Integer> INDICES_MAX_CLAUSE_COUNT_SETTING = Setting.intSetting(

--- a/server/src/main/java/org/opensearch/search/SearchParseException.java
+++ b/server/src/main/java/org/opensearch/search/SearchParseException.java
@@ -41,6 +41,11 @@ import org.opensearch.rest.RestStatus;
 
 import java.io.IOException;
 
+/**
+ * Main error thrown if there is a problem during parsing a query
+ *
+ * @opensearch.internal
+ */
 public class SearchParseException extends SearchException {
 
     public static final int UNKNOWN_POSITION = -1;

--- a/server/src/main/java/org/opensearch/search/SearchPhaseResult.java
+++ b/server/src/main/java/org/opensearch/search/SearchPhaseResult.java
@@ -50,6 +50,8 @@ import java.io.IOException;
  * request ID is particularly important since it is used to reference and maintain a context
  * across search phases to ensure the same point in time snapshot is used for querying and
  * fetching etc.
+ *
+ * @opensearch.internal
  */
 public abstract class SearchPhaseResult extends TransportResponse {
 

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -151,6 +151,11 @@ import static org.opensearch.common.unit.TimeValue.timeValueHours;
 import static org.opensearch.common.unit.TimeValue.timeValueMillis;
 import static org.opensearch.common.unit.TimeValue.timeValueMinutes;
 
+/**
+ * The main search service
+ *
+ * @opensearch.internal
+ */
 public class SearchService extends AbstractLifecycleComponent implements IndexEventListener {
     private static final Logger logger = LogManager.getLogger(SearchService.class);
 

--- a/server/src/main/java/org/opensearch/search/SearchShardTarget.java
+++ b/server/src/main/java/org/opensearch/search/SearchShardTarget.java
@@ -46,6 +46,8 @@ import java.util.Objects;
 
 /**
  * The target that the search request was executed on.
+ *
+ * @opensearch.internal
  */
 public final class SearchShardTarget implements Writeable, Comparable<SearchShardTarget> {
 

--- a/server/src/main/java/org/opensearch/search/SearchSortValues.java
+++ b/server/src/main/java/org/opensearch/search/SearchSortValues.java
@@ -47,6 +47,11 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 
+/**
+ * Values to sort during search
+ *
+ * @opensearch.internal
+ */
 public class SearchSortValues implements ToXContentFragment, Writeable {
 
     private static final Object[] EMPTY_ARRAY = new Object[0];

--- a/server/src/main/java/org/opensearch/search/SearchSortValuesAndFormats.java
+++ b/server/src/main/java/org/opensearch/search/SearchSortValuesAndFormats.java
@@ -41,6 +41,11 @@ import org.opensearch.common.lucene.Lucene;
 import java.io.IOException;
 import java.util.Arrays;
 
+/**
+ * Doc value and formats to sort during search
+ *
+ * @opensearch.internal
+ */
 public class SearchSortValuesAndFormats implements Writeable {
     private final Object[] rawSortValues;
     private final Object[] formattedSortValues;

--- a/server/src/main/java/org/opensearch/search/rescore/QueryRescoreMode.java
+++ b/server/src/main/java/org/opensearch/search/rescore/QueryRescoreMode.java
@@ -39,6 +39,11 @@ import org.opensearch.common.io.stream.Writeable;
 import java.io.IOException;
 import java.util.Locale;
 
+/**
+ * What mode the rescorer should operate in
+ *
+ * @opensearch.internal
+ */
 public enum QueryRescoreMode implements Writeable {
     Avg {
         @Override

--- a/server/src/main/java/org/opensearch/search/rescore/QueryRescorer.java
+++ b/server/src/main/java/org/opensearch/search/rescore/QueryRescorer.java
@@ -47,6 +47,12 @@ import java.util.Set;
 
 import static java.util.stream.Collectors.toSet;
 
+/**
+ * A concrete query rescorer used to re-rank the Top-K results of a previously
+ * executed search.
+ *
+ * @opensearch.internal
+ */
 public final class QueryRescorer implements Rescorer {
 
     public static final Rescorer INSTANCE = new QueryRescorer();

--- a/server/src/main/java/org/opensearch/search/rescore/QueryRescorerBuilder.java
+++ b/server/src/main/java/org/opensearch/search/rescore/QueryRescorerBuilder.java
@@ -50,6 +50,11 @@ import java.util.Objects;
 
 import static org.opensearch.index.query.AbstractQueryBuilder.parseInnerQueryBuilder;
 
+/**
+ * Builds a query rescorer object
+ *
+ * @opensearch.internal
+ */
 public class QueryRescorerBuilder extends RescorerBuilder<QueryRescorerBuilder> {
     public static final String NAME = "query";
 

--- a/server/src/main/java/org/opensearch/search/rescore/RescoreContext.java
+++ b/server/src/main/java/org/opensearch/search/rescore/RescoreContext.java
@@ -42,6 +42,8 @@ import java.util.Set;
  * Context available to the rescore while it is running. Rescore
  * implementations should extend this with any additional resources that
  * they will need while rescoring.
+ *
+ * @opensearch.internal
  */
 public class RescoreContext {
     private final int windowSize;

--- a/server/src/main/java/org/opensearch/search/rescore/RescorePhase.java
+++ b/server/src/main/java/org/opensearch/search/rescore/RescorePhase.java
@@ -42,6 +42,8 @@ import java.io.IOException;
 
 /**
  * Rescore phase of a search request, used to run potentially expensive scoring models against the top matching documents.
+ *
+ * @opensearch.internal
  */
 public class RescorePhase {
 

--- a/server/src/main/java/org/opensearch/search/rescore/Rescorer.java
+++ b/server/src/main/java/org/opensearch/search/rescore/Rescorer.java
@@ -45,6 +45,8 @@ import java.io.IOException;
  * Subclasses should borrow heavily from {@link QueryRescorer} because it is
  * fairly well behaved and documents that tradeoffs that it is making. There
  * is also an {@code ExampleRescorer} that is worth looking at.
+ *
+ * @opensearch.internal
  */
 public interface Rescorer {
     /**

--- a/server/src/main/java/org/opensearch/search/rescore/RescorerBuilder.java
+++ b/server/src/main/java/org/opensearch/search/rescore/RescorerBuilder.java
@@ -49,6 +49,8 @@ import java.util.Objects;
 
 /**
  * The abstract base builder for instances of {@link RescorerBuilder}.
+ *
+ * @opensearch.internal
  */
 public abstract class RescorerBuilder<RB extends RescorerBuilder<RB>>
     implements

--- a/server/src/main/java/org/opensearch/search/searchafter/SearchAfterBuilder.java
+++ b/server/src/main/java/org/opensearch/search/searchafter/SearchAfterBuilder.java
@@ -59,6 +59,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * Builds a search after object
+ *
+ * @opensearch.internal
+ */
 public class SearchAfterBuilder implements ToXContentObject, Writeable {
     public static final ParseField SEARCH_AFTER = new ParseField("search_after");
     private static final Object[] EMPTY_SORT_VALUES = new Object[0];

--- a/server/src/main/java/org/opensearch/search/slice/DocValuesSliceQuery.java
+++ b/server/src/main/java/org/opensearch/search/slice/DocValuesSliceQuery.java
@@ -52,6 +52,8 @@ import java.io.IOException;
  *
  * <b>NOTE</b>: With deterministic field values this query can be used across different readers safely.
  * If updates are accepted on the field you must ensure that the same reader is used for all `slice` queries.
+ *
+ * @opensearch.internal
  */
 public final class DocValuesSliceQuery extends SliceQuery {
     public DocValuesSliceQuery(String field, int id, int max) {

--- a/server/src/main/java/org/opensearch/search/slice/SliceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/slice/SliceBuilder.java
@@ -75,6 +75,8 @@ import java.util.Set;
  *  (instead of {@code numShards*numSlices}).
  *  Otherwise the provided field must be a numeric and doc_values must be enabled. In that case a
  *  {@link org.opensearch.search.slice.DocValuesSliceQuery} is used to filter the results.
+ *
+ *  @opensearch.internal
  */
 public class SliceBuilder implements Writeable, ToXContentObject {
 

--- a/server/src/main/java/org/opensearch/search/slice/SliceQuery.java
+++ b/server/src/main/java/org/opensearch/search/slice/SliceQuery.java
@@ -39,6 +39,8 @@ import java.util.Objects;
 
 /**
  * An abstract {@link Query} that defines an hash function to partition the documents in multiple slices.
+ *
+ * @opensearch.internal
  */
 public abstract class SliceQuery extends Query {
     private final String field;

--- a/server/src/main/java/org/opensearch/search/slice/TermsSliceQuery.java
+++ b/server/src/main/java/org/opensearch/search/slice/TermsSliceQuery.java
@@ -59,6 +59,8 @@ import java.io.IOException;
  * For each segment this filter enumerates the terms dictionary, computes the hash code for each term and fills
  * a bit set with the documents of all terms whose hash code matches the predicate.
  * <b>NOTE</b>: Documents with no value for that field are ignored.
+ *
+ * @opensearch.internal
  */
 public final class TermsSliceQuery extends SliceQuery {
     // Fixed seed for computing term hashCode

--- a/server/src/main/java/org/opensearch/search/sort/BucketedSort.java
+++ b/server/src/main/java/org/opensearch/search/sort/BucketedSort.java
@@ -92,6 +92,8 @@ import static java.util.Collections.emptyList;
  * (like {@link BigArrays#overSize(long)}) to get amortized linear number
  * of allocations and to play well with our paged arrays.
  * </p>
+ *
+ * @opensearch.internal
  */
 public abstract class BucketedSort implements Releasable {
     /**

--- a/server/src/main/java/org/opensearch/search/sort/FieldSortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/FieldSortBuilder.java
@@ -81,6 +81,8 @@ import static org.opensearch.search.sort.NestedSortBuilder.NESTED_FIELD;
 
 /**
  * A sort builder to sort based on a document field.
+ *
+ * @opensearch.internal
  */
 public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(FieldSortBuilder.class);

--- a/server/src/main/java/org/opensearch/search/sort/GeoDistanceSortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/GeoDistanceSortBuilder.java
@@ -84,6 +84,8 @@ import static org.opensearch.search.sort.NestedSortBuilder.NESTED_FIELD;
 
 /**
  * A geo distance based sorting on a geo point like field.
+ *
+ * @opensearch.internal
  */
 public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(GeoDistanceSortBuilder.class);

--- a/server/src/main/java/org/opensearch/search/sort/MinAndMax.java
+++ b/server/src/main/java/org/opensearch/search/sort/MinAndMax.java
@@ -43,6 +43,8 @@ import java.util.Objects;
 
 /**
  * A class that encapsulates a minimum and a maximum, that are of the same type and {@link Comparable}.
+ *
+ * @opensearch.internal
  */
 public class MinAndMax<T extends Comparable<? super T>> implements Writeable {
     private final T minValue;

--- a/server/src/main/java/org/opensearch/search/sort/NestedSortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/NestedSortBuilder.java
@@ -47,6 +47,11 @@ import java.util.Objects;
 
 import static org.opensearch.search.sort.SortBuilder.parseNestedFilter;
 
+/**
+ * Builds a sort on nested objects
+ *
+ * @opensearch.internal
+ */
 public class NestedSortBuilder implements Writeable, ToXContentObject {
     public static final ParseField NESTED_FIELD = new ParseField("nested");
     public static final ParseField PATH_FIELD = new ParseField("path");

--- a/server/src/main/java/org/opensearch/search/sort/ScoreSortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/ScoreSortBuilder.java
@@ -49,6 +49,8 @@ import java.util.Objects;
 
 /**
  * A sort builder allowing to sort by score.
+ *
+ * @opensearch.internal
  */
 public class ScoreSortBuilder extends SortBuilder<ScoreSortBuilder> {
 

--- a/server/src/main/java/org/opensearch/search/sort/ScriptSortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/ScriptSortBuilder.java
@@ -77,6 +77,8 @@ import static org.opensearch.search.sort.NestedSortBuilder.NESTED_FIELD;
 
 /**
  * Script sort builder allows to sort based on a custom script expression.
+ *
+ * @opensearch.internal
  */
 public class ScriptSortBuilder extends SortBuilder<ScriptSortBuilder> {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(ScriptSortBuilder.class);

--- a/server/src/main/java/org/opensearch/search/sort/SortAndFormats.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortAndFormats.java
@@ -34,6 +34,11 @@ package org.opensearch.search.sort;
 import org.apache.lucene.search.Sort;
 import org.opensearch.search.DocValueFormat;
 
+/**
+ * Utility class to hold sort and doc value format instances
+ *
+ * @opensearch.internal
+ */
 public final class SortAndFormats {
 
     public final Sort sort;

--- a/server/src/main/java/org/opensearch/search/sort/SortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortBuilder.java
@@ -60,6 +60,11 @@ import java.util.Optional;
 
 import static org.opensearch.index.query.AbstractQueryBuilder.parseInnerQueryBuilder;
 
+/**
+ * Base class for sort object builders
+ *
+ * @opensearch.internal
+ */
 public abstract class SortBuilder<T extends SortBuilder<T>> implements NamedWriteable, ToXContentObject, Rewriteable<SortBuilder<?>> {
 
     protected SortOrder order = SortOrder.ASC;

--- a/server/src/main/java/org/opensearch/search/sort/SortBuilders.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortBuilders.java
@@ -39,7 +39,7 @@ import org.opensearch.search.sort.ScriptSortBuilder.ScriptSortType;
 /**
  * A set of static factory methods for {@link SortBuilder}s.
  *
- *
+ * @opensearch.internal
  */
 public class SortBuilders {
 

--- a/server/src/main/java/org/opensearch/search/sort/SortFieldAndFormat.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortFieldAndFormat.java
@@ -36,6 +36,11 @@ import java.util.Objects;
 import org.apache.lucene.search.SortField;
 import org.opensearch.search.DocValueFormat;
 
+/**
+ * A holder for SortField and doc value format objects
+ *
+ * @opensearch.internal
+ */
 public final class SortFieldAndFormat {
 
     public final SortField field;

--- a/server/src/main/java/org/opensearch/search/sort/SortMode.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortMode.java
@@ -50,6 +50,8 @@ import java.util.Objects;
  * <li>avg - Use the average of all values as sort value. Only applicable for number based array fields.</li>
  * <li>median - Use the median of all values as sort value. Only applicable for number based array fields.</li>
  * </ul>
+ *
+ * @opensearch.internal
  */
 public enum SortMode implements Writeable {
     /** pick the lowest value **/

--- a/server/src/main/java/org/opensearch/search/sort/SortOrder.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortOrder.java
@@ -43,7 +43,7 @@ import java.util.Locale;
 /**
  * A sorting order.
  *
- *
+ * @opensearch.internal
  */
 public enum SortOrder implements Writeable {
     /**

--- a/server/src/main/java/org/opensearch/search/sort/SortParser.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortParser.java
@@ -12,6 +12,11 @@ import org.opensearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 
+/**
+ * A base parser interface for creating sort objects based on API requests
+ *
+ * @opensearch.internal
+ */
 @FunctionalInterface
 public interface SortParser<SB extends SortBuilder<SB>> {
     /**

--- a/server/src/main/java/org/opensearch/search/sort/SortValue.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortValue.java
@@ -45,6 +45,8 @@ import java.util.List;
 
 /**
  * A {@link Comparable}, {@link DocValueFormat} aware wrapper around a sort value.
+ *
+ * @opensearch.internal
  */
 public abstract class SortValue implements NamedWriteable, Comparable<SortValue> {
     /**

--- a/server/src/main/java/org/opensearch/search/suggest/DirectSpellcheckerSettings.java
+++ b/server/src/main/java/org/opensearch/search/suggest/DirectSpellcheckerSettings.java
@@ -41,6 +41,11 @@ import org.apache.lucene.util.automaton.LevenshteinAutomata;
 
 import java.util.Comparator;
 
+/**
+ * Settings for the direct spell checker
+ *
+ * @opensearch.internal
+ */
 public class DirectSpellcheckerSettings {
 
     // NB: If this changes, make sure to change the default in TermBuilderSuggester

--- a/server/src/main/java/org/opensearch/search/suggest/SortBy.java
+++ b/server/src/main/java/org/opensearch/search/suggest/SortBy.java
@@ -42,6 +42,8 @@ import java.util.Objects;
 
 /**
  * An enum representing the valid sorting options
+ *
+ * @opensearch.internal
  */
 public enum SortBy implements Writeable {
     /** Sort should first be based on score, then document frequency and then the term itself. */

--- a/server/src/main/java/org/opensearch/search/suggest/Suggest.java
+++ b/server/src/main/java/org/opensearch/search/suggest/Suggest.java
@@ -71,6 +71,8 @@ import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedT
 
 /**
  * Top level suggest result, containing the result for each suggestion.
+ *
+ * @opensearch.internal
  */
 public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? extends Option>>>, Writeable, ToXContentFragment {
 

--- a/server/src/main/java/org/opensearch/search/suggest/SuggestBuilder.java
+++ b/server/src/main/java/org/opensearch/search/suggest/SuggestBuilder.java
@@ -57,6 +57,8 @@ import java.util.Objects;
  * <p>
  * Suggesting works by suggesting terms/phrases that appear in the suggest text that are similar compared
  * to the terms in provided text. These suggestions are based on several options described in this class.
+ *
+ * @opensearch.internal
  */
 public class SuggestBuilder implements Writeable, ToXContentObject {
     protected static final ParseField GLOBAL_TEXT_FIELD = new ParseField("text");

--- a/server/src/main/java/org/opensearch/search/suggest/SuggestBuilders.java
+++ b/server/src/main/java/org/opensearch/search/suggest/SuggestBuilders.java
@@ -38,6 +38,8 @@ import org.opensearch.search.suggest.term.TermSuggestionBuilder;
 
 /**
  * A static factory for building suggester lookup queries
+ *
+ * @opensearch.internal
  */
 public abstract class SuggestBuilders {
 

--- a/server/src/main/java/org/opensearch/search/suggest/SuggestPhase.java
+++ b/server/src/main/java/org/opensearch/search/suggest/SuggestPhase.java
@@ -46,6 +46,8 @@ import java.util.Map;
 
 /**
  * Suggest phase of a search request, used to collect suggestions
+ *
+ * @opensearch.internal
  */
 public class SuggestPhase {
 

--- a/server/src/main/java/org/opensearch/search/suggest/Suggester.java
+++ b/server/src/main/java/org/opensearch/search/suggest/Suggester.java
@@ -37,6 +37,11 @@ import org.apache.lucene.util.CharsRefBuilder;
 
 import java.io.IOException;
 
+/**
+ * Base class used for all suggester implementations
+ *
+ * @opensearch.internal
+ */
 public abstract class Suggester<T extends SuggestionSearchContext.SuggestionContext> {
 
     protected abstract Suggest.Suggestion<? extends Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option>> innerExecute(

--- a/server/src/main/java/org/opensearch/search/suggest/SuggestionBuilder.java
+++ b/server/src/main/java/org/opensearch/search/suggest/SuggestionBuilder.java
@@ -53,6 +53,8 @@ import java.util.Objects;
 
 /**
  * Base class for the different suggestion implementations.
+ *
+ * @opensearch.internal
  */
 public abstract class SuggestionBuilder<T extends SuggestionBuilder<T>> implements NamedWriteable, ToXContentFragment {
 

--- a/server/src/main/java/org/opensearch/search/suggest/SuggestionSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/suggest/SuggestionSearchContext.java
@@ -38,6 +38,11 @@ import org.opensearch.index.query.QueryShardContext;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * Context used for suggestion based search
+ *
+ * @opensearch.internal
+ */
 public class SuggestionSearchContext {
 
     private final Map<String, SuggestionContext> suggestions = new LinkedHashMap<>(4);

--- a/server/src/main/java/org/opensearch/search/suggest/completion/CompletionStats.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/CompletionStats.java
@@ -42,6 +42,11 @@ import org.opensearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
+/**
+ * Stats for completion suggester
+ *
+ * @opensearch.internal
+ */
 public class CompletionStats implements Writeable, ToXContentFragment {
 
     private static final String COMPLETION = "completion";

--- a/server/src/main/java/org/opensearch/search/suggest/completion/CompletionSuggester.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/CompletionSuggester.java
@@ -51,6 +51,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * The completion suggester implementation
+ *
+ * @opensearch.internal
+ */
 public class CompletionSuggester extends Suggester<CompletionSuggestionContext> {
 
     public static final CompletionSuggester INSTANCE = new CompletionSuggester();

--- a/server/src/main/java/org/opensearch/search/suggest/completion/CompletionSuggestion.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/CompletionSuggestion.java
@@ -76,6 +76,7 @@ import static org.opensearch.search.suggest.Suggest.COMPARATOR;
  *     ..
  * }
  *
+ * @opensearch.internal
  */
 public final class CompletionSuggestion extends Suggest.Suggestion<CompletionSuggestion.Entry> {
 

--- a/server/src/main/java/org/opensearch/search/suggest/completion/CompletionSuggestionBuilder.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/CompletionSuggestionBuilder.java
@@ -67,6 +67,8 @@ import java.util.Objects;
  * for users as they type search terms. The implementation of the completion service uses FSTs that
  * are created at index-time and so must be defined in the mapping with the type "completion" before
  * indexing.
+ *
+ * @opensearch.internal
  */
 public class CompletionSuggestionBuilder extends SuggestionBuilder<CompletionSuggestionBuilder> {
 

--- a/server/src/main/java/org/opensearch/search/suggest/completion/CompletionSuggestionContext.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/CompletionSuggestionContext.java
@@ -44,6 +44,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Context used for the completion suggester
+ *
+ * @opensearch.internal
+ */
 public class CompletionSuggestionContext extends SuggestionSearchContext.SuggestionContext {
 
     protected CompletionSuggestionContext(QueryShardContext shardContext) {

--- a/server/src/main/java/org/opensearch/search/suggest/completion/FuzzyOptions.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/FuzzyOptions.java
@@ -49,6 +49,8 @@ import java.util.Objects;
 
 /**
  * Fuzzy options for completion suggester
+ *
+ * @opensearch.internal
  */
 public class FuzzyOptions implements ToXContentFragment, Writeable {
     static final ParseField FUZZY_OPTIONS = new ParseField("fuzzy");

--- a/server/src/main/java/org/opensearch/search/suggest/completion/RegexOptions.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/RegexOptions.java
@@ -49,6 +49,8 @@ import java.io.IOException;
 
 /**
  * Regular expression options for completion suggester
+ *
+ * @opensearch.internal
  */
 public class RegexOptions implements ToXContentFragment, Writeable {
     static final ParseField REGEX_OPTIONS = new ParseField("regex");

--- a/server/src/main/java/org/opensearch/search/suggest/completion/TopSuggestGroupDocsCollector.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/TopSuggestGroupDocsCollector.java
@@ -47,6 +47,8 @@ import java.util.Map;
  * This collector groups suggestions coming from the same document but matching different contexts
  * or surface form together. When different contexts or surface forms match the same suggestion form only
  * the best one per document (sorted by weight) is kept.
+ *
+ * @opensearch.internal
  **/
 class TopSuggestGroupDocsCollector extends TopSuggestDocsCollector {
     private Map<Integer, List<CharSequence>> docContexts = new HashMap<>();

--- a/server/src/main/java/org/opensearch/search/suggest/completion/context/CategoryContextMapping.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/context/CategoryContextMapping.java
@@ -61,6 +61,8 @@ import java.util.stream.Collectors;
  * category (string) value.
  * {@link CategoryQueryContext} defines options for constructing
  * a unit of query context for this context type
+ *
+ * @opensearch.internal
  */
 public class CategoryContextMapping extends ContextMapping<CategoryQueryContext> {
 

--- a/server/src/main/java/org/opensearch/search/suggest/completion/context/CategoryQueryContext.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/context/CategoryQueryContext.java
@@ -48,6 +48,8 @@ import static org.opensearch.search.suggest.completion.context.CategoryContextMa
 
 /**
  * Defines the query context for {@link CategoryContextMapping}
+ *
+ * @opensearch.internal
  */
 public final class CategoryQueryContext implements ToXContentObject {
     public static final String NAME = "category";

--- a/server/src/main/java/org/opensearch/search/suggest/completion/context/ContextBuilder.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/context/ContextBuilder.java
@@ -34,6 +34,8 @@ package org.opensearch.search.suggest.completion.context;
 
 /**
  * Builder for {@link ContextMapping}
+ *
+ * @opensearch.internal
  */
 public abstract class ContextBuilder<E extends ContextMapping<?>> {
 

--- a/server/src/main/java/org/opensearch/search/suggest/completion/context/ContextMapping.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/context/ContextMapping.java
@@ -57,6 +57,8 @@ import java.util.function.Function;
  * filter and/or boost suggestions at query time for {@link CompletionFieldMapper}.
  *
  * Implementations have to define how contexts are parsed at query/index time
+ *
+ * @opensearch.internal
  */
 public abstract class ContextMapping<T extends ToXContent> implements ToXContentFragment {
 

--- a/server/src/main/java/org/opensearch/search/suggest/completion/context/ContextMappings.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/context/ContextMappings.java
@@ -65,6 +65,8 @@ import static org.opensearch.search.suggest.completion.context.ContextMapping.FI
  * ContextMappings indexes context-enabled suggestion fields
  * and creates context queries for defined {@link ContextMapping}s
  * for a {@link CompletionFieldMapper}
+ *
+ * @opensearch.internal
  */
 public class ContextMappings implements ToXContent, Iterable<ContextMapping<?>> {
 

--- a/server/src/main/java/org/opensearch/search/suggest/completion/context/GeoContextMapping.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/context/GeoContextMapping.java
@@ -75,6 +75,8 @@ import static org.opensearch.geometry.utils.Geohash.stringEncode;
  *
  * {@link GeoQueryContext} defines the options for constructing
  * a unit of query context for this context type
+ *
+ * @opensearch.internal
  */
 public class GeoContextMapping extends ContextMapping<GeoQueryContext> {
 

--- a/server/src/main/java/org/opensearch/search/suggest/completion/context/GeoQueryContext.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/context/GeoQueryContext.java
@@ -54,6 +54,8 @@ import static org.opensearch.search.suggest.completion.context.GeoContextMapping
 
 /**
  * Defines the query context for {@link GeoContextMapping}
+ *
+ * @opensearch.internal
  */
 public final class GeoQueryContext implements ToXContentObject {
     public static final String NAME = "geo";

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/CandidateGenerator.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/CandidateGenerator.java
@@ -39,6 +39,12 @@ import org.opensearch.search.suggest.phrase.DirectCandidateGenerator.CandidateSe
 import java.io.IOException;
 
 //TODO public for tests
+
+/**
+ * Base class for phrase candidates
+ *
+ * @opensearch.internal
+ */
 public abstract class CandidateGenerator {
 
     public abstract boolean isKnownWord(BytesRef term) throws IOException;

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/CandidateScorer.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/CandidateScorer.java
@@ -37,6 +37,11 @@ import org.opensearch.search.suggest.phrase.DirectCandidateGenerator.CandidateSe
 
 import java.io.IOException;
 
+/**
+ * Scores phrase candidates
+ *
+ * @opensearch.internal
+ */
 final class CandidateScorer {
     private final WordScorer scorer;
     private final int maxNumCorrections;

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/Correction.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/Correction.java
@@ -38,6 +38,12 @@ import org.opensearch.search.suggest.phrase.DirectCandidateGenerator.Candidate;
 import java.util.Arrays;
 
 //TODO public for tests
+
+/**
+ * Correction in phrase suggester
+ *
+ * @opensearch.internal
+ */
 public final class Correction implements Comparable<Correction> {
 
     public static final Correction[] EMPTY = new Correction[0];

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/DirectCandidateGenerator.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/DirectCandidateGenerator.java
@@ -65,6 +65,11 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Math.round;
 
+/**
+ * Generates the phrase directly from the IndexReader
+ *
+ * @opensearch.internal
+ */
 public final class DirectCandidateGenerator extends CandidateGenerator {
 
     private final DirectSpellChecker spellchecker;

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/DirectCandidateGeneratorBuilder.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/DirectCandidateGeneratorBuilder.java
@@ -57,6 +57,11 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.function.Consumer;
 
+/**
+ * Builder for a phrase candidate directly retrieved from an IndexReader
+ *
+ * @opensearch.internal
+ */
 public final class DirectCandidateGeneratorBuilder implements CandidateGenerator {
 
     private static final String TYPE = "direct_generator";

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/Laplace.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/Laplace.java
@@ -54,6 +54,8 @@ import java.util.Objects;
  * href="http://en.wikipedia.org/wiki/N-gram#Smoothing_techniques">N-Gram
  * Smoothing</a> for details.
  * </p>
+ *
+ * @opensearch.internal
  */
 public final class Laplace extends SmoothingModel {
     public static final String NAME = "laplace";

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/LaplaceScorer.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/LaplaceScorer.java
@@ -38,6 +38,11 @@ import org.opensearch.search.suggest.phrase.DirectCandidateGenerator.Candidate;
 
 import java.io.IOException;
 
+/**
+ * Scorer implementation based on a laplace computation
+ *
+ * @opensearch.internal
+ */
 final class LaplaceScorer extends WordScorer {
     private double alpha;
 

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/LinearInterpolatingScorer.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/LinearInterpolatingScorer.java
@@ -38,7 +38,12 @@ import org.opensearch.search.suggest.phrase.DirectCandidateGenerator.Candidate;
 
 import java.io.IOException;
 
-//TODO public for tests
+/**
+ * Linear interpolation based scoring
+ *
+ * @opensearch.internal
+ */
+// TODO public for tests
 public final class LinearInterpolatingScorer extends WordScorer {
 
     private final double unigramLambda;

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/LinearInterpolation.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/LinearInterpolation.java
@@ -54,6 +54,8 @@ import java.util.Objects;
  * href="http://en.wikipedia.org/wiki/N-gram#Smoothing_techniques">N-Gram
  * Smoothing</a> for details.
  * </p>
+ *
+ * @opensearch.internal
  */
 public final class LinearInterpolation extends SmoothingModel {
     public static final String NAME = "linear";

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/MultiCandidateGeneratorWrapper.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/MultiCandidateGeneratorWrapper.java
@@ -39,7 +39,12 @@ import org.opensearch.search.suggest.phrase.DirectCandidateGenerator.CandidateSe
 import java.io.IOException;
 import java.util.Arrays;
 
-//TODO public for tests
+/**
+ * Wrapper for a multi-candidate generator
+ *
+ * @opensearch.internal
+ */
+// TODO public for tests
 public final class MultiCandidateGeneratorWrapper extends CandidateGenerator {
 
     private final CandidateGenerator[] candidateGenerator;

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/NoisyChannelSpellChecker.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/NoisyChannelSpellChecker.java
@@ -45,6 +45,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Spell checker based on a noisy channel
+ *
+ * @opensearch.internal
+ */
 final class NoisyChannelSpellChecker {
     public static final double REAL_WORD_LIKELIHOOD = 0.95d;
     public static final int DEFAULT_TOKEN_LIMIT = 10;

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/PhraseSuggester.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/PhraseSuggester.java
@@ -64,6 +64,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Phrase suggestion implementation
+ *
+ * @opensearch.internal
+ */
 public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
     private final BytesRef SEPARATOR = new BytesRef(" ");
     private static final String SUGGESTION_TEMPLATE_VAR_NAME = "suggestion";

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/PhraseSuggestion.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/PhraseSuggestion.java
@@ -50,6 +50,8 @@ import static org.opensearch.common.xcontent.ConstructingObjectParser.optionalCo
 
 /**
  * Suggestion entry returned from the {@link PhraseSuggester}.
+ *
+ * @opensearch.internal
  */
 public class PhraseSuggestion extends Suggest.Suggestion<PhraseSuggestion.Entry> {
 

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/PhraseSuggestionBuilder.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/PhraseSuggestionBuilder.java
@@ -68,6 +68,8 @@ import java.util.Set;
 
 /**
  * Defines the actual suggest command for phrase suggestions ( {@code phrase}).
+ *
+ * @opensearch.internal
  */
 public class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSuggestionBuilder> {
 

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/PhraseSuggestionContext.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/PhraseSuggestionContext.java
@@ -45,6 +45,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Context used during phrase suggestion
+ *
+ * @opensearch.internal
+ */
 class PhraseSuggestionContext extends SuggestionContext {
     static final boolean DEFAULT_COLLATE_PRUNE = false;
     static final boolean DEFAULT_REQUIRE_UNIGRAM = true;

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/SmoothingModel.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/SmoothingModel.java
@@ -41,6 +41,11 @@ import org.opensearch.search.suggest.phrase.WordScorer.WordScorerFactory;
 
 import java.io.IOException;
 
+/**
+ * Smooths the scoring calculation
+ *
+ * @opensearch.internal
+ */
 public abstract class SmoothingModel implements NamedWriteable, ToXContentFragment {
 
     @Override

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/StupidBackoff.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/StupidBackoff.java
@@ -55,6 +55,8 @@ import java.util.Objects;
  * href="http://en.wikipedia.org/wiki/N-gram#Smoothing_techniques">N-Gram
  * Smoothing</a> for details.
  * </p>
+ *
+ * @opensearch.internal
  */
 public final class StupidBackoff extends SmoothingModel {
     /**

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/StupidBackoffScorer.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/StupidBackoffScorer.java
@@ -38,6 +38,11 @@ import org.opensearch.search.suggest.phrase.DirectCandidateGenerator.Candidate;
 
 import java.io.IOException;
 
+/**
+ * naive backoff scorer
+ *
+ * @opensearch.internal
+ */
 class StupidBackoffScorer extends WordScorer {
     private final double discount;
 

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/WordScorer.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/WordScorer.java
@@ -44,7 +44,12 @@ import org.opensearch.search.suggest.phrase.DirectCandidateGenerator.CandidateSe
 
 import java.io.IOException;
 
-//TODO public for tests
+/**
+ * Scores by words
+ *
+ * @opensearch.internal
+ */
+// TODO public for tests
 public abstract class WordScorer {
     protected final IndexReader reader;
     protected final String field;

--- a/server/src/main/java/org/opensearch/search/suggest/term/TermSuggester.java
+++ b/server/src/main/java/org/opensearch/search/suggest/term/TermSuggester.java
@@ -49,6 +49,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * The Term Suggester implementation
+ *
+ * @opensearch.internal
+ */
 public final class TermSuggester extends Suggester<TermSuggestionContext> {
 
     public static final TermSuggester INSTANCE = new TermSuggester();

--- a/server/src/main/java/org/opensearch/search/suggest/term/TermSuggestion.java
+++ b/server/src/main/java/org/opensearch/search/suggest/term/TermSuggestion.java
@@ -54,6 +54,8 @@ import static org.opensearch.common.xcontent.ConstructingObjectParser.constructo
 
 /**
  * The suggestion responses corresponding with the suggestions in the request.
+ *
+ * @opensearch.internal
  */
 public class TermSuggestion extends Suggestion<TermSuggestion.Entry> {
 

--- a/server/src/main/java/org/opensearch/search/suggest/term/TermSuggestionBuilder.java
+++ b/server/src/main/java/org/opensearch/search/suggest/term/TermSuggestionBuilder.java
@@ -77,6 +77,8 @@ import static org.opensearch.search.suggest.phrase.DirectCandidateGeneratorBuild
  * Defines the actual suggest command. Each command uses the global options
  * unless defined in the suggestion itself. All options are the same as the
  * global options, but are only applicable for this suggestion.
+ *
+ * @opensearch.internal
  */
 public class TermSuggestionBuilder extends SuggestionBuilder<TermSuggestionBuilder> {
 

--- a/server/src/main/java/org/opensearch/search/suggest/term/TermSuggestionContext.java
+++ b/server/src/main/java/org/opensearch/search/suggest/term/TermSuggestionContext.java
@@ -35,6 +35,11 @@ import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.search.suggest.DirectSpellcheckerSettings;
 import org.opensearch.search.suggest.SuggestionSearchContext.SuggestionContext;
 
+/**
+ * Context used during term suggestion
+ *
+ * @opensearch.internal
+ */
 final class TermSuggestionContext extends SuggestionContext {
 
     private final DirectSpellcheckerSettings settings = new DirectSpellcheckerSettings();


### PR DESCRIPTION
Adds class level javadocs to org.opensearch.search, and
org.opensearch.search.rescore, searchAfter, slice, sort, and suggest
subpackages.

relates #221 
relates #2868 