### PR TITLE
Rename master to cluster_manager in the XContent Parser of ClusterHealthResponse

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponse.java
@@ -125,7 +125,7 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
                 unassignedShards,
                 numberOfNodes,
                 numberOfDataNodes,
-                hasDiscoveredClusterManager,
+                hasDiscoveredClusterManager || hasDiscoveredMaster,
                 activeShardsPercent,
                 status,
                 indices

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponse.java
@@ -71,6 +71,7 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
     private static final String TIMED_OUT = "timed_out";
     private static final String NUMBER_OF_NODES = "number_of_nodes";
     private static final String NUMBER_OF_DATA_NODES = "number_of_data_nodes";
+    @Deprecated
     private static final String DISCOVERED_MASTER = "discovered_master";
     private static final String DISCOVERED_CLUSTER_MANAGER = "discovered_cluster_manager";
     private static final String NUMBER_OF_PENDING_TASKS = "number_of_pending_tasks";
@@ -95,6 +96,7 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
             // ClusterStateHealth fields
             int numberOfNodes = (int) parsedObjects[i++];
             int numberOfDataNodes = (int) parsedObjects[i++];
+            boolean hasDiscoveredMaster = Boolean.TRUE.equals(parsedObjects[i++]);
             boolean hasDiscoveredClusterManager = Boolean.TRUE.equals(parsedObjects[i++]);
             int activeShards = (int) parsedObjects[i++];
             int relocatingShards = (int) parsedObjects[i++];
@@ -157,6 +159,7 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
         PARSER.declareInt(constructorArg(), new ParseField(NUMBER_OF_NODES));
         PARSER.declareInt(constructorArg(), new ParseField(NUMBER_OF_DATA_NODES));
         PARSER.declareBoolean(optionalConstructorArg(), new ParseField(DISCOVERED_MASTER));
+        PARSER.declareBoolean(optionalConstructorArg(), new ParseField(DISCOVERED_CLUSTER_MANAGER));
         PARSER.declareInt(constructorArg(), new ParseField(ACTIVE_SHARDS));
         PARSER.declareInt(constructorArg(), new ParseField(RELOCATING_SHARDS));
         PARSER.declareInt(constructorArg(), new ParseField(ACTIVE_PRIMARY_SHARDS));

--- a/server/src/main/java/org/opensearch/cluster/health/ClusterStateHealth.java
+++ b/server/src/main/java/org/opensearch/cluster/health/ClusterStateHealth.java
@@ -58,7 +58,7 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
 
     private final int numberOfNodes;
     private final int numberOfDataNodes;
-    private final boolean hasDiscoveredMaster;
+    private final boolean hasDiscoveredClusterManager;
     private final int activeShards;
     private final int relocatingShards;
     private final int activePrimaryShards;
