### PR TITLE
Update generated ANTLR lexer/parser to match runtime version

### DIFF
--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -139,7 +139,7 @@ tasks.register("generateContextDoc", DefaultTestClustersTask) {
   useCluster testClusters.generateContextCluster
   doFirst {
     project.javaexec {
-      main = 'org.opensearch.painless.ContextDocGenerator'
+      mainClass = 'org.opensearch.painless.ContextDocGenerator'
       classpath = sourceSets.doc.runtimeClasspath
       systemProperty "cluster.uri", "${-> testClusters.generateContextCluster.singleNode().getAllHttpSocketURI().get(0)}"
     }.assertNormalExitValue()
@@ -172,7 +172,7 @@ tasks.register("cleanGenerated", Delete) {
 
 tasks.register("regenLexer", JavaExec) {
   dependsOn "cleanGenerated"
-  main = 'org.antlr.v4.Tool'
+  mainClass = 'org.antlr.v4.Tool'
   classpath = configurations.regenerate
   systemProperty 'file.encoding', 'UTF-8'
   systemProperty 'user.language', 'en'
@@ -186,7 +186,7 @@ tasks.register("regenLexer", JavaExec) {
 
 tasks.register("regenParser", JavaExec) {
   dependsOn "regenLexer"
-  main = 'org.antlr.v4.Tool'
+  mainClass = 'org.antlr.v4.Tool'
   classpath = configurations.regenerate
   systemProperty 'file.encoding', 'UTF-8'
   systemProperty 'user.language', 'en'

--- a/modules/lang-painless/src/main/java/org/opensearch/painless/antlr/PainlessLexer.java
+++ b/modules/lang-painless/src/main/java/org/opensearch/painless/antlr/PainlessLexer.java
@@ -43,7 +43,7 @@ import org.antlr.v4.runtime.misc.*;
 @SuppressWarnings({ "all", "warnings", "unchecked", "unused", "cast" })
 abstract class PainlessLexer extends Lexer {
     static {
-        RuntimeMetaData.checkVersion("4.5.3", RuntimeMetaData.VERSION);
+        RuntimeMetaData.checkVersion("4.9.3", RuntimeMetaData.VERSION);
     }
 
     protected static final DFA[] _decisionToDFA;
@@ -57,266 +57,281 @@ abstract class PainlessLexer extends Lexer {
             68, ALSH = 69, ARSH = 70, AUSH = 71, OCTAL = 72, HEX = 73, INTEGER = 74, DECIMAL = 75, STRING = 76, REGEX = 77, TRUE = 78,
         FALSE = 79, NULL = 80, PRIMITIVE = 81, DEF = 82, ID = 83, DOTINTEGER = 84, DOTID = 85;
     public static final int AFTER_DOT = 1;
+    public static String[] channelNames = { "DEFAULT_TOKEN_CHANNEL", "HIDDEN" };
+
     public static String[] modeNames = { "DEFAULT_MODE", "AFTER_DOT" };
 
-    public static final String[] ruleNames = {
-        "WS",
-        "COMMENT",
-        "LBRACK",
-        "RBRACK",
-        "LBRACE",
-        "RBRACE",
-        "LP",
-        "RP",
-        "DOT",
-        "NSDOT",
-        "COMMA",
-        "SEMICOLON",
-        "IF",
-        "IN",
-        "ELSE",
-        "WHILE",
-        "DO",
-        "FOR",
-        "CONTINUE",
-        "BREAK",
-        "RETURN",
-        "NEW",
-        "TRY",
-        "CATCH",
-        "THROW",
-        "THIS",
-        "INSTANCEOF",
-        "BOOLNOT",
-        "BWNOT",
-        "MUL",
-        "DIV",
-        "REM",
-        "ADD",
-        "SUB",
-        "LSH",
-        "RSH",
-        "USH",
-        "LT",
-        "LTE",
-        "GT",
-        "GTE",
-        "EQ",
-        "EQR",
-        "NE",
-        "NER",
-        "BWAND",
-        "XOR",
-        "BWOR",
-        "BOOLAND",
-        "BOOLOR",
-        "COND",
-        "COLON",
-        "ELVIS",
-        "REF",
-        "ARROW",
-        "FIND",
-        "MATCH",
-        "INCR",
-        "DECR",
-        "ASSIGN",
-        "AADD",
-        "ASUB",
-        "AMUL",
-        "ADIV",
-        "AREM",
-        "AAND",
-        "AXOR",
-        "AOR",
-        "ALSH",
-        "ARSH",
-        "AUSH",
-        "OCTAL",
-        "HEX",
-        "INTEGER",
-        "DECIMAL",
-        "STRING",
-        "REGEX",
-        "TRUE",
-        "FALSE",
-        "NULL",
-        "PRIMITIVE",
-        "DEF",
-        "ID",
-        "DOTINTEGER",
-        "DOTID" };
+    private static String[] makeRuleNames() {
+        return new String[] {
+            "WS",
+            "COMMENT",
+            "LBRACK",
+            "RBRACK",
+            "LBRACE",
+            "RBRACE",
+            "LP",
+            "RP",
+            "DOT",
+            "NSDOT",
+            "COMMA",
+            "SEMICOLON",
+            "IF",
+            "IN",
+            "ELSE",
+            "WHILE",
+            "DO",
+            "FOR",
+            "CONTINUE",
+            "BREAK",
+            "RETURN",
+            "NEW",
+            "TRY",
+            "CATCH",
+            "THROW",
+            "THIS",
+            "INSTANCEOF",
+            "BOOLNOT",
+            "BWNOT",
+            "MUL",
+            "DIV",
+            "REM",
+            "ADD",
+            "SUB",
+            "LSH",
+            "RSH",
+            "USH",
+            "LT",
+            "LTE",
+            "GT",
+            "GTE",
+            "EQ",
+            "EQR",
+            "NE",
+            "NER",
+            "BWAND",
+            "XOR",
+            "BWOR",
+            "BOOLAND",
+            "BOOLOR",
+            "COND",
+            "COLON",
+            "ELVIS",
+            "REF",
+            "ARROW",
+            "FIND",
+            "MATCH",
+            "INCR",
+            "DECR",
+            "ASSIGN",
+            "AADD",
+            "ASUB",
+            "AMUL",
+            "ADIV",
+            "AREM",
+            "AAND",
+            "AXOR",
+            "AOR",
+            "ALSH",
+            "ARSH",
+            "AUSH",
+            "OCTAL",
+            "HEX",
+            "INTEGER",
+            "DECIMAL",
+            "STRING",
+            "REGEX",
+            "TRUE",
+            "FALSE",
+            "NULL",
+            "PRIMITIVE",
+            "DEF",
+            "ID",
+            "DOTINTEGER",
+            "DOTID" };
+    }
 
-    private static final String[] _LITERAL_NAMES = {
-        null,
-        null,
-        null,
-        "'{'",
-        "'}'",
-        "'['",
-        "']'",
-        "'('",
-        "')'",
-        "'.'",
-        "'?.'",
-        "','",
-        "';'",
-        "'if'",
-        "'in'",
-        "'else'",
-        "'while'",
-        "'do'",
-        "'for'",
-        "'continue'",
-        "'break'",
-        "'return'",
-        "'new'",
-        "'try'",
-        "'catch'",
-        "'throw'",
-        "'this'",
-        "'instanceof'",
-        "'!'",
-        "'~'",
-        "'*'",
-        "'/'",
-        "'%'",
-        "'+'",
-        "'-'",
-        "'<<'",
-        "'>>'",
-        "'>>>'",
-        "'<'",
-        "'<='",
-        "'>'",
-        "'>='",
-        "'=='",
-        "'==='",
-        "'!='",
-        "'!=='",
-        "'&'",
-        "'^'",
-        "'|'",
-        "'&&'",
-        "'||'",
-        "'?'",
-        "':'",
-        "'?:'",
-        "'::'",
-        "'->'",
-        "'=~'",
-        "'==~'",
-        "'++'",
-        "'--'",
-        "'='",
-        "'+='",
-        "'-='",
-        "'*='",
-        "'/='",
-        "'%='",
-        "'&='",
-        "'^='",
-        "'|='",
-        "'<<='",
-        "'>>='",
-        "'>>>='",
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        "'true'",
-        "'false'",
-        "'null'",
-        null,
-        "'def'" };
-    private static final String[] _SYMBOLIC_NAMES = {
-        null,
-        "WS",
-        "COMMENT",
-        "LBRACK",
-        "RBRACK",
-        "LBRACE",
-        "RBRACE",
-        "LP",
-        "RP",
-        "DOT",
-        "NSDOT",
-        "COMMA",
-        "SEMICOLON",
-        "IF",
-        "IN",
-        "ELSE",
-        "WHILE",
-        "DO",
-        "FOR",
-        "CONTINUE",
-        "BREAK",
-        "RETURN",
-        "NEW",
-        "TRY",
-        "CATCH",
-        "THROW",
-        "THIS",
-        "INSTANCEOF",
-        "BOOLNOT",
-        "BWNOT",
-        "MUL",
-        "DIV",
-        "REM",
-        "ADD",
-        "SUB",
-        "LSH",
-        "RSH",
-        "USH",
-        "LT",
-        "LTE",
-        "GT",
-        "GTE",
-        "EQ",
-        "EQR",
-        "NE",
-        "NER",
-        "BWAND",
-        "XOR",
-        "BWOR",
-        "BOOLAND",
-        "BOOLOR",
-        "COND",
-        "COLON",
-        "ELVIS",
-        "REF",
-        "ARROW",
-        "FIND",
-        "MATCH",
-        "INCR",
-        "DECR",
-        "ASSIGN",
-        "AADD",
-        "ASUB",
-        "AMUL",
-        "ADIV",
-        "AREM",
-        "AAND",
-        "AXOR",
-        "AOR",
-        "ALSH",
-        "ARSH",
-        "AUSH",
-        "OCTAL",
-        "HEX",
-        "INTEGER",
-        "DECIMAL",
-        "STRING",
-        "REGEX",
-        "TRUE",
-        "FALSE",
-        "NULL",
-        "PRIMITIVE",
-        "DEF",
-        "ID",
-        "DOTINTEGER",
-        "DOTID" };
+    public static final String[] ruleNames = makeRuleNames();
+
+    private static String[] makeLiteralNames() {
+        return new String[] {
+            null,
+            null,
+            null,
+            "'{'",
+            "'}'",
+            "'['",
+            "']'",
+            "'('",
+            "')'",
+            "'.'",
+            "'?.'",
+            "','",
+            "';'",
+            "'if'",
+            "'in'",
+            "'else'",
+            "'while'",
+            "'do'",
+            "'for'",
+            "'continue'",
+            "'break'",
+            "'return'",
+            "'new'",
+            "'try'",
+            "'catch'",
+            "'throw'",
+            "'this'",
+            "'instanceof'",
+            "'!'",
+            "'~'",
+            "'*'",
+            "'/'",
+            "'%'",
+            "'+'",
+            "'-'",
+            "'<<'",
+            "'>>'",
+            "'>>>'",
+            "'<'",
+            "'<='",
+            "'>'",
+            "'>='",
+            "'=='",
+            "'==='",
+            "'!='",
+            "'!=='",
+            "'&'",
+            "'^'",
+            "'|'",
+            "'&&'",
+            "'||'",
+            "'?'",
+            "':'",
+            "'?:'",
+            "'::'",
+            "'->'",
+            "'=~'",
+            "'==~'",
+            "'++'",
+            "'--'",
+            "'='",
+            "'+='",
+            "'-='",
+            "'*='",
+            "'/='",
+            "'%='",
+            "'&='",
+            "'^='",
+            "'|='",
+            "'<<='",
+            "'>>='",
+            "'>>>='",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "'true'",
+            "'false'",
+            "'null'",
+            null,
+            "'def'" };
+    }
+
+    private static final String[] _LITERAL_NAMES = makeLiteralNames();
+
+    private static String[] makeSymbolicNames() {
+        return new String[] {
+            null,
+            "WS",
+            "COMMENT",
+            "LBRACK",
+            "RBRACK",
+            "LBRACE",
+            "RBRACE",
+            "LP",
+            "RP",
+            "DOT",
+            "NSDOT",
+            "COMMA",
+            "SEMICOLON",
+            "IF",
+            "IN",
+            "ELSE",
+            "WHILE",
+            "DO",
+            "FOR",
+            "CONTINUE",
+            "BREAK",
+            "RETURN",
+            "NEW",
+            "TRY",
+            "CATCH",
+            "THROW",
+            "THIS",
+            "INSTANCEOF",
+            "BOOLNOT",
+            "BWNOT",
+            "MUL",
+            "DIV",
+            "REM",
+            "ADD",
+            "SUB",
+            "LSH",
+            "RSH",
+            "USH",
+            "LT",
+            "LTE",
+            "GT",
+            "GTE",
+            "EQ",
+            "EQR",
+            "NE",
+            "NER",
+            "BWAND",
+            "XOR",
+            "BWOR",
+            "BOOLAND",
+            "BOOLOR",
+            "COND",
+            "COLON",
+            "ELVIS",
+            "REF",
+            "ARROW",
+            "FIND",
+            "MATCH",
+            "INCR",
+            "DECR",
+            "ASSIGN",
+            "AADD",
+            "ASUB",
+            "AMUL",
+            "ADIV",
+            "AREM",
+            "AAND",
+            "AXOR",
+            "AOR",
+            "ALSH",
+            "ARSH",
+            "AUSH",
+            "OCTAL",
+            "HEX",
+            "INTEGER",
+            "DECIMAL",
+            "STRING",
+            "REGEX",
+            "TRUE",
+            "FALSE",
+            "NULL",
+            "PRIMITIVE",
+            "DEF",
+            "ID",
+            "DOTINTEGER",
+            "DOTID" };
+    }
+
+    private static final String[] _SYMBOLIC_NAMES = makeSymbolicNames();
     public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);
 
     /**
@@ -374,6 +389,11 @@ abstract class PainlessLexer extends Lexer {
     }
 
     @Override
+    public String[] getChannelNames() {
+        return channelNames;
+    }
+
+    @Override
     public String[] getModeNames() {
         return modeNames;
     }
@@ -410,7 +430,7 @@ abstract class PainlessLexer extends Lexer {
         return true;
     }
 
-    public static final String _serializedATN = "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\2W\u027a\b\1\b\1\4"
+    public static final String _serializedATN = "\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\2W\u027a\b\1\b\1\4"
         + "\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n"
         + "\4\13\t\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22"
         + "\t\22\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31"
@@ -457,50 +477,50 @@ abstract class PainlessLexer extends Lexer {
         + "S\u00a6T\u00a8U\u00aaV\u00acW\4\2\3\25\5\2\13\f\17\17\"\"\4\2\f\f\17\17"
         + "\3\2\629\4\2NNnn\4\2ZZzz\5\2\62;CHch\3\2\63;\3\2\62;\b\2FFHHNNffhhnn\4"
         + "\2GGgg\4\2--//\6\2FFHHffhh\4\2$$^^\4\2))^^\3\2\f\f\4\2\f\f\61\61\t\2W"
-        + "Weekknouuwwzz\5\2C\\aac|\6\2\62;C\\aac|\u02a0\2\4\3\2\2\2\2\6\3\2\2\2"
-        + "\2\b\3\2\2\2\2\n\3\2\2\2\2\f\3\2\2\2\2\16\3\2\2\2\2\20\3\2\2\2\2\22\3"
-        + "\2\2\2\2\24\3\2\2\2\2\26\3\2\2\2\2\30\3\2\2\2\2\32\3\2\2\2\2\34\3\2\2"
-        + "\2\2\36\3\2\2\2\2 \3\2\2\2\2\"\3\2\2\2\2$\3\2\2\2\2&\3\2\2\2\2(\3\2\2"
-        + "\2\2*\3\2\2\2\2,\3\2\2\2\2.\3\2\2\2\2\60\3\2\2\2\2\62\3\2\2\2\2\64\3\2"
-        + "\2\2\2\66\3\2\2\2\28\3\2\2\2\2:\3\2\2\2\2<\3\2\2\2\2>\3\2\2\2\2@\3\2\2"
-        + "\2\2B\3\2\2\2\2D\3\2\2\2\2F\3\2\2\2\2H\3\2\2\2\2J\3\2\2\2\2L\3\2\2\2\2"
-        + "N\3\2\2\2\2P\3\2\2\2\2R\3\2\2\2\2T\3\2\2\2\2V\3\2\2\2\2X\3\2\2\2\2Z\3"
-        + "\2\2\2\2\\\3\2\2\2\2^\3\2\2\2\2`\3\2\2\2\2b\3\2\2\2\2d\3\2\2\2\2f\3\2"
-        + "\2\2\2h\3\2\2\2\2j\3\2\2\2\2l\3\2\2\2\2n\3\2\2\2\2p\3\2\2\2\2r\3\2\2\2"
-        + "\2t\3\2\2\2\2v\3\2\2\2\2x\3\2\2\2\2z\3\2\2\2\2|\3\2\2\2\2~\3\2\2\2\2\u0080"
-        + "\3\2\2\2\2\u0082\3\2\2\2\2\u0084\3\2\2\2\2\u0086\3\2\2\2\2\u0088\3\2\2"
-        + "\2\2\u008a\3\2\2\2\2\u008c\3\2\2\2\2\u008e\3\2\2\2\2\u0090\3\2\2\2\2\u0092"
-        + "\3\2\2\2\2\u0094\3\2\2\2\2\u0096\3\2\2\2\2\u0098\3\2\2\2\2\u009a\3\2\2"
-        + "\2\2\u009c\3\2\2\2\2\u009e\3\2\2\2\2\u00a0\3\2\2\2\2\u00a2\3\2\2\2\2\u00a4"
-        + "\3\2\2\2\2\u00a6\3\2\2\2\2\u00a8\3\2\2\2\3\u00aa\3\2\2\2\3\u00ac\3\2\2"
-        + "\2\4\u00af\3\2\2\2\6\u00ca\3\2\2\2\b\u00ce\3\2\2\2\n\u00d0\3\2\2\2\f\u00d2"
-        + "\3\2\2\2\16\u00d4\3\2\2\2\20\u00d6\3\2\2\2\22\u00d8\3\2\2\2\24\u00da\3"
-        + "\2\2\2\26\u00de\3\2\2\2\30\u00e3\3\2\2\2\32\u00e5\3\2\2\2\34\u00e7\3\2"
-        + "\2\2\36\u00ea\3\2\2\2 \u00ed\3\2\2\2\"\u00f2\3\2\2\2$\u00f8\3\2\2\2&\u00fb"
-        + "\3\2\2\2(\u00ff\3\2\2\2*\u0108\3\2\2\2,\u010e\3\2\2\2.\u0115\3\2\2\2\60"
-        + "\u0119\3\2\2\2\62\u011d\3\2\2\2\64\u0123\3\2\2\2\66\u0129\3\2\2\28\u012e"
-        + "\3\2\2\2:\u0139\3\2\2\2<\u013b\3\2\2\2>\u013d\3\2\2\2@\u013f\3\2\2\2B"
-        + "\u0142\3\2\2\2D\u0144\3\2\2\2F\u0146\3\2\2\2H\u0148\3\2\2\2J\u014b\3\2"
-        + "\2\2L\u014e\3\2\2\2N\u0152\3\2\2\2P\u0154\3\2\2\2R\u0157\3\2\2\2T\u0159"
-        + "\3\2\2\2V\u015c\3\2\2\2X\u015f\3\2\2\2Z\u0163\3\2\2\2\\\u0166\3\2\2\2"
-        + "^\u016a\3\2\2\2`\u016c\3\2\2\2b\u016e\3\2\2\2d\u0170\3\2\2\2f\u0173\3"
-        + "\2\2\2h\u0176\3\2\2\2j\u0178\3\2\2\2l\u017a\3\2\2\2n\u017d\3\2\2\2p\u0180"
-        + "\3\2\2\2r\u0183\3\2\2\2t\u0186\3\2\2\2v\u018a\3\2\2\2x\u018d\3\2\2\2z"
-        + "\u0190\3\2\2\2|\u0192\3\2\2\2~\u0195\3\2\2\2\u0080\u0198\3\2\2\2\u0082"
-        + "\u019b\3\2\2\2\u0084\u019e\3\2\2\2\u0086\u01a1\3\2\2\2\u0088\u01a4\3\2"
-        + "\2\2\u008a\u01a7\3\2\2\2\u008c\u01aa\3\2\2\2\u008e\u01ae\3\2\2\2\u0090"
-        + "\u01b2\3\2\2\2\u0092\u01b7\3\2\2\2\u0094\u01c0\3\2\2\2\u0096\u01d2\3\2"
-        + "\2\2\u0098\u01df\3\2\2\2\u009a\u020f\3\2\2\2\u009c\u0211\3\2\2\2\u009e"
-        + "\u0222\3\2\2\2\u00a0\u0227\3\2\2\2\u00a2\u022d\3\2\2\2\u00a4\u0258\3\2"
-        + "\2\2\u00a6\u025a\3\2\2\2\u00a8\u025e\3\2\2\2\u00aa\u026d\3\2\2\2\u00ac"
-        + "\u0271\3\2\2\2\u00ae\u00b0\t\2\2\2\u00af\u00ae\3\2\2\2\u00b0\u00b1\3\2"
-        + "\2\2\u00b1\u00af\3\2\2\2\u00b1\u00b2\3\2\2\2\u00b2\u00b3\3\2\2\2\u00b3"
-        + "\u00b4\b\2\2\2\u00b4\5\3\2\2\2\u00b5\u00b6\7\61\2\2\u00b6\u00b7\7\61\2"
-        + "\2\u00b7\u00bb\3\2\2\2\u00b8\u00ba\13\2\2\2\u00b9\u00b8\3\2\2\2\u00ba"
-        + "\u00bd\3\2\2\2\u00bb\u00bc\3\2\2\2\u00bb\u00b9\3\2\2\2\u00bc\u00be\3\2"
-        + "\2\2\u00bd\u00bb\3\2\2\2\u00be\u00cb\t\3\2\2\u00bf\u00c0\7\61\2\2\u00c0"
-        + "\u00c1\7,\2\2\u00c1\u00c5\3\2\2\2\u00c2\u00c4\13\2\2\2\u00c3\u00c2\3\2"
-        + "\2\2\u00c4\u00c7\3\2\2\2\u00c5\u00c6\3\2\2\2\u00c5\u00c3\3\2\2\2\u00c6"
+        + "Weekknouuwwzz\5\2C\\aac|\6\2\62;C\\aac|\2\u02a0\2\4\3\2\2\2\2\6\3\2\2"
+        + "\2\2\b\3\2\2\2\2\n\3\2\2\2\2\f\3\2\2\2\2\16\3\2\2\2\2\20\3\2\2\2\2\22"
+        + "\3\2\2\2\2\24\3\2\2\2\2\26\3\2\2\2\2\30\3\2\2\2\2\32\3\2\2\2\2\34\3\2"
+        + "\2\2\2\36\3\2\2\2\2 \3\2\2\2\2\"\3\2\2\2\2$\3\2\2\2\2&\3\2\2\2\2(\3\2"
+        + "\2\2\2*\3\2\2\2\2,\3\2\2\2\2.\3\2\2\2\2\60\3\2\2\2\2\62\3\2\2\2\2\64\3"
+        + "\2\2\2\2\66\3\2\2\2\28\3\2\2\2\2:\3\2\2\2\2<\3\2\2\2\2>\3\2\2\2\2@\3\2"
+        + "\2\2\2B\3\2\2\2\2D\3\2\2\2\2F\3\2\2\2\2H\3\2\2\2\2J\3\2\2\2\2L\3\2\2\2"
+        + "\2N\3\2\2\2\2P\3\2\2\2\2R\3\2\2\2\2T\3\2\2\2\2V\3\2\2\2\2X\3\2\2\2\2Z"
+        + "\3\2\2\2\2\\\3\2\2\2\2^\3\2\2\2\2`\3\2\2\2\2b\3\2\2\2\2d\3\2\2\2\2f\3"
+        + "\2\2\2\2h\3\2\2\2\2j\3\2\2\2\2l\3\2\2\2\2n\3\2\2\2\2p\3\2\2\2\2r\3\2\2"
+        + "\2\2t\3\2\2\2\2v\3\2\2\2\2x\3\2\2\2\2z\3\2\2\2\2|\3\2\2\2\2~\3\2\2\2\2"
+        + "\u0080\3\2\2\2\2\u0082\3\2\2\2\2\u0084\3\2\2\2\2\u0086\3\2\2\2\2\u0088"
+        + "\3\2\2\2\2\u008a\3\2\2\2\2\u008c\3\2\2\2\2\u008e\3\2\2\2\2\u0090\3\2\2"
+        + "\2\2\u0092\3\2\2\2\2\u0094\3\2\2\2\2\u0096\3\2\2\2\2\u0098\3\2\2\2\2\u009a"
+        + "\3\2\2\2\2\u009c\3\2\2\2\2\u009e\3\2\2\2\2\u00a0\3\2\2\2\2\u00a2\3\2\2"
+        + "\2\2\u00a4\3\2\2\2\2\u00a6\3\2\2\2\2\u00a8\3\2\2\2\3\u00aa\3\2\2\2\3\u00ac"
+        + "\3\2\2\2\4\u00af\3\2\2\2\6\u00ca\3\2\2\2\b\u00ce\3\2\2\2\n\u00d0\3\2\2"
+        + "\2\f\u00d2\3\2\2\2\16\u00d4\3\2\2\2\20\u00d6\3\2\2\2\22\u00d8\3\2\2\2"
+        + "\24\u00da\3\2\2\2\26\u00de\3\2\2\2\30\u00e3\3\2\2\2\32\u00e5\3\2\2\2\34"
+        + "\u00e7\3\2\2\2\36\u00ea\3\2\2\2 \u00ed\3\2\2\2\"\u00f2\3\2\2\2$\u00f8"
+        + "\3\2\2\2&\u00fb\3\2\2\2(\u00ff\3\2\2\2*\u0108\3\2\2\2,\u010e\3\2\2\2."
+        + "\u0115\3\2\2\2\60\u0119\3\2\2\2\62\u011d\3\2\2\2\64\u0123\3\2\2\2\66\u0129"
+        + "\3\2\2\28\u012e\3\2\2\2:\u0139\3\2\2\2<\u013b\3\2\2\2>\u013d\3\2\2\2@"
+        + "\u013f\3\2\2\2B\u0142\3\2\2\2D\u0144\3\2\2\2F\u0146\3\2\2\2H\u0148\3\2"
+        + "\2\2J\u014b\3\2\2\2L\u014e\3\2\2\2N\u0152\3\2\2\2P\u0154\3\2\2\2R\u0157"
+        + "\3\2\2\2T\u0159\3\2\2\2V\u015c\3\2\2\2X\u015f\3\2\2\2Z\u0163\3\2\2\2\\"
+        + "\u0166\3\2\2\2^\u016a\3\2\2\2`\u016c\3\2\2\2b\u016e\3\2\2\2d\u0170\3\2"
+        + "\2\2f\u0173\3\2\2\2h\u0176\3\2\2\2j\u0178\3\2\2\2l\u017a\3\2\2\2n\u017d"
+        + "\3\2\2\2p\u0180\3\2\2\2r\u0183\3\2\2\2t\u0186\3\2\2\2v\u018a\3\2\2\2x"
+        + "\u018d\3\2\2\2z\u0190\3\2\2\2|\u0192\3\2\2\2~\u0195\3\2\2\2\u0080\u0198"
+        + "\3\2\2\2\u0082\u019b\3\2\2\2\u0084\u019e\3\2\2\2\u0086\u01a1\3\2\2\2\u0088"
+        + "\u01a4\3\2\2\2\u008a\u01a7\3\2\2\2\u008c\u01aa\3\2\2\2\u008e\u01ae\3\2"
+        + "\2\2\u0090\u01b2\3\2\2\2\u0092\u01b7\3\2\2\2\u0094\u01c0\3\2\2\2\u0096"
+        + "\u01d2\3\2\2\2\u0098\u01df\3\2\2\2\u009a\u020f\3\2\2\2\u009c\u0211\3\2"
+        + "\2\2\u009e\u0222\3\2\2\2\u00a0\u0227\3\2\2\2\u00a2\u022d\3\2\2\2\u00a4"
+        + "\u0258\3\2\2\2\u00a6\u025a\3\2\2\2\u00a8\u025e\3\2\2\2\u00aa\u026d\3\2"
+        + "\2\2\u00ac\u0271\3\2\2\2\u00ae\u00b0\t\2\2\2\u00af\u00ae\3\2\2\2\u00b0"
+        + "\u00b1\3\2\2\2\u00b1\u00af\3\2\2\2\u00b1\u00b2\3\2\2\2\u00b2\u00b3\3\2"
+        + "\2\2\u00b3\u00b4\b\2\2\2\u00b4\5\3\2\2\2\u00b5\u00b6\7\61\2\2\u00b6\u00b7"
+        + "\7\61\2\2\u00b7\u00bb\3\2\2\2\u00b8\u00ba\13\2\2\2\u00b9\u00b8\3\2\2\2"
+        + "\u00ba\u00bd\3\2\2\2\u00bb\u00bc\3\2\2\2\u00bb\u00b9\3\2\2\2\u00bc\u00be"
+        + "\3\2\2\2\u00bd\u00bb\3\2\2\2\u00be\u00cb\t\3\2\2\u00bf\u00c0\7\61\2\2"
+        + "\u00c0\u00c1\7,\2\2\u00c1\u00c5\3\2\2\2\u00c2\u00c4\13\2\2\2\u00c3\u00c2"
+        + "\3\2\2\2\u00c4\u00c7\3\2\2\2\u00c5\u00c6\3\2\2\2\u00c5\u00c3\3\2\2\2\u00c6"
         + "\u00c8\3\2\2\2\u00c7\u00c5\3\2\2\2\u00c8\u00c9\7,\2\2\u00c9\u00cb\7\61"
         + "\2\2\u00ca\u00b5\3\2\2\2\u00ca\u00bf\3\2\2\2\u00cb\u00cc\3\2\2\2\u00cc"
         + "\u00cd\b\3\2\2\u00cd\7\3\2\2\2\u00ce\u00cf\7}\2\2\u00cf\t\3\2\2\2\u00d0"

--- a/modules/lang-painless/src/main/java/org/opensearch/painless/antlr/PainlessParser.java
+++ b/modules/lang-painless/src/main/java/org/opensearch/painless/antlr/PainlessParser.java
@@ -30,7 +30,6 @@
  * Modifications Copyright OpenSearch Contributors. See
  * GitHub history for details.
  */
-
 package org.opensearch.painless.antlr;
 
 import org.antlr.v4.runtime.atn.*;
@@ -43,7 +42,7 @@ import java.util.List;
 @SuppressWarnings({ "all", "warnings", "unchecked", "unused", "cast" })
 class PainlessParser extends Parser {
     static {
-        RuntimeMetaData.checkVersion("4.5.3", RuntimeMetaData.VERSION);
+        RuntimeMetaData.checkVersion("4.9.3", RuntimeMetaData.VERSION);
     }
 
     protected static final DFA[] _decisionToDFA;
@@ -63,218 +62,232 @@ class PainlessParser extends Parser {
         RULE_refcasttype = 22, RULE_chain = 23, RULE_primary = 24, RULE_postfix = 25, RULE_postdot = 26, RULE_callinvoke = 27,
         RULE_fieldaccess = 28, RULE_braceaccess = 29, RULE_arrayinitializer = 30, RULE_listinitializer = 31, RULE_mapinitializer = 32,
         RULE_maptoken = 33, RULE_arguments = 34, RULE_argument = 35, RULE_lambda = 36, RULE_lamtype = 37, RULE_funcref = 38;
-    public static final String[] ruleNames = {
-        "source",
-        "function",
-        "parameters",
-        "statement",
-        "rstatement",
-        "dstatement",
-        "trailer",
-        "block",
-        "empty",
-        "initializer",
-        "afterthought",
-        "declaration",
-        "decltype",
-        "type",
-        "declvar",
-        "trap",
-        "noncondexpression",
-        "expression",
-        "unary",
-        "unarynotaddsub",
-        "castexpression",
-        "primordefcasttype",
-        "refcasttype",
-        "chain",
-        "primary",
-        "postfix",
-        "postdot",
-        "callinvoke",
-        "fieldaccess",
-        "braceaccess",
-        "arrayinitializer",
-        "listinitializer",
-        "mapinitializer",
-        "maptoken",
-        "arguments",
-        "argument",
-        "lambda",
-        "lamtype",
-        "funcref" };
 
-    private static final String[] _LITERAL_NAMES = {
-        null,
-        null,
-        null,
-        "'{'",
-        "'}'",
-        "'['",
-        "']'",
-        "'('",
-        "')'",
-        "'.'",
-        "'?.'",
-        "','",
-        "';'",
-        "'if'",
-        "'in'",
-        "'else'",
-        "'while'",
-        "'do'",
-        "'for'",
-        "'continue'",
-        "'break'",
-        "'return'",
-        "'new'",
-        "'try'",
-        "'catch'",
-        "'throw'",
-        "'this'",
-        "'instanceof'",
-        "'!'",
-        "'~'",
-        "'*'",
-        "'/'",
-        "'%'",
-        "'+'",
-        "'-'",
-        "'<<'",
-        "'>>'",
-        "'>>>'",
-        "'<'",
-        "'<='",
-        "'>'",
-        "'>='",
-        "'=='",
-        "'==='",
-        "'!='",
-        "'!=='",
-        "'&'",
-        "'^'",
-        "'|'",
-        "'&&'",
-        "'||'",
-        "'?'",
-        "':'",
-        "'?:'",
-        "'::'",
-        "'->'",
-        "'=~'",
-        "'==~'",
-        "'++'",
-        "'--'",
-        "'='",
-        "'+='",
-        "'-='",
-        "'*='",
-        "'/='",
-        "'%='",
-        "'&='",
-        "'^='",
-        "'|='",
-        "'<<='",
-        "'>>='",
-        "'>>>='",
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        "'true'",
-        "'false'",
-        "'null'",
-        null,
-        "'def'" };
-    private static final String[] _SYMBOLIC_NAMES = {
-        null,
-        "WS",
-        "COMMENT",
-        "LBRACK",
-        "RBRACK",
-        "LBRACE",
-        "RBRACE",
-        "LP",
-        "RP",
-        "DOT",
-        "NSDOT",
-        "COMMA",
-        "SEMICOLON",
-        "IF",
-        "IN",
-        "ELSE",
-        "WHILE",
-        "DO",
-        "FOR",
-        "CONTINUE",
-        "BREAK",
-        "RETURN",
-        "NEW",
-        "TRY",
-        "CATCH",
-        "THROW",
-        "THIS",
-        "INSTANCEOF",
-        "BOOLNOT",
-        "BWNOT",
-        "MUL",
-        "DIV",
-        "REM",
-        "ADD",
-        "SUB",
-        "LSH",
-        "RSH",
-        "USH",
-        "LT",
-        "LTE",
-        "GT",
-        "GTE",
-        "EQ",
-        "EQR",
-        "NE",
-        "NER",
-        "BWAND",
-        "XOR",
-        "BWOR",
-        "BOOLAND",
-        "BOOLOR",
-        "COND",
-        "COLON",
-        "ELVIS",
-        "REF",
-        "ARROW",
-        "FIND",
-        "MATCH",
-        "INCR",
-        "DECR",
-        "ASSIGN",
-        "AADD",
-        "ASUB",
-        "AMUL",
-        "ADIV",
-        "AREM",
-        "AAND",
-        "AXOR",
-        "AOR",
-        "ALSH",
-        "ARSH",
-        "AUSH",
-        "OCTAL",
-        "HEX",
-        "INTEGER",
-        "DECIMAL",
-        "STRING",
-        "REGEX",
-        "TRUE",
-        "FALSE",
-        "NULL",
-        "PRIMITIVE",
-        "DEF",
-        "ID",
-        "DOTINTEGER",
-        "DOTID" };
+    private static String[] makeRuleNames() {
+        return new String[] {
+            "source",
+            "function",
+            "parameters",
+            "statement",
+            "rstatement",
+            "dstatement",
+            "trailer",
+            "block",
+            "empty",
+            "initializer",
+            "afterthought",
+            "declaration",
+            "decltype",
+            "type",
+            "declvar",
+            "trap",
+            "noncondexpression",
+            "expression",
+            "unary",
+            "unarynotaddsub",
+            "castexpression",
+            "primordefcasttype",
+            "refcasttype",
+            "chain",
+            "primary",
+            "postfix",
+            "postdot",
+            "callinvoke",
+            "fieldaccess",
+            "braceaccess",
+            "arrayinitializer",
+            "listinitializer",
+            "mapinitializer",
+            "maptoken",
+            "arguments",
+            "argument",
+            "lambda",
+            "lamtype",
+            "funcref" };
+    }
+
+    public static final String[] ruleNames = makeRuleNames();
+
+    private static String[] makeLiteralNames() {
+        return new String[] {
+            null,
+            null,
+            null,
+            "'{'",
+            "'}'",
+            "'['",
+            "']'",
+            "'('",
+            "')'",
+            "'.'",
+            "'?.'",
+            "','",
+            "';'",
+            "'if'",
+            "'in'",
+            "'else'",
+            "'while'",
+            "'do'",
+            "'for'",
+            "'continue'",
+            "'break'",
+            "'return'",
+            "'new'",
+            "'try'",
+            "'catch'",
+            "'throw'",
+            "'this'",
+            "'instanceof'",
+            "'!'",
+            "'~'",
+            "'*'",
+            "'/'",
+            "'%'",
+            "'+'",
+            "'-'",
+            "'<<'",
+            "'>>'",
+            "'>>>'",
+            "'<'",
+            "'<='",
+            "'>'",
+            "'>='",
+            "'=='",
+            "'==='",
+            "'!='",
+            "'!=='",
+            "'&'",
+            "'^'",
+            "'|'",
+            "'&&'",
+            "'||'",
+            "'?'",
+            "':'",
+            "'?:'",
+            "'::'",
+            "'->'",
+            "'=~'",
+            "'==~'",
+            "'++'",
+            "'--'",
+            "'='",
+            "'+='",
+            "'-='",
+            "'*='",
+            "'/='",
+            "'%='",
+            "'&='",
+            "'^='",
+            "'|='",
+            "'<<='",
+            "'>>='",
+            "'>>>='",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "'true'",
+            "'false'",
+            "'null'",
+            null,
+            "'def'" };
+    }
+
+    private static final String[] _LITERAL_NAMES = makeLiteralNames();
+
+    private static String[] makeSymbolicNames() {
+        return new String[] {
+            null,
+            "WS",
+            "COMMENT",
+            "LBRACK",
+            "RBRACK",
+            "LBRACE",
+            "RBRACE",
+            "LP",
+            "RP",
+            "DOT",
+            "NSDOT",
+            "COMMA",
+            "SEMICOLON",
+            "IF",
+            "IN",
+            "ELSE",
+            "WHILE",
+            "DO",
+            "FOR",
+            "CONTINUE",
+            "BREAK",
+            "RETURN",
+            "NEW",
+            "TRY",
+            "CATCH",
+            "THROW",
+            "THIS",
+            "INSTANCEOF",
+            "BOOLNOT",
+            "BWNOT",
+            "MUL",
+            "DIV",
+            "REM",
+            "ADD",
+            "SUB",
+            "LSH",
+            "RSH",
+            "USH",
+            "LT",
+            "LTE",
+            "GT",
+            "GTE",
+            "EQ",
+            "EQR",
+            "NE",
+            "NER",
+            "BWAND",
+            "XOR",
+            "BWOR",
+            "BOOLAND",
+            "BOOLOR",
+            "COND",
+            "COLON",
+            "ELVIS",
+            "REF",
+            "ARROW",
+            "FIND",
+            "MATCH",
+            "INCR",
+            "DECR",
+            "ASSIGN",
+            "AADD",
+            "ASUB",
+            "AMUL",
+            "ADIV",
+            "AREM",
+            "AAND",
+            "AXOR",
+            "AOR",
+            "ALSH",
+            "ARSH",
+            "AUSH",
+            "OCTAL",
+            "HEX",
+            "INTEGER",
+            "DECIMAL",
+            "STRING",
+            "REGEX",
+            "TRUE",
+            "FALSE",
+            "NULL",
+            "PRIMITIVE",
+            "DEF",
+            "ID",
+            "DOTINTEGER",
+            "DOTID" };
+    }
+
+    private static final String[] _SYMBOLIC_NAMES = makeSymbolicNames();
     public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);
 
     /**
@@ -545,6 +558,7 @@ class PainlessParser extends Parser {
                 setState(97);
                 match(LP);
                 setState(109);
+                _errHandler.sync(this);
                 _la = _input.LA(1);
                 if (((((_la - 81)) & ~0x3f) == 0
                     && ((1L << (_la - 81)) & ((1L << (PRIMITIVE - 81)) | (1L << (DEF - 81)) | (1L << (ID - 81)))) != 0)) {
@@ -626,6 +640,7 @@ class PainlessParser extends Parser {
         int _la;
         try {
             setState(117);
+            _errHandler.sync(this);
             switch (_input.LA(1)) {
                 case IF:
                 case WHILE:
@@ -670,6 +685,8 @@ class PainlessParser extends Parser {
                     if (!(_la == EOF || _la == SEMICOLON)) {
                         _errHandler.recoverInline(this);
                     } else {
+                        if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                        _errHandler.reportMatch(this);
                         consume();
                     }
                 }
@@ -996,6 +1013,7 @@ class PainlessParser extends Parser {
                     setState(132);
                     match(RP);
                     setState(135);
+                    _errHandler.sync(this);
                     switch (_input.LA(1)) {
                         case LBRACK:
                         case LBRACE:
@@ -1050,6 +1068,7 @@ class PainlessParser extends Parser {
                     setState(138);
                     match(LP);
                     setState(140);
+                    _errHandler.sync(this);
                     _la = _input.LA(1);
                     if ((((_la) & ~0x3f) == 0
                         && ((1L << _la) & ((1L << LBRACE) | (1L << LP) | (1L << NEW) | (1L << BOOLNOT) | (1L << BWNOT) | (1L << ADD) | (1L
@@ -1067,6 +1086,7 @@ class PainlessParser extends Parser {
                     setState(142);
                     match(SEMICOLON);
                     setState(144);
+                    _errHandler.sync(this);
                     _la = _input.LA(1);
                     if ((((_la) & ~0x3f) == 0
                         && ((1L << _la) & ((1L << LBRACE) | (1L << LP) | (1L << NEW) | (1L << BOOLNOT) | (1L << BWNOT) | (1L << ADD) | (1L
@@ -1084,6 +1104,7 @@ class PainlessParser extends Parser {
                     setState(146);
                     match(SEMICOLON);
                     setState(148);
+                    _errHandler.sync(this);
                     _la = _input.LA(1);
                     if ((((_la) & ~0x3f) == 0
                         && ((1L << _la) & ((1L << LBRACE) | (1L << LP) | (1L << NEW) | (1L << BOOLNOT) | (1L << BWNOT) | (1L << ADD) | (1L
@@ -1101,6 +1122,7 @@ class PainlessParser extends Parser {
                     setState(150);
                     match(RP);
                     setState(153);
+                    _errHandler.sync(this);
                     switch (_input.LA(1)) {
                         case LBRACK:
                         case LBRACE:
@@ -1435,6 +1457,7 @@ class PainlessParser extends Parser {
                     setState(191);
                     match(RETURN);
                     setState(193);
+                    _errHandler.sync(this);
                     _la = _input.LA(1);
                     if ((((_la) & ~0x3f) == 0
                         && ((1L << _la) & ((1L << LBRACE) | (1L << LP) | (1L << NEW) | (1L << BOOLNOT) | (1L << BWNOT) | (1L << ADD) | (1L
@@ -1508,6 +1531,7 @@ class PainlessParser extends Parser {
         enterRule(_localctx, 12, RULE_trailer);
         try {
             setState(202);
+            _errHandler.sync(this);
             switch (_input.LA(1)) {
                 case LBRACK:
                     enterOuterAlt(_localctx, 1); {
@@ -1627,6 +1651,7 @@ class PainlessParser extends Parser {
                     _alt = getInterpreter().adaptivePredict(_input, 16, _ctx);
                 }
                 setState(212);
+                _errHandler.sync(this);
                 _la = _input.LA(1);
                 if ((((_la) & ~0x3f) == 0
                     && ((1L << _la) & ((1L << LBRACE) | (1L << LP) | (1L << DO) | (1L << CONTINUE) | (1L << BREAK) | (1L << RETURN) | (1L
@@ -1991,6 +2016,7 @@ class PainlessParser extends Parser {
         try {
             int _alt;
             setState(251);
+            _errHandler.sync(this);
             switch (_input.LA(1)) {
                 case DEF:
                     enterOuterAlt(_localctx, 1); {
@@ -2080,6 +2106,7 @@ class PainlessParser extends Parser {
                 setState(253);
                 match(ID);
                 setState(256);
+                _errHandler.sync(this);
                 _la = _input.LA(1);
                 if (_la == ASSIGN) {
                     {
@@ -2450,6 +2477,8 @@ class PainlessParser extends Parser {
                                     if (!((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << MUL) | (1L << DIV) | (1L << REM))) != 0))) {
                                         _errHandler.recoverInline(this);
                                     } else {
+                                        if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                                        _errHandler.reportMatch(this);
                                         consume();
                                     }
                                     setState(270);
@@ -2466,6 +2495,8 @@ class PainlessParser extends Parser {
                                     if (!(_la == ADD || _la == SUB)) {
                                         _errHandler.recoverInline(this);
                                     } else {
+                                        if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                                        _errHandler.reportMatch(this);
                                         consume();
                                     }
                                     setState(273);
@@ -2482,6 +2513,8 @@ class PainlessParser extends Parser {
                                     if (!(_la == FIND || _la == MATCH)) {
                                         _errHandler.recoverInline(this);
                                     } else {
+                                        if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                                        _errHandler.reportMatch(this);
                                         consume();
                                     }
                                     setState(276);
@@ -2498,6 +2531,8 @@ class PainlessParser extends Parser {
                                     if (!((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LSH) | (1L << RSH) | (1L << USH))) != 0))) {
                                         _errHandler.recoverInline(this);
                                     } else {
+                                        if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                                        _errHandler.reportMatch(this);
                                         consume();
                                     }
                                     setState(279);
@@ -2515,6 +2550,8 @@ class PainlessParser extends Parser {
                                         && ((1L << _la) & ((1L << LT) | (1L << LTE) | (1L << GT) | (1L << GTE))) != 0))) {
                                         _errHandler.recoverInline(this);
                                     } else {
+                                        if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                                        _errHandler.reportMatch(this);
                                         consume();
                                     }
                                     setState(282);
@@ -2532,6 +2569,8 @@ class PainlessParser extends Parser {
                                         && ((1L << _la) & ((1L << EQ) | (1L << EQR) | (1L << NE) | (1L << NER))) != 0))) {
                                         _errHandler.recoverInline(this);
                                     } else {
+                                        if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                                        _errHandler.reportMatch(this);
                                         consume();
                                     }
                                     setState(285);
@@ -2809,6 +2848,8 @@ class PainlessParser extends Parser {
                             | (1L << (ALSH - 60)) | (1L << (ARSH - 60)) | (1L << (AUSH - 60)))) != 0))) {
                         _errHandler.recoverInline(this);
                     } else {
+                        if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                        _errHandler.reportMatch(this);
                         consume();
                     }
                     setState(321);
@@ -2913,6 +2954,7 @@ class PainlessParser extends Parser {
         int _la;
         try {
             setState(330);
+            _errHandler.sync(this);
             switch (_input.LA(1)) {
                 case INCR:
                 case DECR:
@@ -2923,6 +2965,8 @@ class PainlessParser extends Parser {
                     if (!(_la == INCR || _la == DECR)) {
                         _errHandler.recoverInline(this);
                     } else {
+                        if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                        _errHandler.reportMatch(this);
                         consume();
                     }
                     setState(326);
@@ -2938,6 +2982,8 @@ class PainlessParser extends Parser {
                     if (!(_la == ADD || _la == SUB)) {
                         _errHandler.recoverInline(this);
                     } else {
+                        if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                        _errHandler.reportMatch(this);
                         consume();
                     }
                     setState(328);
@@ -3100,6 +3146,8 @@ class PainlessParser extends Parser {
                     if (!(_la == INCR || _la == DECR)) {
                         _errHandler.recoverInline(this);
                     } else {
+                        if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                        _errHandler.reportMatch(this);
                         consume();
                     }
                 }
@@ -3112,6 +3160,8 @@ class PainlessParser extends Parser {
                     if (!(_la == BOOLNOT || _la == BWNOT)) {
                         _errHandler.recoverInline(this);
                     } else {
+                        if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                        _errHandler.reportMatch(this);
                         consume();
                     }
                     setState(337);
@@ -3292,6 +3342,8 @@ class PainlessParser extends Parser {
                 if (!(_la == PRIMITIVE || _la == DEF)) {
                     _errHandler.recoverInline(this);
                 } else {
+                    if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                    _errHandler.reportMatch(this);
                     consume();
                 }
             }
@@ -3372,6 +3424,7 @@ class PainlessParser extends Parser {
         int _la;
         try {
             setState(384);
+            _errHandler.sync(this);
             switch (_input.LA(1)) {
                 case DEF:
                     enterOuterAlt(_localctx, 1); {
@@ -3844,6 +3897,8 @@ class PainlessParser extends Parser {
                             - 72)))) != 0))) {
                         _errHandler.recoverInline(this);
                     } else {
+                        if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                        _errHandler.reportMatch(this);
                         consume();
                     }
                 }
@@ -4100,6 +4155,8 @@ class PainlessParser extends Parser {
                 if (!(_la == DOT || _la == NSDOT)) {
                     _errHandler.recoverInline(this);
                 } else {
+                    if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                    _errHandler.reportMatch(this);
                     consume();
                 }
                 setState(427);
@@ -4162,6 +4219,8 @@ class PainlessParser extends Parser {
                 if (!(_la == DOT || _la == NSDOT)) {
                     _errHandler.recoverInline(this);
                 } else {
+                    if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                    _errHandler.reportMatch(this);
                     consume();
                 }
                 setState(431);
@@ -4169,6 +4228,8 @@ class PainlessParser extends Parser {
                 if (!(_la == DOTINTEGER || _la == DOTID)) {
                     _errHandler.recoverInline(this);
                 } else {
+                    if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                    _errHandler.reportMatch(this);
                     consume();
                 }
             }
@@ -4449,6 +4510,7 @@ class PainlessParser extends Parser {
                     setState(460);
                     match(LBRACK);
                     setState(469);
+                    _errHandler.sync(this);
                     _la = _input.LA(1);
                     if ((((_la) & ~0x3f) == 0
                         && ((1L << _la) & ((1L << LBRACE) | (1L << LP) | (1L << NEW) | (1L << BOOLNOT) | (1L << BWNOT) | (1L << ADD) | (1L
@@ -4808,6 +4870,7 @@ class PainlessParser extends Parser {
                     setState(515);
                     match(LP);
                     setState(524);
+                    _errHandler.sync(this);
                     _la = _input.LA(1);
                     if ((((_la) & ~0x3f) == 0
                         && ((1L << _la) & ((1L << LBRACE) | (1L << LP) | (1L << NEW) | (1L << THIS) | (1L << BOOLNOT) | (1L << BWNOT) | (1L
@@ -4978,6 +5041,7 @@ class PainlessParser extends Parser {
             enterOuterAlt(_localctx, 1);
             {
                 setState(546);
+                _errHandler.sync(this);
                 switch (_input.LA(1)) {
                     case PRIMITIVE:
                     case DEF:
@@ -4990,6 +5054,7 @@ class PainlessParser extends Parser {
                         setState(534);
                         match(LP);
                         setState(543);
+                        _errHandler.sync(this);
                         _la = _input.LA(1);
                         if (((((_la - 81)) & ~0x3f) == 0
                             && ((1L << (_la - 81)) & ((1L << (PRIMITIVE - 81)) | (1L << (DEF - 81)) | (1L << (ID - 81)))) != 0)) {
@@ -5025,6 +5090,7 @@ class PainlessParser extends Parser {
                 setState(548);
                 match(ARROW);
                 setState(551);
+                _errHandler.sync(this);
                 switch (_input.LA(1)) {
                     case LBRACK: {
                         setState(549);
@@ -5313,7 +5379,7 @@ class PainlessParser extends Parser {
         return true;
     }
 
-    public static final String _serializedATN = "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3W\u023e\4\2\t\2\4"
+    public static final String _serializedATN = "\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\3W\u023e\4\2\t\2\4"
         + "\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t"
         + "\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"
         + "\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"
@@ -5357,12 +5423,12 @@ class PainlessParser extends Parser {
         + "\5&\u022a\n&\3\'\5\'\u022d\n\'\3\'\3\'\3(\3(\3(\3(\3(\3(\3(\3(\3(\3(\3"
         + "(\5(\u023c\n(\3(\2\3\")\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*"
         + ",.\60\62\64\668:<>@BDFHJLN\2\20\3\3\16\16\3\2 \"\3\2#$\3\2:;\3\2%\'\3"
-        + "\2(+\3\2,/\3\2>I\3\2<=\3\2\36\37\3\2ST\3\2JM\3\2\13\f\3\2VW\u0279\2S\3"
-        + "\2\2\2\4^\3\2\2\2\6c\3\2\2\2\bw\3\2\2\2\n\u00b5\3\2\2\2\f\u00c8\3\2\2"
-        + "\2\16\u00cc\3\2\2\2\20\u00ce\3\2\2\2\22\u00da\3\2\2\2\24\u00de\3\2\2\2"
-        + "\26\u00e0\3\2\2\2\30\u00e2\3\2\2\2\32\u00eb\3\2\2\2\34\u00fd\3\2\2\2\36"
-        + "\u00ff\3\2\2\2 \u0104\3\2\2\2\"\u010b\3\2\2\2$\u0145\3\2\2\2&\u014c\3"
-        + "\2\2\2(\u0155\3\2\2\2*\u0161\3\2\2\2,\u0163\3\2\2\2.\u0182\3\2\2\2\60"
+        + "\2(+\3\2,/\3\2>I\3\2<=\3\2\36\37\3\2ST\3\2JM\3\2\13\f\3\2VW\2\u0279\2"
+        + "S\3\2\2\2\4^\3\2\2\2\6c\3\2\2\2\bw\3\2\2\2\n\u00b5\3\2\2\2\f\u00c8\3\2"
+        + "\2\2\16\u00cc\3\2\2\2\20\u00ce\3\2\2\2\22\u00da\3\2\2\2\24\u00de\3\2\2"
+        + "\2\26\u00e0\3\2\2\2\30\u00e2\3\2\2\2\32\u00eb\3\2\2\2\34\u00fd\3\2\2\2"
+        + "\36\u00ff\3\2\2\2 \u0104\3\2\2\2\"\u010b\3\2\2\2$\u0145\3\2\2\2&\u014c"
+        + "\3\2\2\2(\u0155\3\2\2\2*\u0161\3\2\2\2,\u0163\3\2\2\2.\u0182\3\2\2\2\60"
         + "\u018c\3\2\2\2\62\u01a1\3\2\2\2\64\u01a6\3\2\2\2\66\u01aa\3\2\2\28\u01ac"
         + "\3\2\2\2:\u01b0\3\2\2\2<\u01b3\3\2\2\2>\u01e0\3\2\2\2@\u01ef\3\2\2\2B"
         + "\u01ff\3\2\2\2D\u0201\3\2\2\2F\u0205\3\2\2\2H\u0215\3\2\2\2J\u0224\3\2"


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description

The ANTLR runtime version was updated to 4.9.3 by dependabot [1] however the runtime checks have been left unchanged and fill the logs with warnings like:

```
[2022-05-12T11:59:22,540][WARN ][stderr                   ] [xxx] ANTLR Tool version 4.5.3 used for code generation does not match the current runtime version 4.9.3
[2022-05-12T11:59:22,565][WARN ][stderr                   ] [xxx] ANTLR Tool version 4.5.3 used for code generation does not match the current runtime version 4.9.3

```

Regenerated lexer and parser using:

```
./gradlew :modules:lang-painless:regenParser
```

[1]  https://github.com/opensearch-project/OpenSearch/commit/fb76361812367ed5dc4ff7aea09ec9e93610d449

### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
