### PR TITLE
Replace 'master' terminology with 'cluster manager' in 'modules' directory

### DIFF
--- a/modules/aggs-matrix-stats/src/yamlRestTest/resources/rest-api-spec/test/stats/10_basic.yml
+++ b/modules/aggs-matrix-stats/src/yamlRestTest/resources/rest-api-spec/test/stats/10_basic.yml
@@ -8,7 +8,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/modules/aggs-matrix-stats/src/yamlRestTest/resources/rest-api-spec/test/stats/10_basic.yml
+++ b/modules/aggs-matrix-stats/src/yamlRestTest/resources/rest-api-spec/test/stats/10_basic.yml
@@ -7,7 +7,7 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
+    # Get cluster-manager node id
     - set: { master_node: master }
 
     - do:

--- a/modules/aggs-matrix-stats/src/yamlRestTest/resources/rest-api-spec/test/stats/10_basic.yml
+++ b/modules/aggs-matrix-stats/src/yamlRestTest/resources/rest-api-spec/test/stats/10_basic.yml
@@ -8,9 +8,9 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: master }
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.modules: { name: aggs-matrix-stats } }
+    - contains:  { nodes.$cluster_manager.modules: { name: aggs-matrix-stats } }

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/10_basic.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/10_basic.yml
@@ -6,9 +6,9 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: master }
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.modules: { name: analysis-common } }
+    - contains:  { nodes.$cluster_manager.modules: { name: analysis-common } }

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/10_basic.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/10_basic.yml
@@ -6,7 +6,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/10_basic.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/10_basic.yml
@@ -5,7 +5,7 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
+    # Get cluster-manager node id
     - set: { master_node: master }
 
     - do:

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/10_basic.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/10_basic.yml
@@ -6,33 +6,33 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: master }
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.modules: { name: ingest-common } }
-    - contains:  { nodes.$master.ingest.processors: { type: append } }
-    - contains:  { nodes.$master.ingest.processors: { type: bytes } }
-    - contains:  { nodes.$master.ingest.processors: { type: convert } }
-    - contains:  { nodes.$master.ingest.processors: { type: date } }
-    - contains:  { nodes.$master.ingest.processors: { type: date_index_name } }
-    - contains:  { nodes.$master.ingest.processors: { type: dissect } }
-    - contains:  { nodes.$master.ingest.processors: { type: dot_expander } }
-    - contains:  { nodes.$master.ingest.processors: { type: fail } }
-    - contains:  { nodes.$master.ingest.processors: { type: foreach } }
-    - contains:  { nodes.$master.ingest.processors: { type: grok } }
-    - contains:  { nodes.$master.ingest.processors: { type: gsub } }
-    - contains:  { nodes.$master.ingest.processors: { type: html_strip } }
-    - contains:  { nodes.$master.ingest.processors: { type: join } }
-    - contains:  { nodes.$master.ingest.processors: { type: json } }
-    - contains:  { nodes.$master.ingest.processors: { type: kv } }
-    - contains:  { nodes.$master.ingest.processors: { type: lowercase } }
-    - contains:  { nodes.$master.ingest.processors: { type: remove } }
-    - contains:  { nodes.$master.ingest.processors: { type: rename } }
-    - contains:  { nodes.$master.ingest.processors: { type: script } }
-    - contains:  { nodes.$master.ingest.processors: { type: set } }
-    - contains:  { nodes.$master.ingest.processors: { type: sort } }
-    - contains:  { nodes.$master.ingest.processors: { type: split } }
-    - contains:  { nodes.$master.ingest.processors: { type: trim } }
-    - contains:  { nodes.$master.ingest.processors: { type: uppercase } }
+    - contains:  { nodes.$cluster_manager.modules: { name: ingest-common } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: append } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: bytes } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: convert } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: date } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: date_index_name } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: dissect } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: dot_expander } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: fail } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: foreach } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: grok } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: gsub } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: html_strip } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: join } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: json } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: kv } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: lowercase } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: remove } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: rename } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: script } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: set } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: sort } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: split } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: trim } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: uppercase } }

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/10_basic.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/10_basic.yml
@@ -6,7 +6,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/10_basic.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/10_basic.yml
@@ -5,7 +5,7 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
+    # Get cluster-manager node id
     - set: { master_node: master }
 
     - do:

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/70_bulk.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/70_bulk.yml
@@ -77,7 +77,7 @@ teardown:
 
   - do:
       cluster.state: {}
