### PR TITLE
Replace 'master' terminology with 'cluster manager' in 'plugins' directory

### DIFF
--- a/plugins/discovery-azure-classic/src/yamlRestTest/resources/rest-api-spec/test/discovery_azure_classic/10_basic.yml
+++ b/plugins/discovery-azure-classic/src/yamlRestTest/resources/rest-api-spec/test/discovery_azure_classic/10_basic.yml
@@ -8,7 +8,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/plugins/discovery-azure-classic/src/yamlRestTest/resources/rest-api-spec/test/discovery_azure_classic/10_basic.yml
+++ b/plugins/discovery-azure-classic/src/yamlRestTest/resources/rest-api-spec/test/discovery_azure_classic/10_basic.yml
@@ -7,10 +7,10 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
-    - set: { master_node: master }
+    # Get cluster-manager node id
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.plugins: { name: discovery-azure-classic } }
+    - contains:  { nodes.$cluster_manager.plugins: { name: discovery-azure-classic } }

--- a/plugins/discovery-ec2/src/internalClusterTest/java/org/opensearch/discovery/ec2/Ec2DiscoveryUpdateSettingsTests.java
+++ b/plugins/discovery-ec2/src/internalClusterTest/java/org/opensearch/discovery/ec2/Ec2DiscoveryUpdateSettingsTests.java
@@ -48,7 +48,7 @@ import static org.hamcrest.CoreMatchers.is;
  */
 @ClusterScope(scope = Scope.TEST, numDataNodes = 0, numClientNodes = 0)
 public class Ec2DiscoveryUpdateSettingsTests extends AbstractAwsTestCase {
-    public void testMinimumMasterNodesStart() {
+    public void testMinimumClusterManagerNodesStart() {
         Settings nodeSettings = Settings.builder().put(DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), "ec2").build();
         internalCluster().startNode(nodeSettings);
 

--- a/plugins/discovery-ec2/src/yamlRestTest/resources/rest-api-spec/test/discovery_ec2/10_basic.yml
+++ b/plugins/discovery-ec2/src/yamlRestTest/resources/rest-api-spec/test/discovery_ec2/10_basic.yml
@@ -7,10 +7,10 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
-    - set: { master_node: master }
+    # Get cluster-manager node id
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.plugins: { name: discovery-ec2 } }
+    - contains:  { nodes.$cluster_manager.plugins: { name: discovery-ec2 } }

--- a/plugins/discovery-ec2/src/yamlRestTest/resources/rest-api-spec/test/discovery_ec2/10_basic.yml
+++ b/plugins/discovery-ec2/src/yamlRestTest/resources/rest-api-spec/test/discovery_ec2/10_basic.yml
@@ -8,7 +8,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/plugins/discovery-gce/src/internalClusterTest/java/org/opensearch/discovery/gce/GceDiscoverTests.java
+++ b/plugins/discovery-gce/src/internalClusterTest/java/org/opensearch/discovery/gce/GceDiscoverTests.java
@@ -85,11 +85,11 @@ public class GceDiscoverTests extends OpenSearchIntegTestCase {
     }
 
     public void testJoin() {
-        // start master node
-        final String masterNode = internalCluster().startClusterManagerOnlyNode();
-        registerGceNode(masterNode);
+        // start cluster-manager node
+        final String clusterManagerNode = internalCluster().startClusterManagerOnlyNode();
+        registerGceNode(clusterManagerNode);
 
-        ClusterStateResponse clusterStateResponse = client(masterNode).admin()
+        ClusterStateResponse clusterStateResponse = client(clusterManagerNode).admin()
             .cluster()
             .prepareState()
             .setMasterNodeTimeout("1s")

--- a/plugins/discovery-gce/src/yamlRestTest/resources/rest-api-spec/test/discovery_gce/10_basic.yml
+++ b/plugins/discovery-gce/src/yamlRestTest/resources/rest-api-spec/test/discovery_gce/10_basic.yml
@@ -7,10 +7,10 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
-    - set: { master_node: master }
+    # Get cluster-manager node id
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.plugins: { name: discovery-gce } }
+    - contains:  { nodes.$cluster_manager.plugins: { name: discovery-gce } }

--- a/plugins/discovery-gce/src/yamlRestTest/resources/rest-api-spec/test/discovery_gce/10_basic.yml
+++ b/plugins/discovery-gce/src/yamlRestTest/resources/rest-api-spec/test/discovery_gce/10_basic.yml
@@ -8,7 +8,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/plugins/examples/custom-significance-heuristic/src/yamlRestTest/resources/rest-api-spec/test/custom-significance-heuristic/10_basic.yml
+++ b/plugins/examples/custom-significance-heuristic/src/yamlRestTest/resources/rest-api-spec/test/custom-significance-heuristic/10_basic.yml
@@ -5,12 +5,12 @@
         reason: "contains is a newly added assertion"
         features: contains
 
-    # Get master node id
+    # Get cluster-manager node id
     - do:
         cluster.state: {}
-    - set: { master_node: master }
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains: { nodes.$master.plugins: { name: custom-significance-heuristic } }
+    - contains: { nodes.$cluster_manager.plugins: { name: custom-significance-heuristic } }

--- a/plugins/examples/custom-significance-heuristic/src/yamlRestTest/resources/rest-api-spec/test/custom-significance-heuristic/10_basic.yml
+++ b/plugins/examples/custom-significance-heuristic/src/yamlRestTest/resources/rest-api-spec/test/custom-significance-heuristic/10_basic.yml
@@ -8,7 +8,7 @@
     # Get cluster-manager node id
     - do:
         cluster.state: {}
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/plugins/examples/custom-suggester/src/yamlRestTest/resources/rest-api-spec/test/custom-suggester/10_basic.yml
+++ b/plugins/examples/custom-suggester/src/yamlRestTest/resources/rest-api-spec/test/custom-suggester/10_basic.yml
@@ -8,7 +8,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/plugins/examples/custom-suggester/src/yamlRestTest/resources/rest-api-spec/test/custom-suggester/10_basic.yml
+++ b/plugins/examples/custom-suggester/src/yamlRestTest/resources/rest-api-spec/test/custom-suggester/10_basic.yml
@@ -7,10 +7,10 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
-    - set: { master_node: master }
+    # Get cluster-manager node id
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.plugins: { name: custom-suggester } }
+    - contains:  { nodes.$cluster_manager.plugins: { name: custom-suggester } }

