### PR TITLE
Replace 'master' terminology with 'cluster manager' in 'qa' directory

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/opensearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/opensearch/upgrades/FullClusterRestartIT.java
@@ -659,7 +659,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                 .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
                 .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1)
                 // if the node with the replica is the first to be restarted, while a replica is still recovering
-                // then delayed allocation will kick in. When the node comes back, the master will search for a copy
+                // then delayed allocation will kick in. When the node comes back, the cluster-manager will search for a copy
                 // but the recovering copy will be seen as invalid and the cluster health won't return to GREEN
                 // before timing out
                 .put(INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), "100ms")

--- a/qa/mixed-cluster/src/test/java/org/opensearch/backwards/IndexingIT.java
+++ b/qa/mixed-cluster/src/test/java/org/opensearch/backwards/IndexingIT.java
@@ -429,23 +429,23 @@ public class IndexingIT extends OpenSearchRestTestCase {
                 HttpHost.create(objectPath.evaluate("nodes." + id + ".http.publish_address"))));
         }
         response = client().performRequest(new Request("GET", "_cluster/state"));
-        nodes.setMasterNodeId(ObjectPath.createFromResponse(response).evaluate("master_node"));
+        nodes.setClusterManagerNodeId(ObjectPath.createFromResponse(response).evaluate("master_node"));
         return nodes;
     }
 
     final class Nodes extends HashMap<String, Node> {
 
-        private String masterNodeId = null;
+        private String clusterManagerNodeId = null;
 
-        public Node getMaster() {
-            return get(masterNodeId);
+        public Node getClusterManager() {
+            return get(clusterManagerNodeId);
         }
 
-        public void setMasterNodeId(String id) {
+        public void setClusterManagerNodeId(String id) {
             if (get(id) == null) {
                 throw new IllegalArgumentException("node with id [" + id + "] not found. got:" + toString());
             }
-            masterNodeId = id;
+            clusterManagerNodeId = id;
         }
 
         public void add(Node node) {
@@ -480,7 +480,7 @@ public class IndexingIT extends OpenSearchRestTestCase {
         @Override
         public String toString() {
             return "Nodes{" +
-                "masterNodeId='" + masterNodeId + "'\n" +
+                "masterNodeId='" + clusterManagerNodeId + "'\n" +
                 values().stream().map(Node::toString).collect(Collectors.joining("\n")) +
                 '}';
         }

--- a/qa/multi-cluster-search/build.gradle
+++ b/qa/multi-cluster-search/build.gradle
@@ -45,7 +45,7 @@ task 'remote-cluster'(type: RestIntegTestTask) {
 
 testClusters.'remote-cluster' {
   numberOfNodes = 2
-  setting 'node.roles', '[data,ingest,master]'
+  setting 'node.roles', '[data,ingest,cluster_manager]'
 }
 
 task mixedClusterTest(type: RestIntegTestTask) {

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/RecoveryIT.java
@@ -90,7 +90,7 @@ public class RecoveryIT extends AbstractRollingTestCase {
                 .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
                 .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1)
                 // if the node with the replica is the first to be restarted, while a replica is still recovering
-                // then delayed allocation will kick in. When the node comes back, the master will search for a copy
+                // then delayed allocation will kick in. When the node comes back, the cluster-manager will search for a copy
                 // but the recovering copy will be seen as invalid and the cluster health won't return to GREEN
                 // before timing out
                 .put(INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), "100ms");
@@ -158,7 +158,7 @@ public class RecoveryIT extends AbstractRollingTestCase {
                     .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
                     .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 2)
                     // if the node with the replica is the first to be restarted, while a replica is still recovering
-                    // then delayed allocation will kick in. When the node comes back, the master will search for a copy
+                    // then delayed allocation will kick in. When the node comes back, the cluster-manager will search for a copy
                     // but the recovering copy will be seen as invalid and the cluster health won't return to GREEN
                     // before timing out
                     .put(INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), "100ms")
@@ -256,7 +256,7 @@ public class RecoveryIT extends AbstractRollingTestCase {
                     .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
                     .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 2)
                     // if the node with the replica is the first to be restarted, while a replica is still recovering
-                    // then delayed allocation will kick in. When the node comes back, the master will search for a copy
+                    // then delayed allocation will kick in. When the node comes back, the cluster-manager will search for a copy
                     // but the recovering copy will be seen as invalid and the cluster health won't return to GREEN
                     // before timing out
                     .put(INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), "100ms")
@@ -266,7 +266,7 @@ public class RecoveryIT extends AbstractRollingTestCase {
                 indexDocs(index, 0, 10);
                 ensureGreen(index);
                 // make sure that no shards are allocated, so we can make sure the primary stays on the old node (when one
-                // node stops, we lose the master too, so a replica will not be promoted)
+                // node stops, we lose the cluster-manager too, so a replica will not be promoted)
                 updateIndexSettings(index, Settings.builder().put(INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), "none"));
                 break;
             case MIXED:
@@ -330,7 +330,7 @@ public class RecoveryIT extends AbstractRollingTestCase {
                 .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
                 .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1)
                 // if the node with the replica is the first to be restarted, while a replica is still recovering
-                // then delayed allocation will kick in. When the node comes back, the master will search for a copy
+                // then delayed allocation will kick in. When the node comes back, the cluster-manager will search for a copy
                 // but the recovering copy will be seen as invalid and the cluster health won't return to GREEN
                 // before timing out
                 .put(INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), "100ms")
@@ -448,7 +448,7 @@ public class RecoveryIT extends AbstractRollingTestCase {
                 .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
                 .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1)
                 // if the node with the replica is the first to be restarted, while a replica is still recovering
-                // then delayed allocation will kick in. When the node comes back, the master will search for a copy
+                // then delayed allocation will kick in. When the node comes back, the cluster-manager will search for a copy
                 // but the recovering copy will be seen as invalid and the cluster health won't return to GREEN
                 // before timing out
                 .put(INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), "100ms")

--- a/qa/smoke-test-ingest-disabled/build.gradle
+++ b/qa/smoke-test-ingest-disabled/build.gradle
@@ -38,5 +38,5 @@ dependencies {
 }
 
 testClusters.integTest {
-  setting 'node.roles', '[data,master,remote_cluster_client]'
+  setting 'node.roles', '[data,cluster_manager,remote_cluster_client]'
 }

--- a/qa/smoke-test-plugins/src/test/resources/rest-api-spec/test/smoke_test_plugins/10_basic.yml
+++ b/qa/smoke-test-plugins/src/test/resources/rest-api-spec/test/smoke_test_plugins/10_basic.yml
@@ -5,7 +5,7 @@
         cluster.state: {}
 
     # Get cluster-manager node id
-    - set: { master_node: cluster_manager }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info: {}

--- a/qa/smoke-test-plugins/src/test/resources/rest-api-spec/test/smoke_test_plugins/10_basic.yml
+++ b/qa/smoke-test-plugins/src/test/resources/rest-api-spec/test/smoke_test_plugins/10_basic.yml
@@ -4,10 +4,10 @@
     - do:
         cluster.state: {}
 
-    # Get master node id
-    - set: { master_node: master }
+    # Get cluster-manager node id
+    - set: { master_node: cluster_manager }
 
     - do:
         nodes.info: {}
 
-    - length:  { nodes.$master.plugins: ${expected.plugins.count}  }
+    - length:  { nodes.$cluster_manager.plugins: ${expected.plugins.count}  }


### PR DESCRIPTION
### Description
- Replace the non-inclusive terminology "master" with "cluster manager" in code comments, internal variable and method names, in `qa` directory.
- Backwards compatibility is not impacted.

Replacement rules:
- `master` -> `cluster_manager` or `clusterManager` (variable name) or `cluster-manager` (code comment)
- `Master` -> `ClusterManager`
 
### Issues Resolved
A part of #1548 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