-    # Get master node id
+    # Get cluster-manager node id
   - set: { master_node: master }
 
   - do:
@@ -113,7 +113,7 @@ teardown:
 
   - do:
       cluster.state: {}
-  # Get master node id
+  # Get cluster-manager node id
   - set: { master_node: master }
 
   - do:

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/70_bulk.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/70_bulk.yml
@@ -78,7 +78,7 @@ teardown:
   - do:
       cluster.state: {}
     # Get cluster-manager node id
-  - set: { master_node: cluster_manager }
+  - set: { cluster_manager_node: cluster_manager }
 
   - do:
       nodes.stats:
@@ -114,7 +114,7 @@ teardown:
   - do:
       cluster.state: {}
   # Get cluster-manager node id
-  - set: { master_node: cluster_manager }
+  - set: { cluster_manager_node: cluster_manager }
 
   - do:
       nodes.stats:

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/70_bulk.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/70_bulk.yml
@@ -78,20 +78,20 @@ teardown:
   - do:
       cluster.state: {}
     # Get cluster-manager node id
-  - set: { master_node: master }
+  - set: { master_node: cluster_manager }
 
   - do:
       nodes.stats:
         metric: [ ingest ]
   #we can't assert anything here since we might have more than one node in the cluster
-  - gte: {nodes.$master.ingest.total.count: 0}
-  - gte: {nodes.$master.ingest.total.failed: 0}
-  - gte: {nodes.$master.ingest.total.time_in_millis: 0}
-  - match: {nodes.$master.ingest.total.current: 0}
-  - gte: {nodes.$master.ingest.pipelines.pipeline1.count: 0}
-  - match: {nodes.$master.ingest.pipelines.pipeline1.failed: 0}
-  - gte: {nodes.$master.ingest.pipelines.pipeline1.time_in_millis: 0}
-  - match: {nodes.$master.ingest.pipelines.pipeline1.current: 0}
+  - gte: {nodes.$cluster_manager.ingest.total.count: 0}
+  - gte: {nodes.$cluster_manager.ingest.total.failed: 0}
+  - gte: {nodes.$cluster_manager.ingest.total.time_in_millis: 0}
+  - match: {nodes.$cluster_manager.ingest.total.current: 0}
+  - gte: {nodes.$cluster_manager.ingest.pipelines.pipeline1.count: 0}
+  - match: {nodes.$cluster_manager.ingest.pipelines.pipeline1.failed: 0}
+  - gte: {nodes.$cluster_manager.ingest.pipelines.pipeline1.time_in_millis: 0}
+  - match: {nodes.$cluster_manager.ingest.pipelines.pipeline1.current: 0}
 
 ---
 "Test bulk request with default pipeline":
@@ -114,20 +114,20 @@ teardown:
   - do:
       cluster.state: {}
   # Get cluster-manager node id
-  - set: { master_node: master }
+  - set: { master_node: cluster_manager }
 
   - do:
       nodes.stats:
         metric: [ ingest ]
   #we can't assert anything here since we might have more than one node in the cluster
-  - gte: {nodes.$master.ingest.total.count: 0}
-  - gte: {nodes.$master.ingest.total.failed: 0}
-  - gte: {nodes.$master.ingest.total.time_in_millis: 0}
-  - match: {nodes.$master.ingest.total.current: 0}
-  - gte: {nodes.$master.ingest.pipelines.pipeline2.count: 0}
-  - match: {nodes.$master.ingest.pipelines.pipeline2.failed: 0}
-  - gte: {nodes.$master.ingest.pipelines.pipeline2.time_in_millis: 0}
-  - match: {nodes.$master.ingest.pipelines.pipeline2.current: 0}
+  - gte: {nodes.$cluster_manager.ingest.total.count: 0}
+  - gte: {nodes.$cluster_manager.ingest.total.failed: 0}
+  - gte: {nodes.$cluster_manager.ingest.total.time_in_millis: 0}
+  - match: {nodes.$cluster_manager.ingest.total.current: 0}
+  - gte: {nodes.$cluster_manager.ingest.pipelines.pipeline2.count: 0}
+  - match: {nodes.$cluster_manager.ingest.pipelines.pipeline2.failed: 0}
+  - gte: {nodes.$cluster_manager.ingest.pipelines.pipeline2.time_in_millis: 0}
+  - match: {nodes.$cluster_manager.ingest.pipelines.pipeline2.current: 0}
 
   - do:
       get:

