### PR TITLE
Support dynamic node role

### DIFF
--- a/distribution/docker/src/test/resources/rest-api-spec/test/11_nodes.yml
+++ b/distribution/docker/src/test/resources/rest-api-spec/test/11_nodes.yml
@@ -24,8 +24,8 @@
 
   - match:
       $body: |
-        /  #ip                          heap.percent        ram.percent     cpu         load_1m                load_5m                load_15m               node.role                   cluster_manager       name
-        ^  ((\d{1,3}\.){3}\d{1,3}  \s+  \d+            \s+  \d*         \s+ (-)?\d* \s+ ((-)?\d*(\.\d+)?)? \s+ ((-)?\d*(\.\d+)?)?\s+  ((-)?\d*(\.\d+)?)? \s+ (-|[cdhilmrstvw]{1,11}) \s+ [-*x]            \s+  (\S+\s?)+     \n)+  $/
+        /  #ip                          heap.percent        ram.percent     cpu         load_1m                load_5m                load_15m               node.role               node.roles                   cluster_manager       name
+        ^  ((\d{1,3}\.){3}\d{1,3}  \s+  \d+            \s+  \d*         \s+ (-)?\d* \s+ ((-)?\d*(\.\d+)?)? \s+ ((-)?\d*(\.\d+)?)?\s+  ((-)?\d*(\.\d+)?)? \s+ (-|[cdhilmrstvw]{1,11}) (\s+ (-|\w+(,\w+)*+))? \s+ [-*x]            \s+  (\S+\s?)+     \n)+  $/
 
   - do:
       cat.nodes:
@@ -33,8 +33,8 @@
 
   - match:
       $body: |
-        /^  ip                     \s+  heap\.percent   \s+  ram\.percent \s+ cpu      \s+ load_1m            \s+ load_5m            \s+ load_15m           \s+ node\.role              \s+  cluster_manager   \s+   name  \n
-           ((\d{1,3}\.){3}\d{1,3}  \s+  \d+             \s+  \d*          \s+ (-)?\d* \s+  ((-)?\d*(\.\d+)?)? \s+ ((-)?\d*(\.\d+)?)? \s+ ((-)?\d*(\.\d+)?)? \s+ (-|[cdhilmrstvw]{1,11}) \s+  [-*x]             \s+   (\S+\s?)+     \n)+  $/
+        /^  ip                     \s+  heap\.percent   \s+  ram\.percent \s+ cpu      \s+ load_1m            \s+ load_5m            \s+ load_15m           \s+ node\.role           \s+ node\.roles              \s+  cluster_manager   \s+   name  \n
+           ((\d{1,3}\.){3}\d{1,3}  \s+  \d+             \s+  \d*          \s+ (-)?\d* \s+  ((-)?\d*(\.\d+)?)? \s+ ((-)?\d*(\.\d+)?)? \s+ ((-)?\d*(\.\d+)?)? \s+ (-|[cdhilmrstvw]{1,11}) (\s+ (-|\w+(,\w+)*+ ))? \s+  [-*x]             \s+   (\S+\s?)+     \n)+  $/
 
   - do:
       cat.nodes:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yml
@@ -33,7 +33,7 @@
   - match:
       $body: |
         /  #ip                          heap.percent        ram.percent     cpu         load_1m                load_5m                load_15m               node.role               node.roles                   cluster_manager       name
-        ^  ((\d{1,3}\.){3}\d{1,3}  \s+  \d+            \s+  \d*         \s+ (-)?\d* \s+ ((-)?\d*(\.\d+)?)? \s+ ((-)?\d*(\.\d+)?)?\s+  ((-)?\d*(\.\d+)?)? \s+ (-|[cdhilmrstvw]{1,11}) \s+ (-|\w+(,\w+)*+) \s+ [-*x]            \s+  (\S+\s?)+     \n)+  $/
+        ^  ((\d{1,3}\.){3}\d{1,3}  \s+  \d+            \s+  \d*         \s+ (-)?\d* \s+ ((-)?\d*(\.\d+)?)? \s+ ((-)?\d*(\.\d+)?)?\s+  ((-)?\d*(\.\d+)?)? \s+ (-|[cdhilmrstvw]{1,11}) (\s+ (-|\w+(,\w+)*+))? \s+ [-*x]            \s+  (\S+\s?)+     \n)+  $/
 
   - do:
       cat.nodes:
