### PR TITLE
[2.x] Deprecate classes in org.opensearch.action.support.master (#3593)

### DIFF
--- a/server/src/main/java/org/opensearch/action/support/master/AcknowledgedRequest.java
+++ b/server/src/main/java/org/opensearch/action/support/master/AcknowledgedRequest.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.action.support.master;
+
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
+import org.opensearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * Abstract class that allows to mark action requests that support acknowledgements.
+ * Facilitates consistency across different api.
+ *
+ * @opensearch.internal
+ */
+public abstract class AcknowledgedRequest<Request extends ClusterManagerNodeRequest<Request>> extends
+    org.opensearch.action.support.clustermanager.AcknowledgedRequest<Request> {
+
+    protected AcknowledgedRequest() {
+        super();
+    }
+
+    protected AcknowledgedRequest(StreamInput in) throws IOException {
+        super(in);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/support/master/AcknowledgedRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/support/master/AcknowledgedRequestBuilder.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.action.support.master;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.action.support.clustermanager.AcknowledgedRequest;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
+import org.opensearch.client.OpenSearchClient;
+
+/**
+ * Base request builder for cluster-manager node operations that support acknowledgements
+ *
+ * @opensearch.internal
+ */
+public abstract class AcknowledgedRequestBuilder<
+    Request extends AcknowledgedRequest<Request>,
+    Response extends AcknowledgedResponse,
+    RequestBuilder extends AcknowledgedRequestBuilder<Request, Response, RequestBuilder>> extends
+    org.opensearch.action.support.clustermanager.AcknowledgedRequestBuilder<Request, Response, RequestBuilder> {
+
+    protected AcknowledgedRequestBuilder(OpenSearchClient client, ActionType action, Request request) {
+        super(client, action, request);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/support/master/AcknowledgedResponse.java
+++ b/server/src/main/java/org/opensearch/action/support/master/AcknowledgedResponse.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.action.support.master;
+
+import org.opensearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * A response that indicates that a request has been acknowledged
+ *
+ * @opensearch.internal
+ */
+public class AcknowledgedResponse extends org.opensearch.action.support.clustermanager.AcknowledgedResponse {
+
+    public AcknowledgedResponse(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    public AcknowledgedResponse(StreamInput in, boolean readAcknowledged) throws IOException {
+        super(in, readAcknowledged);
+    }
+
+    public AcknowledgedResponse(boolean acknowledged) {
+        super(acknowledged);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/support/master/MasterNodeOperationRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/support/master/MasterNodeOperationRequestBuilder.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.action.support.master;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.action.ActionResponse;
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeOperationRequestBuilder;
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
+import org.opensearch.client.OpenSearchClient;
+
+/**
+ * Base request builder for cluster-manager node operations
+ *
+ * @opensearch.internal
+ * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link ClusterManagerNodeOperationRequestBuilder}
+ */
+@Deprecated
+public abstract class MasterNodeOperationRequestBuilder<
+    Request extends ClusterManagerNodeRequest<Request>,
+    Response extends ActionResponse,
+    RequestBuilder extends MasterNodeOperationRequestBuilder<Request, Response, RequestBuilder>> extends
+    ClusterManagerNodeOperationRequestBuilder<Request, Response, RequestBuilder> {
+
+    protected MasterNodeOperationRequestBuilder(OpenSearchClient client, ActionType<Response> action, Request request) {
+        super(client, action, request);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/support/master/MasterNodeReadOperationRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/support/master/MasterNodeReadOperationRequestBuilder.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.action.support.master;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.action.ActionResponse;
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeOperationRequestBuilder;
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeReadOperationRequestBuilder;
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeReadRequest;
+import org.opensearch.client.OpenSearchClient;
+
+/**
+ * Base request builder for cluster-manager node read operations that can be executed on the local node as well
+ *
+ * @opensearch.internal
+ * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link ClusterManagerNodeReadOperationRequestBuilder}
+ */
+@Deprecated
+public abstract class MasterNodeReadOperationRequestBuilder<
+    Request extends ClusterManagerNodeReadRequest<Request>,
+    Response extends ActionResponse,
+    RequestBuilder extends ClusterManagerNodeReadOperationRequestBuilder<Request, Response, RequestBuilder>> extends
+    ClusterManagerNodeOperationRequestBuilder<Request, Response, RequestBuilder> {
+
+    protected MasterNodeReadOperationRequestBuilder(OpenSearchClient client, ActionType<Response> action, Request request) {
+        super(client, action, request);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/support/master/MasterNodeReadRequest.java
+++ b/server/src/main/java/org/opensearch/action/support/master/MasterNodeReadRequest.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.action.support.master;
+
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeReadRequest;
+import org.opensearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * Base request for cluster-manager based read operations that allows to read the cluster state from the local node if needed
+ *
+ * @opensearch.internal
+ * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link ClusterManagerNodeReadRequest}
+ */
+@Deprecated
+public abstract class MasterNodeReadRequest<Request extends MasterNodeReadRequest<Request>> extends ClusterManagerNodeReadRequest<Request> {
+    protected MasterNodeReadRequest() {}
+
+    protected MasterNodeReadRequest(StreamInput in) throws IOException {
+        super(in);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/support/master/MasterNodeRequest.java
+++ b/server/src/main/java/org/opensearch/action/support/master/MasterNodeRequest.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.action.support.master;
+
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
+import org.opensearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * A based request for cluster-manager based operation.
+ *
+ * @opensearch.internal
+ * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link ClusterManagerNodeRequest}
+ */
+@Deprecated
+public abstract class MasterNodeRequest<Request extends MasterNodeRequest<Request>> extends ClusterManagerNodeRequest<Request> {
+
+    protected MasterNodeRequest(StreamInput in) throws IOException {
+        super(in);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/support/master/ShardsAcknowledgedResponse.java
+++ b/server/src/main/java/org/opensearch/action/support/master/ShardsAcknowledgedResponse.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.action.support.master;
+
+import org.opensearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * Transport response for shard acknowledgements
+ *
+ * @opensearch.internal
+ */
+public abstract class ShardsAcknowledgedResponse extends org.opensearch.action.support.clustermanager.ShardsAcknowledgedResponse {
+
+    protected ShardsAcknowledgedResponse(StreamInput in, boolean readShardsAcknowledged) throws IOException {
+        super(in, readShardsAcknowledged);
+    }
+
+}

--- a/server/src/main/java/org/opensearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/master/TransportMasterNodeAction.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.action.support.master;
+
+import org.opensearch.action.ActionResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+/**
+ * A base class for operations that needs to be performed on the cluster-manager node.
+ *
+ * @opensearch.internal
+ * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link ClusterManagerNodeRequest}
+ */
+@Deprecated
+public abstract class TransportMasterNodeAction<Request extends MasterNodeRequest<Request>, Response extends ActionResponse> extends
+    TransportClusterManagerNodeAction<Request, Response> {
+
+    protected TransportMasterNodeAction(
+        String actionName,
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        Writeable.Reader<Request> request,
+        IndexNameExpressionResolver indexNameExpressionResolver
+    ) {
+        super(actionName, true, transportService, clusterService, threadPool, actionFilters, request, indexNameExpressionResolver);
+    }
+
+    protected TransportMasterNodeAction(
+        String actionName,
+        boolean canTripCircuitBreaker,
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        Writeable.Reader<Request> request,
+        IndexNameExpressionResolver indexNameExpressionResolver
+    ) {
+        super(
+            actionName,
+            canTripCircuitBreaker,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            request,
+            indexNameExpressionResolver
+        );
+    }
+
+}

--- a/server/src/main/java/org/opensearch/action/support/master/TransportMasterNodeReadAction.java
+++ b/server/src/main/java/org/opensearch/action/support/master/TransportMasterNodeReadAction.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.action.support.master;
+
+import org.opensearch.action.ActionResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeReadAction;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+/**
+ * A base class for read operations that needs to be performed on the cluster-manager node.
+ * Can also be executed on the local node if needed.
+ *
+ * @opensearch.internal
+ * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link ClusterManagerNodeRequest}
+ */
+@Deprecated
+public abstract class TransportMasterNodeReadAction<Request extends MasterNodeReadRequest<Request>, Response extends ActionResponse> extends
+    TransportClusterManagerNodeReadAction<Request, Response> {
+
+    protected TransportMasterNodeReadAction(
+        String actionName,
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        Writeable.Reader<Request> request,
+        IndexNameExpressionResolver indexNameExpressionResolver
+    ) {
+        super(actionName, true, transportService, clusterService, threadPool, actionFilters, request, indexNameExpressionResolver);
+    }
+
+    protected TransportMasterNodeReadAction(
+        String actionName,
+        boolean checkSizeLimit,
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        Writeable.Reader<Request> request,
+        IndexNameExpressionResolver indexNameExpressionResolver
+    ) {
+        super(
+            actionName,
+            checkSizeLimit,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            request,
+            indexNameExpressionResolver
+        );
+    }
+
+}

--- a/server/src/main/java/org/opensearch/action/support/master/info/ClusterInfoRequest.java
+++ b/server/src/main/java/org/opensearch/action/support/master/info/ClusterInfoRequest.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.action.support.master.info;
+
+import org.opensearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * Transport request for cluster information
+ *
+ * @opensearch.internal
+ */
+public abstract class ClusterInfoRequest<Request extends ClusterInfoRequest<Request>> extends
+    org.opensearch.action.support.clustermanager.info.ClusterInfoRequest<Request> {
+
+    public ClusterInfoRequest() {}
+
+    public ClusterInfoRequest(StreamInput in) throws IOException {
+        super(in);
+    }
+
+}

--- a/server/src/main/java/org/opensearch/action/support/master/info/ClusterInfoRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/support/master/info/ClusterInfoRequestBuilder.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.action.support.master.info;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.action.ActionResponse;
+import org.opensearch.action.support.clustermanager.info.ClusterInfoRequest;
+import org.opensearch.client.OpenSearchClient;
+
+/**
+ * Transport request builder for cluster information
+ *
+ * @opensearch.internal
+ */
+public abstract class ClusterInfoRequestBuilder<
+    Request extends ClusterInfoRequest<Request>,
+    Response extends ActionResponse,
+    Builder extends ClusterInfoRequestBuilder<Request, Response, Builder>> extends
+    org.opensearch.action.support.clustermanager.info.ClusterInfoRequestBuilder<Request, Response, Builder> {
+
+    protected ClusterInfoRequestBuilder(OpenSearchClient client, ActionType<Response> action, Request request) {
+        super(client, action, request);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/support/master/info/TransportClusterInfoAction.java
+++ b/server/src/main/java/org/opensearch/action/support/master/info/TransportClusterInfoAction.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.action.support.master.info;
+
+import org.opensearch.action.ActionResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+/**
+ * Perform cluster information action
+ *
+ * @opensearch.internal
+ */
+public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequest<Request>, Response extends ActionResponse> extends
+    org.opensearch.action.support.clustermanager.info.TransportClusterInfoAction<Request, Response> {
+
+    public TransportClusterInfoAction(
+        String actionName,
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        Writeable.Reader<Request> request,
+        IndexNameExpressionResolver indexNameExpressionResolver
+    ) {
+        super(actionName, transportService, clusterService, threadPool, actionFilters, request, indexNameExpressionResolver);
+    }
+
+}

--- a/server/src/main/java/org/opensearch/action/support/master/info/package-info.java
+++ b/server/src/main/java/org/opensearch/action/support/master/info/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Master Node Information transport handlers.
+ *
+ * As of 2.1, because supporting inclusive language, replaced by {@link org.opensearch.action.support.clustermanager.info}
+ */
+@Deprecated
+package org.opensearch.action.support.master.info;

--- a/server/src/main/java/org/opensearch/action/support/master/package-info.java
+++ b/server/src/main/java/org/opensearch/action/support/master/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Master Node transport handlers.
+ *
+ * As of 2.1, because supporting inclusive language, replaced by {@link org.opensearch.action.support.clustermanager}
+ */
+@Deprecated
+package org.opensearch.action.support.master;


### PR DESCRIPTION
### Description
Backport PR https://github.com/opensearch-project/OpenSearch/pull/3593 / commit https://github.com/opensearch-project/OpenSearch/commit/223d472e6d8ea4454cb05fba7271d213430a1a4e to `2.x` branch
 
To support inclusive language, the master terminology is going to be replaced by cluster manager in the code base.
In PR https://github.com/opensearch-project/OpenSearch/pull/3597, the package `org.opensearch.action.support.master` has be renamed to `org.opensearch.action.support.clustermanager`, and the classes with "master" name are renamed as well.

This PR adds the old [package](https://github.com/opensearch-project/OpenSearch/tree/2.0.0/server/src/main/java/org/opensearch/action/support/master) and classes back to keep the backwards compatibility and marks them as deprecated.
Apply 3 changes to the original classes in the package [org.opensearch.action.support.master](https://github.com/opensearch-project/OpenSearch/tree/2.0.0/server/src/main/java/org/opensearch/action/support/master). 
1 Remove all the methods in the classes.
2 Make them extend the corresponding classes with "cluster manager" name.
3 Add the same constructors with the corresponding "cluster manager" classes.

### Issues Resolved
The second step for issue https://github.com/opensearch-project/OpenSearch/issues/3542 on `2.x` branch.
It will be resolved by a following PR to rename and deprecate the public methods and variables in the package.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
