### PR TITLE
Fix NPE when minBound/maxBound is not set before being called.

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/HistogramAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/HistogramAggregationBuilder.java
@@ -227,12 +227,12 @@ public class HistogramAggregationBuilder extends ValuesSourceAggregationBuilder<
 
     /** Get the current minimum bound that is set on this builder. */
     public double minBound() {
-        return extendedBounds.getMin();
+        return DoubleBounds.getEffectiveMin(extendedBounds);
     }
 
     /** Get the current maximum bound that is set on this builder. */
     public double maxBound() {
-        return extendedBounds.getMax();
+        return DoubleBounds.getEffectiveMax(extendedBounds);
     }
 
     protected DoubleBounds extendedBounds() {

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/HistogramTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/HistogramTests.java
@@ -103,6 +103,19 @@ public class HistogramTests extends BaseAggregationTestCase<HistogramAggregation
         assertThat(ex.getMessage(), equalTo("max bound [0.4] must be greater than min bound [0.5]"));
     }
 
+    /**
+     * Check that minBound/maxBound does not throw {@link NullPointerException} when called before being set.
+     */
+    public void testMinBoundMaxBoundDefaultValues() {
+        HistogramAggregationBuilder factory = new HistogramAggregationBuilder("foo");
+
+        double minValue = factory.minBound();
+        double maxValue = factory.maxBound();
+
+        assertThat(minValue, equalTo(Double.POSITIVE_INFINITY));
+        assertThat(maxValue, equalTo(Double.NEGATIVE_INFINITY));
+    }
+
     private List<BucketOrder> randomOrder() {
         List<BucketOrder> orders = new ArrayList<>();
         switch (randomInt(4)) {


### PR DESCRIPTION
### Description
Resolves a NullPointerException which occurs when the methods minBound() and maxBound
https://github.com/opensearch-project/OpenSearch/blob/8844f0590a96a791f56902b9c3e004d3beb91d10/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/HistogramAggregationBuilder.java#L228-L236
are called before they are set in DoubleBounds
https://github.com/opensearch-project/OpenSearch/blob/8844f0590a96a791f56902b9c3e004d3beb91d10/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/DoubleBounds.java#L154-L160
 
### Issues Resolved
#3604 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