--- a/modules/ingest-geoip/src/main/java/org/opensearch/ingest/geoip/DatabaseReaderLazyLoader.java
+++ b/modules/ingest-geoip/src/main/java/org/opensearch/ingest/geoip/DatabaseReaderLazyLoader.java
@@ -71,7 +71,7 @@ class DatabaseReaderLazyLoader implements Closeable {
 
     /**
      * Read the database type from the database. We do this manually instead of relying on the built-in mechanism to avoid reading the
-     * entire database into memory merely to read the type. This is especially important to maintain on master nodes where pipelines are
+     * entire database into memory merely to read the type. This is especially important to maintain on cluster-manager nodes where pipelines are
      * validated. If we read the entire database into memory, we could potentially run into low-memory constraints on such nodes where
      * loading this data would otherwise be wasteful if they are not also ingest nodes.
      *

--- a/modules/ingest-geoip/src/yamlRestTest/resources/rest-api-spec/test/ingest_geoip/10_basic.yml
+++ b/modules/ingest-geoip/src/yamlRestTest/resources/rest-api-spec/test/ingest_geoip/10_basic.yml
@@ -5,7 +5,7 @@
     - do:
         cluster.state: {}
 
-    - set: {master_node: cluster_manager}
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/modules/ingest-geoip/src/yamlRestTest/resources/rest-api-spec/test/ingest_geoip/10_basic.yml
+++ b/modules/ingest-geoip/src/yamlRestTest/resources/rest-api-spec/test/ingest_geoip/10_basic.yml
@@ -5,10 +5,10 @@
     - do:
         cluster.state: {}
 
-    - set: {master_node: master}
+    - set: {master_node: cluster_manager}
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.modules: { name: ingest-geoip } }
-    - contains:  { nodes.$master.ingest.processors: { type: geoip } }
+    - contains:  { nodes.$cluster_manager.modules: { name: ingest-geoip } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: geoip } }

--- a/modules/ingest-user-agent/src/yamlRestTest/resources/rest-api-spec/test/ingest-useragent/10_basic.yml
+++ b/modules/ingest-user-agent/src/yamlRestTest/resources/rest-api-spec/test/ingest-useragent/10_basic.yml
@@ -5,10 +5,10 @@
     - do:
         cluster.state: {}
 
-    - set: {master_node: master}
+    - set: {master_node: cluster_manager}
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.modules: { name: ingest-user-agent } }
-    - contains:  { nodes.$master.ingest.processors: { type: user_agent } }
+    - contains:  { nodes.$cluster_manager.modules: { name: ingest-user-agent } }
+    - contains:  { nodes.$cluster_manager.ingest.processors: { type: user_agent } }

--- a/modules/ingest-user-agent/src/yamlRestTest/resources/rest-api-spec/test/ingest-useragent/10_basic.yml
+++ b/modules/ingest-user-agent/src/yamlRestTest/resources/rest-api-spec/test/ingest-useragent/10_basic.yml
@@ -5,7 +5,7 @@
     - do:
         cluster.state: {}
 
-    - set: {master_node: cluster_manager}
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/modules/lang-expression/src/yamlRestTest/resources/rest-api-spec/test/lang_expression/10_basic.yml
+++ b/modules/lang-expression/src/yamlRestTest/resources/rest-api-spec/test/lang_expression/10_basic.yml
@@ -8,9 +8,9 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: master }
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.modules: { name: lang-expression  } }
+    - contains:  { nodes.$cluster_manager.modules: { name: lang-expression  } }

--- a/modules/lang-expression/src/yamlRestTest/resources/rest-api-spec/test/lang_expression/10_basic.yml
+++ b/modules/lang-expression/src/yamlRestTest/resources/rest-api-spec/test/lang_expression/10_basic.yml
@@ -8,7 +8,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/modules/lang-expression/src/yamlRestTest/resources/rest-api-spec/test/lang_expression/10_basic.yml
+++ b/modules/lang-expression/src/yamlRestTest/resources/rest-api-spec/test/lang_expression/10_basic.yml
@@ -7,7 +7,7 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
+    # Get cluster-manager node id
     - set: { master_node: master }
 
     - do:

--- a/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/10_basic.yml
+++ b/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/10_basic.yml
@@ -8,7 +8,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/10_basic.yml
+++ b/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/10_basic.yml
@@ -7,7 +7,7 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
+    # Get cluster-manager node id
     - set: { master_node: master }
 
     - do:

--- a/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/10_basic.yml
+++ b/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/10_basic.yml
@@ -8,9 +8,9 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: master }
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.modules: { name: lang-mustache } }
+    - contains:  { nodes.$cluster_manager.modules: { name: lang-mustache } }

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/10_basic.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/10_basic.yml
@@ -8,7 +8,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/10_basic.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/10_basic.yml
@@ -7,7 +7,7 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
+    # Get cluster-manager node id
     - set: { master_node: master }
 
     - do:

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/10_basic.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/10_basic.yml
@@ -8,9 +8,9 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: master }
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.modules: { name: lang-painless } }
+    - contains:  { nodes.$cluster_manager.modules: { name: lang-painless } }

--- a/modules/mapper-extras/src/test/resources/org/opensearch/index/mapper/metricbeat-6.0.template.json
+++ b/modules/mapper-extras/src/test/resources/org/opensearch/index/mapper/metricbeat-6.0.template.json
@@ -229,7 +229,7 @@
                 },
                 "objects": {
                   "properties": {
-                    "master": {
+                    "primary": {
                       "type": "long"
                     },
                     "total": {
@@ -4601,7 +4601,7 @@
                     "connected_replicas": {
                       "type": "long"
                     },
-                    "master_offset": {
+                    "primary_offset": {
                       "type": "long"
                     },
                     "role": {

--- a/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/aggregations/ChildrenIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/aggregations/ChildrenIT.java
@@ -227,7 +227,7 @@ public class ChildrenIT extends AbstractParentChildTestCase {
 
     public void testPostCollection() throws Exception {
         String indexName = "prodcatalog";
-        String masterType = "masterprod";
+        String mainType = "mainprod";
         String childType = "variantsku";
         assertAcked(
             prepareCreate(indexName).setSettings(
@@ -235,7 +235,7 @@ public class ChildrenIT extends AbstractParentChildTestCase {
             )
                 .setMapping(
                     addFieldMappings(
-                        buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, masterType, childType),
+                        buildParentJoinFieldMappingFromSimplifiedDef("join_field", true, mainType, childType),
                         "brand",
                         "text",
                         "name",
@@ -251,7 +251,7 @@ public class ChildrenIT extends AbstractParentChildTestCase {
         );
 
         List<IndexRequestBuilder> requests = new ArrayList<>();
-        requests.add(createIndexRequest(indexName, masterType, "1", null, "brand", "Levis", "name", "Style 501", "material", "Denim"));
+        requests.add(createIndexRequest(indexName, mainType, "1", null, "brand", "Levis", "name", "Style 501", "material", "Denim"));
         requests.add(createIndexRequest(indexName, childType, "3", "1", "color", "blue", "size", "32"));
         requests.add(createIndexRequest(indexName, childType, "4", "1", "color", "blue", "size", "34"));
         requests.add(createIndexRequest(indexName, childType, "5", "1", "color", "blue", "size", "36"));
@@ -259,9 +259,7 @@ public class ChildrenIT extends AbstractParentChildTestCase {
         requests.add(createIndexRequest(indexName, childType, "7", "1", "color", "black", "size", "40"));
         requests.add(createIndexRequest(indexName, childType, "8", "1", "color", "gray", "size", "36"));
 
-        requests.add(
-            createIndexRequest(indexName, masterType, "2", null, "brand", "Wrangler", "name", "Regular Cut", "material", "Leather")
-        );
+        requests.add(createIndexRequest(indexName, mainType, "2", null, "brand", "Wrangler", "name", "Regular Cut", "material", "Leather"));
         requests.add(createIndexRequest(indexName, childType, "9", "2", "color", "blue", "size", "32"));
         requests.add(createIndexRequest(indexName, childType, "10", "2", "color", "blue", "size", "34"));
         requests.add(createIndexRequest(indexName, childType, "12", "2", "color", "black", "size", "36"));

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/RetryTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/RetryTests.java
@@ -118,18 +118,18 @@ public class RetryTests extends OpenSearchIntegTestCase {
     public void testReindexFromRemote() throws Exception {
         Function<Client, AbstractBulkByScrollRequestBuilder<?, ?>> function = client -> {
             /*
-             * Use the master node for the reindex from remote because that node
+             * Use the cluster-manager node for the reindex from remote because that node
              * doesn't have a copy of the data on it.
              */
-            NodeInfo masterNode = null;
+            NodeInfo clusterManagerNode = null;
             for (NodeInfo candidate : client.admin().cluster().prepareNodesInfo().get().getNodes()) {
                 if (candidate.getNode().isMasterNode()) {
-                    masterNode = candidate;
+                    clusterManagerNode = candidate;
                 }
             }
-            assertNotNull(masterNode);
+            assertNotNull(clusterManagerNode);
 
-            TransportAddress address = masterNode.getInfo(HttpInfo.class).getAddress().publishAddress();
+            TransportAddress address = clusterManagerNode.getInfo(HttpInfo.class).getAddress().publishAddress();
             RemoteInfo remote = new RemoteInfo(
                 "http",
                 address.getAddress(),
@@ -262,8 +262,8 @@ public class RetryTests extends OpenSearchIntegTestCase {
      */
     private BulkByScrollTask.Status taskStatus(String action) {
         /*
-         * We always use the master client because we always start the test requests on the
-         * master. We do this simply to make sure that the test request is not started on the
+         * We always use the cluster-manager client because we always start the test requests on the
+         * cluster-manager. We do this simply to make sure that the test request is not started on the
          * node who's queue we're manipulating.
          */
         ListTasksResponse response = client().admin().cluster().prepareListTasks().setActions(action).setDetailed(true).get();

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/90_remote.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/90_remote.yml
@@ -10,12 +10,12 @@
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: master }
+  - set: { master_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]
-  - is_true: nodes.$master.http.publish_address
-  - set: {nodes.$master.http.publish_address: host}
+  - is_true: nodes.$cluster_manager.http.publish_address
+  - set: {nodes.$cluster_manager.http.publish_address: host}
   - do:
       reindex:
         refresh: true
@@ -71,12 +71,12 @@
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: master }
+  - set: { master_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]
-  - is_true: nodes.$master.http.publish_address
-  - set: {nodes.$master.http.publish_address: host}
+  - is_true: nodes.$cluster_manager.http.publish_address
+  - set: {nodes.$cluster_manager.http.publish_address: host}
   - do:
       reindex:
         refresh: true
@@ -121,12 +121,12 @@
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: master }
+  - set: { master_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]
-  - is_true: nodes.$master.http.publish_address
-  - set: {nodes.$master.http.publish_address: host}
+  - is_true: nodes.$cluster_manager.http.publish_address
+  - set: {nodes.$cluster_manager.http.publish_address: host}
   - do:
       reindex:
         refresh: true
@@ -172,12 +172,12 @@
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: master }
+  - set: { master_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]
-  - is_true: nodes.$master.http.publish_address
-  - set: {nodes.$master.http.publish_address: host}
+  - is_true: nodes.$cluster_manager.http.publish_address
+  - set: {nodes.$cluster_manager.http.publish_address: host}
   - do:
       reindex:
         refresh: true
