### PR TITLE
Fix Lucene-snapshots workflow to ensure gradle settings are created first.

### DIFF
--- a/.github/workflows/lucene-snapshots.yml
+++ b/.github/workflows/lucene-snapshots.yml
@@ -40,6 +40,10 @@ jobs:
           echo "::set-output name=REVISION::$(git rev-parse --short HEAD)"
         id: version
 
+      - name: Initialize gradle settings
+        working-directory: ./lucene
+        run: ./gradlew localSettings
+
       - name: Publish Lucene to local maven repo.
         working-directory: ./lucene
         run: ./gradlew publishJarsPublicationToMavenLocal -Pversion.suffix=snapshot-${{ steps.version.outputs.REVISION }}


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
I think the workflow is failing because the `localSettings` task is running before/in parallel to `checkJdkInternalsExportedToGradle`. 

`localSettings` generates a gradle.properties file with jvm args exporting jdk.compiler modules.
`checkJdkInternalsExportedToGradle` ensures that these modules have been exported.

I've tested this on my fork [here](https://github.com/mch2/OpenSearch/runs/6500274889?check_suite_focus=true), note my fork fails at a later step to get aws creds, I don't have it set up to complete the whole workflow.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/3383
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
