### PR TITLE
[Segment Replication] Add components for segment replication to perform file copy.

### DIFF
--- a/server/src/main/java/org/opensearch/indices/RunUnderPrimaryPermit.java
+++ b/server/src/main/java/org/opensearch/indices/RunUnderPrimaryPermit.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices;
+
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.common.lease.Releasable;
+import org.opensearch.common.util.CancellableThreads;
+import org.opensearch.common.util.concurrent.FutureUtils;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.IndexShardRelocatedException;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Execute a Runnable after acquiring the primary's operation permit.
+ *
+ * @opensearch.internal
+ */
+public final class RunUnderPrimaryPermit {
+
+    public static void run(
+        CancellableThreads.Interruptible runnable,
+        String reason,
+        IndexShard primary,
+        CancellableThreads cancellableThreads,
+        Logger logger
+    ) {
+        cancellableThreads.execute(() -> {
+            CompletableFuture<Releasable> permit = new CompletableFuture<>();
+            final ActionListener<Releasable> onAcquired = new ActionListener<>() {
+                @Override
+                public void onResponse(Releasable releasable) {
+                    if (permit.complete(releasable) == false) {
+                        releasable.close();
+                    }
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    permit.completeExceptionally(e);
+                }
+            };
+            primary.acquirePrimaryOperationPermit(onAcquired, ThreadPool.Names.SAME, reason);
+            try (Releasable ignored = FutureUtils.get(permit)) {
+                // check that the IndexShard still has the primary authority. This needs to be checked under operation permit to prevent
+                // races, as IndexShard will switch its authority only when it holds all operation permits, see IndexShard.relocated()
+                if (primary.isRelocatedPrimary()) {
+                    throw new IndexShardRelocatedException(primary.shardId());
+                }
+                runnable.run();
+            } finally {
+                // just in case we got an exception (likely interrupted) while waiting for the get
+                permit.whenComplete((r, e) -> {
+                    if (r != null) {
+                        r.close();
+                    }
+                    if (e != null) {
+                        logger.trace("suppressing exception on completion (it was already bubbled up or the operation was aborted)", e);
+                    }
+                });
+            }
+        });
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/recovery/FileChunkWriter.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/FileChunkWriter.java
@@ -17,6 +17,7 @@ import org.opensearch.index.store.StoreFileMetadata;
  *
  * @opensearch.internal
  */
+@FunctionalInterface
 public interface FileChunkWriter {
 
     void writeFileChunk(

--- a/server/src/main/java/org/opensearch/indices/recovery/FileChunkWriter.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/FileChunkWriter.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.recovery;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.index.store.StoreFileMetadata;
+
+/**
+ * Writes a partial file chunk to the target store.
+ *
+ * @opensearch.internal
+ */
+public interface FileChunkWriter {
+
+    void writeFileChunk(
+        StoreFileMetadata fileMetadata,
+        long position,
+        BytesReference content,
+        boolean lastChunk,
+        int totalTranslogOps,
+        ActionListener<Void> listener
+    );
+}

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
@@ -32,18 +32,13 @@
 
 package org.opensearch.indices.recovery;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexFormatTooNewException;
 import org.apache.lucene.index.IndexFormatTooOldException;
-import org.apache.lucene.store.IOContext;
-import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.RateLimiter;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.SetOnce;
-import org.opensearch.ExceptionsHelper;
 import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionRunnable;
@@ -55,13 +50,10 @@ import org.opensearch.cluster.routing.IndexShardRoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.common.CheckedRunnable;
 import org.opensearch.common.StopWatch;
-import org.opensearch.common.bytes.BytesArray;
-import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lease.Releasables;
 import org.opensearch.common.logging.Loggers;
-import org.opensearch.common.lucene.store.InputStreamIndexInput;
 import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.CancellableThreads;
@@ -77,27 +69,22 @@ import org.opensearch.index.seqno.RetentionLeases;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.IndexShardClosedException;
-import org.opensearch.index.shard.IndexShardRelocatedException;
 import org.opensearch.index.shard.IndexShardState;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.index.translog.Translog;
+import org.opensearch.indices.RunUnderPrimaryPermit;
+import org.opensearch.indices.replication.SegmentFileTransferHandler;
 import org.opensearch.threadpool.ThreadPool;
-import org.opensearch.transport.RemoteTransportException;
 import org.opensearch.transport.Transports;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Deque;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -118,9 +105,8 @@ import java.util.stream.StreamSupport;
  *
  * @opensearch.internal
  */
-public class RecoverySourceHandler {
+public class RecoverySourceHandler extends SegmentFileTransferHandler {
 
-    protected final Logger logger;
     // Shard that is going to be recovered (the "source")
     private final IndexShard shard;
     private final int shardId;
@@ -128,11 +114,8 @@ public class RecoverySourceHandler {
     private final StartRecoveryRequest request;
     private final int chunkSizeInBytes;
     private final RecoveryTargetHandler recoveryTarget;
-    private final int maxConcurrentFileChunks;
     private final int maxConcurrentOperations;
     private final ThreadPool threadPool;
-    private final CancellableThreads cancellableThreads = new CancellableThreads();
-    private final List<Closeable> resources = new CopyOnWriteArrayList<>();
     private final ListenableFuture<RecoveryResponse> future = new ListenableFuture<>();
     public static final String PEER_RECOVERY_NAME = "peer-recovery";
 
@@ -145,15 +128,22 @@ public class RecoverySourceHandler {
         int maxConcurrentFileChunks,
         int maxConcurrentOperations
     ) {
+        super(
+            shard,
+            request.targetNode(),
+            recoveryTarget,
+            Loggers.getLogger(RecoverySourceHandler.class, request.shardId(), "recover to " + request.targetNode().getName()),
+            threadPool,
+            fileChunkSizeInBytes,
+            maxConcurrentFileChunks
+        );
         this.shard = shard;
-        this.recoveryTarget = recoveryTarget;
         this.threadPool = threadPool;
         this.request = request;
+        this.recoveryTarget = recoveryTarget;
         this.shardId = this.request.shardId().id();
-        this.logger = Loggers.getLogger(getClass(), request.shardId(), "recover to " + request.targetNode().getName());
         this.chunkSizeInBytes = fileChunkSizeInBytes;
         // if the target is on an old version, it won't be able to handle out-of-order file chunks.
-        this.maxConcurrentFileChunks = maxConcurrentFileChunks;
         this.maxConcurrentOperations = maxConcurrentOperations;
     }
 
@@ -192,7 +182,7 @@ public class RecoverySourceHandler {
 
             final SetOnce<RetentionLease> retentionLeaseRef = new SetOnce<>();
 
-            runUnderPrimaryPermit(() -> {
+            RunUnderPrimaryPermit.run(() -> {
                 final IndexShardRoutingTable routingTable = shard.getReplicationGroup().getRoutingTable();
                 ShardRouting targetShardRouting = routingTable.getByAllocationId(request.targetAllocationId());
                 if (targetShardRouting == null) {
@@ -286,7 +276,7 @@ public class RecoverySourceHandler {
                     });
 
                     final StepListener<ReplicationResponse> deleteRetentionLeaseStep = new StepListener<>();
-                    runUnderPrimaryPermit(() -> {
+                    RunUnderPrimaryPermit.run(() -> {
                         try {
                             // If the target previously had a copy of this shard then a file-based recovery might move its global
                             // checkpoint backwards. We must therefore remove any existing retention lease so that we can create a
@@ -332,7 +322,7 @@ public class RecoverySourceHandler {
                  * make sure to do this before sampling the max sequence number in the next step, to ensure that we send
                  * all documents up to maxSeqNo in phase2.
                  */
-                runUnderPrimaryPermit(
+                RunUnderPrimaryPermit.run(
                     () -> shard.initiateTracking(request.targetAllocationId()),
                     shardId + " initiating tracking of " + request.targetAllocationId(),
                     shard,
@@ -418,50 +408,6 @@ public class RecoverySourceHandler {
      */
     private int countNumberOfHistoryOperations(long startingSeqNo) throws IOException {
         return shard.countNumberOfHistoryOperations(PEER_RECOVERY_NAME, startingSeqNo, Long.MAX_VALUE);
-    }
-
-    static void runUnderPrimaryPermit(
-        CancellableThreads.Interruptible runnable,
-        String reason,
-        IndexShard primary,
-        CancellableThreads cancellableThreads,
-        Logger logger
-    ) {
-        cancellableThreads.execute(() -> {
-            CompletableFuture<Releasable> permit = new CompletableFuture<>();
-            final ActionListener<Releasable> onAcquired = new ActionListener<Releasable>() {
-                @Override
-                public void onResponse(Releasable releasable) {
-                    if (permit.complete(releasable) == false) {
-                        releasable.close();
-                    }
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    permit.completeExceptionally(e);
-                }
-            };
-            primary.acquirePrimaryOperationPermit(onAcquired, ThreadPool.Names.SAME, reason);
-            try (Releasable ignored = FutureUtils.get(permit)) {
-                // check that the IndexShard still has the primary authority. This needs to be checked under operation permit to prevent
-                // races, as IndexShard will switch its authority only when it holds all operation permits, see IndexShard.relocated()
-                if (primary.isRelocatedPrimary()) {
-                    throw new IndexShardRelocatedException(primary.shardId());
-                }
-                runnable.run();
-            } finally {
-                // just in case we got an exception (likely interrupted) while waiting for the get
-                permit.whenComplete((r, e) -> {
-                    if (r != null) {
-                        r.close();
-                    }
-                    if (e != null) {
-                        logger.trace("suppressing exception on completion (it was already bubbled up or the operation was aborted)", e);
-                    }
-                });
-            }
-        });
     }
 
     /**
@@ -709,7 +655,7 @@ public class RecoverySourceHandler {
     }
 
     void createRetentionLease(final long startingSeqNo, ActionListener<RetentionLease> listener) {
-        runUnderPrimaryPermit(() -> {
+        RunUnderPrimaryPermit.run(() -> {
             // Clone the peer recovery retention lease belonging to the source shard. We are retaining history between the the local
             // checkpoint of the safe commit we're creating and this lease's retained seqno with the retention lock, and by cloning an
             // existing lease we (approximately) know that all our peers are also retaining history as requested by the cloned lease. If
@@ -983,7 +929,7 @@ public class RecoverySourceHandler {
          * marking the shard as in-sync. If the relocation handoff holds all the permits then after the handoff completes and we acquire
          * the permit then the state of the shard will be relocated and this recovery will fail.
          */
-        runUnderPrimaryPermit(
+        RunUnderPrimaryPermit.run(
             () -> shard.markAllocationIdAsInSync(request.targetAllocationId(), targetLocalCheckpoint),
             shardId + " marking " + request.targetAllocationId() + " as in sync",
             shard,
@@ -995,7 +941,7 @@ public class RecoverySourceHandler {
         cancellableThreads.checkForCancel();
         recoveryTarget.finalizeRecovery(globalCheckpoint, trimAboveSeqNo, finalizeListener);
         finalizeListener.whenComplete(r -> {
-            runUnderPrimaryPermit(
+            RunUnderPrimaryPermit.run(
                 () -> shard.updateGlobalCheckpointForShard(request.targetAllocationId(), globalCheckpoint),
                 shardId + " updating " + request.targetAllocationId() + "'s global checkpoint",
                 shard,
@@ -1056,121 +1002,6 @@ public class RecoverySourceHandler {
             + '}';
     }
 
-    /**
-     * A file chunk from the recovery source
-     *
-     * @opensearch.internal
-     */
-    private static class FileChunk implements MultiChunkTransfer.ChunkRequest, Releasable {
-        final StoreFileMetadata md;
-        final BytesReference content;
-        final long position;
-        final boolean lastChunk;
-        final Releasable onClose;
-
-        FileChunk(StoreFileMetadata md, BytesReference content, long position, boolean lastChunk, Releasable onClose) {
-            this.md = md;
-            this.content = content;
-            this.position = position;
-            this.lastChunk = lastChunk;
-            this.onClose = onClose;
-        }
-
-        @Override
-        public boolean lastChunk() {
-            return lastChunk;
-        }
-
-        @Override
-        public void close() {
-            onClose.close();
-        }
-    }
-
-    void sendFiles(Store store, StoreFileMetadata[] files, IntSupplier translogOps, ActionListener<Void> listener) {
-        ArrayUtil.timSort(files, Comparator.comparingLong(StoreFileMetadata::length)); // send smallest first
-
-        final MultiChunkTransfer<StoreFileMetadata, FileChunk> multiFileSender = new MultiChunkTransfer<StoreFileMetadata, FileChunk>(
-            logger,
-            threadPool.getThreadContext(),
-            listener,
-            maxConcurrentFileChunks,
-            Arrays.asList(files)
-        ) {
-
-            final Deque<byte[]> buffers = new ConcurrentLinkedDeque<>();
-            InputStreamIndexInput currentInput = null;
-            long offset = 0;
-
-            @Override
-            protected void onNewResource(StoreFileMetadata md) throws IOException {
-                offset = 0;
-                IOUtils.close(currentInput, () -> currentInput = null);
-                final IndexInput indexInput = store.directory().openInput(md.name(), IOContext.READONCE);
-                currentInput = new InputStreamIndexInput(indexInput, md.length()) {
-                    @Override
-                    public void close() throws IOException {
-                        IOUtils.close(indexInput, super::close); // InputStreamIndexInput's close is a noop
-                    }
-                };
-            }
-
-            private byte[] acquireBuffer() {
-                final byte[] buffer = buffers.pollFirst();
-                if (buffer != null) {
-                    return buffer;
-                }
-                return new byte[chunkSizeInBytes];
-            }
-
-            @Override
-            protected FileChunk nextChunkRequest(StoreFileMetadata md) throws IOException {
-                assert Transports.assertNotTransportThread("read file chunk");
-                cancellableThreads.checkForCancel();
-                final byte[] buffer = acquireBuffer();
-                final int bytesRead = currentInput.read(buffer);
-                if (bytesRead == -1) {
-                    throw new CorruptIndexException("file truncated; length=" + md.length() + " offset=" + offset, md.name());
-                }
-                final boolean lastChunk = offset + bytesRead == md.length();
-                final FileChunk chunk = new FileChunk(
-                    md,
-                    new BytesArray(buffer, 0, bytesRead),
-                    offset,
-                    lastChunk,
-                    () -> buffers.addFirst(buffer)
-                );
-                offset += bytesRead;
-                return chunk;
-            }
-
-            @Override
-            protected void executeChunkRequest(FileChunk request, ActionListener<Void> listener) {
-                cancellableThreads.checkForCancel();
-                recoveryTarget.writeFileChunk(
-                    request.md,
-                    request.position,
-                    request.content,
-                    request.lastChunk,
-                    translogOps.getAsInt(),
-                    ActionListener.runBefore(listener, request::close)
-                );
-            }
-
-            @Override
-            protected void handleError(StoreFileMetadata md, Exception e) throws Exception {
-                handleErrorOnSendFiles(store, e, new StoreFileMetadata[] { md });
-            }
-
-            @Override
-            public void close() throws IOException {
-                IOUtils.close(currentInput, () -> currentInput = null);
-            }
-        };
-        resources.add(multiFileSender);
-        multiFileSender.start();
-    }
-
     private void cleanFiles(
         Store store,
         Store.MetadataSnapshot sourceMetadata,
@@ -1198,48 +1029,5 @@ public class RecoverySourceHandler {
                 throw e;
             }))
         );
-    }
-
-    private void handleErrorOnSendFiles(Store store, Exception e, StoreFileMetadata[] mds) throws Exception {
-        final IOException corruptIndexException = ExceptionsHelper.unwrapCorruption(e);
-        assert Transports.assertNotTransportThread(RecoverySourceHandler.this + "[handle error on send/clean files]");
-        if (corruptIndexException != null) {
-            Exception localException = null;
-            for (StoreFileMetadata md : mds) {
-                cancellableThreads.checkForCancel();
-                logger.debug("checking integrity for file {} after remove corruption exception", md);
-                if (store.checkIntegrityNoException(md) == false) { // we are corrupted on the primary -- fail!
-                    logger.warn("{} Corrupted file detected {} checksum mismatch", shardId, md);
-                    if (localException == null) {
-                        localException = corruptIndexException;
-                    }
-                    failEngine(corruptIndexException);
-                }
-            }
-            if (localException != null) {
-                throw localException;
-            } else { // corruption has happened on the way to replica
-                RemoteTransportException remoteException = new RemoteTransportException(
-                    "File corruption occurred on recovery but checksums are ok",
-                    null
-                );
-                remoteException.addSuppressed(e);
-                logger.warn(
-                    () -> new ParameterizedMessage(
-                        "{} Remote file corruption on node {}, recovering {}. local checksum OK",
-                        shardId,
-                        request.targetNode(),
-                        mds
-                    ),
-                    corruptIndexException
-                );
-                throw remoteException;
-            }
-        }
-        throw e;
-    }
-
-    protected void failEngine(IOException cause) {
-        shard.failShard("recovery", cause);
     }
 }

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
@@ -142,7 +142,6 @@ public class RecoverySourceHandler {
             logger,
             threadPool,
             cancellableThreads,
-            this::failEngine,
             fileChunkSizeInBytes,
             maxConcurrentFileChunks
         );
@@ -1049,9 +1048,5 @@ public class RecoverySourceHandler {
                 throw e;
             }))
         );
-    }
-
-    protected void failEngine(IOException cause) {
-        shard.failShard("recovery", cause);
     }
 }

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
@@ -663,7 +663,7 @@ public class RecoverySourceHandler {
     }
 
     void sendFiles(Store store, StoreFileMetadata[] files, IntSupplier translogOps, ActionListener<Void> listener) {
-        final MultiChunkTransfer<StoreFileMetadata, SegmentFileTransferHandler.FileChunk> transfer = transferHandler.sendFiles(
+        final MultiChunkTransfer<StoreFileMetadata, SegmentFileTransferHandler.FileChunk> transfer = transferHandler.createTransfer(
             store,
             files,
             translogOps,

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoveryTargetHandler.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoveryTargetHandler.java
@@ -32,11 +32,9 @@
 package org.opensearch.indices.recovery;
 
 import org.opensearch.action.ActionListener;
-import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.index.seqno.ReplicationTracker;
 import org.opensearch.index.seqno.RetentionLeases;
 import org.opensearch.index.store.Store;
-import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.index.translog.Translog;
 
 import java.util.List;
@@ -46,7 +44,7 @@ import java.util.List;
  *
  * @opensearch.internal
  */
-public interface RecoveryTargetHandler {
+public interface RecoveryTargetHandler extends FileChunkWriter {
 
     /**
      * Prepares the target to receive translog operations, after all file have been copied
@@ -122,16 +120,6 @@ public interface RecoveryTargetHandler {
      * @param sourceMetadata   meta data of the source store
      */
     void cleanFiles(int totalTranslogOps, long globalCheckpoint, Store.MetadataSnapshot sourceMetadata, ActionListener<Void> listener);
-
-    /** writes a partial file chunk to the target store */
-    void writeFileChunk(
-        StoreFileMetadata fileMetadata,
-        long position,
-        BytesReference content,
-        boolean lastChunk,
-        int totalTranslogOps,
-        ActionListener<Void> listener
-    );
 
     default void cancel() {}
 }

--- a/server/src/main/java/org/opensearch/indices/recovery/RemoteRecoveryTargetHandler.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RemoteRecoveryTargetHandler.java
@@ -34,8 +34,6 @@ package org.opensearch.indices.recovery;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.store.RateLimiter;
-import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.bytes.BytesReference;
@@ -46,12 +44,12 @@ import org.opensearch.index.shard.ShardId;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.index.translog.Translog;
+import org.opensearch.indices.replication.RemoteSegmentFileChunkWriter;
 import org.opensearch.transport.EmptyTransportResponseHandler;
 import org.opensearch.transport.TransportRequestOptions;
 import org.opensearch.transport.TransportResponse;
 import org.opensearch.transport.TransportService;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -72,13 +70,10 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
     private final RecoverySettings recoverySettings;
 
     private final TransportRequestOptions translogOpsRequestOptions;
-    private final TransportRequestOptions fileChunkRequestOptions;
 
-    private final AtomicLong bytesSinceLastPause = new AtomicLong();
     private final AtomicLong requestSeqNoGenerator = new AtomicLong(0);
-
-    private final Consumer<Long> onSourceThrottle;
     private final RetryableTransportClient retryableTransportClient;
+    private final RemoteSegmentFileChunkWriter fileChunkWriter;
 
     public RemoteRecoveryTargetHandler(
         long recoveryId,
@@ -102,15 +97,18 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
         this.shardId = shardId;
         this.targetNode = targetNode;
         this.recoverySettings = recoverySettings;
-        this.onSourceThrottle = onSourceThrottle;
         this.translogOpsRequestOptions = TransportRequestOptions.builder()
             .withType(TransportRequestOptions.Type.RECOVERY)
             .withTimeout(recoverySettings.internalActionLongTimeout())
             .build();
-        this.fileChunkRequestOptions = TransportRequestOptions.builder()
-            .withType(TransportRequestOptions.Type.RECOVERY)
-            .withTimeout(recoverySettings.internalActionTimeout())
-            .build();
+        this.fileChunkWriter = new RemoteSegmentFileChunkWriter(
+            recoveryId,
+            recoverySettings,
+            retryableTransportClient,
+            shardId,
+            PeerRecoveryTargetService.Actions.FILE_CHUNK,
+            onSourceThrottle
+        );
     }
 
     public DiscoveryNode targetNode() {
@@ -236,6 +234,11 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
     }
 
     @Override
+    public void cancel() {
+        retryableTransportClient.cancel();
+    }
+
+    @Override
     public void writeFileChunk(
         StoreFileMetadata fileMetadata,
         long position,
@@ -244,57 +247,6 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
         int totalTranslogOps,
         ActionListener<Void> listener
     ) {
-        // Pause using the rate limiter, if desired, to throttle the recovery
-        final long throttleTimeInNanos;
-        // always fetch the ratelimiter - it might be updated in real-time on the recovery settings
-        final RateLimiter rl = recoverySettings.rateLimiter();
-        if (rl != null) {
-            long bytes = bytesSinceLastPause.addAndGet(content.length());
-            if (bytes > rl.getMinPauseCheckBytes()) {
-                // Time to pause
-                bytesSinceLastPause.addAndGet(-bytes);
-                try {
-                    throttleTimeInNanos = rl.pause(bytes);
-                    onSourceThrottle.accept(throttleTimeInNanos);
-                } catch (IOException e) {
-                    throw new OpenSearchException("failed to pause recovery", e);
-                }
-            } else {
-                throttleTimeInNanos = 0;
-            }
-        } else {
-            throttleTimeInNanos = 0;
-        }
-
-        final String action = PeerRecoveryTargetService.Actions.FILE_CHUNK;
-        final long requestSeqNo = requestSeqNoGenerator.getAndIncrement();
-        /* we send estimateTotalOperations with every request since we collect stats on the target and that way we can
-         * see how many translog ops we accumulate while copying files across the network. A future optimization
-         * would be in to restart file copy again (new deltas) if we have too many translog ops are piling up.
-         */
-        final FileChunkRequest request = new FileChunkRequest(
-            recoveryId,
-            requestSeqNo,
-            shardId,
-            fileMetadata,
-            position,
-            content,
-            lastChunk,
-            totalTranslogOps,
-            throttleTimeInNanos
-        );
-        final Writeable.Reader<TransportResponse.Empty> reader = in -> TransportResponse.Empty.INSTANCE;
-        retryableTransportClient.executeRetryableAction(
-            action,
-            request,
-            fileChunkRequestOptions,
-            ActionListener.map(listener, r -> null),
-            reader
-        );
-    }
-
-    @Override
-    public void cancel() {
-        retryableTransportClient.cancel();
+        fileChunkWriter.writeFileChunk(fileMetadata, position, content, lastChunk, totalTranslogOps, listener);
     }
 }

--- a/server/src/main/java/org/opensearch/indices/recovery/RemoteRecoveryTargetHandler.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RemoteRecoveryTargetHandler.java
@@ -107,6 +107,7 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
             retryableTransportClient,
             shardId,
             PeerRecoveryTargetService.Actions.FILE_CHUNK,
+            requestSeqNoGenerator,
             onSourceThrottle
         );
     }

--- a/server/src/main/java/org/opensearch/indices/recovery/RetryableTransportClient.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RetryableTransportClient.java
@@ -74,7 +74,7 @@ public final class RetryableTransportClient {
         executeRetryableAction(action, request, options, actionListener, reader);
     }
 
-    <T extends TransportResponse> void executeRetryableAction(
+    public <T extends TransportResponse> void executeRetryableAction(
         String action,
         TransportRequest request,
         TransportRequestOptions options,

--- a/server/src/main/java/org/opensearch/indices/replication/GetSegmentFilesRequest.java
+++ b/server/src/main/java/org/opensearch/indices/replication/GetSegmentFilesRequest.java
@@ -57,4 +57,8 @@ public class GetSegmentFilesRequest extends SegmentReplicationTransportRequest {
     public ReplicationCheckpoint getCheckpoint() {
         return checkpoint;
     }
+
+    public List<StoreFileMetadata> getFilesToFetch() {
+        return filesToFetch;
+    }
 }

--- a/server/src/main/java/org/opensearch/indices/replication/OngoingSegmentReplications.java
+++ b/server/src/main/java/org/opensearch/indices/replication/OngoingSegmentReplications.java
@@ -99,7 +99,7 @@ class OngoingSegmentReplications {
         final DiscoveryNode node = request.getTargetNode();
         final SegmentReplicationSourceHandler handler = nodesToHandlers.get(node);
         if (handler != null) {
-            if (handler.isActive()) {
+            if (handler.isReplicating()) {
                 throw new OpenSearchException(
                     "Replication to shard {}, on node {} has already started",
                     request.getCheckpoint().getShardId(),

--- a/server/src/main/java/org/opensearch/indices/replication/OngoingSegmentReplications.java
+++ b/server/src/main/java/org/opensearch/indices/replication/OngoingSegmentReplications.java
@@ -1,0 +1,203 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.index.IndexService;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.recovery.RecoverySettings;
+import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
+import org.opensearch.indices.replication.common.CopyState;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Manages references to ongoing segrep events on a node.
+ *
+ * @opensearch.internal
+ */
+class OngoingSegmentReplications {
+
+    private final RecoverySettings recoverySettings;
+    private final IndicesService indicesService;
+    private final Map<ReplicationCheckpoint, CopyState> copyStateMap;
+    private final Map<DiscoveryNode, SegmentReplicationSourceHandler> nodesToHandlers;
+
+    /**
+     * Constructor.
+     * @param indicesService {@link IndicesService}
+     * @param recoverySettings {@link RecoverySettings}
+     */
+    OngoingSegmentReplications(IndicesService indicesService, RecoverySettings recoverySettings) {
+        this.indicesService = indicesService;
+        this.recoverySettings = recoverySettings;
+        this.copyStateMap = Collections.synchronizedMap(new HashMap<>());
+        this.nodesToHandlers = Collections.synchronizedMap(new HashMap<>());
+    }
+
+    /**
+     * Operations on the {@link #copyStateMap} member.
+     */
+
+    /**
+     * A synchronized method that checks {@link #copyStateMap} for the given {@link ReplicationCheckpoint} key
+     * and returns the cached value if one is present. If the key is not present, a {@link CopyState}
+     * object is constructed and stored in the map before being returned.
+     */
+    synchronized CopyState getCachedCopyState(ReplicationCheckpoint checkpoint) throws IOException {
+        if (isInCopyStateMap(checkpoint)) {
+            final CopyState copyState = fetchFromCopyStateMap(checkpoint);
+            // we incref the copyState for every replica that is using this checkpoint.
+            // decref will happen when copy completes.
+            copyState.incRef();
+            return copyState;
+        } else {
+            // From the checkpoint's shard ID, fetch the IndexShard
+            ShardId shardId = checkpoint.getShardId();
+            final IndexService indexService = indicesService.indexService(shardId.getIndex());
+            final IndexShard indexShard = indexService.getShard(shardId.id());
+            // build the CopyState object and cache it before returning
+            final CopyState copyState = new CopyState(checkpoint, indexShard);
+
+            /**
+             * Use the checkpoint from the request as the key in the map, rather than
+             * the checkpoint from the created CopyState. This maximizes cache hits
+             * if replication targets make a request with an older checkpoint.
+             * Replication targets are expected to fetch the checkpoint in the response
+             * CopyState to bring themselves up to date.
+             */
+            addToCopyStateMap(checkpoint, copyState);
+            return copyState;
+        }
+    }
+
+    void cancelReplication(DiscoveryNode node) {
+        if (nodesToHandlers.containsKey(node)) {
+            final SegmentReplicationSourceHandler handler = nodesToHandlers.remove(node);
+            handler.cancel("Cancel on node left");
+            removeCopyState(handler.getCopyState());
+        }
+    }
+
+    SegmentReplicationSourceHandler createTargetHandler(
+        DiscoveryNode node,
+        CopyState copyState,
+        RemoteSegmentFileChunkWriter segmentFileChunkWriter
+    ) {
+        return new SegmentReplicationSourceHandler(
+            node,
+            segmentFileChunkWriter,
+            copyState.getShard().getThreadPool(),
+            copyState,
+            Math.toIntExact(recoverySettings.getChunkSize().getBytes()),
+            recoverySettings.getMaxConcurrentFileChunks()
+        );
+    }
+
+    /**
+     * Adds the input {@link CopyState} object to {@link #copyStateMap}.
+     * The key is the CopyState's {@link ReplicationCheckpoint} object.
+     */
+    private void addToCopyStateMap(ReplicationCheckpoint checkpoint, CopyState copyState) {
+        copyStateMap.putIfAbsent(checkpoint, copyState);
+    }
+
+    /**
+     * Given a {@link ReplicationCheckpoint}, return the corresponding
+     * {@link CopyState} object, if any, from {@link #copyStateMap}.
+     */
+    private CopyState fetchFromCopyStateMap(ReplicationCheckpoint replicationCheckpoint) {
+        return copyStateMap.get(replicationCheckpoint);
+    }
+
+    /**
+     * Checks if the {@link #copyStateMap} has the input {@link ReplicationCheckpoint}
+     * as a key by invoking {@link Map#containsKey(Object)}.
+     */
+    boolean isInCopyStateMap(ReplicationCheckpoint replicationCheckpoint) {
+        return copyStateMap.containsKey(replicationCheckpoint);
+    }
+
+    void startSegmentCopy(GetSegmentFilesRequest request, ActionListener<GetSegmentFilesResponse> listener) {
+        final DiscoveryNode node = request.getTargetNode();
+        if (nodesToHandlers.containsKey(node)) {
+            final SegmentReplicationSourceHandler handler = nodesToHandlers.get(node);
+            // update the given listener to release the CopyState before it resolves.
+            final ActionListener<GetSegmentFilesResponse> wrappedListener = ActionListener.runBefore(listener, () -> {
+                final SegmentReplicationSourceHandler sourceHandler = nodesToHandlers.remove(node);
+                removeCopyState(sourceHandler.getCopyState());
+            });
+            handler.sendFiles(request, wrappedListener);
+        } else {
+            listener.onResponse(new GetSegmentFilesResponse(Collections.emptyList()));
+        }
+    }
+
+    /**
+     * Remove a CopyState. Intended to be called after a replication event completes.
+     * This method will remove a copyState from the copyStateMap only if its refCount hits 0.
+     * @param copyState {@link CopyState}
+     */
+    private synchronized void removeCopyState(CopyState copyState) {
+        copyState.decRef();
+        if (copyState.refCount() <= 0) {
+            copyStateMap.remove(copyState.getRequestedReplicationCheckpoint());
+        }
+    }
+
+    /**
+     * Prepare for a Replication event. This method constructs a {@link CopyState} holding files to be sent off of the current
+     * nodes's store.  This state is intended to be sent back to Replicas before copy is initiated so the replica can perform a diff against its
+     * local store.  It will then build a handler to orchestrate the segment copy that will be stored locally and started on a subsequent request from replicas
+     * with the list of required files.
+     * @param request {@link CheckpointInfoRequest}
+     * @param segmentSegmentFileChunkWriter {@link RemoteSegmentFileChunkWriter} writer to handle sending files over the transport layer.
+     * @return {@link CopyState} the built CopyState for this replication event.
+     * @throws IOException - When there is an IO error building CopyState.
+     */
+    CopyState prepareForReplication(CheckpointInfoRequest request, RemoteSegmentFileChunkWriter segmentSegmentFileChunkWriter)
+        throws IOException {
+        final CopyState copyState = getCachedCopyState(request.getCheckpoint());
+        final SegmentReplicationSourceHandler handler = createTargetHandler(
+            request.getTargetNode(),
+            copyState,
+            segmentSegmentFileChunkWriter
+        );
+        nodesToHandlers.putIfAbsent(request.getTargetNode(), handler);
+        return copyState;
+    }
+
+    int size() {
+        return nodesToHandlers.size();
+    }
+
+    int cachedCopyStateSize() {
+        return copyStateMap.size();
+    }
+
+    /**
+     * Cancel all Replication events for the given shard, intended to be called when the current primary is shutting down.
+     * @param shard {@link IndexShard}
+     * @param reason  {@link String} - Reason for the cancel
+     */
+    public void cancel(IndexShard shard, String reason) {
+        for (SegmentReplicationSourceHandler entry : nodesToHandlers.values()) {
+            if (entry.getCopyState().getShard().equals(shard)) {
+                entry.cancel(reason);
+            }
+        }
+        copyStateMap.clear();
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/replication/RemoteSegmentFileChunkWriter.java
+++ b/server/src/main/java/org/opensearch/indices/replication/RemoteSegmentFileChunkWriter.java
@@ -33,7 +33,7 @@ import java.util.function.Consumer;
  */
 public class RemoteSegmentFileChunkWriter implements FileChunkWriter {
 
-    protected final AtomicLong requestSeqNoGenerator = new AtomicLong(0);
+    protected final AtomicLong requestSeqNoGenerator;
     protected final RetryableTransportClient retryableTransportClient;
     protected final ShardId shardId;
     protected final RecoverySettings recoverySettings;
@@ -49,12 +49,14 @@ public class RemoteSegmentFileChunkWriter implements FileChunkWriter {
         RetryableTransportClient retryableTransportClient,
         ShardId shardId,
         String action,
+        AtomicLong requestSeqNoGenerator,
         Consumer<Long> onSourceThrottle
     ) {
         this.replicationId = replicationId;
         this.recoverySettings = recoverySettings;
         this.retryableTransportClient = retryableTransportClient;
         this.shardId = shardId;
+        this.requestSeqNoGenerator = requestSeqNoGenerator;
         this.onSourceThrottle = onSourceThrottle;
         this.fileChunkRequestOptions = TransportRequestOptions.builder()
             .withType(TransportRequestOptions.Type.RECOVERY)

--- a/server/src/main/java/org/opensearch/indices/replication/RemoteSegmentFileChunkWriter.java
+++ b/server/src/main/java/org/opensearch/indices/replication/RemoteSegmentFileChunkWriter.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication;
+
+import org.apache.lucene.store.RateLimiter;
+import org.opensearch.OpenSearchException;
+import org.opensearch.action.ActionListener;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.index.store.StoreFileMetadata;
+import org.opensearch.indices.recovery.FileChunkRequest;
+import org.opensearch.indices.recovery.RecoverySettings;
+import org.opensearch.indices.recovery.RetryableTransportClient;
+import org.opensearch.indices.recovery.FileChunkWriter;
+import org.opensearch.transport.TransportRequestOptions;
+import org.opensearch.transport.TransportResponse;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+/**
+ * This class handles sending file chunks over the transport layer to a target shard.
+ *
+ * @opensearch.internal
+ */
+public class RemoteSegmentFileChunkWriter implements FileChunkWriter {
+
+    protected final AtomicLong requestSeqNoGenerator = new AtomicLong(0);
+    protected final RetryableTransportClient retryableTransportClient;
+    protected final ShardId shardId;
+    protected final RecoverySettings recoverySettings;
+    private final long replicationId;
+    private final AtomicLong bytesSinceLastPause = new AtomicLong();
+    private final TransportRequestOptions fileChunkRequestOptions;
+    private final Consumer<Long> onSourceThrottle;
+    private final String action;
+
+    public RemoteSegmentFileChunkWriter(
+        long replicationId,
+        RecoverySettings recoverySettings,
+        RetryableTransportClient retryableTransportClient,
+        ShardId shardId,
+        String action,
+        Consumer<Long> onSourceThrottle
+    ) {
+        this.replicationId = replicationId;
+        this.recoverySettings = recoverySettings;
+        this.retryableTransportClient = retryableTransportClient;
+        this.shardId = shardId;
+        this.onSourceThrottle = onSourceThrottle;
+        this.fileChunkRequestOptions = TransportRequestOptions.builder()
+            .withType(TransportRequestOptions.Type.RECOVERY)
+            .withTimeout(recoverySettings.internalActionTimeout())
+            .build();
+
+        this.action = action;
+    }
+
+    @Override
+    public void writeFileChunk(
+        StoreFileMetadata fileMetadata,
+        long position,
+        BytesReference content,
+        boolean lastChunk,
+        int totalTranslogOps,
+        ActionListener<Void> listener
+    ) {
+        // Pause using the rate limiter, if desired, to throttle the recovery
+        final long throttleTimeInNanos;
+        // always fetch the ratelimiter - it might be updated in real-time on the recovery settings
+        final RateLimiter rl = recoverySettings.rateLimiter();
+        if (rl != null) {
+            long bytes = bytesSinceLastPause.addAndGet(content.length());
+            if (bytes > rl.getMinPauseCheckBytes()) {
+                // Time to pause
+                bytesSinceLastPause.addAndGet(-bytes);
+                try {
+                    throttleTimeInNanos = rl.pause(bytes);
+                    onSourceThrottle.accept(throttleTimeInNanos);
+                } catch (IOException e) {
+                    throw new OpenSearchException("failed to pause recovery", e);
+                }
+            } else {
+                throttleTimeInNanos = 0;
+            }
+        } else {
+            throttleTimeInNanos = 0;
+        }
+
+        final long requestSeqNo = requestSeqNoGenerator.getAndIncrement();
+        /* we send estimateTotalOperations with every request since we collect stats on the target and that way we can
+         * see how many translog ops we accumulate while copying files across the network. A future optimization
+         * would be in to restart file copy again (new deltas) if we have too many translog ops are piling up.
+         */
+        final FileChunkRequest request = new FileChunkRequest(
+            replicationId,
+            requestSeqNo,
+            shardId,
+            fileMetadata,
+            position,
+            content,
+            lastChunk,
+            totalTranslogOps,
+            throttleTimeInNanos
+        );
+        final Writeable.Reader<TransportResponse.Empty> reader = in -> TransportResponse.Empty.INSTANCE;
+        retryableTransportClient.executeRetryableAction(
+            action,
+            request,
+            fileChunkRequestOptions,
+            ActionListener.map(listener, r -> null),
+            reader
+        );
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/replication/RemoteSegmentFileChunkWriter.java
+++ b/server/src/main/java/org/opensearch/indices/replication/RemoteSegmentFileChunkWriter.java
@@ -31,12 +31,12 @@ import java.util.function.Consumer;
  *
  * @opensearch.internal
  */
-public class RemoteSegmentFileChunkWriter implements FileChunkWriter {
+public final class RemoteSegmentFileChunkWriter implements FileChunkWriter {
 
-    protected final AtomicLong requestSeqNoGenerator;
-    protected final RetryableTransportClient retryableTransportClient;
-    protected final ShardId shardId;
-    protected final RecoverySettings recoverySettings;
+    private final AtomicLong requestSeqNoGenerator;
+    private final RetryableTransportClient retryableTransportClient;
+    private final ShardId shardId;
+    private final RecoverySettings recoverySettings;
     private final long replicationId;
     private final AtomicLong bytesSinceLastPause = new AtomicLong();
     private final TransportRequestOptions fileChunkRequestOptions;

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentFileTransferHandler.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentFileTransferHandler.java
@@ -87,7 +87,7 @@ public final class SegmentFileTransferHandler {
      * @param listener {@link ActionListener}
      * @return {@link MultiChunkTransfer}
      */
-    public MultiChunkTransfer<StoreFileMetadata, FileChunk> sendFiles(
+    public MultiChunkTransfer<StoreFileMetadata, FileChunk> createTransfer(
         Store store,
         StoreFileMetadata[] files,
         IntSupplier translogOps,

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentFileTransferHandler.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentFileTransferHandler.java
@@ -1,0 +1,240 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.ArrayUtil;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.ActionListener;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.bytes.BytesArray;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.lease.Releasable;
+import org.opensearch.common.lucene.store.InputStreamIndexInput;
+import org.opensearch.common.util.CancellableThreads;
+import org.opensearch.core.internal.io.IOUtils;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.store.Store;
+import org.opensearch.index.store.StoreFileMetadata;
+import org.opensearch.indices.recovery.MultiChunkTransfer;
+import org.opensearch.indices.recovery.FileChunkWriter;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.RemoteTransportException;
+import org.opensearch.transport.Transports;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.IntSupplier;
+
+/**
+ * SegmentFileSender handles building and starting a {@link MultiChunkTransfer} to orchestrate sending chunks to a given targetNode.
+ * This class delegates to a {@link FileChunkWriter} to handle the transport of chunks.
+ *
+ * @opensearch.internal
+ * // TODO: make this package-private after combining recovery and replication into single package.
+ */
+public class SegmentFileTransferHandler {
+
+    protected final Logger logger;
+    protected final CancellableThreads cancellableThreads = new CancellableThreads();
+    protected final List<Closeable> resources = new CopyOnWriteArrayList<>();
+    private final IndexShard shard;
+    private final FileChunkWriter chunkWriter;
+    private final ThreadPool threadPool;
+    private final int chunkSizeInBytes;
+    private final int maxConcurrentFileChunks;
+    private final DiscoveryNode targetNode;
+
+    public SegmentFileTransferHandler(
+        IndexShard shard,
+        DiscoveryNode targetNode,
+        FileChunkWriter chunkWriter,
+        Logger logger,
+        ThreadPool threadPool,
+        int fileChunkSizeInBytes,
+        int maxConcurrentFileChunks
+    ) {
+        this.shard = shard;
+        this.targetNode = targetNode;
+        this.chunkWriter = chunkWriter;
+        this.logger = logger;
+        this.threadPool = threadPool;
+        this.chunkSizeInBytes = fileChunkSizeInBytes;
+        // if the target is on an old version, it won't be able to handle out-of-order file chunks.
+        this.maxConcurrentFileChunks = maxConcurrentFileChunks;
+    }
+
+    public final void sendFiles(Store store, StoreFileMetadata[] files, IntSupplier translogOps, ActionListener<Void> listener) {
+        ArrayUtil.timSort(files, Comparator.comparingLong(StoreFileMetadata::length)); // send smallest first
+
+        final MultiChunkTransfer<StoreFileMetadata, FileChunk> multiFileSender = new MultiChunkTransfer<>(
+            logger,
+            threadPool.getThreadContext(),
+            listener,
+            maxConcurrentFileChunks,
+            Arrays.asList(files)
+        ) {
+
+            final Deque<byte[]> buffers = new ConcurrentLinkedDeque<>();
+            InputStreamIndexInput currentInput = null;
+            long offset = 0;
+
+            @Override
+            protected void onNewResource(StoreFileMetadata md) throws IOException {
+                offset = 0;
+                IOUtils.close(currentInput, () -> currentInput = null);
+                final IndexInput indexInput = store.directory().openInput(md.name(), IOContext.READONCE);
+                currentInput = new InputStreamIndexInput(indexInput, md.length()) {
+                    @Override
+                    public void close() throws IOException {
+                        IOUtils.close(indexInput, super::close); // InputStreamIndexInput's close is a noop
+                    }
+                };
+            }
+
+            private byte[] acquireBuffer() {
+                final byte[] buffer = buffers.pollFirst();
+                if (buffer != null) {
+                    return buffer;
+                }
+                return new byte[chunkSizeInBytes];
+            }
+
+            @Override
+            protected FileChunk nextChunkRequest(StoreFileMetadata md) throws IOException {
+                assert Transports.assertNotTransportThread("read file chunk");
+                cancellableThreads.checkForCancel();
+                final byte[] buffer = acquireBuffer();
+                final int bytesRead = currentInput.read(buffer);
+                if (bytesRead == -1) {
+                    throw new CorruptIndexException("file truncated; length=" + md.length() + " offset=" + offset, md.name());
+                }
+                final boolean lastChunk = offset + bytesRead == md.length();
+                final FileChunk chunk = new FileChunk(
+                    md,
+                    new BytesArray(buffer, 0, bytesRead),
+                    offset,
+                    lastChunk,
+                    () -> buffers.addFirst(buffer)
+                );
+                offset += bytesRead;
+                return chunk;
+            }
+
+            @Override
+            protected void executeChunkRequest(FileChunk request, ActionListener<Void> listener) {
+                cancellableThreads.checkForCancel();
+                chunkWriter.writeFileChunk(
+                    request.md,
+                    request.position,
+                    request.content,
+                    request.lastChunk,
+                    translogOps.getAsInt(),
+                    ActionListener.runBefore(listener, request::close)
+                );
+            }
+
+            @Override
+            protected void handleError(StoreFileMetadata md, Exception e) throws Exception {
+                handleErrorOnSendFiles(store, e, new StoreFileMetadata[] { md });
+            }
+
+            @Override
+            public void close() throws IOException {
+                IOUtils.close(currentInput, () -> currentInput = null);
+            }
+        };
+        resources.add(multiFileSender);
+        multiFileSender.start();
+    }
+
+    public final void handleErrorOnSendFiles(Store store, Exception e, StoreFileMetadata[] mds) throws Exception {
+        final IOException corruptIndexException = ExceptionsHelper.unwrapCorruption(e);
+        assert Transports.assertNotTransportThread(this + "[handle error on send/clean files]");
+        if (corruptIndexException != null) {
+            Exception localException = null;
+            for (StoreFileMetadata md : mds) {
+                cancellableThreads.checkForCancel();
+                logger.debug("checking integrity for file {} after remove corruption exception", md);
+                if (store.checkIntegrityNoException(md) == false) { // we are corrupted on the primary -- fail!
+                    logger.warn("{} Corrupted file detected {} checksum mismatch", shard.shardId(), md);
+                    if (localException == null) {
+                        localException = corruptIndexException;
+                    }
+                    failEngine(corruptIndexException);
+                }
+            }
+            if (localException != null) {
+                throw localException;
+            } else { // corruption has happened on the way to replica
+                RemoteTransportException remoteException = new RemoteTransportException(
+                    "File corruption occurred on recovery but checksums are ok",
+                    null
+                );
+                remoteException.addSuppressed(e);
+                logger.warn(
+                    () -> new ParameterizedMessage(
+                        "{} Remote file corruption on node {}, recovering {}. local checksum OK",
+                        shard.shardId(),
+                        targetNode,
+                        mds
+                    ),
+                    corruptIndexException
+                );
+                throw remoteException;
+            }
+        }
+        throw e;
+    }
+
+    protected void failEngine(IOException cause) {
+        shard.failShard("recovery", cause);
+    }
+
+    /**
+     * A file chunk from the recovery source
+     *
+     * @opensearch.internal
+     */
+    public static final class FileChunk implements MultiChunkTransfer.ChunkRequest, Releasable {
+        final StoreFileMetadata md;
+        final BytesReference content;
+        final long position;
+        final boolean lastChunk;
+        final Releasable onClose;
+
+        FileChunk(StoreFileMetadata md, BytesReference content, long position, boolean lastChunk, Releasable onClose) {
+            this.md = md;
+            this.content = content;
+            this.position = position;
+            this.lastChunk = lastChunk;
+            this.onClose = onClose;
+        }
+
+        @Override
+        public boolean lastChunk() {
+            return lastChunk;
+        }
+
+        @Override
+        public void close() {
+            onClose.close();
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
@@ -53,7 +53,7 @@ class SegmentReplicationSourceHandler {
     private final ListenableFuture<GetSegmentFilesResponse> future = new ListenableFuture<>();
     private final List<Closeable> resources = new CopyOnWriteArrayList<>();
     private final Logger logger;
-    private final AtomicBoolean active = new AtomicBoolean();
+    private final AtomicBoolean isReplicating = new AtomicBoolean();
 
     /**
      * Constructor.
@@ -99,7 +99,7 @@ class SegmentReplicationSourceHandler {
      * @param listener {@link ActionListener} that completes with the list of files sent.
      */
     public synchronized void sendFiles(GetSegmentFilesRequest request, ActionListener<GetSegmentFilesResponse> listener) {
-        if (active.compareAndSet(false, true) == false) {
+        if (isReplicating.compareAndSet(false, true) == false) {
             throw new OpenSearchException("Replication to {} is already running.", shard.shardId());
         }
         future.addListener(listener, OpenSearchExecutors.newDirectExecutorService());
@@ -164,7 +164,7 @@ class SegmentReplicationSourceHandler {
         return copyState;
     }
 
-    public boolean isActive() {
-        return active.get();
+    public boolean isReplicating() {
+        return isReplicating.get();
     }
 }

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
@@ -1,0 +1,154 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication;
+
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.StepListener;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.routing.IndexShardRoutingTable;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.common.logging.Loggers;
+import org.opensearch.common.util.concurrent.ListenableFuture;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
+import org.opensearch.core.internal.io.IOUtils;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.store.StoreFileMetadata;
+import org.opensearch.indices.RunUnderPrimaryPermit;
+import org.opensearch.indices.recovery.DelayRecoveryException;
+import org.opensearch.indices.recovery.FileChunkWriter;
+import org.opensearch.indices.replication.common.CopyState;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.Transports;
+
+import java.io.Closeable;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+/**
+ * Orchestrates sending requested segment files to a target shard.
+ *
+ * @opensearch.internal
+ */
+class SegmentReplicationSourceHandler {
+
+    protected final IndexShard shard;
+    private final CopyState copyState;
+    private final SegmentFileTransferHandler segmentFileTransferHandler;
+    protected final ListenableFuture<GetSegmentFilesResponse> future = new ListenableFuture<>();
+    protected final List<Closeable> resources = new CopyOnWriteArrayList<>();
+    private final Logger logger;
+
+    /**
+     * Constructor.
+     *
+     * @param targetNode              - {@link DiscoveryNode} target node where files should be sent.
+     * @param writer                  {@link FileChunkWriter} implementation that sends file chunks over the transport layer.
+     * @param threadPool              {@link ThreadPool} Thread pool.
+     * @param copyState               {@link CopyState} CopyState holding segment file metadata.
+     * @param fileChunkSizeInBytes    {@link Integer}
+     * @param maxConcurrentFileChunks {@link Integer}
+     */
+    SegmentReplicationSourceHandler(
+        DiscoveryNode targetNode,
+        FileChunkWriter writer,
+        ThreadPool threadPool,
+        CopyState copyState,
+        int fileChunkSizeInBytes,
+        int maxConcurrentFileChunks
+    ) {
+        this.shard = copyState.getShard();
+        this.logger = Loggers.getLogger(
+            SegmentReplicationSourceHandler.class,
+            copyState.getShard().shardId(),
+            "sending segments to " + targetNode.getName()
+        );
+        this.segmentFileTransferHandler = new SegmentFileTransferHandler(
+            copyState.getShard(),
+            targetNode,
+            writer,
+            logger,
+            threadPool,
+            fileChunkSizeInBytes,
+            maxConcurrentFileChunks
+        );
+        this.copyState = copyState;
+    }
+
+    /**
+     * Sends Segment files from the local node to the given target.
+     *
+     * @param request  {@link GetSegmentFilesRequest} request object containing list of files to be sent.
+     * @param listener {@link ActionListener} that completes with the list of files sent.
+     */
+    public void sendFiles(GetSegmentFilesRequest request, ActionListener<GetSegmentFilesResponse> listener) {
+        future.addListener(listener, OpenSearchExecutors.newDirectExecutorService());
+        final Closeable releaseResources = () -> IOUtils.close(resources);
+        try {
+
+            final Consumer<Exception> onFailure = e -> {
+                assert Transports.assertNotTransportThread(SegmentReplicationSourceHandler.this + "[onFailure]");
+                IOUtils.closeWhileHandlingException(releaseResources, () -> future.onFailure(e));
+            };
+
+            RunUnderPrimaryPermit.run(() -> {
+                final IndexShardRoutingTable routingTable = shard.getReplicationGroup().getRoutingTable();
+                ShardRouting targetShardRouting = routingTable.getByAllocationId(request.getTargetAllocationId());
+                if (targetShardRouting == null) {
+                    logger.debug(
+                        "delaying replication of {} as it is not listed as assigned to target node {}",
+                        shard.shardId(),
+                        request.getTargetNode()
+                    );
+                    throw new DelayRecoveryException("source node does not have the shard listed in its state as allocated on the node");
+                }
+            },
+                shard.shardId() + " validating recovery target [" + request.getTargetAllocationId() + "] registered ",
+                shard,
+                segmentFileTransferHandler.cancellableThreads,
+                logger
+            );
+
+            final StepListener<Void> sendFileStep = new StepListener<>();
+            Set<String> storeFiles = new HashSet<>(Arrays.asList(shard.store().directory().listAll()));
+            final StoreFileMetadata[] storeFileMetadata = request.getFilesToFetch()
+                .stream()
+                .filter(file -> storeFiles.contains(file.name()))
+                .toArray(StoreFileMetadata[]::new);
+
+            segmentFileTransferHandler.sendFiles(shard.store(), storeFileMetadata, () -> 0, sendFileStep);
+            resources.addAll(segmentFileTransferHandler.resources);
+
+            sendFileStep.whenComplete(r -> {
+                try {
+                    future.onResponse(new GetSegmentFilesResponse(List.of(storeFileMetadata)));
+                } finally {
+                    IOUtils.close(resources);
+                }
+            }, onFailure);
+        } catch (Exception e) {
+            IOUtils.closeWhileHandlingException(releaseResources, () -> future.onFailure(e));
+        }
+    }
+
+    /**
+     * Cancels the recovery and interrupts all eligible threads.
+     */
+    public void cancel(String reason) {
+        segmentFileTransferHandler.cancellableThreads.cancel(reason);
+    }
+
+    CopyState getCopyState() {
+        return copyState;
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
@@ -30,7 +30,6 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.Transports;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -84,7 +83,6 @@ class SegmentReplicationSourceHandler {
             logger,
             threadPool,
             cancellableThreads,
-            this::failEngine,
             fileChunkSizeInBytes,
             maxConcurrentFileChunks
         );
@@ -154,10 +152,6 @@ class SegmentReplicationSourceHandler {
      */
     public void cancel(String reason) {
         cancellableThreads.cancel(reason);
-    }
-
-    private void failEngine(IOException e) {
-        shard.failShard("Failed Replication", e);
     }
 
     CopyState getCopyState() {

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
@@ -24,7 +24,6 @@ import org.opensearch.index.shard.ShardId;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.indices.recovery.RetryableTransportClient;
-import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
 import org.opensearch.indices.replication.common.CopyState;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
@@ -88,9 +87,6 @@ public final class SegmentReplicationSourceService extends AbstractLifecycleComp
     private class CheckpointInfoRequestHandler implements TransportRequestHandler<CheckpointInfoRequest> {
         @Override
         public void messageReceived(CheckpointInfoRequest request, TransportChannel channel, Task task) throws Exception {
-            final ReplicationCheckpoint checkpoint = request.getCheckpoint();
-            logger.trace("Received request for checkpoint {}", checkpoint);
-
             final RemoteSegmentFileChunkWriter segmentSegmentFileChunkWriter = new RemoteSegmentFileChunkWriter(
                 request.getReplicationId(),
                 recoverySettings,

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
@@ -33,6 +33,7 @@ import org.opensearch.transport.TransportRequestHandler;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Service class that handles segment replication requests from replica shards.
@@ -101,6 +102,7 @@ public final class SegmentReplicationSourceService extends AbstractLifecycleComp
                 ),
                 request.getCheckpoint().getShardId(),
                 SegmentReplicationTargetService.Actions.FILE_CHUNK,
+                new AtomicLong(0),
                 (throttleTime) -> {}
             );
             final CopyState copyState = ongoingSegmentReplications.prepareForReplication(request, segmentSegmentFileChunkWriter);

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
@@ -60,7 +60,6 @@ public final class SegmentReplicationSourceService extends AbstractLifecycleComp
 
     private final OngoingSegmentReplications ongoingSegmentReplications;
 
-    // TODO mark this as injected and bind in Node
     public SegmentReplicationSourceService(
         IndicesService indicesService,
         TransportService transportService,

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
@@ -10,10 +10,20 @@ package org.opensearch.indices.replication;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.index.IndexService;
+import org.opensearch.action.support.ChannelActionListener;
+import org.opensearch.cluster.ClusterChangedEvent;
+import org.opensearch.cluster.ClusterStateListener;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.Nullable;
+import org.opensearch.common.component.AbstractLifecycleComponent;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.shard.IndexEventListener;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.recovery.RecoverySettings;
+import org.opensearch.indices.recovery.RetryableTransportClient;
 import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
 import org.opensearch.indices.replication.common.CopyState;
 import org.opensearch.tasks.Task;
@@ -23,9 +33,6 @@ import org.opensearch.transport.TransportRequestHandler;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Service class that handles segment replication requests from replica shards.
@@ -33,9 +40,12 @@ import java.util.Map;
  *
  * @opensearch.internal
  */
-public class SegmentReplicationSourceService {
+public final class SegmentReplicationSourceService extends AbstractLifecycleComponent implements ClusterStateListener, IndexEventListener {
 
     private static final Logger logger = LogManager.getLogger(SegmentReplicationSourceService.class);
+    private final RecoverySettings recoverySettings;
+    private final TransportService transportService;
+    private final IndicesService indicesService;
 
     /**
      * Internal actions used by the segment replication source service on the primary shard
@@ -43,20 +53,22 @@ public class SegmentReplicationSourceService {
      * @opensearch.internal
      */
     public static class Actions {
+
         public static final String GET_CHECKPOINT_INFO = "internal:index/shard/replication/get_checkpoint_info";
         public static final String GET_SEGMENT_FILES = "internal:index/shard/replication/get_segment_files";
     }
 
-    private final Map<ReplicationCheckpoint, CopyState> copyStateMap;
-    private final TransportService transportService;
-    private final IndicesService indicesService;
+    private final OngoingSegmentReplications ongoingSegmentReplications;
 
     // TODO mark this as injected and bind in Node
-    public SegmentReplicationSourceService(TransportService transportService, IndicesService indicesService) {
-        copyStateMap = Collections.synchronizedMap(new HashMap<>());
+    public SegmentReplicationSourceService(
+        IndicesService indicesService,
+        TransportService transportService,
+        RecoverySettings recoverySettings
+    ) {
         this.transportService = transportService;
         this.indicesService = indicesService;
-
+        this.recoverySettings = recoverySettings;
         transportService.registerRequestHandler(
             Actions.GET_CHECKPOINT_INFO,
             ThreadPool.Names.GENERIC,
@@ -69,6 +81,7 @@ public class SegmentReplicationSourceService {
             GetSegmentFilesRequest::new,
             new GetSegmentFilesRequestHandler()
         );
+        this.ongoingSegmentReplications = new OngoingSegmentReplications(indicesService, recoverySettings);
     }
 
     private class CheckpointInfoRequestHandler implements TransportRequestHandler<CheckpointInfoRequest> {
@@ -76,7 +89,21 @@ public class SegmentReplicationSourceService {
         public void messageReceived(CheckpointInfoRequest request, TransportChannel channel, Task task) throws Exception {
             final ReplicationCheckpoint checkpoint = request.getCheckpoint();
             logger.trace("Received request for checkpoint {}", checkpoint);
-            final CopyState copyState = getCachedCopyState(checkpoint);
+
+            final RemoteSegmentFileChunkWriter segmentSegmentFileChunkWriter = new RemoteSegmentFileChunkWriter(
+                request.getReplicationId(),
+                recoverySettings,
+                new RetryableTransportClient(
+                    transportService,
+                    request.getTargetNode(),
+                    recoverySettings.internalActionRetryTimeout(),
+                    logger
+                ),
+                request.getCheckpoint().getShardId(),
+                SegmentReplicationTargetService.Actions.FILE_CHUNK,
+                (throttleTime) -> {}
+            );
+            final CopyState copyState = ongoingSegmentReplications.prepareForReplication(request, segmentSegmentFileChunkWriter);
             channel.sendResponse(
                 new CheckpointInfoResponse(
                     copyState.getCheckpoint(),
@@ -88,73 +115,47 @@ public class SegmentReplicationSourceService {
         }
     }
 
-    class GetSegmentFilesRequestHandler implements TransportRequestHandler<GetSegmentFilesRequest> {
+    private class GetSegmentFilesRequestHandler implements TransportRequestHandler<GetSegmentFilesRequest> {
         @Override
         public void messageReceived(GetSegmentFilesRequest request, TransportChannel channel, Task task) throws Exception {
-            if (isInCopyStateMap(request.getCheckpoint())) {
-                // TODO send files
-            } else {
-                // Return an empty list of files
-                channel.sendResponse(new GetSegmentFilesResponse(Collections.emptyList()));
+            ongoingSegmentReplications.startSegmentCopy(request, new ChannelActionListener<>(channel, Actions.GET_SEGMENT_FILES, request));
+        }
+    }
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        if (event.nodesRemoved()) {
+            for (DiscoveryNode removedNode : event.nodesDelta().removedNodes()) {
+                ongoingSegmentReplications.cancelReplication(removedNode);
             }
         }
     }
 
-    /**
-     * Operations on the {@link #copyStateMap} member.
-     */
-
-    /**
-     * A synchronized method that checks {@link #copyStateMap} for the given {@link ReplicationCheckpoint} key
-     * and returns the cached value if one is present. If the key is not present, a {@link CopyState}
-     * object is constructed and stored in the map before being returned.
-     */
-    private synchronized CopyState getCachedCopyState(ReplicationCheckpoint checkpoint) throws IOException {
-        if (isInCopyStateMap(checkpoint)) {
-            final CopyState copyState = fetchFromCopyStateMap(checkpoint);
-            copyState.incRef();
-            return copyState;
-        } else {
-            // From the checkpoint's shard ID, fetch the IndexShard
-            ShardId shardId = checkpoint.getShardId();
-            final IndexService indexService = indicesService.indexService(shardId.getIndex());
-            final IndexShard indexShard = indexService.getShard(shardId.id());
-            // build the CopyState object and cache it before returning
-            final CopyState copyState = new CopyState(indexShard);
-
-            /**
-             * Use the checkpoint from the request as the key in the map, rather than
-             * the checkpoint from the created CopyState. This maximizes cache hits
-             * if replication targets make a request with an older checkpoint.
-             * Replication targets are expected to fetch the checkpoint in the response
-             * CopyState to bring themselves up to date.
-             */
-            addToCopyStateMap(checkpoint, copyState);
-            return copyState;
+    @Override
+    protected void doStart() {
+        final ClusterService clusterService = indicesService.clusterService();
+        if (DiscoveryNode.isDataNode(clusterService.getSettings())) {
+            clusterService.addListener(this);
         }
     }
 
-    /**
-     * Adds the input {@link CopyState} object to {@link #copyStateMap}.
-     * The key is the CopyState's {@link ReplicationCheckpoint} object.
-     */
-    private void addToCopyStateMap(ReplicationCheckpoint checkpoint, CopyState copyState) {
-        copyStateMap.putIfAbsent(checkpoint, copyState);
+    @Override
+    protected void doStop() {
+        final ClusterService clusterService = indicesService.clusterService();
+        if (DiscoveryNode.isDataNode(clusterService.getSettings())) {
+            indicesService.clusterService().removeListener(this);
+        }
     }
 
-    /**
-     * Given a {@link ReplicationCheckpoint}, return the corresponding
-     * {@link CopyState} object, if any, from {@link #copyStateMap}.
-     */
-    private CopyState fetchFromCopyStateMap(ReplicationCheckpoint replicationCheckpoint) {
-        return copyStateMap.get(replicationCheckpoint);
+    @Override
+    protected void doClose() throws IOException {
+
     }
 
-    /**
-     * Checks if the {@link #copyStateMap} has the input {@link ReplicationCheckpoint}
-     * as a key by invoking {@link Map#containsKey(Object)}.
-     */
-    private boolean isInCopyStateMap(ReplicationCheckpoint replicationCheckpoint) {
-        return copyStateMap.containsKey(replicationCheckpoint);
+    @Override
+    public void beforeIndexShardClosed(ShardId shardId, @Nullable IndexShard indexShard, Settings indexSettings) {
+        if (indexShard != null) {
+            ongoingSegmentReplications.cancel(indexShard, "shard is closed");
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/indices/replication/common/CopyState.java
+++ b/server/src/main/java/org/opensearch/indices/replication/common/CopyState.java
@@ -33,14 +33,20 @@ import java.util.Set;
 public class CopyState extends AbstractRefCounted {
 
     private final GatedCloseable<SegmentInfos> segmentInfosRef;
+    /** ReplicationCheckpoint requested */
+    private final ReplicationCheckpoint requestedReplicationCheckpoint;
+    /** Actual ReplicationCheckpoint returned by the shard */
     private final ReplicationCheckpoint replicationCheckpoint;
     private final Store.MetadataSnapshot metadataSnapshot;
     private final HashSet<StoreFileMetadata> pendingDeleteFiles;
     private final byte[] infosBytes;
     private GatedCloseable<IndexCommit> commitRef;
+    private final IndexShard shard;
 
-    public CopyState(IndexShard shard) throws IOException {
+    public CopyState(ReplicationCheckpoint requestedReplicationCheckpoint, IndexShard shard) throws IOException {
         super("CopyState-" + shard.shardId());
+        this.requestedReplicationCheckpoint = requestedReplicationCheckpoint;
+        this.shard = shard;
         this.segmentInfosRef = shard.getSegmentInfosSnapshot();
         SegmentInfos segmentInfos = this.segmentInfosRef.get();
         this.metadataSnapshot = shard.store().getMetadata(segmentInfos);
@@ -99,5 +105,13 @@ public class CopyState extends AbstractRefCounted {
 
     public Set<StoreFileMetadata> getPendingDeleteFiles() {
         return pendingDeleteFiles;
+    }
+
+    public IndexShard getShard() {
+        return shard;
+    }
+
+    public ReplicationCheckpoint getRequestedReplicationCheckpoint() {
+        return requestedReplicationCheckpoint;
     }
 }

--- a/server/src/main/java/org/opensearch/indices/replication/common/SegmentReplicationTransportRequest.java
+++ b/server/src/main/java/org/opensearch/indices/replication/common/SegmentReplicationTransportRequest.java
@@ -46,4 +46,29 @@ public abstract class SegmentReplicationTransportRequest extends TransportReques
         out.writeString(this.targetAllocationId);
         targetNode.writeTo(out);
     }
+
+    public long getReplicationId() {
+        return replicationId;
+    }
+
+    public String getTargetAllocationId() {
+        return targetAllocationId;
+    }
+
+    public DiscoveryNode getTargetNode() {
+        return targetNode;
+    }
+
+    @Override
+    public String toString() {
+        return "SegmentReplicationTransportRequest{"
+            + "replicationId="
+            + replicationId
+            + ", targetAllocationId='"
+            + targetAllocationId
+            + '\''
+            + ", targetNode="
+            + targetNode
+            + '}';
+    }
 }

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.SetOnce;
 import org.opensearch.index.IndexingPressureService;
+import org.opensearch.indices.replication.SegmentReplicationSourceService;
 import org.opensearch.watcher.ResourceWatcherService;
 import org.opensearch.Assertions;
 import org.opensearch.Build;
@@ -932,6 +933,8 @@ public class Node implements Closeable {
                         .toInstance(new PeerRecoverySourceService(transportService, indicesService, recoverySettings));
                     b.bind(PeerRecoveryTargetService.class)
                         .toInstance(new PeerRecoveryTargetService(threadPool, transportService, recoverySettings, clusterService));
+                    b.bind(SegmentReplicationSourceService.class)
+                        .toInstance(new SegmentReplicationSourceService(indicesService, transportService, recoverySettings));
                 }
                 b.bind(HttpServerTransport.class).toInstance(httpServerTransport);
                 pluginComponents.stream().forEach(p -> b.bind((Class) p.getClass()).toInstance(p));

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.SetOnce;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.IndexingPressureService;
 import org.opensearch.indices.replication.SegmentReplicationSourceService;
 import org.opensearch.watcher.ResourceWatcherService;
@@ -220,6 +221,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
+import static org.opensearch.common.util.FeatureFlags.REPLICATION_TYPE;
 import static org.opensearch.index.ShardIndexingPressureSettings.SHARD_INDEXING_PRESSURE_ENABLED_ATTRIBUTE_KEY;
 
 /**
@@ -933,8 +935,10 @@ public class Node implements Closeable {
                         .toInstance(new PeerRecoverySourceService(transportService, indicesService, recoverySettings));
                     b.bind(PeerRecoveryTargetService.class)
                         .toInstance(new PeerRecoveryTargetService(threadPool, transportService, recoverySettings, clusterService));
-                    b.bind(SegmentReplicationSourceService.class)
-                        .toInstance(new SegmentReplicationSourceService(indicesService, transportService, recoverySettings));
+                    if (FeatureFlags.isEnabled(REPLICATION_TYPE)) {
+                        b.bind(SegmentReplicationSourceService.class)
+                            .toInstance(new SegmentReplicationSourceService(indicesService, transportService, recoverySettings));
+                    }
                 }
                 b.bind(HttpServerTransport.class).toInstance(httpServerTransport);
                 pluginComponents.stream().forEach(p -> b.bind((Class) p.getClass()).toInstance(p));

--- a/server/src/test/java/org/opensearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -573,6 +573,7 @@ public class RecoverySourceHandlerTests extends OpenSearchTestCase {
         latch.await();
         assertThat(sendFilesError.get(), instanceOf(IOException.class));
         assertNotNull(ExceptionsHelper.unwrapCorruption(sendFilesError.get()));
+        failedEngine.get();
         assertTrue(failedEngine.get());
         // ensure all chunk requests have been completed; otherwise some files on the target are left open.
         IOUtils.close(() -> terminate(threadPool), () -> threadPool = null);

--- a/server/src/test/java/org/opensearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -94,6 +94,7 @@ import org.opensearch.index.shard.ShardId;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.index.translog.Translog;
+import org.opensearch.indices.RunUnderPrimaryPermit;
 import org.opensearch.indices.replication.common.ReplicationLuceneIndex;
 import org.opensearch.test.CorruptionUtils;
 import org.opensearch.test.DummyShardLock;
@@ -544,8 +545,10 @@ public class RecoverySourceHandlerTests extends OpenSearchTestCase {
                 });
             }
         };
+        IndexShard mockShard = mock(IndexShard.class);
+        when(mockShard.shardId()).thenReturn(new ShardId("testIndex", "testUUID", 0));
         RecoverySourceHandler handler = new RecoverySourceHandler(
-            null,
+            mockShard,
             new AsyncRecoveryTarget(target, recoveryExecutor),
             threadPool,
             request,
@@ -747,7 +750,7 @@ public class RecoverySourceHandlerTests extends OpenSearchTestCase {
         Thread cancelingThread = new Thread(() -> cancellableThreads.cancel("test"));
         cancelingThread.start();
         try {
-            RecoverySourceHandler.runUnderPrimaryPermit(() -> {}, "test", shard, cancellableThreads, logger);
+            RunUnderPrimaryPermit.run(() -> {}, "test", shard, cancellableThreads, logger);
         } catch (CancellableThreads.ExecutionCancelledException e) {
             // expected.
         }

--- a/server/src/test/java/org/opensearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -620,8 +620,10 @@ public class RecoverySourceHandlerTests extends OpenSearchTestCase {
                 }
             }
         };
+        IndexShard mockShard = mock(IndexShard.class);
+        when(mockShard.shardId()).thenReturn(new ShardId("testIndex", "testUUID", 0));
         RecoverySourceHandler handler = new RecoverySourceHandler(
-            null,
+            mockShard,
             new AsyncRecoveryTarget(target, recoveryExecutor),
             threadPool,
             request,

--- a/server/src/test/java/org/opensearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -547,6 +547,11 @@ public class RecoverySourceHandlerTests extends OpenSearchTestCase {
         };
         IndexShard mockShard = mock(IndexShard.class);
         when(mockShard.shardId()).thenReturn(new ShardId("testIndex", "testUUID", 0));
+        doAnswer(invocation -> {
+            assertFalse(failedEngine.get());
+            failedEngine.set(true);
+            return null;
+        }).when(mockShard).failShard(any(), any());
         RecoverySourceHandler handler = new RecoverySourceHandler(
             mockShard,
             new AsyncRecoveryTarget(target, recoveryExecutor),
@@ -555,13 +560,7 @@ public class RecoverySourceHandlerTests extends OpenSearchTestCase {
             Math.toIntExact(recoverySettings.getChunkSize().getBytes()),
             between(1, 8),
             between(1, 8)
-        ) {
-            @Override
-            protected void failEngine(IOException cause) {
-                assertFalse(failedEngine.get());
-                failedEngine.set(true);
-            }
-        };
+        );
         SetOnce<Exception> sendFilesError = new SetOnce<>();
         CountDownLatch latch = new CountDownLatch(1);
         handler.sendFiles(
@@ -623,6 +622,11 @@ public class RecoverySourceHandlerTests extends OpenSearchTestCase {
         };
         IndexShard mockShard = mock(IndexShard.class);
         when(mockShard.shardId()).thenReturn(new ShardId("testIndex", "testUUID", 0));
+        doAnswer(invocation -> {
+            assertFalse(failedEngine.get());
+            failedEngine.set(true);
+            return null;
+        }).when(mockShard).failShard(any(), any());
         RecoverySourceHandler handler = new RecoverySourceHandler(
             mockShard,
             new AsyncRecoveryTarget(target, recoveryExecutor),
@@ -631,13 +635,7 @@ public class RecoverySourceHandlerTests extends OpenSearchTestCase {
             Math.toIntExact(recoverySettings.getChunkSize().getBytes()),
             between(1, 10),
             between(1, 4)
-        ) {
-            @Override
-            protected void failEngine(IOException cause) {
-                assertFalse(failedEngine.get());
-                failedEngine.set(true);
-            }
-        };
+        );
         PlainActionFuture<Void> sendFilesFuture = new PlainActionFuture<>();
         handler.sendFiles(store, metas.toArray(new StoreFileMetadata[0]), () -> 0, sendFilesFuture);
         Exception ex = expectThrows(Exception.class, sendFilesFuture::actionGet);

--- a/server/src/test/java/org/opensearch/indices/replication/OngoingSegmentReplicationsTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/OngoingSegmentReplicationsTests.java
@@ -1,0 +1,217 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication;
+
+import org.junit.Assert;
+import org.opensearch.action.ActionListener;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexService;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.IndexShardTestCase;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.index.store.StoreFileMetadata;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.recovery.RecoverySettings;
+import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
+import org.opensearch.indices.replication.common.CopyState;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class OngoingSegmentReplicationsTests extends IndexShardTestCase {
+
+    private final IndicesService mockIndicesService = mock(IndicesService.class);
+    private ReplicationCheckpoint testCheckpoint;
+    private DiscoveryNode primaryDiscoveryNode;
+    private DiscoveryNode replicaDiscoveryNode;
+    private IndexShard primary;
+    private IndexShard replica;
+
+    private GetSegmentFilesRequest getSegmentFilesRequest;
+
+    final Settings settings = Settings.builder().put("node.name", SegmentReplicationTargetServiceTests.class.getSimpleName()).build();
+    final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+    final RecoverySettings recoverySettings = new RecoverySettings(settings, clusterSettings);
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        primary = newStartedShard(true);
+        replica = newShard(primary.shardId(), false);
+        recoverReplica(replica, primary, true);
+        replicaDiscoveryNode = replica.recoveryState().getTargetNode();
+        primaryDiscoveryNode = replica.recoveryState().getSourceNode();
+
+        ShardId testShardId = primary.shardId();
+
+        // This mirrors the creation of the ReplicationCheckpoint inside CopyState
+        testCheckpoint = new ReplicationCheckpoint(
+            testShardId,
+            primary.getOperationPrimaryTerm(),
+            0L,
+            primary.getProcessedLocalCheckpoint(),
+            0L
+        );
+        IndexService mockIndexService = mock(IndexService.class);
+        when(mockIndicesService.indexService(testShardId.getIndex())).thenReturn(mockIndexService);
+        when(mockIndexService.getShard(testShardId.id())).thenReturn(primary);
+
+        TransportService transportService = mock(TransportService.class);
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        closeShards(primary, replica);
+        super.tearDown();
+    }
+
+    public void testPrepareAndSendSegments() throws IOException {
+        OngoingSegmentReplications replications = spy(new OngoingSegmentReplications(mockIndicesService, recoverySettings));
+        final CheckpointInfoRequest request = new CheckpointInfoRequest(
+            1L,
+            replica.routingEntry().allocationId().getId(),
+            replicaDiscoveryNode,
+            testCheckpoint
+        );
+        final RemoteSegmentFileChunkWriter segmentSegmentFileChunkWriter = mock(RemoteSegmentFileChunkWriter.class);
+        final CopyState copyState = replications.prepareForReplication(request, segmentSegmentFileChunkWriter);
+        assertTrue(replications.isInCopyStateMap(request.getCheckpoint()));
+        assertEquals(1, replications.size());
+        assertEquals(1, copyState.refCount());
+
+        doAnswer((invocation -> {
+            final ActionListener<Void> listener = invocation.getArgument(5);
+            listener.onResponse(null);
+            return null;
+        })).when(segmentSegmentFileChunkWriter).writeFileChunk(any(), anyLong(), any(), anyBoolean(), anyInt(), any());
+
+        getSegmentFilesRequest = new GetSegmentFilesRequest(
+            1L,
+            replica.routingEntry().allocationId().getId(),
+            replicaDiscoveryNode,
+            new ArrayList<>(copyState.getMetadataSnapshot().asMap().values()),
+            testCheckpoint
+        );
+
+        final Collection<StoreFileMetadata> expectedFiles = List.copyOf(primary.store().getMetadata().asMap().values());
+        replications.startSegmentCopy(getSegmentFilesRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(GetSegmentFilesResponse getSegmentFilesResponse) {
+                assertEquals(1, getSegmentFilesResponse.files.size());
+                assertEquals(1, expectedFiles.size());
+                assertTrue(expectedFiles.stream().findFirst().get().isSame(getSegmentFilesResponse.files.get(0)));
+                assertEquals(0, copyState.refCount());
+                assertFalse(replications.isInCopyStateMap(request.getCheckpoint()));
+                assertEquals(0, replications.size());
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.error("Unexpected failure", e);
+                Assert.fail();
+            }
+        });
+    }
+
+    public void testCancelReplication() throws IOException {
+        OngoingSegmentReplications replications = new OngoingSegmentReplications(mockIndicesService, recoverySettings);
+        final CheckpointInfoRequest request = new CheckpointInfoRequest(
+            1L,
+            replica.routingEntry().allocationId().getId(),
+            primaryDiscoveryNode,
+            testCheckpoint
+        );
+        final RemoteSegmentFileChunkWriter segmentSegmentFileChunkWriter = mock(RemoteSegmentFileChunkWriter.class);
+        final CopyState copyState = replications.prepareForReplication(request, segmentSegmentFileChunkWriter);
+        assertEquals(1, replications.size());
+        assertEquals(1, replications.cachedCopyStateSize());
+
+        replications.cancelReplication(primaryDiscoveryNode);
+        assertEquals(0, copyState.refCount());
+        assertEquals(0, replications.size());
+        assertEquals(0, replications.cachedCopyStateSize());
+    }
+
+    public void testMultipleReplicasUseSameCheckpoint() throws IOException {
+        OngoingSegmentReplications replications = new OngoingSegmentReplications(mockIndicesService, recoverySettings);
+        final CheckpointInfoRequest request = new CheckpointInfoRequest(
+            1L,
+            replica.routingEntry().allocationId().getId(),
+            primaryDiscoveryNode,
+            testCheckpoint
+        );
+        final RemoteSegmentFileChunkWriter segmentSegmentFileChunkWriter = mock(RemoteSegmentFileChunkWriter.class);
+
+        final CopyState copyState = replications.prepareForReplication(request, segmentSegmentFileChunkWriter);
+        assertEquals(1, copyState.refCount());
+
+        final CheckpointInfoRequest secondRequest = new CheckpointInfoRequest(
+            1L,
+            replica.routingEntry().allocationId().getId(),
+            replicaDiscoveryNode,
+            testCheckpoint
+        );
+        replications.prepareForReplication(secondRequest, segmentSegmentFileChunkWriter);
+
+        assertEquals(2, copyState.refCount());
+        assertEquals(2, replications.size());
+        assertEquals(1, replications.cachedCopyStateSize());
+
+        replications.cancelReplication(primaryDiscoveryNode);
+        replications.cancelReplication(replicaDiscoveryNode);
+        assertEquals(0, copyState.refCount());
+        assertEquals(0, replications.size());
+        assertEquals(0, replications.cachedCopyStateSize());
+    }
+
+    public void testStartCopyWithoutPrepareStep() {
+        OngoingSegmentReplications replications = new OngoingSegmentReplications(mockIndicesService, recoverySettings);
+        final ActionListener<GetSegmentFilesResponse> listener = spy(new ActionListener<>() {
+            @Override
+            public void onResponse(GetSegmentFilesResponse getSegmentFilesResponse) {
+                assertTrue(getSegmentFilesResponse.files.isEmpty());
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                Assert.fail();
+            }
+        });
+
+        getSegmentFilesRequest = new GetSegmentFilesRequest(
+            1L,
+            replica.routingEntry().allocationId().getId(),
+            replicaDiscoveryNode,
+            Collections.emptyList(),
+            testCheckpoint
+        );
+
+        replications.startSegmentCopy(getSegmentFilesRequest, listener);
+        verify(listener, times(1)).onResponse(any());
+    }
+
+}

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentFileTransferHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentFileTransferHandlerTests.java
@@ -100,7 +100,7 @@ public class SegmentFileTransferHandlerTests extends IndexShardTestCase {
             fileChunkSizeInBytes,
             maxConcurrentFileChunks
         );
-        final MultiChunkTransfer<StoreFileMetadata, SegmentFileTransferHandler.FileChunk> transfer = handler.sendFiles(
+        final MultiChunkTransfer<StoreFileMetadata, SegmentFileTransferHandler.FileChunk> transfer = handler.createTransfer(
             shard.store(),
             filesToSend,
             translogOps,
@@ -139,7 +139,7 @@ public class SegmentFileTransferHandlerTests extends IndexShardTestCase {
             maxConcurrentFileChunks
         );
 
-        final MultiChunkTransfer<StoreFileMetadata, SegmentFileTransferHandler.FileChunk> transfer = handler.sendFiles(
+        final MultiChunkTransfer<StoreFileMetadata, SegmentFileTransferHandler.FileChunk> transfer = handler.createTransfer(
             shard.store(),
             filesToSend,
             translogOps,
@@ -190,7 +190,7 @@ public class SegmentFileTransferHandlerTests extends IndexShardTestCase {
             maxConcurrentFileChunks
         );
 
-        final MultiChunkTransfer<StoreFileMetadata, SegmentFileTransferHandler.FileChunk> transfer = handler.sendFiles(
+        final MultiChunkTransfer<StoreFileMetadata, SegmentFileTransferHandler.FileChunk> transfer = handler.createTransfer(
             shard.store(),
             filesToSend,
             translogOps,

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentFileTransferHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentFileTransferHandlerTests.java
@@ -1,0 +1,251 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication;
+
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.IndexFileNames;
+import org.junit.Assert;
+import org.opensearch.Version;
+import org.opensearch.action.ActionListener;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.util.CancellableThreads;
+import org.opensearch.core.internal.io.IOUtils;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.IndexShardTestCase;
+import org.opensearch.index.store.Store;
+import org.opensearch.index.store.StoreFileMetadata;
+import org.opensearch.indices.recovery.FileChunkWriter;
+import org.opensearch.indices.recovery.MultiChunkTransfer;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.IntSupplier;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static org.mockito.Mockito.*;
+
+public class SegmentFileTransferHandlerTests extends IndexShardTestCase {
+
+    private IndexShard shard;
+    private StoreFileMetadata[] filesToSend;
+    private final DiscoveryNode targetNode = new DiscoveryNode(
+        "foo",
+        buildNewFakeTransportAddress(),
+        emptyMap(),
+        emptySet(),
+        Version.CURRENT
+    );
+
+    final int fileChunkSizeInBytes = 5000;
+    final int maxConcurrentFileChunks = 1;
+    private CancellableThreads cancellableThreads;
+    final IntSupplier translogOps = () -> 0;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        cancellableThreads = new CancellableThreads();
+        shard = spy(newStartedShard(true));
+        filesToSend = getFilestoSend(shard);
+        // we should only have a Segments_N file at this point.
+        assertEquals(1, filesToSend.length);
+    }
+
+    private StoreFileMetadata[] getFilestoSend(IndexShard shard) throws IOException {
+        final Store.MetadataSnapshot metadata = shard.store().getMetadata();
+        return metadata.asMap().values().toArray(StoreFileMetadata[]::new);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        closeShards(shard);
+        super.tearDown();
+    }
+
+    public void testSendFiles_invokesChunkWriter() throws IOException, InterruptedException {
+        // use counDownLatch and countDown when our chunkWriter is invoked.
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        final FileChunkWriter chunkWriter = spy(new FileChunkWriter() {
+            @Override
+            public void writeFileChunk(
+                StoreFileMetadata fileMetadata,
+                long position,
+                BytesReference content,
+                boolean lastChunk,
+                int totalTranslogOps,
+                ActionListener<Void> listener
+            ) {
+                assertTrue(filesToSend[0].isSame(fileMetadata));
+                assertTrue(lastChunk);
+                countDownLatch.countDown();
+            }
+        });
+
+        SegmentFileTransferHandler handler = new SegmentFileTransferHandler(
+            shard,
+            targetNode,
+            chunkWriter,
+            logger,
+            shard.getThreadPool(),
+            cancellableThreads,
+            fileChunkSizeInBytes,
+            maxConcurrentFileChunks
+        );
+        final MultiChunkTransfer<StoreFileMetadata, SegmentFileTransferHandler.FileChunk> transfer = handler.sendFiles(
+            shard.store(),
+            filesToSend,
+            translogOps,
+            mock(ActionListener.class)
+        );
+
+        // start the transfer
+        transfer.start();
+        countDownLatch.await(5, TimeUnit.SECONDS);
+        verify(chunkWriter, times(1)).writeFileChunk(any(), anyLong(), any(), anyBoolean(), anyInt(), any());
+        IOUtils.close(transfer);
+    }
+
+    public void testSendFiles_cancelThreads_beforeStart() throws IOException, InterruptedException {
+        final FileChunkWriter chunkWriter = spy(new FileChunkWriter() {
+            @Override
+            public void writeFileChunk(
+                StoreFileMetadata fileMetadata,
+                long position,
+                BytesReference content,
+                boolean lastChunk,
+                int totalTranslogOps,
+                ActionListener<Void> listener
+            ) {
+                Assert.fail();
+            }
+        });
+        SegmentFileTransferHandler handler = new SegmentFileTransferHandler(
+            shard,
+            targetNode,
+            chunkWriter,
+            logger,
+            shard.getThreadPool(),
+            cancellableThreads,
+            fileChunkSizeInBytes,
+            maxConcurrentFileChunks
+        );
+
+        final MultiChunkTransfer<StoreFileMetadata, SegmentFileTransferHandler.FileChunk> transfer = handler.sendFiles(
+            shard.store(),
+            filesToSend,
+            translogOps,
+            mock(ActionListener.class)
+        );
+
+        // start the transfer
+        cancellableThreads.cancel("test");
+        transfer.start();
+        verifyNoInteractions(chunkWriter);
+        IOUtils.close(transfer);
+    }
+
+    public void testSendFiles_cancelThreads_afterStart() throws IOException, InterruptedException {
+        // index a doc a flush so we have more than 1 file to send.
+        indexDoc(shard, "_doc", "test");
+        flushShard(shard, true);
+        filesToSend = getFilestoSend(shard);
+
+        // we should have 4 files to send now -
+        // [_0.cfe, _0.si, _0.cfs, segments_3]
+        assertEquals(4, filesToSend.length);
+
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        FileChunkWriter chunkWriter = spy(new FileChunkWriter() {
+            @Override
+            public void writeFileChunk(
+                StoreFileMetadata fileMetadata,
+                long position,
+                BytesReference content,
+                boolean lastChunk,
+                int totalTranslogOps,
+                ActionListener<Void> listener
+            ) {
+                // cancel the threads at this point, we'll ensure this is not invoked more than once.
+                cancellableThreads.cancel("test");
+                listener.onResponse(null);
+            }
+        });
+        SegmentFileTransferHandler handler = new SegmentFileTransferHandler(
+            shard,
+            targetNode,
+            chunkWriter,
+            logger,
+            shard.getThreadPool(),
+            cancellableThreads,
+            fileChunkSizeInBytes,
+            maxConcurrentFileChunks
+        );
+
+        final MultiChunkTransfer<StoreFileMetadata, SegmentFileTransferHandler.FileChunk> transfer = handler.sendFiles(
+            shard.store(),
+            filesToSend,
+            translogOps,
+            new ActionListener<Void>() {
+                @Override
+                public void onResponse(Void unused) {
+                    // do nothing here, we will just resolve in test.
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    assertEquals(CancellableThreads.ExecutionCancelledException.class, e.getClass());
+                    countDownLatch.countDown();
+                }
+            }
+        );
+
+        // start the transfer
+        transfer.start();
+        countDownLatch.await(30, TimeUnit.SECONDS);
+        verify(chunkWriter, times(1)).writeFileChunk(any(), anyLong(), any(), anyBoolean(), anyInt(), any());
+        IOUtils.close(transfer);
+    }
+
+    public void testSendFiles_CorruptIndexException() throws Exception {
+        final CancellableThreads cancellableThreads = new CancellableThreads();
+        SegmentFileTransferHandler handler = new SegmentFileTransferHandler(
+            shard,
+            targetNode,
+            mock(FileChunkWriter.class),
+            logger,
+            shard.getThreadPool(),
+            cancellableThreads,
+            fileChunkSizeInBytes,
+            maxConcurrentFileChunks
+        );
+        final StoreFileMetadata SEGMENTS_FILE = new StoreFileMetadata(
+            IndexFileNames.SEGMENTS,
+            1L,
+            "0",
+            org.apache.lucene.util.Version.LATEST
+        );
+
+        doNothing().when(shard).failShard(anyString(), any());
+        assertThrows(
+            CorruptIndexException.class,
+            () -> {
+                handler.handleErrorOnSendFiles(
+                    shard.store(),
+                    new CorruptIndexException("test", "test"),
+                    new StoreFileMetadata[] { SEGMENTS_FILE }
+                );
+            }
+        );
+
+        verify(shard, times(1)).failShard(any(), any());
+    }
+}

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceHandlerTests.java
@@ -1,0 +1,167 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.mockito.Mockito;
+import org.opensearch.OpenSearchException;
+import org.opensearch.Version;
+import org.opensearch.action.ActionListener;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.IndexShardTestCase;
+import org.opensearch.index.store.StoreFileMetadata;
+import org.opensearch.indices.recovery.FileChunkWriter;
+import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
+import org.opensearch.indices.replication.common.CopyState;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+
+public class SegmentReplicationSourceHandlerTests extends IndexShardTestCase {
+
+    private final DiscoveryNode localNode = new DiscoveryNode("local", buildNewFakeTransportAddress(), Version.CURRENT);
+    private DiscoveryNode replicaDiscoveryNode;
+    private IndexShard primary;
+    private IndexShard replica;
+
+    private FileChunkWriter chunkWriter;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        primary = newStartedShard(true);
+        replica = newShard(primary.shardId(), false);
+        recoverReplica(replica, primary, true);
+        replicaDiscoveryNode = replica.recoveryState().getTargetNode();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        closeShards(primary, replica);
+        super.tearDown();
+    }
+
+    public void testSendFiles() throws IOException {
+        chunkWriter = (fileMetadata, position, content, lastChunk, totalTranslogOps, listener) -> listener.onResponse(null);
+
+        final ReplicationCheckpoint latestReplicationCheckpoint = primary.getLatestReplicationCheckpoint();
+        final CopyState copyState = new CopyState(latestReplicationCheckpoint, primary);
+        SegmentReplicationSourceHandler handler = new SegmentReplicationSourceHandler(
+            localNode,
+            chunkWriter,
+            threadPool,
+            copyState,
+            5000,
+            1
+        );
+
+        final List<StoreFileMetadata> expectedFiles = List.copyOf(copyState.getMetadataSnapshot().asMap().values());
+
+        final GetSegmentFilesRequest getSegmentFilesRequest = new GetSegmentFilesRequest(
+            1L,
+            replica.routingEntry().allocationId().getId(),
+            replicaDiscoveryNode,
+            expectedFiles,
+            latestReplicationCheckpoint
+        );
+
+        handler.sendFiles(getSegmentFilesRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(GetSegmentFilesResponse getSegmentFilesResponse) {
+                MatcherAssert.assertThat(getSegmentFilesResponse.files, Matchers.containsInAnyOrder(expectedFiles.toArray()));
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                Assert.fail();
+            }
+        });
+    }
+
+    public void testSendFiles_emptyRequest() throws IOException {
+        chunkWriter = mock(FileChunkWriter.class);
+
+        final ReplicationCheckpoint latestReplicationCheckpoint = primary.getLatestReplicationCheckpoint();
+        final CopyState copyState = new CopyState(latestReplicationCheckpoint, primary);
+        SegmentReplicationSourceHandler handler = new SegmentReplicationSourceHandler(
+            localNode,
+            chunkWriter,
+            threadPool,
+            copyState,
+            5000,
+            1
+        );
+
+        final GetSegmentFilesRequest getSegmentFilesRequest = new GetSegmentFilesRequest(
+            1L,
+            replica.routingEntry().allocationId().getId(),
+            replicaDiscoveryNode,
+            Collections.emptyList(),
+            latestReplicationCheckpoint
+        );
+
+        handler.sendFiles(getSegmentFilesRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(GetSegmentFilesResponse getSegmentFilesResponse) {
+                assertTrue(getSegmentFilesResponse.files.isEmpty());
+                Mockito.verifyNoInteractions(chunkWriter);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                Assert.fail();
+            }
+        });
+    }
+
+    public void testSendFileFails() throws IOException {
+        chunkWriter = (fileMetadata, position, content, lastChunk, totalTranslogOps, listener) -> listener.onFailure(
+            new OpenSearchException("Test")
+        );
+
+        final ReplicationCheckpoint latestReplicationCheckpoint = primary.getLatestReplicationCheckpoint();
+        final CopyState copyState = new CopyState(latestReplicationCheckpoint, primary);
+        SegmentReplicationSourceHandler handler = new SegmentReplicationSourceHandler(
+            localNode,
+            chunkWriter,
+            threadPool,
+            copyState,
+            5000,
+            1
+        );
+
+        final List<StoreFileMetadata> expectedFiles = List.copyOf(copyState.getMetadataSnapshot().asMap().values());
+
+        final GetSegmentFilesRequest getSegmentFilesRequest = new GetSegmentFilesRequest(
+            1L,
+            replica.routingEntry().allocationId().getId(),
+            replicaDiscoveryNode,
+            expectedFiles,
+            latestReplicationCheckpoint
+        );
+
+        handler.sendFiles(getSegmentFilesRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(GetSegmentFilesResponse getSegmentFilesResponse) {
+                Assert.fail();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                assertEquals(e.getClass(), OpenSearchException.class);
+            }
+        });
+    }
+}

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceServiceTests.java
@@ -9,13 +9,16 @@
 package org.opensearch.indices.replication;
 
 import org.opensearch.Version;
+import org.opensearch.action.ActionListener;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
 import org.opensearch.indices.replication.common.CopyStateTests;
 import org.opensearch.test.OpenSearchTestCase;
@@ -30,30 +33,23 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class SegmentReplicationSourceServiceTests extends OpenSearchTestCase {
 
-    private ShardId testShardId;
     private ReplicationCheckpoint testCheckpoint;
-    private IndicesService mockIndicesService;
-    private IndexService mockIndexService;
-    private IndexShard mockIndexShard;
     private TestThreadPool testThreadPool;
-    private CapturingTransport transport;
     private TransportService transportService;
     private DiscoveryNode localNode;
-    private SegmentReplicationSourceService segmentReplicationSourceService;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
         // setup mocks
-        mockIndexShard = CopyStateTests.createMockIndexShard();
-        testShardId = mockIndexShard.shardId();
-        mockIndicesService = mock(IndicesService.class);
-        mockIndexService = mock(IndexService.class);
+        IndexShard mockIndexShard = CopyStateTests.createMockIndexShard();
+        ShardId testShardId = mockIndexShard.shardId();
+        IndicesService mockIndicesService = mock(IndicesService.class);
+        IndexService mockIndexService = mock(IndexService.class);
         when(mockIndicesService.indexService(testShardId.getIndex())).thenReturn(mockIndexService);
         when(mockIndexService.getShard(testShardId.id())).thenReturn(mockIndexShard);
 
@@ -66,7 +62,7 @@ public class SegmentReplicationSourceServiceTests extends OpenSearchTestCase {
             0L
         );
         testThreadPool = new TestThreadPool("test", Settings.EMPTY);
-        transport = new CapturingTransport();
+        CapturingTransport transport = new CapturingTransport();
         localNode = new DiscoveryNode("local", buildNewFakeTransportAddress(), Version.CURRENT);
         transportService = transport.createTransportService(
             Settings.EMPTY,
@@ -78,7 +74,16 @@ public class SegmentReplicationSourceServiceTests extends OpenSearchTestCase {
         );
         transportService.start();
         transportService.acceptIncomingRequests();
-        segmentReplicationSourceService = new SegmentReplicationSourceService(transportService, mockIndicesService);
+
+        final Settings settings = Settings.builder().put("node.name", SegmentReplicationTargetServiceTests.class.getSimpleName()).build();
+        final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        final RecoverySettings recoverySettings = new RecoverySettings(settings, clusterSettings);
+
+        SegmentReplicationSourceService segmentReplicationSourceService = new SegmentReplicationSourceService(
+            mockIndicesService,
+            transportService,
+            recoverySettings
+        );
     }
 
     @Override
@@ -88,7 +93,7 @@ public class SegmentReplicationSourceServiceTests extends OpenSearchTestCase {
         super.tearDown();
     }
 
-    public void testGetSegmentFiles_EmptyResponse() {
+    public void testGetSegmentFiles() {
         final GetSegmentFilesRequest request = new GetSegmentFilesRequest(
             1,
             "allocationId",
@@ -96,35 +101,38 @@ public class SegmentReplicationSourceServiceTests extends OpenSearchTestCase {
             Collections.emptyList(),
             testCheckpoint
         );
-        transportService.sendRequest(
-            localNode,
-            SegmentReplicationSourceService.Actions.GET_SEGMENT_FILES,
-            request,
-            new TransportResponseHandler<GetSegmentFilesResponse>() {
-                @Override
-                public void handleResponse(GetSegmentFilesResponse response) {
-                    assertEquals(0, response.files.size());
-                }
-
-                @Override
-                public void handleException(TransportException e) {
-                    fail("unexpected exception: " + e);
-                }
-
-                @Override
-                public String executor() {
-                    return ThreadPool.Names.SAME;
-                }
-
-                @Override
-                public GetSegmentFilesResponse read(StreamInput in) throws IOException {
-                    return new GetSegmentFilesResponse(in);
-                }
+        executeGetSegmentFiles(request, new ActionListener<>() {
+            @Override
+            public void onResponse(GetSegmentFilesResponse response) {
+                assertEquals(0, response.files.size());
             }
-        );
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected exception: " + e);
+            }
+        });
     }
 
     public void testCheckpointInfo() {
+        executeGetCheckpointInfo(new ActionListener<>() {
+            @Override
+            public void onResponse(CheckpointInfoResponse response) {
+                assertEquals(testCheckpoint, response.getCheckpoint());
+                assertNotNull(response.getInfosBytes());
+                // CopyStateTests sets up one pending delete file and one committed segments file
+                assertEquals(1, response.getPendingDeleteFiles().size());
+                assertEquals(1, response.getSnapshot().size());
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected exception: " + e);
+            }
+        });
+    }
+
+    private void executeGetCheckpointInfo(ActionListener<CheckpointInfoResponse> listener) {
         final CheckpointInfoRequest request = new CheckpointInfoRequest(1L, "testAllocationId", localNode, testCheckpoint);
         transportService.sendRequest(
             localNode,
@@ -133,16 +141,12 @@ public class SegmentReplicationSourceServiceTests extends OpenSearchTestCase {
             new TransportResponseHandler<CheckpointInfoResponse>() {
                 @Override
                 public void handleResponse(CheckpointInfoResponse response) {
-                    assertEquals(testCheckpoint, response.getCheckpoint());
-                    assertNotNull(response.getInfosBytes());
-                    // CopyStateTests sets up one pending delete file and one committed segments file
-                    assertEquals(1, response.getPendingDeleteFiles().size());
-                    assertEquals(1, response.getSnapshot().size());
+                    listener.onResponse(response);
                 }
 
                 @Override
                 public void handleException(TransportException e) {
-                    fail("unexpected exception: " + e);
+                    listener.onFailure(e);
                 }
 
                 @Override
@@ -158,4 +162,32 @@ public class SegmentReplicationSourceServiceTests extends OpenSearchTestCase {
         );
     }
 
+    private void executeGetSegmentFiles(GetSegmentFilesRequest request, ActionListener<GetSegmentFilesResponse> listener) {
+        transportService.sendRequest(
+            localNode,
+            SegmentReplicationSourceService.Actions.GET_SEGMENT_FILES,
+            request,
+            new TransportResponseHandler<GetSegmentFilesResponse>() {
+                @Override
+                public void handleResponse(GetSegmentFilesResponse response) {
+                    listener.onResponse(response);
+                }
+
+                @Override
+                public void handleException(TransportException e) {
+                    listener.onFailure(e);
+                }
+
+                @Override
+                public String executor() {
+                    return ThreadPool.Names.SAME;
+                }
+
+                @Override
+                public GetSegmentFilesResponse read(StreamInput in) throws IOException {
+                    return new GetSegmentFilesResponse(in);
+                }
+            }
+        );
+    }
 }

--- a/server/src/test/java/org/opensearch/indices/replication/common/CopyStateTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/common/CopyStateTests.java
@@ -47,7 +47,15 @@ public class CopyStateTests extends IndexShardTestCase {
     );
 
     public void testCopyStateCreation() throws IOException {
-        CopyState copyState = new CopyState(createMockIndexShard());
+        final IndexShard mockIndexShard = createMockIndexShard();
+        ReplicationCheckpoint testCheckpoint = new ReplicationCheckpoint(
+            mockIndexShard.shardId(),
+            mockIndexShard.getOperationPrimaryTerm(),
+            0L,
+            mockIndexShard.getProcessedLocalCheckpoint(),
+            0L
+        );
+        CopyState copyState = new CopyState(testCheckpoint, mockIndexShard);
         ReplicationCheckpoint checkpoint = copyState.getCheckpoint();
         assertEquals(TEST_SHARD_ID, checkpoint.getShardId());
         // version was never set so this should be zero


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
This change adds the required components to SegmentReplicationSourceService (used on primary shards to send segments to replicas) to initiate copy and react to lifecycle events.
Along with new components it refactors common file copy code from RecoverySourceHandler into reusable pieces.

Refactoring:
- Extracts RunUnderPrimaryPermit from RecoverySourceHandler to a top lvl class.
- Extracts sendFiles method from RecoverySourceHandler to another class, SegmentFileTransferHandler that is used by both RecoverySourceHandler and the segrep equivalent, SegmentReplicationSourceHandler.
- Extracts writeFileChunk into a separate interface, FileChunkWriter, that is extended by RecoveryTargetHandler.
- Moves transport layer handling of file chunks from RemoteRecoveryTargetHandler into an implementation of FileChunkWriter, RemoteSegmentFileChunkWriter.
- Move handling of copystate cache in SegmentReplicationSourceService to new component `OngoingSegmentReplications`.

New components:
`OngoingSegmentReplications` - Manages creating required handlers and copystate for performing copy events.
`SegmentReplicationSourceHandler ` Handler that orchestrates the copy, uses a FileChunkWriter to send files.
 
### Issues Resolved
closes #3322
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