--- a/plugins/examples/painless-whitelist/src/yamlRestTest/resources/rest-api-spec/test/painless_whitelist/10_basic.yml
+++ b/plugins/examples/painless-whitelist/src/yamlRestTest/resources/rest-api-spec/test/painless_whitelist/10_basic.yml
@@ -8,7 +8,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/plugins/examples/painless-whitelist/src/yamlRestTest/resources/rest-api-spec/test/painless_whitelist/10_basic.yml
+++ b/plugins/examples/painless-whitelist/src/yamlRestTest/resources/rest-api-spec/test/painless_whitelist/10_basic.yml
@@ -7,10 +7,10 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
-    - set: { master_node: master }
+    # Get cluster-manager node id
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.plugins: { name: painless-whitelist } }
+    - contains:  { nodes.$cluster_manager.plugins: { name: painless-whitelist } }

--- a/plugins/examples/rescore/src/yamlRestTest/resources/rest-api-spec/test/example-rescore/10_basic.yml
+++ b/plugins/examples/rescore/src/yamlRestTest/resources/rest-api-spec/test/example-rescore/10_basic.yml
@@ -8,7 +8,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/plugins/examples/rescore/src/yamlRestTest/resources/rest-api-spec/test/example-rescore/10_basic.yml
+++ b/plugins/examples/rescore/src/yamlRestTest/resources/rest-api-spec/test/example-rescore/10_basic.yml
@@ -7,10 +7,10 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
-    - set: { master_node: master }
+    # Get cluster-manager node id
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.plugins: { name: example-rescore } }
+    - contains:  { nodes.$cluster_manager.plugins: { name: example-rescore } }

--- a/plugins/examples/script-expert-scoring/src/yamlRestTest/resources/rest-api-spec/test/script_expert_scoring/10_basic.yml
+++ b/plugins/examples/script-expert-scoring/src/yamlRestTest/resources/rest-api-spec/test/script_expert_scoring/10_basic.yml
@@ -8,7 +8,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/plugins/examples/script-expert-scoring/src/yamlRestTest/resources/rest-api-spec/test/script_expert_scoring/10_basic.yml
+++ b/plugins/examples/script-expert-scoring/src/yamlRestTest/resources/rest-api-spec/test/script_expert_scoring/10_basic.yml
@@ -7,10 +7,10 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
-    - set: { master_node: master }
+    # Get cluster-manager node id
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.plugins: { name: script-expert-scoring } }
+    - contains:  { nodes.$cluster_manager.plugins: { name: script-expert-scoring } }

--- a/plugins/ingest-attachment/src/yamlRestTest/resources/rest-api-spec/test/ingest_attachment/10_basic.yml
+++ b/plugins/ingest-attachment/src/yamlRestTest/resources/rest-api-spec/test/ingest_attachment/10_basic.yml
@@ -5,10 +5,10 @@
     - do:
         cluster.state: {}
 
-    - set: {master_node: master}
+    - set: {master_node: cluster_manager}
 
     - do:
         nodes.info: {}
 
-    - contains:  { 'nodes.$master.plugins': { name: ingest-attachment }  }
-    - contains:  { 'nodes.$master.ingest.processors': { type: attachment } }
+    - contains:  { 'nodes.$cluster_manager.plugins': { name: ingest-attachment }  }
+    - contains:  { 'nodes.$cluster_manager.ingest.processors': { type: attachment } }