@@ -239,12 +239,12 @@
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: master }
+  - set: { master_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]
-  - is_true: nodes.$master.http.publish_address
-  - set: {nodes.$master.http.publish_address: host}
+  - is_true: nodes.$cluster_manager.http.publish_address
+  - set: {nodes.$cluster_manager.http.publish_address: host}
   - do:
       reindex:
         refresh: true
@@ -305,12 +305,12 @@
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: master }
+  - set: { master_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]
-  - is_true: nodes.$master.http.publish_address
-  - set: {nodes.$master.http.publish_address: host}
+  - is_true: nodes.$cluster_manager.http.publish_address
+  - set: {nodes.$cluster_manager.http.publish_address: host}
   - do:
       reindex:
         refresh: true
@@ -361,12 +361,12 @@
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: master }
+  - set: { master_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]
-  - is_true: nodes.$master.http.publish_address
-  - set: {nodes.$master.http.publish_address: host}
+  - is_true: nodes.$cluster_manager.http.publish_address
+  - set: {nodes.$cluster_manager.http.publish_address: host}
   - do:
       catch: /query malformed, no start_object after query name/
       reindex:
@@ -414,12 +414,12 @@
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: master }
+  - set: { master_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]
-  - is_true: nodes.$master.http.publish_address
-  - set: {nodes.$master.http.publish_address: host}
+  - is_true: nodes.$cluster_manager.http.publish_address
+  - set: {nodes.$cluster_manager.http.publish_address: host}
   - do:
       reindex:
         refresh: true
