### PR TITLE
[Javadocs] add to o.o.action, index, and transport

### DIFF
--- a/server/src/main/java/org/opensearch/action/DocWriteResponse.java
+++ b/server/src/main/java/org/opensearch/action/DocWriteResponse.java
@@ -391,6 +391,8 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
      * Base class of all {@link DocWriteResponse} builders. These {@link DocWriteResponse.Builder} are used during
      * xcontent parsing to temporarily store the parsed values, then the {@link Builder#build()} method is called to
      * instantiate the appropriate {@link DocWriteResponse} with the parsed values.
+     *
+     * @opensearch.internal
      */
     public abstract static class Builder {
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
@@ -112,6 +112,11 @@ public class TransportNodesHotThreadsAction extends TransportNodesAction<
         }
     }
 
+    /**
+     * Inner node request
+     *
+     * @opensearch.internal
+     */
     public static class NodeRequest extends BaseNodeRequest {
 
         NodesHotThreadsRequest request;

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
@@ -121,6 +121,11 @@ public class TransportNodesInfoAction extends TransportNodesAction<
         );
     }
 
+    /**
+     * Inner Node Info Request
+     *
+     * @opensearch.internal
+     */
     public static class NodeInfoRequest extends BaseNodeRequest {
 
         NodesInfoRequest request;

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponse.java
@@ -105,6 +105,11 @@ public class NodesReloadSecureSettingsResponse extends BaseNodesResponse<NodesRe
         }
     }
 
+    /**
+     * Inner Node Response
+     *
+     * @opensearch.internal
+     */
     public static class NodeResponse extends BaseNodeResponse {
 
         private Exception reloadException = null;

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/reload/TransportNodesReloadSecureSettingsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/reload/TransportNodesReloadSecureSettingsAction.java
@@ -183,6 +183,11 @@ public class TransportNodesReloadSecureSettingsAction extends TransportNodesActi
         }
     }
 
+    /**
+     * Inner Node Request
+     *
+     * @opensearch.internal
+     */
     public static class NodeRequest extends BaseNodeRequest {
 
         NodesReloadSecureSettingsRequest request;

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -122,6 +122,11 @@ public class TransportNodesStatsAction extends TransportNodesAction<
         );
     }
 
+    /**
+     * Inner Node Stats Request
+     *
+     * @opensearch.internal
+     */
     public static class NodeStatsRequest extends BaseNodeRequest {
 
         NodesStatsRequest request;

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/tasks/list/TaskGroup.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/tasks/list/TaskGroup.java
@@ -62,6 +62,11 @@ public class TaskGroup implements ToXContentObject {
         return new Builder(taskInfo);
     }
 
+    /**
+     * Builder for the Task Group
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
         private TaskInfo taskInfo;
         private List<Builder> childTasks;

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/usage/TransportNodesUsageAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/usage/TransportNodesUsageAction.java
@@ -112,6 +112,11 @@ public class TransportNodesUsageAction extends TransportNodesAction<
         return new NodeUsage(clusterService.localNode(), System.currentTimeMillis(), sinceTime, restUsage, aggsUsage);
     }
 
+    /**
+     * Inner Node Usage Request
+     *
+     * @opensearch.internal
+     */
     public static class NodeUsageRequest extends BaseNodeRequest {
 
         NodesUsageRequest request;

--- a/server/src/main/java/org/opensearch/action/admin/cluster/repositories/verify/VerifyRepositoryResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/repositories/verify/VerifyRepositoryResponse.java
@@ -60,6 +60,11 @@ public class VerifyRepositoryResponse extends ActionResponse implements ToXConte
     static final String NODES = "nodes";
     static final String NAME = "name";
 
+    /**
+     * Inner Node View
+     *
+     * @opensearch.internal
+     */
     public static class NodeView implements Writeable, ToXContentObject {
         private static final ObjectParser.NamedObjectParser<NodeView, Void> PARSER;
         static {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
@@ -214,6 +214,11 @@ public class TransportClusterRerouteAction extends TransportMasterNodeAction<Clu
         );
     }
 
+    /**
+     * Inner Reroute Response Acknowledged the Cluster State Update
+     *
+     * @opensearch.internal
+     */
     static class ClusterRerouteResponseAckedClusterStateUpdateTask extends AckedClusterStateUpdateTask<ClusterRerouteResponse> {
 
         private final ClusterRerouteRequest request;

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/SnapshotIndexShardStatus.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/SnapshotIndexShardStatus.java
@@ -166,6 +166,11 @@ public class SnapshotIndexShardStatus extends BroadcastShardResponse implements 
         out.writeOptionalString(failure);
     }
 
+    /**
+     * Inner Fields used for creating XContent and parsing
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String STAGE = "stage";
         static final String REASON = "reason";

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/SnapshotIndexStatus.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/SnapshotIndexStatus.java
@@ -124,6 +124,11 @@ public class SnapshotIndexStatus implements Iterable<SnapshotIndexShardStatus>, 
         return indexShards.values().iterator();
     }
 
+    /**
+     * Inner Fields used for creating XContent and parsing
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String SHARDS = "shards";
     }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/SnapshotShardsStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/SnapshotShardsStats.java
@@ -141,6 +141,11 @@ public class SnapshotShardsStats implements ToXContentObject {
         return totalShards;
     }
 
+    /**
+     * Inner Fields used for creating XContent and parsing
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String SHARDS_STATS = "shards_stats";
         static final String INITIALIZING = "initializing";

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/SnapshotStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/SnapshotStats.java
@@ -170,6 +170,11 @@ public class SnapshotStats implements Writeable, ToXContentObject {
         out.writeVLong(totalSize);
     }
 
+    /**
+     * Inner Fields used for creating XContent and parsing
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String STATS = "stats";
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -145,6 +145,11 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<
         }
     }
 
+    /**
+     * Inner Request
+     *
+     * @opensearch.internal
+     */
     public static class Request extends BaseNodesRequest<Request> {
 
         private Snapshot[] snapshots;
@@ -171,6 +176,11 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<
         }
     }
 
+    /**
+     * Inner Node Snapshot Status
+     *
+     * @opensearch.internal
+     */
     public static class NodesSnapshotStatus extends BaseNodesResponse<NodeSnapshotStatus> {
 
         public NodesSnapshotStatus(StreamInput in) throws IOException {
@@ -192,6 +202,11 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<
         }
     }
 
+    /**
+     * Inner Node Request
+     *
+     * @opensearch.internal
+     */
     public static class NodeRequest extends BaseNodeRequest {
 
         private final List<Snapshot> snapshots;
@@ -212,6 +227,11 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<
         }
     }
 
+    /**
+     * Inner Node Shapshot Status
+     *
+     * @opensearch.internal
+     */
     public static class NodeSnapshotStatus extends BaseNodeResponse {
 
         private final Map<Snapshot, Map<ShardId, SnapshotIndexShardStatus>> status;

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIndices.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIndices.java
@@ -149,6 +149,11 @@ public class ClusterStatsIndices implements ToXContentFragment {
         return analysis;
     }
 
+    /**
+     * Inner Fields used for creating XContent and parsing
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String COUNT = "count";
     }
@@ -172,6 +177,11 @@ public class ClusterStatsIndices implements ToXContentFragment {
         return builder;
     }
 
+    /**
+     * Inner Shard Stats
+     *
+     * @opensearch.internal
+     */
     public static class ShardStats implements ToXContentFragment {
 
         int indices;
@@ -316,6 +326,11 @@ public class ClusterStatsIndices implements ToXContentFragment {
             }
         }
 
+        /**
+         * Inner Fields used for creating XContent and parsing
+         *
+         * @opensearch.internal
+         */
         static final class Fields {
             static final String SHARDS = "shards";
             static final String TOTAL = "total";

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -150,6 +150,11 @@ public class ClusterStatsNodes implements ToXContentFragment {
         return plugins;
     }
 
+    /**
+     * Inner Fields used for creating XContent and parsing
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String COUNT = "count";
         static final String VERSIONS = "versions";
@@ -207,6 +212,11 @@ public class ClusterStatsNodes implements ToXContentFragment {
         return builder;
     }
 
+    /**
+     * Inner Counts
+     *
+     * @opensearch.internal
+     */
     public static class Counts implements ToXContentFragment {
         static final String COORDINATING_ONLY = "coordinating_only";
 
@@ -251,6 +261,11 @@ public class ClusterStatsNodes implements ToXContentFragment {
             return roles;
         }
 
+        /**
+         * Inner Fields used for creating XContent and parsing
+         *
+         * @opensearch.internal
+         */
         static final class Fields {
             static final String TOTAL = "total";
         }
@@ -265,6 +280,11 @@ public class ClusterStatsNodes implements ToXContentFragment {
         }
     }
 
+    /**
+     * Inner Operating System Stats
+     *
+     * @opensearch.internal
+     */
     public static class OsStats implements ToXContentFragment {
         final int availableProcessors;
         final int allocatedProcessors;
@@ -323,6 +343,11 @@ public class ClusterStatsNodes implements ToXContentFragment {
             return mem;
         }
 
+        /**
+         * Inner Fields used for creating XContent and parsing
+         *
+         * @opensearch.internal
+         */
         static final class Fields {
             static final String AVAILABLE_PROCESSORS = "available_processors";
             static final String ALLOCATED_PROCESSORS = "allocated_processors";
@@ -366,6 +391,11 @@ public class ClusterStatsNodes implements ToXContentFragment {
         }
     }
 
+    /**
+     * Inner Process Stats
+     *
+     * @opensearch.internal
+     */
     public static class ProcessStats implements ToXContentFragment {
 
         final int count;
@@ -436,6 +466,11 @@ public class ClusterStatsNodes implements ToXContentFragment {
             return minOpenFileDescriptors;
         }
 
+        /**
+         * Inner Fields used for creating XContent and parsing
+         *
+         * @opensearch.internal
+         */
         static final class Fields {
             static final String CPU = "cpu";
             static final String PERCENT = "percent";
@@ -459,6 +494,11 @@ public class ClusterStatsNodes implements ToXContentFragment {
         }
     }
 
+    /**
+     * Inner JVM Stats
+     *
+     * @opensearch.internal
+     */
     public static class JvmStats implements ToXContentFragment {
 
         private final ObjectIntHashMap<JvmVersion> versions;
@@ -532,6 +572,11 @@ public class ClusterStatsNodes implements ToXContentFragment {
             return new ByteSizeValue(heapMax);
         }
 
+        /**
+         * Inner Fields used for creating XContent and parsing
+         *
+         * @opensearch.internal
+         */
         static final class Fields {
             static final String VERSIONS = "versions";
             static final String VERSION = "version";
@@ -577,6 +622,11 @@ public class ClusterStatsNodes implements ToXContentFragment {
         }
     }
 
+    /**
+     * Inner JVM Version
+     *
+     * @opensearch.internal
+     */
     public static class JvmVersion {
         String version;
         String vmName;
@@ -614,6 +664,11 @@ public class ClusterStatsNodes implements ToXContentFragment {
         }
     }
 
+    /**
+     * Inner Network Types
+     *
+     * @opensearch.internal
+     */
     static class NetworkTypes implements ToXContentFragment {
 
         private final Map<String, AtomicInteger> transportTypes;
@@ -657,6 +712,11 @@ public class ClusterStatsNodes implements ToXContentFragment {
 
     }
 
+    /**
+     * Inner Discovery Types
+     *
+     * @opensearch.internal
+     */
     static class DiscoveryTypes implements ToXContentFragment {
 
         private final Map<String, AtomicInteger> discoveryTypes;
@@ -682,6 +742,11 @@ public class ClusterStatsNodes implements ToXContentFragment {
         }
     }
 
+    /**
+     * Inner Packaging Types
+     *
+     * @opensearch.internal
+     */
     static class PackagingTypes implements ToXContentFragment {
 
         private final Map<String, AtomicInteger> packagingTypes;
@@ -714,6 +779,11 @@ public class ClusterStatsNodes implements ToXContentFragment {
 
     }
 
+    /**
+     * Inner Ingest Stats
+     *
+     * @opensearch.internal
+     */
     static class IngestStats implements ToXContentFragment {
 
         final int pipelineCount;

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -211,6 +211,11 @@ public class TransportClusterStatsAction extends TransportNodesAction<
 
     }
 
+    /**
+     * Inner Cluster Stats Node Request
+     *
+     * @opensearch.internal
+     */
     public static class ClusterStatsNodeRequest extends BaseNodeRequest {
 
         ClusterStatsRequest request;

--- a/server/src/main/java/org/opensearch/action/admin/cluster/tasks/PendingClusterTasksResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/tasks/PendingClusterTasksResponse.java
@@ -113,6 +113,11 @@ public class PendingClusterTasksResponse extends ActionResponse implements Itera
         return builder;
     }
 
+    /**
+     * Inner Fields used for creating XContent and parsing
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
 
         static final String TASKS = "tasks";

--- a/server/src/main/java/org/opensearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -99,6 +99,8 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
 
     /**
      * Request to take one or more actions on one or more indexes and alias combinations.
+     *
+     * @opensearch.internal
      */
     public static class AliasActions implements AliasesRequest, Writeable, ToXContentObject {
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/analyze/AnalyzeAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/analyze/AnalyzeAction.java
@@ -76,6 +76,8 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
     /**
      * A request to analyze a text associated with a specific index. Allow to provide
      * the actual analyzer name to perform the analysis with.
+     *
+     * @opensearch.internal
      */
     public static class Request extends SingleShardRequest<Request> {
 
@@ -303,6 +305,11 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
 
     }
 
+    /**
+     * Inner Response
+     *
+     * @opensearch.internal
+     */
     public static class Response extends ActionResponse implements ToXContentObject {
 
         private final DetailAnalyzeResponse detail;
@@ -405,6 +412,11 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
             return Strings.toString(this, true, true);
         }
 
+        /**
+         * Inner Fields used for creating XContent and parsing
+         *
+         * @opensearch.internal
+         */
         static final class Fields {
             static final String TOKENS = "tokens";
 
@@ -412,6 +424,11 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
         }
     }
 
+    /**
+     * Inner Analyze Token
+     *
+     * @opensearch.internal
+     */
     public static class AnalyzeToken implements Writeable, ToXContentObject {
         private final String term;
         private final int startOffset;
@@ -545,6 +562,11 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
         }
     }
 
+    /**
+     * Inner Detail Analyze Response
+     *
+     * @opensearch.internal
+     */
     public static class DetailAnalyzeResponse implements Writeable, ToXContentFragment {
 
         private final boolean customAnalyzer;
@@ -707,6 +729,11 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
         }
     }
 
+    /**
+     * Inner Analyze Token List
+     *
+     * @opensearch.internal
+     */
     public static class AnalyzeTokenList implements Writeable, ToXContentObject {
         private final String name;
         private final AnalyzeToken[] tokens;
@@ -799,6 +826,11 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
         }
     }
 
+    /**
+     * Inner character filtered text
+     *
+     * @opensearch.internal
+     */
     public static class CharFilteredText implements Writeable, ToXContentObject {
         private final String name;
         private final String[] texts;

--- a/server/src/main/java/org/opensearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -467,6 +467,11 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
         return sb.toString();
     }
 
+    /**
+     * Inner Token Counter
+     *
+     * @opensearch.internal
+     */
     private static class TokenCounter {
         private int tokenCount = 0;
         private int maxTokenCount;
@@ -488,6 +493,11 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
         }
     }
 
+    /**
+     * Inner Token List Creator
+     *
+     * @opensearch.internal
+     */
     private static class TokenListCreator {
         int lastPosition = -1;
         int lastOffset = 0;

--- a/server/src/main/java/org/opensearch/action/admin/indices/close/CloseIndexResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/close/CloseIndexResponse.java
@@ -105,6 +105,11 @@ public class CloseIndexResponse extends ShardsAcknowledgedResponse {
         return Strings.toString(this);
     }
 
+    /**
+     * Inner index result
+     *
+     * @opensearch.internal
+     */
     public static class IndexResult implements Writeable, ToXContentFragment {
 
         private final Index index;
@@ -200,6 +205,11 @@ public class CloseIndexResponse extends ShardsAcknowledgedResponse {
         }
     }
 
+    /**
+     * Shard Result from Close Index Response
+     *
+     * @opensearch.internal
+     */
     public static class ShardResult implements Writeable, ToXContentFragment {
 
         private final int id;
@@ -253,6 +263,11 @@ public class CloseIndexResponse extends ShardsAcknowledgedResponse {
             return Strings.toString(this);
         }
 
+        /**
+         * Inner Failure if something goes wrong
+         *
+         * @opensearch.internal
+         */
         public static class Failure extends DefaultShardOperationFailedException {
 
             private @Nullable String nodeId;

--- a/server/src/main/java/org/opensearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
@@ -191,6 +191,11 @@ public class TransportVerifyShardBeforeCloseAction extends TransportReplicationA
         }
     }
 
+    /**
+     * Shard Request for verifying shards before closing
+     *
+     * @opensearch.internal
+     */
     public static class ShardRequest extends ReplicationRequest<ShardRequest> {
 
         private final ClusterBlock clusterBlock;

--- a/server/src/main/java/org/opensearch/action/admin/indices/create/AutoCreateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/create/AutoCreateAction.java
@@ -74,6 +74,11 @@ public final class AutoCreateAction extends ActionType<CreateIndexResponse> {
         super(NAME, CreateIndexResponse::new);
     }
 
+    /**
+     * Transport Action for Auto Create
+     *
+     * @opensearch.internal
+     */
     public static final class TransportAction extends TransportMasterNodeAction<CreateIndexRequest, CreateIndexResponse> {
 
         private final ActiveShardsObserver activeShardsObserver;

--- a/server/src/main/java/org/opensearch/action/admin/indices/dangling/list/ListDanglingIndicesResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/dangling/list/ListDanglingIndicesResponse.java
@@ -128,7 +128,13 @@ public class ListDanglingIndicesResponse extends BaseNodesResponse<NodeListDangl
         out.writeList(nodes);
     }
 
-    // visible for testing
+    /**
+     * Aggregates dangling index information
+     *
+     * NOTE: visible for testing
+     *
+     * @opensearch.internal
+     */
     static class AggregatedDanglingIndexInfo {
         private final String indexUUID;
         private final String indexName;

--- a/server/src/main/java/org/opensearch/action/admin/indices/datastream/CreateDataStreamAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/datastream/CreateDataStreamAction.java
@@ -72,6 +72,11 @@ public class CreateDataStreamAction extends ActionType<AcknowledgedResponse> {
         super(NAME, AcknowledgedResponse::new);
     }
 
+    /**
+     * Request for Creating Data Stream
+     *
+     * @opensearch.internal
+     */
     public static class Request extends AcknowledgedRequest<Request> implements IndicesRequest {
 
         private final String name;
@@ -124,6 +129,11 @@ public class CreateDataStreamAction extends ActionType<AcknowledgedResponse> {
         }
     }
 
+    /**
+     * Transport Action for Creating Data Stream
+     *
+     * @opensearch.internal
+     */
     public static class TransportAction extends TransportMasterNodeAction<Request, AcknowledgedResponse> {
 
         private final MetadataCreateDataStreamService metadataCreateDataStreamService;

--- a/server/src/main/java/org/opensearch/action/admin/indices/datastream/DataStreamsStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/datastream/DataStreamsStatsAction.java
@@ -92,6 +92,11 @@ public class DataStreamsStatsAction extends ActionType<DataStreamsStatsAction.Re
         super(NAME, DataStreamsStatsAction.Response::new);
     }
 
+    /**
+     * Request for Data Streams Stats
+     *
+     * @opensearch.internal
+     */
     public static class Request extends BroadcastRequest<Request> {
         public Request() {
             super((String[]) null);
@@ -102,6 +107,11 @@ public class DataStreamsStatsAction extends ActionType<DataStreamsStatsAction.Re
         }
     }
 
+    /**
+     * Response for Data Streams Stats
+     *
+     * @opensearch.internal
+     */
     public static class Response extends BroadcastResponse {
         private final int dataStreamCount;
         private final int backingIndices;
@@ -203,6 +213,11 @@ public class DataStreamsStatsAction extends ActionType<DataStreamsStatsAction.Re
         }
     }
 
+    /**
+     * The Data Streams Stats container
+     *
+     * @opensearch.internal
+     */
     public static class DataStreamStats implements ToXContentObject, Writeable {
         private final String dataStream;
         private final int backingIndices;
@@ -294,6 +309,11 @@ public class DataStreamsStatsAction extends ActionType<DataStreamsStatsAction.Re
         }
     }
 
+    /**
+     * Per Shard Data Stream stats
+     *
+     * @opensearch.internal
+     */
     public static class DataStreamShardStats implements Writeable {
         private final ShardRouting shardRouting;
         private final StoreStats storeStats;
@@ -331,12 +351,22 @@ public class DataStreamsStatsAction extends ActionType<DataStreamsStatsAction.Re
         }
     }
 
+    /**
+     * Aggregated data Stream stats
+     *
+     * @opensearch.internal
+     */
     private static class AggregatedStats {
         Set<String> backingIndices = new HashSet<>();
         long storageBytes = 0L;
         long maxTimestamp = 0L;
     }
 
+    /**
+     * Transport Action for Data Stream Stats
+     *
+     * @opensearch.internal
+     */
     public static class TransportAction extends TransportBroadcastByNodeAction<Request, Response, DataStreamShardStats> {
 
         private final ClusterService clusterService;

--- a/server/src/main/java/org/opensearch/action/admin/indices/datastream/DeleteDataStreamAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/datastream/DeleteDataStreamAction.java
@@ -89,6 +89,11 @@ public class DeleteDataStreamAction extends ActionType<AcknowledgedResponse> {
         super(NAME, AcknowledgedResponse::new);
     }
 
+    /**
+     * Request for deleting data streams
+     *
+     * @opensearch.internal
+     */
     public static class Request extends MasterNodeRequest<Request> implements IndicesRequest.Replaceable {
 
         private String[] names;
@@ -154,6 +159,11 @@ public class DeleteDataStreamAction extends ActionType<AcknowledgedResponse> {
         }
     }
 
+    /**
+     * Transport action for deleting data streams
+     *
+     * @opensearch.internal
+     */
     public static class TransportAction extends TransportMasterNodeAction<Request, AcknowledgedResponse> {
 
         private final MetadataDeleteIndexService deleteIndexService;

--- a/server/src/main/java/org/opensearch/action/admin/indices/datastream/GetDataStreamAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/datastream/GetDataStreamAction.java
@@ -87,6 +87,11 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
         super(NAME, Response::new);
     }
 
+    /**
+     * Request for getting data streams
+     *
+     * @opensearch.internal
+     */
     public static class Request extends MasterNodeReadRequest<Request> implements IndicesRequest.Replaceable {
 
         private String[] names;
@@ -148,9 +153,19 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
         }
     }
 
+    /**
+     * Response for getting data streams
+     *
+     * @opensearch.internal
+     */
     public static class Response extends ActionResponse implements ToXContentObject {
         public static final ParseField DATASTREAMS_FIELD = new ParseField("data_streams");
 
+        /**
+         * Data streams information
+         *
+         * @opensearch.internal
+         */
         public static class DataStreamInfo extends AbstractDiffable<DataStreamInfo> implements ToXContentObject {
 
             public static final ParseField STATUS_FIELD = new ParseField("status");
@@ -267,6 +282,11 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
         }
     }
 
+    /**
+     * Transport Action for getting data streams
+     *
+     * @opensearch.internal
+     */
     public static class TransportAction extends TransportMasterNodeReadAction<Request, Response> {
 
         private static final Logger logger = LogManager.getLogger(TransportAction.class);

--- a/server/src/main/java/org/opensearch/action/admin/indices/flush/TransportShardFlushAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/flush/TransportShardFlushAction.java
@@ -125,6 +125,11 @@ public class TransportShardFlushAction extends TransportReplicationAction<ShardF
     // TODO: Remove this transition in OpenSearch 3.0
     private static final String PRE_SYNCED_FLUSH_ACTION_NAME = "internal:indices/flush/synced/pre";
 
+    /**
+     * A Pre Shard Synced Flush Request
+     *
+     * @opensearch.internal
+     */
     private static class PreShardSyncedFlushRequest extends TransportRequest {
         private final ShardId shardId;
 
@@ -146,6 +151,11 @@ public class TransportShardFlushAction extends TransportReplicationAction<ShardF
         }
     }
 
+    /**
+     * Pre synced flush handler for the transport layer
+     *
+     * @opensearch.internal
+     */
     private static final class PreSyncedFlushTransportHandler implements TransportRequestHandler<PreShardSyncedFlushRequest> {
         private final IndicesService indicesService;
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/forcemerge/ForceMergeRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/forcemerge/ForceMergeRequest.java
@@ -59,6 +59,11 @@ import java.util.Arrays;
  */
 public class ForceMergeRequest extends BroadcastRequest<ForceMergeRequest> {
 
+    /**
+     * Defaults for the Force Merge Request
+     *
+     * @opensearch.internal
+     */
     public static final class Defaults {
         public static final int MAX_NUM_SEGMENTS = -1;
         public static final boolean ONLY_EXPUNGE_DELETES = false;

--- a/server/src/main/java/org/opensearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
@@ -175,6 +175,11 @@ public class GetFieldMappingsResponse extends ActionResponse implements ToXConte
         }
     }
 
+    /**
+     * Metadata for field mappings for toXContent
+     *
+     * @opensearch.internal
+     */
     public static class FieldMappingMetadata implements ToXContentFragment {
 
         private static final ParseField FULL_NAME = new ParseField("full_name");

--- a/server/src/main/java/org/opensearch/action/admin/indices/readonly/AddIndexBlockResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/readonly/AddIndexBlockResponse.java
@@ -95,6 +95,11 @@ public class AddIndexBlockResponse extends ShardsAcknowledgedResponse {
         return Strings.toString(this);
     }
 
+    /**
+     * Result for adding a block
+     *
+     * @opensearch.internal
+     */
     public static class AddBlockResult implements Writeable, ToXContentFragment {
 
         private final Index index;
@@ -190,6 +195,11 @@ public class AddIndexBlockResponse extends ShardsAcknowledgedResponse {
         }
     }
 
+    /**
+     * Per shard result for adding a block
+     *
+     * @opensearch.internal
+     */
     public static class AddBlockShardResult implements Writeable, ToXContentFragment {
 
         private final int id;
@@ -244,6 +254,11 @@ public class AddIndexBlockResponse extends ShardsAcknowledgedResponse {
             return Strings.toString(this);
         }
 
+        /**
+         * Contains failure information
+         *
+         * @opensearch.internal
+         */
         public static class Failure extends DefaultShardOperationFailedException {
 
             private @Nullable String nodeId;

--- a/server/src/main/java/org/opensearch/action/admin/indices/readonly/TransportVerifyShardIndexBlockAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/readonly/TransportVerifyShardIndexBlockAction.java
@@ -170,6 +170,8 @@ public class TransportVerifyShardIndexBlockAction extends TransportReplicationAc
      * A {@link ReplicasProxy} that marks as stale the shards that are unavailable during the verification
      * and the flush of the shard. This is done to ensure that such shards won't be later promoted as primary
      * or reopened in an unverified state with potential non flushed translog operations.
+     *
+     * @opensearch.internal
      */
     class VerifyShardReadOnlyActionReplicasProxy extends ReplicasProxy {
         @Override
@@ -183,6 +185,11 @@ public class TransportVerifyShardIndexBlockAction extends TransportReplicationAc
         }
     }
 
+    /**
+     * Per shard request
+     *
+     * @opensearch.internal
+     */
     public static class ShardRequest extends ReplicationRequest<ShardRequest> {
 
         private final ClusterBlock clusterBlock;

--- a/server/src/main/java/org/opensearch/action/admin/indices/resolve/ResolveIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/resolve/ResolveIndexAction.java
@@ -93,6 +93,11 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
         super(NAME, Response::new);
     }
 
+    /**
+     * Request for resolving an index
+     *
+     * @opensearch.internal
+     */
     public static class Request extends ActionRequest implements IndicesRequest.Replaceable {
 
         public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandOpen();
@@ -162,6 +167,11 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
         }
     }
 
+    /**
+     * Abstraction class for resolving an index
+     *
+     * @opensearch.internal
+     */
     public static class ResolvedIndexAbstraction {
 
         static final ParseField NAME_FIELD = new ParseField("name");
@@ -183,6 +193,11 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
         }
     }
 
+    /**
+     * The resolved index
+     *
+     * @opensearch.internal
+     */
     public static class ResolvedIndex extends ResolvedIndexAbstraction implements Writeable, ToXContentObject {
 
         static final ParseField ALIASES_FIELD = new ParseField("aliases");
@@ -266,6 +281,11 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
         }
     }
 
+    /**
+     * The resolved index alias
+     *
+     * @opensearch.internal
+     */
     public static class ResolvedAlias extends ResolvedIndexAbstraction implements Writeable, ToXContentObject {
 
         static final ParseField INDICES_FIELD = new ParseField("indices");
@@ -323,6 +343,11 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
         }
     }
 
+    /**
+     * The resolved data stream
+     *
+     * @opensearch.internal
+     */
     public static class ResolvedDataStream extends ResolvedIndexAbstraction implements Writeable, ToXContentObject {
 
         static final ParseField BACKING_INDICES_FIELD = new ParseField("backing_indices");
@@ -390,6 +415,11 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
         }
     }
 
+    /**
+     * Response for resolving an index
+     *
+     * @opensearch.internal
+     */
     public static class Response extends ActionResponse implements ToXContentObject {
 
         static final ParseField INDICES_FIELD = new ParseField("indices");
@@ -455,6 +485,11 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
         }
     }
 
