### PR TITLE
Remove version check for snapshot preserve causing issues with versio…

### DIFF
--- a/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
@@ -656,7 +656,7 @@ public abstract class OpenSearchRestTestCase extends OpenSearchTestCase {
                     // Since the snapshots are shared within the cluster, another parallel run may delete all
                     // snapshots in the repository.
                     // For now we hack to prevent deletion of snapshots prefixed with "force_preserve"
-                    if (Version.CURRENT.onOrBefore(Version.V_2_0_0) && name.startsWith("force_preserve")) {
+                    if (name.startsWith("force_preserve")) {
                         continue;
                     }
                     if (SnapshotState.valueOf((String) snapshotInfo.get("state")).completed() == false) {


### PR DESCRIPTION
…n upgrades

Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>

### Description
- As a part of #2901 we added the version check to limit `force_preserve` hack to a limited set of versions
- With minor version upgrades or patches, this check fails causing the tests to fail as in #3450 
- Removing the version check to prevent further version as the change is present only on the 2.x and 2.0 branches.
 
### Issues Resolved
- #3450 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
