### PR TITLE
Bump hadoop-minicluster in /test/fixtures/hdfs-fixture (#3359)

### DIFF
--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -31,7 +31,7 @@
 apply plugin: 'opensearch.java'
 
 dependencies {
-  api "org.apache.hadoop:hadoop-minicluster:3.3.1"
+  api "org.apache.hadoop:hadoop-minicluster:3.3.3"
   api "org.apache.commons:commons-compress:1.21"
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api "org.apache.logging.log4j:log4j-core:${versions.log4j}"


### PR DESCRIPTION
Bumps hadoop-minicluster from 3.3.1 to 3.3.3.