### PR TITLE
[Dependency upgrade] Fix jdom2 CVE violation

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -131,6 +131,9 @@ dependencies {
     runtimeOnly("org.apache.logging.log4j:log4j-core:${props.getProperty('log4j')}") {
       because 'log4j CVE'
     }
+    runtimeOnly("org.jdom:jdom2:${props.getProperty('jdom2')}") {
+      because 'CVE-2021-33813 violation'
+    }
   }
 }
 

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -16,6 +16,7 @@ icu4j             = 62.1
 supercsv          = 2.4.0
 log4j             = 2.17.1
 slf4j             = 1.6.2
+jdom2             = 2.0.6.1
 
 # when updating the JNA version, also update the version in buildSrc/build.gradle
 jna               = 5.5.0


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Fix jdom2 CVE violation

```
+--- com.github.jengelman.gradle.plugins:shadow:6.0.0
|    +--- org.jdom:jdom2:2.0.6 -> 2.0.6.1
|    +--- org.ow2.asm:asm:8.0.1
|    +--- org.ow2.asm:asm-commons:8.0.1
|    |    +--- org.ow2.asm:asm:8.0.1
|    |    +--- org.ow2.asm:asm-tree:8.0.1
|    |    |    \--- org.ow2.asm:asm:8.0.1
|    |    \--- org.ow2.asm:asm-analysis:8.0.1
|    |         \--- org.ow2.asm:asm-tree:8.0.1 (*)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
