### PR TITLE
[Type removal] _type removal from tests of yaml tests

### DIFF
--- a/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.test.rest.yaml.section;
 
-import org.opensearch.LegacyESVersion;
-import org.opensearch.Version;
 import org.opensearch.client.NodeSelector;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.xcontent.XContentLocation;

--- a/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
@@ -76,23 +76,9 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
                 + "      indices.get_mapping:\n"
                 + "        index: test_index\n"
                 + "\n"
-                + "  - match: {test_index.test_type.properties.text.type:     string}\n"
-                + "  - match: {test_index.test_type.properties.text.analyzer: whitespace}\n"
+                + "  - match: {test_index.properties.text.type:     string}\n"
+                + "  - match: {test_index.properties.text.analyzer: whitespace}\n"
                 + "\n"
-                + "---\n"
-                + "\"Get type mapping - pre 6.0\":\n"
-                + "\n"
-                + "  - skip:\n"
-                + "      version:     \"6.0.0 - \"\n"
-                + "      reason:      \"for newer versions the index name is always returned\"\n"
-                + "\n"
-                + "  - do:\n"
-                + "      indices.get_mapping:\n"
-                + "        index: test_index\n"
-                + "        type: test_type\n"
-                + "\n"
-                + "  - match: {test_type.properties.text.type:     string}\n"
-                + "  - match: {test_type.properties.text.analyzer: whitespace}\n"
         );
 
         ClientYamlTestSuite restTestSuite = ClientYamlTestSuite.parse(getTestClass().getName(), getTestName(), parser);
@@ -135,7 +121,7 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
             assertThat(restTestSuite.getTeardownSection().isEmpty(), equalTo(true));
         }
 
-        assertThat(restTestSuite.getTestSections().size(), equalTo(2));
+        assertThat(restTestSuite.getTestSections().size(), equalTo(1));
 
         assertThat(restTestSuite.getTestSections().get(0).getName(), equalTo("Get index mapping"));
         assertThat(restTestSuite.getTestSections().get(0).getSkipSection().isEmpty(), equalTo(true));
@@ -147,36 +133,13 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         assertThat(doSection.getApiCallSection().getParams().get("index"), equalTo("test_index"));
         assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(1), instanceOf(MatchAssertion.class));
         MatchAssertion matchAssertion = (MatchAssertion) restTestSuite.getTestSections().get(0).getExecutableSections().get(1);
-        assertThat(matchAssertion.getField(), equalTo("test_index.test_type.properties.text.type"));
+        assertThat(matchAssertion.getField(), equalTo("test_index.properties.text.type"));
         assertThat(matchAssertion.getExpectedValue().toString(), equalTo("string"));
         assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(2), instanceOf(MatchAssertion.class));
         matchAssertion = (MatchAssertion) restTestSuite.getTestSections().get(0).getExecutableSections().get(2);
-        assertThat(matchAssertion.getField(), equalTo("test_index.test_type.properties.text.analyzer"));
+        assertThat(matchAssertion.getField(), equalTo("test_index.properties.text.analyzer"));
         assertThat(matchAssertion.getExpectedValue().toString(), equalTo("whitespace"));
 