--- a/plugins/ingest-attachment/src/yamlRestTest/resources/rest-api-spec/test/ingest_attachment/10_basic.yml
+++ b/plugins/ingest-attachment/src/yamlRestTest/resources/rest-api-spec/test/ingest_attachment/10_basic.yml
@@ -5,7 +5,7 @@
     - do:
         cluster.state: {}
 
-    - set: {master_node: cluster_manager}
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/plugins/repository-azure/src/yamlRestTest/resources/rest-api-spec/test/repository_azure/10_basic.yml
+++ b/plugins/repository-azure/src/yamlRestTest/resources/rest-api-spec/test/repository_azure/10_basic.yml
@@ -7,10 +7,10 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
-    - set: { master_node: master }
+    # Get cluster-manager node id
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.plugins: { name: repository-azure } }
+    - contains:  { nodes.$cluster_manager.plugins: { name: repository-azure } }

--- a/plugins/repository-azure/src/yamlRestTest/resources/rest-api-spec/test/repository_azure/10_basic.yml
+++ b/plugins/repository-azure/src/yamlRestTest/resources/rest-api-spec/test/repository_azure/10_basic.yml
@@ -8,7 +8,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/plugins/repository-gcs/src/yamlRestTest/resources/rest-api-spec/test/repository_gcs/10_basic.yml
+++ b/plugins/repository-gcs/src/yamlRestTest/resources/rest-api-spec/test/repository_gcs/10_basic.yml
@@ -8,7 +8,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/plugins/repository-gcs/src/yamlRestTest/resources/rest-api-spec/test/repository_gcs/10_basic.yml
+++ b/plugins/repository-gcs/src/yamlRestTest/resources/rest-api-spec/test/repository_gcs/10_basic.yml
@@ -7,10 +7,10 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
-    - set: { master_node: master }
+    # Get cluster-manager node id
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.plugins: { name: repository-gcs } }
+    - contains:  { nodes.$cluster_manager.plugins: { name: repository-gcs } }

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/hdfs_repository/10_basic.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/hdfs_repository/10_basic.yml
@@ -9,13 +9,13 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
-    - set: { master_node: master }
+    # Get cluster-manager node id
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.plugins: { name: repository-hdfs } }
+    - contains:  { nodes.$cluster_manager.plugins: { name: repository-hdfs } }
 ---
 #
 # Check that we can't use file:// repositories or anything like that

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/hdfs_repository/10_basic.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/hdfs_repository/10_basic.yml
@@ -10,7 +10,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/10_basic.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/10_basic.yml
@@ -9,13 +9,13 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
-    - set: { master_node: master }
+    # Get cluster-manager node id
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.plugins: { name: repository-hdfs } }
+    - contains:  { nodes.$cluster_manager.plugins: { name: repository-hdfs } }
 ---
 #
 # Check that we can't use file:// repositories or anything like that

--- a/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/10_basic.yml
+++ b/plugins/repository-hdfs/src/test/resources/rest-api-spec/test/secure_hdfs_repository/10_basic.yml
@@ -10,7 +10,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/plugins/repository-s3/src/yamlRestTest/resources/rest-api-spec/test/repository_s3/10_basic.yml
+++ b/plugins/repository-s3/src/yamlRestTest/resources/rest-api-spec/test/repository_s3/10_basic.yml
@@ -8,7 +8,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/plugins/repository-s3/src/yamlRestTest/resources/rest-api-spec/test/repository_s3/10_basic.yml
+++ b/plugins/repository-s3/src/yamlRestTest/resources/rest-api-spec/test/repository_s3/10_basic.yml
@@ -7,10 +7,10 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
-    - set: { master_node: master }
+    # Get cluster-manager node id
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.plugins: { name: repository-s3 } }
+    - contains:  { nodes.$cluster_manager.plugins: { name: repository-s3 } }

--- a/plugins/store-smb/src/yamlRestTest/resources/rest-api-spec/test/store_smb/10_basic.yml
+++ b/plugins/store-smb/src/yamlRestTest/resources/rest-api-spec/test/store_smb/10_basic.yml
@@ -7,10 +7,10 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
-    - set: { master_node: master }
+    # Get cluster-manager node id
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - contains:  { nodes.$master.plugins: { name: store-smb } }
+    - contains:  { nodes.$cluster_manager.plugins: { name: store-smb } }

--- a/plugins/store-smb/src/yamlRestTest/resources/rest-api-spec/test/store_smb/10_basic.yml
+++ b/plugins/store-smb/src/yamlRestTest/resources/rest-api-spec/test/store_smb/10_basic.yml
@@ -8,7 +8,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}


### PR DESCRIPTION
### Description
- Replace the non-inclusive terminology "master" with "cluster manager" in code comments, internal variable and method names, in `plugins` directory.
- Backwards compatibility is not impacted.

Replacement rules:
- `master` -> `cluster_manager` or `clusterManager` (variable name) or `cluster-manager` (code comment)
- `Master` -> `ClusterManager`
 
### Issues Resolved
A part of #1548 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
