### PR TITLE
[Type removal] _type removal from mocked responses of scroll hit tests

### DIFF
--- a/modules/reindex/src/test/resources/responses/failure_with_status.json
+++ b/modules/reindex/src/test/resources/responses/failure_with_status.json
@@ -16,7 +16,6 @@
     "max_score": 0.0,
     "hits": [ {
       "_index": "test",
-      "_type": "test",
       "_id": "10000",
       "_version": 1,
       "_score": 0.0,

--- a/modules/reindex/src/test/resources/responses/rejection.json
+++ b/modules/reindex/src/test/resources/responses/rejection.json
@@ -21,7 +21,6 @@
     "max_score" : null,
     "hits" : [ {
       "_index" : "test",
-      "_type" : "test",
       "_id" : "AVToMiC250DjIiBO3yJ_",
       "_version" : 1,
       "_score" : null,

--- a/modules/reindex/src/test/resources/responses/scroll_fully_loaded.json
+++ b/modules/reindex/src/test/resources/responses/scroll_fully_loaded.json
@@ -13,7 +13,6 @@
     "max_score" : null,
     "hits" : [ {
       "_index" : "test",
-      "_type" : "test",
       "_id" : "AVToMiDL50DjIiBO3yKA",
       "_version" : 1,
       "_score" : null,

--- a/modules/reindex/src/test/resources/responses/scroll_fully_loaded_1_7.json
+++ b/modules/reindex/src/test/resources/responses/scroll_fully_loaded_1_7.json
@@ -13,7 +13,6 @@
     "max_score" : null,
     "hits" : [ {
       "_index" : "test",
-      "_type" : "test",
       "_id" : "AVToMiDL50DjIiBO3yKA",
       "_version" : 1,
       "_score" : null,

--- a/modules/reindex/src/test/resources/responses/scroll_ok.json
+++ b/modules/reindex/src/test/resources/responses/scroll_ok.json
@@ -13,7 +13,6 @@
     "max_score" : null,
     "hits" : [ {
       "_index" : "test",
-      "_type" : "test",
       "_id" : "AVToMiDL50DjIiBO3yKA",
       "_version" : 1,
       "_score" : null,

--- a/modules/reindex/src/test/resources/responses/start_ok.json
+++ b/modules/reindex/src/test/resources/responses/start_ok.json
@@ -12,7 +12,6 @@
     "max_score" : null,
     "hits" : [ {
       "_index" : "test",
-      "_type" : "test",
       "_id" : "AVToMiC250DjIiBO3yJ_",
       "_version" : 1,
       "_score" : null,


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Remove _type in mocked scroll hit responses
 
Related: https://github.com/opensearch-project/OpenSearch/issues/3131


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
