### PR TITLE
Upgrade minio image version

### DIFF
--- a/test/fixtures/minio-fixture/Dockerfile
+++ b/test/fixtures/minio-fixture/Dockerfile
@@ -1,9 +1,9 @@
-FROM minio/minio:RELEASE.2019-01-23T23-18-58Z
+FROM minio/minio:RELEASE.2022-06-25T15-50-16Z
 
 ARG bucket
 ARG accessKey
 ARG secretKey
 
 RUN mkdir -p /minio/data/${bucket}
-ENV MINIO_ACCESS_KEY=${accessKey}
-ENV MINIO_SECRET_KEY=${secretKey}
+ENV MINIO_ROOT_USER=${accessKey}
+ENV MINIO_ROOT_PASSWORD=${secretKey}

--- a/test/fixtures/minio-fixture/docker-compose.yml
+++ b/test/fixtures/minio-fixture/docker-compose.yml
@@ -8,9 +8,13 @@ services:
         accessKey: "access_key"
         secretKey: "secret_key"
       dockerfile: Dockerfile
+    ulimits:
+      nofile:
+        hard: 4096
+        soft: 4096
     ports:
       - "9000"
-    command: ["server", "/minio/data"]
+    command: ["server", "--console-address", ":9001", "/minio/data"]
   minio-fixture-other:
     build:
       context: .
@@ -19,17 +23,25 @@ services:
         accessKey: "access_key"
         secretKey: "secret_key"
       dockerfile: Dockerfile
+    ulimits:
+      nofile:
+        hard: 4096
+        soft: 4096
     ports:
       - "9000"
-    command: ["server", "/minio/data"]
+    command: ["server", "--console-address", ":9001", "/minio/data"]
   minio-fixture-for-snapshot-tool:
-      build:
-        context: .
-        args:
-          bucket: "bucket"
-          accessKey: "sn_tool_access_key"
-          secretKey: "sn_tool_secret_key"
-        dockerfile: Dockerfile
-      ports:
-        - "9000"
-      command: ["server", "/minio/data"]
+    build:
+      context: .
+      args:
+        bucket: "bucket"
+        accessKey: "sn_tool_access_key"
+        secretKey: "sn_tool_secret_key"
+      dockerfile: Dockerfile
+    ulimits:
+      nofile:
+        hard: 4096
+        soft: 4096
+    ports:
+      - "9000"
+    command: ["server", "--console-address", ":9001", "/minio/data"]


### PR DESCRIPTION
Signed-off-by: Lukáš Vlček <lukas.vlcek@aiven.io>

### Description

Upgrading minio image to new version (the previous one was 3 years old).

On top of that addressing MinIO warning:
- setup ulimits
- use of static console port
- do not use deprecated argument names

With regard to static port this is related to a change MinIO introduced in RELEASE.2021-07-08T01-15-01Z where the console was embedded into the server itself. For more details visit: https://docs.min.io/minio/baremetal/console/minio-console.html

We could let the port be assigned dynamically, however, when we set it statically it can give user an option to make use of the console web UI for MinIO troubleshooting (though I think the ports still need to be exported in this case).

A minor note: the third service in docker-compose was using a bit different indentation - fixing it.

### Issues Resolved

Closes #3539
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
