### PR TITLE
[BUG] Fixing org.opensearch.monitor.os.OsProbeTests > testLogWarnCpuMessageOnlyOnes when cgroups are available but cgroup stats is not

### DIFF
--- a/server/src/test/java/org/opensearch/monitor/os/OsProbeTests.java
+++ b/server/src/test/java/org/opensearch/monitor/os/OsProbeTests.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.monitor.os;
 
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.both;
@@ -296,8 +298,12 @@ public class OsProbeTests extends OpenSearchTestCase {
             }
         };
 
-        assumeThat("CGroups are not available", noCpuStatsOsProbe.areCgroupStatsAvailable(), is(true));
-        noCpuStatsOsProbe.osStats();
+        assumeThat("CGroups are available", noCpuStatsOsProbe.areCgroupStatsAvailable(), is(true));
+        OsStats osStats = noCpuStatsOsProbe.osStats();
+
+        // Depending on CGroups v1/v2, the cgroup stats may not be available
+        assumeThat("CGroup is available", osStats.getCgroup(), is(not(nullValue())));
+
         // no nr_throttled and throttled_time
         verify(logger, times(2)).warn(anyString());
         reset(logger);


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Finally, seems to understand what is going on. The issue seems to be a tricky combination of Docker and OS versions, which implies what CGroup version is in use: v1 or v2. I was not able to reproduce the exact issue but was able to trigger the same code path and observe test to fail. 
 
### Issues Resolved
Fixes https://github.com/opensearch-project/OpenSearch/issues/2592
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