-        assertThat(restTestSuite.getTestSections().get(1).getName(), equalTo("Get type mapping - pre 6.0"));
-        assertThat(restTestSuite.getTestSections().get(1).getSkipSection().isEmpty(), equalTo(false));
-        assertThat(
-            restTestSuite.getTestSections().get(1).getSkipSection().getReason(),
-            equalTo("for newer versions the index name is always returned")
-        );
-        assertThat(restTestSuite.getTestSections().get(1).getSkipSection().getLowerVersion(), equalTo(LegacyESVersion.fromString("6.0.0")));
-        assertThat(restTestSuite.getTestSections().get(1).getSkipSection().getUpperVersion(), equalTo(Version.CURRENT));
-        assertThat(restTestSuite.getTestSections().get(1).getExecutableSections().size(), equalTo(3));
-        assertThat(restTestSuite.getTestSections().get(1).getExecutableSections().get(0), instanceOf(DoSection.class));
-        doSection = (DoSection) restTestSuite.getTestSections().get(1).getExecutableSections().get(0);
-        assertThat(doSection.getApiCallSection().getApi(), equalTo("indices.get_mapping"));
-        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(2));
-        assertThat(doSection.getApiCallSection().getParams().get("index"), equalTo("test_index"));
-        assertThat(doSection.getApiCallSection().getParams().get("type"), equalTo("test_type"));
-        assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(1), instanceOf(MatchAssertion.class));
-        matchAssertion = (MatchAssertion) restTestSuite.getTestSections().get(1).getExecutableSections().get(1);
-        assertThat(matchAssertion.getField(), equalTo("test_type.properties.text.type"));
-        assertThat(matchAssertion.getExpectedValue().toString(), equalTo("string"));
-        assertThat(restTestSuite.getTestSections().get(1).getExecutableSections().get(2), instanceOf(MatchAssertion.class));
-        matchAssertion = (MatchAssertion) restTestSuite.getTestSections().get(1).getExecutableSections().get(2);
-        assertThat(matchAssertion.getField(), equalTo("test_type.properties.text.analyzer"));
-        assertThat(matchAssertion.getExpectedValue().toString(), equalTo("whitespace"));
     }
 
     public void testParseTestSingleTestSection() throws Exception {
@@ -188,24 +151,20 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
                 + " - do:\n"
                 + "      index:\n"
                 + "          index:  test-weird-index-中文\n"
-                + "          type:   weird.type\n"
                 + "          id:     1\n"
                 + "          body:   { foo: bar }\n"
                 + "\n"
                 + " - is_true:   ok\n"
                 + " - match:   { _index:   test-weird-index-中文 }\n"
-                + " - match:   { _type:    weird.type }\n"
                 + " - match:   { _id:      \"1\"}\n"
                 + " - match:   { _version: 1}\n"
                 + "\n"
                 + " - do:\n"
                 + "      get:\n"
                 + "          index:  test-weird-index-中文\n"
-                + "          type:   weird.type\n"
                 + "          id:     1\n"
                 + "\n"
                 + " - match:   { _index:   test-weird-index-中文 }\n"
-                + " - match:   { _type:    weird.type }\n"
                 + " - match:   { _id:      \"1\"}\n"
                 + " - match:   { _version: 1}\n"
                 + " - match:   { _source: { foo: bar }}"
@@ -222,12 +181,12 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
 
         assertThat(restTestSuite.getTestSections().get(0).getName(), equalTo("Index with ID"));
         assertThat(restTestSuite.getTestSections().get(0).getSkipSection().isEmpty(), equalTo(true));
-        assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().size(), equalTo(12));
+        assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().size(), equalTo(10));
         assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(0), instanceOf(DoSection.class));
         DoSection doSection = (DoSection) restTestSuite.getTestSections().get(0).getExecutableSections().get(0);
         assertThat(doSection.getCatch(), nullValue());
         assertThat(doSection.getApiCallSection().getApi(), equalTo("index"));
-        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(3));
+        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(2));
         assertThat(doSection.getApiCallSection().hasBody(), equalTo(true));
         assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(1), instanceOf(IsTrueAssertion.class));
         IsTrueAssertion trueAssertion = (IsTrueAssertion) restTestSuite.getTestSections().get(0).getExecutableSections().get(1);
@@ -238,40 +197,32 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         assertThat(matchAssertion.getExpectedValue().toString(), equalTo("test-weird-index-中文"));
         assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(3), instanceOf(MatchAssertion.class));
         matchAssertion = (MatchAssertion) restTestSuite.getTestSections().get(0).getExecutableSections().get(3);
-        assertThat(matchAssertion.getField(), equalTo("_type"));
-        assertThat(matchAssertion.getExpectedValue().toString(), equalTo("weird.type"));
+        assertThat(matchAssertion.getField(), equalTo("_id"));
+        assertThat(matchAssertion.getExpectedValue().toString(), equalTo("1"));
         assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(4), instanceOf(MatchAssertion.class));
         matchAssertion = (MatchAssertion) restTestSuite.getTestSections().get(0).getExecutableSections().get(4);
-        assertThat(matchAssertion.getField(), equalTo("_id"));
-        assertThat(matchAssertion.getExpectedValue().toString(), equalTo("1"));
-        assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(5), instanceOf(MatchAssertion.class));
-        matchAssertion = (MatchAssertion) restTestSuite.getTestSections().get(0).getExecutableSections().get(5);
         assertThat(matchAssertion.getField(), equalTo("_version"));
         assertThat(matchAssertion.getExpectedValue().toString(), equalTo("1"));
