### PR TITLE
[2.0] Revert "Remove deprecated methods from JodaCompatibleZonedDateTime wh…

### DIFF
--- a/modules/lang-painless/src/main/resources/org/opensearch/painless/spi/org.opensearch.txt
+++ b/modules/lang-painless/src/main/resources/org/opensearch/painless/spi/org.opensearch.txt
@@ -124,7 +124,29 @@ class org.opensearch.script.JodaCompatibleZonedDateTime {
   ZonedDateTime withYear(int)
   ZonedDateTime withZoneSameLocal(ZoneId)
   ZonedDateTime withZoneSameInstant(ZoneId)
+
+  #### Joda time methods
+  long getMillis()
+  int getCenturyOfEra()
+  int getEra()
+  int getHourOfDay()
+  int getMillisOfDay()
+  int getMillisOfSecond()
+  int getMinuteOfDay()
+  int getMinuteOfHour()
+  int getMonthOfYear()
+  int getSecondOfDay()
+  int getSecondOfMinute()
+  int getWeekOfWeekyear()
+  int getWeekyear()
+  int getYearOfCentury()
+  int getYearOfEra()
+  String toString(String)
+  String toString(String,Locale)
+
+  # conflicting methods
   DayOfWeek getDayOfWeekEnum()
+  int getDayOfWeek()
 }
 
 class org.opensearch.index.fielddata.ScriptDocValues$Dates {

--- a/server/src/main/java/org/opensearch/script/JodaCompatibleZonedDateTime.java
+++ b/server/src/main/java/org/opensearch/script/JodaCompatibleZonedDateTime.java
@@ -32,9 +32,16 @@
 
 package org.opensearch.script;
 
+import org.joda.time.DateTime;
 import org.opensearch.common.SuppressForbidden;
+import org.opensearch.common.SuppressLoggerChecks;
+import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.time.DateFormatter;
+import org.opensearch.common.time.DateFormatters;
+import org.opensearch.common.time.DateUtils;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -48,6 +55,7 @@ import java.time.ZonedDateTime;
 import java.time.chrono.ChronoZonedDateTime;
 import java.time.chrono.Chronology;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalAdjuster;
@@ -56,6 +64,7 @@ import java.time.temporal.TemporalField;
 import java.time.temporal.TemporalQuery;
 import java.time.temporal.TemporalUnit;
 import java.time.temporal.ValueRange;
+import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -71,6 +80,23 @@ public class JodaCompatibleZonedDateTime
         TemporalAccessor {
 
     private static final DateFormatter DATE_FORMATTER = DateFormatter.forPattern("strict_date_time");
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(JodaCompatibleZonedDateTime.class);
+
+    private static void logDeprecated(String key, String message, Object... params) {
+        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            @SuppressLoggerChecks(reason = "safely delegates to logger")
+            @Override
+            public Void run() {
+                deprecationLogger.deprecate(key, message, params);
+                return null;
+            }
+        });
+    }
+
+    private static void logDeprecatedMethod(String oldMethod, String newMethod) {
+        logDeprecated(oldMethod, "Use of the joda time method [{}] is deprecated. Use [{}] instead.", oldMethod, newMethod);
+    }
+
     private ZonedDateTime dt;
 
     public JodaCompatibleZonedDateTime(Instant instant, ZoneId zone) {
@@ -401,7 +427,120 @@ public class JodaCompatibleZonedDateTime
         return dt.withZoneSameInstant(zone);
     }
 
