### PR TITLE
Filter out invalid URI and HTTP method in the error message of no handler found for a REST request

### DIFF
--- a/server/src/main/java/org/opensearch/rest/RestController.java
+++ b/server/src/main/java/org/opensearch/rest/RestController.java
@@ -448,7 +448,9 @@ public class RestController implements HttpServerTransport.Dispatcher {
                 msg.append("Incorrect HTTP method for uri [").append(uri);
                 msg.append("] and method [").append(method).append("]");
             } else {
-                msg.append(exception.getMessage());
+                // Not using the error message directly from 'exception.getMessage()' to avoid unescaped HTML special characters,
+                // in case false-positive cross site scripting vulnerability is detected by common security scanners.
+                msg.append("Unexpected http method");
             }
             if (validMethodSet.isEmpty() == false) {
                 msg.append(", allowed: ").append(validMethodSet);

--- a/server/src/main/java/org/opensearch/rest/RestController.java
+++ b/server/src/main/java/org/opensearch/rest/RestController.java
@@ -450,7 +450,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
             } else {
                 // Not using the error message directly from 'exception.getMessage()' to avoid unescaped HTML special characters,
                 // in case false-positive cross site scripting vulnerability is detected by common security scanners.
-                msg.append("Unexpected http method");
+                msg.append("Unexpected HTTP method");
             }
             if (validMethodSet.isEmpty() == false) {
                 msg.append(", allowed: ").append(validMethodSet);

--- a/server/src/test/java/org/opensearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/opensearch/rest/RestControllerTests.java
@@ -553,6 +553,18 @@ public class RestControllerTests extends OpenSearchTestCase {
         assertThat(channel.getRestResponse().getHeaders().get("Allow"), hasItem(equalTo(RestRequest.Method.GET.toString())));
     }
 
+    public void testHandleBadRequestWithHtmlSpecialCharsInUri() {
+        final FakeRestRequest fakeRestRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withPath(
+            "/<script>alert('xss');alert(\"&#x6A&#x61&#x76&#x61\");</script>"
+        ).build();
+        final AssertingChannel channel = new AssertingChannel(fakeRestRequest, true, RestStatus.BAD_REQUEST);
+        restController.dispatchRequest(fakeRestRequest, channel, client.threadPool().getThreadContext());
+        assertThat(
+            channel.getRestResponse().content().utf8ToString(),
+            containsString("/&#60;script&#62;alert(&#39;xss&#39;);alert(&#34;&#38;#x6A&#38;#x61&#38;#x76&#38;#x61&#34;);&#60;/script&#62;")
+        );
+    }
+
     public void testDispatchUnsupportedHttpMethod() {
         final boolean hasContent = randomBoolean();
         final RestRequest request = RestRequest.request(xContentRegistry(), new HttpRequest() {

--- a/server/src/test/java/org/opensearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/opensearch/rest/RestControllerTests.java
@@ -559,10 +559,7 @@ public class RestControllerTests extends OpenSearchTestCase {
         ).build();
         final AssertingChannel channel = new AssertingChannel(fakeRestRequest, true, RestStatus.BAD_REQUEST);
         restController.dispatchRequest(fakeRestRequest, channel, client.threadPool().getThreadContext());
-        assertThat(
-            channel.getRestResponse().content().utf8ToString(),
-            containsString("/&#60;script&#62;alert(&#39;xss&#39;);alert(&#34;&#38;#x6A&#38;#x61&#38;#x76&#38;#x61&#34;);&#60;/script&#62;")
-        );
+        assertThat(channel.getRestResponse().content().utf8ToString(), containsString("invalid uri has been requested"));
     }
 
     public void testDispatchUnsupportedHttpMethod() {

--- a/server/src/test/java/org/opensearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/opensearch/rest/RestControllerTests.java
@@ -632,7 +632,10 @@ public class RestControllerTests extends OpenSearchTestCase {
         assertTrue(channel.getSendResponseCalled());
         assertThat(channel.getRestResponse().getHeaders().containsKey("Allow"), equalTo(true));
         assertThat(channel.getRestResponse().getHeaders().get("Allow"), hasItem(equalTo(RestRequest.Method.GET.toString())));
-        assertThat(channel.getRestResponse().content().utf8ToString(), containsString("Unexpected http method"));
+        assertThat(
+            channel.getRestResponse().content().utf8ToString(),
+            equalTo("{\"error\":\"Unexpected HTTP method, allowed: [GET]\",\"status\":405}")
+        );
     }
 
     private static final class TestHttpServerTransport extends AbstractLifecycleComponent implements HttpServerTransport {

--- a/server/src/test/java/org/opensearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/opensearch/rest/RestControllerTests.java
@@ -632,6 +632,7 @@ public class RestControllerTests extends OpenSearchTestCase {
         assertTrue(channel.getSendResponseCalled());
         assertThat(channel.getRestResponse().getHeaders().containsKey("Allow"), equalTo(true));
         assertThat(channel.getRestResponse().getHeaders().get("Allow"), hasItem(equalTo(RestRequest.Method.GET.toString())));
+        assertThat(channel.getRestResponse().content().utf8ToString(), containsString("Unexpected http method"));
     }
 
     private static final class TestHttpServerTransport extends AbstractLifecycleComponent implements HttpServerTransport {


### PR DESCRIPTION
### Description
Filter out invalid URI and HTTP method of a error message, which shown when there is no handler found for a REST request sent by user, so that HTML special characters `<>&"'` will not shown in the error message.

The error message is return as mine-type `application/json`, which can't contain active (script) content, so it's not a vulnerability. Besides, no browsers are going to render as html when the mine-type is that.
While the common security scanners will raise a false-positive alarm for having HTML tags in the response without escaping the HTML special characters, so the solution only aims to satisfy the code security scanners.

If the URI is valid, the error message remains.
If the URI is not valid, the change is:
old error message: `{"error":"no handler found for uri [/<script>cross_site_scripting.nasl</script>.asp] and method [GET]"}`
new error message: `{"error":"invalid uri has been requested"}`

If the HTTP method is not defined in the enum: https://github.com/opensearch-project/OpenSearch/blob/2.0.0/server/src/main/java/org/opensearch/rest/RestRequest.java#L236, the change of error message is:
old error message: `{"error":"Unexpected http method: <script>alert(\"!\")</script>","status":405}`
new error message: `{"error":"Unexpected http method","status":405}`

Reference: https://github.com/opensearch-project/OpenSearch/pull/3459#discussion_r886100693

### Issues Resolved
Resolve #3453 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