-        assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(6), instanceOf(DoSection.class));
-        doSection = (DoSection) restTestSuite.getTestSections().get(0).getExecutableSections().get(6);
+        assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(5), instanceOf(DoSection.class));
+        doSection = (DoSection) restTestSuite.getTestSections().get(0).getExecutableSections().get(5);
         assertThat(doSection.getCatch(), nullValue());
         assertThat(doSection.getApiCallSection().getApi(), equalTo("get"));
-        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(3));
+        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(2));
         assertThat(doSection.getApiCallSection().hasBody(), equalTo(false));
-        assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(7), instanceOf(MatchAssertion.class));
-        matchAssertion = (MatchAssertion) restTestSuite.getTestSections().get(0).getExecutableSections().get(7);
+        assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(6), instanceOf(MatchAssertion.class));
+        matchAssertion = (MatchAssertion) restTestSuite.getTestSections().get(0).getExecutableSections().get(6);
         assertThat(matchAssertion.getField(), equalTo("_index"));
         assertThat(matchAssertion.getExpectedValue().toString(), equalTo("test-weird-index-中文"));
-        assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(8), instanceOf(MatchAssertion.class));
-        matchAssertion = (MatchAssertion) restTestSuite.getTestSections().get(0).getExecutableSections().get(8);
-        assertThat(matchAssertion.getField(), equalTo("_type"));
-        assertThat(matchAssertion.getExpectedValue().toString(), equalTo("weird.type"));
-        assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(9), instanceOf(MatchAssertion.class));
-        matchAssertion = (MatchAssertion) restTestSuite.getTestSections().get(0).getExecutableSections().get(9);
+        assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(7), instanceOf(MatchAssertion.class));
+        matchAssertion = (MatchAssertion) restTestSuite.getTestSections().get(0).getExecutableSections().get(7);
         assertThat(matchAssertion.getField(), equalTo("_id"));
         assertThat(matchAssertion.getExpectedValue().toString(), equalTo("1"));
-        assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(10), instanceOf(MatchAssertion.class));
-        matchAssertion = (MatchAssertion) restTestSuite.getTestSections().get(0).getExecutableSections().get(10);
+        assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(8), instanceOf(MatchAssertion.class));
+        matchAssertion = (MatchAssertion) restTestSuite.getTestSections().get(0).getExecutableSections().get(8);
         assertThat(matchAssertion.getField(), equalTo("_version"));
         assertThat(matchAssertion.getExpectedValue().toString(), equalTo("1"));
-        assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(11), instanceOf(MatchAssertion.class));
-        matchAssertion = (MatchAssertion) restTestSuite.getTestSections().get(0).getExecutableSections().get(11);
+        assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(9), instanceOf(MatchAssertion.class));
+        matchAssertion = (MatchAssertion) restTestSuite.getTestSections().get(0).getExecutableSections().get(9);
         assertThat(matchAssertion.getField(), equalTo("_source"));
         assertThat(matchAssertion.getExpectedValue(), instanceOf(Map.class));
         assertThat(((Map) matchAssertion.getExpectedValue()).get("foo").toString(), equalTo("bar"));
@@ -287,14 +238,12 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
                 + "      catch:      missing\n"
                 + "      update:\n"
                 + "          index:  test_1\n"
-                + "          type:   test\n"
                 + "          id:     1\n"
                 + "          body:   { doc: { foo: bar } }\n"
                 + "\n"
                 + "  - do:\n"
                 + "      update:\n"
                 + "          index: test_1\n"
-                + "          type:  test\n"
                 + "          id:    1\n"
                 + "          body:  { doc: { foo: bar } }\n"
                 + "          ignore: 404\n"
@@ -307,7 +256,6 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
                 + "      catch:      missing\n"
                 + "      update:\n"
                 + "          index:  test_1\n"
-                + "          type:   test\n"
                 + "          id:     1\n"
                 + "          body:\n"
                 + "            script: \"ctx._source.foo = bar\"\n"
@@ -316,7 +264,6 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
                 + "  - do:\n"
                 + "      update:\n"
                 + "          index:  test_1\n"
-                + "          type:   test\n"
                 + "          id:     1\n"
                 + "          ignore: 404\n"
                 + "          body:\n"
