### PR TITLE
Fix for bug showing incorrect awareness attributes count in AwarenessAllocationDecider

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
@@ -210,10 +210,10 @@ public class AwarenessAllocationDecider extends AllocationDecider {
 
             int numberOfAttributes = nodesPerAttribute.size();
             List<String> fullValues = forcedAwarenessAttributes.get(awarenessAttribute);
-            Set<String> attributesSet = new HashSet<>();
+
             if (fullValues != null) {
                 // If forced awareness is enabled, numberOfAttributes = count(distinct((union(discovered_attributes, forced_attributes)))
-                attributesSet.addAll(forcedAwarenessAttributes.get(awarenessAttribute));
+                Set<String> attributesSet = new HashSet<>(fullValues);
                 for (ObjectCursor<String> stringObjectCursor : nodesPerAttribute.keys()) {
                     attributesSet.add(stringObjectCursor.value);
                 }

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
@@ -33,11 +33,14 @@
 package org.opensearch.cluster.routing.allocation.decider;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import com.carrotsearch.hppc.ObjectIntHashMap;
+import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.RoutingNode;
 import org.opensearch.cluster.routing.ShardRouting;
@@ -207,12 +210,14 @@ public class AwarenessAllocationDecider extends AllocationDecider {
 
             int numberOfAttributes = nodesPerAttribute.size();
             List<String> fullValues = forcedAwarenessAttributes.get(awarenessAttribute);
+            Set<String> attributesSet = new HashSet<>();
             if (fullValues != null) {
-                for (String fullValue : fullValues) {
-                    if (shardPerAttribute.containsKey(fullValue) == false) {
-                        numberOfAttributes++;
-                    }
+                // If forced awareness is enabled, numberOfAttributes = count(distinct((union(discovered_attributes, forced_attributes)))
+                attributesSet.addAll(forcedAwarenessAttributes.get(awarenessAttribute));
+                for (ObjectCursor<String> stringObjectCursor : nodesPerAttribute.keys()) {
+                    attributesSet.add(stringObjectCursor.value);
                 }
+                numberOfAttributes = attributesSet.size();
             }
             // TODO should we remove ones that are not part of full list?
 


### PR DESCRIPTION
…Decider

This commit fixes allocation explanation reason displaying incorrect number of awareness attributes in some cases when forced zone awareness is enabled.

Signed-off-by: Anshu Agarwal <anshukag@amazon.com>

### Description
This commit fixes bug in AwarenessAllocationDecider showing incorrect number of awareness attribute in allocation explanation reason. More details on the bug and how to reproduce it can be found in the issue.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/3413
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
