### PR TITLE
Adding onNewCheckpoint to Start Replication on Replica Shard when Segment Replication is turned on

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -173,7 +173,7 @@ public abstract class Engine implements Closeable {
      * Return the latest active SegmentInfos from the engine.
      * @return {@link SegmentInfos}
      */
-    protected abstract SegmentInfos getLatestSegmentInfos();
+    public abstract SegmentInfos getLatestSegmentInfos();
 
     /**
      * In contrast to {@link #getLatestSegmentInfos()}, which returns a {@link SegmentInfos}

--- a/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
@@ -431,7 +431,7 @@ public class NRTReplicationEngine extends Engine {
     }
 
     @Override
-    protected SegmentInfos getLatestSegmentInfos() {
+    public SegmentInfos getLatestSegmentInfos() {
         return readerManager.getSegmentInfos();
     }
 

--- a/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
@@ -271,7 +271,7 @@ public class ReadOnlyEngine extends Engine {
     }
 
     @Override
-    protected SegmentInfos getLatestSegmentInfos() {
+    public SegmentInfos getLatestSegmentInfos() {
         return lastCommittedSegmentInfos;
     }
 

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoverySettings.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoverySettings.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.RateLimiter;
 import org.apache.lucene.store.RateLimiter.SimpleRateLimiter;
+import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
@@ -159,6 +160,7 @@ public class RecoverySettings {
 
     private volatile ByteSizeValue chunkSize = DEFAULT_CHUNK_SIZE;
 
+    @Inject
     public RecoverySettings(Settings settings, ClusterSettings clusterSettings) {
         this.retryDelayStateSync = INDICES_RECOVERY_RETRY_DELAY_STATE_SYNC_SETTING.get(settings);
         this.maxConcurrentFileChunks = INDICES_RECOVERY_MAX_CONCURRENT_FILE_CHUNKS_SETTING.get(settings);

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceFactory.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceFactory.java
@@ -11,6 +11,7 @@ package org.opensearch.indices.replication;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.indices.recovery.RecoverySettings;
@@ -27,6 +28,7 @@ public class SegmentReplicationSourceFactory {
     private RecoverySettings recoverySettings;
     private ClusterService clusterService;
 
+    @Inject
     public SegmentReplicationSourceFactory(
         TransportService transportService,
         RecoverySettings recoverySettings,

--- a/server/src/main/java/org/opensearch/indices/replication/checkpoint/ReplicationCheckpoint.java
+++ b/server/src/main/java/org/opensearch/indices/replication/checkpoint/ReplicationCheckpoint.java
@@ -115,7 +115,7 @@ public class ReplicationCheckpoint implements Writeable {
      * Checks if other is aheadof current replication point by comparing segmentInfosVersion. Returns true for null
      */
     public boolean isAheadOf(@Nullable ReplicationCheckpoint other) {
-        return other == null || segmentInfosVersion > other.getSegmentInfosVersion();
+        return other == null || segmentInfosVersion > other.getSegmentInfosVersion() || primaryTerm > other.getPrimaryTerm();
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/indices/replication/common/ReplicationCollection.java
+++ b/server/src/main/java/org/opensearch/indices/replication/common/ReplicationCollection.java
@@ -236,6 +236,16 @@ public class ReplicationCollection<T extends ReplicationTarget> {
     }
 
     /**
+     * check if a shard is currently replicating
+     *
+     * @param shardId      shardId for which to check if replicating
+     * @return true if shard is currently replicating
+     */
+    public boolean isShardReplicating(ShardId shardId) {
+        return onGoingTargetEvents.values().stream().anyMatch(t -> t.indexShard.shardId().equals(shardId));
+    }
+
+    /**
      * a reference to {@link ReplicationTarget}, which implements {@link AutoCloseable}. closing the reference
      * causes {@link ReplicationTarget#decRef()} to be called. This makes sure that the underlying resources
      * will not be freed until {@link ReplicationRef#close()} is called.

--- a/server/src/test/java/org/opensearch/indices/replication/checkpoint/PublishCheckpointActionTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/checkpoint/PublishCheckpointActionTests.java
@@ -20,15 +20,15 @@ import org.opensearch.core.internal.io.IOUtils;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.shard.IndexShard;
-import org.opensearch.index.shard.ShardId;
+import org.opensearch.index.shard.IndexShardTestCase;
 import org.opensearch.indices.IndicesService;
-import org.opensearch.indices.recovery.RecoverySettings;
-import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.indices.replication.SegmentReplicationTargetService;
 import org.opensearch.test.transport.CapturingTransport;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.*;
 import static org.opensearch.test.ClusterServiceUtils.createClusterService;
 
-public class PublishCheckpointActionTests extends OpenSearchTestCase {
+public class PublishCheckpointActionTests extends IndexShardTestCase {
 
     private ThreadPool threadPool;
     private CapturingTransport transport;
@@ -73,21 +73,16 @@ public class PublishCheckpointActionTests extends OpenSearchTestCase {
         super.tearDown();
     }
 
-    public void testPublishCheckpointActionOnPrimary() throws InterruptedException {
+    public void testPublishCheckpointActionOnPrimary() throws InterruptedException, IOException {
         final IndicesService indicesService = mock(IndicesService.class);
 
         final Index index = new Index("index", "uuid");
         final IndexService indexService = mock(IndexService.class);
         when(indicesService.indexServiceSafe(index)).thenReturn(indexService);
 
-        final int id = randomIntBetween(0, 4);
-        final IndexShard indexShard = mock(IndexShard.class);
-        when(indexService.getShard(id)).thenReturn(indexShard);
+        final IndexShard indexShard = newShard(true);
 
-        final ShardId shardId = new ShardId(index, id);
-        when(indexShard.shardId()).thenReturn(shardId);
-
-        final RecoverySettings recoverySettings = new RecoverySettings(Settings.EMPTY, clusterService.getClusterSettings());
+        final SegmentReplicationTargetService mockTargetService = mock(SegmentReplicationTargetService.class);
 
         final PublishCheckpointAction action = new PublishCheckpointAction(
             Settings.EMPTY,
@@ -96,7 +91,8 @@ public class PublishCheckpointActionTests extends OpenSearchTestCase {
             indicesService,
             threadPool,
             shardStateAction,
-            new ActionFilters(Collections.emptySet())
+            new ActionFilters(Collections.emptySet()),
+            mockTargetService
         );
 
         final ReplicationCheckpoint checkpoint = new ReplicationCheckpoint(indexShard.shardId(), 1111, 111, 11, 1);
@@ -107,24 +103,20 @@ public class PublishCheckpointActionTests extends OpenSearchTestCase {
             // we should forward the request containing the current publish checkpoint to the replica
             assertThat(result.replicaRequest(), sameInstance(request));
         }));
+        closeShards(indexShard);
 
     }
 
-    public void testPublishCheckpointActionOnReplica() {
+    public void testPublishCheckpointActionOnReplica() throws IOException {
         final IndicesService indicesService = mock(IndicesService.class);
 
         final Index index = new Index("index", "uuid");
         final IndexService indexService = mock(IndexService.class);
         when(indicesService.indexServiceSafe(index)).thenReturn(indexService);
 
-        final int id = randomIntBetween(0, 4);
-        final IndexShard indexShard = mock(IndexShard.class);
-        when(indexService.getShard(id)).thenReturn(indexShard);
+        final IndexShard indexShard = newShard(false);
 
-        final ShardId shardId = new ShardId(index, id);
-        when(indexShard.shardId()).thenReturn(shardId);
-
-        final RecoverySettings recoverySettings = new RecoverySettings(Settings.EMPTY, clusterService.getClusterSettings());
+        final SegmentReplicationTargetService mockTargetService = mock(SegmentReplicationTargetService.class);
 
         final PublishCheckpointAction action = new PublishCheckpointAction(
             Settings.EMPTY,
@@ -133,7 +125,8 @@ public class PublishCheckpointActionTests extends OpenSearchTestCase {
             indicesService,
             threadPool,
             shardStateAction,
-            new ActionFilters(Collections.emptySet())
+            new ActionFilters(Collections.emptySet()),
+            mockTargetService
         );
 
         final ReplicationCheckpoint checkpoint = new ReplicationCheckpoint(indexShard.shardId(), 1111, 111, 11, 1);
@@ -145,12 +138,13 @@ public class PublishCheckpointActionTests extends OpenSearchTestCase {
         final TransportReplicationAction.ReplicaResult result = listener.actionGet();
 
         // onNewCheckpoint should be called on shard with checkpoint request
-        verify(indexShard).onNewCheckpoint(request);
+        verify(mockTargetService).onNewCheckpoint(checkpoint, indexShard);
 
         // the result should indicate success
         final AtomicBoolean success = new AtomicBoolean();
         result.runPostReplicaActions(ActionListener.wrap(r -> success.set(true), e -> fail(e.toString())));
         assertTrue(success.get());
+        closeShards(indexShard);
 
     }
 


### PR DESCRIPTION
Signed-off-by: Rishikesh1159 <rishireddy1159@gmail.com>

### Description
This PR will allow us to start replication on replica shard when a new checkpoint is received. The logic of replaying new checkpoints and storing Latest received checkpoint which comes under same issue 3110, but will be implemented later in a different PR. Some changes like making SegmentReplicationTargetService class not final and Injecting SegmentReplicationTargetService needs discussion/opinion from other developers, please drop your thoughts on these changes also.

This is a part of the process of merging our feature branch - feature/segment-replication - back into main by re-PRing our changes from the feature branch.
The breakdown of the plan to merge to main is detailed here: https://github.com/opensearch-project/OpenSearch/issues/2355
For added context on segment replication - here's the design proposal https://github.com/opensearch-project/OpenSearch/issues/2229
 
### Issues Resolved
3110
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
