### PR TITLE
Revert "[Remove] MainResponse version override cluster setting (#3031) (#3032)"

### DIFF
--- a/client/rest-high-level/src/test/java/org/opensearch/client/PingAndInfoIT.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/PingAndInfoIT.java
@@ -33,6 +33,7 @@
 package org.opensearch.client;
 
 import org.apache.http.client.methods.HttpGet;
+import org.opensearch.action.main.TransportMainAction;
 import org.opensearch.client.core.MainResponse;
 
 import java.io.IOException;
@@ -61,5 +62,26 @@ public class PingAndInfoIT extends OpenSearchRestHighLevelClientTestCase {
         assertEquals(versionMap.get("build_snapshot"), info.getVersion().isSnapshot());
         assertTrue(versionMap.get("number").toString().startsWith(info.getVersion().getNumber()));
         assertEquals(versionMap.get("lucene_version"), info.getVersion().getLuceneVersion());
+    }
+
+    public void testInfo_overrideResponseVersion() throws IOException {
+        Request overrideResponseVersionRequest = new Request("PUT", "/_cluster/settings");
+        overrideResponseVersionRequest.setOptions(expectWarnings(TransportMainAction.OVERRIDE_MAIN_RESPONSE_VERSION_DEPRECATION_MESSAGE));
+        overrideResponseVersionRequest.setJsonEntity("{\"persistent\":{\"compatibility\": {\"override_main_response_version\":true}}}");
+        client().performRequest(overrideResponseVersionRequest);
+
+        MainResponse info = highLevelClient().info(RequestOptions.DEFAULT);
+        assertEquals("7.10.2", info.getVersion().getNumber());
+
+        // Set back to default version.
+        Request resetResponseVersionRequest = new Request("PUT", "/_cluster/settings");
+        resetResponseVersionRequest.setJsonEntity("{\"persistent\":{\"compatibility\": {\"override_main_response_version\":null}}}");
+        client().performRequest(resetResponseVersionRequest);
+
+        Map<String, Object> infoAsMap = entityAsMap(adminClient().performRequest(new Request(HttpGet.METHOD_NAME, "/")));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> versionMap = (Map<String, Object>) infoAsMap.get("version");
+        info = highLevelClient().info(RequestOptions.DEFAULT);
+        assertTrue(versionMap.get("number").toString().startsWith(info.getVersion().getNumber()));
     }
 }

--- a/server/src/main/java/org/opensearch/action/main/TransportMainAction.java
+++ b/server/src/main/java/org/opensearch/action/main/TransportMainAction.java
@@ -33,6 +33,7 @@
 package org.opensearch.action.main;
 
 import org.opensearch.Build;
+import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
@@ -40,6 +41,8 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.logging.DeprecationLogger;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.node.Node;
 import org.opensearch.tasks.Task;