@@ -483,12 +483,12 @@
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: master }
+  - set: { master_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]
-  - is_true: nodes.$master.http.publish_address
-  - set: {nodes.$master.http.publish_address: host}
+  - is_true: nodes.$cluster_manager.http.publish_address
+  - set: {nodes.$cluster_manager.http.publish_address: host}
   - do:
       reindex:
         requests_per_second: .00000001 # About 9.5 years to complete the request

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/90_remote.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/90_remote.yml
@@ -10,7 +10,7 @@
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: cluster_manager }
+  - set: { cluster_manager_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]
@@ -71,7 +71,7 @@
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: cluster_manager }
+  - set: { cluster_manager_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]
@@ -121,7 +121,7 @@
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: cluster_manager }
+  - set: { cluster_manager_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]
@@ -172,7 +172,7 @@
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: cluster_manager }
+  - set: { cluster_manager_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]
@@ -239,7 +239,7 @@
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: cluster_manager }
+  - set: { cluster_manager_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]
@@ -305,7 +305,7 @@
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: cluster_manager }
+  - set: { cluster_manager_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]
@@ -361,7 +361,7 @@
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: cluster_manager }
+  - set: { cluster_manager_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]
@@ -414,7 +414,7 @@
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: cluster_manager }
+  - set: { cluster_manager_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]
@@ -483,7 +483,7 @@
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: cluster_manager }
+  - set: { cluster_manager_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/90_remote.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/90_remote.yml
@@ -7,7 +7,7 @@
         body:    { "text": "test" }
         refresh: true
 
-  # Fetch the http host. We use the host of the master because we know there will always be a master.
+  # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
   - set: { master_node: master }
@@ -68,7 +68,7 @@
   - do:
       indices.refresh: {}
 
-  # Fetch the http host. We use the host of the master because we know there will always be a master.
+  # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
   - set: { master_node: master }
@@ -118,7 +118,7 @@
         routing: foo
         refresh: true
 
-  # Fetch the http host. We use the host of the master because we know there will always be a master.
+  # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
   - set: { master_node: master }
@@ -169,7 +169,7 @@
         body:    { "text": "test" }
         refresh: true
 
-  # Fetch the http host. We use the host of the master because we know there will always be a master.
+  # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
   - set: { master_node: master }
@@ -236,7 +236,7 @@
         body:    { "text": "test" }
         refresh: true
 
-  # Fetch the http host. We use the host of the master because we know there will always be a master.
+  # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
   - set: { master_node: master }
@@ -302,7 +302,7 @@
         body:    { "text": "test" }
         refresh: true
 
-  # Fetch the http host. We use the host of the master because we know there will always be a master.
+  # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
   - set: { master_node: master }
@@ -358,7 +358,7 @@
         body:    { "text": "test" }
         refresh: true
 
-  # Fetch the http host. We use the host of the master because we know there will always be a master.
+  # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
   - set: { master_node: master }
@@ -411,7 +411,7 @@
         body:    { "text": "test", "filtered": "removed" }
         refresh: true
 
-  # Fetch the http host. We use the host of the master because we know there will always be a master.
+  # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
   - set: { master_node: master }
@@ -480,7 +480,7 @@
       indices.refresh: {}
 
 
-  # Fetch the http host. We use the host of the master because we know there will always be a master.
+  # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
   - set: { master_node: master }

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/95_parent_join.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/95_parent_join.yml
@@ -88,7 +88,7 @@ setup:
 
 ---
 "Reindex from remote with parent join field":
-  # Fetch the http host. We use the host of the master because we know there will always be a master.
+  # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
   - set: { master_node: master }

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/95_parent_join.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/95_parent_join.yml
@@ -91,12 +91,12 @@ setup:
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: master }
+  - set: { master_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]
-  - is_true: nodes.$master.http.publish_address
-  - set: {nodes.$master.http.publish_address: host}
+  - is_true: nodes.$cluster_manager.http.publish_address
+  - set: {nodes.$cluster_manager.http.publish_address: host}
   - do:
       reindex:
         refresh: true

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/95_parent_join.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/95_parent_join.yml
@@ -91,7 +91,7 @@ setup:
   # Fetch the http host. We use the host of the cluster-manager because we know there will always be a cluster-manager.
   - do:
       cluster.state: {}
