### PR TITLE
[Dependency upgrade] Use log4j-core 2.17.1 to avoid CVE violation

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -127,6 +127,11 @@ dependencies {
   integTestImplementation('org.spockframework:spock-core:1.3-groovy-2.5') {
     exclude module: "groovy"
   }
+  constraints {
+    runtimeOnly("org.apache.logging.log4j:log4j-core:${props.getProperty('log4j')}") {
+      because 'log4j CVE'
+    }
+  }
 }
 
 /*****************************************************************************


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Conflict resolve to latest dependency for log4j-core to avoid CVE. Main and 2.x are already using gradle 7.x which automatically brings the latest log4j-core dependency. 

```
+--- com.github.jengelman.gradle.plugins:shadow:6.0.0
|    +--- org.jdom:jdom2:2.0.6
|    +--- org.ow2.asm:asm:8.0.1
|    +--- org.ow2.asm:asm-commons:8.0.1
|    |    +--- org.ow2.asm:asm:8.0.1
|    |    +--- org.ow2.asm:asm-tree:8.0.1
|    |    |    \--- org.ow2.asm:asm:8.0.1
|    |    \--- org.ow2.asm:asm-analysis:8.0.1
|    |         \--- org.ow2.asm:asm-tree:8.0.1 (*)
|    +--- commons-io:commons-io:2.5 -> 2.7
|    +--- org.apache.ant:ant:1.9.7 -> 1.10.12 (*)
|    +--- org.codehaus.plexus:plexus-utils:3.0.24 -> 3.2.1
|    +--- org.apache.logging.log4j:log4j-core:2.11.0 -> 2.17.1
|    |    \--- org.apache.logging.log4j:log4j-api:2.17.1
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