@@ -52,8 +55,23 @@ import org.opensearch.transport.TransportService;
  */
 public class TransportMainAction extends HandledTransportAction<MainRequest, MainResponse> {
 
+    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(TransportMainAction.class);
+
+    public static final String OVERRIDE_MAIN_RESPONSE_VERSION_KEY = "compatibility.override_main_response_version";
+
+    public static final Setting<Boolean> OVERRIDE_MAIN_RESPONSE_VERSION = Setting.boolSetting(
+        OVERRIDE_MAIN_RESPONSE_VERSION_KEY,
+        false,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    public static final String OVERRIDE_MAIN_RESPONSE_VERSION_DEPRECATION_MESSAGE = "overriding main response version"
+        + " number will be removed in a future version";
+
     private final String nodeName;
     private final ClusterService clusterService;
+    private volatile String responseVersion;
 
     @Inject
     public TransportMainAction(
@@ -65,13 +83,32 @@ public class TransportMainAction extends HandledTransportAction<MainRequest, Mai
         super(MainAction.NAME, transportService, actionFilters, MainRequest::new);
         this.nodeName = Node.NODE_NAME_SETTING.get(settings);
         this.clusterService = clusterService;
+        setResponseVersion(OVERRIDE_MAIN_RESPONSE_VERSION.get(settings));
+
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(OVERRIDE_MAIN_RESPONSE_VERSION, this::setResponseVersion);
+    }
+
+    private void setResponseVersion(boolean isResponseVersionOverrideEnabled) {
+        if (isResponseVersionOverrideEnabled) {
+            DEPRECATION_LOGGER.deprecate(OVERRIDE_MAIN_RESPONSE_VERSION.getKey(), OVERRIDE_MAIN_RESPONSE_VERSION_DEPRECATION_MESSAGE);
+            this.responseVersion = LegacyESVersion.V_7_10_2.toString();
+        } else {
+            this.responseVersion = Build.CURRENT.getQualifiedVersion();
+        }
     }
 
     @Override
     protected void doExecute(Task task, MainRequest request, ActionListener<MainResponse> listener) {
         ClusterState clusterState = clusterService.state();
         listener.onResponse(
-            new MainResponse(nodeName, Version.CURRENT, clusterState.getClusterName(), clusterState.metadata().clusterUUID(), Build.CURRENT)
+            new MainResponse(
+                nodeName,
+                Version.CURRENT,
+                clusterState.getClusterName(),
+                clusterState.metadata().clusterUUID(),
+                Build.CURRENT,
+                responseVersion
+            )
         );
     }
 }

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -32,6 +32,7 @@
 package org.opensearch.common.settings;
 
 import org.apache.logging.log4j.LogManager;
+import org.opensearch.action.main.TransportMainAction;
 import org.opensearch.cluster.routing.allocation.decider.NodeLoadAwareAllocationDecider;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexSettings;
@@ -553,6 +554,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 FsHealthService.REFRESH_INTERVAL_SETTING,
                 FsHealthService.SLOW_PATH_LOGGING_THRESHOLD_SETTING,
                 FsHealthService.HEALTHY_TIMEOUT_SETTING,
+                TransportMainAction.OVERRIDE_MAIN_RESPONSE_VERSION,
                 NodeLoadAwareAllocationDecider.CLUSTER_ROUTING_ALLOCATION_LOAD_AWARENESS_PROVISIONED_CAPACITY_SETTING,
                 NodeLoadAwareAllocationDecider.CLUSTER_ROUTING_ALLOCATION_LOAD_AWARENESS_SKEW_FACTOR_SETTING,
                 NodeLoadAwareAllocationDecider.CLUSTER_ROUTING_ALLOCATION_LOAD_AWARENESS_ALLOW_UNASSIGNED_PRIMARIES_SETTING,

--- a/server/src/test/java/org/opensearch/action/main/MainActionTests.java
+++ b/server/src/test/java/org/opensearch/action/main/MainActionTests.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.action.main;
 
+import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.cluster.ClusterName;
@@ -55,6 +56,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.action.main.TransportMainAction.OVERRIDE_MAIN_RESPONSE_VERSION_KEY;
 
 public class MainActionTests extends OpenSearchTestCase {
 
@@ -127,5 +129,46 @@ public class MainActionTests extends OpenSearchTestCase {
 
         assertNotNull(responseRef.get());
         verify(clusterService, times(1)).state();
+    }
+
+    public void testMainResponseVersionOverrideEnabledByConfigSetting() {
+        final ClusterName clusterName = new ClusterName("opensearch");
+        ClusterState state = ClusterState.builder(clusterName).blocks(mock(ClusterBlocks.class)).build();
+
+        final ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(state);
+        when(clusterService.getClusterSettings()).thenReturn(
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+
+        TransportService transportService = new TransportService(
+            Settings.EMPTY,
+            mock(Transport.class),
+            null,
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            x -> null,
+            null,
+            Collections.emptySet()
+        );
+
+        final Settings settings = Settings.builder().put("node.name", "my-node").put(OVERRIDE_MAIN_RESPONSE_VERSION_KEY, true).build();
+
+        TransportMainAction action = new TransportMainAction(settings, transportService, mock(ActionFilters.class), clusterService);
+        AtomicReference<MainResponse> responseRef = new AtomicReference<>();
+        action.doExecute(mock(Task.class), new MainRequest(), new ActionListener<MainResponse>() {
+            @Override
+            public void onResponse(MainResponse mainResponse) {
+                responseRef.set(mainResponse);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.error("unexpected error", e);
+            }
+        });
+
+        final MainResponse mainResponse = responseRef.get();
+        assertEquals(LegacyESVersion.V_7_10_2.toString(), mainResponse.getVersionNumber());
+        assertWarnings(TransportMainAction.OVERRIDE_MAIN_RESPONSE_VERSION_DEPRECATION_MESSAGE);
     }
 }

--- a/server/src/test/java/org/opensearch/action/main/MainResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/main/MainResponseTests.java
@@ -138,6 +138,22 @@ public class MainResponseTests extends AbstractSerializingTestCase<MainResponse>
         );
     }
 
