### PR TITLE
[REMOVE] Cleanup deprecated thread pool types (FIXED_AUTO_QUEUE_SIZE)

### DIFF
--- a/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
@@ -118,7 +118,6 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         DIRECT("direct"),
         FIXED("fixed"),
         RESIZABLE("resizable"),
-        FIXED_AUTO_QUEUE_SIZE("fixed_auto_queue_size"),
         SCALING("scaling");
 
         private final String type;
@@ -696,7 +695,13 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
 
         public Info(StreamInput in) throws IOException {
             name = in.readString();
-            type = ThreadPoolType.fromType(in.readString());
+            final String typeStr = in.readString();
+            // Opensearch on or after 3.0.0 version doesn't know about "fixed_auto_queue_size" thread pool. Convert it to RESIZABLE.
+            if (typeStr.equalsIgnoreCase("fixed_auto_queue_size")) {
+                type = ThreadPoolType.RESIZABLE;
+            } else {
+                type = ThreadPoolType.fromType(typeStr);
+            }
             min = in.readInt();
             max = in.readInt();
             keepAlive = in.readOptionalTimeValue();


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Removed unused FIXED_AUTO_QUEUE_SIZE thread pool type, leftover of https://github.com/opensearch-project/OpenSearch/pull/3352
 
### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/2595 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
