### PR TITLE
[2.x] Replace internal usages of 'master' term in 'client' directory

### DIFF
--- a/client/rest-high-level/src/main/java/org/opensearch/client/TimedRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/TimedRequest.java
@@ -47,7 +47,7 @@ public abstract class TimedRequest implements Validatable {
     public static final TimeValue DEFAULT_MASTER_NODE_TIMEOUT = TimeValue.timeValueSeconds(30);
 
     private TimeValue timeout = DEFAULT_ACK_TIMEOUT;
-    private TimeValue masterTimeout = DEFAULT_MASTER_NODE_TIMEOUT;
+    private TimeValue clusterManagerTimeout = DEFAULT_MASTER_NODE_TIMEOUT;
 
     /**
      * Sets the timeout to wait for the all the nodes to acknowledge
@@ -58,11 +58,11 @@ public abstract class TimedRequest implements Validatable {
     }
 
     /**
-     * Sets the timeout to connect to the master node
-     * @param masterTimeout timeout as a {@link TimeValue}
+     * Sets the timeout to connect to the cluster-manager node
+     * @param clusterManagerTimeout timeout as a {@link TimeValue}
      */
-    public void setMasterTimeout(TimeValue masterTimeout) {
-        this.masterTimeout = masterTimeout;
+    public void setMasterTimeout(TimeValue clusterManagerTimeout) {
+        this.clusterManagerTimeout = clusterManagerTimeout;
     }
 
     /**
@@ -73,9 +73,9 @@ public abstract class TimedRequest implements Validatable {
     }
 
     /**
-     * Returns the timeout for the request to be completed on the master node
+     * Returns the timeout for the request to be completed on the cluster-manager node
      */
     public TimeValue masterNodeTimeout() {
-        return masterTimeout;
+        return clusterManagerTimeout;
     }
 }

--- a/client/rest-high-level/src/main/java/org/opensearch/client/indices/GetComponentTemplatesRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/indices/GetComponentTemplatesRequest.java
@@ -44,7 +44,7 @@ public class GetComponentTemplatesRequest implements Validatable {
 
     private final String name;
 
-    private TimeValue masterNodeTimeout = TimedRequest.DEFAULT_MASTER_NODE_TIMEOUT;
+    private TimeValue clusterManagerNodeTimeout = TimedRequest.DEFAULT_MASTER_NODE_TIMEOUT;
     private boolean local = false;
 
     /**
@@ -65,23 +65,23 @@ public class GetComponentTemplatesRequest implements Validatable {
     }
 
     /**
-     * @return the timeout for waiting for the master node to respond
+     * @return the timeout for waiting for the cluster-manager node to respond
      */
     public TimeValue getMasterNodeTimeout() {
-        return masterNodeTimeout;
+        return clusterManagerNodeTimeout;
     }
 
-    public void setMasterNodeTimeout(@Nullable TimeValue masterNodeTimeout) {
-        this.masterNodeTimeout = masterNodeTimeout;
+    public void setMasterNodeTimeout(@Nullable TimeValue clusterManagerNodeTimeout) {
+        this.clusterManagerNodeTimeout = clusterManagerNodeTimeout;
     }
 
-    public void setMasterNodeTimeout(String masterNodeTimeout) {
-        final TimeValue timeValue = TimeValue.parseTimeValue(masterNodeTimeout, getClass().getSimpleName() + ".masterNodeTimeout");
+    public void setMasterNodeTimeout(String clusterManagerNodeTimeout) {
+        final TimeValue timeValue = TimeValue.parseTimeValue(clusterManagerNodeTimeout, getClass().getSimpleName() + ".masterNodeTimeout");
         setMasterNodeTimeout(timeValue);
     }
 
     /**
-     * @return true if this request is to read from the local cluster state, rather than the master node - false otherwise
+     * @return true if this request is to read from the local cluster state, rather than the cluster-manager node - false otherwise
      */
     public boolean isLocal() {
         return local;

--- a/client/rest-high-level/src/main/java/org/opensearch/client/indices/GetComposableIndexTemplateRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/indices/GetComposableIndexTemplateRequest.java
@@ -44,7 +44,7 @@ public class GetComposableIndexTemplateRequest implements Validatable {
 
     private final String name;
 
-    private TimeValue masterNodeTimeout = TimedRequest.DEFAULT_MASTER_NODE_TIMEOUT;
+    private TimeValue clusterManagerNodeTimeout = TimedRequest.DEFAULT_MASTER_NODE_TIMEOUT;
     private boolean local = false;
 
     /**
@@ -65,23 +65,23 @@ public class GetComposableIndexTemplateRequest implements Validatable {
     }
 
     /**
-     * @return the timeout for waiting for the master node to respond
+     * @return the timeout for waiting for the cluster-manager node to respond
      */
     public TimeValue getMasterNodeTimeout() {
-        return masterNodeTimeout;
+        return clusterManagerNodeTimeout;
     }
 
-    public void setMasterNodeTimeout(@Nullable TimeValue masterNodeTimeout) {
-        this.masterNodeTimeout = masterNodeTimeout;
+    public void setMasterNodeTimeout(@Nullable TimeValue clusterManagerNodeTimeout) {
+        this.clusterManagerNodeTimeout = clusterManagerNodeTimeout;
     }
 
-    public void setMasterNodeTimeout(String masterNodeTimeout) {
-        final TimeValue timeValue = TimeValue.parseTimeValue(masterNodeTimeout, getClass().getSimpleName() + ".masterNodeTimeout");
+    public void setMasterNodeTimeout(String clusterManagerNodeTimeout) {
+        final TimeValue timeValue = TimeValue.parseTimeValue(clusterManagerNodeTimeout, getClass().getSimpleName() + ".masterNodeTimeout");
         setMasterNodeTimeout(timeValue);
     }
 
     /**
-     * @return true if this request is to read from the local cluster state, rather than the master node - false otherwise
+     * @return true if this request is to read from the local cluster state, rather than the cluster-manager node - false otherwise
      */
     public boolean isLocal() {
         return local;

--- a/client/rest-high-level/src/main/java/org/opensearch/client/indices/GetIndexRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/indices/GetIndexRequest.java
@@ -82,9 +82,9 @@ public class GetIndexRequest extends TimedRequest {
     }
 
     /**
-     * Return local information, do not retrieve the state from master node (default: false).
+     * Return local information, do not retrieve the state from cluster-manager node (default: false).
      * @return <code>true</code> if local information is to be returned;
-     * <code>false</code> if information is to be retrieved from master node (default).
+     * <code>false</code> if information is to be retrieved from cluster-manager node (default).
      */
     public final boolean local() {
         return local;

--- a/client/rest-high-level/src/main/java/org/opensearch/client/indices/GetIndexTemplatesRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/indices/GetIndexTemplatesRequest.java
@@ -51,7 +51,7 @@ public class GetIndexTemplatesRequest implements Validatable {
 
     private final List<String> names;
 
-    private TimeValue masterNodeTimeout = TimedRequest.DEFAULT_MASTER_NODE_TIMEOUT;
+    private TimeValue clusterManagerNodeTimeout = TimedRequest.DEFAULT_MASTER_NODE_TIMEOUT;
     private boolean local = false;
 
     /**
@@ -84,23 +84,23 @@ public class GetIndexTemplatesRequest implements Validatable {
     }
 
     /**
-     * @return the timeout for waiting for the master node to respond
+     * @return the timeout for waiting for the cluster-manager node to respond
      */
     public TimeValue getMasterNodeTimeout() {
-        return masterNodeTimeout;
+        return clusterManagerNodeTimeout;
     }
 
-    public void setMasterNodeTimeout(@Nullable TimeValue masterNodeTimeout) {
-        this.masterNodeTimeout = masterNodeTimeout;
+    public void setMasterNodeTimeout(@Nullable TimeValue clusterManagerNodeTimeout) {
+        this.clusterManagerNodeTimeout = clusterManagerNodeTimeout;
     }
 
-    public void setMasterNodeTimeout(String masterNodeTimeout) {
-        final TimeValue timeValue = TimeValue.parseTimeValue(masterNodeTimeout, getClass().getSimpleName() + ".masterNodeTimeout");
+    public void setMasterNodeTimeout(String clusterManagerNodeTimeout) {
+        final TimeValue timeValue = TimeValue.parseTimeValue(clusterManagerNodeTimeout, getClass().getSimpleName() + ".masterNodeTimeout");
         setMasterNodeTimeout(timeValue);
     }
 
     /**
-     * @return true if this request is to read from the local cluster state, rather than the master node - false otherwise
+     * @return true if this request is to read from the local cluster state, rather than the cluster-manager node - false otherwise
      */
     public boolean isLocal() {
         return local;

--- a/client/rest-high-level/src/test/java/org/opensearch/client/ClusterRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/ClusterRequestConvertersTests.java
@@ -91,7 +91,7 @@ public class ClusterRequestConvertersTests extends OpenSearchTestCase {
         RequestConvertersTests.setRandomLocal(healthRequest::local, expectedParams);
         String timeoutType = OpenSearchTestCase.randomFrom("timeout", "masterTimeout", "both", "none");
         String timeout = OpenSearchTestCase.randomTimeValue();
-        String masterTimeout = OpenSearchTestCase.randomTimeValue();
+        String clusterManagerTimeout = OpenSearchTestCase.randomTimeValue();
         switch (timeoutType) {
             case "timeout":
                 healthRequest.timeout(timeout);
@@ -101,8 +101,8 @@ public class ClusterRequestConvertersTests extends OpenSearchTestCase {
                 break;
             case "masterTimeout":
                 expectedParams.put("timeout", "30s");
-                healthRequest.masterNodeTimeout(masterTimeout);
-                expectedParams.put("master_timeout", masterTimeout);
+                healthRequest.masterNodeTimeout(clusterManagerTimeout);
+                expectedParams.put("master_timeout", clusterManagerTimeout);
                 break;
             case "both":
                 healthRequest.timeout(timeout);

--- a/client/rest-high-level/src/test/java/org/opensearch/client/TimedRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/TimedRequestTests.java
@@ -48,10 +48,10 @@ public class TimedRequestTests extends OpenSearchTestCase {
         TimedRequest timedRequest = new TimedRequest() {
         };
         TimeValue timeout = TimeValue.timeValueSeconds(randomIntBetween(0, 1000));
-        TimeValue masterTimeout = TimeValue.timeValueSeconds(randomIntBetween(0, 1000));
+        TimeValue clusterManagerTimeout = TimeValue.timeValueSeconds(randomIntBetween(0, 1000));
         timedRequest.setTimeout(timeout);
-        timedRequest.setMasterTimeout(masterTimeout);
+        timedRequest.setMasterTimeout(clusterManagerTimeout);
         assertEquals(timedRequest.timeout(), timeout);
-        assertEquals(timedRequest.masterNodeTimeout(), masterTimeout);
+        assertEquals(timedRequest.masterNodeTimeout(), clusterManagerTimeout);
     }
 }

--- a/client/rest-high-level/src/test/java/org/opensearch/client/indices/CloseIndexRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/indices/CloseIndexRequestTests.java
@@ -80,10 +80,10 @@ public class CloseIndexRequestTests extends OpenSearchTestCase {
         final TimeValue timeout = TimeValue.timeValueSeconds(randomIntBetween(0, 1000));
         request.setTimeout(timeout);
 
-        final TimeValue masterTimeout = TimeValue.timeValueSeconds(randomIntBetween(0, 1000));
-        request.setMasterTimeout(masterTimeout);
+        final TimeValue clusterManagerTimeout = TimeValue.timeValueSeconds(randomIntBetween(0, 1000));
+        request.setMasterTimeout(clusterManagerTimeout);
 
         assertEquals(request.timeout(), timeout);
-        assertEquals(request.masterNodeTimeout(), masterTimeout);
+        assertEquals(request.masterNodeTimeout(), clusterManagerTimeout);
     }
 }

--- a/client/rest/src/main/java/org/opensearch/client/Node.java
+++ b/client/rest/src/main/java/org/opensearch/client/Node.java
@@ -210,7 +210,7 @@ public class Node {
         }
 
         /**
-         * Returns whether or not the node <strong>could</strong> be elected master.
+         * Returns whether or not the node <strong>could</strong> be elected cluster-manager.
          */
         public boolean isMasterEligible() {
             return roles.contains("master") || roles.contains("cluster_manager");

--- a/client/rest/src/main/java/org/opensearch/client/NodeSelector.java
+++ b/client/rest/src/main/java/org/opensearch/client/NodeSelector.java
@@ -36,7 +36,7 @@ import java.util.Iterator;
 
 /**
  * Selects nodes that can receive requests. Used to keep requests away
- * from master nodes or to send them to nodes with a particular attribute.
+ * from cluster-manager nodes or to send them to nodes with a particular attribute.
  * Use with {@link RestClientBuilder#setNodeSelector(NodeSelector)}.
  */
 public interface NodeSelector {
@@ -80,10 +80,10 @@ public interface NodeSelector {
 
     /**
      * Selector that matches any node that has metadata and doesn't
-     * have the {@code master} role OR it has the data {@code data}
+     * have the {@code cluster_manager} role OR it has the data {@code data}
      * role.
      */
-    NodeSelector SKIP_DEDICATED_MASTERS = new NodeSelector() {
+    NodeSelector SKIP_DEDICATED_CLUSTER_MANAGERS = new NodeSelector() {
         @Override
         public void select(Iterable<Node> nodes) {
             for (Iterator<Node> itr = nodes.iterator(); itr.hasNext();) {

--- a/client/rest/src/test/java/org/opensearch/client/RestClientMultipleHostsTests.java
+++ b/client/rest/src/test/java/org/opensearch/client/RestClientMultipleHostsTests.java
@@ -297,7 +297,7 @@ public class RestClientMultipleHostsTests extends RestClientTestCase {
     }
 
     public void testSetNodes() throws Exception {
-        RestClient restClient = createRestClient(NodeSelector.SKIP_DEDICATED_MASTERS);
+        RestClient restClient = createRestClient(NodeSelector.SKIP_DEDICATED_CLUSTER_MANAGERS);
         List<Node> newNodes = new ArrayList<>(nodes.size());
         for (int i = 0; i < nodes.size(); i++) {
             Node.Roles roles = i == 0

--- a/client/rest/src/test/java/org/opensearch/client/documentation/RestClientDocumentation.java
+++ b/client/rest/src/test/java/org/opensearch/client/documentation/RestClientDocumentation.java
@@ -133,7 +133,7 @@ public class RestClientDocumentation {
             //tag::rest-client-init-node-selector
             RestClientBuilder builder = RestClient.builder(
                 new HttpHost("localhost", 9200, "http"));
-            builder.setNodeSelector(NodeSelector.SKIP_DEDICATED_MASTERS); // <1>
+            builder.setNodeSelector(NodeSelector.SKIP_DEDICATED_CLUSTER_MANAGERS); // <1>
             //end::rest-client-init-node-selector
         }
         {

--- a/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
@@ -486,7 +486,7 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         int lineNumber = between(1, 10000);
         DoSection doSection = new DoSection(new XContentLocation(lineNumber, 0));
         ApiCallSection apiCall = new ApiCallSection("test");
-        apiCall.setNodeSelector(NodeSelector.SKIP_DEDICATED_MASTERS);
+        apiCall.setNodeSelector(NodeSelector.SKIP_DEDICATED_CLUSTER_MANAGERS);
         doSection.setApiCallSection(apiCall);
         ClientYamlTestSuite testSuite = createTestSuite(SkipSection.EMPTY, doSection);
         Exception e = expectThrows(IllegalArgumentException.class, testSuite::validate);
@@ -553,7 +553,7 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         {
             DoSection doSection = new DoSection(new XContentLocation(thirdLineNumber, 0));
             ApiCallSection apiCall = new ApiCallSection("test");
-            apiCall.setNodeSelector(NodeSelector.SKIP_DEDICATED_MASTERS);
+            apiCall.setNodeSelector(NodeSelector.SKIP_DEDICATED_CLUSTER_MANAGERS);
             doSection.setApiCallSection(apiCall);
             doSections.add(doSection);
         }
@@ -593,7 +593,7 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         SkipSection skipSection = new SkipSection(null, singletonList("node_selector"), null);
         DoSection doSection = new DoSection(new XContentLocation(lineNumber, 0));
         ApiCallSection apiCall = new ApiCallSection("test");
-        apiCall.setNodeSelector(NodeSelector.SKIP_DEDICATED_MASTERS);
+        apiCall.setNodeSelector(NodeSelector.SKIP_DEDICATED_CLUSTER_MANAGERS);
         doSection.setApiCallSection(apiCall);
         createTestSuite(skipSection, doSection).validate();
     }


### PR DESCRIPTION
### Description
Backport commit https://github.com/opensearch-project/OpenSearch/commit/dd7add25681b9fa206a92dceee97c69ca21948ef / PR https://github.com/opensearch-project/OpenSearch/pull/3088 to `2.x` branch.

- Replace the non-inclusive terminology "master" with "cluster manager" in code comments, internal variable and method names, in `client` directory.
- Backwards compatibility is not impacted.

Replacement rules:
- `master` -> `cluster_manager` or `clusterManager` (variable name) or `cluster-manager` (code comment)
- `Master` -> `ClusterManager`
 
### Issues Resolved
A part of #1548
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