@@ -341,13 +288,13 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         DoSection doSection = (DoSection) restTestSuite.getTestSections().get(0).getExecutableSections().get(0);
         assertThat(doSection.getCatch(), equalTo("missing"));
         assertThat(doSection.getApiCallSection().getApi(), equalTo("update"));
-        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(3));
+        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(2));
         assertThat(doSection.getApiCallSection().hasBody(), equalTo(true));
         assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(1), instanceOf(DoSection.class));
         doSection = (DoSection) restTestSuite.getTestSections().get(0).getExecutableSections().get(1);
         assertThat(doSection.getCatch(), nullValue());
         assertThat(doSection.getApiCallSection().getApi(), equalTo("update"));
-        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(4));
+        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(3));
         assertThat(doSection.getApiCallSection().hasBody(), equalTo(true));
 
         assertThat(restTestSuite.getTestSections().get(1).getName(), equalTo("Missing document (script)"));
@@ -358,13 +305,13 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         doSection = (DoSection) restTestSuite.getTestSections().get(1).getExecutableSections().get(0);
         assertThat(doSection.getCatch(), equalTo("missing"));
         assertThat(doSection.getApiCallSection().getApi(), equalTo("update"));
-        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(3));
+        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(2));
         assertThat(doSection.getApiCallSection().hasBody(), equalTo(true));
         assertThat(restTestSuite.getTestSections().get(0).getExecutableSections().get(1), instanceOf(DoSection.class));
         doSection = (DoSection) restTestSuite.getTestSections().get(1).getExecutableSections().get(1);
         assertThat(doSection.getCatch(), nullValue());
         assertThat(doSection.getApiCallSection().getApi(), equalTo("update"));
-        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(4));
+        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(3));
         assertThat(doSection.getApiCallSection().hasBody(), equalTo(true));
     }
 
@@ -378,7 +325,6 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
                 + "      catch:      missing\n"
                 + "      update:\n"
                 + "          index:  test_1\n"
-                + "          type:   test\n"
                 + "          id:     1\n"
                 + "          body:   { doc: { foo: bar } }\n"
                 + "\n"
@@ -390,7 +336,6 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
                 + "      catch:      missing\n"
                 + "      update:\n"
                 + "          index:  test_1\n"
-                + "          type:   test\n"
                 + "          id:     1\n"
                 + "          body:\n"
                 + "            script: \"ctx._source.foo = bar\"\n"

--- a/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/DoSectionTests.java
@@ -180,7 +180,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
 
         assertThat(apiCallSection, notNullValue());
         assertThat(apiCallSection.getApi(), equalTo("get"));
-        assertThat(apiCallSection.getParams().size(), equalTo(3));
+        assertThat(apiCallSection.getParams().size(), equalTo(2));
         assertThat(apiCallSection.getParams().get("index"), equalTo("test_index"));
         assertThat(apiCallSection.getParams().get("id"), equalTo("1"));
         assertThat(apiCallSection.hasBody(), equalTo(false));
@@ -207,7 +207,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
 
         assertThat(apiCallSection, notNullValue());
         assertThat(apiCallSection.getApi(), equalTo("index"));
-        assertThat(apiCallSection.getParams().size(), equalTo(3));
+        assertThat(apiCallSection.getParams().size(), equalTo(2));
         assertThat(apiCallSection.getParams().get("index"), equalTo("test_1"));
         assertThat(apiCallSection.getParams().get("id"), equalTo("1"));
         assertThat(apiCallSection.hasBody(), equalTo(true));
@@ -436,7 +436,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         assertThat(doSection.getCatch(), nullValue());
         assertThat(doSection.getApiCallSection(), notNullValue());
         assertThat(doSection.getApiCallSection().getApi(), equalTo("indices.get_field_mapping"));
-        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(3));
+        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(2));
         assertThat(doSection.getApiCallSection().getParams().get("index"), equalTo("test_index"));
         assertThat(doSection.getApiCallSection().getParams().get("field"), equalTo("text,text1"));
         assertThat(doSection.getApiCallSection().hasBody(), equalTo(false));

--- a/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/DoSectionTests.java
@@ -342,7 +342,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
 
         assertThat(apiCallSection, notNullValue());
         assertThat(apiCallSection.getApi(), equalTo("index"));
