### PR TITLE
Include Homebrew bin when searching for Docker binaries

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/docker/DockerSupportService.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/docker/DockerSupportService.java
@@ -118,9 +118,9 @@ public abstract class DockerSupportService implements BuildService<DockerSupport
 
                     // Since we use a multi-stage Docker build, check the Docker version meets minimum requirement
                     lastResult = runCommand(dockerPath, "version", "--format", "{{.Server.Version}}");
-                    if (LOGGER.isInfoEnabled()) {
-                        LOGGER.info("Docker binary found at: {}", dockerPath);
-                        LOGGER.info("Docker version check: {}", lastResult.toString());
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("Docker binary found at: {}", dockerPath);
+                        LOGGER.debug("Docker version check: {}", lastResult.toString());
                     }
 
                     if (lastResult.isSuccess()) {
@@ -137,9 +137,9 @@ public abstract class DockerSupportService implements BuildService<DockerSupport
                             if (lastResult.isSuccess() && composePath.isPresent()) {
                                 Result composeCmdCheck = runCommand(composePath.get(), "version");
                                 isComposeAvailable = composeCmdCheck.isSuccess();
-                                if (LOGGER.isInfoEnabled()) {
-                                    LOGGER.info("Docker-compose binary found at: {}", composePath);
-                                    LOGGER.info("Docker-compose version check: {}", composeCmdCheck.toString());
+                                if (LOGGER.isDebugEnabled()) {
+                                    LOGGER.debug("Docker-compose binary found at: {}", composePath);
+                                    LOGGER.debug("Docker-compose version check: {}", composeCmdCheck.toString());
                                 }
                             }
                         }


### PR DESCRIPTION
Signed-off-by: Lukáš Vlček <lukas.vlcek@aiven.io>

### Description
When docker and docker-compose are installed using `brew` then the `/bin` location is different (compared to manual binaries installation). This commit extends possible locations that are searched when checking if docker is available on Mac family Os machines.
 
### Issues Resolved
Closes #3476
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
