### PR TITLE
[Javadocs] add to internal classes in o.o.http, indices, and search

### DIFF
--- a/server/src/main/java/org/opensearch/Build.java
+++ b/server/src/main/java/org/opensearch/Build.java
@@ -56,6 +56,11 @@ public class Build {
      */
     public static final Build CURRENT;
 
+    /**
+     * The type of build
+     *
+     * @opensearch.internal
+     */
     public enum Type {
 
         DEB("deb"),

--- a/server/src/main/java/org/opensearch/http/CorsHandler.java
+++ b/server/src/main/java/org/opensearch/http/CorsHandler.java
@@ -261,6 +261,11 @@ public class CorsHandler {
         response.addHeader(ACCESS_CONTROL_MAX_AGE, Long.toString(config.maxAge));
     }
 
+    /**
+     * The cors handler configuration
+     *
+     * @opensearch.internal
+     */
     public static class Config {
 
         private final boolean enabled;

--- a/server/src/main/java/org/opensearch/http/HttpRequest.java
+++ b/server/src/main/java/org/opensearch/http/HttpRequest.java
@@ -49,6 +49,11 @@ import java.util.Map;
  */
 public interface HttpRequest {
 
+    /**
+     * Which HTTP version being used
+     *
+     * @opensearch.internal
+     */
     enum HttpVersion {
         HTTP_1_0,
         HTTP_1_1

--- a/server/src/main/java/org/opensearch/indices/IndexingMemoryController.java
+++ b/server/src/main/java/org/opensearch/indices/IndexingMemoryController.java
@@ -260,6 +260,11 @@ public class IndexingMemoryController implements IndexingOperationListener, Clos
         }
     }
 
+    /**
+     * The bytes used by a shard and a reference to the shard
+     *
+     * @opensearch.internal
+     */
     private static final class ShardAndBytesUsed implements Comparable<ShardAndBytesUsed> {
         final long bytesUsed;
         final IndexShard shard;

--- a/server/src/main/java/org/opensearch/indices/IndicesQueryCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesQueryCache.java
@@ -216,6 +216,11 @@ public class IndicesQueryCache implements QueryCache, Closeable {
         cache.clear();
     }
 
+    /**
+     * Statistics for the indices query cache
+     *
+     * @opensearch.internal
+     */
     private static class Stats implements Cloneable {
 
         final ShardId shardId;
@@ -251,6 +256,11 @@ public class IndicesQueryCache implements QueryCache, Closeable {
         }
     }
 
+    /**
+     * Statistics and Counts
+     *
+     * @opensearch.internal
+     */
     private static class StatsAndCount {
         volatile int count;
         final Stats stats;

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -176,6 +176,11 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
         cache.invalidate(new Key(cacheEntity, reader.getReaderCacheHelper().getKey(), cacheKey));
     }
 
+    /**
+     * Loader for the request cache
+     *
+     * @opensearch.internal
+     */
     private static class Loader implements CacheLoader<Key, BytesReference> {
 
         private final CacheEntity entity;
@@ -238,6 +243,11 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
         void onRemoval(RemovalNotification<Key, BytesReference> notification);
     }
 
+    /**
+     * Unique key for the cache
+     *
+     * @opensearch.internal
+     */
     static class Key implements Accountable {
         private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(Key.class);
 

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -913,6 +913,11 @@ public class IndicesService extends AbstractLifecycleComponent
         return indicesQueryCache;
     }
 
+    /**
+     * Statistics for old shards
+     *
+     * @opensearch.internal
+     */
     static class OldShardsStats implements IndexEventListener {
 
         final SearchStats searchStats = new SearchStats();
@@ -1236,6 +1241,11 @@ public class IndicesService extends AbstractLifecycleComponent
         }
     }
 
+    /**
+     * A pending delete
+     *
+     * @opensearch.internal
+     */
     private static final class PendingDelete implements Comparable<PendingDelete> {
         final Index index;
         final int shardId;
@@ -1386,6 +1396,8 @@ public class IndicesService extends AbstractLifecycleComponent
      * periodically. In this case it is the field data cache, because a cache that
      * has an entry invalidated may not clean up the entry if it is not read from
      * or written to after invalidation.
+     *
+     * @opensearch.internal
      */
     private static final class CacheCleaner implements Runnable, Releasable {
 
@@ -1574,6 +1586,11 @@ public class IndicesService extends AbstractLifecycleComponent
         return indicesRequestCache.getOrCompute(cacheEntity, supplier, reader, cacheKey);
     }
 
+    /**
+     * An item in the index shard cache
+     *
+     * @opensearch.internal
+     */
     static final class IndexShardCacheEntity extends AbstractIndexShardCacheEntity {
         private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(IndexShardCacheEntity.class);
         private final IndexShard indexShard;

--- a/server/src/main/java/org/opensearch/indices/NodeIndicesStats.java
+++ b/server/src/main/java/org/opensearch/indices/NodeIndicesStats.java
@@ -271,6 +271,11 @@ public class NodeIndicesStats implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * Fields used for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String INDICES = "indices";
     }

--- a/server/src/main/java/org/opensearch/indices/analysis/PreBuiltCacheFactory.java
+++ b/server/src/main/java/org/opensearch/indices/analysis/PreBuiltCacheFactory.java
@@ -60,6 +60,11 @@ public class PreBuiltCacheFactory {
         OPENSEARCH
     }
 
+    /**
+     * The prebuilt cache
+     *
+     * @opensearch.internal
+     */
     public interface PreBuiltCache<T> {
 
         T get(Version version);
@@ -86,6 +91,8 @@ public class PreBuiltCacheFactory {
 
     /**
      * This is a pretty simple cache, it only contains one version
+     *
+     * @opensearch.internal
      */
     private static class PreBuiltCacheStrategyOne<T> implements PreBuiltCache<T> {
 
@@ -109,6 +116,8 @@ public class PreBuiltCacheFactory {
 
     /**
      * This cache contains one version for each opensearch version object
+     *
+     * @opensearch.internal
      */
     private static class PreBuiltCacheStrategyOpenSearch<T> implements PreBuiltCache<T> {
 
@@ -132,6 +141,8 @@ public class PreBuiltCacheFactory {
 
     /**
      * This cache uses the lucene version for caching
+     *
+     * @opensearch.internal
      */
     private static class PreBuiltCacheStrategyLucene<T> implements PreBuiltCache<T> {
 

--- a/server/src/main/java/org/opensearch/indices/breaker/AllCircuitBreakerStats.java
+++ b/server/src/main/java/org/opensearch/indices/breaker/AllCircuitBreakerStats.java
@@ -87,6 +87,11 @@ public class AllCircuitBreakerStats implements Writeable, ToXContentFragment {
         return builder;
     }
 
+    /**
+     * Fields used for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String BREAKERS = "breakers";
     }

--- a/server/src/main/java/org/opensearch/indices/breaker/CircuitBreakerStats.java
+++ b/server/src/main/java/org/opensearch/indices/breaker/CircuitBreakerStats.java
@@ -132,6 +132,11 @@ public class CircuitBreakerStats implements Writeable, ToXContentObject {
             + "]";
     }
 
+    /**
+     * Fields used for statistics
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String LIMIT = "limit_size_in_bytes";
         static final String LIMIT_HUMAN = "limit_size";

--- a/server/src/main/java/org/opensearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/opensearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -341,6 +341,11 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
         );
     }
 
+    /**
+     * Tracks memory usage
+     *
+     * @opensearch.internal
+     */
     static class MemoryUsage {
         final long baseUsage;
         final long totalUsage;
@@ -505,6 +510,11 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
         MemoryUsage overLimit(MemoryUsage memoryUsed);
     }
 
+    /**
+     * Kicks in G1GC if heap gets too high
+     *
+     * @opensearch.internal
+     */
     static class G1OverLimitStrategy implements OverLimitStrategy {
         private final long g1RegionSize;
         private final LongSupplier currentMemoryUsageSupplier;

--- a/server/src/main/java/org/opensearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/opensearch/indices/cluster/IndicesClusterStateService.java
@@ -846,6 +846,11 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         }
     }
 
+    /**
+     * A shard
+     *
+     * @opensearch.internal
+     */
     public interface Shard {
 
         /**
@@ -894,6 +899,11 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         ) throws IOException;
     }
 
+    /**
+     * An allocated index
+     *
+     * @opensearch.internal
+     */
     public interface AllocatedIndex<T extends Shard> extends Iterable<T>, IndexComponent {
 
         /**
@@ -926,6 +936,11 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         void removeShard(int shardId, String message);
     }
 
+    /**
+     * Allocated indices
+     *
+     * @opensearch.internal
+     */
     public interface AllocatedIndices<T extends Shard, U extends AllocatedIndex<T>> extends Iterable<U> {
 
         /**
@@ -1012,6 +1027,11 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         void processPendingDeletes(Index index, IndexSettings indexSettings, TimeValue timeValue) throws IOException, InterruptedException,
             ShardLockObtainFailedException;
 
+        /**
+         * Why the index was removed
+         *
+         * @opensearch.internal
+         */
         enum IndexRemovalReason {
             /**
              * Shard of this index were previously assigned to this node but all shards have been relocated.

--- a/server/src/main/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/server/src/main/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -125,6 +125,11 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
         }
     }
 
+    /**
+     * Computes a weight based on ramBytesUsed
+     *
+     * @opensearch.internal
+     */
     public static class FieldDataWeigher implements ToLongBiFunction<Key, Accountable> {
         @Override
         public long applyAsLong(Key key, Accountable ramUsage) {
@@ -135,6 +140,8 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
 
     /**
      * A specific cache instance for the relevant parameters of it (index, fieldNames, fieldType).
+     *
+     * @opensearch.internal
      */
     static class IndexFieldCache implements IndexFieldDataCache, IndexReader.ClosedListener {
         private final Logger logger;
@@ -242,6 +249,11 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
         }
     }
 
+    /**
+     * Key for the indices field data cache
+     *
+     * @opensearch.internal
+     */
     public static class Key {
         public final IndexFieldCache indexCache;
         public final IndexReader.CacheKey readerKey;

--- a/server/src/main/java/org/opensearch/indices/recovery/MultiChunkTransfer.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/MultiChunkTransfer.java
@@ -211,6 +211,11 @@ public abstract class MultiChunkTransfer<Source, Request extends MultiChunkTrans
 
     protected abstract void handleError(Source resource, Exception e) throws Exception;
 
+    /**
+     * A file chunk item as the response
+     *
+     * @opensearch.internal
+     */
     private static class FileChunkResponseItem<Source> {
         final long requestSeqId;
         final Source source;
@@ -223,6 +228,11 @@ public abstract class MultiChunkTransfer<Source, Request extends MultiChunkTrans
         }
     }
 
+    /**
+     * A chunk request
+     *
+     * @opensearch.internal
+     */
     public interface ChunkRequest {
         /**
          * @return {@code true} if this chunk request is the last chunk of the current file

--- a/server/src/main/java/org/opensearch/indices/recovery/MultiFileWriter.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/MultiFileWriter.java
@@ -199,6 +199,11 @@ public class MultiFileWriter extends AbstractRefCounted implements Releasable {
         store.renameTempFilesSafe(tempFileNames);
     }
 
+    /**
+     * A file chunk
+     *
+     * @opensearch.internal
+     */
     static final class FileChunk {
         final StoreFileMetadata md;
         final BytesReference content;

--- a/server/src/main/java/org/opensearch/indices/recovery/PeerRecoverySourceService.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/PeerRecoverySourceService.java
@@ -79,6 +79,11 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
 
     private static final Logger logger = LogManager.getLogger(PeerRecoverySourceService.class);
 
+    /**
+     * The internal actions
+     *
+     * @opensearch.internal
+     */
     public static class Actions {
         public static final String START_RECOVERY = "internal:index/shard/recovery/start_recovery";
         public static final String REESTABLISH_RECOVERY = "internal:index/shard/recovery/reestablish_recovery";

--- a/server/src/main/java/org/opensearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/PeerRecoveryTargetService.java
@@ -102,6 +102,11 @@ public class PeerRecoveryTargetService implements IndexEventListener {
 
     private static final Logger logger = LogManager.getLogger(PeerRecoveryTargetService.class);
 
+    /**
+     * The internal actions
+     *
+     * @opensearch.internal
+     */
     public static class Actions {
         public static final String FILES_INFO = "internal:index/shard/recovery/filesInfo";
         public static final String FILE_CHUNK = "internal:index/shard/recovery/file_chunk";
@@ -340,6 +345,11 @@ public class PeerRecoveryTargetService implements IndexEventListener {
         return request;
     }
 
+    /**
+     * The recovery listener
+     *
+     * @opensearch.internal
+     */
     public interface RecoveryListener {
         void onRecoveryDone(RecoveryState state);
 

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoveriesCollection.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoveriesCollection.java
@@ -274,6 +274,8 @@ public class RecoveriesCollection {
      * a reference to {@link RecoveryTarget}, which implements {@link AutoCloseable}. closing the reference
      * causes {@link RecoveryTarget#decRef()} to be called. This makes sure that the underlying resources
      * will not be freed until {@link RecoveryRef#close()} is called.
+     *
+     * @opensearch.internal
      */
     public static class RecoveryRef extends AutoCloseableRefCounted<RecoveryTarget> {
 

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
@@ -498,6 +498,11 @@ public class RecoverySourceHandler {
         FutureUtils.get(future);
     }
 
+    /**
+     * A send file result
+     *
+     * @opensearch.internal
+     */
     static final class SendFileResult {
         final List<String> phase1FileNames;
         final List<Long> phase1FileSizes;
@@ -853,6 +858,11 @@ public class RecoverySourceHandler {
         sender.start();
     }
 
+    /**
+     * An operation chunk request
+     *
+     * @opensearch.internal
+     */
     private static class OperationChunkRequest implements MultiChunkTransfer.ChunkRequest {
         final List<Translog.Operation> operations;
         final boolean lastChunk;
@@ -1009,6 +1019,11 @@ public class RecoverySourceHandler {
         }, listener::onFailure);
     }
 
+    /**
+     * A result for a send snapshot
+     *
+     * @opensearch.internal
+     */
     static final class SendSnapshotResult {
         final long targetLocalCheckpoint;
         final int sentOperations;
@@ -1041,6 +1056,11 @@ public class RecoverySourceHandler {
             + '}';
     }
 
+    /**
+     * A file chunk from the recovery source
+     *
+     * @opensearch.internal
+     */
     private static class FileChunk implements MultiChunkTransfer.ChunkRequest, Releasable {
         final StoreFileMetadata md;
         final BytesReference content;

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoveryState.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoveryState.java
@@ -58,6 +58,11 @@ import java.util.Locale;
  */
 public class RecoveryState implements ToXContentFragment, Writeable {
 
+    /**
+     * The stage of the recovery state
+     *
+     * @opensearch.internal
+     */
     public enum Stage {
         INIT((byte) 0),
 
@@ -328,6 +333,11 @@ public class RecoveryState implements ToXContentFragment, Writeable {
         return builder;
     }
 
+    /**
+     * Fields used in the recovery state
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String ID = "id";
         static final String TYPE = "type";
@@ -356,6 +366,11 @@ public class RecoveryState implements ToXContentFragment, Writeable {
         static final String PERCENT = "percent";
     }
 
+    /**
+     * Verifys the lucene index
+     *
+     * @opensearch.internal
+     */
     public static class VerifyIndex extends ReplicationTimer implements ToXContentFragment, Writeable {
         private volatile long checkIndexTime;
 
@@ -393,6 +408,11 @@ public class RecoveryState implements ToXContentFragment, Writeable {
         }
     }
 
+    /**
+     * The translog
+     *
+     * @opensearch.internal
+     */
     public static class Translog extends ReplicationTimer implements ToXContentFragment, Writeable {
         public static final int UNKNOWN = -1;
 

--- a/server/src/main/java/org/opensearch/indices/replication/common/ReplicationLuceneIndex.java
+++ b/server/src/main/java/org/opensearch/indices/replication/common/ReplicationLuceneIndex.java
@@ -307,6 +307,11 @@ public final class ReplicationLuceneIndex extends ReplicationTimer implements To
         return filesDetails.get(dest);
     }
 
+    /**
+     * Details about the files
+     *
+     * @opensearch.internal
+     */
     private static final class FilesDetails implements ToXContentFragment, Writeable {
         protected final Map<String, FileMetadata> fileMetadataMap = new HashMap<>();
         protected boolean complete;
@@ -397,6 +402,11 @@ public final class ReplicationLuceneIndex extends ReplicationTimer implements To
         }
     }
 
+    /**
+     * Metadata about a file
+     *
+     * @opensearch.internal
+     */
     public static final class FileMetadata implements ToXContentObject, Writeable {
         private String name;
         private long length;
@@ -500,6 +510,8 @@ public final class ReplicationLuceneIndex extends ReplicationTimer implements To
 
     /**
      * Duplicates many of Field names in {@link RecoveryState}
+     *
+     * @opensearch.internal
      */
     static final class Fields {
         static final String TOTAL_TIME = "total_time";

--- a/server/src/main/java/org/opensearch/indices/store/IndicesStore.java
+++ b/server/src/main/java/org/opensearch/indices/store/IndicesStore.java
@@ -452,6 +452,11 @@ public class IndicesStore implements ClusterStateListener, Closeable {
 
     }
 
+    /**
+     * A shard active request
+     *
+     * @opensearch.internal
+     */
     private static class ShardActiveRequest extends TransportRequest {
         protected TimeValue timeout = null;
         private ClusterName clusterName;
@@ -483,6 +488,11 @@ public class IndicesStore implements ClusterStateListener, Closeable {
         }
     }
 
+    /**
+     * The shard active response
+     *
+     * @opensearch.internal
+     */
     private static class ShardActiveResponse extends TransportResponse {
 
         private final boolean shardActive;

--- a/server/src/main/java/org/opensearch/indices/store/TransportNodesListShardStoreMetadata.java
+++ b/server/src/main/java/org/opensearch/indices/store/TransportNodesListShardStoreMetadata.java
@@ -77,6 +77,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Metadata for shard stores from a list of transport nodes
+ *
+ * @opensearch.internal
+ */
 public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
     TransportNodesListShardStoreMetadata.Request,
     TransportNodesListShardStoreMetadata.NodesStoreFilesMetadata,
@@ -225,6 +230,11 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
         }
     }
 
+    /**
+     * Metadata for store files
+     *
+     * @opensearch.internal
+     */
     public static class StoreFilesMetadata implements Iterable<StoreFileMetadata>, Writeable {
         private final ShardId shardId;
         private final Store.MetadataSnapshot metadataSnapshot;
@@ -318,6 +328,11 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
         }
     }
 
+    /**
+     * The request
+     *
+     * @opensearch.internal
+     */
     public static class Request extends BaseNodesRequest<Request> {
 
         private final ShardId shardId;
@@ -364,6 +379,11 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
         }
     }
 
+    /**
+     * Metadata for the nodes store files
+     *
+     * @opensearch.internal
+     */
     public static class NodesStoreFilesMetadata extends BaseNodesResponse<NodeStoreFilesMetadata> {
 
         public NodesStoreFilesMetadata(StreamInput in) throws IOException {
@@ -385,6 +405,11 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
         }
     }
 
+    /**
+     * The node request
+     *
+     * @opensearch.internal
+     */
     public static class NodeRequest extends BaseNodeRequest {
 
         private final ShardId shardId;
@@ -431,6 +456,11 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
         }
     }
 
+    /**
+     * The metadata for the node store files
+     *
+     * @opensearch.internal
+     */
     public static class NodeStoreFilesMetadata extends BaseNodeResponse {
 
         private StoreFilesMetadata storeFilesMetadata;

--- a/server/src/main/java/org/opensearch/search/DocValueFormat.java
+++ b/server/src/main/java/org/opensearch/search/DocValueFormat.java
@@ -201,6 +201,11 @@ public interface DocValueFormat extends NamedWriteable {
         }
     }
 
+    /**
+     * Date time doc value format
+     *
+     * @opensearch.internal
+     */
     final class DateTime implements DocValueFormat {
 
         public static final String NAME = "date_time";
@@ -406,6 +411,11 @@ public interface DocValueFormat extends NamedWriteable {
         }
     };
 
+    /**
+     * Decimal doc value format
+     *
+     * @opensearch.internal
+     */
     final class Decimal implements DocValueFormat {
 
         public static final String NAME = "decimal";

--- a/server/src/main/java/org/opensearch/search/SearchHit.java
+++ b/server/src/main/java/org/opensearch/search/SearchHit.java
@@ -590,6 +590,11 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         this.innerHits = innerHits;
     }
 
+    /**
+     * Fields in a search hit used for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     public static class Fields {
         static final String _INDEX = "_index";
         static final String _ID = "_id";
@@ -1000,6 +1005,8 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
 
     /**
      * Encapsulates the nested identity of a hit.
+     *
+     * @opensearch.internal
      */
     public static final class NestedIdentity implements Writeable, ToXContentFragment {
 

--- a/server/src/main/java/org/opensearch/search/SearchHits.java
+++ b/server/src/main/java/org/opensearch/search/SearchHits.java
@@ -201,6 +201,11 @@ public final class SearchHits implements Writeable, ToXContentFragment, Iterable
         return Arrays.stream(getHits()).iterator();
     }
 
+    /**
+     * Fields for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     public static final class Fields {
         public static final String HITS = "hits";
         public static final String TOTAL = "total";

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -1418,6 +1418,11 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         return request.source().aggregations().buildPipelineTree();
     }
 
+    /**
+     * Search phase result that can match a response
+     *
+     * @opensearch.internal
+     */
     public static final class CanMatchResponse extends SearchPhaseResult {
         private final boolean canMatch;
         private final MinAndMax<?> estimatedMinAndMax;

--- a/server/src/main/java/org/opensearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/AggregationBuilder.java
@@ -166,6 +166,8 @@ public abstract class AggregationBuilder
      * <p>
      * Unlike {@link CardinalityUpperBound} which is <strong>total</strong>
      * instead of <strong>per parent bucket</strong>.
+     *
+     * @opensearch.internal
      */
     public enum BucketCardinality {
         NONE,
@@ -179,7 +181,11 @@ public abstract class AggregationBuilder
      */
     public abstract BucketCardinality bucketCardinality();
 
-    /** Common xcontent fields shared among aggregator builders */
+    /**
+     * Common xcontent fields shared among aggregator builders
+     *
+     * @opensearch.internal
+     */
     public static final class CommonFields extends ParseField.CommonFields {
         public static final ParseField VALUE_TYPE = new ParseField("value_type");
     }

--- a/server/src/main/java/org/opensearch/search/aggregations/Aggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/Aggregator.java
@@ -63,6 +63,8 @@ public abstract class Aggregator extends BucketCollector implements Releasable {
      * Parses the aggregation request and creates the appropriate aggregator factory for it.
      *
      * @see AggregationBuilder
+     *
+     * @opensearch.internal
      */
     @FunctionalInterface
     public interface Parser {
@@ -157,6 +159,8 @@ public abstract class Aggregator extends BucketCollector implements Releasable {
 
     /**
      * Compare two buckets by their ordinal.
+     *
+     * @opensearch.internal
      */
     @FunctionalInterface
     public interface BucketComparator {
@@ -204,7 +208,11 @@ public abstract class Aggregator extends BucketCollector implements Releasable {
      */
     public void collectDebugInfo(BiConsumer<String, Object> add) {}
 
-    /** Aggregation mode for sub aggregations. */
+    /**
+     * Aggregation mode for sub aggregations.
+     *
+     * @opensearch.internal
+     */
     public enum SubAggCollectionMode implements Writeable {
 
         /**

--- a/server/src/main/java/org/opensearch/search/aggregations/AggregatorFactories.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/AggregatorFactories.java
@@ -295,6 +295,8 @@ public class AggregatorFactories {
     /**
      * A mutable collection of {@link AggregationBuilder}s and
      * {@link PipelineAggregationBuilder}s.
+     *
+     * @opensearch.internal
      */
     public static class Builder implements Writeable, ToXContentObject {
         private final Set<String> names = new HashSet<>();

--- a/server/src/main/java/org/opensearch/search/aggregations/CardinalityUpperBound.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/CardinalityUpperBound.java
@@ -113,6 +113,8 @@ public abstract class CardinalityUpperBound {
 
     /**
      * Cardinality estimate with a known upper bound.
+     *
+     * @opensearch.internal
      */
     private static class KnownCardinalityUpperBound extends CardinalityUpperBound {
         private final int estimate;

--- a/server/src/main/java/org/opensearch/search/aggregations/InternalAggregation.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/InternalAggregation.java
@@ -64,6 +64,8 @@ import static java.util.Objects.requireNonNull;
 public abstract class InternalAggregation implements Aggregation, NamedWriteable {
     /**
      * Builds {@link ReduceContext}.
+     *
+     * @opensearch.internal
      */
     public interface ReduceContextBuilder {
         /**
@@ -77,6 +79,11 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
         ReduceContext forFinalReduction();
     }
 
+    /**
+     * The reduce context
+     *
+     * @opensearch.internal
+     */
     public static class ReduceContext {
         private final BigArrays bigArrays;
         private final ScriptService scriptService;

--- a/server/src/main/java/org/opensearch/search/aggregations/InternalAggregations.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/InternalAggregations.java
@@ -304,6 +304,11 @@ public final class InternalAggregations extends Aggregations implements Writeabl
         }
     }
 
+    /**
+     * A counting stream output
+     *
+     * @opensearch.internal
+     */
     private static class CountingStreamOutput extends StreamOutput {
         long size = 0;
 

--- a/server/src/main/java/org/opensearch/search/aggregations/InternalMultiBucketAggregation.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/InternalMultiBucketAggregation.java
@@ -223,6 +223,11 @@ public abstract class InternalMultiBucketAggregation<
         return reducedBuckets;
     }
 
+    /**
+     * An internal buck for the internal multibucket agg
+     *
+     * @opensearch.internal
+     */
     public abstract static class InternalBucket implements Bucket, Writeable {
 
         public Object getProperty(String containingAggName, List<String> path) {

--- a/server/src/main/java/org/opensearch/search/aggregations/InternalOrder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/InternalOrder.java
@@ -65,6 +65,8 @@ public abstract class InternalOrder extends BucketOrder {
     // TODO merge the contents of this file into BucketOrder. The way it is now is relic.
     /**
      * {@link Bucket} ordering strategy to sort by a sub-aggregation.
+     *
+     * @opensearch.internal
      */
     public static class Aggregation extends InternalOrder {
         static final byte ID = 0;
@@ -133,6 +135,8 @@ public abstract class InternalOrder extends BucketOrder {
 
     /**
      * {@link Bucket} ordering strategy to sort by multiple criteria.
+     *
+     * @opensearch.internal
      */
     public static class CompoundOrder extends BucketOrder {
 
@@ -244,6 +248,8 @@ public abstract class InternalOrder extends BucketOrder {
      * {@link BucketOrder} implementation for simple, fixed orders like
      * {@link InternalOrder#COUNT_ASC}. Complex implementations should not
      * use this.
+     *
+     * @opensearch.internal
      */
     private static class SimpleOrder extends InternalOrder {
         private final byte id;
@@ -405,6 +411,8 @@ public abstract class InternalOrder extends BucketOrder {
 
     /**
      * Contains logic for reading/writing {@link BucketOrder} from/to streams.
+     *
+     * @opensearch.internal
      */
     public static class Streams {
 
@@ -493,6 +501,8 @@ public abstract class InternalOrder extends BucketOrder {
 
     /**
      * Contains logic for parsing a {@link BucketOrder} from a {@link XContentParser}.
+     *
+     * @opensearch.internal
      */
     public static class Parser {
 

--- a/server/src/main/java/org/opensearch/search/aggregations/MultiBucketCollector.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/MultiBucketCollector.java
@@ -176,6 +176,11 @@ public class MultiBucketCollector extends BucketCollector {
         }
     }
 
+    /**
+     * A multi leaf bucket collector
+     *
+     * @opensearch.internal
+     */
     private static class MultiLeafBucketCollector extends LeafBucketCollector {
 
         private final boolean cacheScores;

--- a/server/src/main/java/org/opensearch/search/aggregations/MultiBucketConsumerService.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/MultiBucketConsumerService.java
@@ -76,6 +76,11 @@ public class MultiBucketConsumerService {
         this.maxBucket = maxBucket;
     }
 
+    /**
+     * Thrown when there are too many buckets
+     *
+     * @opensearch.internal
+     */
     public static class TooManyBucketsException extends AggregationExecutionException {
         private final int maxBuckets;
 
@@ -115,6 +120,8 @@ public class MultiBucketConsumerService {
      * when the sum of the provided values is above the limit (`search.max_buckets`).
      * It is used by aggregators to limit the number of bucket creation during
      * {@link Aggregator#buildAggregations} and {@link InternalAggregation#reduce}.
+     *
+     * @opensearch.internal
      */
     public static class MultiBucketConsumer implements IntConsumer {
         private final int limit;

--- a/server/src/main/java/org/opensearch/search/aggregations/ParsedMultiBucketAggregation.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/ParsedMultiBucketAggregation.java
@@ -99,6 +99,11 @@ public abstract class ParsedMultiBucketAggregation<B extends ParsedMultiBucketAg
         }, CommonFields.BUCKETS, ObjectParser.ValueType.OBJECT_ARRAY);
     }
 
+    /**
+     * A parsed bucket
+     *
+     * @opensearch.internal
+     */
     public abstract static class ParsedBucket implements MultiBucketsAggregation.Bucket {
 
         private Aggregations aggregations;

--- a/server/src/main/java/org/opensearch/search/aggregations/PipelineAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/PipelineAggregationBuilder.java
@@ -97,6 +97,11 @@ public abstract class PipelineAggregationBuilder
      */
     protected abstract void validate(ValidationContext context);
 
+    /**
+     * The context used for validation
+     *
+     * @opensearch.internal
+     */
     public abstract static class ValidationContext {
         /**
          * Build the context for the root of the aggregation tree.
@@ -122,6 +127,11 @@ public abstract class PipelineAggregationBuilder
             this.e = validationFailuresSoFar;
         }
 
+        /**
+         * The root of the tree
+         *
+         * @opensearch.internal
+         */
         private static class ForTreeRoot extends ValidationContext {
             private final Collection<AggregationBuilder> siblingAggregations;
             private final Collection<PipelineAggregationBuilder> siblingPipelineAggregations;
@@ -162,6 +172,11 @@ public abstract class PipelineAggregationBuilder
             }
         }
 
+        /**
+         * The internal tree node
+         *
+         * @opensearch.internal
+         */
         private static class ForInsideTree extends ValidationContext {
             private final AggregationBuilder parent;
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
@@ -65,6 +65,11 @@ import java.util.Objects;
  * @opensearch.internal
  */
 public class BestBucketsDeferringCollector extends DeferringBucketCollector {
+    /**
+     * Entry in the bucket collector
+     *
+     * @opensearch.internal
+     */
     static class Entry {
         final LeafReaderContext context;
         final PackedLongValues docDeltas;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/BucketsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/BucketsAggregator.java
@@ -330,6 +330,11 @@ public abstract class BucketsAggregator extends AggregatorBase {
         return results;
     }
 
+    /**
+     * A bucket builder for a fixed count
+     *
+     * @opensearch.internal
+     */
     @FunctionalInterface
     protected interface BucketBuilderForFixedCount<B> {
         B build(int offsetInOwningOrd, int docCount, InternalAggregations subAggregationResults);
@@ -355,6 +360,11 @@ public abstract class BucketsAggregator extends AggregatorBase {
         return results;
     }
 
+    /**
+     * A single bucket result builder
+     *
+     * @opensearch.internal
+     */
     @FunctionalInterface
     protected interface SingleBucketResultBuilder {
         InternalAggregation build(long owningBucketOrd, InternalAggregations subAggregationResults);
@@ -415,11 +425,21 @@ public abstract class BucketsAggregator extends AggregatorBase {
         return results;
     }
 
+    /**
+     * A bucket builder for a variable
+     *
+     * @opensearch.internal
+     */
     @FunctionalInterface
     protected interface BucketBuilderForVariable<B> {
         B build(long bucketValue, int docCount, InternalAggregations subAggregationResults);
     }
 
+    /**
+     * A result builder for a bucket variable
+     *
+     * @opensearch.internal
+     */
     @FunctionalInterface
     protected interface ResultBuilderForVariable<B> {
         InternalAggregation build(long owninigBucketOrd, List<B> buckets);

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/DeferringBucketCollector.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/DeferringBucketCollector.java
@@ -72,6 +72,11 @@ public abstract class DeferringBucketCollector extends BucketCollector {
         return new WrappedAggregator(in);
     }
 
+    /**
+     * A wrapped aggregator
+     *
+     * @opensearch.internal
+     */
     protected class WrappedAggregator extends Aggregator {
         private Aggregator in;
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregator.java
@@ -72,6 +72,11 @@ public class AdjacencyMatrixAggregator extends BucketsAggregator {
 
     public static final ParseField FILTERS_FIELD = new ParseField("filters");
 
+    /**
+     * A keyed filter
+     *
+     * @opensearch.internal
+     */
     protected static class KeyedFilter implements Writeable, ToXContentFragment {
         private final String key;
         private final QueryBuilder filter;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrix.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrix.java
@@ -56,6 +56,12 @@ import java.util.Objects;
 public class InternalAdjacencyMatrix extends InternalMultiBucketAggregation<InternalAdjacencyMatrix, InternalAdjacencyMatrix.InternalBucket>
     implements
         AdjacencyMatrix {
+
+    /**
+     * An internal bucket of the adjacency matrix
+     *
+     * @opensearch.internal
+     */
     public static class InternalBucket extends InternalMultiBucketAggregation.InternalBucket implements AdjacencyMatrix.Bucket {
 
         private final String key;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/adjacency/ParsedAdjacencyMatrix.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/adjacency/ParsedAdjacencyMatrix.java
@@ -90,6 +90,11 @@ public class ParsedAdjacencyMatrix extends ParsedMultiBucketAggregation<ParsedAd
         return aggregation;
     }
 
+    /**
+     * A parsed bucket
+     *
+     * @opensearch.internal
+     */
     public static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket implements AdjacencyMatrix.Bucket {
 
         private String key;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeAggregation.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeAggregation.java
@@ -45,6 +45,11 @@ import java.util.Map;
  * @opensearch.internal
  */
 public interface CompositeAggregation extends MultiBucketsAggregation {
+    /**
+     * Bucket in a composite agg
+     *
+     * @opensearch.internal
+     */
     interface Bucket extends MultiBucketsAggregation.Bucket {
         Map<String, Object> getKey();
     }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeAggregator.java
@@ -577,6 +577,11 @@ final class CompositeAggregator extends BucketsAggregator {
         };
     }
 
+    /**
+     * An entry in the composite aggregator
+     *
+     * @opensearch.internal
+     */
     private static class Entry {
         final LeafReaderContext context;
         final DocIdSet docIdSet;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesSourceConfig.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesSourceConfig.java
@@ -50,6 +50,11 @@ import java.util.function.LongConsumer;
  */
 public class CompositeValuesSourceConfig {
 
+    /**
+     * A single dimension provider
+     *
+     * @opensearch.internal
+     */
     @FunctionalInterface
     public interface SingleDimensionValuesSourceProvider {
         SingleDimensionValuesSource<?> createValuesSource(

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/DateHistogramValuesSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/DateHistogramValuesSourceBuilder.java
@@ -75,6 +75,11 @@ import java.util.function.LongConsumer;
 public class DateHistogramValuesSourceBuilder extends CompositeValuesSourceBuilder<DateHistogramValuesSourceBuilder>
     implements
         DateIntervalConsumer {
+    /**
+     * Supplier for a composite date histogram
+     *
+     * @opensearch.internal
+     */
     @FunctionalInterface
     public interface DateHistogramCompositeSupplier {
         CompositeValuesSourceConfig apply(

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/GeoTileGridValuesSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/GeoTileGridValuesSourceBuilder.java
@@ -68,6 +68,11 @@ import java.util.function.LongUnaryOperator;
  * @opensearch.internal
  */
 public class GeoTileGridValuesSourceBuilder extends CompositeValuesSourceBuilder<GeoTileGridValuesSourceBuilder> {
+    /**
+     * Supplier for a composite geotile
+     *
+     * @opensearch.internal
+     */
     @FunctionalInterface
     public interface GeoTileCompositeSuppier {
         CompositeValuesSourceConfig apply(

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/HistogramValuesSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/HistogramValuesSourceBuilder.java
@@ -61,6 +61,11 @@ import java.util.function.LongConsumer;
  * @opensearch.internal
  */
 public class HistogramValuesSourceBuilder extends CompositeValuesSourceBuilder<HistogramValuesSourceBuilder> {
+    /**
+     * Composite histogram supplier
+     *
+     * @opensearch.internal
+     */
     @FunctionalInterface
     public interface HistogramCompositeSupplier {
         CompositeValuesSourceConfig apply(

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -317,6 +317,11 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         return Objects.hash(super.hashCode(), size, buckets, afterKey, Arrays.hashCode(reverseMuls), Arrays.hashCode(missingOrders));
     }
 
+    /**
+     * The bucket iterator
+     *
+     * @opensearch.internal
+     */
     private static class BucketIterator implements Comparable<BucketIterator> {
         final Iterator<InternalBucket> it;
         InternalBucket current;
@@ -335,6 +340,11 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         }
     }
 
+    /**
+     * Internal bucket for the internal composite agg
+     *
+     * @opensearch.internal
+     */
     public static class InternalBucket extends InternalMultiBucketAggregation.InternalBucket
         implements
             CompositeAggregation.Bucket,
@@ -516,6 +526,11 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         return obj;
     }
 
+    /**
+     * An array map used for the internal composite agg
+     *
+     * @opensearch.internal
+     */
     static class ArrayMap extends AbstractMap<String, Object> implements Comparable<ArrayMap> {
         final List<String> keys;
         final Comparable[] values;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/ParsedComposite.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/ParsedComposite.java
@@ -106,6 +106,11 @@ public class ParsedComposite extends ParsedMultiBucketAggregation<ParsedComposit
         return CompositeAggregation.toXContentFragment(this, builder, params);
     }
 
+    /**
+     * Parsed bucket for the parsed composite agg
+     *
+     * @opensearch.internal
+     */
     public static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket implements CompositeAggregation.Bucket {
         private Map<String, Object> key;
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/TermsValuesSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/TermsValuesSourceBuilder.java
@@ -62,7 +62,11 @@ import java.util.function.LongUnaryOperator;
  * @opensearch.internal
  */
 public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<TermsValuesSourceBuilder> {
-
+    /**
+     * Composite supplier for terms
+     *
+     * @opensearch.internal
+     */
     @FunctionalInterface
     public interface TermsCompositeSupplier {
         CompositeValuesSourceConfig apply(

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/filter/FiltersAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/filter/FiltersAggregator.java
@@ -71,6 +71,11 @@ public class FiltersAggregator extends BucketsAggregator {
     public static final ParseField OTHER_BUCKET_FIELD = new ParseField("other_bucket");
     public static final ParseField OTHER_BUCKET_KEY_FIELD = new ParseField("other_bucket_key");
 
+    /**
+     * Keyed filter for the filters agg
+     *
+     * @opensearch.internal
+     */
     public static class KeyedFilter implements Writeable, ToXContentFragment {
         private final String key;
         private final QueryBuilder filter;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/filter/InternalFilters.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/filter/InternalFilters.java
@@ -53,6 +53,11 @@ import java.util.Objects;
  * @opensearch.internal
  */
 public class InternalFilters extends InternalMultiBucketAggregation<InternalFilters, InternalFilters.InternalBucket> implements Filters {
+    /**
+     * Internal bucket for an internal filters agg
+     *
+     * @opensearch.internal
+     */
     public static class InternalBucket extends InternalMultiBucketAggregation.InternalBucket implements Filters.Bucket {
 
         private final boolean keyed;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/filter/ParsedFilters.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/filter/ParsedFilters.java
@@ -106,6 +106,11 @@ public class ParsedFilters extends ParsedMultiBucketAggregation<ParsedFilters.Pa
         return aggregation;
     }
 
+    /**
+     * Parsed bucket for the parsed filters agg
+     *
+     * @opensearch.internal
+     */
     public static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket implements Filters.Bucket {
 
         private String key;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/geogrid/CellIdSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/geogrid/CellIdSource.java
@@ -89,6 +89,8 @@ public class CellIdSource extends ValuesSource.Numeric {
     /**
      * The encoder to use to convert a geopoint's (lon, lat, precision) into
      * a long-encoded bucket key for aggregating.
+     *
+     * @opensearch.internal
      */
     @FunctionalInterface
     public interface GeoPointLongEncoder {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/geogrid/GeoGridAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/geogrid/GeoGridAggregationBuilder.java
@@ -73,6 +73,11 @@ public abstract class GeoGridAggregationBuilder extends ValuesSourceAggregationB
     protected int shardSize;
     private GeoBoundingBox geoBoundingBox = new GeoBoundingBox(new GeoPoint(Double.NaN, Double.NaN), new GeoPoint(Double.NaN, Double.NaN));
 
+    /**
+     * A precision parser
+     *
+     * @opensearch.internal
+     */
     @FunctionalInterface
     protected interface PrecisionParser {
         int parse(XContentParser parser) throws IOException;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregationBuilder.java
@@ -286,6 +286,11 @@ public class AutoDateHistogramAggregationBuilder extends ValuesSourceAggregation
         return Objects.equals(numBuckets, other.numBuckets) && Objects.equals(minimumIntervalExpression, other.minimumIntervalExpression);
     }
 
+    /**
+     * Round off information
+     *
+     * @opensearch.internal
+     */
     public static class RoundingInfo implements Writeable {
         final Rounding rounding;
         final int[] innerIntervals;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregator.java
@@ -243,6 +243,8 @@ abstract class AutoDateHistogramAggregator extends DeferableBucketAggregator {
      * rebucket roughly {@code O(log number_of_hits_collected_so_far)} because
      * the "shape" of the roundings is <strong>roughly</strong>
      * logarithmically increasing.
+     *
+     * @opensearch.internal
      */
     private static class FromSingle extends AutoDateHistogramAggregator {
         private int roundingIdx;
@@ -406,6 +408,8 @@ abstract class AutoDateHistogramAggregator extends DeferableBucketAggregator {
      * rounding all of the keys for {@code owningBucketOrd} that we're going to
      * collect and picking the rounding based on a real, accurate count and the
      * min and max.
+     *
+     * @opensearch.internal
      */
     private static class FromMany extends AutoDateHistogramAggregator {
         /**

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/DateIntervalWrapper.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/DateIntervalWrapper.java
@@ -75,6 +75,11 @@ public class DateIntervalWrapper implements ToXContentFragment, Writeable {
     private static final ParseField FIXED_INTERVAL_FIELD = new ParseField("fixed_interval");
     private static final ParseField CALENDAR_INTERVAL_FIELD = new ParseField("calendar_interval");
 
+    /**
+     * The type of interval
+     *
+     * @opensearch.internal
+     */
     public enum IntervalTypeEnum implements Writeable {
         NONE,
         FIXED,

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/InternalAutoDateHistogram.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/InternalAutoDateHistogram.java
@@ -66,6 +66,11 @@ public final class InternalAutoDateHistogram extends InternalMultiBucketAggregat
     InternalAutoDateHistogram,
     InternalAutoDateHistogram.Bucket> implements Histogram, HistogramFactory {
 
+    /**
+     * Bucket for the internal auto date histogram agg
+     *
+     * @opensearch.internal
+     */
     public static class Bucket extends InternalMultiBucketAggregation.InternalBucket implements Histogram.Bucket, KeyComparable<Bucket> {
 
         final long key;
@@ -157,6 +162,11 @@ public final class InternalAutoDateHistogram extends InternalMultiBucketAggregat
         }
     }
 
+    /**
+     * Information about the bucket
+     *
+     * @opensearch.internal
+     */
     static class BucketInfo {
 
         final RoundingInfo[] roundingInfos;
@@ -422,6 +432,11 @@ public final class InternalAutoDateHistogram extends InternalMultiBucketAggregat
         return new InternalAutoDateHistogram.Bucket(buckets.get(0).key, docCount, format, aggs);
     }
 
+    /**
+     * The result from a bucket reduce
+     *
+     * @opensearch.internal
+     */
     private static class BucketReduceResult {
         final List<Bucket> buckets;
         final int roundingIdx;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -68,6 +68,11 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         Histogram,
         HistogramFactory {
 
+    /**
+     * Bucket for an internal date histogram agg
+     *
+     * @opensearch.internal
+     */
     public static class Bucket extends InternalMultiBucketAggregation.InternalBucket implements Histogram.Bucket, KeyComparable<Bucket> {
 
         final long key;
@@ -170,6 +175,11 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         }
     }
 
+    /**
+     * Information about an empty bucket
+     *
+     * @opensearch.internal
+     */
     static class EmptyBucketInfo {
 
         final Rounding rounding;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -64,6 +64,11 @@ public final class InternalHistogram extends InternalMultiBucketAggregation<Inte
     implements
         Histogram,
         HistogramFactory {
+    /**
+     * Bucket for an internal histogram agg
+     *
+     * @opensearch.internal
+     */
     public static class Bucket extends InternalMultiBucketAggregation.InternalBucket implements Histogram.Bucket, KeyComparable<Bucket> {
 
         final double key;
@@ -166,6 +171,11 @@ public final class InternalHistogram extends InternalMultiBucketAggregation<Inte
         }
     }
 
+    /**
+     * Information about an empty bucket
+     *
+     * @opensearch.internal
+     */
     public static class EmptyBucketInfo {
 
         final double interval, offset, minBound, maxBound;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogram.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogram.java
@@ -62,8 +62,18 @@ public class InternalVariableWidthHistogram extends InternalMultiBucketAggregati
     InternalVariableWidthHistogram,
     InternalVariableWidthHistogram.Bucket> implements Histogram, HistogramFactory {
 
+    /**
+     * Bucket for an internal variable width histogram
+     *
+     * @opensearch.internal
+     */
     public static class Bucket extends InternalMultiBucketAggregation.InternalBucket implements Histogram.Bucket, KeyComparable<Bucket> {
 
+        /**
+         * Bounds of the bucket
+         *
+         * @opensearch.internal
+         */
         public static class BucketBounds {
             public double min;
             public double max;
@@ -219,6 +229,11 @@ public class InternalVariableWidthHistogram extends InternalMultiBucketAggregati
         }
     }
 
+    /**
+     * Information about an empty bucket
+     *
+     * @opensearch.internal
+     */
     static class EmptyBucketInfo {
 
         final InternalAggregations subAggregations;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/ParsedAutoDateHistogram.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/ParsedAutoDateHistogram.java
@@ -97,6 +97,11 @@ public class ParsedAutoDateHistogram extends ParsedMultiBucketAggregation<Parsed
         return builder;
     }
 
+    /**
+     * A parsed bucket for a parsed auto date histogram agg
+     *
+     * @opensearch.internal
+     */
     public static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket implements Histogram.Bucket {
 
         private Long key;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/ParsedDateHistogram.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/ParsedDateHistogram.java
@@ -78,6 +78,11 @@ public class ParsedDateHistogram extends ParsedMultiBucketAggregation<ParsedDate
         return aggregation;
     }
 
+    /**
+     * Parsed Bucket for a parsed date histogram
+     *
+     * @opensearch.internal
+     */
     public static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket implements Histogram.Bucket {
 
         private Long key;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/ParsedHistogram.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/ParsedHistogram.java
@@ -75,6 +75,11 @@ public class ParsedHistogram extends ParsedMultiBucketAggregation<ParsedHistogra
         return aggregation;
     }
 
+    /**
+     * Parsed bucket for a parsed histogram
+     *
+     * @opensearch.internal
+     */
     static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket implements Histogram.Bucket {
 
         private Double key;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/ParsedVariableWidthHistogram.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/ParsedVariableWidthHistogram.java
@@ -84,6 +84,11 @@ public class ParsedVariableWidthHistogram extends ParsedMultiBucketAggregation<P
         return aggregation;
     }
 
+    /**
+     * Parsed bucket for a parsed variable width histogram
+     *
+     * @opensearch.internal
+     */
     public static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket implements Histogram.Bucket {
         private Double key;
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/missing/InternalMissing.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/missing/InternalMissing.java
@@ -38,6 +38,11 @@ import org.opensearch.search.aggregations.bucket.InternalSingleBucketAggregation
 import java.io.IOException;
 import java.util.Map;
 
+/**
+ * Missing single bucket agg
+ *
+ * @opensearch.internal
+ */
 public class InternalMissing extends InternalSingleBucketAggregation implements Missing {
     InternalMissing(String name, long docCount, InternalAggregations aggregations, Map<String, Object> metadata) {
         super(name, docCount, aggregations, metadata);

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/nested/NestedAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/nested/NestedAggregator.java
@@ -230,6 +230,11 @@ public class NestedAggregator extends BucketsAggregator implements SingleBucketA
         }
     }
 
+    /**
+     * A cached scorable doc
+     *
+     * @opensearch.internal
+     */
     private static class CachedScorable extends Scorable {
         int doc;
         float score;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/nested/NestedAggregatorFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/nested/NestedAggregatorFactory.java
@@ -82,6 +82,11 @@ public class NestedAggregatorFactory extends AggregatorFactory {
         return new NestedAggregator(name, factories, parentObjectMapper, childObjectMapper, searchContext, parent, cardinality, metadata);
     }
 
+    /**
+     * Unmapped class for nested agg
+     *
+     * @opensearch.internal
+     */
     private static final class Unmapped extends NonCollectingAggregator {
 
         Unmapped(String name, SearchContext context, Aggregator parent, AggregatorFactories factories, Map<String, Object> metadata)

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/nested/ReverseNestedAggregatorFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/nested/ReverseNestedAggregatorFactory.java
@@ -83,6 +83,11 @@ public class ReverseNestedAggregatorFactory extends AggregatorFactory {
         }
     }
 
+    /**
+     * Unmapped class for reverse nested agg
+     *
+     * @opensearch.internal
+     */
     private static final class Unmapped extends NonCollectingAggregator {
 
         Unmapped(String name, SearchContext context, Aggregator parent, AggregatorFactories factories, Map<String, Object> metadata)

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/range/BinaryRangeAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/range/BinaryRangeAggregator.java
@@ -62,6 +62,11 @@ import static java.util.Collections.emptyList;
  */
 public final class BinaryRangeAggregator extends BucketsAggregator {
 
+    /**
+     * Range for the binary range agg
+     *
+     * @opensearch.internal
+     */
     public static class Range {
 
         final String key;
@@ -144,6 +149,11 @@ public final class BinaryRangeAggregator extends BucketsAggregator {
         }
     }
 
+    /**
+     * Leaf collector for the sorted set range
+     *
+     * @opensearch.internal
+     */
     abstract static class SortedSetRangeLeafCollector extends LeafBucketCollectorBase {
 
         final long[] froms, tos, maxTos;
@@ -250,6 +260,11 @@ public final class BinaryRangeAggregator extends BucketsAggregator {
         protected abstract void doCollect(LeafBucketCollector sub, int doc, long bucket) throws IOException;
     }
 
+    /**
+     * Base class for a sorted binary range leaf collector
+     *
+     * @opensearch.internal
+     */
     abstract static class SortedBinaryRangeLeafCollector extends LeafBucketCollectorBase {
 
         final Range[] ranges;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
@@ -121,6 +121,11 @@ public class GeoDistanceAggregationBuilder extends ValuesSourceAggregationBuilde
         return builder;
     }
 
+    /**
+     * Range for a geo distance agg
+     *
+     * @opensearch.internal
+     */
     public static class Range extends RangeAggregator.Range {
         public Range(String key, Double from, Double to) {
             super(key(key, from, to), from == null ? 0 : from, to);

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/range/GeoDistanceRangeAggregatorFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/range/GeoDistanceRangeAggregatorFactory.java
@@ -172,6 +172,11 @@ public class GeoDistanceRangeAggregatorFactory extends ValuesSourceAggregatorFac
             );
     }
 
+    /**
+     * The source location for the distance calculation
+     *
+     * @opensearch.internal
+     */
     private static class DistanceSource extends ValuesSource.Numeric {
 
         private final ValuesSource.GeoPoint source;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/range/InternalBinaryRange.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/range/InternalBinaryRange.java
@@ -61,6 +61,11 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
     implements
         Range {
 
+    /**
+     * Bucket for a binary range agg
+     *
+     * @opensearch.internal
+     */
     public static class Bucket extends InternalMultiBucketAggregation.InternalBucket implements Range.Bucket {
 
         private final transient DocValueFormat format;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/range/InternalDateRange.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/range/InternalDateRange.java
@@ -51,6 +51,11 @@ import java.util.Map;
 public class InternalDateRange extends InternalRange<InternalDateRange.Bucket, InternalDateRange> {
     public static final Factory FACTORY = new Factory();
 
+    /**
+     * Bucket for a date range
+     *
+     * @opensearch.internal
+     */
     public static class Bucket extends InternalRange.Bucket {
 
         public Bucket(
@@ -113,6 +118,11 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket, I
         }
     }
 
+    /**
+     * Factory to create a date range
+     *
+     * @opensearch.internal
+     */
     public static class Factory extends InternalRange.Factory<InternalDateRange.Bucket, InternalDateRange> {
         @Override
         public ValueType getValueType() {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/range/InternalGeoDistance.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/range/InternalGeoDistance.java
@@ -50,6 +50,11 @@ import java.util.Map;
 public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucket, InternalGeoDistance> {
     public static final Factory FACTORY = new Factory();
 
+    /**
+     * Bucket for a geo distance range
+     *
+     * @opensearch.internal
+     */
     static class Bucket extends InternalRange.Bucket {
 
         Bucket(String key, double from, double to, long docCount, InternalAggregations aggregations, boolean keyed) {
@@ -66,6 +71,11 @@ public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucke
         }
     }
 
+    /**
+     * Factory for a geo distance bucket
+     *
+     * @opensearch.internal
+     */
     public static class Factory extends InternalRange.Factory<InternalGeoDistance.Bucket, InternalGeoDistance> {
         @Override
         public ValuesSourceType getValueSourceType() {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/range/InternalRange.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/range/InternalRange.java
@@ -59,6 +59,11 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
         Range {
     static final Factory FACTORY = new Factory();
 
+    /**
+     * Bucket for a range
+     *
+     * @opensearch.internal
+     */
     public static class Bucket extends InternalMultiBucketAggregation.InternalBucket implements Range.Bucket {
 
         protected final transient boolean keyed;
@@ -211,6 +216,11 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
         }
     }
 
+    /**
+     * Factory for a range
+     *
+     * @opensearch.internal
+     */
     public static class Factory<B extends Bucket, R extends InternalRange<B, R>> {
         public ValuesSourceType getValueSourceType() {
             return CoreValuesSourceType.NUMERIC;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/range/IpRangeAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/range/IpRangeAggregationBuilder.java
@@ -128,6 +128,11 @@ public final class IpRangeAggregationBuilder extends ValuesSourceAggregationBuil
         }
     }
 
+    /**
+     * Range for an IP range
+     *
+     * @opensearch.internal
+     */
     public static class Range implements ToXContentObject {
 
         private final String key;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/range/ParsedBinaryRange.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/range/ParsedBinaryRange.java
@@ -82,6 +82,11 @@ public class ParsedBinaryRange extends ParsedMultiBucketAggregation<ParsedBinary
         return aggregation;
     }
 
+    /**
+     * Parsed bucket for a binary range
+     *
+     * @opensearch.internal
+     */
     public static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket implements Range.Bucket {
 
         private String key;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/range/ParsedDateRange.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/range/ParsedDateRange.java
@@ -71,6 +71,11 @@ public class ParsedDateRange extends ParsedRange {
         return aggregation;
     }
 
+    /**
+     * Parsed bucket for a date range
+     *
+     * @opensearch.internal
+     */
     public static class ParsedBucket extends ParsedRange.ParsedBucket {
 
         @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/range/ParsedGeoDistance.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/range/ParsedGeoDistance.java
@@ -68,6 +68,11 @@ public class ParsedGeoDistance extends ParsedRange {
         return aggregation;
     }
 
+    /**
+     * Parsed bucket for a geo distance
+     *
+     * @opensearch.internal
+     */
     public static class ParsedBucket extends ParsedRange.ParsedBucket {
 
         static ParsedBucket fromXContent(final XContentParser parser, final boolean keyed) throws IOException {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/range/ParsedRange.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/range/ParsedRange.java
@@ -92,6 +92,11 @@ public class ParsedRange extends ParsedMultiBucketAggregation<ParsedRange.Parsed
         return aggregation;
     }
 
+    /**
+     * Parsed bucket for a range
+     *
+     * @opensearch.internal
+     */
     public static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket implements Range.Bucket {
 
         protected String key;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/range/RangeAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/range/RangeAggregator.java
@@ -75,6 +75,11 @@ public class RangeAggregator extends BucketsAggregator {
     public static final ParseField RANGES_FIELD = new ParseField("ranges");
     public static final ParseField KEYED_FIELD = new ParseField("keyed");
 
+    /**
+     * Range for the range aggregator
+     *
+     * @opensearch.internal
+     */
     public static class Range implements Writeable, ToXContentObject {
         public static final ParseField KEY_FIELD = new ParseField("key");
         public static final ParseField FROM_FIELD = new ParseField("from");
@@ -383,6 +388,11 @@ public class RangeAggregator extends BucketsAggregator {
         return rangeFactory.create(name, buckets, format, keyed, metadata());
     }
 
+    /**
+     * Unmapped range
+     *
+     * @opensearch.internal
+     */
     public static class Unmapped<R extends RangeAggregator.Range> extends NonCollectingAggregator {
 
         private final R[] ranges;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/sampler/SamplerAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/sampler/SamplerAggregator.java
@@ -73,6 +73,11 @@ public class SamplerAggregator extends DeferableBucketAggregator implements Sing
 
     static final long SCOREDOCKEY_SIZE = RamUsageEstimator.shallowSizeOfInstance(DiversifiedTopDocsCollector.ScoreDocKey.class);
 
+    /**
+     * The execution mode for the sampler
+     *
+     * @opensearch.internal
+     */
     public enum ExecutionMode {
 
         MAP(new ParseField("map")) {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/BytesKeyedBucketOrds.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/BytesKeyedBucketOrds.java
@@ -82,6 +82,8 @@ public abstract class BytesKeyedBucketOrds implements Releasable {
 
     /**
      * An iterator for buckets inside a particular {@code owningBucketOrd}.
+     *
+     * @opensearch.internal
      */
     public interface BucketOrdsEnum {
         /**
@@ -122,6 +124,8 @@ public abstract class BytesKeyedBucketOrds implements Releasable {
 
     /**
      * Implementation that only works if it is collecting from a single bucket.
+     *
+     * @opensearch.internal
      */
     private static class FromSingle extends BytesKeyedBucketOrds {
         private final BytesRefHash ords;
@@ -177,6 +181,8 @@ public abstract class BytesKeyedBucketOrds implements Releasable {
 
     /**
      * Implementation that works properly when collecting from many buckets.
+     *
+     * @opensearch.internal
      */
     private static class FromMany extends BytesKeyedBucketOrds {
         // TODO we can almost certainly do better here by building something fit for purpose rather than trying to lego together stuff

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/DoubleTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/DoubleTerms.java
@@ -53,6 +53,11 @@ import java.util.Objects;
 public class DoubleTerms extends InternalMappedTerms<DoubleTerms, DoubleTerms.Bucket> {
     public static final String NAME = "dterms";
 
+    /**
+     * Bucket for a double terms agg
+     *
+     * @opensearch.internal
+     */
     static class Bucket extends InternalTerms.Bucket<Bucket> {
         double term;
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -90,6 +90,11 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
     protected int segmentsWithSingleValuedOrds = 0;
     protected int segmentsWithMultiValuedOrds = 0;
 
+    /**
+     * Lookup global ordinals
+     *
+     * @opensearch.internal
+     */
     public interface GlobalOrdLookupFunction {
         BytesRef apply(long ord) throws IOException;
     }
@@ -231,6 +236,8 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
 
     /**
      * This is used internally only, just for compare using global ordinal instead of term bytes in the PQ
+     *
+     * @opensearch.internal
      */
     static class OrdBucket extends InternalTerms.Bucket<OrdBucket> {
         long globalOrd;
@@ -284,6 +291,8 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
      * This is only supported for the standard {@code terms} aggregation and
      * doesn't support {@code significant_terms} so this forces
      * {@link StandardTermsResults}.
+     *
+     * @opensearch.internal
      */
     static class LowCardinality extends GlobalOrdinalsStringTermsAggregator {
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/IncludeExclude.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/IncludeExclude.java
@@ -162,16 +162,29 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * Base filter class
+     *
+     * @opensearch.internal
+     */
     public abstract static class Filter {}
 
-    // The includeValue and excludeValue ByteRefs which are the result of the parsing
-    // process are converted into a LongFilter when used on numeric fields
-    // in the index.
+    /**
+     * The includeValue and excludeValue ByteRefs which are the result of the parsing
+     * process are converted into a LongFilter when used on numeric fields
+     * in the index.
+     *
+     * @opensearch.internal
+     */
     public abstract static class LongFilter extends Filter {
         public abstract boolean accept(long value);
-
     }
 
+    /**
+     * Long filter that is partitioned
+     *
+     * @opensearch.internal
+     */
     public class PartitionedLongFilter extends LongFilter {
         @Override
         public boolean accept(long value) {
@@ -181,6 +194,11 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * Long filter backed by valid values
+     *
+     * @opensearch.internal
+     */
     public static class SetBackedLongFilter extends LongFilter {
         private LongSet valids;
         private LongSet invalids;
@@ -208,7 +226,11 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
         }
     }
 
-    // Only used for the 'map' execution mode (ie. scripts)
+    /**
+     * Only used for the 'map' execution mode (ie. scripts)
+     *
+     * @opensearch.internal
+     */
     public abstract static class StringFilter extends Filter {
         public abstract boolean accept(BytesRef value);
     }
@@ -220,6 +242,11 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * String filter backed by an automaton
+     *
+     * @opensearch.internal
+     */
     static class AutomatonBackedStringFilter extends StringFilter {
 
         private final ByteRunAutomaton runAutomaton;
@@ -237,6 +264,11 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * String filter backed by a term list
+     *
+     * @opensearch.internal
+     */
     static class TermListBackedStringFilter extends StringFilter {
 
         private final Set<BytesRef> valids;
@@ -257,6 +289,11 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * An ordinals filter
+     *
+     * @opensearch.internal
+     */
     public abstract static class OrdinalsFilter extends Filter {
         public abstract LongBitSet acceptedGlobalOrdinals(SortedSetDocValues globalOrdinals) throws IOException;
 
@@ -284,6 +321,11 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * An ordinals filter backed by an automaton
+     *
+     * @opensearch.internal
+     */
     static class AutomatonBackedOrdinalsFilter extends OrdinalsFilter {
 
         private final CompiledAutomaton compiled;
@@ -311,6 +353,11 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
 
     }
 
+    /**
+     * An ordinals filter backed by a terms list
+     *
+     * @opensearch.internal
+     */
     static class TermListBackedOrdinalsFilter extends OrdinalsFilter {
 
         private final SortedSet<BytesRef> includeValues;
@@ -508,6 +555,8 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
 
     /**
      * Terms adapter around doc values.
+     *
+     * @opensearch.internal
      */
     private static class DocValuesTerms extends Terms {
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalMultiTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalMultiTerms.java
@@ -36,6 +36,8 @@ import java.util.stream.Collectors;
 public class InternalMultiTerms extends InternalTerms<InternalMultiTerms, InternalMultiTerms.Bucket> {
     /**
      * Internal Multi Terms Bucket.
+     *
+     * @opensearch.internal
      */
     public static class Bucket extends InternalTerms.AbstractInternalBucket implements KeyComparable<Bucket> {
 
@@ -193,6 +195,8 @@ public class InternalMultiTerms extends InternalTerms<InternalMultiTerms, Intern
 
         /**
          * Visible for testing.
+         *
+         * @opensearch.internal
          */
         protected static class BucketComparator implements Comparator<List<Object>> {
             @SuppressWarnings({ "unchecked" })

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalRareTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalRareTerms.java
@@ -60,12 +60,19 @@ public abstract class InternalRareTerms<A extends InternalRareTerms<A, B>, B ext
     implements
         RareTerms {
 
+    /**
+     * Bucket for a rare terms agg
+     *
+     * @opensearch.internal
+     */
     public abstract static class Bucket<B extends Bucket<B>> extends InternalMultiBucketAggregation.InternalBucket
         implements
             RareTerms.Bucket,
             KeyComparable<B> {
         /**
          * Reads a bucket. Should be a constructor reference.
+         *
+         * @opensearch.internal
          */
         @FunctionalInterface
         public interface Reader<B extends Bucket<B>> {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
@@ -62,12 +62,19 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
     public static final String SCORE = "score";
     public static final String BG_COUNT = "bg_count";
 
+    /**
+     * Bucket for a significant terms agg
+     *
+     * @opensearch.internal
+     */
     @SuppressWarnings("PMD.ConstructorCallsOverridableMethod")
     public abstract static class Bucket<B extends Bucket<B>> extends InternalMultiBucketAggregation.InternalBucket
         implements
             SignificantTerms.Bucket {
         /**
          * Reads a bucket. Should be a constructor reference.
+         *
+         * @opensearch.internal
          */
         @FunctionalInterface
         public interface Reader<B extends Bucket<B>> {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalTerms.java
@@ -75,6 +75,11 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
     protected static final ParseField DOC_COUNT_ERROR_UPPER_BOUND_FIELD_NAME = new ParseField("doc_count_error_upper_bound");
     protected static final ParseField SUM_OF_OTHER_DOC_COUNTS = new ParseField("sum_other_doc_count");
 
+    /**
+     * Base internal multi bucket
+     *
+     * @opensearch.internal
+     */
     public abstract static class AbstractInternalBucket extends InternalMultiBucketAggregation.InternalBucket implements Terms.Bucket {
         abstract void setDocCountError(long docCountError);
 
@@ -83,9 +88,16 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
         abstract boolean showDocCountError();
     }
 
+    /**
+     * Base bucket class
+     *
+     * @opensearch.internal
+     */
     public abstract static class Bucket<B extends Bucket<B>> extends AbstractInternalBucket implements KeyComparable<B> {
         /**
          * Reads a bucket. Should be a constructor reference.
+         *
+         * @opensearch.internal
          */
         @FunctionalInterface
         public interface Reader<B extends Bucket<B>> {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/LongKeyedBucketOrds.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/LongKeyedBucketOrds.java
@@ -100,6 +100,8 @@ public abstract class LongKeyedBucketOrds implements Releasable {
 
     /**
      * An iterator for buckets inside a particular {@code owningBucketOrd}.
+     *
+     * @opensearch.internal
      */
     public interface BucketOrdsEnum {
         /**
@@ -142,6 +144,8 @@ public abstract class LongKeyedBucketOrds implements Releasable {
 
     /**
      * Implementation that only works if it is collecting from a single bucket.
+     *
+     * @opensearch.internal
      */
     public static class FromSingle extends LongKeyedBucketOrds {
         private final LongHash ords;
@@ -221,6 +225,8 @@ public abstract class LongKeyedBucketOrds implements Releasable {
 
     /**
      * Implementation that works properly when collecting from many buckets.
+     *
+     * @opensearch.internal
      */
     public static class FromMany extends LongKeyedBucketOrds {
         private final LongLongHash ords;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/LongRareTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/LongRareTerms.java
@@ -52,6 +52,11 @@ import java.util.Objects;
 public class LongRareTerms extends InternalMappedRareTerms<LongRareTerms, LongRareTerms.Bucket> {
     public static final String NAME = "lrareterms";
 
+    /**
+     * Bucket for rare long valued terms
+     *
+     * @opensearch.internal
+     */
     public static class Bucket extends InternalRareTerms.Bucket<Bucket> {
         long term;
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/LongTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/LongTerms.java
@@ -53,6 +53,11 @@ import java.util.Objects;
 public class LongTerms extends InternalMappedTerms<LongTerms, LongTerms.Bucket> {
     public static final String NAME = "lterms";
 
+    /**
+     * Bucket for long terms
+     *
+     * @opensearch.internal
+     */
     public static class Bucket extends InternalTerms.Bucket<Bucket> {
         long term;
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MapStringTermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MapStringTermsAggregator.java
@@ -153,6 +153,8 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
 
     /**
      * Abstaction on top of building collectors to fetch values.
+     *
+     * @opensearch.internal
      */
     public interface CollectorSource extends Releasable {
         boolean needsScores();
@@ -166,6 +168,11 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
         ) throws IOException;
     }
 
+    /**
+     * Consumer for the collector
+     *
+     * @opensearch.internal
+     */
     @FunctionalInterface
     public interface CollectConsumer {
         void accept(LeafBucketCollector sub, int doc, long owningBucketOrd, BytesRef bytes) throws IOException;
@@ -173,6 +180,8 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
 
     /**
      * Fetch values from a {@link ValuesSource}.
+     *
+     * @opensearch.internal
      */
     public static class ValuesSourceCollectorSource implements CollectorSource {
         private final ValuesSource valuesSource;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregationFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregationFactory.java
@@ -159,6 +159,11 @@ public class MultiTermsAggregationFactory extends AggregatorFactory {
         );
     }
 
+    /**
+     * Supplier for internal values source
+     *
+     * @opensearch.internal
+     */
     public interface InternalValuesSourceSupplier {
         MultiTermsAggregator.InternalValuesSource build(Tuple<ValuesSourceConfig, IncludeExclude> config);
     }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
@@ -304,6 +304,8 @@ public class MultiTermsAggregator extends DeferableBucketAggregator {
 
     /**
      * Multi_Term ValuesSource, it is a collection of {@link InternalValuesSource}
+     *
+     * @opensearch.internal
      */
     static class MultiTermsValuesSource {
         private final List<InternalValuesSource> valuesSources;
@@ -354,6 +356,8 @@ public class MultiTermsAggregator extends DeferableBucketAggregator {
 
     /**
      * Factory for construct {@link InternalValuesSource}.
+     *
+     * @opensearch.internal
      */
     static class InternalValuesSourceFactory {
         static InternalValuesSource bytesValuesSource(ValuesSource valuesSource, IncludeExclude.StringFilter includeExclude) {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedDoubleTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedDoubleTerms.java
@@ -65,6 +65,11 @@ public class ParsedDoubleTerms extends ParsedTerms {
         return aggregation;
     }
 
+    /**
+     * Parsed bucket for double terms
+     *
+     * @opensearch.internal
+     */
     public static class ParsedBucket extends ParsedTerms.ParsedBucket {
 
         private Double key;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedLongRareTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedLongRareTerms.java
@@ -65,6 +65,11 @@ public class ParsedLongRareTerms extends ParsedRareTerms {
         return aggregation;
     }
 
+    /**
+     * Parsed bucket for rare long values
+     *
+     * @opensearch.internal
+     */
     public static class ParsedBucket extends ParsedRareTerms.ParsedBucket {
 
         private Long key;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedLongTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedLongTerms.java
@@ -65,6 +65,11 @@ public class ParsedLongTerms extends ParsedTerms {
         return aggregation;
     }
 
+    /**
+     * Parsed bucket for long term values
+     *
+     * @opensearch.internal
+     */
     public static class ParsedBucket extends ParsedTerms.ParsedBucket {
 
         private Long key;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedMultiTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedMultiTerms.java
@@ -41,6 +41,11 @@ public class ParsedMultiTerms extends ParsedTerms {
         return aggregation;
     }
 
+    /**
+     * Parsed bucket for multi terms
+     *
+     * @opensearch.internal
+     */
     public static class ParsedBucket extends ParsedTerms.ParsedBucket {
 
         private List<Object> key;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedRareTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedRareTerms.java
@@ -85,6 +85,11 @@ public abstract class ParsedRareTerms extends ParsedMultiBucketAggregation<Parse
         declareMultiBucketAggregationFields(objectParser, bucketParser::apply, bucketParser::apply);
     }
 
+    /**
+     * Parsed Bucket for rare term values
+     *
+     * @opensearch.internal
+     */
     public abstract static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket implements RareTerms.Bucket {
 
         @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedSignificantLongTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedSignificantLongTerms.java
@@ -63,6 +63,11 @@ public class ParsedSignificantLongTerms extends ParsedSignificantTerms {
         return parseSignificantTermsXContent(() -> PARSER.parse(parser, null), name);
     }
 
+    /**
+     * Parsed bucket for significant long values
+     *
+     * @opensearch.internal
+     */
     public static class ParsedBucket extends ParsedSignificantTerms.ParsedBucket {
 
         private Long key;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedSignificantStringTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedSignificantStringTerms.java
@@ -65,6 +65,11 @@ public class ParsedSignificantStringTerms extends ParsedSignificantTerms {
         return parseSignificantTermsXContent(() -> PARSER.parse(parser, null), name);
     }
 
+    /**
+     * Parsed bucket for significant string values
+     *
+     * @opensearch.internal
+     */
     public static class ParsedBucket extends ParsedSignificantTerms.ParsedBucket {
 
         private BytesRef key;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedSignificantTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedSignificantTerms.java
@@ -128,6 +128,11 @@ public abstract class ParsedSignificantTerms extends ParsedMultiBucketAggregatio
         );
     }
 
+    /**
+     * Parsed bucket for significant values
+     *
+     * @opensearch.internal
+     */
     public abstract static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket implements SignificantTerms.Bucket {
 
         protected long subsetDf;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedStringRareTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedStringRareTerms.java
@@ -67,6 +67,11 @@ public class ParsedStringRareTerms extends ParsedRareTerms {
         return aggregation;
     }
 
+    /**
+     * Parsed bucket for rare string terms
+     *
+     * @opensearch.internal
+     */
     public static class ParsedBucket extends ParsedRareTerms.ParsedBucket {
 
         private BytesRef key;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedStringTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedStringTerms.java
@@ -67,6 +67,11 @@ public class ParsedStringTerms extends ParsedTerms {
         return aggregation;
     }
 
+    /**
+     * Parsed bucket for string values
+     *
+     * @opensearch.internal
+     */
     public static class ParsedBucket extends ParsedTerms.ParsedBucket {
 
         private BytesRef key;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/ParsedTerms.java
@@ -109,6 +109,11 @@ public abstract class ParsedTerms extends ParsedMultiBucketAggregation<ParsedTer
         objectParser.declareLong((parsedTerms, value) -> parsedTerms.sumOtherDocCount = value, SUM_OF_OTHER_DOC_COUNTS);
     }
 
+    /**
+     * Base parsed bucket
+     *
+     * @opensearch.internal
+     */
     public abstract static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket implements Terms.Bucket {
 
         boolean showDocCountError = false;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/RareTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/RareTerms.java
@@ -44,6 +44,8 @@ public interface RareTerms extends MultiBucketsAggregation {
 
     /**
      * A bucket that is associated with a single term
+     *
+     * @opensearch.internal
      */
     interface Bucket extends MultiBucketsAggregation.Bucket {
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/RareTermsAggregatorFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/RareTermsAggregatorFactory.java
@@ -237,6 +237,11 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory {
             );
     }
 
+    /**
+     * Execution mode for rare terms agg
+     *
+     * @opensearch.internal
+     */
     public enum ExecutionMode {
 
         MAP(new ParseField("map")) {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantLongTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantLongTerms.java
@@ -51,6 +51,11 @@ import java.util.Objects;
 public class SignificantLongTerms extends InternalMappedSignificantTerms<SignificantLongTerms, SignificantLongTerms.Bucket> {
     public static final String NAME = "siglterms";
 
+    /**
+     * Bucket for significant long values
+     *
+     * @opensearch.internal
+     */
     static class Bucket extends InternalSignificantTerms.Bucket<Bucket> {
 
         long term;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantStringTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantStringTerms.java
@@ -52,6 +52,11 @@ import java.util.Objects;
 public class SignificantStringTerms extends InternalMappedSignificantTerms<SignificantStringTerms, SignificantStringTerms.Bucket> {
     public static final String NAME = "sigsterms";
 
+    /**
+     * Bucket for significant string values
+     *
+     * @opensearch.internal
+     */
     public static class Bucket extends InternalSignificantTerms.Bucket<Bucket> {
 
         BytesRef termBytes;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantTerms.java
@@ -42,6 +42,11 @@ import java.util.List;
  */
 public interface SignificantTerms extends MultiBucketsAggregation, Iterable<SignificantTerms.Bucket> {
 
+    /**
+     * Bucket for significant terms
+     *
+     * @opensearch.internal
+     */
     interface Bucket extends MultiBucketsAggregation.Bucket {
 
         /**

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantTermsAggregatorFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantTermsAggregatorFactory.java
@@ -311,6 +311,11 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
         );
     }
 
+    /**
+     * The execution mode for the significant terms agg
+     *
+     * @opensearch.internal
+     */
     public enum ExecutionMode {
 
         MAP(new ParseField("map")) {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantTextAggregatorFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantTextAggregatorFactory.java
@@ -173,6 +173,11 @@ public class SignificantTextAggregatorFactory extends AggregatorFactory {
         );
     }
 
+    /**
+     * Collects significant text
+     *
+     * @opensearch.internal
+     */
     private static class SignificantTextCollectorSource implements MapStringTermsAggregator.CollectorSource {
         private final SourceLookup sourceLookup;
         private final BigArrays bigArrays;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/StringRareTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/StringRareTerms.java
@@ -53,6 +53,11 @@ import java.util.Objects;
 public class StringRareTerms extends InternalMappedRareTerms<StringRareTerms, StringRareTerms.Bucket> {
     public static final String NAME = "srareterms";
 
+    /**
+     * Bucket for rare string terms
+     *
+     * @opensearch.internal
+     */
     public static class Bucket extends InternalRareTerms.Bucket<Bucket> {
         BytesRef termBytes;
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/StringTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/StringTerms.java
@@ -52,6 +52,11 @@ import java.util.Objects;
 public class StringTerms extends InternalMappedTerms<StringTerms, StringTerms.Bucket> {
     public static final String NAME = "sterms";
 
+    /**
+     * Bucket for string terms
+     *
+     * @opensearch.internal
+     */
     public static class Bucket extends InternalTerms.Bucket<Bucket> {
         BytesRef termBytes;
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/Terms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/Terms.java
@@ -45,6 +45,8 @@ public interface Terms extends MultiBucketsAggregation {
 
     /**
      * A bucket that is associated with a single term
+     *
+     * @opensearch.internal
      */
     interface Bucket extends MultiBucketsAggregation.Bucket {
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/TermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/TermsAggregator.java
@@ -63,6 +63,11 @@ import java.util.Set;
  */
 public abstract class TermsAggregator extends DeferableBucketAggregator {
 
+    /**
+     * Bucket count thresholds
+     *
+     * @opensearch.internal
+     */
     public static class BucketCountThresholds implements Writeable, ToXContentFragment {
         private long minDocCount;
         private long shardMinDocCount;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -365,6 +365,11 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
         }
     }
 
+    /**
+     * The execution mode for the terms agg
+     *
+     * @opensearch.internal
+     */
     public enum ExecutionMode {
 
         MAP(new ParseField("map")) {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/UnmappedRareTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/UnmappedRareTerms.java
@@ -54,6 +54,11 @@ import static java.util.Collections.emptyList;
 public class UnmappedRareTerms extends InternalRareTerms<UnmappedRareTerms, UnmappedRareTerms.Bucket> {
     public static final String NAME = "umrareterms";
 
+    /**
+     * Bucket for unmapped rare values
+     *
+     * @opensearch.internal
+     */
     protected abstract static class Bucket extends InternalRareTerms.Bucket<Bucket> {
         private Bucket(long docCount, InternalAggregations aggregations, DocValueFormat formatter) {
             super(docCount, aggregations, formatter);

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/UnmappedSignificantTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/UnmappedSignificantTerms.java
@@ -60,6 +60,8 @@ public class UnmappedSignificantTerms extends InternalSignificantTerms<UnmappedS
     /**
      * Concrete type that can't be built because Java needs a concrete type so {@link InternalTerms.Bucket} can have a self type but
      * {@linkplain UnmappedTerms} doesn't ever need to build it because it never returns any buckets.
+     *
+     * @opensearch.internal
      */
     protected abstract static class Bucket extends InternalSignificantTerms.Bucket<Bucket> {
         private Bucket(

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/UnmappedTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/UnmappedTerms.java
@@ -57,6 +57,8 @@ public class UnmappedTerms extends InternalTerms<UnmappedTerms, UnmappedTerms.Bu
     /**
      * Concrete type that can't be built because Java needs a concrete type so {@link InternalTerms.Bucket} can have a self type but
      * {@linkplain UnmappedTerms} doesn't ever need to build it because it never returns any buckets.
+     *
+     * @opensearch.internal
      */
     protected abstract static class Bucket extends InternalTerms.Bucket<Bucket> {
         private Bucket(

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/heuristic/ChiSquare.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/heuristic/ChiSquare.java
@@ -108,6 +108,11 @@ public class ChiSquare extends NXYSignificanceHeuristic {
         return builder;
     }
 
+    /**
+     * Builder for a chi squared heuristic
+     *
+     * @opensearch.internal
+     */
     public static class ChiSquareBuilder extends NXYSignificanceHeuristic.NXYBuilder {
         public ChiSquareBuilder(boolean includeNegatives, boolean backgroundIsSuperset) {
             super(includeNegatives, backgroundIsSuperset);

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/heuristic/GND.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/heuristic/GND.java
@@ -127,6 +127,11 @@ public class GND extends NXYSignificanceHeuristic {
         return builder;
     }
 
+    /**
+     * Builder for a GND heuristic
+     *
+     * @opensearch.internal
+     */
     public static class GNDBuilder extends NXYBuilder {
         public GNDBuilder(boolean backgroundIsSuperset) {
             super(true, backgroundIsSuperset);

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/heuristic/JLHScore.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/heuristic/JLHScore.java
@@ -129,6 +129,11 @@ public class JLHScore extends SignificanceHeuristic {
         return getClass().hashCode();
     }
 
+    /**
+     * Builder for a JLH Score heuristic
+     *
+     * @opensearch.internal
+     */
     public static class JLHScoreBuilder implements SignificanceHeuristicBuilder {
 
         @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/heuristic/MutualInformation.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/heuristic/MutualInformation.java
@@ -147,6 +147,11 @@ public class MutualInformation extends NXYSignificanceHeuristic {
         return builder;
     }
 
+    /**
+     * Builder for a Mutual Information heuristic
+     *
+     * @opensearch.internal
+     */
     public static class MutualInformationBuilder extends NXYBuilder {
         public MutualInformationBuilder(boolean includeNegatives, boolean backgroundIsSuperset) {
             super(includeNegatives, backgroundIsSuperset);

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/heuristic/NXYSignificanceHeuristic.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/heuristic/NXYSignificanceHeuristic.java
@@ -106,6 +106,11 @@ public abstract class NXYSignificanceHeuristic extends SignificanceHeuristic {
         return result;
     }
 
+    /**
+     * Frequencies for an NXY significance heuristic
+     *
+     * @opensearch.internal
+     */
     protected static class Frequencies {
         double N00, N01, N10, N11, N0_, N1_, N_0, N_1, N;
     }
@@ -194,6 +199,11 @@ public abstract class NXYSignificanceHeuristic extends SignificanceHeuristic {
         };
     }
 
+    /**
+     * Builder for a NXY Significance heuristic
+     *
+     * @opensearch.internal
+     */
     protected abstract static class NXYBuilder implements SignificanceHeuristicBuilder {
         protected boolean includeNegatives = true;
         protected boolean backgroundIsSuperset = true;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/heuristic/PercentageScore.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/heuristic/PercentageScore.java
@@ -109,6 +109,11 @@ public class PercentageScore extends SignificanceHeuristic {
         return getClass().hashCode();
     }
 
+    /**
+     * Builder for a Percentage Score heuristic
+     *
+     * @opensearch.internal
+     */
     public static class PercentageScoreBuilder implements SignificanceHeuristicBuilder {
 
         @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/heuristic/ScriptHeuristic.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/heuristic/ScriptHeuristic.java
@@ -65,8 +65,12 @@ public class ScriptHeuristic extends SignificanceHeuristic {
 
     private final Script script;
 
-    // This class holds an executable form of the script with private variables ready for execution
-    // on a single search thread.
+    /**
+     * This class holds an executable form of the script with private variables ready for execution
+     * on a single search thread.
+     *
+     * @opensearch.internal
+     */
     static class ExecutableScriptHeuristic extends ScriptHeuristic {
         private final LongAccessor subsetSizeHolder;
         private final LongAccessor supersetSizeHolder;
@@ -178,6 +182,11 @@ public class ScriptHeuristic extends SignificanceHeuristic {
         return Objects.equals(script, other.script);
     }
 
+    /**
+     * Accesses long values
+     *
+     * @opensearch.internal
+     */
     public final class LongAccessor extends Number {
         public long value;
 

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/AbstractHyperLogLog.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/AbstractHyperLogLog.java
@@ -5952,7 +5952,11 @@ public abstract class AbstractHyperLogLog extends AbstractCardinalityAlgorithm {
         return THRESHOLDS[p - 4];
     }
 
-    /** Iterator over a HyperLogLog register */
+    /**
+     * Iterator over a HyperLogLog register
+     *
+     * @opensearch.internal
+     */
     public interface RunLenIterator {
 
         /**

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/AbstractLinearCounting.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/AbstractLinearCounting.java
@@ -102,7 +102,11 @@ public abstract class AbstractLinearCounting extends AbstractCardinalityAlgorith
         return (int) encoded;
     }
 
-    /** Iterator over the hash values */
+    /**
+     * Iterator over the hash values
+     *
+     * @opensearch.internal
+     */
     public interface HashesIterator {
 
         /**

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregator.java
@@ -201,12 +201,22 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
         add.accept("string_hashing_collectors_used", stringHashingCollectorsUsed);
     }
 
+    /**
+     * Collector for the cardinality agg
+     *
+     * @opensearch.internal
+     */
     private abstract static class Collector extends LeafBucketCollector implements Releasable {
 
         public abstract void postCollect() throws IOException;
 
     }
 
+    /**
+     * Empty Collector for the Cardinality agg
+     *
+     * @opensearch.internal
+     */
     private static class EmptyCollector extends Collector {
 
         @Override
@@ -225,6 +235,11 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
         }
     }
 
+    /**
+     * Direct Collector for the cardinality agg
+     *
+     * @opensearch.internal
+     */
     private static class DirectCollector extends Collector {
 
         private final MurmurHash3Values hashes;
@@ -257,6 +272,11 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
 
     }
 
+    /**
+     * Ordinals Collector for the cardinality agg
+     *
+     * @opensearch.internal
+     */
     private static class OrdinalsCollector extends Collector {
 
         private static final long SHALLOW_FIXEDBITSET_SIZE = RamUsageEstimator.shallowSizeOfInstance(FixedBitSet.class);
@@ -345,6 +365,8 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
 
     /**
      * Representation of a list of hash values. There might be dups and there is no guarantee on the order.
+     *
+     * @opensearch.internal
      */
     abstract static class MurmurHash3Values {
 
@@ -375,6 +397,11 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
             return new Bytes(values);
         }
 
+        /**
+         * Long hash value
+         *
+         * @opensearch.internal
+         */
         private static class Long extends MurmurHash3Values {
 
             private final SortedNumericDocValues values;
@@ -399,6 +426,11 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
             }
         }
 
+        /**
+         * Double hash value
+         *
+         * @opensearch.internal
+         */
         private static class Double extends MurmurHash3Values {
 
             private final SortedNumericDoubleValues values;
@@ -423,6 +455,11 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
             }
         }
 
+        /**
+         * Byte hash value
+         *
+         * @opensearch.internal
+         */
         private static class Bytes extends MurmurHash3Values {
 
             private final MurmurHash3.Hash128 hash = new MurmurHash3.Hash128();

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/ExtendedStats.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/ExtendedStats.java
@@ -118,6 +118,11 @@ public interface ExtendedStats extends Stats {
      */
     String getVarianceSamplingAsString();
 
+    /**
+     * The bounds of the extended stats
+     *
+     * @opensearch.internal
+     */
     enum Bounds {
         UPPER,
         LOWER,

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/ExtendedStatsAggregatorProvider.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/ExtendedStatsAggregatorProvider.java
@@ -40,6 +40,8 @@ import java.util.Map;
 
 /**
  * Base supplier of an ExtendesStats aggregator
+ *
+ * @opensearch.internal
  */
 public interface ExtendedStatsAggregatorProvider {
 

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
@@ -225,6 +225,11 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
         }
     }
 
+    /**
+     * The hyper log log
+     *
+     * @opensearch.internal
+     */
     private static class HyperLogLog extends AbstractHyperLogLog implements Releasable {
         private final BigArrays bigArrays;
         private final HyperLogLogIterator iterator;
@@ -269,6 +274,11 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
         }
     }
 
+    /**
+     * Iterator for hyper log log
+     *
+     * @opensearch.internal
+     */
     private static class HyperLogLogIterator implements AbstractHyperLogLog.RunLenIterator {
 
         private final HyperLogLog hll;
@@ -304,6 +314,11 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
         }
     }
 
+    /**
+     * The plus plus
+     *
+     * @opensearch.internal
+     */
     private static class LinearCounting extends AbstractLinearCounting implements Releasable {
 
         protected final int threshold;
@@ -397,6 +412,11 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
         }
     }
 
+    /**
+     * The plus plus iterator
+     *
+     * @opensearch.internal
+     */
     private static class LinearCountingIterator implements AbstractLinearCounting.HashesIterator {
 
         private final LinearCounting lc;

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/HyperLogLogPlusPlusSparse.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/HyperLogLogPlusPlusSparse.java
@@ -98,6 +98,11 @@ final class HyperLogLogPlusPlusSparse extends AbstractHyperLogLogPlusPlus implem
         lc.addEncoded(bucket, encoded);
     }
 
+    /**
+     * The plus plus
+     *
+     * @opensearch.internal
+     */
     private static class LinearCounting extends AbstractLinearCounting implements Releasable {
 
         private final int capacity;
@@ -189,6 +194,11 @@ final class HyperLogLogPlusPlusSparse extends AbstractHyperLogLogPlusPlus implem
         }
     }
 
+    /**
+     * The plus plus iterator
+     *
+     * @opensearch.internal
+     */
     private static class LinearCountingIterator implements AbstractLinearCounting.HashesIterator {
 
         private final LinearCounting lc;

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalExtendedStats.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalExtendedStats.java
@@ -48,6 +48,11 @@ import java.util.Objects;
  * @opensearch.internal
  */
 public class InternalExtendedStats extends InternalStats implements ExtendedStats {
+    /**
+     * The metrics for the extended stats
+     *
+     * @opensearch.internal
+     */
     enum Metrics {
 
         count,
@@ -304,6 +309,11 @@ public class InternalExtendedStats extends InternalStats implements ExtendedStat
         );
     }
 
+    /**
+     * Fields for internal extended stats
+     *
+     * @opensearch.internal
+     */
     static class Fields {
         public static final String SUM_OF_SQRS = "sum_of_squares";
         public static final String SUM_OF_SQRS_AS_STRING = "sum_of_squares_as_string";

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalGeoCentroid.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalGeoCentroid.java
@@ -177,6 +177,11 @@ public class InternalGeoCentroid extends InternalAggregation implements GeoCentr
         }
     }
 
+    /**
+     * Fields for geo centroid
+     *
+     * @opensearch.internal
+     */
     static class Fields {
         static final ParseField CENTROID = new ParseField("location");
         static final ParseField COUNT = new ParseField("count");

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalHDRPercentileRanks.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalHDRPercentileRanks.java
@@ -114,6 +114,11 @@ public class InternalHDRPercentileRanks extends AbstractInternalHDRPercentiles i
         return percentileRank;
     }
 
+    /**
+     * Terator for HDR percentile ranks agg
+     *
+     * @opensearch.internal
+     */
     public static class Iter implements Iterator<Percentile> {
 
         private final double[] values;

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalHDRPercentiles.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalHDRPercentiles.java
@@ -104,6 +104,11 @@ public class InternalHDRPercentiles extends AbstractInternalHDRPercentiles imple
         return new InternalHDRPercentiles(name, keys, merged, keyed, format, metadata);
     }
 
+    /**
+     * Iterator for HDR percentiles
+     *
+     * @opensearch.internal
+     */
     public static class Iter implements Iterator<Percentile> {
 
         private final double[] percents;

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
@@ -53,6 +53,11 @@ public abstract class InternalNumericMetricsAggregation extends InternalAggregat
 
     protected DocValueFormat format = DEFAULT_FORMAT;
 
+    /**
+     * A single numeric metric value
+     *
+     * @opensearch.internal
+     */
     public abstract static class SingleValue extends InternalNumericMetricsAggregation implements NumericMetricsAggregation.SingleValue {
         protected SingleValue(String name, Map<String, Object> metadata) {
             super(name, metadata);
@@ -96,6 +101,11 @@ public abstract class InternalNumericMetricsAggregation extends InternalAggregat
         }
     }
 
+    /**
+     * Multe numeric metric values
+     *
+     * @opensearch.internal
+     */
     public abstract static class MultiValue extends InternalNumericMetricsAggregation implements NumericMetricsAggregation.MultiValue {
         protected MultiValue(String name, Map<String, Object> metadata) {
             super(name, metadata);

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalStats.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalStats.java
@@ -48,6 +48,11 @@ import java.util.Objects;
  * @opensearch.internal
  */
 public class InternalStats extends InternalNumericMetricsAggregation.MultiValue implements Stats {
+    /**
+     * The metrics for the internal stats
+     *
+     * @opensearch.internal
+     */
     enum Metrics {
 
         count,
@@ -195,6 +200,11 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
         return new InternalStats(name, count, kahanSummation.value(), min, max, format, getMetadata());
     }
 
+    /**
+     * Fields for stats agg
+     *
+     * @opensearch.internal
+     */
     static class Fields {
         public static final String COUNT = "count";
         public static final String MIN = "min";

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalTDigestPercentileRanks.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalTDigestPercentileRanks.java
@@ -110,6 +110,11 @@ public class InternalTDigestPercentileRanks extends AbstractInternalTDigestPerce
         return percentileRank * 100;
     }
 
+    /**
+     * Iter for the TDigest percentile ranks agg
+     *
+     * @opensearch.internal
+     */
     public static class Iter implements Iterator<Percentile> {
 
         private final double[] values;

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalTDigestPercentiles.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalTDigestPercentiles.java
@@ -100,6 +100,11 @@ public class InternalTDigestPercentiles extends AbstractInternalTDigestPercentil
         return new InternalTDigestPercentiles(name, keys, merged, keyed, format, metadata);
     }
 
+    /**
+     * Iter for the TDigest percentiles agg
+     *
+     * @opensearch.internal
+     */
     public static class Iter implements Iterator<Percentile> {
 
         private final double[] percents;

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/NumericMetricsAggregation.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/NumericMetricsAggregation.java
@@ -41,6 +41,11 @@ import org.opensearch.search.aggregations.Aggregation;
  */
 public interface NumericMetricsAggregation extends Aggregation {
 
+    /**
+     * A single value for the metrics agg
+     *
+     * @opensearch.internal
+     */
     interface SingleValue extends NumericMetricsAggregation {
 
         double value();
@@ -49,5 +54,10 @@ public interface NumericMetricsAggregation extends Aggregation {
 
     }
 
+    /**
+     * Multi values in a numeric metrics agg
+     *
+     * @opensearch.internal
+     */
     interface MultiValue extends NumericMetricsAggregation {}
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/NumericMetricsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/NumericMetricsAggregator.java
@@ -51,6 +51,11 @@ public abstract class NumericMetricsAggregator extends MetricsAggregator {
         super(name, context, parent, metadata);
     }
 
+    /**
+     * Single numeric metric agg value
+     *
+     * @opensearch.internal
+     */
     public abstract static class SingleValue extends NumericMetricsAggregator {
 
         protected SingleValue(String name, SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {
@@ -75,6 +80,11 @@ public abstract class NumericMetricsAggregator extends MetricsAggregator {
         }
     }
 
+    /**
+     * Multi numeric metric agg value
+     *
+     * @opensearch.internal
+     */
     public abstract static class MultiValue extends NumericMetricsAggregator {
 
         protected MultiValue(String name, SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/PercentilesConfig.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/PercentilesConfig.java
@@ -123,6 +123,11 @@ public abstract class PercentilesConfig implements ToXContent, Writeable {
         return Objects.hash(method);
     }
 
+    /**
+     * The TDigest
+     *
+     * @opensearch.internal
+     */
     public static class TDigest extends PercentilesConfig {
         static final double DEFAULT_COMPRESSION = 100.0;
         private double compression;
@@ -219,6 +224,11 @@ public abstract class PercentilesConfig implements ToXContent, Writeable {
         }
     }
 
+    /**
+     * The HDR value
+     *
+     * @opensearch.internal
+     */
     public static class Hdr extends PercentilesConfig {
         static final int DEFAULT_NUMBER_SIG_FIGS = 3;
         private int numberOfSignificantValueDigits;

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/TopHitsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/TopHitsAggregator.java
@@ -77,6 +77,11 @@ import java.util.Map;
  */
 class TopHitsAggregator extends MetricsAggregator {
 
+    /**
+     * Collectors for top hits
+     *
+     * @opensearch.internal
+     */
     private static class Collectors {
         public final TopDocsCollector<?> topDocsCollector;
         public final MaxScoreCollector maxScoreCollector;

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/BucketHelpers.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/BucketHelpers.java
@@ -67,6 +67,8 @@ public class BucketHelpers {
      *
      * "insert_zeros": empty buckets will be filled with zeros for all metrics
      * "skip": empty buckets will simply be ignored
+     *
+     * @opensearch.internal
      */
     public enum GapPolicy implements Writeable {
         INSERT_ZEROS((byte) 0, "insert_zeros"),

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/EwmaModel.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/EwmaModel.java
@@ -153,6 +153,11 @@ public class EwmaModel extends MovAvgModel {
         return Objects.equals(alpha, other.alpha);
     }
 
+    /**
+     * Builder for the EWMA model
+     *
+     * @opensearch.internal
+     */
     public static class EWMAModelBuilder implements MovAvgModelBuilder {
 
         private double alpha = DEFAULT_ALPHA;

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/HoltLinearModel.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/HoltLinearModel.java
@@ -195,6 +195,11 @@ public class HoltLinearModel extends MovAvgModel {
         return Objects.equals(alpha, other.alpha) && Objects.equals(beta, other.beta);
     }
 
+    /**
+     * Builder for the holt linear model
+     *
+     * @opensearch.internal
+     */
     public static class HoltLinearModelBuilder implements MovAvgModelBuilder {
         private double alpha = DEFAULT_ALPHA;
         private double beta = DEFAULT_BETA;

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/HoltWintersModel.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/HoltWintersModel.java
@@ -63,6 +63,11 @@ public class HoltWintersModel extends MovAvgModel {
     private static final SeasonalityType DEFAULT_SEASONALITY_TYPE = SeasonalityType.ADDITIVE;
     private static final boolean DEFAULT_PAD = false;
 
+    /**
+     * The seasonality type
+     *
+     * @opensearch.internal
+     */
     public enum SeasonalityType {
         ADDITIVE((byte) 0, "add"),
         MULTIPLICATIVE((byte) 1, "mult");
@@ -392,6 +397,11 @@ public class HoltWintersModel extends MovAvgModel {
             && Objects.equals(pad, other.pad);
     }
 
+    /**
+     * Builder for the holt winters model
+     *
+     * @opensearch.internal
+     */
     public static class HoltWintersModelBuilder implements MovAvgModelBuilder {
 
         private double alpha = DEFAULT_ALPHA;

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/InternalPercentilesBucket.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/InternalPercentilesBucket.java
@@ -209,6 +209,11 @@ public class InternalPercentilesBucket extends InternalNumericMetricsAggregation
         return Objects.hash(super.hashCode(), Arrays.hashCode(percents), Arrays.hashCode(percentiles));
     }
 
+    /**
+     * Iterator for the percentiles agg
+     *
+     * @opensearch.internal
+     */
     public static class Iter implements Iterator<Percentile> {
 
         private final double[] percents;

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/LinearModel.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/LinearModel.java
@@ -113,6 +113,11 @@ public class LinearModel extends MovAvgModel {
         }
     };
 
+    /**
+     * Builder for the linear model
+     *
+     * @opensearch.internal
+     */
     public static class LinearModelBuilder implements MovAvgModelBuilder {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/MovAvgModel.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/MovAvgModel.java
@@ -158,6 +158,8 @@ public abstract class MovAvgModel implements NamedWriteable, ToXContentFragment 
 
     /**
      * Abstract class which also provides some concrete parsing functionality.
+     *
+     * @opensearch.internal
      */
     public abstract static class AbstractModelParser {
         /**

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/MovingFunctionScript.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/MovingFunctionScript.java
@@ -51,6 +51,11 @@ public abstract class MovingFunctionScript {
      */
     public abstract double execute(Map<String, Object> params, double[] values);
 
+    /**
+     * Factory interface
+     *
+     * @opensearch.internal
+     */
     public interface Factory extends ScriptFactory {
         MovingFunctionScript newInstance();
     }

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/PipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/PipelineAggregator.java
@@ -57,6 +57,8 @@ import static java.util.Collections.emptyMap;
 public abstract class PipelineAggregator implements NamedWriteable {
     /**
      * Parse the {@link PipelineAggregationBuilder} from a {@link XContentParser}.
+     *
+     * @opensearch.internal
      */
     @FunctionalInterface
     public interface Parser {
@@ -81,6 +83,8 @@ public abstract class PipelineAggregator implements NamedWriteable {
     /**
      * Tree of {@link PipelineAggregator}s to modify a tree of aggregations
      * after their final reduction.
+     *
+     * @opensearch.internal
      */
     public static class PipelineTree {
         /**

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/SimpleModel.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/SimpleModel.java
@@ -112,6 +112,11 @@ public class SimpleModel extends MovAvgModel {
         }
     };
 
+    /**
+     * Builder for the simple model
+     *
+     * @opensearch.internal
+     */
     public static class SimpleModelBuilder implements MovAvgModelBuilder {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {

--- a/server/src/main/java/org/opensearch/search/aggregations/support/AggregationPath.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/AggregationPath.java
@@ -128,6 +128,11 @@ public class AggregationPath {
         return new AggregationPath(tokens);
     }
 
+    /**
+     * Element in an agg path
+     *
+     * @opensearch.internal
+     */
     public static class PathElement {
 
         private final String fullName;

--- a/server/src/main/java/org/opensearch/search/aggregations/support/AggregationUsageService.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/AggregationUsageService.java
@@ -49,6 +49,11 @@ public class AggregationUsageService implements ReportingService<AggregationInfo
 
     public static final String OTHER_SUBTYPE = "other";
 
+    /**
+     * Builder for the Agg usage service to track telemetry
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
         private final Map<String, Map<String, LongAdder>> aggs;
 

--- a/server/src/main/java/org/opensearch/search/aggregations/support/BaseMultiValuesSourceFieldConfig.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/BaseMultiValuesSourceFieldConfig.java
@@ -171,6 +171,11 @@ public abstract class BaseMultiValuesSourceFieldConfig implements Writeable, ToX
 
     abstract void doWriteTo(StreamOutput out) throws IOException;
 
+    /**
+     * Base builder for the multi values source field configuration
+     *
+     * @opensearch.internal
+     */
     public abstract static class Builder<C extends BaseMultiValuesSourceFieldConfig, B extends Builder<C, B>> {
         String fieldName;
         Object missing = null;

--- a/server/src/main/java/org/opensearch/search/aggregations/support/MultiTermsValuesSourceConfig.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/MultiTermsValuesSourceConfig.java
@@ -36,6 +36,11 @@ public class MultiTermsValuesSourceConfig extends BaseMultiValuesSourceFieldConf
     private static final String NAME = "field_config";
     public static final ParseField FILTER = new ParseField("filter");
 
+    /**
+     * Parser supplier function
+     *
+     * @opensearch.internal
+     */
     public interface ParserSupplier {
         ObjectParser<MultiTermsValuesSourceConfig.Builder, Void> apply(
             Boolean scriptable,
@@ -156,6 +161,11 @@ public class MultiTermsValuesSourceConfig extends BaseMultiValuesSourceFieldConf
         return Objects.hash(super.hashCode(), userValueTypeHint, format, includeExclude);
     }
 
+    /**
+     * Builder for the multi terms values source configuration
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends BaseMultiValuesSourceFieldConfig.Builder<MultiTermsValuesSourceConfig, Builder> {
         private ValueType userValueTypeHint = null;
         private String format;

--- a/server/src/main/java/org/opensearch/search/aggregations/support/MultiValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/MultiValuesSource.java
@@ -49,6 +49,11 @@ import java.util.Objects;
 public abstract class MultiValuesSource<VS extends ValuesSource> {
     protected Map<String, VS> values;
 
+    /**
+     * Numeric format
+     *
+     * @opensearch.internal
+     */
     public static class NumericMultiValuesSource extends MultiValuesSource<ValuesSource.Numeric> {
         public NumericMultiValuesSource(Map<String, ValuesSourceConfig> valuesSourceConfigs, QueryShardContext context) {
             values = new HashMap<>(valuesSourceConfigs.size());

--- a/server/src/main/java/org/opensearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
@@ -59,6 +59,11 @@ import java.util.Objects;
 public abstract class MultiValuesSourceAggregationBuilder<AB extends MultiValuesSourceAggregationBuilder<AB>> extends
     AbstractAggregationBuilder<AB> {
 
+    /**
+     * Base leaf only class
+     *
+     * @opensearch.internal
+     */
     public abstract static class LeafOnly<AB extends MultiValuesSourceAggregationBuilder<AB>> extends MultiValuesSourceAggregationBuilder<
         AB> {
 

--- a/server/src/main/java/org/opensearch/search/aggregations/support/MultiValuesSourceFieldConfig.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/MultiValuesSourceFieldConfig.java
@@ -130,6 +130,11 @@ public class MultiValuesSourceFieldConfig extends BaseMultiValuesSourceFieldConf
         return Objects.hash(super.hashCode(), filter);
     }
 
+    /**
+     * Builder for the field config
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends BaseMultiValuesSourceFieldConfig.Builder<BaseMultiValuesSourceFieldConfig, Builder> {
         private QueryBuilder filter = null;
 

--- a/server/src/main/java/org/opensearch/search/aggregations/support/ValuesSource.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/ValuesSource.java
@@ -103,6 +103,11 @@ public abstract class ValuesSource {
         return false;
     }
 
+    /**
+     * Range type
+     *
+     * @opensearch.internal
+     */
     public static class Range extends ValuesSource {
         private final RangeType rangeType;
         protected final IndexFieldData<?> indexFieldData;
@@ -134,6 +139,11 @@ public abstract class ValuesSource {
         }
     }
 
+    /**
+     * Bytes type
+     *
+     * @opensearch.internal
+     */
     public abstract static class Bytes extends ValuesSource {
 
         @Override
@@ -147,6 +157,11 @@ public abstract class ValuesSource {
             throw new AggregationExecutionException("can't round a [BYTES]");
         }
 
+        /**
+         * Provides ordinals for bytes
+         *
+         * @opensearch.internal
+         */
         public abstract static class WithOrdinals extends Bytes {
 
             public static final WithOrdinals EMPTY = new WithOrdinals() {
@@ -211,6 +226,11 @@ public abstract class ValuesSource {
                 }
             }
 
+            /**
+             * Field data for the bytes values source
+             *
+             * @opensearch.internal
+             */
             public static class FieldData extends WithOrdinals {
 
                 protected final IndexOrdinalsFieldData indexFieldData;
@@ -257,6 +277,11 @@ public abstract class ValuesSource {
             }
         }
 
+        /**
+         * Field data without ordinals
+         *
+         * @opensearch.internal
+         */
         public static class FieldData extends Bytes {
 
             protected final IndexFieldData<?> indexFieldData;
@@ -274,6 +299,8 @@ public abstract class ValuesSource {
 
         /**
          * {@link ValuesSource} implementation for stand alone scripts returning a Bytes value
+         *
+         * @opensearch.internal
          */
         public static class Script extends Bytes {
 
@@ -297,6 +324,8 @@ public abstract class ValuesSource {
         // No need to implement ReaderContextAware here, the delegate already takes care of updating data structures
         /**
          * {@link ValuesSource} subclass for Bytes fields with a Value Script applied
+         *
+         * @opensearch.internal
          */
         public static class WithScript extends Bytes {
 
@@ -318,6 +347,11 @@ public abstract class ValuesSource {
                 return new BytesValues(delegate.bytesValues(context), script.newInstance(context));
             }
 
+            /**
+             * Bytes values
+             *
+             * @opensearch.internal
+             */
             static class BytesValues extends SortingBinaryDocValues implements ScorerAware {
 
                 private final SortedBinaryDocValues bytesValues;
@@ -358,6 +392,11 @@ public abstract class ValuesSource {
         }
     }
 
+    /**
+     * Numeric values source type
+     *
+     * @opensearch.internal
+     */
     public abstract static class Numeric extends ValuesSource {
 
         public static final Numeric EMPTY = new Numeric() {
@@ -411,6 +450,8 @@ public abstract class ValuesSource {
 
         /**
          * {@link ValuesSource} subclass for Numeric fields with a Value Script applied
+         *
+         * @opensearch.internal
          */
         public static class WithScript extends Numeric {
 
@@ -447,6 +488,11 @@ public abstract class ValuesSource {
                 return new DoubleValues(delegate.doubleValues(context), script.newInstance(context));
             }
 
+            /**
+             * Long values source type
+             *
+             * @opensearch.internal
+             */
             static class LongValues extends AbstractSortingNumericDocValues implements ScorerAware {
 
                 private final SortedNumericDocValues longValues;
@@ -478,6 +524,11 @@ public abstract class ValuesSource {
                 }
             }
 
+            /**
+             * Double values source type
+             *
+             * @opensearch.internal
+             */
             static class DoubleValues extends SortingNumericDoubleValues implements ScorerAware {
 
                 private final SortedNumericDoubleValues doubleValues;
@@ -510,6 +561,11 @@ public abstract class ValuesSource {
             }
         }
 
+        /**
+         * Field data for numerics
+         *
+         * @opensearch.internal
+         */
         public static class FieldData extends Numeric {
 
             protected final IndexNumericFieldData indexFieldData;
@@ -541,6 +597,8 @@ public abstract class ValuesSource {
 
         /**
          * {@link ValuesSource} implementation for stand alone scripts returning a Numeric value
+         *
+         * @opensearch.internal
          */
         public static class Script extends Numeric {
             private final AggregationScript.LeafFactory script;
@@ -579,6 +637,11 @@ public abstract class ValuesSource {
 
     }
 
+    /**
+     * Geo point values source
+     *
+     * @opensearch.internal
+     */
     public abstract static class GeoPoint extends ValuesSource {
 
         public static final GeoPoint EMPTY = new GeoPoint() {
@@ -608,6 +671,11 @@ public abstract class ValuesSource {
 
         public abstract MultiGeoPointValues geoPointValues(LeafReaderContext context);
 
+        /**
+         * Field data for geo point values source
+         *
+         * @opensearch.internal
+         */
         public static class Fielddata extends GeoPoint {
 
             protected final IndexGeoPointFieldData indexFieldData;

--- a/server/src/main/java/org/opensearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
@@ -140,6 +140,11 @@ public abstract class ValuesSourceAggregationBuilder<AB extends ValuesSourceAggr
         }
     }
 
+    /**
+     * Base leaf only
+     *
+     * @opensearch.internal
+     */
     public abstract static class LeafOnly<VS extends ValuesSource, AB extends ValuesSourceAggregationBuilder<AB>> extends
         ValuesSourceAggregationBuilder<AB> {
 

--- a/server/src/main/java/org/opensearch/search/aggregations/support/ValuesSourceRegistry.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/ValuesSourceRegistry.java
@@ -53,6 +53,11 @@ import java.util.stream.Collectors;
  */
 public class ValuesSourceRegistry {
 
+    /**
+     * The registry key for the values source registry key
+     *
+     * @opensearch.internal
+     */
     public static final class RegistryKey<T> {
         private final String name;
         private final Class<T> supplierType;
@@ -82,6 +87,11 @@ public class ValuesSourceRegistry {
 
     public static final RegistryKey UNREGISTERED_KEY = new RegistryKey("unregistered", RegistryKey.class);
 
+    /**
+     * Builder for the values source registry
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
         private final AggregationUsageService.Builder usageServiceBuilder;
         private Map<RegistryKey<?>, List<Map.Entry<ValuesSourceType, ?>>> aggregatorRegistry = new HashMap<>();

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -1471,6 +1471,11 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         return builder;
     }
 
+    /**
+     * Boosts on an index
+     *
+     * @opensearch.internal
+     */
     public static class IndexBoost implements Writeable, ToXContentObject {
         private final String index;
         private final float boost;
@@ -1567,6 +1572,11 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
 
     }
 
+    /**
+     * Script field
+     *
+     * @opensearch.internal
+     */
     public static class ScriptField implements Writeable, ToXContentFragment {
 
         private final boolean ignoreFailure;

--- a/server/src/main/java/org/opensearch/search/fetch/FetchSubPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchSubPhase.java
@@ -47,6 +47,11 @@ import java.io.IOException;
  */
 public interface FetchSubPhase {
 
+    /**
+     * The hit context for the fetch subphase
+     *
+     * @opensearch.internal
+     */
     class HitContext {
         private final SearchHit hit;
         private final LeafReaderContext readerContext;

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/ScriptFieldsContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/ScriptFieldsContext.java
@@ -44,6 +44,11 @@ import java.util.List;
  */
 public class ScriptFieldsContext {
 
+    /**
+     * Script field use in the script fields context
+     *
+     * @opensearch.internal
+     */
     public static class ScriptField {
         private final String name;
         private final FieldScript.LeafFactory script;

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/HighlightBuilder.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/HighlightBuilder.java
@@ -469,6 +469,11 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
 
     }
 
+    /**
+     * Field for highlight builder
+     *
+     * @opensearch.internal
+     */
     public static class Field extends AbstractHighlighterBuilder<Field> {
         static final NamedObjectParser<Field, Void> PARSER;
         static {
@@ -572,6 +577,11 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
         }
     }
 
+    /**
+     * Order for highlight builder
+     *
+     * @opensearch.internal
+     */
     public enum Order implements Writeable {
         NONE,
         SCORE;
@@ -598,6 +608,11 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
         }
     }
 
+    /**
+     * Boundary scanner type
+     *
+     * @opensearch.internal
+     */
     public enum BoundaryScannerType implements Writeable {
         CHARS,
         WORD,

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/HighlightUtils.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/HighlightUtils.java
@@ -80,6 +80,11 @@ public final class HighlightUtils {
         return fetcher.fetchValues(hitContext.sourceLookup());
     }
 
+    /**
+     * Encoders for the highlighters
+     *
+     * @opensearch.internal
+     */
     public static class Encoders {
         public static final Encoder DEFAULT = new DefaultEncoder();
         public static final Encoder HTML = new SimpleHTMLEncoder();

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/SearchHighlightContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/SearchHighlightContext.java
@@ -79,6 +79,11 @@ public class SearchHighlightContext {
         return _field == null ? false : _field.fieldOptions.forceSource;
     }
 
+    /**
+     * Field for the search highlight context
+     *
+     * @opensearch.internal
+     */
     public static class Field {
         private final String field;
         private final FieldOptions fieldOptions;
@@ -99,6 +104,11 @@ public class SearchHighlightContext {
         }
     }
 
+    /**
+     * Field options for the search highlight context
+     *
+     * @opensearch.internal
+     */
     public static class FieldOptions {
 
         // Field options that default to null or -1 are often set to their real default in HighlighterParseElement#parse

--- a/server/src/main/java/org/opensearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryPhase.java
@@ -388,6 +388,8 @@ public class QueryPhase {
 
     /**
      * The exception being raised when search timeout is reached.
+     *
+     * @opensearch.internal
      */
     public static class TimeExceededException extends RuntimeException {
         private static final long serialVersionUID = 1L;
@@ -395,6 +397,8 @@ public class QueryPhase {
 
     /**
      * Default {@link QueryPhaseSearcher} implementation which delegates to the {@link QueryPhase}.
+     *
+     * @opensearch.internal
      */
     public static class DefaultQueryPhaseSearcher implements QueryPhaseSearcher {
         /**

--- a/server/src/main/java/org/opensearch/search/rescore/QueryRescorer.java
+++ b/server/src/main/java/org/opensearch/search/rescore/QueryRescorer.java
@@ -184,6 +184,11 @@ public final class QueryRescorer implements Rescorer {
         return in;
     }
 
+    /**
+     * Context used during query rescoring
+     *
+     * @opensearch.internal
+     */
     public static class QueryRescoreContext extends RescoreContext {
         private Query query;
         private float queryWeight = 1.0f;

--- a/server/src/main/java/org/opensearch/search/sort/BucketedSort.java
+++ b/server/src/main/java/org/opensearch/search/sort/BucketedSort.java
@@ -98,6 +98,8 @@ import static java.util.Collections.emptyList;
 public abstract class BucketedSort implements Releasable {
     /**
      * Callbacks for storing extra data along with competitive sorts.
+     *
+     * @opensearch.internal
      */
     public interface ExtraData {
         /**
@@ -115,6 +117,11 @@ public abstract class BucketedSort implements Releasable {
          */
         Loader loader(LeafReaderContext ctx) throws IOException;
 
+        /**
+         * Loader for extra data
+         *
+         * @opensearch.internal
+         */
         @FunctionalInterface
         interface Loader {
             /**
@@ -185,6 +192,8 @@ public abstract class BucketedSort implements Releasable {
     /**
      * Used with {@link BucketedSort#getValues(long, ResultBuilder)} to
      * build results from the sorting operation.
+     *
+     * @opensearch.internal
      */
     @FunctionalInterface
     public interface ResultBuilder<T> {
@@ -532,6 +541,11 @@ public abstract class BucketedSort implements Releasable {
             values.set(rhs, tmp);
         }
 
+        /**
+         * Leaf for doubles
+         *
+         * @opensearch.internal
+         */
         protected abstract class Leaf extends BucketedSort.Leaf {
             protected Leaf(LeafReaderContext ctx) {
                 super(ctx);
@@ -625,6 +639,11 @@ public abstract class BucketedSort implements Releasable {
             values.set(rhs, tmp);
         }
 
+        /**
+         * Leaf for floats
+         *
+         * @opensearch.internal
+         */
         protected abstract class Leaf extends BucketedSort.Leaf {
             protected Leaf(LeafReaderContext ctx) {
                 super(ctx);
@@ -704,6 +723,11 @@ public abstract class BucketedSort implements Releasable {
             values.set(rhs, tmp);
         }
 
+        /**
+         * Leaf for bucketed sort
+         *
+         * @opensearch.internal
+         */
         protected abstract class Leaf extends BucketedSort.Leaf {
             protected Leaf(LeafReaderContext ctx) {
                 super(ctx);

--- a/server/src/main/java/org/opensearch/search/sort/ScriptSortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/ScriptSortBuilder.java
@@ -460,6 +460,11 @@ public class ScriptSortBuilder extends SortBuilder<ScriptSortBuilder> {
         return NAME;
     }
 
+    /**
+     * Sort type for scripting
+     *
+     * @opensearch.internal
+     */
     public enum ScriptSortType implements Writeable {
         /** script sort for a string value **/
         STRING,

--- a/server/src/main/java/org/opensearch/search/suggest/SuggestionSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/suggest/SuggestionSearchContext.java
@@ -55,6 +55,11 @@ public class SuggestionSearchContext {
         return suggestions;
     }
 
+    /**
+     * The suggestion context
+     *
+     * @opensearch.internal
+     */
     public abstract static class SuggestionContext {
 
         private BytesRef text;

--- a/server/src/main/java/org/opensearch/search/suggest/completion/CompletionSuggestion.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/CompletionSuggestion.java
@@ -256,6 +256,11 @@ public final class CompletionSuggestion extends Suggest.Suggestion<CompletionSug
         return new Entry(in);
     }
 
+    /**
+     * Entry in the completion suggester
+     *
+     * @opensearch.internal
+     */
     public static final class Entry extends Suggest.Suggestion.Entry<CompletionSuggestion.Entry.Option> {
 
         public Entry(Text text, int offset, int length) {
@@ -287,6 +292,11 @@ public final class CompletionSuggestion extends Suggest.Suggestion<CompletionSug
             return PARSER.apply(parser, null);
         }
 
+        /**
+         * Options for the completion suggester
+         *
+         * @opensearch.internal
+         */
         public static class Option extends Suggest.Suggestion.Entry.Option {
             private final Map<String, Set<String>> contexts;
             private final ScoreDoc doc;

--- a/server/src/main/java/org/opensearch/search/suggest/completion/FuzzyOptions.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/FuzzyOptions.java
@@ -220,6 +220,8 @@ public class FuzzyOptions implements ToXContentFragment, Writeable {
 
     /**
      * Options for fuzzy queries
+     *
+     * @opensearch.internal
      */
     public static class Builder {
 

--- a/server/src/main/java/org/opensearch/search/suggest/completion/RegexOptions.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/RegexOptions.java
@@ -155,6 +155,8 @@ public class RegexOptions implements ToXContentFragment, Writeable {
 
     /**
      * Options for regular expression queries
+     *
+     * @opensearch.internal
      */
     public static class Builder {
         private int flagsValue = RegExp.ALL;

--- a/server/src/main/java/org/opensearch/search/suggest/completion/context/CategoryContextMapping.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/context/CategoryContextMapping.java
@@ -219,6 +219,8 @@ public class CategoryContextMapping extends ContextMapping<CategoryQueryContext>
 
     /**
      * Builder for {@link CategoryContextMapping}
+     *
+     * @opensearch.internal
      */
     public static class Builder extends ContextBuilder<CategoryContextMapping> {
 

--- a/server/src/main/java/org/opensearch/search/suggest/completion/context/CategoryQueryContext.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/context/CategoryQueryContext.java
@@ -151,6 +151,11 @@ public final class CategoryQueryContext implements ToXContentObject {
         return builder;
     }
 
+    /**
+     * Builder for the category query context
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
         private String category;
         private boolean isPrefix = false;

--- a/server/src/main/java/org/opensearch/search/suggest/completion/context/ContextMapping.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/context/ContextMapping.java
@@ -67,6 +67,11 @@ public abstract class ContextMapping<T extends ToXContent> implements ToXContent
     protected final Type type;
     protected final String name;
 
+    /**
+     * Type of context mapping
+     *
+     * @opensearch.internal
+     */
     public enum Type {
         CATEGORY,
         GEO;
@@ -189,6 +194,11 @@ public abstract class ContextMapping<T extends ToXContent> implements ToXContent
         }
     }
 
+    /**
+     * The internal query context
+     *
+     * @opensearch.internal
+     */
     public static class InternalQueryContext {
         public final String context;
         public final int boost;

--- a/server/src/main/java/org/opensearch/search/suggest/completion/context/GeoContextMapping.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/context/GeoContextMapping.java
@@ -363,6 +363,11 @@ public class GeoContextMapping extends ContextMapping<GeoQueryContext> {
         return Objects.hash(super.hashCode(), precision, fieldName);
     }
 
+    /**
+     * Builder for geo context mapping
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends ContextBuilder<GeoContextMapping> {
 
         private int precision = DEFAULT_PRECISION;

--- a/server/src/main/java/org/opensearch/search/suggest/completion/context/GeoQueryContext.java
+++ b/server/src/main/java/org/opensearch/search/suggest/completion/context/GeoQueryContext.java
@@ -177,6 +177,11 @@ public final class GeoQueryContext implements ToXContentObject {
         return builder;
     }
 
+    /**
+     * Builder for the geo context
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
         private GeoPoint geoPoint;
         private int boost = 1;

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/DirectCandidateGenerator.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/DirectCandidateGenerator.java
@@ -278,6 +278,11 @@ public final class DirectCandidateGenerator extends CandidateGenerator {
         return 0;
     }
 
+    /**
+     * Token consumer for a direct candidate
+     *
+     * @opensearch.internal
+     */
     public abstract static class TokenConsumer {
         protected CharTermAttribute charTermAttr;
         protected PositionIncrementAttribute posIncAttr;
@@ -299,6 +304,11 @@ public final class DirectCandidateGenerator extends CandidateGenerator {
         public void end() {}
     }
 
+    /**
+     * Candidate set of terms
+     *
+     * @opensearch.internal
+     */
     public static class CandidateSet {
         public Candidate[] candidates;
         public final Candidate originalTerm;
@@ -328,6 +338,11 @@ public final class DirectCandidateGenerator extends CandidateGenerator {
 
     }
 
+    /**
+     * Candidate term
+     *
+     * @opensearch.internal
+     */
     public static class Candidate implements Comparable<Candidate> {
         public static final Candidate[] EMPTY = new Candidate[0];
         public final BytesRef term;

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/PhraseSuggestion.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/PhraseSuggestion.java
@@ -87,6 +87,11 @@ public class PhraseSuggestion extends Suggest.Suggestion<PhraseSuggestion.Entry>
         return suggestion;
     }
 
+    /**
+     * Entry in the phrase suggester
+     *
+     * @opensearch.internal
+     */
     public static class Entry extends Suggestion.Entry<PhraseSuggestion.Entry.Option> {
 
         protected double cutoffScore = Double.MIN_VALUE;
@@ -170,6 +175,11 @@ public class PhraseSuggestion extends Suggest.Suggestion<PhraseSuggestion.Entry>
             return Objects.hash(super.hashCode(), cutoffScore);
         }
 
+        /**
+         * Options for phrase suggestion
+         *
+         * @opensearch.internal
+         */
         public static class Option extends Suggestion.Entry.Option {
 
             public Option(Text text, Text highlighted, float score, Boolean collateMatch) {

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/PhraseSuggestionBuilder.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/PhraseSuggestionBuilder.java
@@ -772,6 +772,8 @@ public class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSuggestionB
 
     /**
      * {@link CandidateGenerator} interface.
+     *
+     * @opensearch.internal
      */
     public interface CandidateGenerator extends Writeable, ToXContentObject {
         String getType();

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/WordScorer.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/WordScorer.java
@@ -133,6 +133,11 @@ public abstract class WordScorer {
         return result.get();
     }
 
+    /**
+     * Factory for a new scorer
+     *
+     * @opensearch.internal
+     */
     public interface WordScorerFactory {
         WordScorer newScorer(IndexReader reader, Terms terms, String field, double realWordLikelihood, BytesRef separator)
             throws IOException;

--- a/server/src/main/java/org/opensearch/search/suggest/term/TermSuggestion.java
+++ b/server/src/main/java/org/opensearch/search/suggest/term/TermSuggestion.java
@@ -79,8 +79,12 @@ public class TermSuggestion extends Suggestion<TermSuggestion.Entry> {
         }
     }
 
-    // Same behaviour as comparators in suggest module, but for SuggestedWord
-    // Highest score first, then highest freq first, then lowest term first
+    /**
+     * Same behaviour as comparators in suggest module, but for SuggestedWord
+     * Highest score first, then highest freq first, then lowest term first
+     *
+     * @opensearch.internal
+     */
     public static class Score implements Comparator<Suggestion.Entry.Option> {
 
         @Override
@@ -94,8 +98,12 @@ public class TermSuggestion extends Suggestion<TermSuggestion.Entry> {
         }
     }
 
-    // Same behaviour as comparators in suggest module, but for SuggestedWord
-    // Highest freq first, then highest score first, then lowest term first
+    /**
+     * Same behaviour as comparators in suggest module, but for SuggestedWord
+     * Highest freq first, then highest score first, then lowest term first
+     *
+     * @opensearch.internal
+     */
     public static class Frequency implements Comparator<Suggestion.Entry.Option> {
 
         @Override
@@ -181,6 +189,8 @@ public class TermSuggestion extends Suggestion<TermSuggestion.Entry> {
 
     /**
      * Represents a part from the suggest text with suggested options.
+     *
+     * @opensearch.internal
      */
     public static class Entry extends Suggest.Suggestion.Entry<TermSuggestion.Entry.Option> {
 
@@ -215,6 +225,8 @@ public class TermSuggestion extends Suggestion<TermSuggestion.Entry> {
 
         /**
          * Contains the suggested text with its document frequency and score.
+         *
+         * @opensearch.internal
          */
         public static class Option extends Suggest.Suggestion.Entry.Option {
 

--- a/server/src/main/java/org/opensearch/search/suggest/term/TermSuggestionBuilder.java
+++ b/server/src/main/java/org/opensearch/search/suggest/term/TermSuggestionBuilder.java
@@ -512,7 +512,11 @@ public class TermSuggestionBuilder extends SuggestionBuilder<TermSuggestionBuild
         );
     }
 
-    /** An enum representing the valid suggest modes. */
+    /**
+     * An enum representing the valid suggest modes.
+     *
+     * @opensearch.internal
+     */
     public enum SuggestMode implements Writeable {
         /** Only suggest terms in the suggest text that aren't in the index. This is the default. */
         MISSING {
@@ -553,7 +557,11 @@ public class TermSuggestionBuilder extends SuggestionBuilder<TermSuggestionBuild
         public abstract org.apache.lucene.search.spell.SuggestMode toLucene();
     }
 
-    /** An enum representing the valid string edit distance algorithms for determining suggestions. */
+    /**
+     * An enum representing the valid string edit distance algorithms for determining suggestions.
+     *
+     * @opensearch.internal
+     */
     public enum StringDistanceImpl implements Writeable {
         /** This is the default and is based on <code>damerau_levenshtein</code>, but highly optimized
          * for comparing string distance for terms inside the index. */


### PR DESCRIPTION
Adds javadocs to internal classes in org.opensearch.http, indices, and search
packages.

relates #221 
relates #2868 