### PR TITLE
[Javadocs] add remaining internal classes and reenable missingJavadoc on server

### DIFF
--- a/gradle/missing-javadoc.gradle
+++ b/gradle/missing-javadoc.gradle
@@ -178,8 +178,7 @@ configure([
 
 configure(project(":server")) {
   project.tasks.withType(MissingJavadocTask) {
-    isExcluded = true
-    // TODO: reenable after fixing missing javadocs
+    // TODO: bump to variable missing level after increasing javadoc coverage
     javadocMissingLevel = "class"
   }
 }

--- a/server/src/main/java/org/opensearch/action/IndicesRequest.java
+++ b/server/src/main/java/org/opensearch/action/IndicesRequest.java
@@ -64,6 +64,11 @@ public interface IndicesRequest {
         return false;
     }
 
+    /**
+     * Replaceable interface.
+     *
+     * @opensearch.internal
+     */
     interface Replaceable extends IndicesRequest {
         /**
          * Sets the indices that the action relates to.

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -289,6 +289,11 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
         return null;
     }
 
+    /**
+     * The level of the health request.
+     *
+     * @opensearch.internal
+     */
     public enum Level {
         CLUSTER,
         INDICES,

--- a/server/src/main/java/org/opensearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -120,6 +120,11 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
         private static final ParseField REMOVE = new ParseField("remove");
         private static final ParseField REMOVE_INDEX = new ParseField("remove_index");
 
+        /**
+         * The type of request.
+         *
+         * @opensearch.internal
+         */
         public enum Type {
             ADD((byte) 0, AliasActions.ADD),
             REMOVE((byte) 1, AliasActions.REMOVE),

--- a/server/src/main/java/org/opensearch/action/admin/indices/get/GetIndexRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/get/GetIndexRequest.java
@@ -46,6 +46,11 @@ import java.io.IOException;
  * @opensearch.internal
  */
 public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
+    /**
+     * The features to get.
+     *
+     * @opensearch.internal
+     */
     public enum Feature {
         ALIASES((byte) 0),
         MAPPINGS((byte) 1),

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -261,6 +261,11 @@ public class CommonStatsFlags implements Writeable, Cloneable {
         }
     }
 
+    /**
+     * The flags.
+     *
+     * @opensearch.internal
+     */
     public enum Flag {
         Store("store", 0),
         Indexing("indexing", 1),

--- a/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
@@ -284,6 +284,11 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         executeRequest(task, searchRequest, this::searchAsyncAction, listener);
     }
 
+    /**
+     * The single phase search action.
+     *
+     * @opensearch.internal
+     */
     public interface SinglePhaseSearchAction {
         void executeOnShardTarget(
             SearchTask searchTask,

--- a/server/src/main/java/org/opensearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/opensearch/action/support/IndicesOptions.java
@@ -60,6 +60,11 @@ import static org.opensearch.common.xcontent.support.XContentMapValues.nodeStrin
  */
 public class IndicesOptions implements ToXContentFragment {
 
+    /**
+     * The wildcard states.
+     *
+     * @opensearch.internal
+     */
     public enum WildcardStates {
         OPEN,
         CLOSED,
@@ -120,6 +125,11 @@ public class IndicesOptions implements ToXContentFragment {
         }
     }
 
+    /**
+     * The options.
+     *
+     * @opensearch.internal
+     */
     public enum Option {
         IGNORE_UNAVAILABLE,
         IGNORE_ALIASES,

--- a/server/src/main/java/org/opensearch/action/support/WriteRequest.java
+++ b/server/src/main/java/org/opensearch/action/support/WriteRequest.java
@@ -75,6 +75,11 @@ public interface WriteRequest<R extends WriteRequest<R>> extends Writeable {
 
     ActionRequestValidationException validate();
 
+    /**
+     * The refresh policy of the request.
+     *
+     * @opensearch.internal
+     */
     enum RefreshPolicy implements Writeable {
         /**
          * Don't refresh after this request. The default.

--- a/server/src/main/java/org/opensearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/opensearch/action/support/replication/ReplicationOperation.java
@@ -616,6 +616,11 @@ public class ReplicationOperation<
         }
     }
 
+    /**
+     * The result of the primary.
+     *
+     * @opensearch.internal
+     */
     public interface PrimaryResult<RequestT extends ReplicationRequest<RequestT>> {
 
         /**

--- a/server/src/main/java/org/opensearch/action/termvectors/TermVectorsRequest.java
+++ b/server/src/main/java/org/opensearch/action/termvectors/TermVectorsRequest.java
@@ -568,6 +568,11 @@ public class TermVectorsRequest extends SingleShardRequest<TermVectorsRequest> i
         out.writeLong(version);
     }
 
+    /**
+     * The flags.
+     *
+     * @opensearch.internal
+     */
     public enum Flag {
         // Do not change the order of these flags we use
         // the ordinal for encoding! Only append to the end!

--- a/server/src/main/java/org/opensearch/bootstrap/jvm/DenyJvmVersionsParser.java
+++ b/server/src/main/java/org/opensearch/bootstrap/jvm/DenyJvmVersionsParser.java
@@ -24,8 +24,15 @@ import java.util.stream.Collectors;
 /**
  * Parses the list of JVM versions which should be denied to run Opensearch engine with due to discovered
  * issues or flaws.
+ *
+ * @opensearch.internal
  */
 public class DenyJvmVersionsParser {
+    /**
+     * Provides the reason for the denial
+     *
+     * @opensearch.internal
+     */
     public interface VersionPredicate extends Predicate<Version> {
         String getReason();
     }

--- a/server/src/main/java/org/opensearch/bootstrap/jvm/package-info.java
+++ b/server/src/main/java/org/opensearch/bootstrap/jvm/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** jvm specific bootstrapping */
+package org.opensearch.bootstrap.jvm;

--- a/server/src/main/java/org/opensearch/cluster/AbstractDiffable.java
+++ b/server/src/main/java/org/opensearch/cluster/AbstractDiffable.java
@@ -66,6 +66,11 @@ public abstract class AbstractDiffable<T extends Diffable<T>> implements Diffabl
         return (Diff<T>) EMPTY;
     }
 
+    /**
+     * A complete diff.
+     *
+     * @opensearch.internal
+     */
     private static class CompleteDiff<T extends Diffable<T>> implements Diff<T> {
 
         @Nullable

--- a/server/src/main/java/org/opensearch/cluster/AbstractNamedDiffable.java
+++ b/server/src/main/java/org/opensearch/cluster/AbstractNamedDiffable.java
@@ -62,6 +62,11 @@ public abstract class AbstractNamedDiffable<T extends NamedDiffable<T>> implemen
         return new CompleteNamedDiff<>(tClass, name, in);
     }
 
+    /**
+     * A complete named diff.
+     *
+     * @opensearch.internal
+     */
     private static class CompleteNamedDiff<T extends NamedDiffable<T>> implements NamedDiff<T> {
 
         @Nullable

--- a/server/src/main/java/org/opensearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterInfo.java
@@ -244,6 +244,8 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
 
     /**
      * Represents a data path on a node
+     *
+     * @opensearch.internal
      */
     public static class NodeAndPath implements Writeable {
         public final String nodeId;
@@ -281,6 +283,8 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
 
     /**
      * Represents the total amount of "reserved" space on a particular data path, together with the set of shards considered.
+     *
+     * @opensearch.internal
      */
     public static class ReservedSpace implements Writeable {
 
@@ -344,6 +348,11 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
             builder.endArray(); // end "shards"
         }
 
+        /**
+         * Builder for Reserved Space.
+         *
+         * @opensearch.internal
+         */
         public static class Builder {
             private long total;
             private ObjectHashSet<ShardId> shardIds = new ObjectHashSet<>();

--- a/server/src/main/java/org/opensearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterState.java
@@ -106,6 +106,8 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
 
     /**
      * An interface that implementors use when a class requires a client to maybe have a feature.
+     *
+     * @opensearch.internal
      */
     public interface FeatureAware {
 
@@ -135,6 +137,11 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
 
     }
 
+    /**
+     * Custom cluster state.
+     *
+     * @opensearch.internal
+     */
     public interface Custom extends NamedDiffable<Custom>, ToXContentFragment, FeatureAware {
 
         /**
@@ -403,6 +410,11 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
 
     }
 
+    /**
+     * Metrics for cluster state.
+     *
+     * @opensearch.internal
+     */
     public enum Metric {
         VERSION("version"),
 
@@ -582,6 +594,11 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
         return new Builder(state);
     }
 
+    /**
+     * Builder for cluster state.
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
 
         private final ClusterName clusterName;
@@ -778,6 +795,11 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
         out.writeVInt(minimumClusterManagerNodesOnPublishingClusterManager);
     }
 
+    /**
+     * The cluster state diff.
+     *
+     * @opensearch.internal
+     */
     private static class ClusterStateDiff implements Diff<ClusterState> {
 
         private final long toVersion;

--- a/server/src/main/java/org/opensearch/cluster/ClusterStateObserver.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterStateObserver.java
@@ -207,6 +207,11 @@ public class ClusterStateObserver {
         }
     }
 
+    /**
+     * An observer of the cluster state for changes.
+     *
+     * @opensearch.internal
+     */
     class ObserverClusterStateListener implements TimeoutClusterStateListener {
 
         @Override
@@ -298,6 +303,8 @@ public class ClusterStateObserver {
 
     /**
      * The observer considers two cluster states to be the same if they have the same version and cluster-manager node id (i.e. null or set)
+     *
+     * @opensearch.internal
      */
     private static class StoredState {
         private final String clusterManagerNodeId;
@@ -317,6 +324,11 @@ public class ClusterStateObserver {
         }
     }
 
+    /**
+     * Listener for the observer.
+     *
+     * @opensearch.internal
+     */
     public interface Listener {
 
         /** called when a new state is observed */
@@ -328,6 +340,11 @@ public class ClusterStateObserver {
         void onTimeout(TimeValue timeout);
     }
 
+    /**
+     * Context for the observer.
+     *
+     * @opensearch.internal
+     */
     static class ObservingContext {
         public final Listener listener;
         public final Predicate<ClusterState> statePredicate;
@@ -343,6 +360,11 @@ public class ClusterStateObserver {
         }
     }
 
+    /**
+     * A context preserving listener.
+     *
+     * @opensearch.internal
+     */
     private static final class ContextPreservingListener implements Listener {
         private final Listener delegate;
         private final Supplier<ThreadContext.StoredContext> contextSupplier;

--- a/server/src/main/java/org/opensearch/cluster/ClusterStateTaskConfig.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterStateTaskConfig.java
@@ -85,6 +85,11 @@ public interface ClusterStateTaskConfig {
         return new Basic(priority, timeout);
     }
 
+    /**
+     * Basic task config.
+     *
+     * @opensearch.internal
+     */
     class Basic implements ClusterStateTaskConfig {
         final TimeValue timeout;
         final Priority priority;

--- a/server/src/main/java/org/opensearch/cluster/ClusterStateTaskExecutor.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterStateTaskExecutor.java
@@ -81,6 +81,8 @@ public interface ClusterStateTaskExecutor<T> {
     /**
      * Represents the result of a batched execution of cluster state update tasks
      * @param <T> the type of the cluster state update task
+     *
+     * @opensearch.internal
      */
     class ClusterTasksResult<T> {
         @Nullable
@@ -101,6 +103,11 @@ public interface ClusterStateTaskExecutor<T> {
             return new Builder<>();
         }
 
+        /**
+         * Builder for cluster state task.
+         *
+         * @opensearch.internal
+         */
         public static class Builder<T> {
             private final Map<T, TaskResult> executionResults = new IdentityHashMap<>();
 
@@ -142,6 +149,11 @@ public interface ClusterStateTaskExecutor<T> {
         }
     }
 
+    /**
+     * The task result.
+     *
+     * @opensearch.internal
+     */
     final class TaskResult {
         private final Exception failure;
 

--- a/server/src/main/java/org/opensearch/cluster/DiffableUtils.java
+++ b/server/src/main/java/org/opensearch/cluster/DiffableUtils.java
@@ -229,6 +229,8 @@ public final class DiffableUtils {
      * Represents differences between two Maps of (possibly diffable) objects.
      *
      * @param <T> the diffable object
+     *
+     * @opensearch.internal
      */
     private static class JdkMapDiff<K, T> extends MapDiff<K, T, Map<K, T>> {
 
@@ -283,6 +285,8 @@ public final class DiffableUtils {
      * Represents differences between two ImmutableOpenMap of (possibly diffable) objects
      *
      * @param <T> the object type
+     *
+     * @opensearch.internal
      */
     public static class ImmutableOpenMapDiff<K, T> extends MapDiff<K, T, ImmutableOpenMap<K, T>> {
 
@@ -369,6 +373,8 @@ public final class DiffableUtils {
      * Represents differences between two ImmutableOpenIntMap of (possibly diffable) objects
      *
      * @param <T> the object type
+     *
+     * @opensearch.internal
      */
     private static class ImmutableOpenIntMapDiff<T> extends MapDiff<Integer, T, ImmutableOpenIntMap<T>> {
 
@@ -434,6 +440,8 @@ public final class DiffableUtils {
      * @param <K> the type of map keys
      * @param <T> the type of map values
      * @param <M> the map implementation type
+     *
+     * @opensearch.internal
      */
     public abstract static class MapDiff<K, T, M> implements Diff<M> {
 
@@ -553,6 +561,8 @@ public final class DiffableUtils {
     /**
      * Provides read and write operations to serialize keys of map
      * @param <K> type of key
+     *
+     * @opensearch.internal
      */
     public interface KeySerializer<K> {
         void writeKey(K key, StreamOutput out) throws IOException;
@@ -562,6 +572,8 @@ public final class DiffableUtils {
 
     /**
      * Serializes String keys of a map
+     *
+     * @opensearch.internal
      */
     private static final class StringKeySerializer implements KeySerializer<String> {
         private static final StringKeySerializer INSTANCE = new StringKeySerializer();
@@ -579,6 +591,8 @@ public final class DiffableUtils {
 
     /**
      * Serializes Integer keys of a map as an Int
+     *
+     * @opensearch.internal
      */
     private static final class IntKeySerializer implements KeySerializer<Integer> {
         public static final IntKeySerializer INSTANCE = new IntKeySerializer();
@@ -596,6 +610,8 @@ public final class DiffableUtils {
 
     /**
      * Serializes Integer keys of a map as a VInt. Requires keys to be positive.
+     *
+     * @opensearch.internal
      */
     private static final class VIntKeySerializer implements KeySerializer<Integer> {
         public static final IntKeySerializer INSTANCE = new IntKeySerializer();
@@ -625,6 +641,8 @@ public final class DiffableUtils {
      *
      * @param <K> key type of map
      * @param <V> value type of map
+     *
+     * @opensearch.internal
      */
     public interface ValueSerializer<K, V> {
 
@@ -679,6 +697,8 @@ public final class DiffableUtils {
      *
      * @param <K> type of map keys
      * @param <V> type of map values
+     *
+     * @opensearch.internal
      */
     public abstract static class DiffableValueSerializer<K, V extends Diffable<V>> implements ValueSerializer<K, V> {
         private static final DiffableValueSerializer WRITE_ONLY_INSTANCE = new DiffableValueSerializer() {
@@ -722,6 +742,8 @@ public final class DiffableUtils {
      *
      * @param <K> type of map keys
      * @param <V> type of map values
+     *
+     * @opensearch.internal
      */
     public abstract static class NonDiffableValueSerializer<K, V> implements ValueSerializer<K, V> {
         @Override
@@ -749,6 +771,8 @@ public final class DiffableUtils {
      * Implementation of the ValueSerializer that wraps value and diff readers.
      *
      * Note: this implementation is ignoring the key.
+     *
+     * @opensearch.internal
      */
     public static class DiffableValueReader<K, V extends Diffable<V>> extends DiffableValueSerializer<K, V> {
         private final Reader<V> reader;
@@ -774,6 +798,8 @@ public final class DiffableUtils {
      * Implementation of ValueSerializer that serializes immutable sets
      *
      * @param <K> type of map key
+     *
+     * @opensearch.internal
      */
     public static class StringSetValueSerializer<K> extends NonDiffableValueSerializer<K, Set<String>> {
         private static final StringSetValueSerializer INSTANCE = new StringSetValueSerializer();

--- a/server/src/main/java/org/opensearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/opensearch/cluster/InternalClusterInfoService.java
@@ -469,6 +469,11 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
         }
     }
 
+    /**
+     * Indices statistics summary.
+     *
+     * @opensearch.internal
+     */
     private static class IndicesStatsSummary {
         static final IndicesStatsSummary EMPTY = new IndicesStatsSummary(
             ImmutableOpenMap.of(),
@@ -493,6 +498,8 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
 
     /**
      * Runs {@link InternalClusterInfoService#refresh()}, logging failures/rejections appropriately.
+     *
+     * @opensearch.internal
      */
     private class RefreshRunnable extends AbstractRunnable {
         private final String reason;
@@ -526,6 +533,8 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
 
     /**
      * Runs {@link InternalClusterInfoService#refresh()}, logging failures/rejections appropriately, and reschedules itself on completion.
+     *
+     * @opensearch.internal
      */
     private class RefreshAndRescheduleRunnable extends RefreshRunnable {
         RefreshAndRescheduleRunnable() {

--- a/server/src/main/java/org/opensearch/cluster/NodeConnectionsService.java
+++ b/server/src/main/java/org/opensearch/cluster/NodeConnectionsService.java
@@ -229,6 +229,11 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
         runnables.forEach(Runnable::run);
     }
 
+    /**
+     * A connection checker.
+     *
+     * @opensearch.internal
+     */
     class ConnectionChecker extends AbstractRunnable {
         protected void doRun() {
             if (connectionChecker == this) {
@@ -311,6 +316,8 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
      * Similarly if we are currently disconnecting and then {@link ConnectionTarget#connect(ActionListener)} is called then all
      * disconnection listeners are immediately removed for failure notification and a connection is started once the disconnection is
      * complete.
+     *
+     * @opensearch.internal
      */
     private class ConnectionTarget {
         private final DiscoveryNode discoveryNode;

--- a/server/src/main/java/org/opensearch/cluster/RepositoryCleanupInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/RepositoryCleanupInProgress.java
@@ -117,6 +117,11 @@ public final class RepositoryCleanupInProgress extends AbstractNamedDiffable<Clu
         return LegacyESVersion.V_7_4_0;
     }
 
+    /**
+     * Entry in the collection.
+     *
+     * @opensearch.internal
+     */
     public static final class Entry implements Writeable, RepositoryOperation {
 
         private final String repository;

--- a/server/src/main/java/org/opensearch/cluster/RestoreInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/RestoreInProgress.java
@@ -112,6 +112,11 @@ public class RestoreInProgress extends AbstractNamedDiffable<Custom> implements 
         return entries.valuesIt();
     }
 
+    /**
+     * Builder of the restore.
+     *
+     * @opensearch.internal
+     */
     public static final class Builder {
 
         private final ImmutableOpenMap.Builder<String, Entry> entries = ImmutableOpenMap.builder();
@@ -134,6 +139,8 @@ public class RestoreInProgress extends AbstractNamedDiffable<Custom> implements 
 
     /**
      * Restore metadata
+     *
+     * @opensearch.internal
      */
     public static class Entry {
         private final String uuid;
@@ -237,6 +244,8 @@ public class RestoreInProgress extends AbstractNamedDiffable<Custom> implements 
 
     /**
      * Represents status of a restored shard
+     *
+     * @opensearch.internal
      */
     public static class ShardRestoreStatus implements Writeable {
         private State state;
@@ -360,6 +369,8 @@ public class RestoreInProgress extends AbstractNamedDiffable<Custom> implements 
 
     /**
      * Shard restore process state
+     *
+     * @opensearch.internal
      */
     public enum State {
         /**

--- a/server/src/main/java/org/opensearch/cluster/SnapshotDeletionsInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/SnapshotDeletionsInProgress.java
@@ -219,6 +219,8 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
 
     /**
      * A class representing a snapshot deletion request entry in the cluster state.
+     *
+     * @opensearch.internal
      */
     public static final class Entry implements Writeable, RepositoryOperation {
         private final List<SnapshotId> snapshots;
@@ -375,6 +377,11 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
         }
     }
 
+    /**
+     * State of the deletions.
+     *
+     * @opensearch.internal
+     */
     public enum State implements Writeable {
 
         /**

--- a/server/src/main/java/org/opensearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/SnapshotsInProgress.java
@@ -177,6 +177,11 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         );
     }
 
+    /**
+     * Entry in the collection.
+     *
+     * @opensearch.internal
+     */
     public static class Entry implements Writeable, ToXContent, RepositoryOperation {
         private final State state;
         private final Snapshot snapshot;
@@ -778,6 +783,11 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         return false;
     }
 
+    /**
+     * Status of shard snapshots.
+     *
+     * @opensearch.internal
+     */
     public static class ShardSnapshotStatus implements Writeable {
 
         /**
@@ -913,6 +923,11 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         }
     }
 
+    /**
+     * State of the snapshots.
+     *
+     * @opensearch.internal
+     */
     public enum State {
         INIT((byte) 0, false),
         STARTED((byte) 1, false),
@@ -1050,6 +1065,11 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         return builder;
     }
 
+    /**
+     * The shard state.
+     *
+     * @opensearch.internal
+     */
     public enum ShardState {
         INIT((byte) 0, false, false),
         SUCCESS((byte) 2, true, false),

--- a/server/src/main/java/org/opensearch/cluster/action/index/MappingUpdatedAction.java
+++ b/server/src/main/java/org/opensearch/cluster/action/index/MappingUpdatedAction.java
@@ -171,6 +171,11 @@ public class MappingUpdatedAction {
         return new UncategorizedExecutionException("Failed execution", root);
     }
 
+    /**
+     * An adjustable semaphore
+     *
+     * @opensearch.internal
+     */
     static class AdjustableSemaphore extends Semaphore {
 
         private final Object maxPermitsMutex = new Object();

--- a/server/src/main/java/org/opensearch/cluster/action/index/NodeMappingRefreshAction.java
+++ b/server/src/main/java/org/opensearch/cluster/action/index/NodeMappingRefreshAction.java
@@ -87,6 +87,11 @@ public class NodeMappingRefreshAction {
         transportService.sendRequest(clusterManagerNode, ACTION_NAME, request, EmptyTransportResponseHandler.INSTANCE_SAME);
     }
 
+    /**
+     * A handler for a node mapping refresh transport request.
+     *
+     * @opensearch.internal
+     */
     private class NodeMappingRefreshTransportHandler implements TransportRequestHandler<NodeMappingRefreshRequest> {
 
         @Override
@@ -96,6 +101,11 @@ public class NodeMappingRefreshAction {
         }
     }
 
+    /**
+     * Request to refresh node mapping.
+     *
+     * @opensearch.internal
+     */
     public static class NodeMappingRefreshRequest extends TransportRequest implements IndicesRequest {
 
         private String index;

--- a/server/src/main/java/org/opensearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/opensearch/cluster/action/shard/ShardStateAction.java
@@ -333,6 +333,11 @@ public class ShardStateAction {
         this.followUpRerouteTaskPriority = followUpRerouteTaskPriority;
     }
 
+    /**
+     * A transport handler for a shard failed action.
+     *
+     * @opensearch.internal
+     */
     private static class ShardFailedTransportHandler implements TransportRequestHandler<FailedShardEntry> {
         private final ClusterService clusterService;
         private final ShardFailedClusterStateTaskExecutor shardFailedClusterStateTaskExecutor;
@@ -416,6 +421,11 @@ public class ShardStateAction {
         }
     }
 
+    /**
+     * Executor if shard fails cluster state task.
+     *
+     * @opensearch.internal
+     */
     public static class ShardFailedClusterStateTaskExecutor implements ClusterStateTaskExecutor<FailedShardEntry> {
         private final AllocationService allocationService;
         private final RerouteService rerouteService;
@@ -552,6 +562,11 @@ public class ShardStateAction {
         }
     }
 
+    /**
+     * Entry for a failed shard.
+     *
+     * @opensearch.internal
+     */
     public static class FailedShardEntry extends TransportRequest {
         final ShardId shardId;
         final String allocationId;
@@ -658,6 +673,11 @@ public class ShardStateAction {
         sendShardAction(SHARD_STARTED_ACTION_NAME, currentState, entry, listener);
     }
 
+    /**
+     * Handler for a shard started action.
+     *
+     * @opensearch.internal
+     */
     private static class ShardStartedTransportHandler implements TransportRequestHandler<StartedShardEntry> {
         private final ClusterService clusterService;
         private final ShardStartedClusterStateTaskExecutor shardStartedClusterStateTaskExecutor;
@@ -687,6 +707,11 @@ public class ShardStateAction {
         }
     }
 
+    /**
+     * Executor for when shard starts cluster state.
+     *
+     * @opensearch.internal
+     */
     public static class ShardStartedClusterStateTaskExecutor
         implements
             ClusterStateTaskExecutor<StartedShardEntry>,
@@ -812,6 +837,11 @@ public class ShardStateAction {
         }
     }
 
+    /**
+     * try for started shard.
+     *
+     * @opensearch.internal
+     */
     public static class StartedShardEntry extends TransportRequest {
         final ShardId shardId;
         final String allocationId;
@@ -855,6 +885,11 @@ public class ShardStateAction {
         }
     }
 
+    /**
+     * Error thrown when a shard is no longer primary.
+     *
+     * @opensearch.internal
+     */
     public static class NoLongerPrimaryShardException extends OpenSearchException {
 
         public NoLongerPrimaryShardException(ShardId shardId, String msg) {

--- a/server/src/main/java/org/opensearch/cluster/block/ClusterBlocks.java
+++ b/server/src/main/java/org/opensearch/cluster/block/ClusterBlocks.java
@@ -321,6 +321,11 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> {
         return AbstractDiffable.readDiffFrom(ClusterBlocks::readFrom, in);
     }
 
+    /**
+     * An immutable level holder.
+     *
+     * @opensearch.internal
+     */
     static class ImmutableLevelHolder {
 
         private final Set<ClusterBlock> global;
@@ -344,6 +349,11 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> {
         return new Builder();
     }
 
+    /**
+     * Builder for cluster blocks.
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
 
         private final Set<ClusterBlock> global = new HashSet<>();

--- a/server/src/main/java/org/opensearch/cluster/coordination/ClusterFormationFailureHelper.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/ClusterFormationFailureHelper.java
@@ -107,6 +107,11 @@ public class ClusterFormationFailureHelper {
         warningScheduler = null;
     }
 
+    /**
+     * A warning scheduler.
+     *
+     * @opensearch.internal
+     */
     private class WarningScheduler {
 
         private boolean isActive() {
@@ -143,6 +148,11 @@ public class ClusterFormationFailureHelper {
         }
     }
 
+    /**
+     * State of the cluster formation.
+     *
+     * @opensearch.internal
+     */
     static class ClusterFormationState {
         private final Settings settings;
         private final ClusterState clusterState;

--- a/server/src/main/java/org/opensearch/cluster/coordination/ClusterStatePublisher.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/ClusterStatePublisher.java
@@ -56,6 +56,11 @@ public interface ClusterStatePublisher {
      */
     void publish(ClusterChangedEvent clusterChangedEvent, ActionListener<Void> publishListener, AckListener ackListener);
 
+    /**
+     * An acknowledgement listener.
+     *
+     * @opensearch.internal
+     */
     interface AckListener {
         /**
          * Should be called when the cluster coordination layer has committed the cluster state (i.e. even if this publication fails,

--- a/server/src/main/java/org/opensearch/cluster/coordination/CoordinationMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/CoordinationMetadata.java
@@ -211,6 +211,11 @@ public class CoordinationMetadata implements Writeable, ToXContentFragment {
             + '}';
     }
 
+    /**
+     * Builder for coordination metadata.
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
         private long term = 0;
         private VotingConfiguration lastCommittedConfiguration = VotingConfiguration.EMPTY_CONFIG;
@@ -258,6 +263,11 @@ public class CoordinationMetadata implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * Excluded nodes from voting config.
+     *
+     * @opensearch.internal
+     */
     public static class VotingConfigExclusion implements Writeable, ToXContentFragment {
         public static final String MISSING_VALUE_MARKER = "_absent_";
         private final String nodeId;
@@ -351,6 +361,8 @@ public class CoordinationMetadata implements Writeable, ToXContentFragment {
 
     /**
      * A collection of persistent node ids, denoting the voting configuration for cluster state changes.
+     *
+     * @opensearch.internal
      */
     public static class VotingConfiguration implements Writeable, ToXContentFragment {
 

--- a/server/src/main/java/org/opensearch/cluster/coordination/CoordinationState.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/CoordinationState.java
@@ -569,6 +569,8 @@ public class CoordinationState {
 
     /**
      * Pluggable persistence layer for {@link CoordinationState}.
+     *
+     * @opensearch.internal
      */
     public interface PersistedState extends Closeable {
 
@@ -641,6 +643,8 @@ public class CoordinationState {
 
     /**
      * A collection of votes, used to calculate quorums. Optionally records the Joins as well.
+     *
+     * @opensearch.internal
      */
     public static class VoteCollection {
 

--- a/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java
@@ -1351,12 +1351,22 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         return onJoinValidators;
     }
 
+    /**
+     * The mode of the coordinator.
+     *
+     * @opensearch.internal
+     */
     public enum Mode {
         CANDIDATE,
         LEADER,
         FOLLOWER
     }
 
+    /**
+     * The coordinator peer finder.
+     *
+     * @opensearch.internal
+     */
     private class CoordinatorPeerFinder extends PeerFinder {
 
         CoordinatorPeerFinder(
@@ -1480,6 +1490,11 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         }
     }
 
+    /**
+     * The coordinator publication.
+     *
+     * @opensearch.internal
+     */
     class CoordinatorPublication extends Publication {
 
         private final PublishRequest publishRequest;

--- a/server/src/main/java/org/opensearch/cluster/coordination/ElectionSchedulerFactory.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/ElectionSchedulerFactory.java
@@ -183,6 +183,11 @@ public class ElectionSchedulerFactory {
             + '}';
     }
 
+    /**
+     * The Election scheduler.
+     *
+     * @opensearch.internal
+     */
     private class ElectionScheduler implements Releasable {
         private final AtomicBoolean isClosed = new AtomicBoolean();
         private final AtomicLong attempt = new AtomicLong();

--- a/server/src/main/java/org/opensearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/FollowersChecker.java
@@ -294,6 +294,11 @@ public class FollowersChecker {
         }
     }
 
+    /**
+     * A fast response state.
+     *
+     * @opensearch.internal
+     */
     static class FastResponseState {
         final long term;
         final Mode mode;
@@ -311,6 +316,8 @@ public class FollowersChecker {
 
     /**
      * A checker for an individual follower.
+     *
+     * @opensearch.internal
      */
     private class FollowerChecker {
         private final DiscoveryNode discoveryNode;
@@ -449,6 +456,11 @@ public class FollowersChecker {
         }
     }
 
+    /**
+     * Request to check follower.
+     *
+     * @opensearch.internal
+     */
     public static class FollowerCheckRequest extends TransportRequest {
 
         private final long term;

--- a/server/src/main/java/org/opensearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/JoinHelper.java
@@ -253,6 +253,11 @@ public class JoinHelper {
         sendJoinRequest(destination, term, optionalJoin, () -> {});
     }
 
+    /**
+     * A failed join attempt.
+     *
+     * @opensearch.internal
+     */
     // package-private for testing
     static class FailedJoinAttempt {
         private final DiscoveryNode destination;
@@ -392,12 +397,22 @@ public class JoinHelper {
         );
     }
 
+    /**
+     * The callback interface.
+     *
+     * @opensearch.internal
+     */
     public interface JoinCallback {
         void onSuccess();
 
         void onFailure(Exception e);
     }
 
+    /**
+     * Listener for the join task
+     *
+     * @opensearch.internal
+     */
     static class JoinTaskListener implements ClusterStateTaskListener {
         private final JoinTaskExecutor.Task task;
         private final JoinCallback joinCallback;
@@ -429,6 +444,11 @@ public class JoinHelper {
         default void close(Mode newMode) {}
     }
 
+    /**
+     * A leader join accumulator.
+     *
+     * @opensearch.internal
+     */
     class LeaderJoinAccumulator implements JoinAccumulator {
         @Override
         public void handleJoinRequest(DiscoveryNode sender, JoinCallback joinCallback) {
@@ -449,6 +469,11 @@ public class JoinHelper {
         }
     }
 
+    /**
+     * An initial join accumulator.
+     *
+     * @opensearch.internal
+     */
     static class InitialJoinAccumulator implements JoinAccumulator {
         @Override
         public void handleJoinRequest(DiscoveryNode sender, JoinCallback joinCallback) {
@@ -462,6 +487,11 @@ public class JoinHelper {
         }
     }
 
+    /**
+     * A follower join accumulator.
+     *
+     * @opensearch.internal
+     */
     static class FollowerJoinAccumulator implements JoinAccumulator {
         @Override
         public void handleJoinRequest(DiscoveryNode sender, JoinCallback joinCallback) {
@@ -474,6 +504,11 @@ public class JoinHelper {
         }
     }
 
+    /**
+     * A candidate join accumulator.
+     *
+     * @opensearch.internal
+     */
     class CandidateJoinAccumulator implements JoinAccumulator {
 
         private final Map<DiscoveryNode, JoinCallback> joinRequestAccumulator = new HashMap<>();

--- a/server/src/main/java/org/opensearch/cluster/coordination/JoinTaskExecutor.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/JoinTaskExecutor.java
@@ -75,6 +75,11 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
     private final RerouteService rerouteService;
     private final TransportService transportService;
 
+    /**
+     * Task for the join task executor.
+     *
+     * @opensearch.internal
+     */
     public static class Task {
 
         private final DiscoveryNode node;

--- a/server/src/main/java/org/opensearch/cluster/coordination/LagDetector.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/LagDetector.java
@@ -151,6 +151,11 @@ public class LagDetector {
         return Collections.unmodifiableSet(appliedStateTrackersByNode.keySet());
     }
 
+    /**
+     * A tracker that the node applied state.
+     *
+     * @opensearch.internal
+     */
     private class NodeAppliedStateTracker {
         private final DiscoveryNode discoveryNode;
         private final AtomicLong appliedVersion = new AtomicLong();

--- a/server/src/main/java/org/opensearch/cluster/coordination/LeaderChecker.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/LeaderChecker.java
@@ -233,6 +233,11 @@ public class LeaderChecker {
         }
     }
 
+    /**
+     * A check scheduler.
+     *
+     * @opensearch.internal
+     */
     private class CheckScheduler implements Releasable {
 
         private final AtomicBoolean isClosed = new AtomicBoolean();
@@ -380,6 +385,11 @@ public class LeaderChecker {
         }
     }
 
+    /**
+     * A leader check request.
+     *
+     * @opensearch.internal
+     */
     static class LeaderCheckRequest extends TransportRequest {
 
         private final DiscoveryNode sender;

--- a/server/src/main/java/org/opensearch/cluster/coordination/NodeRemovalClusterStateTaskExecutor.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/NodeRemovalClusterStateTaskExecutor.java
@@ -56,6 +56,11 @@ public class NodeRemovalClusterStateTaskExecutor
     private final AllocationService allocationService;
     private final Logger logger;
 
+    /**
+     * Task for the executor.
+     *
+     * @opensearch.internal
+     */
     public static class Task {
 
         private final DiscoveryNode node;

--- a/server/src/main/java/org/opensearch/cluster/coordination/OpenSearchNodeCommand.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/OpenSearchNodeCommand.java
@@ -230,6 +230,11 @@ public abstract class OpenSearchNodeCommand extends EnvironmentAwareCommand {
         return parser;
     }
 
+    /**
+     * Custom unknown metadata.
+     *
+     * @opensearch.internal
+     */
     public static class UnknownMetadataCustom implements Metadata.Custom {
 
         private final String name;
@@ -274,6 +279,11 @@ public abstract class OpenSearchNodeCommand extends EnvironmentAwareCommand {
         }
     }
 
+    /**
+     * An unknown condition.
+     *
+     * @opensearch.internal
+     */
     public static class UnknownCondition extends Condition<Object> {
 
         public UnknownCondition(String name, Object value) {

--- a/server/src/main/java/org/opensearch/cluster/coordination/PendingClusterStateStats.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/PendingClusterStateStats.java
@@ -92,6 +92,11 @@ public class PendingClusterStateStats implements Writeable, ToXContentFragment {
         return builder;
     }
 
+    /**
+     * Fields for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     static final class Fields {
         static final String QUEUE = "cluster_state_queue";
         static final String TOTAL = "total";

--- a/server/src/main/java/org/opensearch/cluster/coordination/PreVoteCollector.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/PreVoteCollector.java
@@ -167,6 +167,11 @@ public class PreVoteCollector {
         return "PreVoteCollector{" + "state=" + state + '}';
     }
 
+    /**
+     * The pre vote round.
+     *
+     * @opensearch.internal
+     */
     private class PreVotingRound implements Releasable {
         private final Map<DiscoveryNode, PreVoteResponse> preVotesReceived = newConcurrentMap();
         private final AtomicBoolean electionStarted = new AtomicBoolean();

--- a/server/src/main/java/org/opensearch/cluster/coordination/Publication.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/Publication.java
@@ -252,6 +252,11 @@ public abstract class Publication {
         APPLIED_COMMIT,
     }
 
+    /**
+     * A publication target.
+     *
+     * @opensearch.internal
+     */
     class PublicationTarget {
         private final DiscoveryNode discoveryNode;
         private boolean ackIsPending = true;
@@ -363,6 +368,11 @@ public abstract class Publication {
             return state == PublicationTargetState.FAILED;
         }
 
+        /**
+         * A handler for a publish response.
+         *
+         * @opensearch.internal
+         */
         private class PublishResponseHandler implements ActionListener<PublishWithJoinResponse> {
 
             @Override
@@ -404,6 +414,11 @@ public abstract class Publication {
 
         }
 
+        /**
+         * An apply commit response handler.
+         *
+         * @opensearch.internal
+         */
         private class ApplyCommitResponseHandler implements ActionListener<TransportResponse.Empty> {
 
             @Override

--- a/server/src/main/java/org/opensearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/PublicationTransportHandler.java
@@ -284,6 +284,8 @@ public class PublicationTransportHandler {
      * Publishing a cluster state typically involves sending the same cluster state (or diff) to every node, so the work of diffing,
      * serializing, and compressing the state can be done once and the results shared across publish requests. The
      * {@code PublicationContext} implements this sharing.
+     *
+     * @opensearch.internal
      */
     public class PublicationContext {
 

--- a/server/src/main/java/org/opensearch/cluster/coordination/Reconfigurator.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/Reconfigurator.java
@@ -170,6 +170,11 @@ public class Reconfigurator {
         }
     }
 
+    /**
+     * A node to handle voting configs.
+     *
+     * @opensearch.internal
+     */
     static class VotingConfigNode implements Comparable<VotingConfigNode> {
         final String id;
         final boolean live;

--- a/server/src/main/java/org/opensearch/cluster/metadata/AliasAction.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AliasAction.java
@@ -76,6 +76,8 @@ public abstract class AliasAction {
 
     /**
      * Validate a new alias.
+     *
+     * @opensearch.internal
      */
     @FunctionalInterface
     public interface NewAliasValidator {
@@ -84,6 +86,8 @@ public abstract class AliasAction {
 
     /**
      * Operation to add an alias to an index.
+     *
+     * @opensearch.internal
      */
     public static class Add extends AliasAction {
         private final String alias;
@@ -174,6 +178,8 @@ public abstract class AliasAction {
 
     /**
      * Operation to remove an alias from an index.
+     *
+     * @opensearch.internal
      */
     public static class Remove extends AliasAction {
         private final String alias;
@@ -220,6 +226,8 @@ public abstract class AliasAction {
     /**
      * Operation to remove an index. This is an "alias action" because it allows us to remove an index at the same time as we remove add an
      * alias to replace it.
+     *
+     * @opensearch.internal
      */
     public static class RemoveIndex extends AliasAction {
         public RemoveIndex(String index) {

--- a/server/src/main/java/org/opensearch/cluster/metadata/AliasMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AliasMetadata.java
@@ -276,6 +276,11 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
         return builder;
     }
 
+    /**
+     * Builder of alias metadata.
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
 
         private final String alias;

--- a/server/src/main/java/org/opensearch/cluster/metadata/ClusterNameExpressionResolver.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/ClusterNameExpressionResolver.java
@@ -68,6 +68,11 @@ public final class ClusterNameExpressionResolver {
         }
     }
 
+    /**
+     * A wildcard expression resolver.
+     *
+     * @opensearch.internal
+     */
     private static class WildcardExpressionResolver {
 
         private List<String> resolve(Set<String> remoteClusters, String clusterExpression) {

--- a/server/src/main/java/org/opensearch/cluster/metadata/ComponentTemplateMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/ComponentTemplateMetadata.java
@@ -156,6 +156,11 @@ public class ComponentTemplateMetadata implements Metadata.Custom {
         return Strings.toString(this);
     }
 
+    /**
+     * A diff between component template metadata.
+     *
+     * @opensearch.internal
+     */
     static class ComponentTemplateMetadataDiff implements NamedDiff<Metadata.Custom> {
 
         final Diff<Map<String, ComponentTemplate>> componentTemplateDiff;

--- a/server/src/main/java/org/opensearch/cluster/metadata/ComposableIndexTemplate.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/ComposableIndexTemplate.java
@@ -289,6 +289,11 @@ public class ComposableIndexTemplate extends AbstractDiffable<ComposableIndexTem
         return Strings.toString(this);
     }
 
+    /**
+     * Template for data stream.
+     *
+     * @opensearch.internal
+     */
     public static class DataStreamTemplate implements Writeable, ToXContentObject {
 
         private static final ParseField TIMESTAMP_FIELD_FIELD = new ParseField("timestamp_field");

--- a/server/src/main/java/org/opensearch/cluster/metadata/ComposableIndexTemplateMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/ComposableIndexTemplateMetadata.java
@@ -157,6 +157,11 @@ public class ComposableIndexTemplateMetadata implements Metadata.Custom {
         return Strings.toString(this);
     }
 
+    /**
+     * A diff between composable metadata templates.
+     *
+     * @opensearch.internal
+     */
     static class ComposableIndexTemplateMetadataDiff implements NamedDiff<Metadata.Custom> {
 
         final Diff<Map<String, ComposableIndexTemplate>> indexTemplateDiff;

--- a/server/src/main/java/org/opensearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/DataStream.java
@@ -232,6 +232,11 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
         return Objects.hash(name, timeStampField, indices, generation);
     }
 
+    /**
+     * A timestamp field.
+     *
+     * @opensearch.internal
+     */
     public static final class TimestampField implements Writeable, ToXContentObject {
 
         static ParseField NAME_FIELD = new ParseField("name");

--- a/server/src/main/java/org/opensearch/cluster/metadata/DataStreamMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/DataStreamMetadata.java
@@ -161,6 +161,11 @@ public class DataStreamMetadata implements Metadata.Custom {
         return Strings.toString(this);
     }
 
+    /**
+     * Builder of data stream metadata.
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
 
         private final Map<String, DataStream> dataStreams = new HashMap<>();
@@ -175,6 +180,11 @@ public class DataStreamMetadata implements Metadata.Custom {
         }
     }
 
+    /**
+     * A diff between data stream metadata.
+     *
+     * @opensearch.internal
+     */
     static class DataStreamMetadataDiff implements NamedDiff<Metadata.Custom> {
 
         final Diff<Map<String, DataStream>> dataStreamDiff;

--- a/server/src/main/java/org/opensearch/cluster/metadata/DiffableStringMap.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/DiffableStringMap.java
@@ -90,6 +90,8 @@ public class DiffableStringMap extends AbstractMap<String, String> implements Di
 
     /**
      * Represents differences between two DiffableStringMaps.
+     *
+     * @opensearch.internal
      */
     public static class DiffableStringMapDiff implements Diff<DiffableStringMap> {
 

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexAbstraction.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexAbstraction.java
@@ -139,6 +139,8 @@ public interface IndexAbstraction {
 
     /**
      * Represents an concrete index and encapsulates its {@link IndexMetadata}
+     *
+     * @opensearch.internal
      */
     class Index implements IndexAbstraction {
 
@@ -192,6 +194,8 @@ public interface IndexAbstraction {
 
     /**
      * Represents an alias and groups all {@link IndexMetadata} instances sharing the same alias name together.
+     *
+     * @opensearch.internal
      */
     class Alias implements IndexAbstraction {
 
@@ -329,6 +333,11 @@ public interface IndexAbstraction {
         }
     }
 
+    /**
+     * A data stream.
+     *
+     * @opensearch.internal
+     */
     class DataStream implements IndexAbstraction {
 
         private final org.opensearch.cluster.metadata.DataStream dataStream;

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexGraveyard.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexGraveyard.java
@@ -190,6 +190,8 @@ public final class IndexGraveyard implements Metadata.Custom {
 
     /**
      * A class to build an IndexGraveyard.
+     *
+     * @opensearch.internal
      */
     public static final class Builder {
         private List<Tombstone> tombstones;
@@ -275,6 +277,8 @@ public final class IndexGraveyard implements Metadata.Custom {
 
     /**
      * A class representing a diff of two IndexGraveyard objects.
+     *
+     * @opensearch.internal
      */
     public static final class IndexGraveyardDiff implements NamedDiff<Metadata.Custom> {
 
@@ -362,6 +366,8 @@ public final class IndexGraveyard implements Metadata.Custom {
 
     /**
      * An individual tombstone entry for representing a deleted index.
+     *
+     * @opensearch.internal
      */
     public static final class Tombstone implements ToXContentObject, Writeable {
 
@@ -460,6 +466,8 @@ public final class IndexGraveyard implements Metadata.Custom {
 
         /**
          * A builder for building tombstone entries.
+         *
+         * @opensearch.internal
          */
         private static final class Builder {
             private Index index;

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -149,6 +149,11 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         EnumSet.of(ClusterBlockLevel.METADATA_WRITE, ClusterBlockLevel.WRITE)
     );
 
+    /**
+     * The state of the index.
+     *
+     * @opensearch.internal
+     */
     public enum State {
         OPEN((byte) 0),
         CLOSE((byte) 1);
@@ -281,6 +286,11 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     public static final String SETTING_AUTO_EXPAND_REPLICAS = "index.auto_expand_replicas";
     public static final Setting<AutoExpandReplicas> INDEX_AUTO_EXPAND_REPLICAS_SETTING = AutoExpandReplicas.SETTING;
 
+    /**
+     * Blocks the API.
+     *
+     * @opensearch.internal
+     */
     public enum APIBlock implements Writeable {
         READ_ONLY("read_only", INDEX_READ_ONLY_BLOCK),
         READ("read", INDEX_READ_BLOCK),
@@ -832,6 +842,11 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         return builder;
     }
 
+    /**
+     * A diff of index metadata.
+     *
+     * @opensearch.internal
+     */
     private static class IndexMetadataDiff implements Diff<IndexMetadata> {
 
         private final String index;
@@ -1058,6 +1073,11 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         return new Builder(indexMetadata);
     }
 
+    /**
+     * Builder of index metadata.
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
 
         private String index;

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -773,6 +773,11 @@ public class IndexNameExpressionResolver {
         return Booleans.parseBoolean(threadContext.getHeader(SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY), true);
     }
 
+    /**
+     * Context for the resolver.
+     *
+     * @opensearch.internal
+     */
     public static class Context {
 
         private final ClusterState state;
@@ -912,6 +917,8 @@ public class IndexNameExpressionResolver {
 
     /**
      * Resolves alias/index name expressions with wildcards into the corresponding concrete indices/aliases
+     *
+     * @opensearch.internal
      */
     static final class WildcardExpressionResolver implements ExpressionResolver {
 
@@ -1192,6 +1199,11 @@ public class IndexNameExpressionResolver {
         }
     }
 
+    /**
+     * A date math expression resolver.
+     *
+     * @opensearch.internal
+     */
     public static final class DateMathExpressionResolver implements ExpressionResolver {
 
         private static final DateFormatter DEFAULT_DATE_FORMATTER = DateFormatter.forPattern("uuuu.MM.dd");

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexTemplateMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexTemplateMetadata.java
@@ -270,6 +270,11 @@ public class IndexTemplateMetadata extends AbstractDiffable<IndexTemplateMetadat
         }
     }
 
+    /**
+     * Builder of index template metadata.
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
 
         private static final Set<String> VALID_FIELDS = Sets.newHashSet(

--- a/server/src/main/java/org/opensearch/cluster/metadata/Manifest.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/Manifest.java
@@ -233,6 +233,11 @@ public class Manifest implements ToXContentFragment {
         return globalGeneration == MISSING_GLOBAL_GENERATION;
     }
 
+    /**
+     * An index entry.
+     *
+     * @opensearch.internal
+     */
     private static final class IndexEntry implements ToXContentFragment {
         private static final ParseField INDEX_GENERATION_PARSE_FIELD = new ParseField("generation");
         private static final ParseField INDEX_PARSE_FIELD = new ParseField("index");

--- a/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
@@ -112,6 +112,11 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
     public static final String UNKNOWN_CLUSTER_UUID = "_na_";
     public static final Pattern NUMBER_PATTERN = Pattern.compile("[0-9]+$");
 
+    /**
+     * Context of the XContent.
+     *
+     * @opensearch.internal
+     */
     public enum XContentContext {
         /* Custom metadata should be returns as part of API call */
         API,
@@ -146,6 +151,11 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
      */
     public static EnumSet<XContentContext> ALL_CONTEXTS = EnumSet.allOf(XContentContext.class);
 
+    /**
+     * Custom metadata.
+     *
+     * @opensearch.internal
+     */
     public interface Custom extends NamedDiffable<Custom>, ToXContentFragment, ClusterState.FeatureAware {
 
         EnumSet<XContentContext> context();
@@ -920,6 +930,11 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         return builder;
     }
 
+    /**
+     * A diff of metadata.
+     *
+     * @opensearch.internal
+     */
     private static class MetadataDiff implements Diff<Metadata> {
 
         private final long version;
@@ -1088,6 +1103,11 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         return new Builder(metadata);
     }
 
+    /**
+     * Builder of metadata.
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
 
         private String clusterUUID;

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -125,6 +125,11 @@ public class MetadataCreateDataStreamService {
         return createDataStream(metadataCreateIndexService, current, request);
     }
 
+    /**
+     * A request to create a data stream cluster state update
+     *
+     * @opensearch.internal
+     */
     public static final class CreateDataStreamClusterStateUpdateRequest extends ClusterStateUpdateRequest {
 
         private final String name;

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexStateService.java
@@ -583,6 +583,8 @@ public class MetadataIndexStateService {
      * This step iterates over the indices previously blocked and sends a {@link TransportVerifyShardBeforeCloseAction} to each shard. If
      * this action succeed then the shard is considered to be ready for closing. When all shards of a given index are ready for closing,
      * the index is considered ready to be closed.
+     *
+     * @opensearch.internal
      */
     class WaitForClosedBlocksApplied extends ActionRunnable<Map<Index, IndexResult>> {
 
@@ -715,6 +717,8 @@ public class MetadataIndexStateService {
     /**
      * Helper class that coordinates with shards to ensure that blocks have been properly applied to all shards using
      * {@link TransportVerifyShardIndexBlockAction}.
+     *
+     * @opensearch.metadata
      */
     class WaitForBlocksApplied extends ActionRunnable<Map<Index, AddBlockResult>> {
 

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -1498,6 +1498,11 @@ public class MetadataIndexTemplateService {
         }
     }
 
+    /**
+     * Listener for putting metadata in the template
+     *
+     * @opensearch.internal
+     */
     public interface PutListener {
 
         void onResponse(PutResponse response);
@@ -1505,6 +1510,11 @@ public class MetadataIndexTemplateService {
         void onFailure(Exception e);
     }
 
+    /**
+     * A PUT request.
+     *
+     * @opensearch.internal
+     */
     public static class PutRequest {
         final String name;
         final String cause;
@@ -1564,6 +1574,11 @@ public class MetadataIndexTemplateService {
         }
     }
 
+    /**
+     * The PUT response.
+     *
+     * @opensearch.internal
+     */
     public static class PutResponse {
         private final boolean acknowledged;
 
@@ -1576,6 +1591,11 @@ public class MetadataIndexTemplateService {
         }
     }
 
+    /**
+     * A remove Request.
+     *
+     * @opensearch.internal
+     */
     public static class RemoveRequest {
         final String name;
         TimeValue masterTimeout = MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT;
@@ -1590,6 +1610,11 @@ public class MetadataIndexTemplateService {
         }
     }
 
+    /**
+     * A remove Response.
+     *
+     * @opensearch.internal
+     */
     public static class RemoveResponse {
         private final boolean acknowledged;
 
@@ -1602,6 +1627,11 @@ public class MetadataIndexTemplateService {
         }
     }
 
+    /**
+     * A remove listener.
+     *
+     * @opensearch.internal
+     */
     public interface RemoveListener {
 
         void onResponse(RemoveResponse response);

--- a/server/src/main/java/org/opensearch/cluster/metadata/SystemIndexMetadataUpgradeService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/SystemIndexMetadataUpgradeService.java
@@ -94,6 +94,11 @@ public class SystemIndexMetadataUpgradeService implements ClusterStateListener {
         }
     }
 
+    /**
+     * Task to update system index metadata.
+     *
+     * @opensearch.internal
+     */
     public class SystemIndexMetadataUpdateTask extends ClusterStateUpdateTask {
 
         @Override

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeFilters.java
@@ -52,6 +52,11 @@ import java.util.stream.Collectors;
  */
 public class DiscoveryNodeFilters {
 
+    /**
+     * Operation type.
+     *
+     * @opensearch.internal
+     */
     public enum OpType {
         AND,
         OR

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodes.java
@@ -515,6 +515,11 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
         return sb.toString();
     }
 
+    /**
+     * Delta between nodes.
+     *
+     * @opensearch.internal
+     */
     public static class Delta {
 
         private final String localNodeId;
@@ -658,6 +663,11 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
         return new Builder(nodes);
     }
 
+    /**
+     * Builder of a map of discovery nodes.
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
 
         private final ImmutableOpenMap.Builder<String, DiscoveryNode> nodes;

--- a/server/src/main/java/org/opensearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/IndexRoutingTable.java
@@ -365,6 +365,11 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
         return new Builder(index);
     }
 
+    /**
+     * Builder of a routing table.
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
 
         private final Index index;

--- a/server/src/main/java/org/opensearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/IndexShardRoutingTable.java
@@ -698,6 +698,11 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
         return count;
     }
 
+    /**
+     * Builder of an index shard routing table.
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
 
         private ShardId shardId;

--- a/server/src/main/java/org/opensearch/cluster/routing/RecoverySource.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RecoverySource.java
@@ -106,6 +106,11 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
 
     }
 
+    /**
+     * Type of recovery.
+     *
+     * @opensearch.internal
+     */
     public enum Type {
         EMPTY_STORE,
         EXISTING_STORE,
@@ -141,6 +146,8 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
 
     /**
      * Recovery from a fresh copy
+     *
+     * @opensearch.internal
      */
     public static final class EmptyStoreRecoverySource extends RecoverySource {
         public static final EmptyStoreRecoverySource INSTANCE = new EmptyStoreRecoverySource();
@@ -158,6 +165,8 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
 
     /**
      * Recovery from an existing on-disk store
+     *
+     * @opensearch.internal
      */
     public static final class ExistingStoreRecoverySource extends RecoverySource {
         /**
@@ -211,6 +220,8 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
 
     /**
      * recovery from other shards on same node (shrink index action)
+     *
+     * @opensearch.internal
      */
     public static class LocalShardsRecoverySource extends RecoverySource {
 
@@ -232,6 +243,8 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
 
     /**
      * recovery from a snapshot
+     *
+     * @opensearch.internal
      */
     public static class SnapshotRecoverySource extends RecoverySource {
 
@@ -338,6 +351,8 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
 
     /**
      * peer recovery from a primary shard
+     *
+     * @opensearch.internal
      */
     public static class PeerRecoverySource extends RecoverySource {
 

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingChangesObserver.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingChangesObserver.java
@@ -137,6 +137,11 @@ public interface RoutingChangesObserver {
         }
     }
 
+    /**
+     * Observer of routing changes.
+     *
+     * @opensearch.internal
+     */
     class DelegatingRoutingChangesObserver implements RoutingChangesObserver {
 
         private final RoutingChangesObserver[] routingChangesObservers;

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
@@ -893,6 +893,11 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         return nodesToShards.size();
     }
 
+    /**
+     * Unassigned shard list.
+     *
+     * @opensearch.internal
+     */
     public static final class UnassignedShards implements Iterable<ShardRouting> {
 
         private final RoutingNodes nodes;
@@ -989,6 +994,11 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             ignored.add(shard);
         }
 
+        /**
+         * An unassigned iterator.
+         *
+         * @opensearch.internal
+         */
         public class UnassignedIterator implements Iterator<ShardRouting>, ExistingShardsAllocator.UnassignedAllocationHandler {
 
             private final ListIterator<ShardRouting> iterator;
@@ -1369,6 +1379,11 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         }
     }
 
+    /**
+     * A collection of recoveries.
+     *
+     * @opensearch.internal
+     */
     private static final class Recoveries {
         private static final Recoveries EMPTY = new Recoveries();
         private int incoming = 0;

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
@@ -424,6 +424,8 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
 
     /**
      * Builder for the routing table. Note that build can only be called one time.
+     *
+     * @opensearch.internal
      */
     public static class Builder {
 

--- a/server/src/main/java/org/opensearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/UnassignedInfo.java
@@ -81,6 +81,8 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
      * <p>
      * Note, ordering of the enum is important, make sure to add new values
      * at the end and handle version serialization properly.
+     *
+     * @opensearch.internal
      */
     public enum Reason {
         /**
@@ -155,6 +157,8 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
      *
      * Note, ordering of the enum is important, make sure to add new values
      * at the end and handle version serialization properly.
+     *
+     * @opensearch.internal
      */
     public enum AllocationStatus implements Writeable {
         /**

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/AllocationService.java
@@ -742,6 +742,8 @@ public class AllocationService {
     /**
      * this class is used to describe results of applying a set of
      * {@link org.opensearch.cluster.routing.allocation.command.AllocationCommand}
+     *
+     * @opensearch.internal
      */
     public static class CommandsResult {
 

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
@@ -142,6 +142,11 @@ public class DiskThresholdSettings {
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING, this::setEnabled);
     }
 
+    /**
+     * Validates a low disk watermark.
+     *
+     * @opensearch.internal
+     */
     static final class LowDiskWatermarkValidator implements Setting.Validator<String> {
 
         @Override
@@ -167,6 +172,11 @@ public class DiskThresholdSettings {
 
     }
 
+    /**
+     * Validates a high disk watermark.
+     *
+     * @opensearch.internal
+     */
     static final class HighDiskWatermarkValidator implements Setting.Validator<String> {
 
         @Override
@@ -192,6 +202,11 @@ public class DiskThresholdSettings {
 
     }
 
+    /**
+     * Validates the flood stage.
+     *
+     * @opensearch.internal
+     */
     static final class FloodStageValidator implements Setting.Validator<String> {
 
         @Override

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/NodeAllocationResult.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/NodeAllocationResult.java
@@ -188,7 +188,11 @@ public class NodeAllocationResult implements ToXContentObject, Writeable, Compar
         return nodeResultComparator.compare(this, other);
     }
 
-    /** A class that captures metadata about a shard store on a node. */
+    /**
+     * A class that captures metadata about a shard store on a node.
+     *
+     * @openserach.internal
+     */
     public static final class ShardStoreInfo implements ToXContentFragment, Writeable {
         private final boolean inSync;
         @Nullable

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/NodeAllocationResult.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/NodeAllocationResult.java
@@ -191,7 +191,7 @@ public class NodeAllocationResult implements ToXContentObject, Writeable, Compar
     /**
      * A class that captures metadata about a shard store on a node.
      *
-     * @openserach.internal
+     * @opensearch.internal
      */
     public static final class ShardStoreInfo implements ToXContentFragment, Writeable {
         private final boolean inSync;

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/RoutingAllocation.java
@@ -315,6 +315,11 @@ public class RoutingAllocation {
         this.hasPendingAsyncFetch = true;
     }
 
+    /**
+     * Debug mode.
+     *
+     * @opensearch.internal
+     */
     public enum DebugMode {
         /**
          * debug mode is off

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -291,6 +291,8 @@ public class BalancedShardsAllocator implements ShardsAllocator {
 
     /**
      * A {@link Balancer}
+     *
+     * @opensearch.internal
      */
     public static class Balancer {
         private final Logger logger;
@@ -1192,6 +1194,11 @@ public class BalancedShardsAllocator implements ShardsAllocator {
 
     }
 
+    /**
+     * A model node.
+     *
+     * @opensearch.internal
+     */
     public static class ModelNode implements Iterable<ModelIndex> {
         private final Map<String, ModelIndex> indices = new HashMap<>();
         private int numShards = 0;
@@ -1270,6 +1277,11 @@ public class BalancedShardsAllocator implements ShardsAllocator {
 
     }
 
+    /**
+     * A model index.
+     *
+     * @opensearch.internal
+     */
     static final class ModelIndex implements Iterable<ShardRouting> {
         private final String id;
         private final Set<ShardRouting> shards = new HashSet<>(4); // expect few shards of same index to be allocated on same node
@@ -1322,6 +1334,11 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         }
     }
 
+    /**
+     * A node sorter.
+     *
+     * @opensearch.internal
+     */
     static final class NodeSorter extends IntroSorter {
 
         final ModelNode[] modelNodes;

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/command/AllocateEmptyPrimaryAllocationCommand.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/command/AllocateEmptyPrimaryAllocationCommand.java
@@ -98,6 +98,11 @@ public class AllocateEmptyPrimaryAllocationCommand extends BasePrimaryAllocation
         return new Builder().parse(parser).build();
     }
 
+    /**
+     * Builder for an empty primary allocation.
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends BasePrimaryAllocationCommand.Builder<AllocateEmptyPrimaryAllocationCommand> {
 
         @Override

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/command/AllocateReplicaAllocationCommand.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/command/AllocateReplicaAllocationCommand.java
@@ -88,6 +88,11 @@ public class AllocateReplicaAllocationCommand extends AbstractAllocateAllocation
         return new Builder().parse(parser).build();
     }
 
+    /**
+     * A builder for the command.
+     *
+     * @opensearch.internal
+     */
     protected static class Builder extends AbstractAllocateAllocationCommand.Builder<AllocateReplicaAllocationCommand> {
 
         @Override

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/command/AllocateStalePrimaryAllocationCommand.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/command/AllocateStalePrimaryAllocationCommand.java
@@ -95,6 +95,11 @@ public class AllocateStalePrimaryAllocationCommand extends BasePrimaryAllocation
         return new Builder().parse(parser).build();
     }
 
+    /**
+     * Builder for a stale primary allocation
+     *
+     * @opensearch.internal
+     */
     public static class Builder extends BasePrimaryAllocationCommand.Builder<AllocateStalePrimaryAllocationCommand> {
 
         @Override

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/command/BasePrimaryAllocationCommand.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/command/BasePrimaryAllocationCommand.java
@@ -85,6 +85,11 @@ public abstract class BasePrimaryAllocationCommand extends AbstractAllocateAlloc
         return acceptDataLoss;
     }
 
+    /**
+     * Base builder class for the primary allocation command.
+     *
+     * @opensearch.internal
+     */
     protected abstract static class Builder<T extends BasePrimaryAllocationCommand> extends AbstractAllocateAllocationCommand.Builder<T> {
         protected boolean acceptDataLoss;
 

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/ClusterRebalanceAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/ClusterRebalanceAllocationDecider.java
@@ -78,6 +78,8 @@ public class ClusterRebalanceAllocationDecider extends AllocationDecider {
 
     /**
      * An enum representation for the configured re-balance type.
+     *
+     * @opensearch.internal
      */
     public enum ClusterRebalanceType {
         /**

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/Decision.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/Decision.java
@@ -97,6 +97,8 @@ public abstract class Decision implements ToXContent, Writeable {
     /**
      * This enumeration defines the
      * possible types of decisions
+     *
+     * @opensearch.internal
      */
     public enum Type implements Writeable {
         YES(1),
@@ -170,6 +172,8 @@ public abstract class Decision implements ToXContent, Writeable {
 
     /**
      * Simple class representing a single decision
+     *
+     * @opensearch.internal
      */
     public static class Single extends Decision implements ToXContentObject {
         private Type type;
@@ -287,6 +291,8 @@ public abstract class Decision implements ToXContent, Writeable {
 
     /**
      * Simple class representing a list of decisions
+     *
+     * @opensearch.internal
      */
     public static class Multi extends Decision implements ToXContentFragment {
 

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
@@ -282,6 +282,8 @@ public class EnableAllocationDecider extends AllocationDecider {
      * {@link EnableAllocationDecider#CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING} /
      * {@link EnableAllocationDecider#INDEX_ROUTING_ALLOCATION_ENABLE_SETTING}
      * via cluster / index settings.
+     *
+     * @opensearch.internal
      */
     public enum Allocation {
 
@@ -314,6 +316,8 @@ public class EnableAllocationDecider extends AllocationDecider {
      * {@link EnableAllocationDecider#CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING} /
      * {@link EnableAllocationDecider#INDEX_ROUTING_REBALANCE_ENABLE_SETTING}
      * via cluster / index settings.
+     *
+     * @opensearch.internal
      */
     public enum Rebalance {
 

--- a/server/src/main/java/org/opensearch/common/LocalTimeOffset.java
+++ b/server/src/main/java/org/opensearch/common/LocalTimeOffset.java
@@ -148,6 +148,11 @@ public abstract class LocalTimeOffset {
      */
     public abstract long localToUtc(long localMillis, Strategy strat);
 
+    /**
+     * Strategy for a local time
+     *
+     * @opensearch.internal
+     */
     public interface Strategy {
         /**
          * Handle a local time that never actually happened because a "gap"

--- a/server/src/main/java/org/opensearch/common/Rounding.java
+++ b/server/src/main/java/org/opensearch/common/Rounding.java
@@ -81,6 +81,11 @@ import java.util.concurrent.TimeUnit;
 public abstract class Rounding implements Writeable {
     private static final Logger logger = LogManager.getLogger(Rounding.class);
 
+    /**
+     * A Date Time Unit
+     *
+     * @opensearch.internal
+     */
     public enum DateTimeUnit {
         WEEK_OF_WEEKYEAR((byte) 1, "week", IsoFields.WEEK_OF_WEEK_BASED_YEAR, true, TimeUnit.DAYS.toMillis(7)) {
             private final long extraLocalOffsetLookup = TimeUnit.DAYS.toMillis(7);
@@ -262,6 +267,8 @@ public abstract class Rounding implements Writeable {
 
     /**
      * A strategy for rounding milliseconds since epoch.
+     *
+     * @opensearch.internal
      */
     public interface Prepared {
         /**

--- a/server/src/main/java/org/opensearch/common/breaker/CircuitBreaker.java
+++ b/server/src/main/java/org/opensearch/common/breaker/CircuitBreaker.java
@@ -69,6 +69,11 @@ public interface CircuitBreaker {
      */
     String IN_FLIGHT_REQUESTS = "in_flight_requests";
 
+    /**
+     * The type of breaker
+     *
+     * @opensearch.internal
+     */
     enum Type {
         // A regular or ChildMemoryCircuitBreaker
         MEMORY,
@@ -91,6 +96,11 @@ public interface CircuitBreaker {
         }
     }
 
+    /**
+     * The breaker durability
+     *
+     * @opensearch.internal
+     */
     enum Durability {
         // The condition that tripped the circuit breaker fixes itself eventually.
         TRANSIENT,

--- a/server/src/main/java/org/opensearch/common/cache/RemovalNotification.java
+++ b/server/src/main/java/org/opensearch/common/cache/RemovalNotification.java
@@ -38,6 +38,11 @@ package org.opensearch.common.cache;
  * @opensearch.internal
  */
 public class RemovalNotification<K, V> {
+    /**
+     * Reason for notification removal
+     *
+     * @opensearch.internal
+     */
     public enum RemovalReason {
         REPLACED,
         INVALIDATED,

--- a/server/src/main/java/org/opensearch/common/collect/HppcMaps.java
+++ b/server/src/main/java/org/opensearch/common/collect/HppcMaps.java
@@ -147,7 +147,17 @@ public final class HppcMaps {
         };
     }
 
+    /**
+     * Object for the map
+     *
+     * @opensearch.internal
+     */
     public static final class Object {
+        /**
+         * Integer type for the map
+         *
+         * @opensearch.internal
+         */
         public static final class Integer {
             public static <V> ObjectIntHashMap<V> ensureNoNullKeys(int capacity, float loadFactor) {
                 return new ObjectIntHashMap<V>(capacity, loadFactor) {

--- a/server/src/main/java/org/opensearch/common/collect/Iterators.java
+++ b/server/src/main/java/org/opensearch/common/collect/Iterators.java
@@ -35,6 +35,11 @@ package org.opensearch.common.collect;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+/**
+ * Iterators utility class.
+ *
+ * @opensearch.internal
+ */
 public class Iterators {
     public static <T> Iterator<T> concat(Iterator<? extends T>... iterators) {
         if (iterators == null) {

--- a/server/src/main/java/org/opensearch/common/component/Lifecycle.java
+++ b/server/src/main/java/org/opensearch/common/component/Lifecycle.java
@@ -77,6 +77,11 @@ package org.opensearch.common.component;
  */
 public class Lifecycle {
 
+    /**
+     * State in the lifecycle
+     *
+     * @opensearch.internal
+     */
     public enum State {
         INITIALIZED,
         STOPPED,

--- a/server/src/main/java/org/opensearch/common/geo/GeoUtils.java
+++ b/server/src/main/java/org/opensearch/common/geo/GeoUtils.java
@@ -421,6 +421,8 @@ public class GeoUtils {
 
     /**
      * Represents the point of the geohash cell that should be used as the value of geohash
+     *
+     * @opensearch.internal
      */
     public enum EffectivePoint {
         TOP_LEFT,

--- a/server/src/main/java/org/opensearch/common/geo/builders/ShapeBuilder.java
+++ b/server/src/main/java/org/opensearch/common/geo/builders/ShapeBuilder.java
@@ -420,6 +420,11 @@ public abstract class ShapeBuilder<T extends Shape, G extends org.opensearch.geo
         }
     }
 
+    /**
+     * The orientation of the vertices
+     *
+     * @opensearch.internal
+     */
     public enum Orientation {
         LEFT,
         RIGHT;

--- a/server/src/main/java/org/opensearch/common/inject/BindingProcessor.java
+++ b/server/src/main/java/org/opensearch/common/inject/BindingProcessor.java
@@ -314,6 +314,11 @@ class BindingProcessor extends AbstractProcessor {
     );
     // TODO(jessewilson): fix BuiltInModule, then add Stage
 
+    /**
+     * A listener for a process creation
+     *
+     * @opensearch.internal
+     */
     interface CreationListener {
         void notify(Errors errors);
     }

--- a/server/src/main/java/org/opensearch/common/inject/InjectorImpl.java
+++ b/server/src/main/java/org/opensearch/common/inject/InjectorImpl.java
@@ -676,6 +676,8 @@ class InjectorImpl implements Injector, Lookups {
 
     /**
      * Invokes a method.
+     *
+     * @opensearch.internal
      */
     interface MethodInvoker {
         Object invoke(Object target, Object... parameters) throws IllegalAccessException, InvocationTargetException;

--- a/server/src/main/java/org/opensearch/common/inject/Key.java
+++ b/server/src/main/java/org/opensearch/common/inject/Key.java
@@ -325,6 +325,11 @@ public class Key<T> {
         return new Key<>(typeLiteral, annotationStrategy.withoutAttributes());
     }
 
+    /**
+     * Strategy for annotations
+     *
+     * @opensearch.internal
+     */
     interface AnnotationStrategy {
         Annotation getAnnotation();
 

--- a/server/src/main/java/org/opensearch/common/inject/TypeLiteral.java
+++ b/server/src/main/java/org/opensearch/common/inject/TypeLiteral.java
@@ -270,6 +270,8 @@ public class TypeLiteral<T> {
      *
      * @param supertype a superclass of, or interface implemented by, this.
      * @since 2.0
+     *
+     * @opensearch.internal
      */
     public TypeLiteral<?> getSupertype(Class<?> supertype) {
         if (!supertype.isAssignableFrom(rawType)) {

--- a/server/src/main/java/org/opensearch/common/inject/internal/MoreTypes.java
+++ b/server/src/main/java/org/opensearch/common/inject/internal/MoreTypes.java
@@ -677,6 +677,8 @@ public class MoreTypes {
 
     /**
      * A type formed from other types, such as arrays, parameterized types or wildcard types
+     *
+     * @opensearch.internal
      */
     private interface CompositeType {
         /**

--- a/server/src/main/java/org/opensearch/common/inject/spi/InjectionPoint.java
+++ b/server/src/main/java/org/opensearch/common/inject/spi/InjectionPoint.java
@@ -406,6 +406,11 @@ public final class InjectionPoint {
         return Modifier.isStatic(member.getModifiers());
     }
 
+    /**
+     * Factory for the injection point
+     *
+     * @opensearch.internal
+     */
     private interface Factory<M extends Member & AnnotatedElement> {
         Factory<Field> FIELDS = new Factory<Field>() {
             @Override

--- a/server/src/main/java/org/opensearch/common/inject/util/Modules.java
+++ b/server/src/main/java/org/opensearch/common/inject/util/Modules.java
@@ -130,6 +130,8 @@ public final class Modules {
 
     /**
      * See the EDSL example at {@link Modules#override(Module[]) override()}.
+     *
+     * @opensearch.internal
      */
     public interface OverriddenModuleBuilder {
 

--- a/server/src/main/java/org/opensearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/opensearch/common/logging/DeprecationLogger.java
@@ -105,6 +105,11 @@ public class DeprecationLogger {
         return new DeprecationLoggerBuilder().withDeprecation(key, msg, params);
     }
 
+    /**
+     * The builder for the deprecation logger
+     *
+     * @opensearch.internal
+     */
     public class DeprecationLoggerBuilder {
 
         public DeprecationLoggerBuilder withDeprecation(String key, String msg, Object[] params) {

--- a/server/src/main/java/org/opensearch/common/lucene/search/function/FieldValueFactorFunction.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/function/FieldValueFactorFunction.java
@@ -176,6 +176,8 @@ public class FieldValueFactorFunction extends ScoreFunction {
     /**
      * The Type class encapsulates the modification types that can be applied
      * to the score/value product.
+     *
+     * @opensearch.internal
      */
     public enum Modifier implements Writeable {
         NONE {

--- a/server/src/main/java/org/opensearch/common/lucene/search/function/FunctionScoreQuery.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/function/FunctionScoreQuery.java
@@ -141,6 +141,11 @@ public class FunctionScoreQuery extends Query {
         }
     }
 
+    /**
+     * The mode of the score
+     *
+     * @opensearch.internal
+     */
     public enum ScoreMode implements Writeable {
         FIRST,
         AVG,

--- a/server/src/main/java/org/opensearch/common/network/NetworkService.java
+++ b/server/src/main/java/org/opensearch/common/network/NetworkService.java
@@ -113,6 +113,8 @@ public final class NetworkService {
     /**
      * A custom name resolver can support custom lookup keys (my_net_key:ipv4) and also change
      * the default inet address used in case no settings is provided.
+     *
+     * @opensearch.internal
      */
     public interface CustomNameResolver {
         /**

--- a/server/src/main/java/org/opensearch/common/path/PathTrie.java
+++ b/server/src/main/java/org/opensearch/common/path/PathTrie.java
@@ -77,6 +77,11 @@ public class PathTrie<T> {
         TrieMatchingMode.WILDCARD_ROOT_NODES_ALLOWED
     );
 
+    /**
+     * Decoder for the path
+     *
+     * @opensearch.internal
+     */
     public interface Decoder {
         String decode(String value);
     }
@@ -93,6 +98,11 @@ public class PathTrie<T> {
         root = new TrieNode(SEPARATOR, null, WILDCARD);
     }
 
+    /**
+     * Node for the trie
+     *
+     * @opensearch.internal
+     */
     public class TrieNode {
         private transient String key;
         private transient T value;

--- a/server/src/main/java/org/opensearch/common/recycler/Recycler.java
+++ b/server/src/main/java/org/opensearch/common/recycler/Recycler.java
@@ -42,10 +42,20 @@ import org.opensearch.common.lease.Releasable;
  */
 public interface Recycler<T> {
 
+    /**
+     * Base factory interface
+     *
+     * @opensearch.internal
+     */
     interface Factory<T> {
         Recycler<T> build();
     }
 
+    /**
+     * Generic for recycler
+     *
+     * @opensearch.internal
+     */
     interface C<T> {
 
         /** Create a new empty instance of the given size. */
@@ -58,6 +68,11 @@ public interface Recycler<T> {
         void destroy(T value);
     }
 
+    /**
+     * Generic releasable
+     *
+     * @opensearch.internal
+     */
     interface V<T> extends Releasable {
 
         /** Reference to the value. */

--- a/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
@@ -631,6 +631,8 @@ public abstract class AbstractScopedSettings {
      * Transactional interface to update settings.
      * @see Setting
      * @param <T> the type of the value of the setting
+     *
+     * @opensearch.internal
      */
     public interface SettingUpdater<T> {
 

--- a/server/src/main/java/org/opensearch/common/settings/PropertyPlaceholder.java
+++ b/server/src/main/java/org/opensearch/common/settings/PropertyPlaceholder.java
@@ -162,6 +162,8 @@ class PropertyPlaceholder {
      * Strategy interface used to resolve replacement values for placeholders contained in Strings.
      *
      * @see PropertyPlaceholder
+     *
+     * @opensearch.internal
      */
     interface PlaceholderResolver {
 

--- a/server/src/main/java/org/opensearch/common/settings/Setting.java
+++ b/server/src/main/java/org/opensearch/common/settings/Setting.java
@@ -102,6 +102,11 @@ import java.util.stream.Stream;
  */
 public class Setting<T> implements ToXContentObject {
 
+    /**
+     * Property of the setting
+     *
+     * @opensearch.internal
+     */
     public enum Property {
         /**
          * should be filtered in some api (mask password/credentials)
@@ -620,6 +625,8 @@ public class Setting<T> implements ToXContentObject {
     /**
      * Allows a setting to declare a dependency on another setting being set. Optionally, a setting can validate the value of the dependent
      * setting.
+     *
+     * @opensearch.internal
      */
     public interface SettingDependency {
 
@@ -767,6 +774,8 @@ public class Setting<T> implements ToXContentObject {
 
     /**
      * Allows an affix setting to declare a dependency on another affix setting.
+     *
+     * @opensearch.internal
      */
     public interface AffixSettingDependency extends SettingDependency {
 
@@ -1007,6 +1016,8 @@ public class Setting<T> implements ToXContentObject {
      * {@link #settings()}} to their values. All these values come from the same {@link Settings} instance.
      *
      * @param <T> the type of the {@link Setting}
+     *
+     * @opensearch.internal
      */
     @FunctionalInterface
     public interface Validator<T> {
@@ -2247,6 +2258,11 @@ public class Setting<T> implements ToXContentObject {
         return new AffixSetting<>(key, delegate, delegateFactory, dependencies);
     }
 
+    /**
+     * Key for the setting
+     *
+     * @opensearch.internal
+     */
     public interface Key {
         boolean match(String key);
     }
@@ -2287,6 +2303,11 @@ public class Setting<T> implements ToXContentObject {
         }
     }
 
+    /**
+     * Settings Group keys
+     *
+     * @opensearch.internal
+     */
     public static final class GroupKey extends SimpleKey {
         public GroupKey(String key) {
             super(key);
@@ -2301,6 +2322,11 @@ public class Setting<T> implements ToXContentObject {
         }
     }
 
+    /**
+     * List settings key
+     *
+     * @opensearch.internal
+     */
     public static final class ListKey extends SimpleKey {
         private final Pattern pattern;
 
@@ -2318,6 +2344,8 @@ public class Setting<T> implements ToXContentObject {
     /**
      * A key that allows for static pre and suffix. This is used for settings
      * that have dynamic namespaces like for different accounts etc.
+     *
+     * @opensearch.internal
      */
     public static final class AffixKey implements Key {
         private final Pattern pattern;

--- a/server/src/main/java/org/opensearch/common/transport/PortsRange.java
+++ b/server/src/main/java/org/opensearch/common/transport/PortsRange.java
@@ -94,6 +94,11 @@ public class PortsRange {
         return success;
     }
 
+    /**
+     * Callback for the port
+     *
+     * @opensearch.internal
+     */
     public interface PortCallback {
         boolean onPortNumber(int portNumber);
     }

--- a/server/src/main/java/org/opensearch/common/util/CancellableThreads.java
+++ b/server/src/main/java/org/opensearch/common/util/CancellableThreads.java
@@ -180,10 +180,20 @@ public class CancellableThreads {
         threads.clear();
     }
 
+    /**
+     * Interruptible interface
+     *
+     * @opensearch.internal
+     */
     public interface Interruptible extends IOInterruptible {
         void run() throws InterruptedException;
     }
 
+    /**
+     * IO Interruptible
+     *
+     * @opensearch.internal
+     */
     public interface IOInterruptible {
         void run() throws IOException, InterruptedException;
     }
@@ -211,6 +221,11 @@ public class CancellableThreads {
         this.onCancel.set(onCancel);
     }
 
+    /**
+     * Called when a thread is cancelled
+     *
+     * @opensearch.internal
+     */
     @FunctionalInterface
     public interface OnCancel {
         /**

--- a/server/src/main/java/org/opensearch/common/util/LongObjectPagedHashMap.java
+++ b/server/src/main/java/org/opensearch/common/util/LongObjectPagedHashMap.java
@@ -202,6 +202,11 @@ public class LongObjectPagedHashMap<T> extends AbstractPagedHashMap implements I
         assert removed == null;
     }
 
+    /**
+     * Cursor for the map
+     *
+     * @opensearch.internal
+     */
     public static final class Cursor<T> {
         public long index;
         public long key;

--- a/server/src/main/java/org/opensearch/common/util/PageCacheRecycler.java
+++ b/server/src/main/java/org/opensearch/common/util/PageCacheRecycler.java
@@ -231,6 +231,11 @@ public class PageCacheRecycler {
         return recycler;
     }
 
+    /**
+     * Type of the page cache recycler
+     *
+     * @opensearch.internal
+     */
     public enum Type {
         QUEUE {
             @Override

--- a/server/src/main/java/org/opensearch/common/util/concurrent/OpenSearchThreadPoolExecutor.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/OpenSearchThreadPoolExecutor.java
@@ -114,6 +114,11 @@ public class OpenSearchThreadPoolExecutor extends ThreadPoolExecutor {
         }
     }
 
+    /**
+     * Listener on shut down
+     *
+     * @opensearch.internal
+     */
     public interface ShutdownListener {
         void onTerminated();
     }

--- a/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
@@ -486,6 +486,11 @@ public final class ThreadContext implements Writeable {
         return threadLocal.get().isSystemContext;
     }
 
+    /**
+     * A stored context
+     *
+     * @opensearch.internal
+     */
     @FunctionalInterface
     public interface StoredContext extends AutoCloseable {
         @Override

--- a/server/src/main/java/org/opensearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/opensearch/discovery/PeerFinder.java
@@ -228,6 +228,11 @@ public abstract class PeerFinder {
         return lastResolvedAddresses;
     }
 
+    /**
+     * Transport address connector interface.
+     *
+     * @opensearch.internal
+     */
     public interface TransportAddressConnector {
         /**
          * Identify the node at the given address and, if it is a cluster-manager node and not the local node then establish a full connection to it.
@@ -235,6 +240,11 @@ public abstract class PeerFinder {
         void connectToRemoteMasterNode(TransportAddress transportAddress, ActionListener<DiscoveryNode> listener);
     }
 
+    /**
+     * Resolves the configured unicast host.
+     *
+     * @opensearch.internal
+     */
     public interface ConfiguredHostsResolver {
         /**
          * Attempt to resolve the configured unicast hosts list to a list of transport addresses.

--- a/server/src/main/java/org/opensearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/opensearch/env/NodeEnvironment.java
@@ -111,6 +111,11 @@ import static java.util.Collections.unmodifiableSet;
  * @opensearch.internal
  */
 public final class NodeEnvironment implements Closeable {
+    /**
+     * A node path.
+     *
+     * @opensearch.internal
+     */
     public static class NodePath {
         /* ${data.paths}/nodes/{node.id} */
         public final Path path;
@@ -214,6 +219,11 @@ public final class NodeEnvironment implements Closeable {
     public static final String INDICES_FOLDER = "indices";
     public static final String NODE_LOCK_FILENAME = "node.lock";
 
+    /**
+     * The node lock.
+     *
+     * @opensearch.internal
+     */
     public static class NodeLock implements Releasable {
 
         private final int nodeId;

--- a/server/src/main/java/org/opensearch/gateway/Gateway.java
+++ b/server/src/main/java/org/opensearch/gateway/Gateway.java
@@ -144,6 +144,11 @@ public class Gateway {
         listener.onSuccess(recoveredState);
     }
 
+    /**
+     * The lister for state recovered.
+     *
+     * @opensearch.internal
+     */
     public interface GatewayStateRecoveredListener {
         void onSuccess(ClusterState build);
 

--- a/server/src/main/java/org/opensearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/opensearch/gateway/LocalAllocateDangledIndices.java
@@ -266,6 +266,12 @@ public class LocalAllocateDangledIndices {
         }
     }
 
+    /**
+     * The request.
+     *
+     * @opensearch.internal
+     */
+
     public static class AllocateDangledRequest extends TransportRequest {
 
         DiscoveryNode fromNode;
@@ -290,6 +296,11 @@ public class LocalAllocateDangledIndices {
         }
     }
 
+    /**
+     * The response.
+     *
+     * @opensearch.internal
+     */
     public static class AllocateDangledResponse extends TransportResponse {
 
         private boolean ack;

--- a/server/src/main/java/org/opensearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/PersistedClusterStateService.java
@@ -268,6 +268,11 @@ public class PersistedClusterStateService {
         return dataPaths;
     }
 
+    /**
+     * The on disk state.
+     *
+     * @opensearch.internal
+     */
     public static class OnDiskState {
         private static final OnDiskState NO_ON_DISK_STATE = new OnDiskState(null, null, 0L, 0L, Metadata.EMPTY_METADATA);
 
@@ -585,6 +590,11 @@ public class PersistedClusterStateService {
         }
     }
 
+    /**
+     * Writer for cluster state service
+     *
+     * @opensearch.internal
+     */
     public static class Writer implements Closeable {
 
         private final List<MetadataIndexWriter> metadataIndexWriters;

--- a/server/src/main/java/org/opensearch/gateway/TransportNodesListGatewayMetaState.java
+++ b/server/src/main/java/org/opensearch/gateway/TransportNodesListGatewayMetaState.java
@@ -121,6 +121,11 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<
         return new NodeGatewayMetaState(clusterService.localNode(), metaState.getMetadata());
     }
 
+    /**
+     * The request.
+     *
+     * @opensearch.internal
+     */
     public static class Request extends BaseNodesRequest<Request> {
 
         public Request(StreamInput in) throws IOException {
@@ -132,6 +137,11 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<
         }
     }
 
+    /**
+     * The nodes gateway metastate.
+     *
+     * @opensearch.internal
+     */
     public static class NodesGatewayMetaState extends BaseNodesResponse<NodeGatewayMetaState> {
 
         public NodesGatewayMetaState(StreamInput in) throws IOException {
@@ -153,6 +163,11 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<
         }
     }
 
+    /**
+     * The node request.
+     *
+     * @opensearch.internal
+     */
     public static class NodeRequest extends BaseNodeRequest {
         NodeRequest() {}
 
@@ -161,6 +176,11 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<
         }
     }
 
+    /**
+     * The node gateway metastate.
+     *
+     * @opensearch.internal
+     */
     public static class NodeGatewayMetaState extends BaseNodeResponse {
 
         private Metadata metadata;

--- a/server/src/main/java/org/opensearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/server/src/main/java/org/opensearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -211,6 +211,11 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
         }
     }
 
+    /**
+     * The nodes request.
+     *
+     * @opensearch.internal
+     */
     public static class Request extends BaseNodesRequest<Request> {
 
         private final ShardId shardId;
@@ -257,6 +262,11 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
         }
     }
 
+    /**
+     *  The nodes response.
+     *
+     * @opensearch.internal
+     */
     public static class NodesGatewayStartedShards extends BaseNodesResponse<NodeGatewayStartedShards> {
 
         public NodesGatewayStartedShards(StreamInput in) throws IOException {
@@ -282,6 +292,11 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
         }
     }
 
+    /**
+     * The request.
+     *
+     * @opensearch.internal
+     */
     public static class NodeRequest extends BaseNodeRequest {
 
         private final ShardId shardId;
@@ -328,6 +343,11 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
         }
     }
 
+    /**
+     * The response.
+     *
+     * @opensearch.internal
+     */
     public static class NodeGatewayStartedShards extends BaseNodeResponse {
 
         private final String allocationId;

--- a/server/src/main/java/org/opensearch/ingest/DropProcessor.java
+++ b/server/src/main/java/org/opensearch/ingest/DropProcessor.java
@@ -58,6 +58,11 @@ public final class DropProcessor extends AbstractProcessor {
         return TYPE;
     }
 
+    /**
+     * A factory for the processor.
+     *
+     * @opensearch.internal
+     */
     public static final class Factory implements Processor.Factory {
 
         @Override

--- a/server/src/main/java/org/opensearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/opensearch/ingest/IngestDocument.java
@@ -845,6 +845,11 @@ public final class IngestDocument {
         return "IngestDocument{" + " sourceAndMetadata=" + sourceAndMetadata + ", ingestMetadata=" + ingestMetadata + '}';
     }
 
+    /**
+     * The ingest metadata.
+     *
+     * @opensearch.internal
+     */
     public enum Metadata {
         INDEX(IndexFieldMapper.NAME),
         ID(IdFieldMapper.NAME),

--- a/server/src/main/java/org/opensearch/ingest/IngestStats.java
+++ b/server/src/main/java/org/opensearch/ingest/IngestStats.java
@@ -180,6 +180,11 @@ public class IngestStats implements Writeable, ToXContentFragment {
         return Objects.hash(totalStats, pipelineStats, processorStats);
     }
 
+    /**
+     * The ingest statistics.
+     *
+     * @opensearch.internal
+     */
     public static class Stats implements Writeable, ToXContentFragment {
 
         private final long ingestCount;

--- a/server/src/main/java/org/opensearch/ingest/PipelineProcessor.java
+++ b/server/src/main/java/org/opensearch/ingest/PipelineProcessor.java
@@ -91,6 +91,11 @@ public class PipelineProcessor extends AbstractProcessor {
         return pipelineTemplate;
     }
 
+    /**
+     * Factory for the processor.
+     *
+     * @opensearch.internal
+     */
     public static final class Factory implements Processor.Factory {
 
         private final IngestService ingestService;

--- a/server/src/main/java/org/opensearch/ingest/ValueSource.java
+++ b/server/src/main/java/org/opensearch/ingest/ValueSource.java
@@ -101,6 +101,11 @@ public interface ValueSource {
         }
     }
 
+    /**
+     * A map value source.
+     *
+     * @opensearch.internal
+     */
     final class MapValue implements ValueSource {
 
         private final Map<ValueSource, ValueSource> map;
@@ -134,6 +139,11 @@ public interface ValueSource {
         }
     }
 
+    /**
+     * A list value source.
+     *
+     * @opensearch.internal
+     */
     final class ListValue implements ValueSource {
 
         private final List<ValueSource> values;
@@ -167,6 +177,11 @@ public interface ValueSource {
         }
     }
 
+    /**
+     * An object value source.
+     *
+     * @opensearch.internal
+     */
     final class ObjectValue implements ValueSource {
 
         private final Object value;
@@ -195,6 +210,11 @@ public interface ValueSource {
         }
     }
 
+    /**
+     * A byte value source.
+     *
+     * @opensearch.internal
+     */
     final class ByteValue implements ValueSource {
 
         private final byte[] value;
@@ -224,6 +244,11 @@ public interface ValueSource {
 
     }
 
+    /**
+     * A templated value.
+     *
+     * @opensearch.internal
+     */
     final class TemplatedValue implements ValueSource {
 
         private final TemplateScript.Factory template;

--- a/server/src/main/java/org/opensearch/monitor/StatusInfo.java
+++ b/server/src/main/java/org/opensearch/monitor/StatusInfo.java
@@ -40,6 +40,11 @@ package org.opensearch.monitor;
  */
 public class StatusInfo {
 
+    /**
+     * The status.
+     *
+     * @opensearch.internal
+     */
     public enum Status {
         HEALTHY,
         UNHEALTHY

--- a/server/src/main/java/org/opensearch/monitor/fs/FsInfo.java
+++ b/server/src/main/java/org/opensearch/monitor/fs/FsInfo.java
@@ -56,6 +56,11 @@ import java.util.Set;
  */
 public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragment {
 
+    /**
+     * Path for the file system
+     *
+     * @opensearch.internal
+     */
     public static class Path implements Writeable, ToXContentObject {
 
         String path;
@@ -183,6 +188,11 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
         }
     }
 
+    /**
+     * The device status.
+     *
+     * @opensearch.internal
+     */
     public static class DeviceStats implements Writeable, ToXContentFragment {
 
         final int majorDeviceNumber;
@@ -320,6 +330,11 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
 
     }
 
+    /**
+     * The I/O statistics.
+     *
+     * @opensearch.internal
+     */
     public static class IoStats implements Writeable, ToXContentFragment {
 
         private static final String OPERATIONS = "operations";

--- a/server/src/main/java/org/opensearch/monitor/jvm/DeadlockAnalyzer.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/DeadlockAnalyzer.java
@@ -140,6 +140,11 @@ public class DeadlockAnalyzer {
         return unmodifiableMap(threadInfoMap);
     }
 
+    /**
+     * The deadlock being analyzed.
+     *
+     * @opensearch.internal
+     */
     public static class Deadlock {
         private final ThreadInfo members[];
         private final String description;

--- a/server/src/main/java/org/opensearch/monitor/jvm/JvmInfo.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/JvmInfo.java
@@ -599,6 +599,11 @@ public class JvmInfo implements ReportingService.Info {
         static final String INPUT_ARGUMENTS = "input_arguments";
     }
 
+    /**
+     * Memory information.
+     *
+     * @opensearch.internal
+     */
     public static class Mem implements Writeable {
 
         private final long heapInit;

--- a/server/src/main/java/org/opensearch/monitor/jvm/JvmStats.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/JvmStats.java
@@ -371,6 +371,11 @@ public class JvmStats implements Writeable, ToXContentFragment {
         static final String TOTAL_UNLOADED_COUNT = "total_unloaded_count";
     }
 
+    /**
+     * Garbage collector references.
+     *
+     * @opensearch.internal
+     */
     public static class GarbageCollectors implements Writeable, Iterable<GarbageCollector> {
 
         private final GarbageCollector[] collectors;
@@ -398,6 +403,11 @@ public class JvmStats implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * The garbage collector.
+     *
+     * @opensearch.internal
+     */
     public static class GarbageCollector implements Writeable {
 
         private final String name;
@@ -436,6 +446,11 @@ public class JvmStats implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * Thread information.
+     *
+     * @opensearch.internal
+     */
     public static class Threads implements Writeable {
 
         private final int count;
@@ -470,6 +485,8 @@ public class JvmStats implements Writeable, ToXContentFragment {
      * Stores the memory usage after the Java virtual machine
      * most recently expended effort in recycling unused objects
      * in particular memory pool.
+     *
+     * @openesearch.internal
      */
     public static class MemoryPoolGcStats implements Writeable {
 
@@ -508,6 +525,11 @@ public class JvmStats implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * A memory pool.
+     *
+     * @opensearch.internal
+     */
     public static class MemoryPool implements Writeable {
 
         private final String name;
@@ -579,6 +601,11 @@ public class JvmStats implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * Memory data.
+     *
+     * @opensearch.internal
+     */
     public static class Mem implements Writeable, Iterable<MemoryPool> {
 
         private final long heapCommitted;
@@ -655,6 +682,11 @@ public class JvmStats implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * A buffer pool.
+     *
+     * @opensearch.internal
+     */
     public static class BufferPool implements Writeable {
 
         private final String name;
@@ -701,6 +733,11 @@ public class JvmStats implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * Class information.
+     *
+     * @opensearch.internal
+     */
     public static class Classes implements Writeable {
 
         private final long loadedClassCount;

--- a/server/src/main/java/org/opensearch/monitor/jvm/JvmStats.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/JvmStats.java
@@ -486,7 +486,7 @@ public class JvmStats implements Writeable, ToXContentFragment {
      * most recently expended effort in recycling unused objects
      * in particular memory pool.
      *
-     * @openesearch.internal
+     * @opensearch.internal
      */
     public static class MemoryPoolGcStats implements Writeable {
 

--- a/server/src/main/java/org/opensearch/monitor/os/OsStats.java
+++ b/server/src/main/java/org/opensearch/monitor/os/OsStats.java
@@ -140,6 +140,11 @@ public class OsStats implements Writeable, ToXContentFragment {
         return builder;
     }
 
+    /**
+     * CPU Information.
+     *
+     * @opensearch.internal
+     */
     public static class Cpu implements Writeable, ToXContentFragment {
 
         private final short percent;
@@ -200,6 +205,11 @@ public class OsStats implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * Swap information.
+     *
+     * @opensearch.internal
+     */
     public static class Swap implements Writeable, ToXContentFragment {
 
         private static final Logger logger = LogManager.getLogger(Swap.class);
@@ -263,6 +273,11 @@ public class OsStats implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * OS Memory information.
+     *
+     * @opensearch.internal
+     */
     public static class Mem implements Writeable, ToXContentFragment {
 
         private static final Logger logger = LogManager.getLogger(Mem.class);
@@ -337,6 +352,8 @@ public class OsStats implements Writeable, ToXContentFragment {
 
     /**
      * Encapsulates basic cgroup statistics.
+     *
+     * @opensearch.internal
      */
     public static class Cgroup implements Writeable, ToXContentFragment {
 
@@ -528,6 +545,8 @@ public class OsStats implements Writeable, ToXContentFragment {
 
         /**
          * Encapsulates CPU time statistics.
+         *
+         * @opensearch.internal
          */
         public static class CpuStat implements Writeable, ToXContentFragment {
 

--- a/server/src/main/java/org/opensearch/monitor/process/ProcessStats.java
+++ b/server/src/main/java/org/opensearch/monitor/process/ProcessStats.java
@@ -138,6 +138,11 @@ public class ProcessStats implements Writeable, ToXContentFragment {
         return builder;
     }
 
+    /**
+     * Process memory information.
+     *
+     * @opensearch.internal
+     */
     public static class Mem implements Writeable {
 
         private final long totalVirtual;
@@ -160,6 +165,11 @@ public class ProcessStats implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * Process CPU information.
+     *
+     * @opensearch.internal
+     */
     public static class Cpu implements Writeable {
 
         private final short percent;

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -297,6 +297,11 @@ public class Node implements Closeable {
 
     private static final String CLIENT_TYPE = "node";
 
+    /**
+     * The discovery settings for the node.
+     *
+     * @opensearch.internal
+     */
     public static class DiscoverySettings {
         public static final Setting<TimeValue> INITIAL_STATE_TIMEOUT_SETTING = Setting.positiveTimeSetting(
             "discovery.initial_state_timeout",

--- a/server/src/main/java/org/opensearch/node/ReportingService.java
+++ b/server/src/main/java/org/opensearch/node/ReportingService.java
@@ -43,6 +43,11 @@ import org.opensearch.common.xcontent.ToXContent;
 public interface ReportingService<I extends ReportingService.Info> {
     I info();
 
+    /**
+     * Information interface.
+     *
+     * @opensearch.internal
+     */
     interface Info extends Writeable, ToXContent {
 
     }

--- a/server/src/main/java/org/opensearch/persistent/AllocatedPersistentTask.java
+++ b/server/src/main/java/org/opensearch/persistent/AllocatedPersistentTask.java
@@ -206,6 +206,11 @@ public class AllocatedPersistentTask extends CancellableTask {
         }
     }
 
+    /**
+     * The state of the task.
+     *
+     * @opensearch.internal
+     */
     public enum State {
         STARTED,  // the task is currently running
         PENDING_CANCEL, // the task is cancelled on master, cancelling it locally

--- a/server/src/main/java/org/opensearch/persistent/CompletionPersistentTaskAction.java
+++ b/server/src/main/java/org/opensearch/persistent/CompletionPersistentTaskAction.java
@@ -70,6 +70,11 @@ public class CompletionPersistentTaskAction extends ActionType<PersistentTaskRes
         super(NAME, PersistentTaskResponse::new);
     }
 
+    /**
+     * The request.
+     *
+     * @opensearch.internal
+     */
     public static class Request extends MasterNodeRequest<Request> {
 
         private String taskId;
@@ -129,6 +134,11 @@ public class CompletionPersistentTaskAction extends ActionType<PersistentTaskRes
         }
     }
 
+    /**
+     * The request bulder.
+     *
+     * @opensearch.internal
+     */
     public static class RequestBuilder extends MasterNodeOperationRequestBuilder<
         CompletionPersistentTaskAction.Request,
         PersistentTaskResponse,
@@ -139,6 +149,11 @@ public class CompletionPersistentTaskAction extends ActionType<PersistentTaskRes
         }
     }
 
+    /**
+     * The transport action.
+     *
+     * @opensearch.internal
+     */
     public static class TransportAction extends TransportMasterNodeAction<Request, PersistentTaskResponse> {
 
         private final PersistentTasksClusterService persistentTasksClusterService;

--- a/server/src/main/java/org/opensearch/persistent/PersistentTasksCustomMetadata.java
+++ b/server/src/main/java/org/opensearch/persistent/PersistentTasksCustomMetadata.java
@@ -276,6 +276,12 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
         return ClusterState.builder(clusterState).metadata(metadataBuilder).build();
     }
 
+    /**
+     * The assignment.
+     *
+     * @opensearch.internal
+     */
+
     public static class Assignment {
         @Nullable
         private final String executorNode;
@@ -598,6 +604,11 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
         return new Builder(tasks);
     }
 
+    /**
+     * The task builder.
+     *
+     * @opensearch.internal
+     */
     public static class Builder {
         private final Map<String, PersistentTask<?>> tasks = new HashMap<>();
         private long lastAllocationId;

--- a/server/src/main/java/org/opensearch/persistent/PersistentTasksNodeService.java
+++ b/server/src/main/java/org/opensearch/persistent/PersistentTasksNodeService.java
@@ -324,6 +324,11 @@ public class PersistentTasksNodeService implements ClusterStateListener {
         }
     }
 
+    /**
+     * The executor status.
+     *
+     * @opensearch.internal
+     */
     public static class Status implements Task.Status {
 
         public static final String NAME = "persistent_executor";

--- a/server/src/main/java/org/opensearch/persistent/PersistentTasksService.java
+++ b/server/src/main/java/org/opensearch/persistent/PersistentTasksService.java
@@ -245,6 +245,11 @@ public class PersistentTasksService {
         }
     }
 
+    /**
+     * Interface for a class that waits and listens for a persistent task.
+     *
+     * @opensearch.internal
+     */
     public interface WaitForPersistentTaskListener<P extends PersistentTaskParams> extends ActionListener<PersistentTask<P>> {
         default void onTimeout(TimeValue timeout) {
             onFailure(new IllegalStateException("Timed out when waiting for persistent task after " + timeout));

--- a/server/src/main/java/org/opensearch/persistent/RemovePersistentTaskAction.java
+++ b/server/src/main/java/org/opensearch/persistent/RemovePersistentTaskAction.java
@@ -67,6 +67,11 @@ public class RemovePersistentTaskAction extends ActionType<PersistentTaskRespons
         super(NAME, PersistentTaskResponse::new);
     }
 
+    /**
+     * The request.
+     *
+     * @opensearch.internal
+     */
     public static class Request extends MasterNodeRequest<Request> {
 
         private String taskId;
@@ -111,6 +116,11 @@ public class RemovePersistentTaskAction extends ActionType<PersistentTaskRespons
         }
     }
 
+    /**
+     * The request builder.
+     *
+     * @opensearch.internal
+     */
     public static class RequestBuilder extends MasterNodeOperationRequestBuilder<
         RemovePersistentTaskAction.Request,
         PersistentTaskResponse,
@@ -127,6 +137,11 @@ public class RemovePersistentTaskAction extends ActionType<PersistentTaskRespons
 
     }
 
+    /**
+     * The transport action.
+     *
+     * @opensearch.internal
+     */
     public static class TransportAction extends TransportMasterNodeAction<Request, PersistentTaskResponse> {
 
         private final PersistentTasksClusterService persistentTasksClusterService;

--- a/server/src/main/java/org/opensearch/persistent/StartPersistentTaskAction.java
+++ b/server/src/main/java/org/opensearch/persistent/StartPersistentTaskAction.java
@@ -70,6 +70,11 @@ public class StartPersistentTaskAction extends ActionType<PersistentTaskResponse
         super(NAME, PersistentTaskResponse::new);
     }
 
+    /**
+     * Request for the action.
+     *
+     * @opensearch.internal
+     */
     public static class Request extends MasterNodeRequest<Request> {
 
         private String taskId;
@@ -163,6 +168,11 @@ public class StartPersistentTaskAction extends ActionType<PersistentTaskResponse
 
     }
 
+    /**
+     * The request builder.
+     *
+     * @opensearch.internal
+     */
     public static class RequestBuilder extends MasterNodeOperationRequestBuilder<
         StartPersistentTaskAction.Request,
         PersistentTaskResponse,
@@ -189,6 +199,11 @@ public class StartPersistentTaskAction extends ActionType<PersistentTaskResponse
 
     }
 
+    /**
+     * The transport action.
+     *
+     * @opensearch.internal
+     */
     public static class TransportAction extends TransportMasterNodeAction<Request, PersistentTaskResponse> {
 
         private final PersistentTasksClusterService persistentTasksClusterService;

--- a/server/src/main/java/org/opensearch/persistent/UpdatePersistentTaskStatusAction.java
+++ b/server/src/main/java/org/opensearch/persistent/UpdatePersistentTaskStatusAction.java
@@ -69,6 +69,11 @@ public class UpdatePersistentTaskStatusAction extends ActionType<PersistentTaskR
         super(NAME, PersistentTaskResponse::new);
     }
 
+    /**
+     * The action request.
+     *
+     * @opensearch.internal
+     */
     public static class Request extends MasterNodeRequest<Request> {
 
         private String taskId;
@@ -138,6 +143,11 @@ public class UpdatePersistentTaskStatusAction extends ActionType<PersistentTaskR
         }
     }
 
+    /**
+     * The request builder.
+     *
+     * @opensearch.internal
+     */
     public static class RequestBuilder extends MasterNodeOperationRequestBuilder<
         UpdatePersistentTaskStatusAction.Request,
         PersistentTaskResponse,
@@ -157,6 +167,12 @@ public class UpdatePersistentTaskStatusAction extends ActionType<PersistentTaskR
             return this;
         }
     }
+
+    /**
+     * The transport action.
+     *
+     * @opensearch.internal
+     */
 
     public static class TransportAction extends TransportMasterNodeAction<Request, PersistentTaskResponse> {
 

--- a/server/src/main/java/org/opensearch/persistent/decider/AssignmentDecision.java
+++ b/server/src/main/java/org/opensearch/persistent/decider/AssignmentDecision.java
@@ -67,6 +67,11 @@ public final class AssignmentDecision {
         return "assignment decision [type=" + type + ", reason=" + reason + "]";
     }
 
+    /**
+     * The decision.
+     *
+     * @opensearch.internal
+     */
     public enum Type {
         NO(0),
         YES(1);

--- a/server/src/main/java/org/opensearch/repositories/ShardGenerations.java
+++ b/server/src/main/java/org/opensearch/repositories/ShardGenerations.java
@@ -195,6 +195,11 @@ public final class ShardGenerations {
         return new Builder();
     }
 
+    /**
+     * Builder for the shard generations.
+     *
+     * @opensearch.internal
+     */
     public static final class Builder {
 
         private final Map<IndexId, Map<Integer, String>> generations = new HashMap<>();

--- a/server/src/main/java/org/opensearch/repositories/VerifyNodeRepositoryAction.java
+++ b/server/src/main/java/org/opensearch/repositories/VerifyNodeRepositoryAction.java
@@ -161,6 +161,11 @@ public class VerifyNodeRepositoryAction {
         repository.verify(verificationToken, localNode);
     }
 
+    /**
+     * Request to verify a node repository.
+     *
+     * @opensearch.internal
+     */
     public static class VerifyNodeRepositoryRequest extends TransportRequest {
 
         private String repository;

--- a/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/BaseRestHandler.java
@@ -233,6 +233,11 @@ public abstract class BaseRestHandler implements RestHandler {
         }
     }
 
+    /**
+     * A wrapper for the base handler.
+     *
+     * @opensearch.internal
+     */
     public static class Wrapper extends BaseRestHandler {
 
         protected final BaseRestHandler delegate;

--- a/server/src/main/java/org/opensearch/rest/RestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/RestHandler.java
@@ -119,6 +119,11 @@ public interface RestHandler {
         return new Wrapper(delegate);
     }
 
+    /**
+     * Wrapper for a handler.
+     *
+     * @opensearch.internal
+     */
     class Wrapper implements RestHandler {
         private final RestHandler delegate;
 
@@ -172,6 +177,11 @@ public interface RestHandler {
         }
     }
 
+    /**
+     * Route for the request.
+     *
+     * @opensearch.internal
+     */
     class Route {
 
         private final String path;

--- a/server/src/main/java/org/opensearch/rest/RestRequest.java
+++ b/server/src/main/java/org/opensearch/rest/RestRequest.java
@@ -228,6 +228,11 @@ public class RestRequest implements ToXContent.Params {
         );
     }
 
+    /**
+     * The method used.
+     *
+     * @opensearch.internal
+     */
     public enum Method {
         GET,
         POST,
@@ -583,6 +588,11 @@ public class RestRequest implements ToXContent.Params {
         throw new IllegalArgumentException("empty Content-Type header");
     }
 
+    /**
+     * Thrown if there is an error in the content type header.
+     *
+     * @opensearch.internal
+     */
     public static class ContentTypeHeaderException extends RuntimeException {
 
         ContentTypeHeaderException(final IllegalArgumentException cause) {
@@ -591,6 +601,11 @@ public class RestRequest implements ToXContent.Params {
 
     }
 
+    /**
+     * Thrown if there is a bad parameter.
+     *
+     * @opensearch.internal
+     */
     public static class BadParameterException extends RuntimeException {
 
         BadParameterException(final IllegalArgumentException cause) {

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestAnalyzeAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestAnalyzeAction.java
@@ -54,6 +54,11 @@ import static org.opensearch.rest.RestRequest.Method.POST;
  */
 public class RestAnalyzeAction extends BaseRestHandler {
 
+    /**
+     * Fields for parsing and toXContent
+     *
+     * @opensearch.internal
+     */
     public static class Fields {
         public static final ParseField ANALYZER = new ParseField("analyzer");
         public static final ParseField TEXT = new ParseField("text");

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestResizeHandler.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestResizeHandler.java
@@ -102,6 +102,11 @@ public abstract class RestResizeHandler extends BaseRestHandler {
         return channel -> client.admin().indices().resizeIndex(resizeRequest, new RestToXContentListener<>(channel));
     }
 
+    /**
+     * Shrink index action.
+     *
+     * @opensearch.internal
+     */
     public static class RestShrinkIndexAction extends RestResizeHandler {
 
         @Override
@@ -121,6 +126,11 @@ public abstract class RestResizeHandler extends BaseRestHandler {
 
     }
 
+    /**
+     * Split index action.
+     *
+     * @opensearch.internal
+     */
     public static class RestSplitIndexAction extends RestResizeHandler {
 
         @Override
@@ -140,6 +150,11 @@ public abstract class RestResizeHandler extends BaseRestHandler {
 
     }
 
+    /**
+     * Clone index action.
+     *
+     * @opensearch.internal
+     */
     public static class RestCloneIndexAction extends RestResizeHandler {
 
         @Override

--- a/server/src/main/java/org/opensearch/rest/action/document/RestIndexAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/document/RestIndexAction.java
@@ -71,6 +71,11 @@ public class RestIndexAction extends BaseRestHandler {
         return "document_index_action";
     }
 
+    /**
+     * Create handler action.
+     *
+     * @opensearch.internal
+     */
     public static final class CreateHandler extends RestIndexAction {
 
         @Override
@@ -97,6 +102,11 @@ public class RestIndexAction extends BaseRestHandler {
         }
     }
 
+    /**
+     * The auto id handler.
+     *
+     * @opensearch.internal
+     */
     public static final class AutoIdHandler extends RestIndexAction {
 
         private final Supplier<DiscoveryNodes> nodesInCluster;

--- a/server/src/main/java/org/opensearch/script/AggregationScript.java
+++ b/server/src/main/java/org/opensearch/script/AggregationScript.java
@@ -167,6 +167,8 @@ public abstract class AggregationScript implements ScorerAware {
 
     /**
      * A factory to construct {@link AggregationScript} instances.
+     *
+     * @opensearch.internal
      */
     public interface LeafFactory {
         AggregationScript newInstance(LeafReaderContext ctx) throws IOException;
@@ -179,6 +181,8 @@ public abstract class AggregationScript implements ScorerAware {
 
     /**
      * A factory to construct stateful {@link AggregationScript} factories for a specific index.
+     *
+     * @opensearch.internal
      */
     public interface Factory extends ScriptFactory {
         LeafFactory newFactory(Map<String, Object> params, SearchLookup lookup);

--- a/server/src/main/java/org/opensearch/script/BucketAggregationScript.java
+++ b/server/src/main/java/org/opensearch/script/BucketAggregationScript.java
@@ -63,6 +63,11 @@ public abstract class BucketAggregationScript {
 
     public abstract Number execute();
 
+    /**
+     * Factory for bucket agg script
+     *
+     * @opensearch.internal
+     */
     public interface Factory extends ScriptFactory {
         BucketAggregationScript newInstance(Map<String, Object> params);
     }

--- a/server/src/main/java/org/opensearch/script/BucketAggregationSelectorScript.java
+++ b/server/src/main/java/org/opensearch/script/BucketAggregationSelectorScript.java
@@ -63,6 +63,11 @@ public abstract class BucketAggregationSelectorScript {
 
     public abstract boolean execute();
 
+    /**
+     * Factory for bucket agg selector script
+     *
+     * @opensearch.internal
+     */
     public interface Factory {
         BucketAggregationSelectorScript newInstance(Map<String, Object> params);
     }

--- a/server/src/main/java/org/opensearch/script/FieldScript.java
+++ b/server/src/main/java/org/opensearch/script/FieldScript.java
@@ -110,11 +110,20 @@ public abstract class FieldScript {
         leafLookup.setDocument(docid);
     }
 
-    /** A factory to construct {@link FieldScript} instances. */
+    /**
+     * A factory to construct {@link FieldScript} instances.
+     *
+     * @opensearch.internal
+     */
     public interface LeafFactory {
         FieldScript newInstance(LeafReaderContext ctx) throws IOException;
     }
 
+    /**
+     * Factory for field script
+     *
+     * @opensearch.internal
+     */
     public interface Factory extends ScriptFactory {
         LeafFactory newFactory(Map<String, Object> params, SearchLookup lookup);
     }

--- a/server/src/main/java/org/opensearch/script/FilterScript.java
+++ b/server/src/main/java/org/opensearch/script/FilterScript.java
@@ -79,12 +79,20 @@ public abstract class FilterScript {
         leafLookup.setDocument(docid);
     }
 
-    /** A factory to construct {@link FilterScript} instances. */
+    /**
+     * A factory to construct {@link FilterScript} instances.
+     *
+     * @opensearch.internal
+     */
     public interface LeafFactory {
         FilterScript newInstance(LeafReaderContext ctx) throws IOException;
     }
 
-    /** A factory to construct stateful {@link FilterScript} factories for a specific index. */
+    /**
+     * A factory to construct stateful {@link FilterScript} factories for a specific index.
+     *
+     * @opensearch.internal
+     */
     public interface Factory extends ScriptFactory {
         LeafFactory newFactory(Map<String, Object> params, SearchLookup lookup);
     }

--- a/server/src/main/java/org/opensearch/script/IngestConditionalScript.java
+++ b/server/src/main/java/org/opensearch/script/IngestConditionalScript.java
@@ -68,6 +68,11 @@ public abstract class IngestConditionalScript {
 
     public abstract boolean execute(Map<String, Object> ctx);
 
+    /**
+     * Factory for ingest condition script
+     *
+     * @opensearch.internal
+     */
     public interface Factory {
         IngestConditionalScript newInstance(Map<String, Object> params);
     }

--- a/server/src/main/java/org/opensearch/script/IngestScript.java
+++ b/server/src/main/java/org/opensearch/script/IngestScript.java
@@ -68,6 +68,11 @@ public abstract class IngestScript {
 
     public abstract void execute(Map<String, Object> ctx);
 
+    /**
+     * Factory for ingest script
+     *
+     * @opensearch.internal
+     */
     public interface Factory {
         IngestScript newInstance(Map<String, Object> params);
     }

--- a/server/src/main/java/org/opensearch/script/NumberSortScript.java
+++ b/server/src/main/java/org/opensearch/script/NumberSortScript.java
@@ -59,6 +59,8 @@ public abstract class NumberSortScript extends AbstractSortScript {
 
     /**
      * A factory to construct {@link NumberSortScript} instances.
+     *
+     * @opensearch.internal
      */
     public interface LeafFactory {
         NumberSortScript newInstance(LeafReaderContext ctx) throws IOException;
@@ -71,6 +73,8 @@ public abstract class NumberSortScript extends AbstractSortScript {
 
     /**
      * A factory to construct stateful {@link NumberSortScript} factories for a specific index.
+     *
+     * @opensearch.internal
      */
     public interface Factory extends ScriptFactory {
         LeafFactory newFactory(Map<String, Object> params, SearchLookup lookup);

--- a/server/src/main/java/org/opensearch/script/ScoreScript.java
+++ b/server/src/main/java/org/opensearch/script/ScoreScript.java
@@ -55,7 +55,11 @@ import java.util.function.Function;
  */
 public abstract class ScoreScript {
 
-    /** A helper to take in an explanation from a script and turn it into an {@link org.apache.lucene.search.Explanation}  */
+    /**
+     * A helper to take in an explanation from a script and turn it into an {@link org.apache.lucene.search.Explanation}
+     *
+     * @opensearch.internal
+     */
     public static class ExplanationHolder {
         private String description;
 
@@ -242,7 +246,11 @@ public abstract class ScoreScript {
         this.indexVersion = indexVersion;
     }
 
-    /** A factory to construct {@link ScoreScript} instances. */
+    /**
+     * A factory to construct {@link ScoreScript} instances.
+     *
+     * @opensearch.internal
+     */
     public interface LeafFactory {
 
         /**
@@ -253,7 +261,11 @@ public abstract class ScoreScript {
         ScoreScript newInstance(LeafReaderContext ctx) throws IOException;
     }
 
-    /** A factory to construct stateful {@link ScoreScript} factories for a specific index. */
+    /**
+     * A factory to construct stateful {@link ScoreScript} factories for a specific index.
+     *
+     * @opensearch.internal
+     */
     public interface Factory extends ScriptFactory {
 
         ScoreScript.LeafFactory newFactory(Map<String, Object> params, SearchLookup lookup);

--- a/server/src/main/java/org/opensearch/script/ScoreScriptUtils.java
+++ b/server/src/main/java/org/opensearch/script/ScoreScriptUtils.java
@@ -69,7 +69,11 @@ public final class ScoreScriptUtils {
         return Math.pow(value, a) / (Math.pow(k, a) + Math.pow(value, a));
     }
 
-    // random score based on the documents' values of the given field
+    /**
+     * random score based on the documents' values of the given field
+     *
+     * @opensearch.internal
+     */
     public static final class RandomScoreField {
         private final ScoreScript scoreScript;
         private final ScriptDocValues docValues;
@@ -95,7 +99,11 @@ public final class ScoreScriptUtils {
         }
     }
 
-    // random score based on the internal Lucene document Ids
+    /**
+     * random score based on the internal Lucene document Ids
+     *
+     * @opensearch.internal
+     */
     public static final class RandomScoreDoc {
         private final ScoreScript scoreScript;
         private final int saltedSeed;
@@ -113,7 +121,11 @@ public final class ScoreScriptUtils {
         }
     }
 
-    // **** Decay functions on geo field
+    /**
+     * **** Decay functions on geo field
+     *
+     * @opensearch.internal
+     */
     public static final class DecayGeoLinear {
         // cached variables calculated once per script execution
         double originLat;
@@ -137,6 +149,11 @@ public final class ScoreScriptUtils {
         }
     }
 
+    /**
+     * Exponential geo decay
+     *
+     * @opensearch.internal
+     */
     public static final class DecayGeoExp {
         double originLat;
         double originLon;
@@ -159,6 +176,11 @@ public final class ScoreScriptUtils {
         }
     }
 
+    /**
+     * Gaussian geo decay
+     *
+     * @opensearch.internal
+     */
     public static final class DecayGeoGauss {
         double originLat;
         double originLon;
@@ -183,6 +205,11 @@ public final class ScoreScriptUtils {
 
     // **** Decay functions on numeric field
 
+    /**
+     * Linear numeric decay
+     *
+     * @opensearch.internal
+     */
     public static final class DecayNumericLinear {
         double origin;
         double offset;
@@ -200,6 +227,11 @@ public final class ScoreScriptUtils {
         }
     }
 
+    /**
+     * Exponential numeric decay
+     *
+     * @opensearch.internal
+     */
     public static final class DecayNumericExp {
         double origin;
         double offset;
@@ -217,6 +249,11 @@ public final class ScoreScriptUtils {
         }
     }
 
+    /**
+     * Gaussian numeric decay
+     *
+     * @opensearch.internal
+     */
     public static final class DecayNumericGauss {
         double origin;
         double offset;
@@ -245,6 +282,11 @@ public final class ScoreScriptUtils {
     private static final ZoneId defaultZoneId = ZoneId.of("UTC");
     private static final DateMathParser dateParser = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.toDateMathParser();
 
+    /**
+     * Linear date decay
+     *
+     * @opensearch.internal
+     */
     public static final class DecayDateLinear {
         long origin;
         long offset;
@@ -268,6 +310,11 @@ public final class ScoreScriptUtils {
         }
     }
 
+    /**
+     * Exponential date decay
+     *
+     * @opensearch.internal
+     */
     public static final class DecayDateExp {
         long origin;
         long offset;
@@ -290,6 +337,11 @@ public final class ScoreScriptUtils {
         }
     }
 
+    /**
+     * Gaussian date decay
+     *
+     * @opensearch.internal
+     */
     public static final class DecayDateGauss {
         long origin;
         long offset;

--- a/server/src/main/java/org/opensearch/script/ScriptCache.java
+++ b/server/src/main/java/org/opensearch/script/ScriptCache.java
@@ -264,6 +264,11 @@ public class ScriptCache {
         }
     }
 
+    /**
+     * Tracking compilation rate
+     *
+     * @opensearch.internal
+     */
     public static class CompilationRate {
         public final int count;
         public final TimeValue time;

--- a/server/src/main/java/org/opensearch/script/ScriptContextInfo.java
+++ b/server/src/main/java/org/opensearch/script/ScriptContextInfo.java
@@ -199,6 +199,11 @@ public class ScriptContextInfo implements ToXContentObject, Writeable {
         return builder.endArray().endObject();
     }
 
+    /**
+     * Script method information
+     *
+     * @opensearch.internal
+     */
     public static class ScriptMethodInfo implements ToXContentObject, Writeable {
         public final String name, returnType;
         public final List<ParameterInfo> parameters;
@@ -277,6 +282,11 @@ public class ScriptContextInfo implements ToXContentObject, Writeable {
             return builder.endArray().endObject();
         }
 
+        /**
+         * Parameter information
+         *
+         * @opensearch.internal
+         */
         public static class ParameterInfo implements ToXContentObject, Writeable {
             public final String type, name;
 

--- a/server/src/main/java/org/opensearch/script/ScriptException.java
+++ b/server/src/main/java/org/opensearch/script/ScriptException.java
@@ -188,6 +188,11 @@ public class ScriptException extends OpenSearchException {
         return RestStatus.BAD_REQUEST;
     }
 
+    /**
+     * Position data
+     *
+     * @opensearch.internal
+     */
     public static class Position {
         public final int offset;
         public final int start;

--- a/server/src/main/java/org/opensearch/script/ScriptMetadata.java
+++ b/server/src/main/java/org/opensearch/script/ScriptMetadata.java
@@ -72,6 +72,8 @@ public final class ScriptMetadata implements Metadata.Custom, Writeable, ToXCont
      * the {@link ClusterState}.  Scripts can be added or deleted, then built
      * to generate a new {@link Map} of scripts that will be used to update
      * the current {@link ClusterState}.
+     *
+     * @opensearch.internal
      */
     public static final class Builder {
 

--- a/server/src/main/java/org/opensearch/script/ScriptedMetricAggContexts.java
+++ b/server/src/main/java/org/opensearch/script/ScriptedMetricAggContexts.java
@@ -54,6 +54,11 @@ import java.util.function.Function;
  */
 public class ScriptedMetricAggContexts {
 
+    /**
+     * Base initialization script
+     *
+     * @opensearch.internal
+     */
     public abstract static class InitScript {
         private final Map<String, Object> params;
         private final Map<String, Object> state;
@@ -73,6 +78,11 @@ public class ScriptedMetricAggContexts {
 
         public abstract void execute();
 
+        /**
+         * Factory for a scripted metric agg context
+         *
+         * @opensearch.internal
+         */
         public interface Factory extends ScriptFactory {
             InitScript newInstance(Map<String, Object> params, Map<String, Object> state);
         }
@@ -81,6 +91,11 @@ public class ScriptedMetricAggContexts {
         public static ScriptContext<Factory> CONTEXT = new ScriptContext<>("aggs_init", Factory.class);
     }
 
+    /**
+     * Base map script
+     *
+     * @opensearch.internal
+     */
     public abstract static class MapScript {
 
         private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(DynamicMap.class);
@@ -162,10 +177,20 @@ public class ScriptedMetricAggContexts {
 
         public abstract void execute();
 
+        /**
+         * Factory for a scripted metric agg context
+         *
+         * @opensearch.internal
+         */
         public interface LeafFactory {
             MapScript newInstance(LeafReaderContext ctx);
         }
 
+        /**
+         * Factory for a scripted metric agg factory
+         *
+         * @opensearch.internal
+         */
         public interface Factory extends ScriptFactory {
             LeafFactory newFactory(Map<String, Object> params, Map<String, Object> state, SearchLookup lookup);
         }
@@ -174,6 +199,11 @@ public class ScriptedMetricAggContexts {
         public static ScriptContext<Factory> CONTEXT = new ScriptContext<>("aggs_map", Factory.class);
     }
 
+    /**
+     * Base combination script
+     *
+     * @opensearch.internal
+     */
     public abstract static class CombineScript {
         private final Map<String, Object> params;
         private final Map<String, Object> state;
@@ -193,6 +223,11 @@ public class ScriptedMetricAggContexts {
 
         public abstract Object execute();
 
+        /**
+         * Factory for a scripted metric agg context
+         *
+         * @opensearch.internal
+         */
         public interface Factory extends ScriptFactory {
             CombineScript newInstance(Map<String, Object> params, Map<String, Object> state);
         }
@@ -201,6 +236,11 @@ public class ScriptedMetricAggContexts {
         public static ScriptContext<Factory> CONTEXT = new ScriptContext<>("aggs_combine", Factory.class);
     }
 
+    /**
+     * Base reduce script
+     *
+     * @opensearch.internal
+     */
     public abstract static class ReduceScript {
         private final Map<String, Object> params;
         private final List<Object> states;
@@ -220,6 +260,11 @@ public class ScriptedMetricAggContexts {
 
         public abstract Object execute();
 
+        /**
+         * Factory for a scripted metric agg context
+         *
+         * @opensearch.internal
+         */
         public interface Factory extends ScriptFactory {
             ReduceScript newInstance(Map<String, Object> params, List<Object> states);
         }

--- a/server/src/main/java/org/opensearch/script/SignificantTermsHeuristicScoreScript.java
+++ b/server/src/main/java/org/opensearch/script/SignificantTermsHeuristicScoreScript.java
@@ -47,6 +47,11 @@ public abstract class SignificantTermsHeuristicScoreScript {
 
     public abstract double execute(Map<String, Object> params);
 
+    /**
+     * Factory for a significant terms heuristic score script
+     *
+     * @opensearch.internal
+     */
     public interface Factory extends ScriptFactory {
         SignificantTermsHeuristicScoreScript newInstance();
     }

--- a/server/src/main/java/org/opensearch/script/SimilarityScript.java
+++ b/server/src/main/java/org/opensearch/script/SimilarityScript.java
@@ -56,6 +56,11 @@ public abstract class SimilarityScript {
         ScriptedSimilarity.Doc doc
     );
 
+    /**
+     * Factory for a similarity script
+     *
+     * @opensearch.internal
+     */
     public interface Factory extends ScriptFactory {
         SimilarityScript newInstance();
     }

--- a/server/src/main/java/org/opensearch/script/SimilarityWeightScript.java
+++ b/server/src/main/java/org/opensearch/script/SimilarityWeightScript.java
@@ -48,6 +48,11 @@ public abstract class SimilarityWeightScript {
      */
     public abstract double execute(ScriptedSimilarity.Query query, ScriptedSimilarity.Field field, ScriptedSimilarity.Term term);
 
+    /**
+     * Factory for a similarity weight script
+     *
+     * @opensearch.internal
+     */
     public interface Factory extends ScriptFactory {
         SimilarityWeightScript newInstance();
     }

--- a/server/src/main/java/org/opensearch/script/StringSortScript.java
+++ b/server/src/main/java/org/opensearch/script/StringSortScript.java
@@ -55,6 +55,8 @@ public abstract class StringSortScript extends AbstractSortScript {
 
     /**
      * A factory to construct {@link StringSortScript} instances.
+     *
+     * @opensearch.internal
      */
     public interface LeafFactory {
         StringSortScript newInstance(LeafReaderContext ctx) throws IOException;
@@ -62,6 +64,8 @@ public abstract class StringSortScript extends AbstractSortScript {
 
     /**
      * A factory to construct stateful {@link StringSortScript} factories for a specific index.
+     *
+     * @opensearch.internal
      */
     public interface Factory extends ScriptFactory {
         LeafFactory newFactory(Map<String, Object> params, SearchLookup lookup);

--- a/server/src/main/java/org/opensearch/script/TemplateScript.java
+++ b/server/src/main/java/org/opensearch/script/TemplateScript.java
@@ -57,6 +57,11 @@ public abstract class TemplateScript {
     /** Run a template and return the resulting string, encoded in utf8 bytes. */
     public abstract String execute();
 
+    /**
+     * Factory for a template script
+     *
+     * @opensearch.internal
+     */
     public interface Factory {
         TemplateScript newInstance(Map<String, Object> params);
     }

--- a/server/src/main/java/org/opensearch/script/TermsSetQueryScript.java
+++ b/server/src/main/java/org/opensearch/script/TermsSetQueryScript.java
@@ -125,6 +125,8 @@ public abstract class TermsSetQueryScript {
 
     /**
      * A factory to construct {@link TermsSetQueryScript} instances.
+     *
+     * @opensearch.internal
      */
     public interface LeafFactory {
         TermsSetQueryScript newInstance(LeafReaderContext ctx) throws IOException;
@@ -132,6 +134,8 @@ public abstract class TermsSetQueryScript {
 
     /**
      * A factory to construct stateful {@link TermsSetQueryScript} factories for a specific index.
+     *
+     * @opensearch.internal
      */
     public interface Factory extends ScriptFactory {
         LeafFactory newFactory(Map<String, Object> params, SearchLookup lookup);

--- a/server/src/main/java/org/opensearch/script/UpdateScript.java
+++ b/server/src/main/java/org/opensearch/script/UpdateScript.java
@@ -78,6 +78,11 @@ public abstract class UpdateScript {
 
     public abstract void execute();
 
+    /**
+     * Factory for an update script
+     *
+     * @opensearch.internal
+     */
     public interface Factory {
         UpdateScript newInstance(Map<String, Object> params, Map<String, Object> ctx);
     }

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -776,6 +776,11 @@ public class RestoreService implements ClusterStateApplier {
         }
     }
 
+    /**
+     * Response once restore is completed.
+     *
+     * @opensearch.internal
+     */
     public static final class RestoreCompletionResponse {
         private final String uuid;
         private final Snapshot snapshot;

--- a/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
@@ -81,6 +81,11 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
 
     private static final Logger logger = LogManager.getLogger(ThreadPool.class);
 
+    /**
+     * The threadpool names.
+     *
+     * @opensearch.internal
+     */
     public static class Names {
         public static final String SAME = "same";
         public static final String GENERIC = "generic";
@@ -103,6 +108,11 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         public static final String SYSTEM_WRITE = "system_write";
     }
 
+    /**
+     * The threadpool type.
+     *
+     * @opensearch.internal
+     */
     public enum ThreadPoolType {
         DIRECT("direct"),
         FIXED("fixed"),
@@ -657,6 +667,11 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         }
     }
 
+    /**
+     * The thread pool information.
+     *
+     * @opensearch.internal
+     */
     public static class Info implements Writeable, ToXContentFragment {
 
         private final String name;

--- a/server/src/main/java/org/opensearch/threadpool/ThreadPoolStats.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPoolStats.java
@@ -51,6 +51,11 @@ import java.util.List;
  */
 public class ThreadPoolStats implements Writeable, ToXContentFragment, Iterable<ThreadPoolStats.Stats> {
 
+    /**
+     * The statistics.
+     *
+     * @opensearch.internal
+     */
     public static class Stats implements Writeable, ToXContentFragment, Comparable<Stats> {
 
         private final String name;

--- a/server/src/main/java/org/opensearch/watcher/ResourceWatcherService.java
+++ b/server/src/main/java/org/opensearch/watcher/ResourceWatcherService.java
@@ -59,6 +59,11 @@ import java.util.concurrent.CopyOnWriteArraySet;
 public class ResourceWatcherService implements Closeable {
     private static final Logger logger = LogManager.getLogger(ResourceWatcherService.class);
 
+    /**
+     * Frequency level to watch.
+     *
+     * @opensearch.internal
+     */
     public enum Frequency {
 
         /**


### PR DESCRIPTION
Adds the remaining javadocs to internal classes and reenables the missingJavadoc
gradle task on the server module. From here forward if class level javadocs are 
missing in the server module, gradle check will fail!

relates #221 
relates #2868 