### PR TITLE
Add release notes workflow

### DIFF
--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -1,0 +1,44 @@
+# The overall template of the release notes
+template: |
+  Version $RESOLVED_VERSION Release Notes
+  $CHANGES
+# Setting the formatting and sorting for the release notes body
+name-template: Version $RESOLVED_VERSION
+change-template: "* $TITLE ([#$NUMBER](https://github.com/opensearch-project/OpenSearch/pull/$NUMBER))"
+sort-by: merged_at
+sort-direction: ascending
+replacers:
+  - search: '##'
+    replace: '###'
+
+# Organizing the tagged PRs into unified categories
+categories:
+  - title: 'Breaking Changes'
+    labels:
+      - 'Breaking Changes'
+  - title: 'Features'
+    labels:
+      - 'feature'
+  - title: 'Enhancements'
+    labels:
+      - 'enhancement'
+  - title: 'Bug Fixes'
+    labels:
+      - 'bug'
+  - title: 'Infrastructure'
+    labels:
+      - 'infra'
+      - 'test'
+      - 'dependencies'
+      - 'github actions'
+  - title: 'Documentation'
+    labels:
+      - 'documentation'
+  - title: 'Maintenance'
+    labels:
+      - "version compatibility"
+      - "maintenance"
+  - title: 'Refactoring'
+    labels:
+      - 'refactor'
+      - 'code quality'

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -1,0 +1,20 @@
+name: Draft Release Notes
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    name: Update draft release notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update draft release notes
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: draft-release-notes-config.yml
+          name: Version (set here)
+          tag: (None)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>

### Description
- Add initial support for release-drafter workflow to automate release notes
 
### Issues Resolved
#1868
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