+    @Deprecated
+    public long getMillis() {
+        logDeprecatedMethod("getMillis()", "toInstant().toEpochMilli()");
+        return dt.toInstant().toEpochMilli();
+    }
+
+    @Deprecated
+    public int getCenturyOfEra() {
+        logDeprecatedMethod("getCenturyOfEra()", "get(ChronoField.YEAR_OF_ERA) / 100");
+        return dt.get(ChronoField.YEAR_OF_ERA) / 100;
+    }
+
+    @Deprecated
+    public int getEra() {
+        logDeprecatedMethod("getEra()", "get(ChronoField.ERA)");
+        return dt.get(ChronoField.ERA);
+    }
+
+    @Deprecated
+    public int getHourOfDay() {
+        logDeprecatedMethod("getHourOfDay()", "getHour()");
+        return dt.getHour();
+    }
+
+    @Deprecated
+    public int getMillisOfDay() {
+        logDeprecatedMethod("getMillisOfDay()", "get(ChronoField.MILLI_OF_DAY)");
+        return dt.get(ChronoField.MILLI_OF_DAY);
+    }
+
+    @Deprecated
+    public int getMillisOfSecond() {
+        logDeprecatedMethod("getMillisOfSecond()", "get(ChronoField.MILLI_OF_SECOND)");
+        return dt.get(ChronoField.MILLI_OF_SECOND);
+    }
+
+    @Deprecated
+    public int getMinuteOfDay() {
+        logDeprecatedMethod("getMinuteOfDay()", "get(ChronoField.MINUTE_OF_DAY)");
+        return dt.get(ChronoField.MINUTE_OF_DAY);
+    }
+
+    @Deprecated
+    public int getMinuteOfHour() {
+        logDeprecatedMethod("getMinuteOfHour()", "getMinute()");
+        return dt.getMinute();
+    }
+
+    @Deprecated
+    public int getMonthOfYear() {
+        logDeprecatedMethod("getMonthOfYear()", "getMonthValue()");
+        return dt.getMonthValue();
+    }
+
+    @Deprecated
+    public int getSecondOfDay() {
+        logDeprecatedMethod("getSecondOfDay()", "get(ChronoField.SECOND_OF_DAY)");
+        return dt.get(ChronoField.SECOND_OF_DAY);
+    }
+
+    @Deprecated
+    public int getSecondOfMinute() {
+        logDeprecatedMethod("getSecondOfMinute()", "getSecond()");
+        return dt.getSecond();
+    }
+
+    @Deprecated
+    public int getWeekOfWeekyear() {
+        logDeprecatedMethod("getWeekOfWeekyear()", "get(DateFormatters.WEEK_FIELDS_ROOT.weekOfWeekBasedYear())");
+        return dt.get(DateFormatters.WEEK_FIELDS_ROOT.weekOfWeekBasedYear());
+    }
+
+    @Deprecated
+    public int getWeekyear() {
+        logDeprecatedMethod("getWeekyear()", "get(DateFormatters.WEEK_FIELDS_ROOT.weekBasedYear())");
+        return dt.get(DateFormatters.WEEK_FIELDS_ROOT.weekBasedYear());
+    }
+
+    @Deprecated
+    public int getYearOfCentury() {
+        logDeprecatedMethod("getYearOfCentury()", "get(ChronoField.YEAR_OF_ERA) % 100");
+        return dt.get(ChronoField.YEAR_OF_ERA) % 100;
+    }
+
+    @Deprecated
+    public int getYearOfEra() {
+        logDeprecatedMethod("getYearOfEra()", "get(ChronoField.YEAR_OF_ERA)");
+        return dt.get(ChronoField.YEAR_OF_ERA);
+    }
+
+    @Deprecated
+    public String toString(String format) {
+        logDeprecatedMethod("toString(String)", "a DateTimeFormatter");
+        // TODO: replace with bwc formatter
+        return new DateTime(dt.toInstant().toEpochMilli(), DateUtils.zoneIdToDateTimeZone(dt.getZone())).toString(format);
+    }
+
+    @Deprecated
+    public String toString(String format, Locale locale) {
+        logDeprecatedMethod("toString(String,Locale)", "a DateTimeFormatter");
+        // TODO: replace with bwc formatter
+        return new DateTime(dt.toInstant().toEpochMilli(), DateUtils.zoneIdToDateTimeZone(dt.getZone())).toString(format, locale);
+    }
+
     public DayOfWeek getDayOfWeekEnum() {
         return dt.getDayOfWeek();
+    }
+
+    @Deprecated
+    public int getDayOfWeek() {
+        logDeprecated(
+            "getDayOfWeek()",
+            "The return type of [getDayOfWeek()] will change to an enum in 7.0. Use getDayOfWeekEnum().getValue()."
+        );
+        return dt.getDayOfWeek().getValue();
     }
 }


### PR DESCRIPTION
This reverts commit a764fde5af6032c47bc158821d88d9de988b88c3.

Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Reverting this change in 2.0 to unblock the release.
Coming from: https://github.com/opensearch-project/OpenSearch/pull/3346#issuecomment-1130668153
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