@@ -41,8 +41,8 @@
 
   - match:
       $body: |
-        /^  ip                     \s+  heap\.percent   \s+  ram\.percent \s+ cpu      \s+ load_1m            \s+ load_5m            \s+ load_15m           \s+ node\.role           \s+ node\.roles              \s+  cluster_manager   \s+   name  \n
-           ((\d{1,3}\.){3}\d{1,3}  \s+  \d+             \s+  \d*          \s+ (-)?\d* \s+  ((-)?\d*(\.\d+)?)? \s+ ((-)?\d*(\.\d+)?)? \s+ ((-)?\d*(\.\d+)?)? \s+ (-|[cdhilmrstvw]{1,11}) \s+ (-|\w+(,\w+)*+ ) \s+ [-*x]             \s+   (\S+\s?)+     \n)+  $/
+        /^  ip                     \s+  heap\.percent   \s+  ram\.percent \s+ cpu      \s+ load_1m            \s+ load_5m            \s+ load_15m           \s+ node\.role           (\s+ node\.roles)?              \s+  cluster_manager   \s+   name  \n
+           ((\d{1,3}\.){3}\d{1,3}  \s+  \d+             \s+  \d*          \s+ (-)?\d* \s+  ((-)?\d*(\.\d+)?)? \s+ ((-)?\d*(\.\d+)?)? \s+ ((-)?\d*(\.\d+)?)? \s+ (-|[cdhilmrstvw]{1,11}) (\s+ (-|\w+(,\w+)*+ ))? \s+ [-*x]             \s+   (\S+\s?)+     \n)+  $/
 
   - do:
       cat.nodes:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.nodes/10_basic.yml
@@ -10,9 +10,9 @@
         v: true
       node_selector:
         # Only send request to nodes in <2.0 versions, especially during ':qa:mixed-cluster:v1.x.x#mixedClusterTest'.
-        # Because YAML REST test takes the minimum OpenSearch version in the cluster to apply the filter in 'skip' section, 
+        # Because YAML REST test takes the minimum OpenSearch version in the cluster to apply the filter in 'skip' section,
         # see OpenSearchClientYamlSuiteTestCase#initAndResetContext() for detail.
-        # During 'mixedClusterTest', the cluster can be mixed with nodes in 1.x and 2.x versions, 
+        # During 'mixedClusterTest', the cluster can be mixed with nodes in 1.x and 2.x versions,
         # so node_selector is required, and only filtering version in 'skip' is not enough.
         version: "1.0.0 - 1.4.99"
 
@@ -32,8 +32,8 @@
 
   - match:
       $body: |
-        /  #ip                          heap.percent        ram.percent     cpu         load_1m                load_5m                load_15m               node.role                   cluster_manager       name
-        ^  ((\d{1,3}\.){3}\d{1,3}  \s+  \d+            \s+  \d*         \s+ (-)?\d* \s+ ((-)?\d*(\.\d+)?)? \s+ ((-)?\d*(\.\d+)?)?\s+  ((-)?\d*(\.\d+)?)? \s+ (-|[cdhilmrstvw]{1,11}) \s+ [-*x]            \s+  (\S+\s?)+     \n)+  $/
+        /  #ip                          heap.percent        ram.percent     cpu         load_1m                load_5m                load_15m               node.role               node.roles                   cluster_manager       name
+        ^  ((\d{1,3}\.){3}\d{1,3}  \s+  \d+            \s+  \d*         \s+ (-)?\d* \s+ ((-)?\d*(\.\d+)?)? \s+ ((-)?\d*(\.\d+)?)?\s+  ((-)?\d*(\.\d+)?)? \s+ (-|[cdhilmrstvw]{1,11}) \s+ (-|\w+(,\w+)*+) \s+ [-*x]            \s+  (\S+\s?)+     \n)+  $/
 
   - do:
       cat.nodes:
@@ -41,8 +41,8 @@
 
   - match:
       $body: |
-        /^  ip                     \s+  heap\.percent   \s+  ram\.percent \s+ cpu      \s+ load_1m            \s+ load_5m            \s+ load_15m           \s+ node\.role              \s+  cluster_manager   \s+   name  \n
-           ((\d{1,3}\.){3}\d{1,3}  \s+  \d+             \s+  \d*          \s+ (-)?\d* \s+  ((-)?\d*(\.\d+)?)? \s+ ((-)?\d*(\.\d+)?)? \s+ ((-)?\d*(\.\d+)?)? \s+ (-|[cdhilmrstvw]{1,11}) \s+  [-*x]             \s+   (\S+\s?)+     \n)+  $/
+        /^  ip                     \s+  heap\.percent   \s+  ram\.percent \s+ cpu      \s+ load_1m            \s+ load_5m            \s+ load_15m           \s+ node\.role           \s+ node\.roles              \s+  cluster_manager   \s+   name  \n
+           ((\d{1,3}\.){3}\d{1,3}  \s+  \d+             \s+  \d*          \s+ (-)?\d* \s+  ((-)?\d*(\.\d+)?)? \s+ ((-)?\d*(\.\d+)?)? \s+ ((-)?\d*(\.\d+)?)? \s+ (-|[cdhilmrstvw]{1,11}) \s+ (-|\w+(,\w+)*+ ) \s+ [-*x]             \s+   (\S+\s?)+     \n)+  $/
 
   - do:
       cat.nodes:

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -328,7 +328,11 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
                 }
                 final DiscoveryNodeRole role = roleMap.get(roleName);
                 if (role == null) {
-                    roles.add(new DiscoveryNodeRole.UnknownRole(roleName, roleNameAbbreviation, canContainData));
+                    if (in.getVersion().onOrAfter(Version.V_2_1_0)) {
+                        roles.add(new DiscoveryNodeRole.DynamicRole(roleName, roleNameAbbreviation, canContainData));
+                    } else {
+                        roles.add(new DiscoveryNodeRole.UnknownRole(roleName, roleNameAbbreviation, canContainData));
+                    }
                 } else {
                     assert roleName.equals(role.roleName()) : "role name [" + roleName + "] does not match role [" + role.roleName() + "]";
                     assert roleNameAbbreviation.equals(role.roleNameAbbreviation()) : "role name abbreviation ["
@@ -570,7 +574,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         if (roleMap.containsKey(roleName)) {
             return roleMap.get(roleName);
         }
-        return new DiscoveryNodeRole.UnknownRole(roleName, roleName, false);
+        return new DiscoveryNodeRole.DynamicRole(roleName, roleName, false);
     }
 
     public static Set<DiscoveryNodeRole> getPossibleRoles() {

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -52,6 +52,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -571,10 +572,12 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
     private static Map<String, DiscoveryNodeRole> roleMap = rolesToMap(DiscoveryNodeRole.BUILT_IN_ROLES.stream());
 
     public static DiscoveryNodeRole getRoleFromRoleName(final String roleName) {
-        if (roleMap.containsKey(roleName)) {
-            return roleMap.get(roleName);
+        //As we are supporting dynamic role, should make role name case-insensitive to avoid confusion of role name like "Data"/"DATA"
+        String lowerCasedRoleName = Objects.requireNonNull(roleName).toLowerCase(Locale.ROOT);
+        if (roleMap.containsKey(lowerCasedRoleName)) {
+            return roleMap.get(lowerCasedRoleName);
         }
-        return new DiscoveryNodeRole.DynamicRole(roleName, roleName, false);
+        return new DiscoveryNodeRole.DynamicRole(lowerCasedRoleName, lowerCasedRoleName, false);
     }
 
     public static Set<DiscoveryNodeRole> getPossibleRoles() {

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -567,10 +567,10 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
     private static Map<String, DiscoveryNodeRole> roleMap = rolesToMap(DiscoveryNodeRole.BUILT_IN_ROLES.stream());
 
     public static DiscoveryNodeRole getRoleFromRoleName(final String roleName) {
-        if (roleMap.containsKey(roleName) == false) {
-            throw new IllegalArgumentException("unknown role [" + roleName + "]");
+        if (roleMap.containsKey(roleName)) {
+            return roleMap.get(roleName);
         }
-        return roleMap.get(roleName);
+        return new DiscoveryNodeRole.UnknownRole(roleName, roleName, false);
     }
 
     public static Set<DiscoveryNodeRole> getPossibleRoles() {

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -572,7 +572,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
     private static Map<String, DiscoveryNodeRole> roleMap = rolesToMap(DiscoveryNodeRole.BUILT_IN_ROLES.stream());
 
     public static DiscoveryNodeRole getRoleFromRoleName(final String roleName) {
-        //As we are supporting dynamic role, should make role name case-insensitive to avoid confusion of role name like "Data"/"DATA"
+        // As we are supporting dynamic role, should make role name case-insensitive to avoid confusion of role name like "Data"/"DATA"
         String lowerCasedRoleName = Objects.requireNonNull(roleName).toLowerCase(Locale.ROOT);
         if (roleMap.containsKey(lowerCasedRoleName)) {
             return roleMap.get(lowerCasedRoleName);

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
@@ -128,7 +128,8 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
     ) {
         this.isKnownRole = isKnownRole;
         this.isDynamicRole = isDynamicRole;
-        this.roleName = Objects.requireNonNull(roleName);
+        //As we are supporting dynamic role, should make role name case-insensitive to avoid confusion of role name like "Data"/"DATA"
+        this.roleName = Objects.requireNonNull(roleName).toLowerCase(Locale.ROOT);
         this.roleNameAbbreviation = Objects.requireNonNull(roleNameAbbreviation);
         this.canContainData = canContainData;
     }

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
@@ -130,7 +130,7 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
         this.isDynamicRole = isDynamicRole;
         //As we are supporting dynamic role, should make role name case-insensitive to avoid confusion of role name like "Data"/"DATA"
         this.roleName = Objects.requireNonNull(roleName).toLowerCase(Locale.ROOT);
-        this.roleNameAbbreviation = Objects.requireNonNull(roleNameAbbreviation);
+        this.roleNameAbbreviation = Objects.requireNonNull(roleNameAbbreviation).toLowerCase(Locale.ROOT);
         this.canContainData = canContainData;
     }
 

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
@@ -128,7 +128,7 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
     ) {
         this.isKnownRole = isKnownRole;
         this.isDynamicRole = isDynamicRole;
-        //As we are supporting dynamic role, should make role name case-insensitive to avoid confusion of role name like "Data"/"DATA"
+        // As we are supporting dynamic role, should make role name case-insensitive to avoid confusion of role name like "Data"/"DATA"
         this.roleName = Objects.requireNonNull(roleName).toLowerCase(Locale.ROOT);
         this.roleNameAbbreviation = Objects.requireNonNull(roleNameAbbreviation).toLowerCase(Locale.ROOT);
         this.canContainData = canContainData;

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
@@ -346,7 +346,7 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
          * @param roleNameAbbreviation the role name abbreviation
          * @param canContainData       whether or not nodes with the role can contain data
          */
-        public DynamicRole(final String roleName, final String roleNameAbbreviation, final boolean canContainData) {
+        DynamicRole(final String roleName, final String roleNameAbbreviation, final boolean canContainData) {
             super(false, true, roleName, roleNameAbbreviation, canContainData);
         }
 

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
@@ -58,7 +58,6 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(DiscoveryNodeRole.class);
     public static final String MASTER_ROLE_DEPRECATION_MESSAGE =
         "Assigning [master] role in setting [node.roles] is deprecated. To promote inclusive language, please use [cluster_manager] role instead.";
-
     private final String roleName;
 
     /**
@@ -299,7 +298,7 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
 
     /**
      * Represents an unknown role. This can occur if a newer version adds a role that an older version does not know about, or a newer
-     * version removes a role that an older version knows about.
+     * version removes a role that an older version knows about, or some custom role for extension function provided by plugin.
      */
     static class UnknownRole extends DiscoveryNodeRole {
 

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestNodesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestNodesAction.java
@@ -195,10 +195,12 @@ public class RestNodesAction extends AbstractCatAction {
         table.addCell("load_5m", "alias:l;text-align:right;desc:5m load avg");
         table.addCell("load_15m", "alias:l;text-align:right;desc:15m load avg");
         table.addCell("uptime", "default:false;alias:u;text-align:right;desc:node uptime");
+        // TODO: Deprecate "node.role", use "node.roles" which shows full node role names
         table.addCell(
             "node.role",
             "alias:r,role,nodeRole;desc:m:master eligible node, d:data node, i:ingest node, -:coordinating node only"
         );
+        table.addCell("node.roles", "alias:rs,all roles;desc: -:coordinating node only");
         // TODO: Remove the header alias 'master', after removing MASTER_ROLE. It's added for compatibility when using parameter 'h=master'.
         table.addCell("cluster_manager", "alias:cm,m,master;desc:*:current cluster manager");
         table.addCell("name", "alias:n;desc:node name");
@@ -423,12 +425,22 @@ public class RestNodesAction extends AbstractCatAction {
             table.addCell(jvmStats == null ? null : jvmStats.getUptime());
 
             final String roles;
+            final String allRoles;
             if (node.getRoles().isEmpty()) {
                 roles = "-";
+                allRoles = "-";
             } else {
-                roles = node.getRoles().stream().map(DiscoveryNodeRole::roleNameAbbreviation).sorted().collect(Collectors.joining());
+                List<DiscoveryNodeRole> knownNodeRoles = node.getRoles()
+                    .stream()
+                    .filter(DiscoveryNodeRole::isKnownRole)
+                    .collect(Collectors.toList());
+                roles = knownNodeRoles.size() > 0
+                    ? knownNodeRoles.stream().map(DiscoveryNodeRole::roleNameAbbreviation).sorted().collect(Collectors.joining())
+                    : "-";
+                allRoles = node.getRoles().stream().map(DiscoveryNodeRole::roleName).sorted().collect(Collectors.joining(","));
             }
             table.addCell(roles);
+            table.addCell(allRoles);
             table.addCell(clusterManagerId == null ? "x" : clusterManagerId.equals(node.getId()) ? "*" : "-");
             table.addCell(node.getName());
 

--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeRoleGenerator.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeRoleGenerator.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.node;
+
+public class DiscoveryNodeRoleGenerator {
+
+    public static DiscoveryNodeRole createUnknownRole(String roleName) {
+        return new DiscoveryNodeRole.UnknownRole(roleName, roleName, false);
+    }
+}

--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeRoleGenerator.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeRoleGenerator.java
@@ -10,7 +10,7 @@ package org.opensearch.cluster.node;
 
 public class DiscoveryNodeRoleGenerator {
 
-    public static DiscoveryNodeRole createUnknownRole(String roleName) {
-        return new DiscoveryNodeRole.UnknownRole(roleName, roleName, false);
+    public static DiscoveryNodeRole createDynamicRole(String roleName) {
+        return new DiscoveryNodeRole.DynamicRole(roleName, roleName, false);
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeRoleTests.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeRoleTests.java
@@ -117,7 +117,7 @@ public class DiscoveryNodeRoleTests extends OpenSearchTestCase {
 
     }
 
-    public void testUnknownRoleIsDistinctFromKnownRoles() {
+    public void testUnknownRoleIsDistinctFromKnownOrDynamicRoles() {
         for (DiscoveryNodeRole buildInRole : DiscoveryNodeRole.BUILT_IN_ROLES) {
             final DiscoveryNodeRole.UnknownRole unknownDataRole = new DiscoveryNodeRole.UnknownRole(
                 buildInRole.roleName(),
@@ -126,6 +126,15 @@ public class DiscoveryNodeRoleTests extends OpenSearchTestCase {
             );
             assertNotEquals(buildInRole, unknownDataRole);
             assertNotEquals(buildInRole.toString(), unknownDataRole.toString());
+            final DiscoveryNodeRole.DynamicRole dynamicRole = new DiscoveryNodeRole.DynamicRole(
+                buildInRole.roleName(),
+                buildInRole.roleNameAbbreviation(),
+                buildInRole.canContainData()
+            );
+            assertNotEquals(buildInRole, dynamicRole);
+            assertNotEquals(buildInRole.toString(), dynamicRole.toString());
+            assertNotEquals(unknownDataRole, dynamicRole);
+            assertNotEquals(unknownDataRole.toString(), dynamicRole.toString());
         }
     }
 

--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeRoleTests.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeRoleTests.java
@@ -38,6 +38,7 @@ import org.opensearch.test.EqualsHashCodeTestUtils;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasToString;
@@ -146,5 +147,16 @@ public class DiscoveryNodeRoleTests extends OpenSearchTestCase {
         assertTrue(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.isClusterManager());
         assertTrue(DiscoveryNodeRole.MASTER_ROLE.isClusterManager());
         assertFalse(randomFrom(DiscoveryNodeRole.DATA_ROLE.isClusterManager(), DiscoveryNodeRole.INGEST_ROLE.isClusterManager()));
+    }
+
+    public void testRoleNameIsCaseInsensitive() {
+        String roleName = "TestRole";
+        String roleNameAbbreviation = "T";
+        DiscoveryNodeRole unknownRole = new DiscoveryNodeRole.UnknownRole(roleName, roleNameAbbreviation, false);
+        assertEquals(roleName.toLowerCase(Locale.ROOT), unknownRole.roleName());
+        assertEquals(roleNameAbbreviation.toLowerCase(Locale.ROOT), unknownRole.roleNameAbbreviation());
+        DiscoveryNodeRole dynamicRole = new DiscoveryNodeRole.DynamicRole(roleName, roleNameAbbreviation, false);
+        assertEquals(roleName.toLowerCase(Locale.ROOT), dynamicRole.roleName());
+        assertEquals(roleNameAbbreviation.toLowerCase(Locale.ROOT), dynamicRole.roleNameAbbreviation());
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeTests.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeTests.java
@@ -44,6 +44,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.net.InetAddress;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -193,4 +194,14 @@ public class DiscoveryNodeTests extends OpenSearchTestCase {
         }
     }
 
+    public void testGetRoleFromRoleNameIsCaseInsensitive() {
+        String dataRoleName = "DATA";
+        DiscoveryNodeRole dataNodeRole = DiscoveryNode.getRoleFromRoleName(dataRoleName);
+        assertEquals(DiscoveryNodeRole.DATA_ROLE, dataNodeRole);
+
+        String dynamicRoleName = "TestRole";
+        DiscoveryNodeRole dynamicNodeRole = DiscoveryNode.getRoleFromRoleName(dynamicRoleName);
+        assertEquals(dynamicRoleName.toLowerCase(Locale.ROOT), dynamicNodeRole.roleName());
+        assertEquals(dynamicRoleName.toLowerCase(Locale.ROOT), dynamicNodeRole.roleNameAbbreviation());
+    }
 }

--- a/server/src/test/java/org/opensearch/node/NodeRoleSettingsTests.java
+++ b/server/src/test/java/org/opensearch/node/NodeRoleSettingsTests.java
@@ -15,6 +15,7 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 
@@ -53,5 +54,24 @@ public class NodeRoleSettingsTests extends OpenSearchTestCase {
         Settings roleSettings = Settings.builder().put(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), "master").build();
         assertEquals(Collections.singletonList(DiscoveryNodeRole.MASTER_ROLE), NodeRoleSettings.NODE_ROLES_SETTING.get(roleSettings));
         assertWarnings(DiscoveryNodeRole.MASTER_ROLE_DEPRECATION_MESSAGE);
+    }
+
+    public void testUnknownNodeRoleAndBuiltInRoleCanCoexist() {
+        String testRole = "test_role";
+        Settings roleSettings = Settings.builder().put(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), "data, " + testRole).build();
+        List<DiscoveryNodeRole> nodeRoles = NodeRoleSettings.NODE_ROLES_SETTING.get(roleSettings);
+        assertEquals(2, nodeRoles.size());
+        assertEquals(DiscoveryNodeRole.DATA_ROLE, nodeRoles.get(0));
+        assertEquals(testRole, nodeRoles.get(1).roleName());
+        assertEquals(testRole, nodeRoles.get(1).roleNameAbbreviation());
+    }
+
+    public void testUnknownNodeRoleOnly() {
+        String testRole = "test_role";
+        Settings roleSettings = Settings.builder().put(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), testRole).build();
+        List<DiscoveryNodeRole> nodeRoles = NodeRoleSettings.NODE_ROLES_SETTING.get(roleSettings);
+        assertEquals(1, nodeRoles.size());
+        assertEquals(testRole, nodeRoles.get(0).roleName());
+        assertEquals(testRole, nodeRoles.get(0).roleNameAbbreviation());
     }
 }

--- a/server/src/test/java/org/opensearch/rest/action/cat/RestNodesActionTests.java
+++ b/server/src/test/java/org/opensearch/rest/action/cat/RestNodesActionTests.java
@@ -40,7 +40,10 @@ import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodeRole;
+import org.opensearch.cluster.node.DiscoveryNodeRoleGenerator;
 import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.common.Table;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.rest.FakeRestRequest;
@@ -48,6 +51,11 @@ import org.opensearch.threadpool.TestThreadPool;
 import org.junit.Before;
 
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
@@ -64,18 +72,15 @@ public class RestNodesActionTests extends OpenSearchTestCase {
     }
 
     public void testBuildTableDoesNotThrowGivenNullNodeInfoAndStats() {
-        ClusterName clusterName = new ClusterName("cluster-1");
-        DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
-        builder.add(new DiscoveryNode("node-1", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT));
-        DiscoveryNodes discoveryNodes = builder.build();
-        ClusterState clusterState = mock(ClusterState.class);
-        when(clusterState.nodes()).thenReturn(discoveryNodes);
-
-        ClusterStateResponse clusterStateResponse = new ClusterStateResponse(clusterName, clusterState, false);
-        NodesInfoResponse nodesInfoResponse = new NodesInfoResponse(clusterName, Collections.emptyList(), Collections.emptyList());
-        NodesStatsResponse nodesStatsResponse = new NodesStatsResponse(clusterName, Collections.emptyList(), Collections.emptyList());
-
-        action.buildTable(false, new FakeRestRequest(), clusterStateResponse, nodesInfoResponse, nodesStatsResponse);
+        testBuildTableWithRoles(emptySet(), (table) -> {
+            Map<String, List<Table.Cell>> nodeInfoMap = table.getAsMap();
+            List<Table.Cell> cells = nodeInfoMap.get("node.role");
+            assertEquals(1, cells.size());
+            assertEquals("-", cells.get(0).value);
+            cells = nodeInfoMap.get("node.roles");
+            assertEquals(1, cells.size());
+            assertEquals("-", cells.get(0).value);
+        });
     }
 
     public void testCatNodesWithLocalDeprecationWarning() {
@@ -88,5 +93,52 @@ public class RestNodesActionTests extends OpenSearchTestCase {
         assertWarnings(RestNodesAction.LOCAL_DEPRECATED_MESSAGE);
 
         terminate(threadPool);
+    }
+
+    public void testBuildTableWithUnknownRoleOnly() {
+        Set<DiscoveryNodeRole> roles = new HashSet<>();
+        String roleName = "test_role";
+        DiscoveryNodeRole testRole = DiscoveryNodeRoleGenerator.createUnknownRole(roleName);
+        roles.add(testRole);
+
+        testBuildTableWithRoles(roles, (table) -> {
+            Map<String, List<Table.Cell>> nodeInfoMap = table.getAsMap();
+            List<Table.Cell> cells = nodeInfoMap.get("node.roles");
+            assertEquals(1, cells.size());
+            assertEquals(roleName, cells.get(0).value);
+        });
+    }
+
+    public void testBuildTableWithBothBuiltInAndUnknownRoles() {
+        Set<DiscoveryNodeRole> roles = new HashSet<>();
+        roles.add(DiscoveryNodeRole.DATA_ROLE);
+        String roleName = "test_role";
+        DiscoveryNodeRole testRole = DiscoveryNodeRoleGenerator.createUnknownRole(roleName);
+        roles.add(testRole);
+
+        testBuildTableWithRoles(roles, (table) -> {
+            Map<String, List<Table.Cell>> nodeInfoMap = table.getAsMap();
+            List<Table.Cell> cells = nodeInfoMap.get("node.roles");
+            assertEquals(1, cells.size());
+            assertEquals("data,test_role", cells.get(0).value);
+        });
+    }
+
+    private void testBuildTableWithRoles(Set<DiscoveryNodeRole> roles, Consumer<Table> verificationFunction) {
+        ClusterName clusterName = new ClusterName("cluster-1");
+        DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
+
+        builder.add(new DiscoveryNode("node-1", buildNewFakeTransportAddress(), emptyMap(), roles, Version.CURRENT));
+        DiscoveryNodes discoveryNodes = builder.build();
+        ClusterState clusterState = mock(ClusterState.class);
+        when(clusterState.nodes()).thenReturn(discoveryNodes);
+
+        ClusterStateResponse clusterStateResponse = new ClusterStateResponse(clusterName, clusterState, false);
+        NodesInfoResponse nodesInfoResponse = new NodesInfoResponse(clusterName, Collections.emptyList(), Collections.emptyList());
+        NodesStatsResponse nodesStatsResponse = new NodesStatsResponse(clusterName, Collections.emptyList(), Collections.emptyList());
+
+        Table table = action.buildTable(false, new FakeRestRequest(), clusterStateResponse, nodesInfoResponse, nodesStatsResponse);
+
+        verificationFunction.accept(table);
     }
 }

--- a/server/src/test/java/org/opensearch/rest/action/cat/RestNodesActionTests.java
+++ b/server/src/test/java/org/opensearch/rest/action/cat/RestNodesActionTests.java
@@ -95,10 +95,10 @@ public class RestNodesActionTests extends OpenSearchTestCase {
         terminate(threadPool);
     }
 
-    public void testBuildTableWithUnknownRoleOnly() {
+    public void testBuildTableWithDynamicRoleOnly() {
         Set<DiscoveryNodeRole> roles = new HashSet<>();
         String roleName = "test_role";
-        DiscoveryNodeRole testRole = DiscoveryNodeRoleGenerator.createUnknownRole(roleName);
+        DiscoveryNodeRole testRole = DiscoveryNodeRoleGenerator.createDynamicRole(roleName);
         roles.add(testRole);
 
         testBuildTableWithRoles(roles, (table) -> {
@@ -109,11 +109,11 @@ public class RestNodesActionTests extends OpenSearchTestCase {
         });
     }
 
-    public void testBuildTableWithBothBuiltInAndUnknownRoles() {
+    public void testBuildTableWithBothBuiltInAndDynamicRoles() {
         Set<DiscoveryNodeRole> roles = new HashSet<>();
         roles.add(DiscoveryNodeRole.DATA_ROLE);
         String roleName = "test_role";
-        DiscoveryNodeRole testRole = DiscoveryNodeRoleGenerator.createUnknownRole(roleName);
+        DiscoveryNodeRole testRole = DiscoveryNodeRoleGenerator.createDynamicRole(roleName);
         roles.add(testRole);
 
         testBuildTableWithRoles(roles, (table) -> {


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
Currently OpenSearch only supports several built-in nodes like data node
role. If specify unknown node role, OpenSearch node will fail to start.
This limit how to extend OpenSearch to support specific tasks. For
example, user may prefer to run ML tasks on some dedicated node which
doesn't serve as any built-in node roles. So the ML tasks won't impact
OpenSearch core function. This PR removed the limitation. So user can
specify any node role and OpenSearch will start node correctly with that
unknown role. This opens the door for plugin developer to run specific
tasks on dedicated nodes.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/2877
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