-        assertThat(apiCallSection.getParams().size(), equalTo(3));
+        assertThat(apiCallSection.getParams().size(), equalTo(2));
         assertThat(apiCallSection.getParams().get("index"), equalTo("test_1"));
         assertThat(apiCallSection.getParams().get("id"), equalTo("1"));
         assertThat(apiCallSection.hasBody(), equalTo(true));
@@ -457,7 +457,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         assertThat(doSection.getCatch(), nullValue());
         assertThat(doSection.getApiCallSection(), notNullValue());
         assertThat(doSection.getApiCallSection().getApi(), equalTo("indices.get_field_mapping"));
-        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(2));
+        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(1));
         assertThat(doSection.getApiCallSection().getParams().get("index"), equalTo("test_index"));
         assertThat(doSection.getApiCallSection().hasBody(), equalTo(false));
         assertThat(doSection.getApiCallSection().getBodies().size(), equalTo(0));
@@ -493,7 +493,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         assertThat(doSection.getCatch(), nullValue());
         assertThat(doSection.getApiCallSection(), notNullValue());
         assertThat(doSection.getApiCallSection().getApi(), equalTo("indices.get_field_mapping"));
-        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(2));
+        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(1));
         assertThat(doSection.getApiCallSection().getParams().get("index"), equalTo("test_index"));
         assertThat(doSection.getApiCallSection().hasBody(), equalTo(false));
         assertThat(doSection.getApiCallSection().getBodies().size(), equalTo(0));