-  - set: { master_node: cluster_manager }
+  - set: { cluster_manager_node: cluster_manager }
   - do:
       nodes.info:
         metric: [ http ]

--- a/modules/repository-url/src/yamlRestTest/resources/rest-api-spec/test/repository_url/10_basic.yml
+++ b/modules/repository-url/src/yamlRestTest/resources/rest-api-spec/test/repository_url/10_basic.yml
@@ -102,7 +102,7 @@ teardown:
     - do:
         cluster.state: {}
 
-    # Get master node id
+    # Get cluster-manager node id
     - set: { master_node: master }
 
     - do:

--- a/modules/repository-url/src/yamlRestTest/resources/rest-api-spec/test/repository_url/10_basic.yml
+++ b/modules/repository-url/src/yamlRestTest/resources/rest-api-spec/test/repository_url/10_basic.yml
@@ -103,12 +103,12 @@ teardown:
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: master }
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains: { nodes.$master.modules: { name: repository-url } }
+    - contains: { nodes.$cluster_manager.modules: { name: repository-url } }
 
 ---
 "Restore with repository-url using http://":

--- a/modules/repository-url/src/yamlRestTest/resources/rest-api-spec/test/repository_url/10_basic.yml
+++ b/modules/repository-url/src/yamlRestTest/resources/rest-api-spec/test/repository_url/10_basic.yml
@@ -103,7 +103,7 @@ teardown:
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/modules/transport-netty4/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
+++ b/modules/transport-netty4/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
@@ -8,7 +8,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/modules/transport-netty4/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
+++ b/modules/transport-netty4/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
@@ -7,7 +7,7 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
+    # Get cluster-manager node id
     - set: { master_node: master }
 
     - do:

--- a/modules/transport-netty4/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
+++ b/modules/transport-netty4/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
@@ -8,12 +8,12 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: master }
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.modules: { name: transport-netty4  } }
+    - contains:  { nodes.$cluster_manager.modules: { name: transport-netty4  } }
 
     - do:
         cluster.stats: {}


### PR DESCRIPTION
### Description
- Replace the non-inclusive terminology "master" with "cluster manager" in code comments, internal variable and method names, in `modules` directory.
- Backwards compatibility is not impacted.

Replacement rules:
- `master` -> `cluster_manager` or `clusterManager` (variable name) or `cluster-manager` (code comment)
- `Master` -> `ClusterManager`
 
### Issues Resolved
A part of #1548 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