+    /**
+     * Transport action for resolving an index
+     *
+     * @opensearch.internal
+     */
     public static class TransportAction extends HandledTransportAction<Request, Response> {
 
         private final ThreadPool threadPool;

--- a/server/src/main/java/org/opensearch/action/admin/indices/rollover/Condition.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/rollover/Condition.java
@@ -95,6 +95,8 @@ public abstract class Condition<T> implements NamedWriteable, ToXContentFragment
 
     /**
      * Holder for index stats used to evaluate conditions
+     *
+     * @opensearch.internal
      */
     public static class Stats {
         public final long numDocs;
@@ -110,6 +112,8 @@ public abstract class Condition<T> implements NamedWriteable, ToXContentFragment
 
     /**
      * Holder for evaluated condition result
+     *
+     * @opensearch.internal
      */
     public static class Result {
         public final Condition<?> condition;

--- a/server/src/main/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -94,6 +94,11 @@ public class MetadataRolloverService {
         this.indexNameExpressionResolver = indexNameExpressionResolver;
     }
 
+    /**
+     * Result for rollover request
+     *
+     * @opensearch.internal
+     */
     public static class RolloverResult {
         public final String rolloverIndexName;
         public final String sourceIndexName;

--- a/server/src/main/java/org/opensearch/action/admin/indices/segments/IndicesSegmentResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/segments/IndicesSegmentResponse.java
@@ -212,6 +212,11 @@ public class IndicesSegmentResponse extends BroadcastResponse {
         builder.endObject();
     }
 
+    /**
+     * Fields for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String INDICES = "indices";
         static final String SHARDS = "shards";

--- a/server/src/main/java/org/opensearch/action/admin/indices/shards/IndicesShardStoresResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/shards/IndicesShardStoresResponse.java
@@ -63,6 +63,8 @@ public class IndicesShardStoresResponse extends ActionResponse implements ToXCon
 
     /**
      * Shard store information from a node
+     *
+     * @opensearch.internal
      */
     public static class StoreStatus implements Writeable, ToXContentFragment, Comparable<StoreStatus> {
         private final DiscoveryNode node;
@@ -233,6 +235,8 @@ public class IndicesShardStoresResponse extends ActionResponse implements ToXCon
 
     /**
      * Single node failure while retrieving shard store information
+     *
+     * @opensearch.internal
      */
     public static class Failure extends DefaultShardOperationFailedException {
         private String nodeId;
@@ -369,6 +373,11 @@ public class IndicesShardStoresResponse extends ActionResponse implements ToXCon
         return builder;
     }
 
+    /**
+     * Fields for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String INDICES = "indices";
         static final String SHARDS = "shards";

--- a/server/src/main/java/org/opensearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
@@ -162,6 +162,11 @@ public class TransportIndicesShardStoresAction extends TransportMasterNodeReadAc
             .indicesBlockedException(ClusterBlockLevel.METADATA_READ, indexNameExpressionResolver.concreteIndexNames(state, request));
     }
 
+    /**
+     * Information for async shard stores
+     *
+     * @opensearch.internal
+     */
     private class AsyncShardStoresInfoFetches {
         private final DiscoveryNodes nodes;
         private final RoutingNodes routingNodes;
@@ -195,6 +200,11 @@ public class TransportIndicesShardStoresAction extends TransportMasterNodeReadAc
             }
         }
 
+        /**
+         * Internal async fetch
+         *
+         * @opensearch.internal
+         */
         private class InternalAsyncFetch extends AsyncShardFetch<NodeGatewayStartedShards> {
 
             InternalAsyncFetch(
@@ -309,6 +319,11 @@ public class TransportIndicesShardStoresAction extends TransportMasterNodeReadAc
                 // no-op
             }
 
+            /**
+             * Response for shard stores action
+             *
+             * @opensearch.internal
+             */
             public class Response {
                 private final ShardId shardId;
                 private final List<NodeGatewayStartedShards> responses;

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/IndexStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/IndexStats.java
@@ -132,6 +132,11 @@ public class IndexStats implements Iterable<IndexShardStats> {
         return stats;
     }
 
+    /**
+     * Builder for Index Stats
+     *
+     * @opensearch.internal
+     */
     public static class IndexStatsBuilder {
         private final String indexName;
         private final String uuid;

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/IndicesStatsResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/IndicesStatsResponse.java
@@ -213,6 +213,11 @@ public class IndicesStatsResponse extends BroadcastResponse {
         }
     }
 
+    /**
+     * Fields for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String INDICES = "indices";
         static final String SHARDS = "shards";

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/ShardStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/ShardStats.java
@@ -177,6 +177,11 @@ public class ShardStats implements Writeable, ToXContentFragment {
         return builder;
     }
 
+    /**
+     * Fields for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String ROUTING = "routing";
         static final String STATE = "state";

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/delete/DeleteComponentTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/delete/DeleteComponentTemplateAction.java
@@ -57,6 +57,11 @@ public class DeleteComponentTemplateAction extends ActionType<AcknowledgedRespon
         super(NAME, AcknowledgedResponse::new);
     }
 
+    /**
+     * Inner Request class for deleting component template
+     *
+     * @opensearch.internal
+     */
     public static class Request extends MasterNodeRequest<Request> {
 
         private String name;

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/delete/DeleteComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/delete/DeleteComposableIndexTemplateAction.java
@@ -58,6 +58,11 @@ public class DeleteComposableIndexTemplateAction extends ActionType<Acknowledged
         super(NAME, AcknowledgedResponse::new);
     }
 
+    /**
+     * Inner Request class for deleting composable index template
+     *
+     * @opensearch.internal
+     */
     public static class Request extends MasterNodeRequest<Request> {
 
         private String name;

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/get/GetComponentTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/get/GetComponentTemplateAction.java
@@ -64,6 +64,8 @@ public class GetComponentTemplateAction extends ActionType<GetComponentTemplateA
 
     /**
      * Request that to retrieve one or more component templates
+     *
+     * @opensearch.internal
      */
     public static class Request extends MasterNodeReadRequest<Request> {
 
@@ -108,6 +110,11 @@ public class GetComponentTemplateAction extends ActionType<GetComponentTemplateA
         }
     }
 
+    /**
+     * Inner response for getting component template
+     *
+     * @opensearch.internal
+     */
     public static class Response extends ActionResponse implements ToXContentObject {
         public static final ParseField NAME = new ParseField("name");
         public static final ParseField COMPONENT_TEMPLATES = new ParseField("component_templates");

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/get/GetComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/get/GetComposableIndexTemplateAction.java
@@ -64,6 +64,8 @@ public class GetComposableIndexTemplateAction extends ActionType<GetComposableIn
 
     /**
      * Request that to retrieve one or more index templates
+     *
+     * @opensearch.internal
      */
     public static class Request extends MasterNodeReadRequest<Request> {
 
@@ -125,6 +127,11 @@ public class GetComposableIndexTemplateAction extends ActionType<GetComposableIn
         }
     }
 
+    /**
+     * Inner response for getting composable index template
+     *
+     * @opensearch.internal
+     */
     public static class Response extends ActionResponse implements ToXContentObject {
         public static final ParseField NAME = new ParseField("name");
         public static final ParseField INDEX_TEMPLATES = new ParseField("index_templates");

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/post/SimulateTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/post/SimulateTemplateAction.java
@@ -59,6 +59,11 @@ public class SimulateTemplateAction extends ActionType<SimulateIndexTemplateResp
         super(NAME, SimulateIndexTemplateResponse::new);
     }
 
+    /**
+     * Request for simulating a template action
+     *
+     * @opensearch.internal
+     */
     public static class Request extends MasterNodeReadRequest<Request> {
 
         @Nullable

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/put/PutComponentTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/put/PutComponentTemplateAction.java
@@ -62,6 +62,8 @@ public class PutComponentTemplateAction extends ActionType<AcknowledgedResponse>
 
     /**
      * A request for putting a single component template into the cluster state
+     *
+     * @opensearch.internal
      */
     public static class Request extends MasterNodeRequest<Request> {
         private final String name;

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/put/PutComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/put/PutComposableIndexTemplateAction.java
@@ -67,6 +67,8 @@ public class PutComposableIndexTemplateAction extends ActionType<AcknowledgedRes
 
     /**
      * A request for putting a single index template into the cluster state
+     *
+     * @opensearch.internal
      */
     public static class Request extends MasterNodeRequest<Request> implements IndicesRequest {
         private final String name;

--- a/server/src/main/java/org/opensearch/action/admin/indices/upgrade/get/UpgradeStatusResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/upgrade/get/UpgradeStatusResponse.java
@@ -205,6 +205,11 @@ public class UpgradeStatusResponse extends BroadcastResponse {
         return builder;
     }
 
+    /**
+     * Fields for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String INDICES = "indices";
         static final String SHARDS = "shards";

--- a/server/src/main/java/org/opensearch/action/admin/indices/upgrade/post/UpgradeRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/upgrade/post/UpgradeRequest.java
@@ -49,6 +49,11 @@ import java.io.IOException;
  */
 public class UpgradeRequest extends BroadcastRequest<UpgradeRequest> {
 
+    /**
+     * Default config for Upgrade Requests
+     *
+     * @opensearch.internal
+     */
     public static final class Defaults {
         public static final boolean UPGRADE_ONLY_ANCIENT_SEGMENTS = false;
     }

--- a/server/src/main/java/org/opensearch/action/bulk/BackoffPolicy.java
+++ b/server/src/main/java/org/opensearch/action/bulk/BackoffPolicy.java
@@ -119,6 +119,11 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
         return delay;
     }
 
+    /**
+     * Concrete No Back Off Policy
+     *
+     * @opensearch.internal
+     */
     private static class NoBackoff extends BackoffPolicy {
         @Override
         public Iterator<TimeValue> iterator() {
@@ -136,6 +141,11 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
         }
     }
 
+    /**
+     * Concrete Exponential Back Off Policy
+     *
+     * @opensearch.internal
+     */
     private static class ExponentialBackoff extends BackoffPolicy {
         private final int start;
 
@@ -154,6 +164,11 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
         }
     }
 
+    /**
+     * Concrete Exponential Back Off Iterator
+     *
+     * @opensearch.internal
+     */
     private static class ExponentialBackoffIterator implements Iterator<TimeValue> {
         private final int numberOfElements;
 
@@ -182,6 +197,11 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
         }
     }
 
+    /**
+     * Concrete Constant Back Off Policy
+     *
+     * @opensearch.internal
+     */
     private static final class ConstantBackoff extends BackoffPolicy {
         private final TimeValue delay;
 
@@ -199,6 +219,11 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
         }
     }
 
+    /**
+     * Concrete Constant Back Off Iterator
+     *
+     * @opensearch.internal
+     */
     private static final class ConstantBackoffIterator implements Iterator<TimeValue> {
         private final TimeValue delay;
         private final int numberOfElements;
@@ -224,6 +249,11 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
         }
     }
 
+    /**
+     * Concrete Wrapped Back Off Policy
+     *
+     * @opensearch.internal
+     */
     private static final class WrappedBackoffPolicy extends BackoffPolicy {
         private final BackoffPolicy delegate;
         private final Runnable onBackoff;
@@ -239,6 +269,11 @@ public abstract class BackoffPolicy implements Iterable<TimeValue> {
         }
     }
 
+    /**
+     * Concrete Wrapped Back Off Iterator
+     *
+     * @opensearch.internal
+     */
     private static final class WrappedBackoffIterator implements Iterator<TimeValue> {
         private final Iterator<TimeValue> delegate;
         private final Runnable onBackoff;

--- a/server/src/main/java/org/opensearch/action/bulk/BulkItemResponse.java
+++ b/server/src/main/java/org/opensearch/action/bulk/BulkItemResponse.java
@@ -178,6 +178,8 @@ public class BulkItemResponse implements Writeable, StatusToXContentObject {
 
     /**
      * Represents a failure.
+     *
+     * @opensearch.internal
      */
     public static class Failure implements Writeable, ToXContentFragment {
         public static final String INDEX_FIELD = "index";

--- a/server/src/main/java/org/opensearch/action/bulk/BulkProcessor.java
+++ b/server/src/main/java/org/opensearch/action/bulk/BulkProcessor.java
@@ -94,6 +94,8 @@ public class BulkProcessor implements Closeable {
 
     /**
      * A builder used to create a build an instance of a bulk processor.
+     *
+     * @opensearch.internal
      */
     public static class Builder {
 
@@ -545,6 +547,11 @@ public class BulkProcessor implements Closeable {
         }
     }
 
+    /**
+     * Flush for bulk processor
+     *
+     * @opensearch.internal
+     */
     class Flush implements Runnable {
         @Override
         public void run() {

--- a/server/src/main/java/org/opensearch/action/bulk/Retry.java
+++ b/server/src/main/java/org/opensearch/action/bulk/Retry.java
@@ -94,6 +94,11 @@ public class Retry {
         return future;
     }
 
+    /**
+     * Retry handler
+     *
+     * @opensearch.internal
+     */
     static class RetryHandler implements ActionListener<BulkResponse> {
         private static final RestStatus RETRY_STATUS = RestStatus.TOO_MANY_REQUESTS;
         private static final Logger logger = LogManager.getLogger(RetryHandler.class);

--- a/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java
@@ -483,7 +483,9 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
     /**
      * retries on retryable cluster blocks, resolves item requests,
      * constructs shard bulk requests and delegates execution to shard bulk action
-     * */
+     *
+     * @opensearch.internal
+     */
     private final class BulkOperation extends ActionRunnable<BulkResponse> {
         private final Task task;
         private BulkRequest bulkRequest; // set to null once all requests are sent out
@@ -772,6 +774,11 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         new BulkOperation(task, bulkRequest, listener, responses, startTimeNanos, indicesThatCannotBeCreated).run();
     }
 
+    /**
+     * Concrete indices
+     *
+     * @opensearch.internal
+     */
     private static class ConcreteIndices {
         private final ClusterState state;
         private final IndexNameExpressionResolver indexNameExpressionResolver;
@@ -874,6 +881,11 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         );
     }
 
+    /**
+     * A modifier for a bulk request
+     *
+     * @opensearch.internal
+     */
     static final class BulkRequestModifier implements Iterator<DocWriteRequest<?>> {
 
         final BulkRequest bulkRequest;

--- a/server/src/main/java/org/opensearch/action/delete/DeleteResponse.java
+++ b/server/src/main/java/org/opensearch/action/delete/DeleteResponse.java
@@ -111,6 +111,8 @@ public class DeleteResponse extends DocWriteResponse {
      * Builder class for {@link DeleteResponse}. This builder is usually used during xcontent parsing to
      * temporarily store the parsed values, then the {@link DocWriteResponse.Builder#build()} method is called to
      * instantiate the {@link DeleteResponse}.
+     *
+     * @opensearch.internal
      */
     public static class Builder extends DocWriteResponse.Builder {
 

--- a/server/src/main/java/org/opensearch/action/fieldcaps/FieldCapabilities.java
+++ b/server/src/main/java/org/opensearch/action/fieldcaps/FieldCapabilities.java
@@ -298,6 +298,11 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
         return Strings.toString(this);
     }
 
+    /**
+     * Builder for field capabilities
+     *
+     * @opensearch.internal
+     */
     static class Builder {
         private String name;
         private String type;
@@ -387,6 +392,11 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
         }
     }
 
+    /**
+     * Inner index capabilities
+     *
+     * @opensearch.internal
+     */
     private static class IndexCaps {
         final String name;
         final boolean isSearchable;

--- a/server/src/main/java/org/opensearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
@@ -217,6 +217,8 @@ public class TransportFieldCapabilitiesIndexAction extends HandledTransportActio
      * An action that executes on each shard sequentially until it finds one that can match the provided
      * {@link FieldCapabilitiesIndexRequest#indexFilter()}. In which case the shard is used
      * to create the final {@link FieldCapabilitiesIndexResponse}.
+     *
+     * @opensearch.internal
      */
     class AsyncShardsAction {
         private final FieldCapabilitiesIndexRequest request;
@@ -341,6 +343,11 @@ public class TransportFieldCapabilitiesIndexAction extends HandledTransportActio
         }
     }
 
+    /**
+     * Shard transport handler for field capabilities index action
+     *
+     * @opensearch.internal
+     */
     private class ShardTransportHandler implements TransportRequestHandler<FieldCapabilitiesIndexRequest> {
         @Override
         public void messageReceived(final FieldCapabilitiesIndexRequest request, final TransportChannel channel, Task task)

--- a/server/src/main/java/org/opensearch/action/get/MultiGetRequest.java
+++ b/server/src/main/java/org/opensearch/action/get/MultiGetRequest.java
@@ -90,6 +90,8 @@ public class MultiGetRequest extends ActionRequest
 
     /**
      * A single get item.
+     *
+     * @opensearch.internal
      */
     public static class Item implements Writeable, IndicesRequest, ToXContentObject {
 

--- a/server/src/main/java/org/opensearch/action/get/MultiGetResponse.java
+++ b/server/src/main/java/org/opensearch/action/get/MultiGetResponse.java
@@ -66,6 +66,8 @@ public class MultiGetResponse extends ActionResponse implements Iterable<MultiGe
 
     /**
      * Represents a failure.
+     *
+     * @opensearch.internal
      */
     public static class Failure implements Writeable, ToXContentObject {
 

--- a/server/src/main/java/org/opensearch/action/index/IndexResponse.java
+++ b/server/src/main/java/org/opensearch/action/index/IndexResponse.java
@@ -114,6 +114,8 @@ public class IndexResponse extends DocWriteResponse {
      * Builder class for {@link IndexResponse}. This builder is usually used during xcontent parsing to
      * temporarily store the parsed values, then the {@link Builder#build()} method is called to
      * instantiate the {@link IndexResponse}.
+     *
+     * @opensearch.internal
      */
     public static class Builder extends DocWriteResponse.Builder {
         @Override

--- a/server/src/main/java/org/opensearch/action/ingest/SimulatePipelineRequest.java
+++ b/server/src/main/java/org/opensearch/action/ingest/SimulatePipelineRequest.java
@@ -130,6 +130,11 @@ public class SimulatePipelineRequest extends ActionRequest implements ToXContent
         return builder;
     }
 
+    /**
+     * Fields for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     public static final class Fields {
         static final String PIPELINE = "pipeline";
         static final String DOCS = "docs";

--- a/server/src/main/java/org/opensearch/action/ingest/SimulatePipelineResponse.java
+++ b/server/src/main/java/org/opensearch/action/ingest/SimulatePipelineResponse.java
@@ -178,6 +178,11 @@ public class SimulatePipelineResponse extends ActionResponse implements ToXConte
         return PARSER.apply(parser, null);
     }
 
+    /**
+     * Fields for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String DOCUMENTS = "docs";
     }

--- a/server/src/main/java/org/opensearch/action/resync/ResyncReplicationRequest.java
+++ b/server/src/main/java/org/opensearch/action/resync/ResyncReplicationRequest.java
@@ -43,7 +43,8 @@ import java.util.Objects;
 
 /**
  * Represents a batch of operations sent from the primary to its replicas during the primary-replica resync.
- * @opensearch.internal
+ *
+ *  @opensearch.internal
  */
 public final class ResyncReplicationRequest extends ReplicatedWriteRequest<ResyncReplicationRequest> {
 

--- a/server/src/main/java/org/opensearch/action/resync/TransportResyncReplicationAction.java
+++ b/server/src/main/java/org/opensearch/action/resync/TransportResyncReplicationAction.java
@@ -258,6 +258,8 @@ public class TransportResyncReplicationAction extends TransportWriteAction<
      * A proxy for primary-replica resync operations which are performed on replicas when a new primary is promoted.
      * Replica shards fail to execute resync operations will be failed but won't be marked as stale.
      * This avoids marking shards as stale during cluster restart but enforces primary-replica resync mandatory.
+     *
+     * @opensearch.internal
      */
     class ResyncActionReplicasProxy extends ReplicasProxy {
 

--- a/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
@@ -751,6 +751,11 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
         }
     }
 
+    /**
+     * Pending Executions
+     *
+     * @opensearch.internal
+     */
     private static final class PendingExecutions {
         private final int permits;
         private int permitsTaken = 0;

--- a/server/src/main/java/org/opensearch/action/search/CanMatchPreFilterSearchPhase.java
+++ b/server/src/main/java/org/opensearch/action/search/CanMatchPreFilterSearchPhase.java
@@ -204,6 +204,11 @@ final class CanMatchPreFilterSearchPhase extends AbstractSearchAsyncAction<CanMa
         return comparator.thenComparing(index -> shardsIts.get(index).shardId());
     }
 
+    /**
+     * Inner class for determining if canMatch search phase results
+     *
+     * @opensearch.internal
+     */
     private static final class CanMatchSearchPhaseResults extends SearchPhaseResults<CanMatchResponse> {
         private final FixedBitSet possibleMatches;
         private final MinAndMax<?>[] minAndMaxes;

--- a/server/src/main/java/org/opensearch/action/search/MultiSearchResponse.java
+++ b/server/src/main/java/org/opensearch/action/search/MultiSearchResponse.java
@@ -77,6 +77,8 @@ public class MultiSearchResponse extends ActionResponse implements Iterable<Mult
 
     /**
      * A search response item, holding the actual search response, or an error message if it failed.
+     *
+     * @opensearch.internal
      */
     public static class Item implements Writeable {
         private final SearchResponse response;
@@ -247,6 +249,11 @@ public class MultiSearchResponse extends ActionResponse implements Iterable<Mult
         return item;
     }
 
+    /**
+     * Fields for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String RESPONSES = "responses";
         static final String STATUS = "status";

--- a/server/src/main/java/org/opensearch/action/search/QueryPhaseResultConsumer.java
+++ b/server/src/main/java/org/opensearch/action/search/QueryPhaseResultConsumer.java
@@ -242,6 +242,11 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
         return pendingMerges.numReducePhases;
     }
 
+    /**
+     * Class representing pending merges
+     *
+     * @opensearch.internal
+     */
     private class PendingMerges implements Releasable {
         private final int batchReduceSize;
         private final List<QuerySearchResult> buffer = new ArrayList<>();
@@ -498,6 +503,11 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
         }
     }
 
+    /**
+     * A single merge result
+     *
+     * @opensearch.internal
+     */
     private static class MergeResult {
         private final List<SearchShard> processedShards;
         private final TopDocs reducedTopDocs;
@@ -517,6 +527,11 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
         }
     }
 
+    /**
+     * A single merge task
+     *
+     * @opensearch.internal
+     */
     private static class MergeTask {
         private final List<SearchShard> emptyResults;
         private QuerySearchResult[] buffer;

--- a/server/src/main/java/org/opensearch/action/search/SearchPhaseController.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchPhaseController.java
@@ -613,6 +613,11 @@ public final class SearchPhaseController {
             : source.from());
     }
 
+    /**
+     * The reduced query phase
+     *
+     * @opensearch.internal
+     */
     public static final class ReducedQueryPhase {
         // the sum of all hits across all reduces shards
         final TotalHits totalHits;
@@ -714,6 +719,11 @@ public final class SearchPhaseController {
         );
     }
 
+    /**
+     * The top docs statistics
+     *
+     * @opensearch.internal
+     */
     static final class TopDocsStats {
         final int trackTotalHitsUpTo;
         long totalHits;
@@ -778,6 +788,11 @@ public final class SearchPhaseController {
         }
     }
 
+    /**
+     * Top docs that have been sorted
+     *
+     * @opensearch.internal
+     */
     static final class SortedTopDocs {
         static final SortedTopDocs EMPTY = new SortedTopDocs(EMPTY_DOCS, false, null, null, null);
         // the searches merged top docs

--- a/server/src/main/java/org/opensearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchResponse.java
@@ -475,6 +475,8 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
     /**
      * Holds info about the clusters that the search was executed on: how many in total, how many of them were successful
      * and how many of them were skipped.
+     *
+     * @opensearch.internal
      */
     public static class Clusters implements ToXContentFragment, Writeable {
 

--- a/server/src/main/java/org/opensearch/action/search/SearchResponseMerger.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchResponseMerger.java
@@ -410,6 +410,11 @@ final class SearchResponseMerger {
         );
     }
 
+    /**
+     * Holds a field search hit and doc
+     *
+     * @opensearch.internal
+     */
     private static final class FieldDocAndSearchHit extends FieldDoc {
         private final SearchHit searchHit;
 
@@ -426,6 +431,8 @@ final class SearchResponseMerger {
      * (see TopDocs#tieBreakLessThan line 86). Generally, indices with same names on different clusters have different index uuids which
      * make their ShardIds different, which is not the case if the index is really the same one from the same cluster, in which case we
      * need to look at the cluster alias and make sure to assign a different shardIndex based on that.
+     *
+     * @opensearch.internal
      */
     private static final class ShardIdAndClusterAlias implements Comparable<ShardIdAndClusterAlias> {
         private final ShardId shardId;

--- a/server/src/main/java/org/opensearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchTransportService.java
@@ -309,6 +309,11 @@ public class SearchTransportService {
         return new HashMap<>(clientConnections);
     }
 
+    /**
+     * A scroll free context request
+     *
+     * @opensearch.internal
+     */
     static class ScrollFreeContextRequest extends TransportRequest {
         private ShardSearchContextId contextId;
 
@@ -333,6 +338,11 @@ public class SearchTransportService {
 
     }
 
+    /**
+     * A search free context request
+     *
+     * @opensearch.internal
+     */
     static class SearchFreeContextRequest extends ScrollFreeContextRequest implements IndicesRequest {
         private OriginalIndices originalIndices;
 
@@ -370,6 +380,11 @@ public class SearchTransportService {
 
     }
 
+    /**
+     * A search free context response
+     *
+     * @opensearch.internal
+     */
     public static class SearchFreeContextResponse extends TransportResponse {
 
         private boolean freed;
@@ -564,6 +579,11 @@ public class SearchTransportService {
         }
     }
 
+    /**
+     * A handler that counts connections
+     *
+     * @opensearch.internal
+     */
     final class ConnectionCountingHandler<Response extends TransportResponse> extends ActionListenerResponseHandler<Response> {
         private final Map<String, Long> clientConnections;
         private final String nodeId;

--- a/server/src/main/java/org/opensearch/action/search/TransportMultiSearchAction.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportMultiSearchAction.java
@@ -220,6 +220,11 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
         });
     }
 
+    /**
+     * Slots a search request
+     *
+     * @opensearch.internal
+     */
     static final class SearchRequestSlot {
 
         final SearchRequest request;

--- a/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
@@ -232,6 +232,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
      * clock for measuring how long an operation took (they often lack precision, they are subject
      * to moving backwards due to NTP and other such complexities, etc.). There are also issues with
      * using a relative clock for reporting real time. Thus, we simply separate these two uses.
+     *
+     * @opensearch.internal
      */
     static final class SearchTimeProvider {
 
@@ -1222,6 +1224,11 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         }
     }
 
+    /**
+     * xcluster search listener
+     *
+     * @opensearch.internal
+     */
     abstract static class CCSActionListener<Response, FinalResponse> implements ActionListener<Response> {
         private final String clusterAlias;
         private final boolean skipUnavailable;

--- a/server/src/main/java/org/opensearch/action/support/AutoCreateIndex.java
+++ b/server/src/main/java/org/opensearch/action/support/AutoCreateIndex.java
@@ -144,6 +144,11 @@ public final class AutoCreateIndex {
         this.autoCreate = autoCreate;
     }
 
+    /**
+     * An auto create object
+     *
+     * @opensearch.internal
+     */
     static class AutoCreate {
         private final boolean autoCreateIndex;
         private final List<Tuple<String, Boolean>> expressions;

--- a/server/src/main/java/org/opensearch/action/support/HandledTransportAction.java
+++ b/server/src/main/java/org/opensearch/action/support/HandledTransportAction.java
@@ -90,6 +90,11 @@ public abstract class HandledTransportAction<Request extends ActionRequest, Resp
         transportService.registerRequestHandler(actionName, executor, false, canTripCircuitBreaker, requestReader, new TransportHandler());
     }
 
+    /**
+     * Inner transport handler
+     *
+     * @opensearch.internal
+     */
     class TransportHandler implements TransportRequestHandler<Request> {
         @Override
         public final void messageReceived(final Request request, final TransportChannel channel, Task task) {

--- a/server/src/main/java/org/opensearch/action/support/ListenerTimeouts.java
+++ b/server/src/main/java/org/opensearch/action/support/ListenerTimeouts.java
@@ -96,6 +96,11 @@ public class ListenerTimeouts {
         return wrappedListener;
     }
 
+    /**
+     * Listener that can time out
+     *
+     * @opensearch.internal
+     */
     private static class TimeoutableListener<Response> implements ActionListener<Response>, Runnable {
 
         private final AtomicBoolean isDone = new AtomicBoolean(false);

--- a/server/src/main/java/org/opensearch/action/support/TimeoutTaskCancellationUtility.java
+++ b/server/src/main/java/org/opensearch/action/support/TimeoutTaskCancellationUtility.java
@@ -104,6 +104,8 @@ public class TimeoutTaskCancellationUtility {
      * Timeout listener which executes the provided runnable after timeout is expired and if a response/failure is not yet received.
      * If either a response/failure is received before timeout then the scheduled task is cancelled and response/failure is sent back to
      * the original listener.
+     *
+     * @opensearch.internal
      */
     private static class TimeoutRunnableListener<Response> implements ActionListener<Response>, Runnable {
 

--- a/server/src/main/java/org/opensearch/action/support/TransportAction.java
+++ b/server/src/main/java/org/opensearch/action/support/TransportAction.java
@@ -176,6 +176,11 @@ public abstract class TransportAction<Request extends ActionRequest, Response ex
 
     protected abstract void doExecute(Task task, Request request, ActionListener<Response> listener);
 
+    /**
+     * A request filter chain
+     *
+     * @opensearch.internal
+     */
     private static class RequestFilterChain<Request extends ActionRequest, Response extends ActionResponse>
         implements
             ActionFilterChain<Request, Response> {
@@ -210,6 +215,8 @@ public abstract class TransportAction<Request extends ActionRequest, Response ex
 
     /**
      * Wrapper for an action listener that stores the result at the end of the execution
+     *
+     * @opensearch.internal
      */
     private static class TaskResultStoringActionListener<Response extends ActionResponse> implements ActionListener<Response> {
         private final ActionListener<Response> delegate;

--- a/server/src/main/java/org/opensearch/action/support/broadcast/TransportBroadcastAction.java
+++ b/server/src/main/java/org/opensearch/action/support/broadcast/TransportBroadcastAction.java
@@ -124,6 +124,11 @@ public abstract class TransportBroadcastAction<
 
     protected abstract ClusterBlockException checkRequestBlock(ClusterState state, Request request, String[] concreteIndices);
 
+    /**
+     * Asynchronous broadcast action
+     *
+     * @opensearch.internal
+     */
     protected class AsyncBroadcastAction {
 
         private final Task task;
@@ -320,6 +325,11 @@ public abstract class TransportBroadcastAction<
         }
     }
 
+    /**
+     * A shard transport handler
+     *
+     * @opensearch.internal
+     */
     class ShardTransportHandler implements TransportRequestHandler<ShardRequest> {
 
         @Override

--- a/server/src/main/java/org/opensearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -273,6 +273,11 @@ public abstract class TransportBroadcastByNodeAction<
         new AsyncAction(task, request, listener).start();
     }
 
+    /**
+     * Asynchronous action
+     *
+     * @opensearch.internal
+     */
     protected class AsyncAction {
         private final Task task;
         private final Request request;
@@ -443,6 +448,11 @@ public abstract class TransportBroadcastByNodeAction<
         }
     }
 
+    /**
+     * Broadcast by a node's transport request handler
+     *
+     * @opensearch.internal
+     */
     class BroadcastByNodeTransportRequestHandler implements TransportRequestHandler<NodeRequest> {
         @Override
         public void messageReceived(final NodeRequest request, TransportChannel channel, Task task) throws Exception {
@@ -522,6 +532,11 @@ public abstract class TransportBroadcastByNodeAction<
         }
     }
 
+    /**
+     * A node request
+     *
+     * @opensearch.internal
+     */
     public class NodeRequest extends TransportRequest implements IndicesRequest {
         private String nodeId;
 
@@ -569,6 +584,11 @@ public abstract class TransportBroadcastByNodeAction<
         }
     }
 
+    /**
+     * A node response
+     *
+     * @opensearch.internal
+     */
     class NodeResponse extends TransportResponse {
         protected String nodeId;
         protected int totalShards;
@@ -633,6 +653,8 @@ public abstract class TransportBroadcastByNodeAction<
     /**
      * Can be used for implementations of {@link #shardOperation(BroadcastRequest, ShardRouting) shardOperation} for
      * which there is no shard-level return value.
+     *
+     * @opensearch.internal
      */
     public static final class EmptyResult implements Writeable {
         public static EmptyResult INSTANCE = new EmptyResult();

--- a/server/src/main/java/org/opensearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/master/TransportMasterNodeAction.java
@@ -142,6 +142,11 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
         new AsyncSingleAction(task, request, listener).doStart(state);
     }
 
+    /**
+     * Asynchronous single action
+     *
+     * @opensearch.internal
+     */
     class AsyncSingleAction {
 
         private final ActionListener<Response> listener;

--- a/server/src/main/java/org/opensearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/opensearch/action/support/nodes/TransportNodesAction.java
@@ -216,6 +216,11 @@ public abstract class TransportNodesAction<
         return transportNodeAction;
     }
 
+    /**
+     * Asynchronous action
+     *
+     * @opensearch.internal
+     */
     class AsyncAction {
 
         private final NodesRequest request;
@@ -311,6 +316,11 @@ public abstract class TransportNodesAction<
         }
     }
 
+    /**
+     * A node transport handler
+     *
+     * @opensearch.internal
+     */
     class NodeTransportHandler implements TransportRequestHandler<NodeRequest> {
 
         @Override

--- a/server/src/main/java/org/opensearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/opensearch/action/support/replication/ReplicationOperation.java
@@ -596,6 +596,11 @@ public class ReplicationOperation<
 
     }
 
+    /**
+     * Thrown if there are any errors retrying on primary
+     *
+     * @opensearch.internal
+     */
     public static class RetryOnPrimaryException extends OpenSearchException {
         RetryOnPrimaryException(ShardId shardId, String msg) {
             this(shardId, msg, null);

--- a/server/src/main/java/org/opensearch/action/support/replication/ReplicationResponse.java
+++ b/server/src/main/java/org/opensearch/action/support/replication/ReplicationResponse.java
@@ -85,6 +85,11 @@ public class ReplicationResponse extends ActionResponse {
         this.shardInfo = shardInfo;
     }
 
+    /**
+     * Holds shard information
+     *
+     * @opensearch.internal
+     */
     public static class ShardInfo implements Writeable, ToXContentObject {
 
         private static final String TOTAL = "total";
@@ -227,6 +232,11 @@ public class ReplicationResponse extends ActionResponse {
             return "ShardInfo{" + "total=" + total + ", successful=" + successful + ", failures=" + Arrays.toString(failures) + '}';
         }
 
+        /**
+         * Holds failure information
+         *
+         * @opensearch.internal
+         */
         public static class Failure extends ShardOperationFailedException implements ToXContentObject {
 
             private static final String _INDEX = "_index";

--- a/server/src/main/java/org/opensearch/action/support/replication/ReplicationTask.java
+++ b/server/src/main/java/org/opensearch/action/support/replication/ReplicationTask.java
@@ -75,6 +75,11 @@ public class ReplicationTask extends Task {
         return new Status(phase);
     }
 
+    /**
+     * Status of the replication task
+     *
+     * @opensearch.internal
+     */
     public static class Status implements Task.Status {
         public static final String NAME = "replication";
 

--- a/server/src/main/java/org/opensearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/opensearch/action/support/replication/TransportReplicationAction.java
@@ -386,6 +386,11 @@ public abstract class TransportReplicationAction<
         return () -> {};
     }
 
+    /**
+     * Asynchronous primary action
+     *
+     * @opensearch.internal
+     */
     class AsyncPrimaryAction extends AbstractRunnable {
         private final ActionListener<Response> onCompletionListener;
         private final ReplicationTask replicationTask;
@@ -554,6 +559,11 @@ public abstract class TransportReplicationAction<
 
     }
 
+    /**
+     * The Primary Result
+     *
+     * @opensearch.internal
+     */
     public static class PrimaryResult<ReplicaRequest extends ReplicationRequest<ReplicaRequest>, Response extends ReplicationResponse>
         implements
             ReplicationOperation.PrimaryResult<ReplicaRequest> {
@@ -603,6 +613,11 @@ public abstract class TransportReplicationAction<
         }
     }
 
+    /**
+     * The replica result
+     *
+     * @opensearch.internal
+     */
     public static class ReplicaResult {
         final Exception finalFailure;
 
@@ -645,6 +660,11 @@ public abstract class TransportReplicationAction<
         return () -> {};
     }
 
+    /**
+     * Thrown if there are any errors retrying on the replica
+     *
+     * @opensearch.internal
+     */
     public static class RetryOnReplicaException extends OpenSearchException {
 
         public RetryOnReplicaException(ShardId shardId, String msg) {
@@ -657,6 +677,11 @@ public abstract class TransportReplicationAction<
         }
     }
 
+    /**
+     * Asynchronous replica action
+     *
+     * @opensearch.internal
+     */
     private final class AsyncReplicaAction extends AbstractRunnable implements ActionListener<Releasable> {
         private final ActionListener<ReplicaResponse> onCompletionListener;
         private final IndexShard replica;
@@ -799,6 +824,8 @@ public abstract class TransportReplicationAction<
      * node with primary copy.
      *
      * Resolves index and shard id for the request before routing it to target node
+     *
+     * @opensearch.internal
      */
     final class ReroutePhase extends AbstractRunnable {
         private final ActionListener<Response> listener;
@@ -1133,6 +1160,11 @@ public abstract class TransportReplicationAction<
         replica.acquireReplicaOperationPermit(primaryTerm, globalCheckpoint, maxSeqNoOfUpdatesOrDeletes, onAcquired, executor, request);
     }
 
+    /**
+     * The primary shard reference
+     *
+     * @opensearch.internal
+     */
     class PrimaryShardReference
         implements
             Releasable,
@@ -1225,6 +1257,11 @@ public abstract class TransportReplicationAction<
         }
     }
 
+    /**
+     * The replica response
+     *
+     * @opensearch.internal
+     */
     public static class ReplicaResponse extends ActionResponse implements ReplicationOperation.ReplicaResponse {
         private long localCheckpoint;
         private long globalCheckpoint;
@@ -1281,6 +1318,8 @@ public abstract class TransportReplicationAction<
      * interface that performs the actual {@code ReplicaRequest} on the replica
      * shards. It also encapsulates the logic required for failing the replica
      * if deemed necessary as well as marking it as stale when needed.
+     *
+     * @opensearch.internal
      */
     protected class ReplicasProxy implements ReplicationOperation.Replicas<ReplicaRequest> {
 
@@ -1338,7 +1377,11 @@ public abstract class TransportReplicationAction<
         }
     }
 
-    /** a wrapper class to encapsulate a request when being sent to a specific allocation id **/
+    /**
+     * a wrapper class to encapsulate a request when being sent to a specific allocation id
+     *
+     * @opensearch.internal
+     */
     public static class ConcreteShardRequest<R extends TransportRequest> extends TransportRequest {
 
         /** {@link AllocationId#getId()} of the shard this request is sent to **/
@@ -1442,6 +1485,11 @@ public abstract class TransportReplicationAction<
         }
     }
 
+    /**
+     * Internal request for concrete replica
+     *
+     * @opensearch.internal
+     */
     protected static final class ConcreteReplicaRequest<R extends TransportRequest> extends ConcreteShardRequest<R> {
 
         private final long globalCheckpoint;

--- a/server/src/main/java/org/opensearch/action/support/replication/TransportWriteAction.java
+++ b/server/src/main/java/org/opensearch/action/support/replication/TransportWriteAction.java
@@ -267,6 +267,8 @@ public abstract class TransportWriteAction<
      * Result of taking the action on the primary.
      *
      * NOTE: public for testing
+     *
+     * @opensearch.internal
      */
     public static class WritePrimaryResult<
         ReplicaRequest extends ReplicatedWriteRequest<ReplicaRequest>,
@@ -322,6 +324,8 @@ public abstract class TransportWriteAction<
 
     /**
      * Result of taking the action on the replica.
+     *
+     * @opensearch.internal
      */
     public static class WriteReplicaResult<ReplicaRequest extends ReplicatedWriteRequest<ReplicaRequest>> extends ReplicaResult {
         public final Location location;
@@ -394,6 +398,8 @@ public abstract class TransportWriteAction<
      * This class encapsulates post write actions like async waits for
      * translog syncs or waiting for a refresh to happen making the write operation
      * visible.
+     *
+     * @opensearch.internal
      */
     static final class AsyncAfterWriteAction {
         private final Location location;
@@ -492,6 +498,8 @@ public abstract class TransportWriteAction<
      *
      * This extends {@code TransportReplicationAction.ReplicasProxy} to do the
      * failing and stale-ing.
+     *
+     * @opensearch.internal
      */
     class WriteActionReplicasProxy extends ReplicasProxy {
 

--- a/server/src/main/java/org/opensearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
+++ b/server/src/main/java/org/opensearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
@@ -140,6 +140,11 @@ public abstract class TransportInstanceSingleOperationAction<
      */
     protected abstract ShardIterator shards(ClusterState clusterState, Request request);
 
+    /**
+     * Asynchronous single action
+     *
+     * @opensearch.internal
+     */
     class AsyncSingleAction {
 
         private final ActionListener<Response> listener;
@@ -291,6 +296,11 @@ public abstract class TransportInstanceSingleOperationAction<
         }
     }
 
+    /**
+     * Transport handler per shard
+     *
+     * @opensearch.internal
+     */
     private class ShardTransportHandler implements TransportRequestHandler<Request> {
 
         @Override

--- a/server/src/main/java/org/opensearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/server/src/main/java/org/opensearch/action/support/single/shard/TransportSingleShardAction.java
@@ -153,6 +153,11 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
     @Nullable
     protected abstract ShardsIterator shards(ClusterState state, InternalRequest request);
 
+    /**
+     * Asynchronous single action
+     *
+     * @opensearch.internal
+     */
     class AsyncSingleAction {
 
         private final ActionListener<Response> listener;
@@ -299,6 +304,11 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
         }
     }
 
+    /**
+     * Internal transport handler
+     *
+     * @opensearch.internal
+     */
     private class TransportHandler implements TransportRequestHandler<Request> {
 
         @Override
@@ -308,6 +318,11 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
         }
     }
 
+    /**
+     * Shard level transport handler
+     *
+     * @opensearch.internal
+     */
     private class ShardTransportHandler implements TransportRequestHandler<Request> {
 
         @Override
@@ -321,6 +336,8 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
 
     /**
      * Internal request class that gets built on each node. Holds the original request plus additional info.
+     *
+     * @opensearch.internal
      */
     protected class InternalRequest {
         final Request request;

--- a/server/src/main/java/org/opensearch/action/support/tasks/TransportTasksAction.java
+++ b/server/src/main/java/org/opensearch/action/support/tasks/TransportTasksAction.java
@@ -237,6 +237,11 @@ public abstract class TransportTasksAction<
      */
     protected abstract void taskOperation(TasksRequest request, OperationTask task, ActionListener<TaskResponse> listener);
 
+    /**
+     * Asynchronous single action
+     *
+     * @opensearch.internal
+     */
     private class AsyncAction {
 
         private final TasksRequest request;
@@ -353,6 +358,11 @@ public abstract class TransportTasksAction<
         }
     }
 
+    /**
+     * Node level transport handler
+     *
+     * @opensearch.internal
+     */
     class NodeTransportHandler implements TransportRequestHandler<NodeTaskRequest> {
 
         @Override
@@ -368,6 +378,11 @@ public abstract class TransportTasksAction<
         }
     }
 
+    /**
+     * Node level task request
+     *
+     * @opensearch.internal
+     */
     private class NodeTaskRequest extends TransportRequest {
         private TasksRequest tasksRequest;
 
@@ -389,6 +404,11 @@ public abstract class TransportTasksAction<
 
     }
 
+    /**
+     * Node level task response
+     *
+     * @opensearch.internal
+     */
     private class NodeTasksResponse extends TransportResponse {
         protected String nodeId;
         protected List<TaskOperationFailure> exceptions;

--- a/server/src/main/java/org/opensearch/action/termvectors/MultiTermVectorsResponse.java
+++ b/server/src/main/java/org/opensearch/action/termvectors/MultiTermVectorsResponse.java
@@ -54,6 +54,8 @@ public class MultiTermVectorsResponse extends ActionResponse implements Iterable
 
     /**
      * Represents a failure.
+     *
+     * @opensearch.internal
      */
     public static class Failure implements Writeable {
         private final String index;
@@ -151,6 +153,11 @@ public class MultiTermVectorsResponse extends ActionResponse implements Iterable
         return builder;
     }
 
+    /**
+     * Fields used for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String DOCS = "docs";
         static final String _INDEX = "_index";

--- a/server/src/main/java/org/opensearch/action/termvectors/TermVectorsFields.java
+++ b/server/src/main/java/org/opensearch/action/termvectors/TermVectorsFields.java
@@ -204,6 +204,11 @@ public final class TermVectorsFields extends Fields {
         return fieldMap.size();
     }
 
+    /**
+     * Internal term vector
+     *
+     * @opensearch.internal
+     */
     private final class TermVector extends Terms {
 
         private final StreamInput perFieldTermVectorInput;
@@ -420,6 +425,11 @@ public final class TermVectorsFields extends Fields {
         }
     }
 
+    /**
+     * Internal postings enumerator for term vectors
+     *
+     * @opensearch.internal
+     */
     private final class TermVectorPostingsEnum extends PostingsEnum {
         private boolean hasPositions;
         private boolean hasOffsets;

--- a/server/src/main/java/org/opensearch/action/termvectors/TermVectorsFilter.java
+++ b/server/src/main/java/org/opensearch/action/termvectors/TermVectorsFilter.java
@@ -176,6 +176,11 @@ public class TermVectorsFilter {
         this.maxWordLength = maxWordLength;
     }
 
+    /**
+     * Internal score term
+     *
+     * @opensearch.internal
+     */
     public static final class ScoreTerm {
         public String field;
         public String word;
@@ -295,6 +300,11 @@ public class TermVectorsFilter {
         return freq * similarity.idf(docFreq, numDocs);
     }
 
+    /**
+     * Internal queue of score terms
+     *
+     * @opensearch.internal
+     */
     private static class ScoreTermsQueue extends org.apache.lucene.util.PriorityQueue<ScoreTerm> {
         private final int limit;
 

--- a/server/src/main/java/org/opensearch/action/termvectors/TermVectorsRequest.java
+++ b/server/src/main/java/org/opensearch/action/termvectors/TermVectorsRequest.java
@@ -115,6 +115,11 @@ public class TermVectorsRequest extends SingleShardRequest<TermVectorsRequest> i
 
     private FilterSettings filterSettings;
 
+    /**
+     * Internal filter settings
+     *
+     * @opensearch.internal
+     */
     public static final class FilterSettings {
         public Integer maxNumTerms;
         public Integer minTermFreq;

--- a/server/src/main/java/org/opensearch/action/termvectors/TermVectorsResponse.java
+++ b/server/src/main/java/org/opensearch/action/termvectors/TermVectorsResponse.java
@@ -66,6 +66,11 @@ import java.util.Set;
  */
 public class TermVectorsResponse extends ActionResponse implements ToXContentObject {
 
+    /**
+     * Fields used for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     private static class FieldStrings {
         // term statistics strings
         public static final String TTF = "ttf";

--- a/server/src/main/java/org/opensearch/action/update/UpdateHelper.java
+++ b/server/src/main/java/org/opensearch/action/update/UpdateHelper.java
@@ -390,6 +390,11 @@ public class UpdateHelper {
         );
     }
 
+    /**
+     * Internal result
+     *
+     * @opensearch.internal
+     */
     public static class Result {
 
         private final Writeable action;
@@ -468,6 +473,8 @@ public class UpdateHelper {
 
     /**
      * Field names used to populate the script context
+     *
+     * @opensearch.internal
      */
     public static class ContextFields {
         public static final String CTX = "ctx";

--- a/server/src/main/java/org/opensearch/action/update/UpdateResponse.java
+++ b/server/src/main/java/org/opensearch/action/update/UpdateResponse.java
@@ -172,6 +172,8 @@ public class UpdateResponse extends DocWriteResponse {
      * Builder class for {@link UpdateResponse}. This builder is usually used during xcontent parsing to
      * temporarily store the parsed values, then the {@link DocWriteResponse.Builder#build()} method is called to
      * instantiate the {@link UpdateResponse}.
+     *
+     * @opensearch.internal
      */
     public static class Builder extends DocWriteResponse.Builder {
 

--- a/server/src/main/java/org/opensearch/index/Index.java
+++ b/server/src/main/java/org/opensearch/index/Index.java
@@ -136,6 +136,8 @@ public class Index implements Writeable, ToXContentObject {
 
     /**
      * Builder for Index objects.  Used by ObjectParser instances only.
+     *
+     * @opensearch.internal
      */
     private static final class Builder {
         private String name;

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -387,6 +387,11 @@ public final class IndexModule {
         return false;
     }
 
+    /**
+     * Type of file system
+     *
+     * @opensearch.internal
+     */
     public enum Type {
         HYBRIDFS("hybridfs"),
         NIOFS("niofs"),

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -279,6 +279,11 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             && indexCreationContext == IndexCreationContext.CREATE_INDEX); // metadata verification needs a mapper service
     }
 
+    /**
+     * Context for index creation
+     *
+     * @opensearch.internal
+     */
     public enum IndexCreationContext {
         CREATE_INDEX,
         METADATA_VERIFICATION
@@ -741,6 +746,11 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         }
     }
 
+    /**
+     * Cache listener for bitsets
+     *
+     * @opensearch.internal
+     */
     private static final class BitsetCacheListener implements BitsetFilterCache.Listener {
         final IndexService indexService;
 
@@ -894,6 +904,11 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         }
     }
 
+    /**
+     * Shard Store Deleter Interface
+     *
+     * @opensearch.internal
+     */
     public interface ShardStoreDeleter {
         void deleteShardStore(String reason, ShardLock lock, IndexSettings indexSettings) throws IOException;
 
@@ -1000,6 +1015,11 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         }
     }
 
+    /**
+     * Base asynchronous task
+     *
+     * @opensearch.internal
+     */
     abstract static class BaseAsyncTask extends AbstractAsyncTask {
 
         protected final IndexService indexService;
@@ -1020,6 +1040,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
 
     /**
      * FSyncs the translog for all shards of this index in a defined interval.
+     *
+     * @opensearch.internal
      */
     static final class AsyncTranslogFSync extends BaseAsyncTask {
 

--- a/server/src/main/java/org/opensearch/index/IndexSortConfig.java
+++ b/server/src/main/java/org/opensearch/index/IndexSortConfig.java
@@ -244,6 +244,11 @@ public final class IndexSortConfig {
         }
     }
 
+    /**
+     * Field sort specification
+     *
+     * @opensearch.internal
+     */
     static class FieldSortSpec {
         final String field;
         SortOrder order;

--- a/server/src/main/java/org/opensearch/index/IndexWarmer.java
+++ b/server/src/main/java/org/opensearch/index/IndexWarmer.java
@@ -108,7 +108,11 @@ public final class IndexWarmer {
         }
     }
 
-    /** A handle on the execution of  warm-up action. */
+    /**
+     * A handle on the execution of  warm-up action.
+     *
+     * @opensearch.internal
+     */
     public interface TerminationHandle {
 
         TerminationHandle NO_WAIT = () -> {};
@@ -117,12 +121,22 @@ public final class IndexWarmer {
         void awaitTermination() throws InterruptedException;
     }
 
+    /**
+     * Listener for the index warmer
+     *
+     * @opensearch.internal
+     */
     public interface Listener {
         /** Queue tasks to warm-up the given segments and return handles that allow to wait for termination of the
          *  execution of those tasks. */
         TerminationHandle warmReader(IndexShard indexShard, OpenSearchDirectoryReader reader);
     }
 
+    /**
+     * Warmer for field data
+     *
+     * @opensearch.internal
+     */
     private static class FieldDataWarmer implements IndexWarmer.Listener {
 
         private final Executor executor;

--- a/server/src/main/java/org/opensearch/index/IndexingSlowLog.java
+++ b/server/src/main/java/org/opensearch/index/IndexingSlowLog.java
@@ -211,6 +211,11 @@ public final class IndexingSlowLog implements IndexingOperationListener {
         }
     }
 
+    /**
+     * Slow log message for indexing
+     *
+     * @opensearch.internal
+     */
     static final class IndexingSlowLogMessage extends OpenSearchLogMessage {
 
         IndexingSlowLogMessage(Index index, ParsedDocument doc, long tookInNanos, boolean reformat, int maxSourceCharsToLog) {

--- a/server/src/main/java/org/opensearch/index/SearchSlowLog.java
+++ b/server/src/main/java/org/opensearch/index/SearchSlowLog.java
@@ -208,6 +208,11 @@ public final class SearchSlowLog implements SearchOperationListener {
         }
     }
 
+    /**
+     * Search slow log message
+     *
+     * @opensearch.internal
+     */
     static final class SearchSlowLogMessage extends OpenSearchLogMessage {
 
         SearchSlowLogMessage(SearchContext context, long tookInNanos) {

--- a/server/src/main/java/org/opensearch/index/ShardIndexingPressureTracker.java
+++ b/server/src/main/java/org/opensearch/index/ShardIndexingPressureTracker.java
@@ -92,6 +92,8 @@ public class ShardIndexingPressureTracker {
      * a. StatsTracker : To track request level aggregated statistics for a shard
      * b. RejectionTracker : To track the rejection statistics for a shard
      * c. Performance Tracker : To track the request performance statistics for a shard
+     *
+     * @opensearch.internal
      */
     public static class OperationTracker {
         private final StatsTracker statsTracker = new StatsTracker();
@@ -116,6 +118,8 @@ public class ShardIndexingPressureTracker {
      * a. currentBytes - Bytes of data that is inflight/processing for a shard.
      * b. totalBytes - Total bytes that are processed/completed successfully for a shard.
      * c. requestCount - Total number of requests that are processed/completed successfully for a shard.
+     *
+     * @opensearch.internal
      */
     public static class StatsTracker {
         private final AtomicLong currentBytes = new AtomicLong();
@@ -156,6 +160,8 @@ public class ShardIndexingPressureTracker {
      *          last successful request limits breached for a shard i.e. complete path failure (black-hole).
      * d. throughputDegradationLimitsBreachedRejections - Total number of requests that were rejected due to the
      *          throughput degradation in the request path for a shard i.e. partial failure.
+     *
+     * @opensearch.internal
      */
     public static class RejectionTracker {
         private final AtomicLong totalRejections = new AtomicLong();
@@ -205,6 +211,8 @@ public class ShardIndexingPressureTracker {
      * e. ThroughputMovingQueue - Queue that holds the last N requests throughput such that there exists a sliding window
      *          which keeps moving everytime a new request comes. At any given point it tracks last N requests only.
      *          EWMA cannot be used here as it evaluate the historical average, while here it just needs the average of last N requests.
+     *
+     * @opensearch.internal
      */
     public static class PerformanceTracker {
         private final AtomicLong latencyInMillis = new AtomicLong();
@@ -273,6 +281,8 @@ public class ShardIndexingPressureTracker {
      *      when primary is local to coordinator node. Hence common accounting for coordinator and primary operation.
      * b. totalCombinedCoordinatingAndPrimaryBytes - Total bytes that are processed/completed successfully for a shard
      *      when primary is local to coordinator node. Hence common accounting for coordinator and primary operation.
+     *
+     * @opensearch.internal
      */
     public static class CommonOperationTracker {
         private final AtomicLong currentCombinedCoordinatingAndPrimaryBytes = new AtomicLong();

--- a/server/src/main/java/org/opensearch/index/analysis/AnalysisRegistry.java
+++ b/server/src/main/java/org/opensearch/index/analysis/AnalysisRegistry.java
@@ -570,6 +570,11 @@ public final class AnalysisRegistry implements Closeable {
         return type;
     }
 
+    /**
+     * Internal prebuilt analysis class
+     *
+     * @opensearch.internal
+     */
     private static class PrebuiltAnalysis implements Closeable {
 
         final Map<String, AnalysisProvider<AnalyzerProvider<?>>> analyzerProviderFactories;

--- a/server/src/main/java/org/opensearch/index/analysis/PreBuiltAnalyzerProviderFactory.java
+++ b/server/src/main/java/org/opensearch/index/analysis/PreBuiltAnalyzerProviderFactory.java
@@ -104,6 +104,8 @@ public class PreBuiltAnalyzerProviderFactory extends PreConfiguredAnalysisCompon
      *
      *  This can be removed when all analyzers have been moved away from PreBuiltAnalyzers to
      *  PreBuiltAnalyzerProviderFactory either in server or analysis-common.
+     *
+     * @opensearch.internal
      */
     static class PreBuiltAnalyzersDelegateCache implements PreBuiltCacheFactory.PreBuiltCache<AnalyzerProvider<?>> {
 

--- a/server/src/main/java/org/opensearch/index/analysis/ShingleTokenFilterFactory.java
+++ b/server/src/main/java/org/opensearch/index/analysis/ShingleTokenFilterFactory.java
@@ -121,6 +121,11 @@ public class ShingleTokenFilterFactory extends AbstractTokenFilterFactory {
         return this.factory;
     }
 
+    /**
+     * Factory for single token filter
+     *
+     * @opensearch.internal
+     */
     public static final class Factory implements TokenFilterFactory {
         private final int maxShingleSize;
 

--- a/server/src/main/java/org/opensearch/index/cache/bitset/BitsetFilterCache.java
+++ b/server/src/main/java/org/opensearch/index/cache/bitset/BitsetFilterCache.java
@@ -192,6 +192,11 @@ public final class BitsetFilterCache extends AbstractIndexComponent
         }
     }
 
+    /**
+     * Value for bitset filter cache
+     *
+     * @opensearch.internal
+     */
     public static final class Value {
 
         final BitSet bitset;
@@ -316,6 +321,8 @@ public final class BitsetFilterCache extends AbstractIndexComponent
 
     /**
      *  A listener interface that is executed for each onCache / onRemoval event
+     *
+     * @opensearch.internal
      */
     public interface Listener {
         /**

--- a/server/src/main/java/org/opensearch/index/cache/query/QueryCacheStats.java
+++ b/server/src/main/java/org/opensearch/index/cache/query/QueryCacheStats.java
@@ -155,6 +155,11 @@ public class QueryCacheStats implements Writeable, ToXContentFragment {
         return builder;
     }
 
+    /**
+     * Fields used for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String QUERY_CACHE = "query_cache";
         static final String MEMORY_SIZE = "memory_size";

--- a/server/src/main/java/org/opensearch/index/cache/request/RequestCacheStats.java
+++ b/server/src/main/java/org/opensearch/index/cache/request/RequestCacheStats.java
@@ -115,6 +115,11 @@ public class RequestCacheStats implements Writeable, ToXContentFragment {
         return builder;
     }
 
+    /**
+     * Fields used for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String REQUEST_CACHE_STATS = "request_cache";
         static final String MEMORY_SIZE = "memory_size";

--- a/server/src/main/java/org/opensearch/index/engine/CombinedDeletionPolicy.java
+++ b/server/src/main/java/org/opensearch/index/engine/CombinedDeletionPolicy.java
@@ -265,6 +265,8 @@ public class CombinedDeletionPolicy extends IndexDeletionPolicy {
 
     /**
      * A wrapper of an index commit that prevents it from being deleted.
+     *
+     * @opensearch.internal
      */
     private static class SnapshotIndexCommit extends IndexCommit {
         private final IndexCommit delegate;

--- a/server/src/main/java/org/opensearch/index/engine/CommitStats.java
+++ b/server/src/main/java/org/opensearch/index/engine/CommitStats.java
@@ -112,6 +112,11 @@ public final class CommitStats implements Writeable, ToXContentFragment {
         out.writeInt(numDocs);
     }
 
+    /**
+     * Fields used for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String GENERATION = "generation";
         static final String USER_DATA = "user_data";

--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -243,6 +243,8 @@ public abstract class Engine implements Closeable {
      * A throttling class that can be activated, causing the
      * {@code acquireThrottle} method to block on a lock when throttling
      * is enabled
+     *
+     * @opensearch.internal
      */
     protected static final class IndexThrottle {
         private final CounterMetric throttleTimeMillisMetric = new CounterMetric();
@@ -317,7 +319,11 @@ public abstract class Engine implements Closeable {
      */
     public abstract void trimOperationsFromTranslog(long belowTerm, long aboveSeqNo) throws EngineException;
 
-    /** A Lock implementation that always allows the lock to be acquired */
+    /**
+     * A Lock implementation that always allows the lock to be acquired
+     *
+     * @opensearch.internal
+     */
     protected static final class NoOpLock implements Lock {
 
         @Override
@@ -371,6 +377,8 @@ public abstract class Engine implements Closeable {
      * Base class for index and delete operation results
      * Holds result meta data (e.g. translog location, updated version)
      * for an executed write {@link Operation}
+     *
+     * @opensearch.internal
      **/
     public abstract static class Result {
         private final Operation.TYPE operationType;
@@ -484,6 +492,11 @@ public abstract class Engine implements Closeable {
             freeze.set(true);
         }
 
+        /**
+         * Type of the result
+         *
+         * @opensearch.internal
+         */
         public enum Type {
             SUCCESS,
             FAILURE,
@@ -491,6 +504,11 @@ public abstract class Engine implements Closeable {
         }
     }
 
+    /**
+     * Index result
+     *
+     * @opensearch.internal
+     */
     public static class IndexResult extends Result {
 
         private final boolean created;
@@ -523,6 +541,11 @@ public abstract class Engine implements Closeable {
 
     }
 
+    /**
+     * The delete result
+     *
+     * @opensearch.internal
+     */
     public static class DeleteResult extends Result {
 
         private final boolean found;
@@ -555,6 +578,11 @@ public abstract class Engine implements Closeable {
 
     }
 
+    /**
+     * A noop result
+     *
+     * @opensearch.internal
+     */
     public static class NoOpResult extends Result {
 
         NoOpResult(long term, long seqNo) {
@@ -713,6 +741,11 @@ public abstract class Engine implements Closeable {
         return true;
     }
 
+    /**
+     * Scope of the searcher
+     *
+     * @opensearch.internal
+     */
     public enum SearcherScope {
         EXTERNAL,
         INTERNAL
@@ -1228,6 +1261,11 @@ public abstract class Engine implements Closeable {
         return false;
     }
 
+    /**
+     * Event listener for the engine
+     *
+     * @opensearch.internal
+     */
     public interface EventListener {
         /**
          * Called when a fatal exception occurred
@@ -1235,6 +1273,11 @@ public abstract class Engine implements Closeable {
         default void onFailedEngine(String reason, @Nullable Exception e) {}
     }
 
+    /**
+     * Supplier for the searcher
+     *
+     * @opensearch.internal
+     */
     public abstract static class SearcherSupplier implements Releasable {
         private final Function<Searcher, Searcher> wrapper;
         private final AtomicBoolean released = new AtomicBoolean(false);
@@ -1265,6 +1308,11 @@ public abstract class Engine implements Closeable {
         protected abstract Searcher acquireSearcherInternal(String source);
     }
 
+    /**
+     * The engine searcher
+     *
+     * @opensearch.internal
+     */
     public static final class Searcher extends IndexSearcher implements Releasable {
         private final String source;
         private final Closeable onClose;
@@ -1312,9 +1360,18 @@ public abstract class Engine implements Closeable {
         }
     }
 
+    /**
+     * Base operation class
+     *
+     * @opensearch.internal
+     */
     public abstract static class Operation {
 
-        /** type of operation (index, delete), subclasses use static types */
+        /**
+         * type of operation (index, delete), subclasses use static types
+         *
+         * @opensearch.internal
+         */
         public enum TYPE {
             INDEX,
             DELETE,
@@ -1349,6 +1406,11 @@ public abstract class Engine implements Closeable {
             this.startTime = startTime;
         }
 
+        /**
+         * Origin of the operation
+         *
+         * @opensearch.internal
+         */
         public enum Origin {
             PRIMARY,
             REPLICA,
@@ -1403,6 +1465,11 @@ public abstract class Engine implements Closeable {
         public abstract TYPE operationType();
     }
 
+    /**
+     * Index operation
+     *
+     * @opensearch.internal
+     */
     public static class Index extends Operation {
 
         private final ParsedDocument doc;
@@ -1516,6 +1583,11 @@ public abstract class Engine implements Closeable {
         }
     }
 
+    /**
+     * Delete operation
+     *
+     * @opensearch.internal
+     */
     public static class Delete extends Operation {
 
         private final String id;
@@ -1599,6 +1671,11 @@ public abstract class Engine implements Closeable {
         }
     }
 
+    /**
+     * noop operation
+     *
+     * @opensearch.internal
+     */
     public static class NoOp extends Operation {
 
         private final String reason;
@@ -1644,6 +1721,11 @@ public abstract class Engine implements Closeable {
 
     }
 
+    /**
+     * Get operation
+     *
+     * @opensearch.internal
+     */
     public static class Get {
         private final boolean realtime;
         private final Term uid;
@@ -1715,6 +1797,11 @@ public abstract class Engine implements Closeable {
 
     }
 
+    /**
+     * The Get result
+     *
+     * @opensearch.internal
+     */
     public static class GetResult implements Releasable {
         private final boolean exists;
         private final long version;
@@ -1835,6 +1922,8 @@ public abstract class Engine implements Closeable {
      * Called for each new opened engine reader to warm new segments
      *
      * @see EngineConfig#getWarmer()
+     *
+     * @opensearch.internal
      */
     public interface Warmer {
         /**
@@ -1904,6 +1993,11 @@ public abstract class Engine implements Closeable {
      */
     public abstract void updateMaxUnsafeAutoIdTimestamp(long newTimestamp);
 
+    /**
+     * The runner for translog recovery
+     *
+     * @opensearch.internal
+     */
     @FunctionalInterface
     public interface TranslogRecoveryRunner {
         int run(Engine engine, Translog.Snapshot snapshot) throws IOException;

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
@@ -463,6 +463,8 @@ public final class EngineConfig {
     /**
      * A supplier supplies tombstone documents which will be used in soft-update methods.
      * The returned document consists only _uid, _seqno, _term and _version fields; other metadata fields are excluded.
+     *
+     * @opensearch.internal
      */
     public interface TombstoneDocSupplier {
         /**

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -379,6 +379,8 @@ public class InternalEngine extends Engine {
      * since no indexing is happening and refreshes are only happening to the external reader manager, while with
      * this specialized implementation an external refresh will immediately be reflected on the internal reader
      * and old segments can be released in the same way previous version did this (as a side-effect of _refresh)
+     *
+     * @opensearch.internal
      */
     @SuppressForbidden(reason = "reference counting is required here")
     private static final class ExternalReaderManager extends ReferenceManager<OpenSearchDirectoryReader> {
@@ -1295,6 +1297,11 @@ public class InternalEngine extends Engine {
         }
     }
 
+    /**
+     * The indexing strategy
+     *
+     * @opensearch.internal
+     */
     protected static final class IndexingStrategy {
         final boolean currentNotFoundOrDeleted;
         final boolean useLuceneUpdateDocument;
@@ -1644,6 +1651,11 @@ public class InternalEngine extends Engine {
         }
     }
 
+    /**
+     * The deletion strategy
+     *
+     * @opensearch.internal
+     */
     protected static final class DeletionStrategy {
         // of a rare double delete
         final boolean deleteFromLucene;
@@ -2457,7 +2469,11 @@ public class InternalEngine extends Engine {
         return iwc;
     }
 
-    /** A listener that warms the segments if needed when acquiring a new reader */
+    /**
+     * A listener that warms the segments if needed when acquiring a new reader
+     *
+     * @opensearch.internal
+     */
     static final class RefreshWarmerListener implements BiConsumer<OpenSearchDirectoryReader, OpenSearchDirectoryReader> {
         private final Engine.Warmer warmer;
         private final Logger logger;
@@ -2868,6 +2884,11 @@ public class InternalEngine extends Engine {
         return commitData;
     }
 
+    /**
+     * Internal Asserting Index Writer
+     *
+     * @opensearch.internal
+     */
     private static class AssertingIndexWriter extends IndexWriter {
         AssertingIndexWriter(Directory d, IndexWriterConfig conf) throws IOException {
             super(d, conf);

--- a/server/src/main/java/org/opensearch/index/engine/LiveVersionMap.java
+++ b/server/src/main/java/org/opensearch/index/engine/LiveVersionMap.java
@@ -55,6 +55,11 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
 
     private final KeyedLock<BytesRef> keyedLock = new KeyedLock<>();
 
+    /**
+     * Looks up document version
+     *
+     * @opensearch.internal
+     */
     private static final class VersionLookup {
 
         /** Tracks bytes used by current map, i.e. what is freed on refresh. For deletes, which are also added to tombstones,
@@ -120,6 +125,11 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
 
     }
 
+    /**
+     * Map of version lookups
+     *
+     * @opensearch.internal
+     */
     private static final class Maps {
 
         // All writes (adds and deletes) go into here:

--- a/server/src/main/java/org/opensearch/index/engine/LuceneChangesSnapshot.java
+++ b/server/src/main/java/org/opensearch/index/engine/LuceneChangesSnapshot.java
@@ -350,6 +350,11 @@ final class LuceneChangesSnapshot implements Translog.Snapshot {
         return ndv.longValue() == 1;
     }
 
+    /**
+     * Parallel array to hold translog operations
+     *
+     * @opensearch.internal
+     */
     private static final class ParallelArray {
         final LeafReaderContext[] leafReaderContexts;
         final long[] version;

--- a/server/src/main/java/org/opensearch/index/engine/PrunePostingsMergePolicy.java
+++ b/server/src/main/java/org/opensearch/index/engine/PrunePostingsMergePolicy.java
@@ -168,6 +168,11 @@ final class PrunePostingsMergePolicy extends OneMergeWrappingMergePolicy {
         };
     }
 
+    /**
+     * Class holder for only live docs and the postings enumerator
+     *
+     * @opensearch.internal
+     */
     private static final class OnlyLiveDocsPostingsEnum extends PostingsEnum {
 
         private final Bits liveDocs;

--- a/server/src/main/java/org/opensearch/index/engine/RecoverySourcePruneMergePolicy.java
+++ b/server/src/main/java/org/opensearch/index/engine/RecoverySourcePruneMergePolicy.java
@@ -100,6 +100,11 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
         }
     }
 
+    /**
+     * A codec reader that prunes the source using a filter
+     *
+     * @opensearch.internal
+     */
     private static class SourcePruningFilterCodecReader extends FilterCodecReader {
         private final BitSet recoverySourceToKeep;
         private final String recoverySourceField;
@@ -166,6 +171,11 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
             return null;
         }
 
+        /**
+         * A producer of filtered doc vlaues
+         *
+         * @opensearch.internal
+         */
         private static class FilterDocValuesProducer extends DocValuesProducer {
             private final DocValuesProducer in;
 
@@ -209,6 +219,11 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
             }
         }
 
+        /**
+         * A fields reader that provides a filtered stored field
+         *
+         * @opensearch.internal
+         */
         private abstract static class FilterStoredFieldsReader extends StoredFieldsReader {
 
             protected final StoredFieldsReader in;
@@ -236,6 +251,11 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
             }
         }
 
+        /**
+         * A reader of pruned stored fields
+         *
+         * @opensearch.internal
+         */
         private static class RecoverySourcePruningStoredFieldsReader extends FilterStoredFieldsReader {
 
             private final BitSet recoverySourceToKeep;
@@ -276,6 +296,11 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
 
         }
 
+        /**
+         * A visitor pattern for filtered stored fields
+         *
+         * @opensearch.internal
+         */
         private static class FilterStoredFieldVisitor extends StoredFieldVisitor {
             private final StoredFieldVisitor visitor;
 

--- a/server/src/main/java/org/opensearch/index/engine/SegmentsStats.java
+++ b/server/src/main/java/org/opensearch/index/engine/SegmentsStats.java
@@ -244,6 +244,11 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
         return builder;
     }
 
+    /**
+     * Fields for segment statistics
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String SEGMENTS = "segments";
         static final String COUNT = "count";

--- a/server/src/main/java/org/opensearch/index/fielddata/FieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/FieldData.java
@@ -446,6 +446,11 @@ public enum FieldData {
 
     }
 
+    /**
+     * Values casted as a double type
+     *
+     * @opensearch.internal
+     */
     private static class DoubleCastedValues extends NumericDoubleValues {
 
         private final NumericDocValues values;
@@ -466,6 +471,11 @@ public enum FieldData {
 
     }
 
+    /**
+     * Sorted values casted as a double type
+     *
+     * @opensearch.internal
+     */
     private static class SortedDoubleCastedValues extends SortedNumericDoubleValues {
 
         private final SortedNumericDocValues values;
@@ -491,6 +501,11 @@ public enum FieldData {
 
     }
 
+    /**
+     * Values casted as a long type
+     *
+     * @opensearch.internal
+     */
     private static class LongCastedValues extends AbstractNumericDocValues {
 
         private final NumericDoubleValues values;
@@ -517,6 +532,11 @@ public enum FieldData {
         }
     }
 
+    /**
+     * Sorted values casted as a long type
+     *
+     * @opensearch.internal
+     */
     private static class SortedLongCastedValues extends AbstractSortedNumericDocValues {
 
         private final SortedNumericDoubleValues values;

--- a/server/src/main/java/org/opensearch/index/fielddata/IndexFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/IndexFieldData.java
@@ -108,9 +108,13 @@ public interface IndexFieldData<FD extends LeafFieldData> {
         BucketedSort.ExtraData extra
     );
 
-    // we need this extended source we we have custom comparators to reuse our field data
-    // in this case, we need to reduce type that will be used when search results are reduced
-    // on another node (we don't have the custom source them...)
+    /**
+     *  we need this extended source we we have custom comparators to reuse our field data
+     *  in this case, we need to reduce type that will be used when search results are reduced
+     *  on another node (we don't have the custom source them...)
+     *
+     * @opensearch.internal
+     */
     abstract class XFieldComparatorSource extends FieldComparatorSource {
 
         protected final MultiValueMode sortMode;
@@ -273,11 +277,21 @@ public interface IndexFieldData<FD extends LeafFieldData> {
         );
     }
 
+    /**
+     * Base builder interface
+     *
+     * @opensearch.internal
+     */
     interface Builder {
 
         IndexFieldData<?> build(IndexFieldDataCache cache, CircuitBreakerService breakerService);
     }
 
+    /**
+     * Base Global field data class
+     *
+     * @opensearch.internal
+     */
     interface Global<FD extends LeafFieldData> extends IndexFieldData<FD> {
 
         IndexFieldData<FD> loadGlobal(DirectoryReader indexReader);

--- a/server/src/main/java/org/opensearch/index/fielddata/IndexFieldDataCache.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/IndexFieldDataCache.java
@@ -59,6 +59,11 @@ public interface IndexFieldDataCache {
      */
     void clear(String fieldName);
 
+    /**
+     * The listener interface
+     *
+     * @opensearch.internal
+     */
     interface Listener {
 
         /**
@@ -72,6 +77,11 @@ public interface IndexFieldDataCache {
         default void onRemoval(ShardId shardId, String fieldName, boolean wasEvicted, long sizeInBytes) {}
     }
 
+    /**
+     * No index field data cache
+     *
+     * @opensearch.internal
+     */
     class None implements IndexFieldDataCache {
 
         @Override

--- a/server/src/main/java/org/opensearch/index/fielddata/IndexNumericFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/IndexNumericFieldData.java
@@ -61,6 +61,8 @@ import java.util.function.LongUnaryOperator;
 public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumericFieldData> {
     /**
      * The type of number.
+     *
+     * @opensearch.internal
      */
     public enum NumericType {
         BOOLEAN(false, SortField.Type.LONG, CoreValuesSourceType.BOOLEAN),

--- a/server/src/main/java/org/opensearch/index/fielddata/ScriptDocValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/ScriptDocValues.java
@@ -93,6 +93,11 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         throw new UnsupportedOperationException("doc values are unmodifiable");
     }
 
+    /**
+     * Long values for scripted doc values
+     *
+     * @opensearch.internal
+     */
     public static final class Longs extends ScriptDocValues<Long> {
         private final SortedNumericDocValues in;
         private long[] values = new long[0];
@@ -147,6 +152,11 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
     }
 
+    /**
+     * Date values for scripted doc values
+     *
+     * @opensearch.internal
+     */
     public static final class Dates extends ScriptDocValues<JodaCompatibleZonedDateTime> {
 
         private final SortedNumericDocValues in;
@@ -223,6 +233,11 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
     }
 
+    /**
+     * Double values for scripted doc values
+     *
+     * @opensearch.internal
+     */
     public static final class Doubles extends ScriptDocValues<Double> {
 
         private final SortedNumericDoubleValues in;
@@ -279,6 +294,11 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
     }
 
+    /**
+     * Geo points for scripted doc values
+     *
+     * @opensearch.internal
+     */
     public static final class GeoPoints extends ScriptDocValues<GeoPoint> {
 
         private final MultiGeoPointValues in;
@@ -399,6 +419,11 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
     }
 
+    /**
+     * Boolean values for scripted doc values
+     *
+     * @opensearch.internal
+     */
     public static final class Booleans extends ScriptDocValues<Boolean> {
 
         private final SortedNumericDocValues in;
@@ -459,6 +484,11 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
 
     }
 
+    /**
+     * Base class for binary script doc values
+     *
+     * @opensearch.internal
+     */
     abstract static class BinaryScriptDocValues<T> extends ScriptDocValues<T> {
 
         private final SortedBinaryDocValues in;
@@ -505,6 +535,11 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
     }
 
+    /**
+     * String class for scripted doc values
+     *
+     * @opensearch.internal
+     */
     public static class Strings extends BinaryScriptDocValues<String> {
         public Strings(SortedBinaryDocValues in) {
             super(in);
@@ -533,6 +568,11 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
     }
 
+    /**
+     * BytesRef values for scripted doc values
+     *
+     * @opensearch.internal
+     */
     public static final class BytesRefs extends BinaryScriptDocValues<BytesRef> {
 
         public BytesRefs(SortedBinaryDocValues in) {

--- a/server/src/main/java/org/opensearch/index/fielddata/fieldcomparator/BytesRefFieldComparatorSource.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/fieldcomparator/BytesRefFieldComparatorSource.java
@@ -169,6 +169,8 @@ public class BytesRefFieldComparatorSource extends IndexFieldData.XFieldComparat
     /**
      * A view of a SortedDocValues where missing values
      * are replaced with the specified term
+     *
+     * @opensearch.internal
      */
     // TODO: move this out if we need it for other reasons
     static class ReplaceMissing extends AbstractSortedDocValues {

--- a/server/src/main/java/org/opensearch/index/fielddata/ordinals/MultiOrdinals.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/ordinals/MultiOrdinals.java
@@ -129,6 +129,11 @@ public class MultiOrdinals extends Ordinals {
         }
     }
 
+    /**
+     * Single doc type
+     *
+     * @opensearch.internal
+     */
     private static class SingleDocs extends AbstractSortedDocValues {
 
         private final int valueCount;
@@ -177,6 +182,11 @@ public class MultiOrdinals extends Ordinals {
 
     }
 
+    /**
+     * Multiple docs
+     *
+     * @opensearch.internal
+     */
     private static class MultiDocs extends AbstractSortedSetDocValues {
 
         private final long valueCount;

--- a/server/src/main/java/org/opensearch/index/fielddata/ordinals/Ordinals.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/ordinals/Ordinals.java
@@ -62,6 +62,11 @@ public abstract class Ordinals implements Accountable {
         return ordinals(NO_VALUES);
     }
 
+    /**
+     * Holder of values
+     *
+     * @opensearch.internal
+     */
     public interface ValuesHolder {
 
         BytesRef lookupOrd(long ord);

--- a/server/src/main/java/org/opensearch/index/fielddata/ordinals/OrdinalsBuilder.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/ordinals/OrdinalsBuilder.java
@@ -84,6 +84,8 @@ public final class OrdinalsBuilder implements Closeable {
      * <p>
      * In addition to these structures, there is another array which stores the current position (level + slice + offset in the slice)
      * in order to be able to append data in constant time.
+     *
+     * @opensearch.internal
      */
     private static class OrdinalsStore {
 

--- a/server/src/main/java/org/opensearch/index/fielddata/ordinals/SinglePackedOrdinals.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/ordinals/SinglePackedOrdinals.java
@@ -84,6 +84,11 @@ class SinglePackedOrdinals extends Ordinals {
         return (SortedSetDocValues) DocValues.singleton(new Docs(this, values));
     }
 
+    /**
+     * Doc class
+     *
+     * @opensearch.internal
+     */
     private static class Docs extends AbstractSortedDocValues {
 
         private final int maxOrd;

--- a/server/src/main/java/org/opensearch/index/fielddata/plain/AbstractIndexOrdinalsFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/plain/AbstractIndexOrdinalsFieldData.java
@@ -182,6 +182,8 @@ public abstract class AbstractIndexOrdinalsFieldData implements IndexOrdinalsFie
      * <p>
      * Note that the .beforeLoad(...) and .afterLoad(...) methods must be
      * manually called.
+     *
+     * @opensearch.internal
      */
     public interface PerValueEstimator {
 

--- a/server/src/main/java/org/opensearch/index/fielddata/plain/AbstractLatLonPointIndexFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/plain/AbstractLatLonPointIndexFieldData.java
@@ -100,6 +100,11 @@ public abstract class AbstractLatLonPointIndexFieldData implements IndexGeoPoint
         throw new IllegalArgumentException("can't sort on geo_point field without using specific sorting feature, like geo_distance");
     }
 
+    /**
+     * Lucene LatLonPoint as indexed field data type
+     *
+     * @opensearch.internal
+     */
     public static class LatLonPointIndexFieldData extends AbstractLatLonPointIndexFieldData {
         public LatLonPointIndexFieldData(String fieldName, ValuesSourceType valuesSourceType) {
             super(fieldName, valuesSourceType);
@@ -138,6 +143,11 @@ public abstract class AbstractLatLonPointIndexFieldData implements IndexGeoPoint
         }
     }
 
+    /**
+     * Builder for LatLonPoint based field data
+     *
+     * @opensearch.internal
+     */
     public static class Builder implements IndexFieldData.Builder {
         private final String name;
         private final ValuesSourceType valuesSourceType;

--- a/server/src/main/java/org/opensearch/index/fielddata/plain/BinaryIndexFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/plain/BinaryIndexFieldData.java
@@ -54,6 +54,11 @@ import org.opensearch.search.sort.SortOrder;
  */
 public class BinaryIndexFieldData implements IndexFieldData<BinaryDVLeafFieldData> {
 
+    /**
+     * Builder for binary index field data
+     *
+     * @opensearch.internal
+     */
     public static class Builder implements IndexFieldData.Builder {
         private final String name;
         private final ValuesSourceType valuesSourceType;

--- a/server/src/main/java/org/opensearch/index/fielddata/plain/BytesBinaryIndexFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/plain/BytesBinaryIndexFieldData.java
@@ -107,6 +107,11 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<BytesBinaryDVLe
         return load(context);
     }
 
+    /**
+     * Builder for bytes binary index field data
+     *
+     * @opensearch.internal
+     */
     public static class Builder implements IndexFieldData.Builder {
         private final String name;
         private final ValuesSourceType valuesSourceType;

--- a/server/src/main/java/org/opensearch/index/fielddata/plain/ConstantIndexFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/plain/ConstantIndexFieldData.java
@@ -66,6 +66,11 @@ import java.util.Collections;
  */
 public class ConstantIndexFieldData extends AbstractIndexOrdinalsFieldData {
 
+    /**
+     * Builder for Constant Index Field Data
+     *
+     * @opensearch.internal
+     */
     public static class Builder implements IndexFieldData.Builder {
 
         private final String constantValue;
@@ -84,6 +89,11 @@ public class ConstantIndexFieldData extends AbstractIndexOrdinalsFieldData {
         }
     }
 
+    /**
+     * Field data for constant values
+     *
+     * @opensearch.internal
+     */
     private static class ConstantLeafFieldData extends AbstractLeafOrdinalsFieldData {
 
         private final String value;

--- a/server/src/main/java/org/opensearch/index/fielddata/plain/PagedBytesIndexFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/plain/PagedBytesIndexFieldData.java
@@ -74,6 +74,11 @@ public class PagedBytesIndexFieldData extends AbstractIndexOrdinalsFieldData {
     private final double minFrequency, maxFrequency;
     private final int minSegmentSize;
 
+    /**
+     * Builder for paged bytes index field data
+     *
+     * @opensearch.internal
+     */
     public static class Builder implements IndexFieldData.Builder {
         private final String name;
         private final double minFrequency, maxFrequency;
@@ -280,6 +285,11 @@ public class PagedBytesIndexFieldData extends AbstractIndexOrdinalsFieldData {
         }
     }
 
+    /**
+     * A frequency filter
+     *
+     * @opensearch.internal
+     */
     private static final class FrequencyFilter extends FilteredTermsEnum {
         private final int minFreq;
         private final int maxFreq;

--- a/server/src/main/java/org/opensearch/index/fielddata/plain/PagedBytesLeafFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/plain/PagedBytesLeafFieldData.java
@@ -89,6 +89,11 @@ public class PagedBytesLeafFieldData extends AbstractLeafOrdinalsFieldData {
         return ordinals.ordinals(new ValuesHolder(bytes, termOrdToBytesOffset));
     }
 
+    /**
+     * Value holder for paged bytes leaf field data
+     *
+     * @opensearch.internal
+     */
     private static class ValuesHolder implements Ordinals.ValuesHolder {
 
         private final BytesRef scratch = new BytesRef();

--- a/server/src/main/java/org/opensearch/index/fielddata/plain/SortedNumericIndexFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/plain/SortedNumericIndexFieldData.java
@@ -69,6 +69,12 @@ import java.util.Objects;
  * @opensearch.internal
  */
 public class SortedNumericIndexFieldData extends IndexNumericFieldData {
+
+    /**
+     * Builder for sorted numeric index field data
+     *
+     * @opensearch.internal
+     */
     public static class Builder implements IndexFieldData.Builder {
         private final String name;
         private final NumericType numericType;
@@ -229,6 +235,8 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
      * for the case where documents have at most one value. In this case
      * {@link DocValues#unwrapSingleton(SortedNumericDocValues)} will return
      * the underlying single-valued NumericDocValues representation.
+     *
+     * @opensearch.internal
      */
     static final class SortedNumericLongFieldData extends LeafLongFieldData {
         final LeafReader reader;
@@ -267,6 +275,8 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
      * for the case where documents have at most one value. In this case
      * {@link FieldData#unwrapSingleton(SortedNumericDoubleValues)} will return
      * the underlying single-valued NumericDoubleValues representation.
+     *
+     * @opensearch.internal
      */
     static final class SortedNumericHalfFloatFieldData extends LeafDoubleFieldData {
         final LeafReader reader;
@@ -302,6 +312,8 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
 
     /**
      * Wraps a NumericDocValues and exposes a single 16-bit float per document.
+     *
+     * @opensearch.internal
      */
     static final class SingleHalfFloatValues extends NumericDoubleValues {
         final NumericDocValues in;
@@ -323,6 +335,8 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
 
     /**
      * Wraps a SortedNumericDocValues and exposes multiple 16-bit floats per document.
+     *
+     * @opensearch.internal
      */
     static final class MultiHalfFloatValues extends SortedNumericDoubleValues {
         final SortedNumericDocValues in;
@@ -359,6 +373,8 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
      * for the case where documents have at most one value. In this case
      * {@link FieldData#unwrapSingleton(SortedNumericDoubleValues)} will return
      * the underlying single-valued NumericDoubleValues representation.
+     *
+     * @opensearch.internal
      */
     static final class SortedNumericFloatFieldData extends LeafDoubleFieldData {
         final LeafReader reader;
@@ -394,6 +410,8 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
 
     /**
      * Wraps a NumericDocValues and exposes a single 32-bit float per document.
+     *
+     * @opensearch.internal
      */
     static final class SingleFloatValues extends NumericDoubleValues {
         final NumericDocValues in;
@@ -415,6 +433,8 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
 
     /**
      * Wraps a SortedNumericDocValues and exposes multiple 32-bit floats per document.
+     *
+     * @opensearch.internal
      */
     static final class MultiFloatValues extends SortedNumericDoubleValues {
         final SortedNumericDocValues in;
@@ -451,6 +471,8 @@ public class SortedNumericIndexFieldData extends IndexNumericFieldData {
      * for the case where documents have at most one value. In this case
      * {@link FieldData#unwrapSingleton(SortedNumericDoubleValues)} will return
      * the underlying single-valued NumericDoubleValues representation.
+     *
+     * @opensearch.internal
      */
     static final class SortedNumericDoubleFieldData extends LeafDoubleFieldData {
         final LeafReader reader;

--- a/server/src/main/java/org/opensearch/index/fielddata/plain/SortedSetOrdinalsIndexFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/plain/SortedSetOrdinalsIndexFieldData.java
@@ -62,6 +62,11 @@ import java.util.function.Function;
  */
 public class SortedSetOrdinalsIndexFieldData extends AbstractIndexOrdinalsFieldData {
 
+    /**
+     * Builder for sorted set ordinals
+     *
+     * @opensearch.internal
+     */
     public static class Builder implements IndexFieldData.Builder {
         private final String name;
         private final Function<SortedSetDocValues, ScriptDocValues<?>> scriptFunction;

--- a/server/src/main/java/org/opensearch/index/flush/FlushStats.java
+++ b/server/src/main/java/org/opensearch/index/flush/FlushStats.java
@@ -125,6 +125,11 @@ public class FlushStats implements Writeable, ToXContentFragment {
         return builder;
     }
 
+    /**
+     * Fields for flush statistics
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String FLUSH = "flush";
         static final String TOTAL = "total";

--- a/server/src/main/java/org/opensearch/index/get/GetStats.java
+++ b/server/src/main/java/org/opensearch/index/get/GetStats.java
@@ -145,6 +145,11 @@ public class GetStats implements Writeable, ToXContentFragment {
         return builder;
     }
 
+    /**
+     * Fields for get statistics
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String GET = "get";
         static final String TOTAL = "total";

--- a/server/src/main/java/org/opensearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -67,11 +67,21 @@ import java.util.function.Function;
  */
 public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends FieldMapper {
 
+    /**
+     * String parameter names for the base geometry field mapper
+     *
+     * @opensearch.internal
+     */
     public static class Names {
         public static final ParseField IGNORE_MALFORMED = new ParseField("ignore_malformed");
         public static final ParseField IGNORE_Z_VALUE = new ParseField("ignore_z_value");
     }
 
+    /**
+     * Default parameters for the base geometry field mapper
+     *
+     * @opensearch.internal
+     */
     public static class Defaults {
         public static final Explicit<Boolean> IGNORE_MALFORMED = new Explicit<>(false, false);
         public static final Explicit<Boolean> IGNORE_Z_VALUE = new Explicit<>(true, false);
@@ -86,6 +96,8 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
 
     /**
      * Interface representing an preprocessor in geometry indexing pipeline
+     *
+     * @opensearch.internal
      */
     public interface Indexer<Parsed, Processed> {
         Processed prepareForIndexing(Parsed geometry);
@@ -97,6 +109,8 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
 
     /**
      * Interface representing parser in geometry indexing pipeline.
+     *
+     * @opensearch.internal
      */
     public abstract static class Parser<Parsed> {
         /**
@@ -143,6 +157,11 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
         }
     }
 
+    /**
+     * Builder for the base geometry field mapper
+     *
+     * @opensearch.internal
+     */
     public abstract static class Builder<T extends Builder<T, FT>, FT extends AbstractGeometryFieldType> extends FieldMapper.Builder<T> {
         protected Boolean ignoreMalformed;
         protected Boolean ignoreZValue;
@@ -200,6 +219,11 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
         }
     }
 
+    /**
+     * Base type parser for geometry field mappers
+     *
+     * @opensearch.internal
+     */
     public abstract static class TypeParser<T extends Builder> implements Mapper.TypeParser {
         protected abstract T newBuilder(String name, Map<String, Object> params);
 
@@ -243,6 +267,11 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
         }
     }
 
+    /**
+     * Base field type for all geometry fields
+     *
+     * @opensearch.internal
+     */
     public abstract static class AbstractGeometryFieldType<Parsed, Processed> extends MappedFieldType {
 
         protected Indexer<Parsed, Processed> geometryIndexer;

--- a/server/src/main/java/org/opensearch/index/mapper/AbstractPointGeometryFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/AbstractPointGeometryFieldMapper.java
@@ -63,6 +63,11 @@ import static org.opensearch.index.mapper.TypeParsers.parseField;
  */
 public abstract class AbstractPointGeometryFieldMapper<Parsed, Processed> extends AbstractGeometryFieldMapper<Parsed, Processed> {
 
+    /**
+     * Common parameter names for the base point geometry field mapper
+     *
+     * @opensearch.internal
+     */
     public static class Names extends AbstractGeometryFieldMapper.Names {
         public static final ParseField NULL_VALUE = new ParseField("null_value");
     }
@@ -74,6 +79,11 @@ public abstract class AbstractPointGeometryFieldMapper<Parsed, Processed> extend
         DEFAULT_FIELD_TYPE.freeze();
     }
 
+    /**
+     * Base builder for the base point geometry field mapper
+     *
+     * @opensearch.internal
+     */
     public abstract static class Builder<T extends Builder<T, FT>, FT extends AbstractPointGeometryFieldType> extends
         AbstractGeometryFieldMapper.Builder<T, FT> {
 
@@ -113,6 +123,11 @@ public abstract class AbstractPointGeometryFieldMapper<Parsed, Processed> extend
         }
     }
 
+    /**
+     * Base type parser for the base point geometry field mapper
+     *
+     * @opensearch.internal
+     */
     public abstract static class TypeParser<T extends Builder> extends AbstractGeometryFieldMapper.TypeParser<Builder> {
         protected abstract ParsedPoint parseNullValue(Object nullValue, boolean ignoreZValue, boolean ignoreMalformed);
 
@@ -144,6 +159,11 @@ public abstract class AbstractPointGeometryFieldMapper<Parsed, Processed> extend
 
     ParsedPoint nullValue;
 
+    /**
+     * Base field type for the base point geometry field mapper
+     *
+     * @opensearch.internal
+     */
     public abstract static class AbstractPointGeometryFieldType<Parsed, Processed> extends AbstractGeometryFieldType<Parsed, Processed> {
         protected AbstractPointGeometryFieldType(
             String name,
@@ -197,7 +217,11 @@ public abstract class AbstractPointGeometryFieldMapper<Parsed, Processed> extend
         return nullValue;
     }
 
-    /** represents a Point that has been parsed by {@link PointParser} */
+    /**
+     * represents a Point that has been parsed by {@link PointParser}
+     *
+     * @opensearch.internal
+     */
     public interface ParsedPoint {
         void validate(String fieldName);
 
@@ -212,7 +236,11 @@ public abstract class AbstractPointGeometryFieldMapper<Parsed, Processed> extend
         }
     }
 
-    /** A parser implementation that can parse the various point formats */
+    /**
+     * A parser implementation that can parse the various point formats
+     *
+     * @opensearch.internal
+     */
     public static class PointParser<P extends ParsedPoint> extends Parser<List<P>> {
         /**
          * Note that this parser is only used for formatting values.

--- a/server/src/main/java/org/opensearch/index/mapper/AbstractShapeGeometryFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/AbstractShapeGeometryFieldMapper.java
@@ -53,16 +53,31 @@ import java.util.Map;
  */
 public abstract class AbstractShapeGeometryFieldMapper<Parsed, Processed> extends AbstractGeometryFieldMapper<Parsed, Processed> {
 
+    /**
+     * Common parameters for the base shape geometry field mapper
+     *
+     * @opensearch.internal
+     */
     public static class Names extends AbstractGeometryFieldMapper.Names {
         public static final ParseField ORIENTATION = new ParseField("orientation");
         public static final ParseField COERCE = new ParseField("coerce");
     }
 
+    /**
+     * Parameter defaults for the base shape geometry field mapper
+     *
+     * @opensearch.internal
+     */
     public static class Defaults extends AbstractGeometryFieldMapper.Defaults {
         public static final Explicit<Orientation> ORIENTATION = new Explicit<>(Orientation.RIGHT, false);
         public static final Explicit<Boolean> COERCE = new Explicit<>(false, false);
     }
 
+    /**
+     * Base builder for the base shape geometry field mapper
+     *
+     * @opensearch.internal
+     */
     public abstract static class Builder<T extends Builder<T, FT>, FT extends AbstractShapeGeometryFieldType> extends
         AbstractGeometryFieldMapper.Builder<T, FT> {
         protected Boolean coerce;
@@ -124,6 +139,11 @@ public abstract class AbstractShapeGeometryFieldMapper<Parsed, Processed> extend
 
     protected static final String DEPRECATED_PARAMETERS_KEY = "deprecated_parameters";
 
+    /**
+     * Base type parser for the base shape geometry field mapper
+     *
+     * @opensearch.internal
+     */
     public abstract static class TypeParser extends AbstractGeometryFieldMapper.TypeParser<Builder> {
         protected abstract Builder newBuilder(String name, Map<String, Object> params);
 
@@ -180,6 +200,11 @@ public abstract class AbstractShapeGeometryFieldMapper<Parsed, Processed> extend
         }
     }
 
+    /**
+     * Base field type for the base shape geometry field mapper
+     *
+     * @opensearch.internal
+     */
     public abstract static class AbstractShapeGeometryFieldType<Parsed, Processed> extends AbstractGeometryFieldType<Parsed, Processed> {
         protected Orientation orientation = Defaults.ORIENTATION.value();
 

--- a/server/src/main/java/org/opensearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/BinaryFieldMapper.java
@@ -72,6 +72,11 @@ public class BinaryFieldMapper extends ParametrizedFieldMapper {
         return (BinaryFieldMapper) in;
     }
 
+    /**
+     * Builder for the binary field mapper
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
         private final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).stored, false);
@@ -106,6 +111,11 @@ public class BinaryFieldMapper extends ParametrizedFieldMapper {
 
     public static final TypeParser PARSER = new TypeParser((n, c) -> new Builder(n));
 
+    /**
+     * Binary field type
+     *
+     * @opensearch.internal
+     */
     public static final class BinaryFieldType extends MappedFieldType {
 
         private BinaryFieldType(String name, boolean isStored, boolean hasDocValues, Map<String, String> meta) {
@@ -223,6 +233,11 @@ public class BinaryFieldMapper extends ParametrizedFieldMapper {
         return CONTENT_TYPE;
     }
 
+    /**
+     * Custom binary doc values field for the binary field mapper
+     *
+     * @opensearch.internal
+     */
     public static class CustomBinaryDocValuesField extends CustomDocValuesField {
 
         private final ObjectArrayList<byte[]> bytesList;

--- a/server/src/main/java/org/opensearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/BooleanFieldMapper.java
@@ -68,6 +68,11 @@ public class BooleanFieldMapper extends ParametrizedFieldMapper {
 
     public static final String CONTENT_TYPE = "boolean";
 
+    /**
+     * Default parameters for the boolean field mapper
+     *
+     * @opensearch.internal
+     */
     public static class Defaults {
         public static final FieldType FIELD_TYPE = new FieldType();
 
@@ -79,6 +84,11 @@ public class BooleanFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
+    /**
+     * Values that can be used for this field mapper
+     *
+     * @opensearch.internal
+     */
     public static class Values {
         public static final BytesRef TRUE = new BytesRef("T");
         public static final BytesRef FALSE = new BytesRef("F");
@@ -88,6 +98,11 @@ public class BooleanFieldMapper extends ParametrizedFieldMapper {
         return (BooleanFieldMapper) in;
     }
 
+    /**
+     * Builder for this field mapper
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
         private final Parameter<Boolean> docValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, true);
@@ -131,6 +146,11 @@ public class BooleanFieldMapper extends ParametrizedFieldMapper {
 
     public static final TypeParser PARSER = new TypeParser((n, c) -> new Builder(n));
 
+    /**
+     * Field type for boolean field mapper
+     *
+     * @opensearch.internal
+     */
     public static final class BooleanFieldType extends TermBasedFieldType {
 
         private final Boolean nullValue;

--- a/server/src/main/java/org/opensearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/CompletionFieldMapper.java
@@ -106,6 +106,11 @@ public class CompletionFieldMapper extends ParametrizedFieldMapper {
         return new Builder(simpleName(), defaultAnalyzer, indexVersionCreated).init(this);
     }
 
+    /**
+     * Default parameters
+     *
+     * @opensearch.internal
+     */
     public static class Defaults {
         public static final FieldType FIELD_TYPE = new FieldType();
         static {
@@ -121,6 +126,11 @@ public class CompletionFieldMapper extends ParametrizedFieldMapper {
         public static final int DEFAULT_MAX_INPUT_LENGTH = 50;
     }
 
+    /**
+     * Parameter fields
+     *
+     * @opensearch.internal
+     */
     public static class Fields {
         // Content field names
         public static final String CONTENT_FIELD_NAME_INPUT = "input";
@@ -134,6 +144,8 @@ public class CompletionFieldMapper extends ParametrizedFieldMapper {
 
     /**
      * Builder for {@link CompletionFieldMapper}
+     *
+     * @opensearch.internal
      */
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
@@ -255,6 +267,11 @@ public class CompletionFieldMapper extends ParametrizedFieldMapper {
         (n, c) -> new Builder(n, c.getIndexAnalyzers().get("simple"), c.indexVersionCreated())
     );
 
+    /**
+     * Field type for Completion Field Mapper
+     *
+     * @opensearch.internal
+     */
     public static final class CompletionFieldType extends TermBasedFieldType {
 
         private static PostingsFormat postingsFormat;
@@ -608,6 +625,11 @@ public class CompletionFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
+    /**
+     * Metadata for completion input
+     *
+     * @opensearch.internal
+     */
     static class CompletionInputMetadata {
         public final String input;
         public final Map<String, Set<String>> contexts;

--- a/server/src/main/java/org/opensearch/index/mapper/DataStreamFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DataStreamFieldMapper.java
@@ -32,11 +32,21 @@ public class DataStreamFieldMapper extends MetadataFieldMapper {
     public static final String NAME = "_data_stream_timestamp";
     public static final String CONTENT_TYPE = "_data_stream_timestamp";
 
+    /**
+     * Default parameters
+     *
+     * @opensearch.internal
+     */
     public static final class Defaults {
         public static final boolean ENABLED = false;
         public static final TimestampField TIMESTAMP_FIELD = new TimestampField("@timestamp");
     }
 
+    /**
+     * Builder for the field mapper
+     *
+     * @opensearch.internal
+     */
     public static final class Builder extends MetadataFieldMapper.Builder {
         final Parameter<Boolean> enabledParam = Parameter.boolParam("enabled", false, mapper -> toType(mapper).enabled, Defaults.ENABLED);
 
@@ -63,6 +73,11 @@ public class DataStreamFieldMapper extends MetadataFieldMapper {
         }
     }
 
+    /**
+     * Field type for data stream field mapper
+     *
+     * @opensearch.internal
+     */
     public static final class DataStreamFieldType extends MappedFieldType {
         public static final DataStreamFieldType INSTANCE = new DataStreamFieldType();
 

--- a/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
@@ -94,6 +94,11 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
     public static final String DATE_NANOS_CONTENT_TYPE = "date_nanos";
     public static final DateFormatter DEFAULT_DATE_TIME_FORMATTER = DateFormatter.forPattern("strict_date_optional_time||epoch_millis");
 
+    /**
+     * Resolution of the date time
+     *
+     * @opensearch.internal
+     */
     public enum Resolution {
         MILLISECONDS(CONTENT_TYPE, NumericType.DATE) {
             @Override
@@ -201,6 +206,11 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
         return (DateFieldMapper) in;
     }
 
+    /**
+     * Builder for the date field mapper
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
         private final Parameter<Boolean> index = Parameter.indexParam(m -> toType(m).indexed, true);
@@ -312,6 +322,11 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
         return new Builder(n, Resolution.NANOSECONDS, c.getDateFormatter(), ignoreMalformedByDefault, c.indexVersionCreated());
     });
 
+    /**
+     * Field type for date field mapper
+     *
+     * @opensearch.internal
+     */
     public static final class DateFieldType extends MappedFieldType {
         protected final DateFormatter dateTimeFormatter;
         protected final DateMathParser dateMathParser;

--- a/server/src/main/java/org/opensearch/index/mapper/DocValueFetcher.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocValueFetcher.java
@@ -74,6 +74,11 @@ public final class DocValueFetcher implements ValueFetcher {
         return result;
     }
 
+    /**
+     * Leaf interface
+     *
+     * @opensearch.internal
+     */
     public interface Leaf {
         /**
          * Advance the doc values reader to the provided doc.

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentMapper.java
@@ -70,6 +70,11 @@ import java.util.stream.Stream;
  */
 public class DocumentMapper implements ToXContentFragment {
 
+    /**
+     * Builder for the Document Field Mapper
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
 
         private final Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> metadataMappers = new LinkedHashMap<>();

--- a/server/src/main/java/org/opensearch/index/mapper/DynamicTemplate.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DynamicTemplate.java
@@ -51,6 +51,11 @@ import java.util.TreeMap;
  */
 public class DynamicTemplate implements ToXContentObject {
 
+    /**
+     * Match type of the template
+     *
+     * @opensearch.internal
+     */
     public enum MatchType {
         SIMPLE {
             @Override
@@ -88,7 +93,11 @@ public class DynamicTemplate implements ToXContentObject {
         public abstract boolean matches(String regex, String value);
     }
 
-    /** The type of a field as detected while parsing a json document. */
+    /**
+     * The type of a field as detected while parsing a json document.
+     *
+     * @opensearch.internal
+     */
     public enum XContentFieldType {
         OBJECT {
             @Override

--- a/server/src/main/java/org/opensearch/index/mapper/FieldAliasMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FieldAliasMapper.java
@@ -52,6 +52,11 @@ import java.util.Objects;
 public final class FieldAliasMapper extends Mapper {
     public static final String CONTENT_TYPE = "alias";
 
+    /**
+     * Parameter names
+     *
+     * @opensearch.internal
+     */
     public static class Names {
         public static final String PATH = "path";
     }
@@ -138,6 +143,11 @@ public final class FieldAliasMapper extends Mapper {
         }
     }
 
+    /**
+     * The type parser
+     *
+     * @opensearch.internal
+     */
     public static class TypeParser implements Mapper.TypeParser {
         @Override
         public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
@@ -151,6 +161,11 @@ public final class FieldAliasMapper extends Mapper {
         }
     }
 
+    /**
+     * The bulider for the field alias field mapper
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends Mapper.Builder<FieldAliasMapper.Builder> {
         private String name;
         private String path;

--- a/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
@@ -73,6 +73,11 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
     );
     public static final Setting<Boolean> COERCE_SETTING = Setting.boolSetting("index.mapping.coerce", false, Property.IndexScope);
 
+    /**
+     * Base builder for all field mappers
+     *
+     * @opensearch.internal
+     */
     public abstract static class Builder<T extends Builder<T>> extends Mapper.Builder<T> {
 
         protected final FieldType fieldType;
@@ -560,12 +565,22 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
 
     protected abstract String contentType();
 
+    /**
+     * Multi field implementation used across field mappers
+     *
+     * @opensearch.internal
+     */
     public static class MultiFields implements Iterable<Mapper> {
 
         public static MultiFields empty() {
             return new MultiFields(ImmutableOpenMap.<String, FieldMapper>of());
         }
 
+        /**
+         * Concrete builder for field mappers
+         *
+         * @opensearch.internal
+         */
         public static class Builder {
 
             private final ImmutableOpenMap.Builder<String, Mapper.Builder> mapperBuilders = ImmutableOpenMap.builder();
@@ -689,6 +704,8 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
 
     /**
      * Represents a list of fields with optional boost factor where the current field should be copied to
+     *
+     * @opensearch.internal
      */
     public static class CopyTo {
 
@@ -715,6 +732,11 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             return builder;
         }
 
+        /**
+         * Builder for the copyTo field
+         *
+         * @opensearch.internal
+         */
         public static class Builder {
             private final List<String> copyToBuilders = new ArrayList<>();
 

--- a/server/src/main/java/org/opensearch/index/mapper/FieldNamesFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FieldNamesFieldMapper.java
@@ -64,6 +64,11 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
         return new Builder(indexVersionCreated).init(this);
     }
 
+    /**
+     * Parameter defaults
+     *
+     * @opensearch.internal
+     */
     public static class Defaults {
         public static final String NAME = FieldNamesFieldMapper.NAME;
 
@@ -87,6 +92,11 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
         "Disabling _field_names is not necessary because it no longer carries a large index overhead. Support for the `enabled` "
             + "setting will be removed in a future major version. Please remove it from your mappings and templates.";
 
+    /**
+     * Builder for the FieldNames field mapper
+     *
+     * @opensearch.internal
+     */
     static class Builder extends MetadataFieldMapper.Builder {
 
         private final Parameter<Explicit<Boolean>> enabled = updateableBoolParam(
@@ -122,6 +132,11 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
         c -> new Builder(c.indexVersionCreated())
     );
 
+    /**
+     * Field type for FieldNames field mapper
+     *
+     * @opensearch.internal
+     */
     public static final class FieldNamesFieldType extends TermBasedFieldType {
 
         private final boolean enabled;

--- a/server/src/main/java/org/opensearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/GeoPointFieldMapper.java
@@ -78,6 +78,11 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<List<P
         FIELD_TYPE.freeze();
     }
 
+    /**
+     * Concrete builder for geo_point types
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends AbstractPointGeometryFieldMapper.Builder<Builder, GeoPointFieldType> {
 
         public Builder(String name) {
@@ -107,6 +112,11 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<List<P
         }
     }
 
+    /**
+     * Concrete parser for geo_point types
+     *
+     * @opensearch.internal
+     */
     public static class TypeParser extends AbstractPointGeometryFieldMapper.TypeParser<Builder> {
         @Override
         protected Builder newBuilder(String name, Map<String, Object> params) {
@@ -189,6 +199,11 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<List<P
         return (GeoPointFieldType) mappedFieldType;
     }
 
+    /**
+     * Concrete field type for geo_point
+     *
+     * @opensearch.internal
+     */
     public static class GeoPointFieldType extends AbstractPointGeometryFieldType<List<ParsedGeoPoint>, List<? extends GeoPoint>>
         implements
             GeoShapeQueryable {
@@ -242,6 +257,11 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<List<P
 
     // Eclipse requires the AbstractPointGeometryFieldMapper prefix or it can't find ParsedPoint
     // See https://bugs.eclipse.org/bugs/show_bug.cgi?id=565255
+    /**
+     * A geo point parsed from geojson
+     *
+     * @opensearch.internal
+     */
     protected static class ParsedGeoPoint extends GeoPoint implements AbstractPointGeometryFieldMapper.ParsedPoint {
         @Override
         public void validate(String fieldName) {
@@ -299,6 +319,11 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<List<P
         }
     }
 
+    /**
+     * The indexer for geo_point
+     *
+     * @opensearch.internal
+     */
     protected static class GeoPointIndexer implements Indexer<List<ParsedGeoPoint>, List<? extends GeoPoint>> {
 
         protected final GeoPointFieldType fieldType;

--- a/server/src/main/java/org/opensearch/index/mapper/GeoShapeFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/GeoShapeFieldMapper.java
@@ -78,6 +78,11 @@ public class GeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geomet
         FIELD_TYPE.freeze();
     }
 
+    /**
+     * Concrete builder for geo_shape types
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends AbstractShapeGeometryFieldMapper.Builder<Builder, GeoShapeFieldType> {
 
         public Builder(String name) {
@@ -110,6 +115,11 @@ public class GeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geomet
         }
     }
 
+    /**
+     * Concrete field type for geo_shape fields
+     *
+     * @opensearch.internal
+     */
     public static class GeoShapeFieldType extends AbstractShapeGeometryFieldType<Geometry, Geometry> implements GeoShapeQueryable {
 
         private final VectorGeoShapeQueryProcessor queryProcessor;
@@ -130,6 +140,11 @@ public class GeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geomet
         }
     }
 
+    /**
+     * The type parser
+     *
+     * @opensearch.internal
+     */
     public static final class TypeParser extends AbstractShapeGeometryFieldMapper.TypeParser {
 
         @Override

--- a/server/src/main/java/org/opensearch/index/mapper/GeoShapeIndexer.java
+++ b/server/src/main/java/org/opensearch/index/mapper/GeoShapeIndexer.java
@@ -202,6 +202,11 @@ public class GeoShapeIndexer implements AbstractGeometryFieldMapper.Indexer<Geom
         return visitor.fields();
     }
 
+    /**
+     * The shape indexer
+     *
+     * @opensearch.internal
+     */
     private static class LuceneGeometryIndexer implements GeometryVisitor<Void, RuntimeException> {
         private List<IndexableField> fields = new ArrayList<>();
         private final String name;

--- a/server/src/main/java/org/opensearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/IdFieldMapper.java
@@ -87,6 +87,11 @@ public class IdFieldMapper extends MetadataFieldMapper {
 
     public static final String CONTENT_TYPE = "_id";
 
+    /**
+     * Default parameters
+     *
+     * @opensearch.internal
+     */
     public static class Defaults {
         public static final String NAME = IdFieldMapper.NAME;
 
@@ -112,6 +117,11 @@ public class IdFieldMapper extends MetadataFieldMapper {
 
     public static final TypeParser PARSER = new FixedTypeParser(c -> new IdFieldMapper(() -> c.mapperService().isIdFieldDataEnabled()));
 
+    /**
+     * Field type for ID field
+     *
+     * @opensearch.internal
+     */
     static final class IdFieldType extends TermBasedFieldType {
 
         private final Supplier<Boolean> fieldDataEnabled;

--- a/server/src/main/java/org/opensearch/index/mapper/IgnoredFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/IgnoredFieldMapper.java
@@ -53,6 +53,11 @@ public final class IgnoredFieldMapper extends MetadataFieldMapper {
 
     public static final String CONTENT_TYPE = "_ignored";
 
+    /**
+     * Default parameters
+     *
+     * @opensearch.internal
+     */
     public static class Defaults {
         public static final String NAME = IgnoredFieldMapper.NAME;
 
@@ -69,6 +74,11 @@ public final class IgnoredFieldMapper extends MetadataFieldMapper {
 
     public static final TypeParser PARSER = new FixedTypeParser(c -> new IgnoredFieldMapper());
 
+    /**
+     * Field type for Ignored fields
+     *
+     * @opensearch.internal
+     */
     public static final class IgnoredFieldType extends StringFieldType {
 
         public static final IgnoredFieldType INSTANCE = new IgnoredFieldType();

--- a/server/src/main/java/org/opensearch/index/mapper/IndexFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/IndexFieldMapper.java
@@ -57,6 +57,11 @@ public class IndexFieldMapper extends MetadataFieldMapper {
 
     public static final TypeParser PARSER = new FixedTypeParser(c -> new IndexFieldMapper());
 
+    /**
+     * Field type for Index field mapper
+     *
+     * @opensearch.internal
+     */
     static final class IndexFieldType extends ConstantFieldType {
 
         static final IndexFieldType INSTANCE = new IndexFieldType();

--- a/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
@@ -78,6 +78,11 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
         return (IpFieldMapper) in;
     }
 
+    /**
+     * Builder
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
         private final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).indexed, true);
@@ -155,6 +160,11 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
         return new Builder(n, ignoreMalformedByDefault, c.indexVersionCreated());
     });
 
+    /**
+     * Field type for IP fields
+     *
+     * @opensearch.internal
+     */
     public static final class IpFieldType extends SimpleMappedFieldType {
 
         private final InetAddress nullValue;
@@ -305,6 +315,11 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
             return builder.apply(lower, upper);
         }
 
+        /**
+         * Field type for IP Scripted doc values
+         *
+         * @opensearch.internal
+         */
         public static final class IpScriptDocValues extends ScriptDocValues<String> {
 
             private final SortedSetDocValues in;

--- a/server/src/main/java/org/opensearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/KeywordFieldMapper.java
@@ -68,6 +68,11 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
 
     public static final String CONTENT_TYPE = "keyword";
 
+    /**
+     * Default parameters
+     *
+     * @opensearch.internal
+     */
     public static class Defaults {
         public static final FieldType FIELD_TYPE = new FieldType();
 
@@ -79,6 +84,11 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
+    /**
+     * The keyword field for the field mapper
+     *
+     * @opensearch.internal
+     */
     public static class KeywordField extends Field {
 
         public KeywordField(String field, BytesRef term, FieldType ft) {
@@ -91,6 +101,11 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
         return (KeywordFieldMapper) in;
     }
 
+    /**
+     * The builder for the field mapper
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
         private final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).indexed, true);
@@ -225,6 +240,11 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
 
     public static final TypeParser PARSER = new TypeParser((n, c) -> new Builder(n, c.getIndexAnalyzers()));
 
+    /**
+     * Field type for keyword fields
+     *
+     * @opensearch.internal
+     */
     public static final class KeywordFieldType extends StringFieldType {
 
         private final int ignoreAbove;

--- a/server/src/main/java/org/opensearch/index/mapper/LegacyGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/LegacyGeoShapeFieldMapper.java
@@ -101,8 +101,18 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
 
     public static final String CONTENT_TYPE = "geo_shape";
 
+    /**
+     * Legacy prefix tree parameters that are now deprecated
+     *
+     * @opensearch.internal
+     */
     @Deprecated
     public static class DeprecatedParameters {
+        /**
+         * Deprecated parameter names for Prefix trees
+         *
+         * @opensearch.internal
+         */
         public static class Names {
             public static final ParseField STRATEGY = new ParseField("strategy");
             public static final ParseField TREE = new ParseField("tree");
@@ -112,12 +122,22 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
             public static final ParseField POINTS_ONLY = new ParseField("points_only");
         }
 
+        /**
+         * Deprecated prefix tree types
+         *
+         * @opensearch.internal
+         */
         public static class PrefixTrees {
             public static final String LEGACY_QUADTREE = "legacyquadtree";
             public static final String QUADTREE = "quadtree";
             public static final String GEOHASH = "geohash";
         }
 
+        /**
+         * Deprecated defaults for legacy prefix trees
+         *
+         * @opensearch.internal
+         */
         public static class Defaults {
             public static final SpatialStrategy STRATEGY = SpatialStrategy.RECURSIVE;
             public static final String TREE = "quadtree";
@@ -203,6 +223,11 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
 
     private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(LegacyGeoShapeFieldMapper.class);
 
+    /**
+     * The builder for the deprecated prefix tree implementation
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends AbstractShapeGeometryFieldMapper.Builder<Builder, LegacyGeoShapeFieldMapper.GeoShapeFieldType> {
 
         DeprecatedParameters deprecatedParameters;
@@ -325,6 +350,11 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
         }
     }
 
+    /**
+     * A legacy parser for prefix trees
+     *
+     * @opensearch.internal
+     */
     private static class LegacyGeoShapeParser extends Parser<ShapeBuilder<?, ?, ?>> {
         /**
          * Note that this parser is only used for formatting values.
@@ -347,6 +377,11 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
         }
     }
 
+    /**
+     * Field type for GeoShape fields
+     *
+     * @opensearch.internal
+     */
     public static final class GeoShapeFieldType extends AbstractShapeGeometryFieldType<ShapeBuilder<?, ?, ?>, Shape>
         implements
             GeoShapeQueryable {

--- a/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
@@ -378,6 +378,8 @@ public abstract class MappedFieldType {
     /**
      * An enum used to describe the relation between the range of terms in a
      * shard when compared with a query range
+     *
+     * @opensearch.internal
      */
     public enum Relation {
         WITHIN,

--- a/server/src/main/java/org/opensearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/Mapper.java
@@ -55,6 +55,11 @@ import java.util.function.Supplier;
  */
 public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
+    /**
+     * The builder context used in field mappings
+     *
+     * @opensearch.internal
+     */
     public static class BuilderContext {
         private final Settings indexSettings;
         private final ContentPath contentPath;
@@ -86,6 +91,11 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
         }
     }
 
+    /**
+     * Base mapper builder
+     *
+     * @opensearch.internal
+     */
     public abstract static class Builder<T extends Builder> {
 
         public String name;
@@ -104,8 +114,18 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
         public abstract Mapper build(BuilderContext context);
     }
 
+    /**
+     * Type parser for the mapper
+     *
+     * @opensearch.internal
+     */
     public interface TypeParser {
 
+        /**
+         * Parser context for the type parser
+         *
+         * @opensearch.internal
+         */
         class ParserContext {
 
             private final Function<String, SimilarityProvider> similarityLookupService;
@@ -200,6 +220,11 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                 return new MultiFieldParserContext(in);
             }
 
+            /**
+             * Base mutiple field parser context
+             *
+             * @opensearch.internal
+             */
             static class MultiFieldParserContext extends ParserContext {
                 MultiFieldParserContext(ParserContext in) {
                     super(

--- a/server/src/main/java/org/opensearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MapperService.java
@@ -96,6 +96,8 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
 
     /**
      * The reason why a mapping is being merged.
+     *
+     * @opensearch.internal
      */
     public enum MergeReason {
         /**

--- a/server/src/main/java/org/opensearch/index/mapper/MetadataFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MetadataFieldMapper.java
@@ -47,6 +47,11 @@ import java.util.function.Function;
  */
 public abstract class MetadataFieldMapper extends ParametrizedFieldMapper {
 
+    /**
+     * Type parser for the field mapper
+     *
+     * @opensearch.internal
+     */
     public interface TypeParser extends Mapper.TypeParser {
 
         @Override
@@ -91,6 +96,8 @@ public abstract class MetadataFieldMapper extends ParametrizedFieldMapper {
 
     /**
      * A type parser for an unconfigurable metadata field.
+     *
+     * @opensearch.internal
      */
     public static class FixedTypeParser implements TypeParser {
 
@@ -111,6 +118,11 @@ public abstract class MetadataFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
+    /**
+     * Type parser that is configurable
+     *
+     * @opensearch.internal
+     */
     public static class ConfigurableTypeParser implements TypeParser {
 
         final Function<ParserContext, MetadataFieldMapper> defaultMapperParser;
@@ -137,6 +149,11 @@ public abstract class MetadataFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
+    /**
+     * Base builder for internal metadata fields
+     *
+     * @opensearch.internal
+     */
     public abstract static class Builder extends ParametrizedFieldMapper.Builder {
 
         protected Builder(String name) {

--- a/server/src/main/java/org/opensearch/index/mapper/NestedPathFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/NestedPathFieldMapper.java
@@ -31,6 +31,11 @@ public class NestedPathFieldMapper extends MetadataFieldMapper {
     public static final String LEGACY_NAME = "_type";
     public static final String NAME = "_nested_path";
 
+    /**
+     * Default parameters for the field mapper
+     *
+     * @opensearch.internal
+     */
     public static class Defaults {
         public static final FieldType FIELD_TYPE = new FieldType();
         static {
@@ -77,7 +82,11 @@ public class NestedPathFieldMapper extends MetadataFieldMapper {
         return new TermQuery(new Term(name(version), new BytesRef(path)));
     }
 
-    /** field type for the NestPath field */
+    /**
+     * field type for the NestPath field
+     *
+     * @opensearch.internal
+     */
     public static final class NestedPathFieldType extends StringFieldType {
         private NestedPathFieldType(String name) {
             super(name, true, false, false, TextSearchInfo.SIMPLE_MATCH_ONLY, Collections.emptyMap());

--- a/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java
@@ -90,6 +90,11 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
         return (NumberFieldMapper) in;
     }
 
+    /**
+     * Builder for the number field mappers
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
         private final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).indexed, true);
@@ -156,6 +161,11 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
+    /**
+     * Type of number
+     *
+     * @opensearch.internal
+     */
     public enum NumberType {
         HALF_FLOAT("half_float", NumericType.HALF_FLOAT) {
             @Override
@@ -964,6 +974,11 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
+    /**
+     * Field type for numeric fields
+     *
+     * @opensearch.internal
+     */
     public static class NumberFieldType extends SimpleMappedFieldType {
 
         private final NumberType type;

--- a/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
@@ -67,18 +67,33 @@ public class ObjectMapper extends Mapper implements Cloneable {
     public static final String CONTENT_TYPE = "object";
     public static final String NESTED_CONTENT_TYPE = "nested";
 
+    /**
+     * Parameter defaults
+     *
+     * @opensearch.internal
+     */
     public static class Defaults {
         public static final boolean ENABLED = true;
         public static final Nested NESTED = Nested.NO;
         public static final Dynamic DYNAMIC = null; // not set, inherited from root
     }
 
+    /**
+     * Dynamic field mapping specification
+     *
+     * @opensearch.internal
+     */
     public enum Dynamic {
         TRUE,
         FALSE,
         STRICT
     }
 
+    /**
+     * Nested objects
+     *
+     * @opensearch.internal
+     */
     public static class Nested {
 
         public static final Nested NO = new Nested(false, new Explicit<>(false, false), new Explicit<>(false, false));
@@ -150,6 +165,11 @@ public class ObjectMapper extends Mapper implements Cloneable {
         }
     }
 
+    /**
+     * Builder for object field mapper
+     *
+     * @opensearch.internal
+     */
     @SuppressWarnings("rawtypes")
     public static class Builder<T extends Builder> extends Mapper.Builder<T> {
 
@@ -227,6 +247,11 @@ public class ObjectMapper extends Mapper implements Cloneable {
         }
     }
 
+    /**
+     * Type parser for object field mapper
+     *
+     * @opensearch.internal
+     */
     public static class TypeParser implements Mapper.TypeParser {
         @Override
         public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {

--- a/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
@@ -173,6 +173,8 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
     /**
      * A configurable parameter for a field mapper
      * @param <T> the type of the value the parameter holds
+     *
+     * @opensearch.internal
      */
     public static final class Parameter<T> implements Supplier<T> {
 
@@ -544,6 +546,11 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
 
     }
 
+    /**
+     * Conflicts in the field mapper
+     *
+     * @opensearch.internal
+     */
     private static final class Conflicts {
 
         private final String mapperName;
@@ -569,6 +576,8 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
 
     /**
      * A Builder for a ParametrizedFieldMapper
+     *
+     * @opensearch.internal
      */
     public abstract static class Builder extends Mapper.Builder<Builder> {
 
@@ -725,6 +734,8 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
 
     /**
      * TypeParser implementation that automatically handles parsing
+     *
+     * @opensearch.internal
      */
     public static final class TypeParser implements Mapper.TypeParser {
 

--- a/server/src/main/java/org/opensearch/index/mapper/ParseContext.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ParseContext.java
@@ -56,7 +56,11 @@ import java.util.Set;
  */
 public abstract class ParseContext implements Iterable<ParseContext.Document> {
 
-    /** Fork of {@link org.apache.lucene.document.Document} with additional functionality. */
+    /**
+     * Fork of {@link org.apache.lucene.document.Document} with additional functionality.
+     *
+     * @opensearch.internal
+     */
     public static class Document implements Iterable<IndexableField> {
 
         private final Document parent;
@@ -171,6 +175,11 @@ public abstract class ParseContext implements Iterable<ParseContext.Document> {
 
     }
 
+    /**
+     * Filter parse context.
+     *
+     * @opensearch.internal
+     */
     private static class FilterParseContext extends ParseContext {
 
         private final ParseContext in;
@@ -305,6 +314,11 @@ public abstract class ParseContext implements Iterable<ParseContext.Document> {
         }
     }
 
+    /**
+     * An internal parse context
+     *
+     * @opensearch.internal
+     */
     public static class InternalParseContext extends ParseContext {
 
         private final DocumentMapper docMapper;

--- a/server/src/main/java/org/opensearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/RangeFieldMapper.java
@@ -86,6 +86,11 @@ public class RangeFieldMapper extends ParametrizedFieldMapper {
     public static final boolean DEFAULT_INCLUDE_UPPER = true;
     public static final boolean DEFAULT_INCLUDE_LOWER = true;
 
+    /**
+     * Default parameters for range fields
+     *
+     * @opensearch.internal
+     */
     public static class Defaults {
         public static final Explicit<Boolean> COERCE = new Explicit<>(true, false);
         public static final DateFormatter DATE_FORMATTER = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER;
@@ -98,6 +103,11 @@ public class RangeFieldMapper extends ParametrizedFieldMapper {
         return (RangeFieldMapper) in;
     }
 
+    /**
+     * Builder for range fields
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
         private final Parameter<Boolean> index = Parameter.indexParam(m -> toType(m).index, true);
@@ -233,6 +243,11 @@ public class RangeFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
+    /**
+     * Field type for range fields
+     *
+     * @opensearch.internal
+     */
     public static final class RangeFieldType extends MappedFieldType {
         protected final RangeType rangeType;
         protected final DateFormatter dateTimeFormatter;
@@ -559,7 +574,11 @@ public class RangeFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
-    /** Class defining a range */
+    /**
+     * Class defining a range
+     *
+     * @opensearch.internal
+     */
     public static class Range {
         RangeType type;
         Object from;
@@ -618,6 +637,11 @@ public class RangeFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
+    /**
+     * Doc values field for binary ranges
+     *
+     * @opensearch.internal
+     */
     static class BinaryRangesDocValuesField extends CustomDocValuesField {
 
         private final Set<Range> ranges;

--- a/server/src/main/java/org/opensearch/index/mapper/RangeType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/RangeType.java
@@ -982,6 +982,11 @@ public enum RangeType {
     private final NumberFieldMapper.NumberType numberType;
     public final LengthType lengthType;
 
+    /**
+     * Type of length
+     *
+     * @opensearch.internal
+     */
     public enum LengthType {
         FIXED_4 {
             @Override

--- a/server/src/main/java/org/opensearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/RootObjectMapper.java
@@ -65,6 +65,11 @@ import static org.opensearch.index.mapper.TypeParsers.parseDateTimeFormatter;
 public class RootObjectMapper extends ObjectMapper {
     private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(RootObjectMapper.class);
 
+    /**
+     * Default parameters for root object
+     *
+     * @opensearch.internal
+     */
     public static class Defaults {
         public static final DateFormatter[] DYNAMIC_DATE_TIME_FORMATTERS = new DateFormatter[] {
             DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER,
@@ -73,6 +78,11 @@ public class RootObjectMapper extends ObjectMapper {
         public static final boolean NUMERIC_DETECTION = false;
     }
 
+    /**
+     * Builder for the root object
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends ObjectMapper.Builder<Builder> {
 
         protected Explicit<DynamicTemplate[]> dynamicTemplates = new Explicit<>(new DynamicTemplate[0], false);
@@ -153,6 +163,11 @@ public class RootObjectMapper extends ObjectMapper {
         }
     }
 
+    /**
+     * Type parser for the root object
+     *
+     * @opensearch.internal
+     */
     public static class TypeParser extends ObjectMapper.TypeParser {
 
         @Override

--- a/server/src/main/java/org/opensearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/RoutingFieldMapper.java
@@ -57,6 +57,11 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
         return new Builder().init(this);
     }
 
+    /**
+     * Default parameters for routing fields
+     *
+     * @opensearch.internal
+     */
     public static class Defaults {
 
         public static final FieldType FIELD_TYPE = new FieldType();
@@ -75,6 +80,11 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
         return (RoutingFieldMapper) in;
     }
 
+    /**
+     * Builder for routing fields
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends MetadataFieldMapper.Builder {
 
         final Parameter<Boolean> required = Parameter.boolParam("required", false, m -> toType(m).required, Defaults.REQUIRED);
@@ -96,6 +106,11 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
 
     public static final TypeParser PARSER = new ConfigurableTypeParser(c -> new RoutingFieldMapper(Defaults.REQUIRED), c -> new Builder());
 
+    /**
+     * Field type for routing fields
+     *
+     * @opensearch.internal
+     */
     static final class RoutingFieldType extends StringFieldType {
 
         static RoutingFieldType INSTANCE = new RoutingFieldType();

--- a/server/src/main/java/org/opensearch/index/mapper/SeqNoFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/SeqNoFieldMapper.java
@@ -73,6 +73,8 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
     /**
      * A sequence ID, which is made up of a sequence number (both the searchable
      * and doc_value version of the field) and the primary term.
+     *
+     * @opensearch.internal
      */
     public static class SequenceIDFields {
 
@@ -108,6 +110,11 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
 
     public static final TypeParser PARSER = new FixedTypeParser(c -> new SeqNoFieldMapper());
 
+    /**
+     * Field type for internal sequence numbers
+     *
+     * @opensearch.internal
+     */
     static final class SeqNoFieldType extends SimpleMappedFieldType {
 
         private static final SeqNoFieldType INSTANCE = new SeqNoFieldType();

--- a/server/src/main/java/org/opensearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/SourceFieldMapper.java
@@ -73,6 +73,11 @@ public class SourceFieldMapper extends MetadataFieldMapper {
     public static final String CONTENT_TYPE = "_source";
     private final Function<Map<String, ?>, Map<String, Object>> filter;
 
+    /**
+     * Default parameters for source fields
+     *
+     * @opensearch.internal
+     */
     public static class Defaults {
         public static final String NAME = SourceFieldMapper.NAME;
         public static final boolean ENABLED = true;
@@ -91,6 +96,11 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         return (SourceFieldMapper) in;
     }
 
+    /**
+     * Builder for source fields
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends MetadataFieldMapper.Builder {
 
         private final Parameter<Boolean> enabled = Parameter.boolParam("enabled", false, m -> toType(m).enabled, Defaults.ENABLED);
@@ -128,6 +138,11 @@ public class SourceFieldMapper extends MetadataFieldMapper {
 
     public static final TypeParser PARSER = new ConfigurableTypeParser(c -> new SourceFieldMapper(), c -> new Builder());
 
+    /**
+     * Field type for source field mapper
+     *
+     * @opensearch.internal
+     */
     static final class SourceFieldType extends MappedFieldType {
 
         private SourceFieldType(boolean enabled) {

--- a/server/src/main/java/org/opensearch/index/mapper/SourceToParse.java
+++ b/server/src/main/java/org/opensearch/index/mapper/SourceToParse.java
@@ -90,6 +90,11 @@ public class SourceToParse {
         return this.xContentType;
     }
 
+    /**
+     * Origin of the source
+     *
+     * @opensearch.internal
+     */
     public enum Origin {
         PRIMARY,
         REPLICA

--- a/server/src/main/java/org/opensearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/TextFieldMapper.java
@@ -113,6 +113,11 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
     private static final int POSITION_INCREMENT_GAP_USE_ANALYZER = -1;
     private static final String FAST_PHRASE_SUFFIX = "._index_phrase";
 
+    /**
+     * Default paramters for text fields
+     *
+     * @opensearch.internal
+     */
     public static class Defaults {
         public static final double FIELDDATA_MIN_FREQUENCY = 0;
         public static final double FIELDDATA_MAX_FREQUENCY = Integer.MAX_VALUE;
@@ -142,6 +147,11 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
         return ((TextFieldMapper) in).builder;
     }
 
+    /**
+     * Prefix configuration
+     *
+     * @opensearch.internal
+     */
     private static final class PrefixConfig implements ToXContent {
         final int minChars;
         final int maxChars;
@@ -199,6 +209,11 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
         return new PrefixConfig(minChars, maxChars);
     }
 
+    /**
+     * Frequency filter for field data
+     *
+     * @opensearch.internal
+     */
     private static final class FielddataFrequencyFilter implements ToXContent {
         final double minFreq;
         final double maxFreq;
@@ -256,6 +271,11 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
         return new FielddataFrequencyFilter(minFrequency, maxFrequency, minSegmentSize);
     }
 
+    /**
+     * Builder for text fields
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
         private final Version indexCreatedVersion;
@@ -456,6 +476,11 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
 
     public static final TypeParser PARSER = new TypeParser((n, c) -> new Builder(n, c.indexVersionCreated(), c.getIndexAnalyzers()));
 
+    /**
+     * A phrase wrapped field analyzer
+     *
+     * @opensearch.internal
+     */
     private static class PhraseWrappedAnalyzer extends AnalyzerWrapper {
 
         private final Analyzer delegate;
@@ -476,6 +501,11 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
+    /**
+     * A prefix wrapped analyzer
+     *
+     * @opensearch.internal
+     */
     private static class PrefixWrappedAnalyzer extends AnalyzerWrapper {
 
         private final int minChars;
@@ -501,6 +531,11 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
+    /**
+     * Field type for phrase fields
+     *
+     * @opensearch.internal
+     */
     static final class PhraseFieldType extends StringFieldType {
 
         final TextFieldType parent;
@@ -533,6 +568,11 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
+    /**
+     * Field type for prefix fields
+     *
+     * @opensearch.internal
+     */
     static final class PrefixFieldType extends StringFieldType {
 
         final int minChars;
@@ -626,6 +666,11 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
+    /**
+     * Field mapper for phrase fields
+     *
+     * @opensearch.internal
+     */
     private static final class PhraseFieldMapper extends FieldMapper {
 
         PhraseFieldMapper(FieldType fieldType, PhraseFieldType mappedFieldType) {
@@ -648,6 +693,11 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
+    /**
+     * Field mapper for prefix fields
+     *
+     * @opensearch.internal
+     */
     private static final class PrefixFieldMapper extends FieldMapper {
 
         protected PrefixFieldMapper(FieldType fieldType, PrefixFieldType mappedFieldType) {
@@ -679,6 +729,11 @@ public class TextFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
+    /**
+     * Field type for text fields
+     *
+     * @opensearch.internal
+     */
     public static class TextFieldType extends StringFieldType {
 
         private boolean fielddata;

--- a/server/src/main/java/org/opensearch/index/mapper/TextParams.java
+++ b/server/src/main/java/org/opensearch/index/mapper/TextParams.java
@@ -54,6 +54,11 @@ public final class TextParams {
 
     private TextParams() {}
 
+    /**
+     * Analyzers for text
+     *
+     * @opensearch.internal
+     */
     public static final class Analyzers {
         public final Parameter<NamedAnalyzer> indexAnalyzer;
         public final Parameter<NamedAnalyzer> searchAnalyzer;

--- a/server/src/main/java/org/opensearch/index/mapper/TextSearchInfo.java
+++ b/server/src/main/java/org/opensearch/index/mapper/TextSearchInfo.java
@@ -144,6 +144,8 @@ public class TextSearchInfo {
 
     /**
      * What sort of term vectors are available
+     *
+     * @opensearch.internal
      */
     public enum TermVector {
         NONE,

--- a/server/src/main/java/org/opensearch/index/mapper/VersionFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/VersionFieldMapper.java
@@ -54,6 +54,11 @@ public class VersionFieldMapper extends MetadataFieldMapper {
 
     public static final TypeParser PARSER = new FixedTypeParser(c -> new VersionFieldMapper());
 
+    /**
+     * Field type for internal version field
+     *
+     * @opensearch.internal
+     */
     static final class VersionFieldType extends MappedFieldType {
 
         public static final VersionFieldType INSTANCE = new VersionFieldType();

--- a/server/src/main/java/org/opensearch/index/merge/MergeStats.java
+++ b/server/src/main/java/org/opensearch/index/merge/MergeStats.java
@@ -244,6 +244,11 @@ public class MergeStats implements Writeable, ToXContentFragment {
         return builder;
     }
 
+    /**
+     * Fields used for merge statistics
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String MERGES = "merges";
         static final String CURRENT = "current";

--- a/server/src/main/java/org/opensearch/index/query/AbstractGeometryQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/AbstractGeometryQueryBuilder.java
@@ -524,7 +524,11 @@ public abstract class AbstractGeometryQueryBuilder<QB extends AbstractGeometryQu
         return this;
     }
 
-    /** local class that encapsulates xcontent parsed shape parameters */
+    /**
+     * local class that encapsulates xcontent parsed shape parameters
+     *
+     * @opensearch.internal
+     */
     protected abstract static class ParsedGeometryQueryParams {
         public String fieldName;
         public ShapeRelation relation;

--- a/server/src/main/java/org/opensearch/index/query/DistanceFeatureQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/DistanceFeatureQueryBuilder.java
@@ -158,6 +158,11 @@ public class DistanceFeatureQueryBuilder extends AbstractQueryBuilder<DistanceFe
         return this.field.equals(other.field) && Objects.equals(this.origin, other.origin) && this.pivot.equals(other.pivot);
     }
 
+    /**
+     * Origin of a distance feature query
+     *
+     * @opensearch.internal
+     */
     public static class Origin {
         private final Object origin;
 

--- a/server/src/main/java/org/opensearch/index/query/GeoShapeQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/GeoShapeQueryBuilder.java
@@ -231,6 +231,11 @@ public class GeoShapeQueryBuilder extends AbstractGeometryQueryBuilder<GeoShapeQ
         return builder;
     }
 
+    /**
+     * Geoshape query parameters that have been parsed from xcontent
+     *
+     * @opensearch.internal
+     */
     private static class ParsedGeoShapeQueryParams extends ParsedGeometryQueryParams {
         SpatialStrategy strategy;
 

--- a/server/src/main/java/org/opensearch/index/query/IntervalFilterScript.java
+++ b/server/src/main/java/org/opensearch/index/query/IntervalFilterScript.java
@@ -43,6 +43,11 @@ import org.opensearch.script.ScriptFactory;
  */
 public abstract class IntervalFilterScript {
 
+    /**
+     * Internal interval
+     *
+     * @opensearch.internal
+     */
     public static class Interval {
 
         private IntervalIterator iterator;
@@ -66,6 +71,11 @@ public abstract class IntervalFilterScript {
 
     public abstract boolean execute(Interval interval);
 
+    /**
+     * Factory to create a script
+     *
+     * @opensearch.internal
+     */
     public interface Factory extends ScriptFactory {
         IntervalFilterScript newInstance();
     }

--- a/server/src/main/java/org/opensearch/index/query/IntervalsSourceProvider.java
+++ b/server/src/main/java/org/opensearch/index/query/IntervalsSourceProvider.java
@@ -127,6 +127,11 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         return isp;
     }
 
+    /**
+     * Match interval
+     *
+     * @opensearch.internal
+     */
     public static class Match extends IntervalsSourceProvider {
 
         public static final String NAME = "match";
@@ -312,6 +317,11 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         }
     }
 
+    /**
+     * Disjunction interval
+     *
+     * @opensearch.internal
+     */
     public static class Disjunction extends IntervalsSourceProvider {
 
         public static final String NAME = "any_of";
@@ -417,6 +427,11 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         }
     }
 
+    /**
+     * Combine interval
+     *
+     * @opensearch.internal
+     */
     public static class Combine extends IntervalsSourceProvider {
 
         public static final String NAME = "all_of";
@@ -567,6 +582,11 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         }
     }
 
+    /**
+     * Prefix interval
+     *
+     * @opensearch.internal
+     */
     public static class Prefix extends IntervalsSourceProvider {
 
         public static final String NAME = "prefix";
@@ -681,6 +701,11 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         }
     }
 
+    /**
+     * Regular expression interval
+     *
+     * @opensearch.internal
+     */
     public static class Regexp extends IntervalsSourceProvider {
 
         public static final String NAME = "regexp";
@@ -860,6 +885,11 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         }
     }
 
+    /**
+     * Wildcard interval
+     *
+     * @opensearch.internal
+     */
     public static class Wildcard extends IntervalsSourceProvider {
 
         public static final String NAME = "wildcard";
@@ -1010,6 +1040,11 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         }
     }
 
+    /**
+     * Fuzzy interval
+     *
+     * @opensearch.internal
+     */
     public static class Fuzzy extends IntervalsSourceProvider {
 
         public static final String NAME = "fuzzy";
@@ -1180,6 +1215,11 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         }
     }
 
+    /**
+     * Script filter source
+     *
+     * @opensearch.internal
+     */
     static class ScriptFilterSource extends FilteredIntervalsSource {
 
         final IntervalFilterScript script;
@@ -1197,6 +1237,11 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         }
     }
 
+    /**
+     * An interval filter
+     *
+     * @opensearch.internal
+     */
     public static class IntervalFilter implements ToXContentObject, Writeable {
 
         public static final String NAME = "filter";

--- a/server/src/main/java/org/opensearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/MoreLikeThisQueryBuilder.java
@@ -161,6 +161,8 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
 
     /**
      * A single item to be used for a {@link MoreLikeThisQueryBuilder}.
+     *
+     * @opensearch.internal
      */
     public static final class Item implements ToXContentObject, Writeable {
         public static final Item[] EMPTY_ARRAY = new Item[0];

--- a/server/src/main/java/org/opensearch/index/query/MultiMatchQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/MultiMatchQueryBuilder.java
@@ -117,6 +117,11 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
     private boolean autoGenerateSynonymsPhraseQuery = true;
     private boolean fuzzyTranspositions = DEFAULT_FUZZY_TRANSPOSITIONS;
 
+    /**
+     * Type of the match
+     *
+     * @opensearch.internal
+     */
     public enum Type implements Writeable {
 
         /**

--- a/server/src/main/java/org/opensearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/NestedQueryBuilder.java
@@ -358,6 +358,11 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
         }
     }
 
+    /**
+     * Context builder for nested inner hits
+     *
+     * @opensearch.internal
+     */
     static class NestedInnerHitContextBuilder extends InnerHitContextBuilder {
         private final String path;
 
@@ -396,6 +401,11 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
         }
     }
 
+    /**
+     * Inner hits sub context
+     *
+     * @opensearch.internal
+     */
     static final class NestedInnerHitSubContext extends InnerHitsContext.InnerHitSubContext {
 
         private final ObjectMapper parentObjectMapper;

--- a/server/src/main/java/org/opensearch/index/query/ScriptQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/ScriptQueryBuilder.java
@@ -164,6 +164,11 @@ public class ScriptQueryBuilder extends AbstractQueryBuilder<ScriptQueryBuilder>
         return new ScriptQuery(script, filterScript, queryName);
     }
 
+    /**
+     * Internal script query
+     *
+     * @opensearch.internal
+     */
     static class ScriptQuery extends Query {
 
         final Script script;

--- a/server/src/main/java/org/opensearch/index/query/SpanNearQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SpanNearQueryBuilder.java
@@ -306,6 +306,8 @@ public class SpanNearQueryBuilder extends AbstractQueryBuilder<SpanNearQueryBuil
      * can be invoked for it.
      * This QueryBuilder is only applicable as a clause in SpanGapQueryBuilder but
      * yet to enforce this restriction.
+     *
+     * @opensearch.internal
      */
     public static class SpanGapQueryBuilder implements SpanQueryBuilder {
         public static final String NAME = "span_gap";

--- a/server/src/main/java/org/opensearch/index/query/SpanQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SpanQueryBuilder.java
@@ -42,6 +42,11 @@ import org.opensearch.common.xcontent.XContentParser;
  */
 public interface SpanQueryBuilder extends QueryBuilder {
 
+    /**
+     * Utility for span query builders
+     *
+     * @opensearch.internal
+     */
     class SpanQueryBuilderUtil {
         private SpanQueryBuilderUtil() {
             // utility class

--- a/server/src/main/java/org/opensearch/index/query/TermsSetQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/TermsSetQueryBuilder.java
@@ -298,6 +298,11 @@ public final class TermsSetQueryBuilder extends AbstractQueryBuilder<TermsSetQue
         return longValuesSource;
     }
 
+    /**
+     * Values Source for scripted long values
+     *
+     * @opensearch.internal
+     */
     static final class ScriptLongValueSource extends LongValuesSource {
 
         private final Script script;
@@ -366,8 +371,12 @@ public final class TermsSetQueryBuilder extends AbstractQueryBuilder<TermsSetQue
 
     }
 
-    // Forked from LongValuesSource.FieldValuesSource and changed getValues() method to always use sorted numeric
-    // doc values, because that is what is being used in NumberFieldMapper.
+    /**
+     * Forked from LongValuesSource.FieldValuesSource and changed getValues() method to always use sorted numeric
+     * doc values, because that is what is being used in NumberFieldMapper.
+     *
+     * @opensearch.internal
+     */
     static class FieldValuesSource extends LongValuesSource {
 
         private final String fieldName;

--- a/server/src/main/java/org/opensearch/index/query/VectorGeoShapeQueryProcessor.java
+++ b/server/src/main/java/org/opensearch/index/query/VectorGeoShapeQueryProcessor.java
@@ -88,6 +88,11 @@ public class VectorGeoShapeQueryProcessor {
         );
     }
 
+    /**
+     * Geometry collector for LatLonShape indexing types
+     *
+     * @opensearch.internal
+     */
     private static class LuceneGeometryCollector implements GeometryVisitor<Void, RuntimeException> {
         private final List<LatLonGeometry> geometries = new ArrayList<>();
         private final String name;

--- a/server/src/main/java/org/opensearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -424,6 +424,11 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
         );
     }
 
+    /**
+     * Score function for geo field data
+     *
+     * @opensearch.internal
+     */
     static class GeoFieldDataScoreFunction extends AbstractDistanceScoreFunction {
 
         private final GeoPoint origin;
@@ -520,6 +525,11 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
         }
     }
 
+    /**
+     * Score function for numeric data
+     *
+     * @opensearch.internal
+     */
     static class NumericFieldDataScoreFunction extends AbstractDistanceScoreFunction {
 
         private final IndexNumericFieldData fieldData;
@@ -610,7 +620,8 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
     /**
      * This is the base class for scoring a single field.
      *
-     * */
+     * @opensearch.internal
+     */
     public abstract static class AbstractDistanceScoreFunction extends ScoreFunction {
 
         private final double scale;

--- a/server/src/main/java/org/opensearch/index/query/functionscore/ExponentialDecayFunctionBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/ExponentialDecayFunctionBuilder.java
@@ -96,6 +96,11 @@ public class ExponentialDecayFunctionBuilder extends DecayFunctionBuilder<Expone
         return EXP_DECAY_FUNCTION;
     }
 
+    /**
+     * Exponential decay
+     *
+     * @opensearch.internal
+     */
     private static final class ExponentialDecayScoreFunction implements DecayFunction {
 
         @Override

--- a/server/src/main/java/org/opensearch/index/query/functionscore/FunctionScoreQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/FunctionScoreQueryBuilder.java
@@ -371,6 +371,8 @@ public class FunctionScoreQueryBuilder extends AbstractQueryBuilder<FunctionScor
     /**
      * Function to be associated with an optional filter, meaning it will be executed only for the documents
      * that match the given filter.
+     *
+     * @opensearch.internal
      */
     public static class FilterFunctionBuilder implements ToXContentObject, Writeable {
         private final QueryBuilder filter;

--- a/server/src/main/java/org/opensearch/index/query/functionscore/GaussDecayFunctionBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/GaussDecayFunctionBuilder.java
@@ -96,6 +96,11 @@ public class GaussDecayFunctionBuilder extends DecayFunctionBuilder<GaussDecayFu
         return GAUSS_DECAY_FUNCTION;
     }
 
+    /**
+     * Gaussian scoring
+     *
+     * @opensearch.internal
+     */
     private static final class GaussScoreFunction implements DecayFunction {
         @Override
         public double evaluate(double value, double scale) {

--- a/server/src/main/java/org/opensearch/index/query/functionscore/LinearDecayFunctionBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/LinearDecayFunctionBuilder.java
@@ -94,6 +94,11 @@ public class LinearDecayFunctionBuilder extends DecayFunctionBuilder<LinearDecay
         return LINEAR_DECAY_FUNCTION;
     }
 
+    /**
+     * Linear decay
+     *
+     * @opensearch.internal
+     */
     private static final class LinearDecayScoreFunction implements DecayFunction {
 
         @Override

--- a/server/src/main/java/org/opensearch/index/recovery/RecoveryStats.java
+++ b/server/src/main/java/org/opensearch/index/recovery/RecoveryStats.java
@@ -127,6 +127,11 @@ public class RecoveryStats implements ToXContentFragment, Writeable {
         return builder;
     }
 
+    /**
+     * Fields for recovery statistics
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String RECOVERY = "recovery";
         static final String CURRENT_AS_SOURCE = "current_as_source";

--- a/server/src/main/java/org/opensearch/index/reindex/BulkByScrollTask.java
+++ b/server/src/main/java/org/opensearch/index/reindex/BulkByScrollTask.java
@@ -222,6 +222,8 @@ public class BulkByScrollTask extends CancellableTask {
      * This class acts as a builder for {@link Status}. Once the {@link Status} object is built by calling
      * {@link #buildStatus()} it is immutable. Used by an instance of {@link ObjectParser} when parsing from
      * XContent.
+     *
+     * @opensearch.internal
      */
     public static class StatusBuilder {
         private Integer sliceId = null;
@@ -355,6 +357,8 @@ public class BulkByScrollTask extends CancellableTask {
      * implementations, this one has become defacto standardized because Kibana
      * parses it. As such, we should be very careful about removing things from
      * this.
+     *
+     * @opensearch.internal
      */
     public static class Status implements Task.Status, SuccessfullyProcessed {
         public static final String NAME = "bulk-by-scroll";
@@ -927,6 +931,8 @@ public class BulkByScrollTask extends CancellableTask {
     /**
      * The status of a slice of the request. Successful requests store the {@link StatusOrException#status} while failing requests store a
      * {@link StatusOrException#exception}.
+     *
+     * @opensearch.internal
      */
     public static class StatusOrException implements Writeable, ToXContentObject {
         private final Status status;

--- a/server/src/main/java/org/opensearch/index/reindex/ClientScrollableHitSource.java
+++ b/server/src/main/java/org/opensearch/index/reindex/ClientScrollableHitSource.java
@@ -179,6 +179,11 @@ public class ClientScrollableHitSource extends ScrollableHitSource {
         return new Response(response.isTimedOut(), failures, total, hits, response.getScrollId());
     }
 
+    /**
+     * A Client hit
+     *
+     * @opensearch.internal
+     */
     private static class ClientHit implements Hit {
         private final SearchHit delegate;
         private final BytesReference source;

--- a/server/src/main/java/org/opensearch/index/reindex/LeaderBulkByScrollTaskState.java
+++ b/server/src/main/java/org/opensearch/index/reindex/LeaderBulkByScrollTaskState.java
@@ -156,6 +156,11 @@ public class LeaderBulkByScrollTaskState {
         }
     }
 
+    /**
+     * Result
+     *
+     * @opensearch.internal
+     */
     private static final class Result {
         final BulkByScrollResponse response;
         final int sliceId;

--- a/server/src/main/java/org/opensearch/index/reindex/ScrollableHitSource.java
+++ b/server/src/main/java/org/opensearch/index/reindex/ScrollableHitSource.java
@@ -178,6 +178,11 @@ public abstract class ScrollableHitSource {
         this.scrollId.set(scrollId);
     }
 
+    /**
+     * Asynchronous response
+     *
+     * @opensearch.internal
+     */
     public interface AsyncResponse {
         /**
          * The response data made available.
@@ -193,6 +198,8 @@ public abstract class ScrollableHitSource {
 
     /**
      * Response from each scroll batch.
+     *
+     * @opensearch.internal
      */
     public static class Response {
         private final boolean timedOut;
@@ -248,6 +255,8 @@ public abstract class ScrollableHitSource {
     /**
      * A document returned as part of the response. Think of it like {@link SearchHit} but with all the things reindex needs in convenient
      * methods.
+     *
+     * @opensearch.internal
      */
     public interface Hit {
         /**
@@ -298,6 +307,8 @@ public abstract class ScrollableHitSource {
 
     /**
      * An implementation of {@linkplain Hit} that uses getters and setters.
+     *
+     * @opensearch.internal
      */
     public static class BasicHit implements Hit {
         private final String index;
@@ -378,6 +389,8 @@ public abstract class ScrollableHitSource {
 
     /**
      * A failure during search. Like {@link ShardSearchFailure} but useful for reindex from remote as well.
+     *
+     * @opensearch.internal
      */
     public static class SearchFailure implements Writeable, ToXContentObject {
         private final Throwable reason;

--- a/server/src/main/java/org/opensearch/index/search/MatchQuery.java
+++ b/server/src/main/java/org/opensearch/index/search/MatchQuery.java
@@ -89,6 +89,11 @@ import static org.opensearch.common.lucene.search.Queries.newUnmappedFieldQuery;
  */
 public class MatchQuery {
 
+    /**
+     * Type of the match
+     *
+     * @opensearch.internal
+     */
     public enum Type implements Writeable {
         /**
          * The text is analyzed and terms are added to a boolean query.
@@ -129,6 +134,11 @@ public class MatchQuery {
         }
     }
 
+    /**
+     * Query with zero terms
+     *
+     * @opensearch.internal
+     */
     public enum ZeroTermsQuery implements Writeable {
         NONE(0),
         ALL(1),

--- a/server/src/main/java/org/opensearch/index/search/MultiMatchQuery.java
+++ b/server/src/main/java/org/opensearch/index/search/MultiMatchQuery.java
@@ -345,6 +345,11 @@ public class MultiMatchQuery extends MatchQuery {
         }
     }
 
+    /**
+     * Holder for a field and it's boost value
+     *
+     * @opensearch.internal
+     */
     static final class FieldAndBoost {
         final MappedFieldType fieldType;
         final float boost;

--- a/server/src/main/java/org/opensearch/index/search/SimpleQueryStringQueryParser.java
+++ b/server/src/main/java/org/opensearch/index/search/SimpleQueryStringQueryParser.java
@@ -310,6 +310,8 @@ public class SimpleQueryStringQueryParser extends SimpleQueryParser {
     /**
      * Class encapsulating the settings for the SimpleQueryString query, with
      * their default values
+     *
+     * @opensearch.internal
      */
     public static class Settings {
         /** Specifies whether lenient query parsing should be used. */

--- a/server/src/main/java/org/opensearch/index/search/stats/SearchStats.java
+++ b/server/src/main/java/org/opensearch/index/search/stats/SearchStats.java
@@ -54,6 +54,11 @@ import java.util.Map;
  */
 public class SearchStats implements Writeable, ToXContentFragment {
 
+    /**
+     * Statistics for search
+     *
+     * @opensearch.internal
+     */
     public static class Stats implements Writeable, ToXContentFragment {
 
         private long queryCount;
@@ -359,6 +364,11 @@ public class SearchStats implements Writeable, ToXContentFragment {
         return Strings.toString(this, true, true);
     }
 
+    /**
+     * Fields for search statistics
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String SEARCH = "search";
         static final String OPEN_CONTEXTS = "open_contexts";

--- a/server/src/main/java/org/opensearch/index/search/stats/ShardSearchStats.java
+++ b/server/src/main/java/org/opensearch/index/search/stats/ShardSearchStats.java
@@ -187,6 +187,11 @@ public final class ShardSearchStats implements SearchOperationListener {
         totalStats.scrollMetric.inc(TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - readerContext.getStartTimeInNano()));
     }
 
+    /**
+     * Holder of statistics values
+     *
+     * @opensearch.internal
+     */
     static final class StatsHolder {
         final MeanMetric queryMetric = new MeanMetric();
         final MeanMetric fetchMetric = new MeanMetric();

--- a/server/src/main/java/org/opensearch/index/seqno/GlobalCheckpointSyncAction.java
+++ b/server/src/main/java/org/opensearch/index/seqno/GlobalCheckpointSyncAction.java
@@ -139,6 +139,11 @@ public class GlobalCheckpointSyncAction extends TransportReplicationAction<
         }
     }
 
+    /**
+     * Request for checkpoint sync action
+     *
+     * @opensearch.internal
+     */
     public static final class Request extends ReplicationRequest<Request> {
 
         private Request(StreamInput in) throws IOException {

--- a/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
@@ -662,6 +662,11 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
         assert invariant();
     }
 
+    /**
+     * The state of the lucene checkpoint
+     *
+     * @opensearch.internal
+     */
     public static class CheckpointState implements Writeable {
 
         /**
@@ -1594,6 +1599,8 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
     /**
      * Represents the sequence number component of the primary context. This is the knowledge on the primary of the in-sync and initializing
      * shards and their local checkpoints.
+     *
+     * @opensearch.internal
      */
     public static class PrimaryContext implements Writeable {
 

--- a/server/src/main/java/org/opensearch/index/seqno/RetentionLeaseActions.java
+++ b/server/src/main/java/org/opensearch/index/seqno/RetentionLeaseActions.java
@@ -71,6 +71,11 @@ public class RetentionLeaseActions {
 
     public static final long RETAIN_ALL = -1;
 
+    /**
+     * Base class for transport retention lease actions
+     *
+     * @opensearch.internal
+     */
     abstract static class TransportRetentionLeaseAction<T extends Request<T>> extends TransportSingleShardAction<T, Response> {
 
         private final IndicesService indicesService;
@@ -134,6 +139,11 @@ public class RetentionLeaseActions {
 
     }
 
+    /**
+     * Add retention lease action
+     *
+     * @opensearch.internal
+     */
     public static class Add extends ActionType<Response> {
 
         public static final Add INSTANCE = new Add();
@@ -143,6 +153,11 @@ public class RetentionLeaseActions {
             super(ACTION_NAME, Response::new);
         }
 
+        /**
+         * Internal transport action
+         *
+         * @opensearch.internal
+         */
         public static class TransportAction extends TransportRetentionLeaseAction<AddRequest> {
 
             @Inject
@@ -184,6 +199,11 @@ public class RetentionLeaseActions {
         }
     }
 
+    /**
+     * Renew the retention lease
+     *
+     * @opensearch.internal
+     */
     public static class Renew extends ActionType<Response> {
 
         public static final Renew INSTANCE = new Renew();
@@ -193,6 +213,11 @@ public class RetentionLeaseActions {
             super(ACTION_NAME, Response::new);
         }
 
+        /**
+         * Internal transport action for renew
+         *
+         * @opensearch.internal
+         */
         public static class TransportAction extends TransportRetentionLeaseAction<RenewRequest> {
 
             @Inject
@@ -225,6 +250,11 @@ public class RetentionLeaseActions {
         }
     }
 
+    /**
+     * Remove retention lease action
+     *
+     * @opensearch.internal
+     */
     public static class Remove extends ActionType<Response> {
 
         public static final Remove INSTANCE = new Remove();
@@ -234,6 +264,11 @@ public class RetentionLeaseActions {
             super(ACTION_NAME, Response::new);
         }
 
+        /**
+         * Internal transport action for remove
+         *
+         * @opensearch.internal
+         */
         public static class TransportAction extends TransportRetentionLeaseAction<RemoveRequest> {
 
             @Inject
@@ -265,6 +300,11 @@ public class RetentionLeaseActions {
         }
     }
 
+    /**
+     * Base request
+     *
+     * @opensearch.internal
+     */
     private abstract static class Request<T extends SingleShardRequest<T>> extends SingleShardRequest<T> {
 
         private final ShardId shardId;
@@ -305,6 +345,11 @@ public class RetentionLeaseActions {
 
     }
 
+    /**
+     * Base add or renew request
+     *
+     * @opensearch.internal
+     */
     private abstract static class AddOrRenewRequest<T extends SingleShardRequest<T>> extends Request<T> {
 
         private final long retainingSequenceNumber;
@@ -343,6 +388,11 @@ public class RetentionLeaseActions {
 
     }
 
+    /**
+     * Add retention lease request
+     *
+     * @opensearch.internal
+     */
     public static class AddRequest extends AddOrRenewRequest<AddRequest> {
 
         AddRequest(StreamInput in) throws IOException {
@@ -355,6 +405,11 @@ public class RetentionLeaseActions {
 
     }
 
+    /**
+     * Renew Request action
+     *
+     * @opensearch.internal
+     */
     public static class RenewRequest extends AddOrRenewRequest<RenewRequest> {
 
         RenewRequest(StreamInput in) throws IOException {
@@ -367,6 +422,11 @@ public class RetentionLeaseActions {
 
     }
 
+    /**
+     * Remove request
+     *
+     * @opensearch.internal
+     */
     public static class RemoveRequest extends Request<RemoveRequest> {
 
         RemoveRequest(StreamInput in) throws IOException {
@@ -379,6 +439,11 @@ public class RetentionLeaseActions {
 
     }
 
+    /**
+     * The response
+     *
+     * @opensearch.internal
+     */
     public static class Response extends ActionResponse {
 
         public Response() {}

--- a/server/src/main/java/org/opensearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
+++ b/server/src/main/java/org/opensearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
@@ -198,6 +198,11 @@ public class RetentionLeaseBackgroundSyncAction extends TransportReplicationActi
         });
     }
 
+    /**
+     * Request for retention lease bground sync action
+     *
+     * @opensearch.internal
+     */
     public static final class Request extends ReplicationRequest<Request> {
 
         private RetentionLeases retentionLeases;

--- a/server/src/main/java/org/opensearch/index/seqno/RetentionLeaseSyncAction.java
+++ b/server/src/main/java/org/opensearch/index/seqno/RetentionLeaseSyncAction.java
@@ -211,6 +211,11 @@ public class RetentionLeaseSyncAction extends TransportWriteAction<
         return null;
     }
 
+    /**
+     * Request for retention lease sync action
+     *
+     * @opensearch.internal
+     */
     public static final class Request extends ReplicatedWriteRequest<Request> {
 
         private RetentionLeases retentionLeases;
@@ -260,6 +265,11 @@ public class RetentionLeaseSyncAction extends TransportWriteAction<
 
     }
 
+    /**
+     * Response for retention lease sync action
+     *
+     * @opensearch.internal
+     */
     public static final class Response extends ReplicationResponse implements WriteResponse {
 
         public Response() {}

--- a/server/src/main/java/org/opensearch/index/seqno/RetentionLeaseSyncer.java
+++ b/server/src/main/java/org/opensearch/index/seqno/RetentionLeaseSyncer.java
@@ -80,6 +80,8 @@ public class RetentionLeaseSyncer {
     /**
      * Represents an action that is invoked to sync retention leases to replica shards after a retention lease is added
      * or removed on the primary. The specified listener is invoked when the syncing completes with success or failure.
+     *
+     * @opensearch.internal
      */
     public interface SyncAction {
         void sync(
@@ -94,6 +96,8 @@ public class RetentionLeaseSyncer {
     /**
      * Represents an action that is invoked periodically to sync retention leases to replica shards after some retention
      * lease has been renewed or expired.
+     *
+     * @opensearch.internal
      */
     public interface BackgroundSyncAction {
         void backgroundSync(ShardId shardId, String primaryAllocationId, long primaryTerm, RetentionLeases retentionLeases);

--- a/server/src/main/java/org/opensearch/index/seqno/SequenceNumbers.java
+++ b/server/src/main/java/org/opensearch/index/seqno/SequenceNumbers.java
@@ -129,6 +129,11 @@ public class SequenceNumbers {
         }
     }
 
+    /**
+     * Commit information
+     *
+     * @opensearch.internal
+     */
     public static final class CommitInfo {
         public final long maxSeqNo;
         public final long localCheckpoint;

--- a/server/src/main/java/org/opensearch/index/shard/DocsStats.java
+++ b/server/src/main/java/org/opensearch/index/shard/DocsStats.java
@@ -121,6 +121,11 @@ public class DocsStats implements Writeable, ToXContentFragment {
         return builder;
     }
 
+    /**
+     * Fields for document statistics
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String DOCS = "docs";
         static final String COUNT = "count";

--- a/server/src/main/java/org/opensearch/index/shard/GlobalCheckpointListeners.java
+++ b/server/src/main/java/org/opensearch/index/shard/GlobalCheckpointListeners.java
@@ -65,6 +65,8 @@ public class GlobalCheckpointListeners implements Closeable {
 
     /**
      * A global checkpoint listener consisting of a callback that is notified when the global checkpoint is updated or the shard is closed.
+     *
+     * @opensearch.internal
      */
     public interface GlobalCheckpointListener {
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1503,6 +1503,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
     }
 
+    /**
+     * Wrapper for a non-closing reader
+     *
+     * @opensearch.internal
+     */
     private static final class NonClosingReaderWrapper extends FilterDirectoryReader {
 
         private NonClosingReaderWrapper(DirectoryReader in) throws IOException {
@@ -3608,6 +3613,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * Simple struct encapsulating a shard failure
      *
      * @see IndexShard#addShardFailureCallback(Consumer)
+     *
+     * @opensearch.internal
      */
     public static final class ShardFailure {
         public final ShardRouting routing;
@@ -3773,6 +3780,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
     }
 
+    /**
+     * Metrics updater for a refresh
+     *
+     * @opensearch.internal
+     */
     private static class RefreshMetricUpdater implements ReferenceManager.RefreshListener {
 
         private final MeanMetric refreshMetric;

--- a/server/src/main/java/org/opensearch/index/shard/IndexShardOperationPermits.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShardOperationPermits.java
@@ -361,6 +361,11 @@ final class IndexShardOperationPermits implements Closeable {
             .collect(Collectors.toList());
     }
 
+    /**
+     * Represents a delayed operation
+     *
+     * @opensearch.internal
+     */
     private static class DelayedOperation {
         private final ActionListener<Releasable> listener;
         private final String debugInfo;

--- a/server/src/main/java/org/opensearch/index/shard/IndexShardState.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShardState.java
@@ -34,6 +34,8 @@ package org.opensearch.index.shard;
 
 /**
  * Index Shard States
+ *
+ * @opensearch.internal
  */
 public enum IndexShardState {
     CREATED((byte) 0),

--- a/server/src/main/java/org/opensearch/index/shard/IndexingStats.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexingStats.java
@@ -52,6 +52,11 @@ import java.util.Map;
  */
 public class IndexingStats implements Writeable, ToXContentFragment {
 
+    /**
+     * Internal statistics for indexing
+     *
+     * @opensearch.internal
+     */
     public static class Stats implements Writeable, ToXContentFragment {
 
         private long indexCount;
@@ -269,6 +274,11 @@ public class IndexingStats implements Writeable, ToXContentFragment {
         return builder;
     }
 
+    /**
+     * Fields for indexing statistics
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String INDEXING = "indexing";
         static final String INDEX_TOTAL = "index_total";

--- a/server/src/main/java/org/opensearch/index/shard/InternalIndexingStats.java
+++ b/server/src/main/java/org/opensearch/index/shard/InternalIndexingStats.java
@@ -129,6 +129,11 @@ final class InternalIndexingStats implements IndexingOperationListener {
         totalStats.noopUpdates.inc();
     }
 
+    /**
+     * Holder for base indexing statistics
+     *
+     * @opensearch.internal
+     */
     static class StatsHolder {
         private final MeanMetric indexMetric = new MeanMetric();
         private final MeanMetric deleteMetric = new MeanMetric();

--- a/server/src/main/java/org/opensearch/index/shard/PrimaryReplicaSyncer.java
+++ b/server/src/main/java/org/opensearch/index/shard/PrimaryReplicaSyncer.java
@@ -225,6 +225,11 @@ public class PrimaryReplicaSyncer {
         }
     }
 
+    /**
+     * Synchronous action
+     *
+     * @opensearch.internal
+     */
     public interface SyncAction {
         void sync(
             ResyncReplicationRequest request,
@@ -235,6 +240,11 @@ public class PrimaryReplicaSyncer {
         );
     }
 
+    /**
+     * Sends a snapshot
+     *
+     * @opensearch.internal
+     */
     static class SnapshotSender extends AbstractRunnable implements ActionListener<ResyncReplicationResponse> {
         private final Logger logger;
         private final SyncAction syncAction;
@@ -348,6 +358,11 @@ public class PrimaryReplicaSyncer {
         }
     }
 
+    /**
+     * Request to resync primary and replica
+     *
+     * @opensearch.internal
+     */
     public static class ResyncRequest extends ActionRequest {
 
         private final ShardId shardId;
@@ -379,6 +394,11 @@ public class PrimaryReplicaSyncer {
         }
     }
 
+    /**
+     * Task to resync primary and replica
+     *
+     * @opensearch.internal
+     */
     public static class ResyncTask extends Task {
         private volatile String phase = "starting";
         private volatile int totalOperations;
@@ -441,6 +461,11 @@ public class PrimaryReplicaSyncer {
             return new ResyncTask.Status(phase, totalOperations, resyncedOperations, skippedOperations);
         }
 
+        /**
+         * Status for primary replica syncer
+         *
+         * @opensearch.internal
+         */
         public static class Status implements Task.Status {
             public static final String NAME = "resync";
 

--- a/server/src/main/java/org/opensearch/index/shard/RemoveCorruptedShardDataCommand.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoveCorruptedShardDataCommand.java
@@ -528,6 +528,11 @@ public class RemoveCorruptedShardDataCommand extends OpenSearchNodeCommand {
         return nodePath;
     }
 
+    /**
+     * Status of the shard cleaning operation
+     *
+     * @opensearch.internal
+     */
     public enum CleanStatus {
         CLEAN("clean"),
         CLEAN_WITH_CORRUPTED_MARKER("marked corrupted, but no corruption detected"),

--- a/server/src/main/java/org/opensearch/index/shard/ShardSplittingQuery.java
+++ b/server/src/main/java/org/opensearch/index/shard/ShardSplittingQuery.java
@@ -296,6 +296,8 @@ final class ShardSplittingQuery extends Query {
     /**
      * This two phase iterator visits every live doc and selects all docs that don't belong into this
      * shard based on their id and routing value. This is only used in a routing partitioned index.
+     *
+     * @opensearch.internal
      */
     private static final class RoutingPartitionedDocIdSetIterator extends TwoPhaseIterator {
         private final Visitor visitor;
@@ -318,6 +320,8 @@ final class ShardSplittingQuery extends Query {
 
     /**
      * This TwoPhaseIterator marks all nested docs of matching parents as matches as well.
+     *
+     * @opensearch.internal
      */
     private static final class NestedRoutingPartitionedDocIdSetIterator extends TwoPhaseIterator {
         private final Visitor visitor;

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -232,6 +232,8 @@ final class StoreRecovery {
 
     /**
      * Directory wrapper that records copy process for recovery statistics
+     *
+     * @opensearch.internal
      */
     static final class StatsDirectoryWrapper extends FilterDirectory {
         private final ReplicationLuceneIndex index;

--- a/server/src/main/java/org/opensearch/index/similarity/ScriptedSimilarity.java
+++ b/server/src/main/java/org/opensearch/index/similarity/ScriptedSimilarity.java
@@ -163,7 +163,11 @@ public final class ScriptedSimilarity extends Similarity {
         }
     }
 
-    /** Scoring factors that come from the query. */
+    /**
+     * Scoring factors that come from the query.
+     *
+     * @opensearch.internal
+     */
     public static class Query {
         private final float boost;
 
@@ -177,7 +181,11 @@ public final class ScriptedSimilarity extends Similarity {
         }
     }
 
-    /** Statistics that are specific to a given field. */
+    /**
+     * Statistics that are specific to a given field.
+     *
+     * @opensearch.internal
+     */
     public static class Field {
         private final long docCount;
         private final long sumDocFreq;
@@ -207,7 +215,11 @@ public final class ScriptedSimilarity extends Similarity {
         }
     }
 
-    /** Statistics that are specific to a given term. */
+    /**
+     * Statistics that are specific to a given term.
+     *
+     * @opensearch.internal
+     */
     public static class Term {
         private final long docFreq;
         private final long totalTermFreq;
@@ -228,7 +240,11 @@ public final class ScriptedSimilarity extends Similarity {
         }
     }
 
-    /** Statistics that are specific to a document. */
+    /**
+     * Statistics that are specific to a document.
+     *
+     * @opensearch.internal
+     */
     public static class Doc {
         private float freq;
         private long norm;

--- a/server/src/main/java/org/opensearch/index/similarity/SimilarityService.java
+++ b/server/src/main/java/org/opensearch/index/similarity/SimilarityService.java
@@ -208,6 +208,11 @@ public final class SimilarityService extends AbstractIndexComponent {
         return defaultSimilarity;
     }
 
+    /**
+     * Similarity per field
+     *
+     * @opensearch.internal
+     */
     static class PerFieldSimilarity extends PerFieldSimilarityWrapper {
 
         private final Similarity defaultSimilarity;

--- a/server/src/main/java/org/opensearch/index/snapshots/IndexShardSnapshotStatus.java
+++ b/server/src/main/java/org/opensearch/index/snapshots/IndexShardSnapshotStatus.java
@@ -44,6 +44,8 @@ public class IndexShardSnapshotStatus {
 
     /**
      * Snapshot stage
+     *
+     * @opensearch.internal
      */
     public enum Stage {
         /**
@@ -245,6 +247,8 @@ public class IndexShardSnapshotStatus {
 
     /**
      * Returns an immutable state of {@link IndexShardSnapshotStatus} at a given point in time.
+     *
+     * @opensearch.internal
      */
     public static class Copy {
 

--- a/server/src/main/java/org/opensearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
+++ b/server/src/main/java/org/opensearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
@@ -61,6 +61,8 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
 
     /**
      * Information about snapshotted file
+     *
+     * @opensearch.internal
      */
     public static class FileInfo {
 

--- a/server/src/main/java/org/opensearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
+++ b/server/src/main/java/org/opensearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
@@ -178,11 +178,21 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
         return shardSnapshots.iterator();
     }
 
+    /**
+     * Fields for blob store index shard snapshot
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String FILES = "files";
         static final String SNAPSHOTS = "snapshots";
     }
 
+    /**
+     * Parse fields for blob store index shard snapshots
+     *
+     * @opensearch.internal
+     */
     static final class ParseFields {
         static final ParseField FILES = new ParseField("files");
         static final ParseField SHARD_STATE_ID = new ParseField("shard_state_id");

--- a/server/src/main/java/org/opensearch/index/snapshots/blobstore/RateLimitingInputStream.java
+++ b/server/src/main/java/org/opensearch/index/snapshots/blobstore/RateLimitingInputStream.java
@@ -52,6 +52,11 @@ public class RateLimitingInputStream extends FilterInputStream {
 
     private long bytesSinceLastRateLimit;
 
+    /**
+     * Internal listener
+     *
+     * @opensearch.internal
+     */
     public interface Listener {
         void onPause(long nanos);
     }

--- a/server/src/main/java/org/opensearch/index/store/ByteSizeCachingDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/ByteSizeCachingDirectory.java
@@ -54,6 +54,11 @@ import java.util.Set;
  */
 final class ByteSizeCachingDirectory extends FilterDirectory {
 
+    /**
+     * Internal caching size and modulo count
+     *
+     * @opensearch.internal
+     */
     private static class SizeAndModCount {
         final long size;
         final long modCount;

--- a/server/src/main/java/org/opensearch/index/store/FsDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/FsDirectoryFactory.java
@@ -135,6 +135,11 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
         return unwrap instanceof HybridDirectory;
     }
 
+    /**
+     * A hybrid directory implementation
+     *
+     * @opensearch.internal
+     */
     static final class HybridDirectory extends NIOFSDirectory {
         private final MMapDirectory delegate;
 
@@ -201,6 +206,11 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
         }
     }
 
+    /**
+     * Pre loaded mmap directory
+     *
+     * @opensearch.internal
+     */
     // TODO it would be nice to share code between PreLoadMMapDirectory and HybridDirectory but due to the nesting aspect of
     // directories here makes it tricky. It would be nice to allow MMAPDirectory to pre-load on a per IndexInput basis.
     static final class PreLoadMMapDirectory extends MMapDirectory {

--- a/server/src/main/java/org/opensearch/index/store/Store.java
+++ b/server/src/main/java/org/opensearch/index/store/Store.java
@@ -736,6 +736,11 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         shardLock.setDetails("closing shard");
     }
 
+    /**
+     * A store directory
+     *
+     * @opensearch.internal
+     */
     static final class StoreDirectory extends FilterDirectory {
 
         private final Logger deletesLogger;
@@ -792,6 +797,8 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
      * change concurrently for safety reasons.
      *
      * @see StoreFileMetadata
+     *
+     * @opensearch.internal
      */
     public static final class MetadataSnapshot implements Iterable<StoreFileMetadata>, Writeable {
         private final Map<String, StoreFileMetadata> metadata;
@@ -865,6 +872,11 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
             return numDocs;
         }
 
+        /**
+         * Metadata that is currently loaded
+         *
+         * @opensearch.internal
+         */
         static class LoadedMetadata {
             final Map<String, StoreFileMetadata> fileMetadata;
             final Map<String, String> userData;
@@ -1162,6 +1174,8 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
      * A class representing the diff between a recovery source and recovery target
      *
      * @see MetadataSnapshot#recoveryDiff(org.opensearch.index.store.Store.MetadataSnapshot)
+     *
+     * @opensearch.internal
      */
     public static final class RecoveryDiff {
         /**
@@ -1211,6 +1225,11 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         return Long.toString(digest, Character.MAX_RADIX);
     }
 
+    /**
+     * Class to verify the lucene index output
+     *
+     * @opensearch.internal
+     */
     static class LuceneVerifyingIndexOutput extends VerifyingIndexOutput {
 
         private final StoreFileMetadata metadata;
@@ -1309,6 +1328,8 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
      * This class supports random access (it is possible to seek backward and forward) in order to accommodate retry
      * mechanism that is used in some repository plugins (S3 for example). However, the checksum is only calculated on
      * the first read. All consecutive reads of the same data are not used to calculate the checksum.
+     *
+     * @opensearch.internal
      */
     static class VerifyingIndexInput extends ChecksumIndexInput {
         private final IndexInput input;
@@ -1481,6 +1502,8 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
 
     /**
      * A listener that is executed once the store is closed and all references to it are released
+     *
+     * @opensearch.internal
      */
     public interface OnClose extends Consumer<ShardLock> {
         OnClose EMPTY = new OnClose() {

--- a/server/src/main/java/org/opensearch/index/store/StoreStats.java
+++ b/server/src/main/java/org/opensearch/index/store/StoreStats.java
@@ -138,6 +138,11 @@ public class StoreStats implements Writeable, ToXContentFragment {
         return builder;
     }
 
+    /**
+     * Fields for store statistics
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String STORE = "store";
         static final String SIZE = "size";

--- a/server/src/main/java/org/opensearch/index/termvectors/TermVectorsService.java
+++ b/server/src/main/java/org/opensearch/index/termvectors/TermVectorsService.java
@@ -423,7 +423,11 @@ public class TermVectorsService {
         return parallelFields;
     }
 
-    // Poached from Lucene ParallelLeafReader
+    /**
+     * Poached from Lucene ParallelLeafReader
+     *
+     * @opensearch.internal
+     */
     private static final class ParallelFields extends Fields {
         final Map<String, Terms> fields = new TreeMap<>();
 

--- a/server/src/main/java/org/opensearch/index/translog/MultiSnapshot.java
+++ b/server/src/main/java/org/opensearch/index/translog/MultiSnapshot.java
@@ -98,6 +98,11 @@ final class MultiSnapshot implements Translog.Snapshot {
         onClose.close();
     }
 
+    /**
+     * Sequence number set
+     *
+     * @opensearch.internal
+     */
     static final class SeqNoSet {
         static final short BIT_SET_SIZE = 1024;
         private final LongObjectHashMap<CountedBitSet> bitSets = new LongObjectHashMap<>();

--- a/server/src/main/java/org/opensearch/index/translog/Translog.java
+++ b/server/src/main/java/org/opensearch/index/translog/Translog.java
@@ -952,6 +952,11 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         return deletionPolicy;
     }
 
+    /**
+     * Location in the translot
+     *
+     * @opensearch.internal
+     */
     public static class Location implements Comparable<Location> {
 
         public final long generation;
@@ -1008,6 +1013,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
     /**
      * A snapshot of the transaction log, allows to iterate over all the transaction log operations.
+     *
+     * @opensearch.internal
      */
     public interface Snapshot extends Closeable {
 
@@ -1035,6 +1042,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
      * between {@code fromSeqNo} (inclusive) and {@code toSeqNo} (inclusive). This filtered snapshot
      * shares the same underlying resources with the {@code delegate} snapshot, therefore we should not
      * use the {@code delegate} after passing it to this filtered snapshot.
+     *
+     * @opensearch.internal
      */
     private static final class SeqNoFilterSnapshot implements Snapshot {
         private final Snapshot delegate;
@@ -1090,8 +1099,15 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
     /**
      * A generic interface representing an operation performed on the transaction log.
      * Each is associated with a type.
+     *
+     * @opensearch.internal
      */
     public interface Operation {
+        /**
+         * The type of operation
+         *
+         * @opensearch.internal
+         */
         enum Type {
             @Deprecated
             CREATE((byte) 1),
@@ -1179,6 +1195,11 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
     }
 
+    /**
+     * The source in the translog
+     *
+     * @opensearch.internal
+     */
     public static class Source {
 
         public final BytesReference source;
@@ -1191,6 +1212,11 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
     }
 
+    /**
+     * Indexing operation
+     *
+     * @opensearch.internal
+     */
     public static class Index implements Operation {
 
         public static final int FORMAT_6_0 = 8; // since 6.0.0
@@ -1378,6 +1404,11 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
     }
 
+    /**
+     * Delete operation
+     *
+     * @opensearch.internal
+     */
     public static class Delete implements Operation {
 
         private static final int FORMAT_6_0 = 4; // 6.0 - *
@@ -1509,6 +1540,11 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         }
     }
 
+    /**
+     * Translog no op
+     *
+     * @opensearch.internal
+     */
     public static class NoOp implements Operation {
 
         private final long seqNo;
@@ -1588,6 +1624,11 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         }
     }
 
+    /**
+     * How to sync the translog
+     *
+     * @opensearch.internal
+     */
     public enum Durability {
 
         /**
@@ -1844,6 +1885,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
     /**
      * References a transaction log generation
+     *
+     * @opensearch.internal
      */
     public static final class TranslogGeneration {
         public final String translogUUID;

--- a/server/src/main/java/org/opensearch/index/warmer/WarmerStats.java
+++ b/server/src/main/java/org/opensearch/index/warmer/WarmerStats.java
@@ -120,6 +120,11 @@ public class WarmerStats implements Writeable, ToXContentFragment {
         return builder;
     }
 
+    /**
+     * Fields for warmer statistics
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String WARMER = "warmer";
         static final String CURRENT = "current";

--- a/server/src/main/java/org/opensearch/transport/ConnectionManager.java
+++ b/server/src/main/java/org/opensearch/transport/ConnectionManager.java
@@ -76,11 +76,21 @@ public interface ConnectionManager extends Closeable {
 
     ConnectionProfile getConnectionProfile();
 
+    /**
+     * Validates a connection
+     *
+     * @opensearch.internal
+     */
     @FunctionalInterface
     interface ConnectionValidator {
         void validate(Transport.Connection connection, ConnectionProfile profile, ActionListener<Void> listener);
     }
 
+    /**
+     * Connection listener for a delegating node
+     *
+     * @opensearch.internal
+     */
     final class DelegatingNodeConnectionListener implements TransportConnectionListener {
 
         private final CopyOnWriteArrayList<TransportConnectionListener> listeners = new CopyOnWriteArrayList<>();

--- a/server/src/main/java/org/opensearch/transport/ConnectionProfile.java
+++ b/server/src/main/java/org/opensearch/transport/ConnectionProfile.java
@@ -174,6 +174,8 @@ public final class ConnectionProfile {
 
     /**
      * A builder to build a new {@link ConnectionProfile}
+     *
+     * @opensearch.internal
      */
     public static class Builder {
         private final List<ConnectionTypeHandle> handles = new ArrayList<>();

--- a/server/src/main/java/org/opensearch/transport/InboundAggregator.java
+++ b/server/src/main/java/org/opensearch/transport/InboundAggregator.java
@@ -239,6 +239,11 @@ public class InboundAggregator implements Releasable {
         }
     }
 
+    /**
+     * Internal circuit breaker control
+     *
+     * @opensearch.internal
+     */
     private static class BreakerControl implements Releasable {
 
         private static final int CLOSED = -1;

--- a/server/src/main/java/org/opensearch/transport/InboundHandler.java
+++ b/server/src/main/java/org/opensearch/transport/InboundHandler.java
@@ -432,6 +432,11 @@ public class InboundHandler {
         assert version.equals(in.getVersion()) : "Stream version [" + in.getVersion() + "] does not match version [" + version + "]";
     }
 
+    /**
+     * Internal request handler
+     *
+     * @opensearch.internal
+     */
     private static class RequestHandler<T extends TransportRequest> extends AbstractRunnable {
         private final RequestHandlerRegistry<T> reg;
         private final T request;

--- a/server/src/main/java/org/opensearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/opensearch/transport/OutboundHandler.java
@@ -212,6 +212,11 @@ final class OutboundHandler {
         }
     }
 
+    /**
+     * Internal message serializer
+     *
+     * @opensearch.internal
+     */
     private static class MessageSerializer implements CheckedSupplier<BytesReference, IOException>, Releasable {
 
         private final OutboundMessage message;

--- a/server/src/main/java/org/opensearch/transport/OutboundMessage.java
+++ b/server/src/main/java/org/opensearch/transport/OutboundMessage.java
@@ -117,6 +117,11 @@ abstract class OutboundMessage extends NetworkMessage {
         }
     }
 
+    /**
+     * Internal outbound message request
+     *
+     * @opensearch.internal
+     */
     static class Request extends OutboundMessage {
 
         private final String[] features;
@@ -158,6 +163,11 @@ abstract class OutboundMessage extends NetworkMessage {
         }
     }
 
+    /**
+     * Internal message response
+     *
+     * @opensearch.internal
+     */
     static class Response extends OutboundMessage {
 
         private final Set<String> features;

--- a/server/src/main/java/org/opensearch/transport/ProxyConnectionStrategy.java
+++ b/server/src/main/java/org/opensearch/transport/ProxyConnectionStrategy.java
@@ -344,6 +344,11 @@ public class ProxyConnectionStrategy extends RemoteConnectionStrategy {
         return new TransportAddress(parseConfiguredAddress(address));
     }
 
+    /**
+     * Contains information about the proxy mode
+     *
+     * @opensearch.internal
+     */
     public static class ProxyModeInfo implements RemoteConnectionInfo.ModeInfo {
 
         private final String address;

--- a/server/src/main/java/org/opensearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/opensearch/transport/RemoteClusterService.java
@@ -436,6 +436,11 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
         return remoteClusters.values();
     }
 
+    /**
+     * Internal class to hold cluster alias and key and track a remote connection
+     *
+     * @opensearch.internal
+     */
     private static class RemoteConnectionEnabled<T> implements Setting.Validator<T> {
 
         private final String clusterAlias;

--- a/server/src/main/java/org/opensearch/transport/RemoteConnectionInfo.java
+++ b/server/src/main/java/org/opensearch/transport/RemoteConnectionInfo.java
@@ -222,6 +222,11 @@ public final class RemoteConnectionInfo implements ToXContentFragment, Writeable
         return Objects.hash(modeInfo, initialConnectionTimeout, clusterAlias, skipUnavailable);
     }
 
+    /**
+     * Mode information
+     *
+     * @opensearch.internal
+     */
     public interface ModeInfo extends ToXContentFragment, Writeable {
 
         boolean isConnected();

--- a/server/src/main/java/org/opensearch/transport/RemoteConnectionStrategy.java
+++ b/server/src/main/java/org/opensearch/transport/RemoteConnectionStrategy.java
@@ -422,6 +422,11 @@ public abstract class RemoteConnectionStrategy implements TransportConnectionLis
             || Objects.equals(oldProfile.getPingInterval(), newProfile.getPingInterval()) == false;
     }
 
+    /**
+     * Internal strategy validation object
+     *
+     * @opensearch.internal
+     */
     static class StrategyValidator<T> implements Setting.Validator<T> {
 
         private final String key;

--- a/server/src/main/java/org/opensearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/opensearch/transport/SniffConnectionStrategy.java
@@ -561,6 +561,11 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
         return Objects.equals(oldProxy, newProxy) == false;
     }
 
+    /**
+     * Information about the sniff mode
+     *
+     * @opensearch.internal
+     */
     public static class SniffModeInfo implements RemoteConnectionInfo.ModeInfo {
 
         final List<String> seedNodes;

--- a/server/src/main/java/org/opensearch/transport/TcpChannel.java
+++ b/server/src/main/java/org/opensearch/transport/TcpChannel.java
@@ -96,6 +96,11 @@ public interface TcpChannel extends CloseableChannel {
      */
     ChannelStats getChannelStats();
 
+    /**
+     * Channel statistics
+     *
+     * @opensearch.internal
+     */
     class ChannelStats {
 
         private volatile long lastAccessedTime;

--- a/server/src/main/java/org/opensearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/opensearch/transport/TcpTransport.java
@@ -244,6 +244,11 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         inboundHandler.setSlowLogThreshold(slowLogThreshold);
     }
 
+    /**
+     * List of node connection channels
+     *
+     * @opensearch.internal
+     */
     public final class NodeChannels extends CloseableConnection {
         private final Map<TransportRequestOptions.Type, ConnectionProfile.ConnectionTypeHandle> typeMapping;
         private final List<TcpChannel> channels;
@@ -872,6 +877,8 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     /**
      * A helper exception to mark an incoming connection as potentially being HTTP
      * so an appropriate error code can be returned
+     *
+     * @opensearch.internal
      */
     public static class HttpRequestOnTransportException extends OpenSearchException {
 

--- a/server/src/main/java/org/opensearch/transport/Transport.java
+++ b/server/src/main/java/org/opensearch/transport/Transport.java
@@ -268,6 +268,11 @@ public interface Transport extends LifecycleComponent {
         }
     }
 
+    /**
+     * Request handler implementations
+     *
+     * @opensearch.internal
+     */
     final class RequestHandlers {
 
         private volatile Map<String, RequestHandlerRegistry<? extends TransportRequest>> requestHandlers = Collections.emptyMap();

--- a/server/src/main/java/org/opensearch/transport/TransportActionProxy.java
+++ b/server/src/main/java/org/opensearch/transport/TransportActionProxy.java
@@ -53,6 +53,11 @@ public final class TransportActionProxy {
 
     private TransportActionProxy() {} // no instance
 
+    /**
+     * Handler for proxy requests
+     *
+     * @opensearch.internal
+     */
     private static class ProxyRequestHandler<T extends ProxyRequest> implements TransportRequestHandler<T> {
 
         private final TransportService service;
@@ -82,6 +87,11 @@ public final class TransportActionProxy {
         }
     }
 
+    /**
+     * Handler for the proxy response
+     *
+     * @opensearch.internal
+     */
     private static class ProxyResponseHandler<T extends TransportResponse> implements TransportResponseHandler<T> {
 
         private final Writeable.Reader<T> reader;
@@ -121,6 +131,11 @@ public final class TransportActionProxy {
         }
     }
 
+    /**
+     * The proxy request
+     *
+     * @opensearch.internal
+     */
     static class ProxyRequest<T extends TransportRequest> extends TransportRequest {
         final T wrapped;
         final DiscoveryNode targetNode;

--- a/server/src/main/java/org/opensearch/transport/TransportRequest.java
+++ b/server/src/main/java/org/opensearch/transport/TransportRequest.java
@@ -45,6 +45,11 @@ import java.io.IOException;
  * @opensearch.internal
  */
 public abstract class TransportRequest extends TransportMessage implements TaskAwareRequest {
+    /**
+     * Empty transport request
+     *
+     * @opensearch.internal
+     */
     public static class Empty extends TransportRequest {
         public static final Empty INSTANCE = new Empty();
 

--- a/server/src/main/java/org/opensearch/transport/TransportRequestOptions.java
+++ b/server/src/main/java/org/opensearch/transport/TransportRequestOptions.java
@@ -59,6 +59,11 @@ public class TransportRequestOptions {
 
     public static final TransportRequestOptions EMPTY = new TransportRequestOptions.Builder().build();
 
+    /**
+     * Type of transport request
+     *
+     * @opensearch.internal
+     */
     public enum Type {
         RECOVERY,
         BULK,
@@ -71,6 +76,11 @@ public class TransportRequestOptions {
         return new Builder();
     }
 
+    /**
+     * Builder for transport request options
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
         private TimeValue timeout;
         private Type type = Type.REG;

--- a/server/src/main/java/org/opensearch/transport/TransportResponse.java
+++ b/server/src/main/java/org/opensearch/transport/TransportResponse.java
@@ -58,6 +58,11 @@ public abstract class TransportResponse extends TransportMessage {
         super(in);
     }
 
+    /**
+     * Empty transport response
+     *
+     * @opensearch.internal
+     */
     public static class Empty extends TransportResponse {
         public static final Empty INSTANCE = new Empty();
 

--- a/server/src/main/java/org/opensearch/transport/TransportService.java
+++ b/server/src/main/java/org/opensearch/transport/TransportService.java
@@ -566,6 +566,11 @@ public class TransportService extends AbstractLifecycleComponent
         return connectionManager;
     }
 
+    /**
+     * Internal Handshake request
+     *
+     * @opensearch.internal
+     */
     static class HandshakeRequest extends TransportRequest {
 
         public static final HandshakeRequest INSTANCE = new HandshakeRequest();
@@ -578,6 +583,11 @@ public class TransportService extends AbstractLifecycleComponent
 
     }
 
+    /**
+     * Internal handshake response
+     *
+     * @opensearch.internal
+     */
     public static class HandshakeResponse extends TransportResponse {
         private final DiscoveryNode discoveryNode;
         private final ClusterName clusterName;
@@ -1285,6 +1295,11 @@ public class TransportService extends AbstractLifecycleComponent
         }
     }
 
+    /**
+     * Holder for timeout information
+     *
+     * @opensearch.internal
+     */
     static class TimeoutInfoHolder {
 
         private final DiscoveryNode node;
@@ -1372,6 +1387,11 @@ public class TransportService extends AbstractLifecycleComponent
 
     }
 
+    /**
+     * A channel for a direct response
+     *
+     * @opensearch.internal
+     */
     static class DirectResponseChannel implements TransportChannel {
         final DiscoveryNode localNode;
         private final String action;


### PR DESCRIPTION
Adds javadocs to internal classes in org.opensearch.action, index, and transport
packages.

relates #221 
relates #2868