--- a/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/DoSectionTests.java
@@ -173,10 +173,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
     }
 
     public void testParseDoSectionNoBody() throws Exception {
-        parser = createParser(
-            YamlXContent.yamlXContent,
-            "get:\n" + "    index:    test_index\n" + "    id:        1"
-        );
+        parser = createParser(YamlXContent.yamlXContent, "get:\n" + "    index:    test_index\n" + "    id:        1");
 
         DoSection doSection = DoSection.parse(parser);
         ApiCallSection apiCallSection = doSection.getApiCallSection();
@@ -203,10 +200,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
 
     public void testParseDoSectionWithJsonBody() throws Exception {
         String body = "{ \"include\": { \"field1\": \"v1\", \"field2\": \"v2\" }, \"count\": 1 }";
-        parser = createParser(
-            YamlXContent.yamlXContent,
-            "index:\n" + "    index:  test_1\n" + "    id:     1\n" + "    body:   " + body
-        );
+        parser = createParser(YamlXContent.yamlXContent, "index:\n" + "    index:  test_1\n" + "    id:     1\n" + "    body:   " + body);
 
         DoSection doSection = DoSection.parse(parser);
         ApiCallSection apiCallSection = doSection.getApiCallSection();
@@ -321,10 +315,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
                 + "            - { _index: test_2, _id: 1}\n"
                 + "            - { _index: test_1, _id: 1}"
         );
-        String body = "{ \"docs\": [ "
-            + "{\"_index\": \"test_2\", \"_id\":1}, "
-            + "{\"_index\": \"test_1\", \"_id\":1} "
-            + "]}";
+        String body = "{ \"docs\": [ " + "{\"_index\": \"test_2\", \"_id\":1}, " + "{\"_index\": \"test_1\", \"_id\":1} " + "]}";
 
         DoSection doSection = DoSection.parse(parser);
         ApiCallSection apiCallSection = doSection.getApiCallSection();

--- a/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/DoSectionTests.java
@@ -175,7 +175,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
     public void testParseDoSectionNoBody() throws Exception {
         parser = createParser(
             YamlXContent.yamlXContent,
-            "get:\n" + "    index:    test_index\n" + "    type:    test_type\n" + "    id:        1"
+            "get:\n" + "    index:    test_index\n" + "    id:        1"
         );
 
         DoSection doSection = DoSection.parse(parser);
@@ -185,7 +185,6 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         assertThat(apiCallSection.getApi(), equalTo("get"));
         assertThat(apiCallSection.getParams().size(), equalTo(3));
         assertThat(apiCallSection.getParams().get("index"), equalTo("test_index"));
-        assertThat(apiCallSection.getParams().get("type"), equalTo("test_type"));
         assertThat(apiCallSection.getParams().get("id"), equalTo("1"));
         assertThat(apiCallSection.hasBody(), equalTo(false));
     }
@@ -206,7 +205,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         String body = "{ \"include\": { \"field1\": \"v1\", \"field2\": \"v2\" }, \"count\": 1 }";
         parser = createParser(
             YamlXContent.yamlXContent,
-            "index:\n" + "    index:  test_1\n" + "    type:   test\n" + "    id:     1\n" + "    body:   " + body
+            "index:\n" + "    index:  test_1\n" + "    id:     1\n" + "    body:   " + body
         );
 
         DoSection doSection = DoSection.parse(parser);
@@ -216,7 +215,6 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         assertThat(apiCallSection.getApi(), equalTo("index"));
         assertThat(apiCallSection.getParams().size(), equalTo(3));
         assertThat(apiCallSection.getParams().get("index"), equalTo("test_1"));
-        assertThat(apiCallSection.getParams().get("type"), equalTo("test"));
         assertThat(apiCallSection.getParams().get("id"), equalTo("1"));
         assertThat(apiCallSection.hasBody(), equalTo(true));
 
@@ -225,9 +223,9 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
 
     public void testParseDoSectionWithJsonMultipleBodiesAsLongString() throws Exception {
         String bodies[] = new String[] {
-            "{ \"index\": { \"_index\":\"test_index\", \"_type\":\"test_type\", \"_id\":\"test_id\" } }\n",
+            "{ \"index\": { \"_index\":\"test_index\", \"_id\":\"test_id\" } }\n",
             "{ \"f1\":\"v1\", \"f2\":42 }\n",
-            "{ \"index\": { \"_index\":\"test_index2\", \"_type\":\"test_type2\", \"_id\":\"test_id2\" } }\n",
+            "{ \"index\": { \"_index\":\"test_index2\", \"_id\":\"test_id2\" } }\n",
             "{ \"f1\":\"v2\", \"f2\":47 }\n" };
         parser = createParser(
             YamlXContent.yamlXContent,
@@ -284,21 +282,19 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
                 + "    body:\n"
                 + "        - index:\n"
                 + "            _index: test_index\n"
-                + "            _type:  test_type\n"
                 + "            _id:    test_id\n"
                 + "        - f1: v1\n"
                 + "          f2: 42\n"
                 + "        - index:\n"
                 + "            _index: test_index2\n"
-                + "            _type:  test_type2\n"
                 + "            _id:    test_id2\n"
                 + "        - f1: v2\n"
                 + "          f2: 47"
         );
         String[] bodies = new String[4];
-        bodies[0] = "{\"index\": {\"_index\": \"test_index\", \"_type\":  \"test_type\", \"_id\": \"test_id\"}}";
+        bodies[0] = "{\"index\": {\"_index\": \"test_index\", \"_id\": \"test_id\"}}";
         bodies[1] = "{ \"f1\":\"v1\", \"f2\": 42 }";
-        bodies[2] = "{\"index\": {\"_index\": \"test_index2\", \"_type\":  \"test_type2\", \"_id\": \"test_id2\"}}";
+        bodies[2] = "{\"index\": {\"_index\": \"test_index2\", \"_id\": \"test_id2\"}}";
         bodies[3] = "{ \"f1\":\"v2\", \"f2\": 47 }";
 
         DoSection doSection = DoSection.parse(parser);
@@ -322,12 +318,12 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
             "mget:\n"
                 + "    body:\n"
                 + "        docs:\n"
-                + "            - { _index: test_2, _type: test, _id: 1}\n"
-                + "            - { _index: test_1, _type: none, _id: 1}"
+                + "            - { _index: test_2, _id: 1}\n"
+                + "            - { _index: test_1, _id: 1}"
         );
         String body = "{ \"docs\": [ "
-            + "{\"_index\": \"test_2\", \"_type\":\"test\", \"_id\":1}, "
-            + "{\"_index\": \"test_1\", \"_type\":\"none\", \"_id\":1} "
+            + "{\"_index\": \"test_2\", \"_id\":1}, "
+            + "{\"_index\": \"test_1\", \"_id\":1} "
             + "]}";
 
         DoSection doSection = DoSection.parse(parser);
@@ -346,7 +342,6 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
             YamlXContent.yamlXContent,
             "index:\n"
                 + "    index:  test_1\n"
-                + "    type:   test\n"
                 + "    id:     1\n"
                 + "    body:   \"{ \\\"_source\\\": true, \\\"query\\\": { \\\"match_all\\\": {} } }\""
         );
@@ -358,7 +353,6 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         assertThat(apiCallSection.getApi(), equalTo("index"));
         assertThat(apiCallSection.getParams().size(), equalTo(3));
         assertThat(apiCallSection.getParams().get("index"), equalTo("test_1"));
