### PR TITLE
Add ppc64le architecture

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/Architecture.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/Architecture.java
@@ -42,6 +42,7 @@ public enum Architecture {
         switch (architecture) {
             case "amd64":
             case "x86_64":
+            case "ppc64le":
                 return X64;
             case "aarch64":
                 return ARM64;


### PR DESCRIPTION
Add ppc64le architecture for the current architecture check.

### Description
Ability to build OpenSearch on ppc64le architecture
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/1303
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).