### PR TITLE
Bump version 2.1 to Lucene 9.2 after upgrade

### DIFF
--- a/server/src/main/java/org/opensearch/Version.java
+++ b/server/src/main/java/org/opensearch/Version.java
@@ -88,7 +88,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_1_3_2 = new Version(1030299, org.apache.lucene.util.Version.LUCENE_8_10_1);
     public static final Version V_1_3_3 = new Version(1030399, org.apache.lucene.util.Version.LUCENE_8_10_1);
     public static final Version V_2_0_0 = new Version(2000099, org.apache.lucene.util.Version.LUCENE_9_1_0);
-    public static final Version V_2_1_0 = new Version(2010099, org.apache.lucene.util.Version.LUCENE_9_1_0);
+    public static final Version V_2_1_0 = new Version(2010099, org.apache.lucene.util.Version.LUCENE_9_2_0);
     public static final Version V_3_0_0 = new Version(3000099, org.apache.lucene.util.Version.LUCENE_9_2_0);
     public static final Version CURRENT = V_3_0_0;
 


### PR DESCRIPTION
Bumps Version.V_2_1_0 lucene version to 9.2 after backporting upgrage in #3422.