-        assertThat(apiCallSection.getParams().get("type"), equalTo("test"));
         assertThat(apiCallSection.getParams().get("id"), equalTo("1"));
         assertThat(apiCallSection.hasBody(), equalTo(true));
         assertThat(apiCallSection.getBodies().size(), equalTo(1));
@@ -444,7 +438,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
     public void testParseDoSectionMultivaluedField() throws Exception {
         parser = createParser(
             YamlXContent.yamlXContent,
-            "indices.get_field_mapping:\n" + "        index: test_index\n" + "        type: test_type\n" + "        field: [ text , text1 ]"
+            "indices.get_field_mapping:\n" + "        index: test_index\n" + "        field: [ text , text1 ]"
         );
 
         DoSection doSection = DoSection.parse(parser);
@@ -453,7 +447,6 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         assertThat(doSection.getApiCallSection().getApi(), equalTo("indices.get_field_mapping"));
         assertThat(doSection.getApiCallSection().getParams().size(), equalTo(3));
         assertThat(doSection.getApiCallSection().getParams().get("index"), equalTo("test_index"));
-        assertThat(doSection.getApiCallSection().getParams().get("type"), equalTo("test_type"));
         assertThat(doSection.getApiCallSection().getParams().get("field"), equalTo("text,text1"));
         assertThat(doSection.getApiCallSection().hasBody(), equalTo(false));
         assertThat(doSection.getApiCallSection().getBodies().size(), equalTo(0));
@@ -464,7 +457,6 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
             YamlXContent.yamlXContent,
             "indices.get_field_mapping:\n"
                 + "        index: test_index\n"
-                + "        type: test_type\n"
                 + "warnings:\n"
                 + "    - some test warning they are typically pretty long\n"
                 + "    - some other test warning sometimes they have [in] them"
@@ -476,7 +468,6 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         assertThat(doSection.getApiCallSection().getApi(), equalTo("indices.get_field_mapping"));
         assertThat(doSection.getApiCallSection().getParams().size(), equalTo(2));
         assertThat(doSection.getApiCallSection().getParams().get("index"), equalTo("test_index"));
-        assertThat(doSection.getApiCallSection().getParams().get("type"), equalTo("test_type"));
         assertThat(doSection.getApiCallSection().hasBody(), equalTo(false));
         assertThat(doSection.getApiCallSection().getBodies().size(), equalTo(0));
         assertThat(
@@ -502,7 +493,6 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
             YamlXContent.yamlXContent,
             "indices.get_field_mapping:\n"
                 + "        index: test_index\n"
-                + "        type: test_type\n"
                 + "allowed_warnings:\n"
                 + "    - some test warning they are typically pretty long\n"
                 + "    - some other test warning sometimes they have [in] them"
@@ -514,7 +504,6 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         assertThat(doSection.getApiCallSection().getApi(), equalTo("indices.get_field_mapping"));
         assertThat(doSection.getApiCallSection().getParams().size(), equalTo(2));
         assertThat(doSection.getApiCallSection().getParams().get("index"), equalTo("test_index"));
-        assertThat(doSection.getApiCallSection().getParams().get("type"), equalTo("test_type"));
         assertThat(doSection.getApiCallSection().hasBody(), equalTo(false));
         assertThat(doSection.getApiCallSection().getBodies().size(), equalTo(0));
         assertThat(

--- a/test/framework/src/test/resources/rest-api-spec/test/suite1/10_basic.yml
+++ b/test/framework/src/test/resources/rest-api-spec/test/suite1/10_basic.yml
@@ -4,18 +4,15 @@
   - do:
       index:
         index: test_1
-        type:  test
         id:    中文
         body:  { "foo": "Hello: 中文" }
 
   - do:
       get:
         index: test_1
-        type:  test
         id:    中文
 
   - match: { _index:   test_1 }
-  - match: { _type:    test   }
   - match: { _id:      中文      }
   - match: { _source:  { foo: "Hello: 中文" } }
 
@@ -26,6 +23,5 @@
         id:    中文
 
   - match: { _index:   test_1 }
-  - match: { _type:    test   }
   - match: { _id:      中文      }
   - match: { _source:  { foo: "Hello: 中文" } }


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Remove mapping types from tests; testing yaml test sections.

Related: #3131 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