+    public void toXContent_overrideMainResponseVersion() throws IOException {
+        String responseVersion = LegacyESVersion.V_7_10_2.toString();
+        MainResponse response = new MainResponse(
+            "nodeName",
+            Version.CURRENT,
+            new ClusterName("clusterName"),
+            randomAlphaOfLengthBetween(10, 20),
+            Build.CURRENT,
+            responseVersion
+        );
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertTrue(Strings.toString(builder).contains("\"number\":\"" + responseVersion + "\","));
+        assertFalse(Strings.toString(builder).contains("\"distribution\":\"" + Build.CURRENT.getDistribution() + "\","));
+    }
+
     @Override
     protected MainResponse mutateInstance(MainResponse mutateInstance) {
         String clusterUuid = mutateInstance.getClusterUuid();


### PR DESCRIPTION
This reverts commit 199fbb817c45346b40c98c23a7558aff05236920 which removed the `opensearch.http.override_main_response_version` cluster setting.

The setting was originally added so users of legacy clients would not have to upgrade their client to begin using OpenSearch 1.x. 
With 2.0 the REST API is further fragmented from legacy clients such that users are [forced to upgrade](https://github.com/opensearch-project/OpenSearch/issues/3023#issuecomment-1105681019) to the latest OpenSearch client. 
To reduce this friction OpenSearch is working on a [REST API Versioning](https://github.com/opensearch-project/OpenSearch/issues/3035) mechanism to support API compatibility with at least the legacy 7.x line; but this will not be ready until 2.2 at the earliest.

The immediate problem is that there is no OpenSearch version of Beats and Logstash and the upstream maintainers of these projects [have no plans to support OpenSearch](https://discuss.elastic.co/t/type-usage-in-libbeat-outputs-elasticsearch-client-causes-issue-on-opensearch-2-0-engine/306166/3).
This has already lead to [user pain regarding document type removal](https://github.com/opensearch-project/OpenSearch/issues/3484) in beats which is alleviated by [ignoring type removal in the bulk API](https://github.com/opensearch-project/OpenSearch/pull/3505) and temporarily [adding the docType endpoints back for certain REST APIs](https://github.com/opensearch-project/OpenSearch/pull/3524). 
It is also leading to [pain for users of different pipeline processor types in filebeat](https://github.com/opensearch-project/OpenSearch/issues/3395#issuecomment-1148492164) as these processors have [explicit version checks for compatibility only with Elasticsearch](https://github.com/elastic/beats/blob/7.12/filebeat/fileset/compatibility.go#L38).

To alleviate this pain, OpenSearch adds back the `opensearch.http.override_main_response_version` setting so users of Beats and logstash can continue to function by spoofing the OpenSearch cluster version to `7.10.2`.