@@ -86,7 +86,7 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
     public ClusterStateHealth(final ClusterState clusterState, final String[] concreteIndices) {
         numberOfNodes = clusterState.nodes().getSize();
         numberOfDataNodes = clusterState.nodes().getDataNodes().size();
-        hasDiscoveredMaster = clusterState.nodes().getMasterNodeId() != null;
+        hasDiscoveredClusterManager = clusterState.nodes().getMasterNodeId() != null;
         indices = new HashMap<>();
         for (String index : concreteIndices) {
             IndexRoutingTable indexRoutingTable = clusterState.routingTable().index(index);
@@ -155,9 +155,9 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
         numberOfNodes = in.readVInt();
         numberOfDataNodes = in.readVInt();
         if (in.getVersion().onOrAfter(Version.V_1_0_0)) {
-            hasDiscoveredMaster = in.readBoolean();
+            hasDiscoveredClusterManager = in.readBoolean();
         } else {
-            hasDiscoveredMaster = true;
+            hasDiscoveredClusterManager = true;
         }
         status = ClusterHealthStatus.fromValue(in.readByte());
         int size = in.readVInt();
@@ -180,7 +180,7 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
         int unassignedShards,
         int numberOfNodes,
         int numberOfDataNodes,
-        boolean hasDiscoveredMaster,
+        boolean hasDiscoveredClusterManager,
         double activeShardsPercent,
         ClusterHealthStatus status,
         Map<String, ClusterIndexHealth> indices
@@ -192,7 +192,7 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
         this.unassignedShards = unassignedShards;
         this.numberOfNodes = numberOfNodes;
         this.numberOfDataNodes = numberOfDataNodes;
-        this.hasDiscoveredMaster = hasDiscoveredMaster;
+        this.hasDiscoveredClusterManager = hasDiscoveredClusterManager;
         this.activeShardsPercent = activeShardsPercent;
         this.status = status;
         this.indices = indices;
@@ -239,7 +239,7 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
     }
 
     public boolean hasDiscoveredMaster() {
-        return hasDiscoveredMaster;
+        return hasDiscoveredClusterManager;
     }
 
     @Override
@@ -257,7 +257,7 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
         out.writeVInt(numberOfNodes);
         out.writeVInt(numberOfDataNodes);
         if (out.getVersion().onOrAfter(Version.V_1_0_0)) {
-            out.writeBoolean(hasDiscoveredMaster);
+            out.writeBoolean(hasDiscoveredClusterManager);
         }
         out.writeByte(status.value());
         out.writeVInt(indices.size());
@@ -274,8 +274,8 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
             + numberOfNodes
             + ", numberOfDataNodes="
             + numberOfDataNodes
-            + ", hasDiscoveredMaster="
-            + hasDiscoveredMaster
+            + ", hasDiscoveredClusterManager="
+            + hasDiscoveredClusterManager
             + ", activeShards="
             + activeShards
             + ", relocatingShards="
@@ -302,7 +302,7 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
         ClusterStateHealth that = (ClusterStateHealth) o;
         return numberOfNodes == that.numberOfNodes
             && numberOfDataNodes == that.numberOfDataNodes
-            && hasDiscoveredMaster == that.hasDiscoveredMaster
+            && hasDiscoveredClusterManager == that.hasDiscoveredClusterManager
             && activeShards == that.activeShards
             && relocatingShards == that.relocatingShards
             && activePrimaryShards == that.activePrimaryShards
@@ -318,7 +318,7 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
         return Objects.hash(
             numberOfNodes,
             numberOfDataNodes,
-            hasDiscoveredMaster,
+            hasDiscoveredClusterManager,
             activeShards,
             relocatingShards,
             activePrimaryShards,

--- a/server/src/test/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponsesTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponsesTests.java
@@ -157,13 +157,13 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
         return clusterHealth;
     }
 
-    public void testParseFromXContentWithDiscoveredMasterField() throws IOException {
+    public void testParseFromXContentWithDiscoveredClusterManagerField() throws IOException {
         try (
             XContentParser parser = JsonXContent.jsonXContent.createParser(
                 NamedXContentRegistry.EMPTY,
                 DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
                 "{\"cluster_name\":\"535799904437:7-1-3-node\",\"status\":\"green\","
-                    + "\"timed_out\":false,\"number_of_nodes\":6,\"number_of_data_nodes\":3,\"discovered_master\":true,"
+                    + "\"timed_out\":false,\"number_of_nodes\":6,\"number_of_data_nodes\":3,\"discovered_cluster_manager\":true,"
                     + "\"active_primary_shards\":4,\"active_shards\":5,\"relocating_shards\":0,\"initializing_shards\":0,"
                     + "\"unassigned_shards\":0,\"delayed_unassigned_shards\":0,\"number_of_pending_tasks\":0,"
                     + "\"number_of_in_flight_fetch\":0,\"task_max_waiting_in_queue_millis\":0,"
@@ -179,7 +179,7 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
         }
     }
 
-    public void testParseFromXContentWithoutDiscoveredMasterField() throws IOException {
+    public void testParseFromXContentWithoutDiscoveredClusterManagerField() throws IOException {
         try (
             XContentParser parser = JsonXContent.jsonXContent.createParser(
                 NamedXContentRegistry.EMPTY,
@@ -197,6 +197,44 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
             assertThat(clusterHealth.getClusterName(), Matchers.equalTo("535799904437:7-1-3-node"));
             assertThat(clusterHealth.getNumberOfNodes(), Matchers.equalTo(6));
             assertThat(clusterHealth.hasDiscoveredMaster(), Matchers.equalTo(false));
+        }
+    }
+
+    /**
+     * Validate the ClusterHealthResponse can be parsed from JsonXContent that contains the deprecated "discovered_master" field.
+     * As of 2.0, to support inclusive language, "discovered_master" field will be replaced by "discovered_cluster_manager".
+     */
+    public void testParseFromXContentWithDeprecatedDiscoveredMasterField() throws IOException {
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                "{\"cluster_name\":\"opensearch-cluster\",\"status\":\"green\",\"timed_out\":false,"
+                    + "\"number_of_nodes\":6,\"number_of_data_nodes\":3,\"discovered_cluster_manager\":true,\"discovered_master\":true,"
+                    + "\"active_primary_shards\":4,\"active_shards\":5,\"relocating_shards\":0,\"initializing_shards\":0,"
+                    + "\"unassigned_shards\":0,\"delayed_unassigned_shards\":0,\"number_of_pending_tasks\":0,"
+                    + "\"number_of_in_flight_fetch\":0,\"task_max_waiting_in_queue_millis\":0,"
+                    + "\"active_shards_percent_as_number\":100}"
+            )
+        ) {
+            ClusterHealthResponse clusterHealth = ClusterHealthResponse.fromXContent(parser);
+            assertThat(clusterHealth.hasDiscoveredMaster(), Matchers.equalTo(true));
+        }
+
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                "{\"cluster_name\":\"opensearch-cluster\",\"status\":\"green\","
+                    + "\"timed_out\":false,\"number_of_nodes\":6,\"number_of_data_nodes\":3,\"discovered_master\":true,"
+                    + "\"active_primary_shards\":4,\"active_shards\":5,\"relocating_shards\":0,\"initializing_shards\":0,"
+                    + "\"unassigned_shards\":0,\"delayed_unassigned_shards\":0,\"number_of_pending_tasks\":0,"
+                    + "\"number_of_in_flight_fetch\":0,\"task_max_waiting_in_queue_millis\":0,"
+                    + "\"active_shards_percent_as_number\":100}"
+            )
+        ) {
+            ClusterHealthResponse clusterHealth = ClusterHealthResponse.fromXContent(parser);
+            assertThat(clusterHealth.hasDiscoveredMaster(), Matchers.equalTo(true));
         }
     }
 


### PR DESCRIPTION
### Description
- Add optional field "discovered_cluster_manager" in the XContent Parser of `ClusterHealthResponse`. 
One benefit is JSON format of `Cluster Health API` response with `discovered_cluster_manager` field can be parsed to `ClusterHealthResponse` object.
- Add temporary unit test for the above change.
- Replace `discovered_master` to `discovered_cluster_manager` in the internal variable name from the related classes.
 
### Issues Resolved
A part of #1548 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
