### PR TITLE
Fixing flakiness of ShuffleForcedMergePolicyTests

### DIFF
--- a/server/src/test/java/org/opensearch/lucene/index/ShuffleForcedMergePolicyTests.java
+++ b/server/src/test/java/org/opensearch/lucene/index/ShuffleForcedMergePolicyTests.java
@@ -58,7 +58,7 @@ import static org.hamcrest.Matchers.greaterThan;
 public class ShuffleForcedMergePolicyTests extends BaseMergePolicyTestCase {
     public void testDiagnostics() throws IOException {
         try (Directory dir = newDirectory()) {
-            IndexWriterConfig iwc = newIndexWriterConfig();
+            IndexWriterConfig iwc = newIndexWriterConfig().setMaxFullFlushMergeWaitMillis(0);
             MergePolicy mp = new ShuffleForcedMergePolicy(newTieredMergePolicy());
             iwc.setMergePolicy(mp);
             boolean sorted = random().nextBoolean();


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Fixing potential flakiness for ShuffleForcedMergePolicyTests, first observed in https://github.com/opensearch-project/OpenSearch/pull/3556:

```
org.opensearch.lucene.index.ShuffleForcedMergePolicyTests > testDiagnostics FAILED
    java.lang.AssertionError: 
    Expected: a value greater than <2>
         but: <2> was equal to <2>
        at __randomizedtesting.SeedInfo.seed([1161A2BF9C23F5EE:241F7C459E731AC7]:0)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
        at org.junit.Assert.assertThat(Assert.java:964)
        at org.junit.Assert.assertThat(Assert.java:930)
        at org.opensearch.lucene.index.ShuffleForcedMergePolicyTests.testDiagnostics(ShuffleForcedMergePolicyTests.java:81)

  2> NOTE: reproduce with: gradlew test --tests ShuffleForcedMergePolicyTests.testDiagnostics -Dtests.seed=1161A2BF9C23F5EE -Dtests.badapples=true -Dtests.locale=sk -Dtests.timezone=America/Lower_Princes -Dtests.asserts=true -Dtests.file.encoding=UTF-8

```
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
