### PR TITLE
[Type removal] Remove redundant _type in pipeline simulate action

### DIFF
--- a/client/rest-high-level/src/test/java/org/opensearch/client/IngestRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/IngestRequestConvertersTests.java
@@ -121,7 +121,6 @@ public class IngestRequestConvertersTests extends OpenSearchTestCase {
             + "  \"docs\": ["
             + "    {"
             + "      \"_index\": \"index\","
-            + "      \"_type\": \"_doc\","
             + "      \"_id\": \"id\","
             + "      \"_source\": {"
             + "        \"foo\": \"rab\""

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/120_grok.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/120_grok.yml
@@ -134,7 +134,6 @@ teardown:
             "docs": [
               {
                 "_index": "index",
-                "_type": "type",
                 "_id": "id",
                 "_source": {
                   "field": "abc2xyz"

--- a/server/src/internalClusterTest/java/org/opensearch/ingest/IngestClientIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/ingest/IngestClientIT.java
@@ -111,7 +111,6 @@ public class IngestClientIT extends OpenSearchIntegTestCase {
                 .startArray("docs")
                 .startObject()
                 .field("_index", "index")
-                .field("_type", "type")
                 .field("_id", "id")
                 .startObject("_source")
                 .field("foo", "bar")


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Remove redundant _type from pipeline simulate action

Related: https://github.com/opensearch-project/OpenSearch/issues/3131

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
