### PR TITLE
[TEST] Fix testSetAdditionalRolesCanAddDeprecatedMasterRole() by removing the initial assertion

### DIFF
--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeTests.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeTests.java
@@ -179,9 +179,6 @@ public class DiscoveryNodeTests extends OpenSearchTestCase {
     // as a workaround for making the new CLUSTER_MANAGER_ROLE has got the same abbreviation 'm'.
     // The test validate this behavior.
     public void testSetAdditionalRolesCanAddDeprecatedMasterRole() {
-        // Validate MASTER_ROLE is not in DiscoveryNodeRole.BUILT_IN_ROLES
-        assertFalse(DiscoveryNode.getPossibleRoleNames().contains(DiscoveryNodeRole.MASTER_ROLE.roleName()));
-
         DiscoveryNode.setAdditionalRoles(Collections.emptySet());
         assertTrue(DiscoveryNode.getPossibleRoleNames().contains(DiscoveryNodeRole.MASTER_ROLE.roleName()));
     }


### PR DESCRIPTION
### Description
There is a flaky test failure, caused by the newly added assertion statement by PR https://github.com/opensearch-project/OpenSearch/pull/2825, which doesn't fail the Gradle check.
Such as https://github.com/opensearch-project/OpenSearch/pull/2825#issuecomment-1137826254, https://github.com/opensearch-project/OpenSearch/pull/3359#issuecomment-1135046268 and https://github.com/opensearch-project/OpenSearch/pull/3436#issuecomment-1136543205
 
The reason for adding the assertion is to validate the deprecated `master` role is not in the BUILT_IN_ROLES list any more. While the "[roleMap](https://github.com/opensearch-project/OpenSearch/blob/2.0.0-rc1/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java#L565)" variable is a static variable in class `DiscoveryNode`, the value is likely to be influenced by other tests (non-deterministic test run order), so the assertion usually fails.
The PR removes the assertion, because there is no existing method to reset the `roleMap`, and the assertion is not so necessary.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/pull/2825#issuecomment-1137826254
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
