### PR TITLE
Move bash flag to set statement

### DIFF
--- a/buildSrc/src/main/resources/deb/postinst.ftl
+++ b/buildSrc/src/main/resources/deb/postinst.ftl
@@ -1,2 +1,3 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+set -e -o pipefail
 <% commands.each {command -> %><%= command %><% } %>

--- a/buildSrc/src/main/resources/deb/preinst.ftl
+++ b/buildSrc/src/main/resources/deb/preinst.ftl
@@ -1,2 +1,3 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+set -e -o pipefail
 <% commands.each {command -> %><%= command %><% } %>


### PR DESCRIPTION
Signed-off-by: Cole White <cwhite@wikimedia.org>

### Description
Passing bash with flags to the first argument of /usr/bin/env requires its
own flag to interpret it correctly.  Rather than use `env -S` to split
the argument, have the script `set -e` to enable the same behavior
explicitly in preinst and postinst scripts.
 
### Issues Resolved
Closes: #3492
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
