### PR TITLE
[Type removal] Remove type from BulkRequestParser

### DIFF
--- a/server/src/main/java/org/opensearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/opensearch/action/bulk/BulkRequest.java
@@ -287,7 +287,7 @@ public class BulkRequest extends ActionRequest implements CompositeIndicesReques
         String routing = valueOrDefault(defaultRouting, globalRouting);
         String pipeline = valueOrDefault(defaultPipeline, globalPipeline);
         Boolean requireAlias = valueOrDefault(defaultRequireAlias, globalRequireAlias);
-        new BulkRequestParser(true).parse(
+        new BulkRequestParser().parse(
             data,
             defaultIndex,
             routing,
@@ -296,7 +296,7 @@ public class BulkRequest extends ActionRequest implements CompositeIndicesReques
             requireAlias,
             allowExplicitIndex,
             xContentType,
-            (indexRequest, type) -> internalAdd(indexRequest),
+            this::internalAdd,
             this::internalAdd,
             this::add
         );

--- a/server/src/test/java/org/opensearch/action/bulk/BulkRequestParserTests.java
+++ b/server/src/test/java/org/opensearch/action/bulk/BulkRequestParserTests.java
@@ -47,9 +47,9 @@ public class BulkRequestParserTests extends OpenSearchTestCase {
 
     public void testIndexRequest() throws IOException {
         BytesArray request = new BytesArray("{ \"index\":{ \"_id\": \"bar\" } }\n{}\n");
-        BulkRequestParser parser = new BulkRequestParser(randomBoolean());
+        BulkRequestParser parser = new BulkRequestParser();
         final AtomicBoolean parsed = new AtomicBoolean();
-        parser.parse(request, "foo", null, null, null, null, false, XContentType.JSON, (indexRequest, type) -> {
+        parser.parse(request, "foo", null, null, null, null, false, XContentType.JSON, indexRequest -> {
             assertFalse(parsed.get());
             assertEquals("foo", indexRequest.index());
             assertEquals("bar", indexRequest.id());
@@ -67,7 +67,7 @@ public class BulkRequestParserTests extends OpenSearchTestCase {
             true,
             false,
             XContentType.JSON,
-            (indexRequest, type) -> { assertTrue(indexRequest.isRequireAlias()); },
+            indexRequest -> { assertTrue(indexRequest.isRequireAlias()); },
             req -> fail(),
             req -> fail()
         );
@@ -82,7 +82,7 @@ public class BulkRequestParserTests extends OpenSearchTestCase {
             null,
             false,
             XContentType.JSON,
-            (indexRequest, type) -> { assertTrue(indexRequest.isRequireAlias()); },
+            indexRequest -> { assertTrue(indexRequest.isRequireAlias()); },
             req -> fail(),
             req -> fail()
         );
@@ -97,7 +97,7 @@ public class BulkRequestParserTests extends OpenSearchTestCase {
             true,
             false,
             XContentType.JSON,
-            (indexRequest, type) -> { assertFalse(indexRequest.isRequireAlias()); },
+            indexRequest -> { assertFalse(indexRequest.isRequireAlias()); },
             req -> fail(),
             req -> fail()
         );
@@ -105,34 +105,22 @@ public class BulkRequestParserTests extends OpenSearchTestCase {
 
     public void testDeleteRequest() throws IOException {
         BytesArray request = new BytesArray("{ \"delete\":{ \"_id\": \"bar\" } }\n");
-        BulkRequestParser parser = new BulkRequestParser(randomBoolean());
+        BulkRequestParser parser = new BulkRequestParser();
         final AtomicBoolean parsed = new AtomicBoolean();
-        parser.parse(
-            request,
-            "foo",
-            null,
-            null,
-            null,
-            null,
-            false,
-            XContentType.JSON,
-            (req, type) -> fail(),
-            req -> fail(),
-            deleteRequest -> {
-                assertFalse(parsed.get());
-                assertEquals("foo", deleteRequest.index());
-                assertEquals("bar", deleteRequest.id());
-                parsed.set(true);
-            }
-        );
+        parser.parse(request, "foo", null, null, null, null, false, XContentType.JSON, req -> fail(), req -> fail(), deleteRequest -> {
+            assertFalse(parsed.get());
+            assertEquals("foo", deleteRequest.index());
+            assertEquals("bar", deleteRequest.id());
+            parsed.set(true);
+        });
         assertTrue(parsed.get());
     }
 
     public void testUpdateRequest() throws IOException {
         BytesArray request = new BytesArray("{ \"update\":{ \"_id\": \"bar\" } }\n{}\n");
-        BulkRequestParser parser = new BulkRequestParser(randomBoolean());
+        BulkRequestParser parser = new BulkRequestParser();
         final AtomicBoolean parsed = new AtomicBoolean();
-        parser.parse(request, "foo", null, null, null, null, false, XContentType.JSON, (req, type) -> fail(), updateRequest -> {
+        parser.parse(request, "foo", null, null, null, null, false, XContentType.JSON, req -> fail(), updateRequest -> {
             assertFalse(parsed.get());
             assertEquals("foo", updateRequest.index());
             assertEquals("bar", updateRequest.id());
@@ -150,7 +138,7 @@ public class BulkRequestParserTests extends OpenSearchTestCase {
             true,
             false,
             XContentType.JSON,
-            (req, type) -> fail(),
+            req -> fail(),
             updateRequest -> { assertTrue(updateRequest.isRequireAlias()); },
             req -> fail()
         );
@@ -165,7 +153,7 @@ public class BulkRequestParserTests extends OpenSearchTestCase {
             null,
             false,
             XContentType.JSON,
-            (req, type) -> fail(),
+            req -> fail(),
             updateRequest -> { assertTrue(updateRequest.isRequireAlias()); },
             req -> fail()
         );
@@ -180,7 +168,7 @@ public class BulkRequestParserTests extends OpenSearchTestCase {
             true,
             false,
             XContentType.JSON,
-            (req, type) -> fail(),
+            req -> fail(),
             updateRequest -> { assertFalse(updateRequest.isRequireAlias()); },
             req -> fail()
         );
@@ -188,7 +176,7 @@ public class BulkRequestParserTests extends OpenSearchTestCase {
 
     public void testBarfOnLackOfTrailingNewline() {
         BytesArray request = new BytesArray("{ \"index\":{ \"_id\": \"bar\" } }\n{}");
-        BulkRequestParser parser = new BulkRequestParser(randomBoolean());
+        BulkRequestParser parser = new BulkRequestParser();
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
             () -> parser.parse(
@@ -200,7 +188,7 @@ public class BulkRequestParserTests extends OpenSearchTestCase {
                 null,
                 false,
                 XContentType.JSON,
-                (indexRequest, type) -> fail(),
+                indexRequest -> fail(),
                 req -> fail(),
                 req -> fail()
             )
@@ -210,23 +198,11 @@ public class BulkRequestParserTests extends OpenSearchTestCase {
 
     public void testFailOnExplicitIndex() {
         BytesArray request = new BytesArray("{ \"index\":{ \"_index\": \"foo\", \"_id\": \"bar\" } }\n{}\n");
-        BulkRequestParser parser = new BulkRequestParser(randomBoolean());
+        BulkRequestParser parser = new BulkRequestParser();
 
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> parser.parse(
-                request,
-                null,
-                null,
-                null,
-                null,
-                null,
-                false,
-                XContentType.JSON,
-                (req, type) -> fail(),
-                req -> fail(),
-                req -> fail()
-            )
+            () -> parser.parse(request, null, null, null, null, null, false, XContentType.JSON, req -> fail(), req -> fail(), req -> fail())
         );
         assertEquals("explicit index in bulk is not allowed", ex.getMessage());
     }
@@ -235,7 +211,7 @@ public class BulkRequestParserTests extends OpenSearchTestCase {
         BytesArray request = new BytesArray("{ \"index\":{ \"_type\": \"quux\", \"_id\": \"bar\" } }\n{}\n");
         BulkRequestParser parser = new BulkRequestParser(false);
         final AtomicBoolean parsed = new AtomicBoolean();
-        parser.parse(request, "foo", null, null, null, null, false, XContentType.JSON, (indexRequest, type) -> {
+        parser.parse(request, "foo", null, null, null, null, false, XContentType.JSON, indexRequest -> {
             assertFalse(parsed.get());
             assertEquals("foo", indexRequest.index());
             assertEquals("bar", indexRequest.id());
@@ -249,7 +225,7 @@ public class BulkRequestParserTests extends OpenSearchTestCase {
             "{ \"index\":{ \"_index\": \"bar\", \"pipeline\": \"foo\", \"routing\": \"blub\"} }\n{}\n"
                 + "{ \"index\":{ \"_index\": \"bar\", \"pipeline\": \"foo\", \"routing\": \"blub\" } }\n{}\n"
         );
-        BulkRequestParser parser = new BulkRequestParser(randomBoolean());
+        BulkRequestParser parser = new BulkRequestParser();
         final List<IndexRequest> indexRequests = new ArrayList<>();
         parser.parse(
             request,
@@ -260,7 +236,7 @@ public class BulkRequestParserTests extends OpenSearchTestCase {
             null,
             true,
             XContentType.JSON,
-            (indexRequest, type) -> indexRequests.add(indexRequest),
+            indexRequest -> indexRequests.add(indexRequest),
             req -> fail(),
             req -> fail()
         );

--- a/server/src/test/java/org/opensearch/action/bulk/BulkRequestParserTests.java
+++ b/server/src/test/java/org/opensearch/action/bulk/BulkRequestParserTests.java
@@ -207,19 +207,6 @@ public class BulkRequestParserTests extends OpenSearchTestCase {
         assertEquals("explicit index in bulk is not allowed", ex.getMessage());
     }
 
-    public void testTypesStillParsedForBulkMonitoring() throws IOException {
-        BytesArray request = new BytesArray("{ \"index\":{ \"_type\": \"quux\", \"_id\": \"bar\" } }\n{}\n");
-        BulkRequestParser parser = new BulkRequestParser(false);
-        final AtomicBoolean parsed = new AtomicBoolean();
-        parser.parse(request, "foo", null, null, null, null, false, XContentType.JSON, indexRequest -> {
-            assertFalse(parsed.get());
-            assertEquals("foo", indexRequest.index());
-            assertEquals("bar", indexRequest.id());
-            parsed.set(true);
-        }, req -> fail(), req -> fail());
-        assertTrue(parsed.get());
-    }
-
     public void testParseDeduplicatesParameterStrings() throws IOException {
         BytesArray request = new BytesArray(
             "{ \"index\":{ \"_index\": \"bar\", \"pipeline\": \"foo\", \"routing\": \"blub\"} }\n{}\n"


### PR DESCRIPTION
### Description
Removes type handling in BulkRequestParser's parsing and perform related cleanup 

Related: #3131 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
