### PR TITLE
Fixing VerifyVersionConstantsIT test failure

### DIFF
--- a/server/src/main/java/org/opensearch/Version.java
+++ b/server/src/main/java/org/opensearch/Version.java
@@ -89,7 +89,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_1_3_3 = new Version(1030399, org.apache.lucene.util.Version.LUCENE_8_10_1);
     public static final Version V_2_0_0 = new Version(2000099, org.apache.lucene.util.Version.LUCENE_9_1_0);
     public static final Version V_2_0_1 = new Version(2000199, org.apache.lucene.util.Version.LUCENE_9_1_0);
-    public static final Version V_2_1_0 = new Version(2010099, org.apache.lucene.util.Version.LUCENE_9_2_0);
+    public static final Version V_2_1_0 = new Version(2010099, org.apache.lucene.util.Version.LUCENE_9_3_0);
     public static final Version V_3_0_0 = new Version(3000099, org.apache.lucene.util.Version.LUCENE_9_3_0);
     public static final Version CURRENT = V_3_0_0;
 


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Cause by https://github.com/opensearch-project/OpenSearch/pull/3555

```
org.opensearch.qa.verify_version_constants.VerifyVersionConstantsIT > testLuceneVersionConstant FAILED
    java.lang.AssertionError: 
    Expected: <9.3.0>
         but: was <9.2.0>
        at __randomizedtesting.SeedInfo.seed([7F490400E9B4F125:F22C395CCEBC326C]:0)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
        at org.junit.Assert.assertThat(Assert.java:964)
        at org.junit.Assert.assertThat(Assert.java:930)
        at org.opensearch.qa.verify_version_constants.VerifyVersionConstantsIT.testLuceneVersionConstant(VerifyVersionConstantsIT.java:56)
```
 
### Issues Resolved
Closes  https://github.com/opensearch-project/OpenSearch/issues/3565
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
