### PR TITLE
[Remote Store] Delete merged away segments in periodic flow

### DIFF
--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -119,8 +119,6 @@ public final class IndexModule {
 
     private static final FsDirectoryFactory DEFAULT_DIRECTORY_FACTORY = new FsDirectoryFactory();
 
-    private static final RemoteDirectoryFactory REMOTE_DIRECTORY_FACTORY = new RemoteDirectoryFactory();
-
     private static final IndexStorePlugin.RecoveryStateFactory DEFAULT_RECOVERY_STATE_FACTORY = RecoveryState::new;
 
     public static final Setting<String> INDEX_STORE_TYPE_SETTING = new Setting<>(
@@ -189,9 +187,9 @@ public final class IndexModule {
      * Construct the index module for the index with the specified index settings. The index module contains extension points for plugins
      * via {@link org.opensearch.plugins.PluginsService#onIndexModule(IndexModule)}.
      *
-     * @param indexSettings       the index settings
-     * @param analysisRegistry    the analysis registry
-     * @param engineFactory       the engine factory
+     * @param indexSettings      the index settings
+     * @param analysisRegistry   the analysis registry
+     * @param engineFactory      the engine factory
      * @param directoryFactories the available store types
      */
     public IndexModule(
@@ -476,7 +474,8 @@ public final class IndexModule {
         IndicesFieldDataCache indicesFieldDataCache,
         NamedWriteableRegistry namedWriteableRegistry,
         BooleanSupplier idFieldDataEnabled,
-        ValuesSourceRegistry valuesSourceRegistry
+        ValuesSourceRegistry valuesSourceRegistry,
+        RemoteDirectoryFactory remoteDirectoryFactory
     ) throws IOException {
         final IndexEventListener eventListener = freeze();
         Function<IndexService, CheckedFunction<DirectoryReader, DirectoryReader, IOException>> readerWrapperFactory = indexReaderWrapper
@@ -519,7 +518,7 @@ public final class IndexModule {
                 client,
                 queryCache,
                 directoryFactory,
-                REMOTE_DIRECTORY_FACTORY,
+                remoteDirectoryFactory,
                 eventListener,
                 readerWrapperFactory,
                 mapperRegistry,

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -98,7 +98,6 @@ import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpoin
 import org.opensearch.plugins.IndexStorePlugin;
 import org.opensearch.script.ScriptService;
 import org.opensearch.search.aggregations.support.ValuesSourceRegistry;
-import org.opensearch.threadpool.Scheduler;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.Closeable;
@@ -112,7 +111,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
@@ -174,7 +172,6 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     private final IndexNameExpressionResolver expressionResolver;
     private final Supplier<Sort> indexSortSupplier;
     private final ValuesSourceRegistry valuesSourceRegistry;
-    private final ScheduledThreadPoolExecutor remoteSegmentsDeleteScheduler;
 
     public IndexService(
         IndexSettings indexSettings,
@@ -279,7 +276,6 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         this.globalCheckpointTask = new AsyncGlobalCheckpointTask(this);
         this.retentionLeaseSyncTask = new AsyncRetentionLeaseSyncTask(this);
         updateFsyncTaskIfNecessary();
-        this.remoteSegmentsDeleteScheduler = new Scheduler.SafeScheduledThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
     }
 
     static boolean needsMapperService(IndexSettings indexSettings, IndexCreationContext indexCreationContext) {
@@ -386,7 +382,6 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                     globalCheckpointTask,
                     retentionLeaseSyncTask
                 );
-                remoteSegmentsDeleteScheduler.shutdown();
             }
         }
     }

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -98,6 +98,7 @@ import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpoin
 import org.opensearch.plugins.IndexStorePlugin;
 import org.opensearch.script.ScriptService;
 import org.opensearch.search.aggregations.support.ValuesSourceRegistry;
+import org.opensearch.threadpool.Scheduler;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.Closeable;
@@ -111,6 +112,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
@@ -172,6 +174,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     private final IndexNameExpressionResolver expressionResolver;
     private final Supplier<Sort> indexSortSupplier;
     private final ValuesSourceRegistry valuesSourceRegistry;
+    private final ScheduledThreadPoolExecutor remoteSegmentsDeleteScheduler;
 
     public IndexService(
         IndexSettings indexSettings,
@@ -276,6 +279,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         this.globalCheckpointTask = new AsyncGlobalCheckpointTask(this);
         this.retentionLeaseSyncTask = new AsyncRetentionLeaseSyncTask(this);
         updateFsyncTaskIfNecessary();
+        this.remoteSegmentsDeleteScheduler = new Scheduler.SafeScheduledThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
     }
 
     static boolean needsMapperService(IndexSettings indexSettings, IndexCreationContext indexCreationContext) {
@@ -382,6 +386,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                     globalCheckpointTask,
                     retentionLeaseSyncTask
                 );
+                remoteSegmentsDeleteScheduler.shutdown();
             }
         }
     }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -48,6 +48,8 @@ import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.UsageTrackingQueryCachingPolicy;
 import org.apache.lucene.store.AlreadyClosedException;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.util.SetOnce;
 import org.apache.lucene.util.ThreadInterruptedException;
 import org.opensearch.Assertions;
@@ -305,7 +307,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     private volatile boolean useRetentionLeasesInPeerRecovery;
     private final ReferenceManager.RefreshListener checkpointRefreshListener;
 
-    private final RemoteStoreRefreshListener remoteStoreRefreshListener;
+    private final Store remoteStore;
 
     public IndexShard(
         final ShardRouting shardRouting,
@@ -329,7 +331,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         final RetentionLeaseSyncer retentionLeaseSyncer,
         final CircuitBreakerService circuitBreakerService,
         @Nullable final SegmentReplicationCheckpointPublisher checkpointPublisher,
-        @Nullable final RemoteStoreRefreshListener remoteStoreRefreshListener
+        @Nullable final Store remoteStore
     ) throws IOException {
         super(shardRouting.shardId(), indexSettings);
         assert shardRouting.initializing();
@@ -417,7 +419,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         } else {
             this.checkpointRefreshListener = null;
         }
-        this.remoteStoreRefreshListener = remoteStoreRefreshListener;
+        this.remoteStore = remoteStore;
     }
 
     public ThreadPool getThreadPool() {
@@ -426,6 +428,10 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
     public Store store() {
         return this.store;
+    }
+
+    public Store remoteStore() {
+        return this.remoteStore;
     }
 
     /**
@@ -3193,7 +3199,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return mapperService.documentMapperWithAutoCreate();
     }
 
-    private EngineConfig newEngineConfig(LongSupplier globalCheckpointSupplier) {
+    private EngineConfig newEngineConfig(LongSupplier globalCheckpointSupplier) throws IOException {
         final Sort indexSort = indexSortSupplier.get();
         final Engine.Warmer warmer = reader -> {
             assert Thread.holdsLock(mutex) == false : "warming engine under mutex";
@@ -3205,8 +3211,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
         final List<ReferenceManager.RefreshListener> internalRefreshListener = new ArrayList<>();
         internalRefreshListener.add(new RefreshMetricUpdater(refreshMetric));
-        if (remoteStoreRefreshListener != null && shardRouting.primary()) {
-            internalRefreshListener.add(remoteStoreRefreshListener);
+        if (remoteStore != null && shardRouting.primary()) {
+            Directory remoteDirectory = ((FilterDirectory) ((FilterDirectory) remoteStore.directory()).getDelegate()).getDelegate();
+            internalRefreshListener.add(new RemoteStoreRefreshListener(store.directory(), remoteDirectory));
         }
         if (this.checkpointRefreshListener != null) {
             internalRefreshListener.add(checkpointRefreshListener);

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -3213,7 +3213,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         internalRefreshListener.add(new RefreshMetricUpdater(refreshMetric));
         if (remoteStore != null && shardRouting.primary()) {
             Directory remoteDirectory = ((FilterDirectory) ((FilterDirectory) remoteStore.directory()).getDelegate()).getDelegate();
-            internalRefreshListener.add(new RemoteStoreRefreshListener(store.directory(), remoteDirectory));
+            internalRefreshListener.add(new RemoteStoreRefreshListener(this, store.directory(), remoteDirectory));
         }
         if (this.checkpointRefreshListener != null) {
             internalRefreshListener.add(checkpointRefreshListener);

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -11,32 +11,108 @@ package org.opensearch.index.shard;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IOContext;
+import org.apache.lucene.util.Version;
+import org.opensearch.index.store.StoreFileMetadata;
 
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
-import java.util.Arrays;
-import java.util.HashSet;
+import java.text.ParseException;
 import java.util.Set;
+import java.util.Map;
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * RefreshListener implementation to upload newly created segment files to the remote store
+ *
+ * @opensearch.internal
  */
 public class RemoteStoreRefreshListener implements ReferenceManager.RefreshListener {
 
+    public static final String REMOTE_SEGMENTS_METADATA = "remote_segments_metadata";
+    private static final int DELETE_PERIOD_IN_MINS = 15;
+    private static final Set<String> EXCLUDE_FILES = Set.of("write.lock", REMOTE_SEGMENTS_METADATA);
     private final Directory storeDirectory;
     private final Directory remoteDirectory;
-    // ToDo: This can be a map with metadata of the uploaded file as value of the map (GitHub #3398)
-    private final Set<String> filesUploadedToRemoteStore;
+    private final ConcurrentHashMap<String, StoreFileMetadata> segmentsUploadedToRemoteStore;
     private static final Logger logger = LogManager.getLogger(RemoteStoreRefreshListener.class);
 
-    public RemoteStoreRefreshListener(Directory storeDirectory, Directory remoteDirectory) throws IOException {
+    public RemoteStoreRefreshListener(Directory storeDirectory, Directory remoteDirectory, ScheduledThreadPoolExecutor executor)
+        throws IOException {
         this.storeDirectory = storeDirectory;
         this.remoteDirectory = remoteDirectory;
         // ToDo: Handle failures in reading list of files (GitHub #3397)
-        this.filesUploadedToRemoteStore = new HashSet<>(Arrays.asList(remoteDirectory.listAll()));
+        this.segmentsUploadedToRemoteStore = readRemoteSegmentsMetadata(remoteDirectory);
+        scheduleStaleSegmentDeletion(executor);
+    }
+
+    private void scheduleStaleSegmentDeletion(ScheduledThreadPoolExecutor executor) {
+        executor.scheduleWithFixedDelay(() -> {
+            try {
+                Set<String> localFiles = Set.of(storeDirectory.listAll());
+                // Upload new segments, if any, before proceeding with deleting stale segments
+                uploadNewSegments(localFiles);
+                deleteStaleSegments(localFiles);
+                uploadRemoteSegmentsMetadata(localFiles);
+            } catch (Throwable t) {
+                logger.warn(
+                    () -> new ParameterizedMessage(
+                        "Exception while deleting stale segments from the remote segment store, will retry again after {} minutes",
+                        DELETE_PERIOD_IN_MINS
+                    ),
+                    t
+                );
+            }
+        }, DELETE_PERIOD_IN_MINS, DELETE_PERIOD_IN_MINS, TimeUnit.MINUTES);
+    }
+
+    // Visible for testing
+    ConcurrentHashMap<String, StoreFileMetadata> readRemoteSegmentsMetadata(Directory directory) throws IOException {
+        ConcurrentHashMap<String, StoreFileMetadata> remoteSegmentsMetadata = new ConcurrentHashMap<>();
+        try (IndexInput input = directory.openInput(REMOTE_SEGMENTS_METADATA, IOContext.READ)) {
+            StoreFileMetadata storeFileMetadata = readMetadata(input);
+            while (storeFileMetadata != null) {
+                remoteSegmentsMetadata.put(storeFileMetadata.name(), storeFileMetadata);
+                storeFileMetadata = readMetadata(input);
+            }
+            return remoteSegmentsMetadata;
+        } catch (NoSuchFileException e) {
+            logger.info(
+                () -> new ParameterizedMessage(
+                    "Missing file {}, this can happen during the very first refresh of the shard",
+                    REMOTE_SEGMENTS_METADATA
+                )
+            );
+            return new ConcurrentHashMap<>();
+        }
+    }
+
+    private StoreFileMetadata readMetadata(IndexInput in) {
+        try {
+            String name = in.readString();
+            if (name.isEmpty()) {
+                return null;
+            }
+            long length = in.readVLong();
+            String checksum = in.readString();
+            try {
+                Version writtenBy = org.apache.lucene.util.Version.parse(in.readString());
+                return new StoreFileMetadata(name, length, checksum, writtenBy);
+            } catch (ParseException e) {
+                throw new AssertionError(e);
+            }
+        } catch (IOException e) {
+            return null;
+        }
     }
 
     @Override
@@ -46,42 +122,125 @@ public class RemoteStoreRefreshListener implements ReferenceManager.RefreshListe
 
     /**
      * Upload new segment files created as part of the last refresh to the remote segment store.
-     * The method also deletes segment files from remote store which are not part of local filesystem.
+     * This method also uploads remote_segments_metadata file which contains metadata of each segment file uploaded.
      * @param didRefresh true if the refresh opened a new reference
      * @throws IOException in case of I/O error in reading list of local files
      */
     @Override
     public void afterRefresh(boolean didRefresh) throws IOException {
         if (didRefresh) {
-            Set<String> localFiles = Set.of(storeDirectory.listAll());
-            localFiles.stream().filter(file -> !filesUploadedToRemoteStore.contains(file)).forEach(file -> {
+            try {
+                Set<String> localFiles = Set.of(storeDirectory.listAll());
+                boolean uploadStatus = uploadNewSegments(localFiles);
+                if (uploadStatus) {
+                    uploadRemoteSegmentsMetadata(localFiles);
+                }
+            } catch (IOException e) {
+                // We don't want to fail refresh if upload of new segments fails. The missed segments will be re-tried
+                // in the next refresh. This should not affect durability of the indexed data after remote trans-log integration.
+                logger.warn("Exception while uploading new segments to the remote segment store", e);
+            }
+        }
+    }
+
+    // Visible for testing
+    synchronized boolean uploadNewSegments(Set<String> localFiles) throws IOException {
+        AtomicBoolean newSegmentsUploaded = new AtomicBoolean(false);
+        AtomicBoolean uploadSuccess = new AtomicBoolean(true);
+        localFiles.stream().filter(file -> !EXCLUDE_FILES.contains(file)).forEach(file -> {
+            try {
+                String checksum = getChecksumOfLocalFile(file);
+                StoreFileMetadata storeFileMetadata = segmentsUploadedToRemoteStore.get(file);
+                if (storeFileMetadata != null && storeFileMetadata.checksum().equals(checksum)) {
+                    return;
+                }
+                newSegmentsUploaded.set(true);
                 try {
                     remoteDirectory.copyFrom(storeDirectory, file, file, IOContext.DEFAULT);
-                    filesUploadedToRemoteStore.add(file);
-                } catch (NoSuchFileException e) {
-                    logger.info(
-                        () -> new ParameterizedMessage("The file {} does not exist anymore. It can happen in case of temp files", file),
-                        e
+                    StoreFileMetadata newFileMetadata = new StoreFileMetadata(
+                        file,
+                        storeDirectory.fileLength(file),
+                        checksum,
+                        org.opensearch.Version.CURRENT.minimumIndexCompatibilityVersion().luceneVersion
                     );
+                    segmentsUploadedToRemoteStore.put(file, newFileMetadata);
+                } catch (NoSuchFileException e) {
+                    logger.info("The file {} does not exist anymore. It can happen in case of temp files", file);
                 } catch (IOException e) {
+                    uploadSuccess.set(false);
                     // ToDO: Handle transient and permanent un-availability of the remote store (GitHub #3397)
                     logger.warn(() -> new ParameterizedMessage("Exception while uploading file {} to the remote segment store", file), e);
                 }
-            });
+            } catch (Exception e) {
+                logger.info("Exception while uploading segment file {} to remote store", file);
+            }
+        });
 
-            Set<String> remoteFilesToBeDeleted = new HashSet<>();
-            // ToDo: Instead of deleting files in sync, mark them and delete in async/periodic flow (GitHub #3142)
-            filesUploadedToRemoteStore.stream().filter(file -> !localFiles.contains(file)).forEach(file -> {
+        return newSegmentsUploaded.get() && uploadSuccess.get();
+    }
+
+    private String getChecksumOfLocalFile(String file) throws IOException {
+        try (IndexInput indexInput = storeDirectory.openInput(file, IOContext.DEFAULT)) {
+            return Long.toString(CodecUtil.retrieveChecksum(indexInput));
+        }
+    }
+
+    /**
+     * Deletes segment files from remote store which are not part of local filesystem.
+     * @param localFiles set of segment files in local
+     * @throws IOException in case of I/O error in reading list of remote files
+     */
+    // Visible for testing
+    synchronized void deleteStaleSegments(Set<String> localFiles) throws IOException {
+        Arrays.stream(remoteDirectory.listAll())
+            .filter(file -> !localFiles.contains(file))
+            .filter(file -> !file.equals(REMOTE_SEGMENTS_METADATA))
+            .forEach(file -> {
                 try {
                     remoteDirectory.deleteFile(file);
-                    remoteFilesToBeDeleted.add(file);
+                    segmentsUploadedToRemoteStore.remove(file);
                 } catch (IOException e) {
                     // ToDO: Handle transient and permanent un-availability of the remote store (GitHub #3397)
                     logger.warn(() -> new ParameterizedMessage("Exception while deleting file {} from the remote segment store", file), e);
                 }
             });
+    }
 
-            remoteFilesToBeDeleted.forEach(filesUploadedToRemoteStore::remove);
+    // Visible for testing
+    synchronized void uploadRemoteSegmentsMetadata(Set<String> localFiles) throws IOException {
+        try {
+            storeDirectory.deleteFile(REMOTE_SEGMENTS_METADATA);
+        } catch (NoSuchFileException e) {
+            logger.info(
+                () -> new ParameterizedMessage(
+                    "Missing file {}, this can happen during the very first refresh of the shard",
+                    REMOTE_SEGMENTS_METADATA
+                )
+            );
         }
+        try (IndexOutput indexOutput = storeDirectory.createOutput(REMOTE_SEGMENTS_METADATA, IOContext.DEFAULT)) {
+            segmentsUploadedToRemoteStore.forEach((file, metadata) -> {
+                try {
+                    if (localFiles.contains(file)) {
+                        writeMetadata(indexOutput, metadata);
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+        remoteDirectory.copyFrom(storeDirectory, REMOTE_SEGMENTS_METADATA, REMOTE_SEGMENTS_METADATA, IOContext.DEFAULT);
+    }
+
+    private void writeMetadata(IndexOutput indexOutput, StoreFileMetadata storeFileMetadata) throws IOException {
+        indexOutput.writeString(storeFileMetadata.name());
+        indexOutput.writeVLong(storeFileMetadata.length());
+        indexOutput.writeString(storeFileMetadata.checksum());
+        indexOutput.writeString(storeFileMetadata.writtenBy().toString());
+    }
+
+    // Visible for testing
+    Map<String, StoreFileMetadata> getUploadedSegments() {
+        return this.segmentsUploadedToRemoteStore;
     }
 }

--- a/server/src/main/java/org/opensearch/index/store/RemoteDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteDirectoryFactory.java
@@ -14,7 +14,9 @@ import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.shard.ShardPath;
 import org.opensearch.plugins.IndexStorePlugin;
+import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
+import org.opensearch.repositories.RepositoryMissingException;
 import org.opensearch.repositories.blobstore.BlobStoreRepository;
 
 import java.io.IOException;
@@ -26,12 +28,24 @@ import java.io.IOException;
  */
 public class RemoteDirectoryFactory implements IndexStorePlugin.RemoteDirectoryFactory {
 
-    @Override
-    public Directory newDirectory(IndexSettings indexSettings, ShardPath path, Repository repository) throws IOException {
-        assert repository instanceof BlobStoreRepository : "repository should be instance of BlobStoreRepository";
-        BlobPath blobPath = new BlobPath();
-        blobPath = blobPath.add(indexSettings.getIndex().getName()).add(String.valueOf(path.getShardId().getId()));
-        BlobContainer blobContainer = ((BlobStoreRepository) repository).blobStore().blobContainer(blobPath);
-        return new RemoteDirectory(blobContainer);
+    private final RepositoriesService repositoriesService;
+
+    public RemoteDirectoryFactory(RepositoriesService repositoriesService) {
+        this.repositoriesService = repositoriesService;
     }
+
+    @Override
+    public Directory newDirectory(String repositoryName, IndexSettings indexSettings, ShardPath path) throws IOException {
+        try {
+            Repository repository = repositoriesService.repository(repositoryName);
+            assert repository instanceof BlobStoreRepository : "repository should be instance of BlobStoreRepository";
+            BlobPath blobPath = new BlobPath();
+            blobPath = blobPath.add(indexSettings.getIndex().getName()).add(String.valueOf(path.getShardId().getId()));
+            BlobContainer blobContainer = ((BlobStoreRepository) repository).blobStore().blobContainer(blobPath);
+            return new RemoteDirectory(blobContainer);
+        } catch (RepositoryMissingException e) {
+            throw new IllegalArgumentException("Repository should be created before creating index with remote_store enabled setting", e);
+        }
+    }
+
 }

--- a/server/src/main/java/org/opensearch/index/store/RemoteDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteDirectoryFactory.java
@@ -20,6 +20,7 @@ import org.opensearch.repositories.RepositoryMissingException;
 import org.opensearch.repositories.blobstore.BlobStoreRepository;
 
 import java.io.IOException;
+import java.util.function.Supplier;
 
 /**
  * Factory for a remote store directory
@@ -28,16 +29,15 @@ import java.io.IOException;
  */
 public class RemoteDirectoryFactory implements IndexStorePlugin.RemoteDirectoryFactory {
 
-    private final RepositoriesService repositoriesService;
+    private final Supplier<RepositoriesService> repositoriesService;
 
-    public RemoteDirectoryFactory(RepositoriesService repositoriesService) {
+    public RemoteDirectoryFactory(Supplier<RepositoriesService> repositoriesService) {
         this.repositoriesService = repositoriesService;
     }
 
     @Override
     public Directory newDirectory(String repositoryName, IndexSettings indexSettings, ShardPath path) throws IOException {
-        try {
-            Repository repository = repositoriesService.repository(repositoryName);
+        try (Repository repository = repositoriesService.get().repository(repositoryName)) {
             assert repository instanceof BlobStoreRepository : "repository should be instance of BlobStoreRepository";
             BlobPath blobPath = new BlobPath();
             blobPath = blobPath.add(indexSettings.getIndex().getName()).add(String.valueOf(path.getShardId().getId()));

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -623,7 +623,7 @@ public class Node implements Closeable {
             rerouteServiceReference.set(rerouteService);
             clusterService.setRerouteService(rerouteService);
 
-            final RemoteDirectoryFactory remoteDirectoryFactory = new RemoteDirectoryFactory(repositoriesServiceReference.get());
+            final RemoteDirectoryFactory remoteDirectoryFactory = new RemoteDirectoryFactory(repositoriesServiceReference::get);
 
             final IndicesService indicesService = new IndicesService(
                 settings,

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -41,6 +41,7 @@ import org.opensearch.index.IndexingPressureService;
 import org.opensearch.indices.replication.SegmentReplicationSourceFactory;
 import org.opensearch.indices.replication.SegmentReplicationTargetService;
 import org.opensearch.indices.replication.SegmentReplicationSourceService;
+import org.opensearch.index.store.RemoteDirectoryFactory;
 import org.opensearch.watcher.ResourceWatcherService;
 import org.opensearch.Assertions;
 import org.opensearch.Build;
@@ -622,6 +623,8 @@ public class Node implements Closeable {
             rerouteServiceReference.set(rerouteService);
             clusterService.setRerouteService(rerouteService);
 
+            final RemoteDirectoryFactory remoteDirectoryFactory = new RemoteDirectoryFactory(repositoriesServiceReference.get());
+
             final IndicesService indicesService = new IndicesService(
                 settings,
                 pluginsService,
@@ -642,7 +645,8 @@ public class Node implements Closeable {
                 engineFactoryProviders,
                 indexStoreFactories,
                 searchModule.getValuesSourceRegistry(),
-                recoveryStateFactories
+                recoveryStateFactories,
+                remoteDirectoryFactory
             );
 
             final AliasValidator aliasValidator = new AliasValidator();

--- a/server/src/main/java/org/opensearch/plugins/IndexStorePlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/IndexStorePlugin.java
@@ -39,7 +39,6 @@ import org.opensearch.common.Nullable;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.shard.ShardPath;
 import org.opensearch.indices.recovery.RecoveryState;
-import org.opensearch.repositories.Repository;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -74,13 +73,13 @@ public interface IndexStorePlugin {
     interface RemoteDirectoryFactory {
         /**
          * Creates a new remote directory per shard. This method is called once per shard on shard creation.
+         * @param repositoryName repository name
          * @param indexSettings the shards index settings
          * @param shardPath the path the shard is using
-         * @param repository to get the BlobContainer details
          * @return a new RemoteDirectory instance
          * @throws IOException if an IOException occurs while opening the directory
          */
-        Directory newDirectory(IndexSettings indexSettings, ShardPath shardPath, Repository repository) throws IOException;
+        Directory newDirectory(String repositoryName, IndexSettings indexSettings, ShardPath shardPath) throws IOException;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
@@ -107,6 +107,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         public static final String FETCH_SHARD_STORE = "fetch_shard_store";
         public static final String SYSTEM_READ = "system_read";
         public static final String SYSTEM_WRITE = "system_write";
+        public static final String REMOTE_STORE = "remote_store";
     }
 
     /**
@@ -171,6 +172,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         map.put(Names.SEARCH_THROTTLED, ThreadPoolType.RESIZABLE);
         map.put(Names.SYSTEM_READ, ThreadPoolType.FIXED);
         map.put(Names.SYSTEM_WRITE, ThreadPoolType.FIXED);
+        map.put(Names.REMOTE_STORE, ThreadPoolType.FIXED);
         THREAD_POOL_TYPES = Collections.unmodifiableMap(map);
     }
 
@@ -232,6 +234,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         );
         builders.put(Names.SYSTEM_READ, new FixedExecutorBuilder(settings, Names.SYSTEM_READ, halfProcMaxAt5, 2000, false));
         builders.put(Names.SYSTEM_WRITE, new FixedExecutorBuilder(settings, Names.SYSTEM_WRITE, halfProcMaxAt5, 1000, false));
+        builders.put(Names.REMOTE_STORE, new FixedExecutorBuilder(settings, Names.REMOTE_STORE, halfProcMaxAt5, 1000, false));
 
         for (final ExecutorBuilder<?> builder : customBuilders) {
             if (builders.containsKey(builder.name())) {

--- a/server/src/test/java/org/opensearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexModuleTests.java
@@ -234,7 +234,7 @@ public class IndexModuleTests extends OpenSearchTestCase {
             writableRegistry(),
             () -> false,
             null,
-            new RemoteDirectoryFactory(repositoriesService)
+            new RemoteDirectoryFactory(() -> repositoriesService)
         );
     }
 

--- a/server/src/test/java/org/opensearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexModuleTests.java
@@ -54,6 +54,7 @@ import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.UnassignedInfo;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.CheckedFunction;
+import org.opensearch.common.UUIDs;
 import org.opensearch.common.breaker.CircuitBreaker;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
@@ -88,6 +89,7 @@ import org.opensearch.index.shard.ShardPath;
 import org.opensearch.index.similarity.NonNegativeScoresSimilarity;
 import org.opensearch.index.similarity.SimilarityService;
 import org.opensearch.index.store.FsDirectoryFactory;
+import org.opensearch.index.store.RemoteDirectoryFactory;
 import org.opensearch.indices.IndicesModule;
 import org.opensearch.indices.IndicesQueryCache;
 import org.opensearch.indices.analysis.AnalysisModule;
@@ -98,6 +100,7 @@ import org.opensearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.opensearch.indices.mapper.MapperRegistry;
 import org.opensearch.indices.recovery.RecoveryState;
 import org.opensearch.plugins.IndexStorePlugin;
+import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
 import org.opensearch.search.internal.ReaderContext;
 import org.opensearch.test.ClusterServiceUtils;
@@ -107,6 +110,8 @@ import org.opensearch.test.engine.MockEngineFactory;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.hamcrest.Matchers;
+import org.opensearch.transport.Transport;
+import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -151,6 +156,7 @@ public class IndexModuleTests extends OpenSearchTestCase {
     private BigArrays bigArrays;
     private ScriptService scriptService;
     private ClusterService clusterService;
+    private RepositoriesService repositoriesService;
 
     @Override
     public void setUp() throws Exception {
@@ -183,6 +189,24 @@ public class IndexModuleTests extends OpenSearchTestCase {
         clusterService = ClusterServiceUtils.createClusterService(threadPool);
         nodeEnvironment = new NodeEnvironment(settings, environment);
         mapperRegistry = new IndicesModule(Collections.emptyList()).getMapperRegistry();
+        TransportService transportService = new TransportService(
+            settings,
+            mock(Transport.class),
+            threadPool,
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            boundAddress -> DiscoveryNode.createLocal(settings, boundAddress.publishAddress(), UUIDs.randomBase64UUID()),
+            null,
+            Collections.emptySet()
+        );
+        repositoriesService = new RepositoriesService(
+            settings,
+            clusterService,
+            transportService,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            threadPool
+        );
+
     }
 
     @Override
@@ -209,7 +233,8 @@ public class IndexModuleTests extends OpenSearchTestCase {
             new IndicesFieldDataCache(settings, listener),
             writableRegistry(),
             () -> false,
-            null
+            null,
+            new RemoteDirectoryFactory(repositoriesService)
         );
     }
 

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -8,132 +8,297 @@
 
 package org.opensearch.index.shard;
 
+import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BytesRef;
+import org.junit.After;
+import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
+import java.util.Set;
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.opensearch.index.shard.RemoteStoreRefreshListener.REMOTE_SEGMENTS_METADATA;
 
 public class RemoteStoreRefreshListenerTests extends OpenSearchTestCase {
     private Directory storeDirectory;
     private Directory remoteDirectory;
+    private ScheduledThreadPoolExecutor executor;
+
+    private List<IndexInput> openedInputs;
 
     private RemoteStoreRefreshListener remoteStoreRefreshListener;
 
-    public void setup(String[] remoteFiles) throws IOException {
-        storeDirectory = mock(Directory.class);
+    public void setup(Set<String> remoteFiles, Set<String> localFiles) throws IOException {
+        storeDirectory = newDirectory();
         remoteDirectory = mock(Directory.class);
-        when(remoteDirectory.listAll()).thenReturn(remoteFiles);
-        remoteStoreRefreshListener = new RemoteStoreRefreshListener(storeDirectory, remoteDirectory);
+        executor = mock(ScheduledThreadPoolExecutor.class);
+
+        openedInputs = new ArrayList<>();
+        writeSegmentFilesToDir(localFiles);
+
+        IndexOutput output = storeDirectory.createOutput(REMOTE_SEGMENTS_METADATA, IOContext.DEFAULT);
+        for (String remoteFile : remoteFiles) {
+            StoreFileMetadata storeFileMetadata;
+            if (localFiles.contains(remoteFile)) {
+                IndexInput indexInput = storeDirectory.openInput(remoteFile, IOContext.DEFAULT);
+                storeFileMetadata = new StoreFileMetadata(
+                    remoteFile,
+                    storeDirectory.fileLength(remoteFile),
+                    Long.toString(CodecUtil.retrieveChecksum(indexInput)),
+                    org.opensearch.Version.CURRENT.minimumIndexCompatibilityVersion().luceneVersion
+                );
+                openedInputs.add(indexInput);
+            } else {
+                storeFileMetadata = new StoreFileMetadata(
+                    remoteFile,
+                    scaledRandomIntBetween(10, 100),
+                    Long.toString(scaledRandomIntBetween(10, 100)),
+                    org.opensearch.Version.CURRENT.minimumIndexCompatibilityVersion().luceneVersion
+                );
+            }
+            writeMetadata(output, storeFileMetadata);
+        }
+        output.close();
+
+        if (remoteFiles.isEmpty()) {
+            when(remoteDirectory.openInput(REMOTE_SEGMENTS_METADATA, IOContext.READ)).thenThrow(
+                new NoSuchFileException(REMOTE_SEGMENTS_METADATA)
+            );
+        } else {
+            IndexInput indexInput = storeDirectory.openInput(REMOTE_SEGMENTS_METADATA, IOContext.READ);
+            when(remoteDirectory.openInput(REMOTE_SEGMENTS_METADATA, IOContext.READ)).thenReturn(indexInput);
+            openedInputs.add(indexInput);
+        }
+        when(remoteDirectory.listAll()).thenReturn(remoteFiles.toArray(new String[0]));
+
+        remoteStoreRefreshListener = new RemoteStoreRefreshListener(storeDirectory, remoteDirectory, executor);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        for (IndexInput indexInput : openedInputs) {
+            indexInput.close();
+        }
+        storeDirectory.close();
+    }
+
+    private void writeSegmentFilesToDir(Set<String> files) throws IOException {
+        for (String file : files) {
+            IndexOutput output = storeDirectory.createOutput(file, IOContext.DEFAULT);
+            int iters = scaledRandomIntBetween(10, 100);
+            for (int i = 0; i < iters; i++) {
+                BytesRef bytesRef = new BytesRef(TestUtil.randomRealisticUnicodeString(random(), 10, 1024));
+                output.writeBytes(bytesRef.bytes, bytesRef.offset, bytesRef.length);
+            }
+            CodecUtil.writeFooter(output);
+            output.close();
+        }
+    }
+
+    private void writeMetadata(IndexOutput indexOutput, StoreFileMetadata storeFileMetadata) throws IOException {
+        indexOutput.writeString(storeFileMetadata.name());
+        indexOutput.writeVLong(storeFileMetadata.length());
+        indexOutput.writeString(storeFileMetadata.checksum());
+        indexOutput.writeString(storeFileMetadata.writtenBy().toString());
     }
 
     public void testAfterRefreshFalse() throws IOException {
-        setup(new String[0]);
+        setup(Set.of(), Set.of());
+
         remoteStoreRefreshListener.afterRefresh(false);
-        verify(storeDirectory, times(0)).listAll();
+
+        verify(remoteDirectory, times(0)).copyFrom(any(), any(), any(), any());
+        verify(remoteDirectory, times(0)).copyFrom(storeDirectory, REMOTE_SEGMENTS_METADATA, REMOTE_SEGMENTS_METADATA, IOContext.DEFAULT);
+        assertEquals(Set.of(), remoteStoreRefreshListener.getUploadedSegments().keySet());
     }
 
     public void testAfterRefreshTrueNoLocalFiles() throws IOException {
-        setup(new String[0]);
-
-        when(storeDirectory.listAll()).thenReturn(new String[0]);
+        setup(Set.of(), Set.of());
 
         remoteStoreRefreshListener.afterRefresh(true);
-        verify(storeDirectory).listAll();
+
         verify(remoteDirectory, times(0)).copyFrom(any(), any(), any(), any());
-        verify(remoteDirectory, times(0)).deleteFile(any());
+        verify(remoteDirectory, times(0)).copyFrom(storeDirectory, REMOTE_SEGMENTS_METADATA, REMOTE_SEGMENTS_METADATA, IOContext.DEFAULT);
+        assertEquals(Set.of(), remoteStoreRefreshListener.getUploadedSegments().keySet());
     }
 
     public void testAfterRefreshOnlyUploadFiles() throws IOException {
-        setup(new String[0]);
-
-        String[] localFiles = new String[] { "segments_1", "0.si", "0.cfs", "0.cfe" };
-        when(storeDirectory.listAll()).thenReturn(localFiles);
+        setup(Set.of(), Set.of("0.si", "0.cfs", "0.cfe", "write.lock"));
 
         remoteStoreRefreshListener.afterRefresh(true);
-        verify(storeDirectory).listAll();
-        verify(remoteDirectory).copyFrom(storeDirectory, "segments_1", "segments_1", IOContext.DEFAULT);
+
         verify(remoteDirectory).copyFrom(storeDirectory, "0.si", "0.si", IOContext.DEFAULT);
         verify(remoteDirectory).copyFrom(storeDirectory, "0.cfs", "0.cfs", IOContext.DEFAULT);
         verify(remoteDirectory).copyFrom(storeDirectory, "0.cfe", "0.cfe", IOContext.DEFAULT);
-        verify(remoteDirectory, times(0)).deleteFile(any());
+        verify(remoteDirectory).copyFrom(storeDirectory, REMOTE_SEGMENTS_METADATA, REMOTE_SEGMENTS_METADATA, IOContext.DEFAULT);
+        assertEquals(Set.of("0.si", "0.cfs", "0.cfe"), remoteStoreRefreshListener.getUploadedSegments().keySet());
     }
 
-    public void testAfterRefreshOnlyUploadAndDelete() throws IOException {
-        setup(new String[] { "0.si", "0.cfs" });
-
-        String[] localFiles = new String[] { "segments_1", "1.si", "1.cfs", "1.cfe" };
-        when(storeDirectory.listAll()).thenReturn(localFiles);
+    public void testAfterRefreshUploadWithExistingRemoteFiles() throws IOException {
+        setup(Set.of("0.si", "0.cfs"), Set.of("1.si", "1.cfs", "1.cfe"));
 
         remoteStoreRefreshListener.afterRefresh(true);
-        verify(storeDirectory).listAll();
-        verify(remoteDirectory).copyFrom(storeDirectory, "segments_1", "segments_1", IOContext.DEFAULT);
+
         verify(remoteDirectory).copyFrom(storeDirectory, "1.si", "1.si", IOContext.DEFAULT);
         verify(remoteDirectory).copyFrom(storeDirectory, "1.cfs", "1.cfs", IOContext.DEFAULT);
         verify(remoteDirectory).copyFrom(storeDirectory, "1.cfe", "1.cfe", IOContext.DEFAULT);
-        verify(remoteDirectory).deleteFile("0.si");
-        verify(remoteDirectory).deleteFile("0.cfs");
+        verify(remoteDirectory).copyFrom(storeDirectory, REMOTE_SEGMENTS_METADATA, REMOTE_SEGMENTS_METADATA, IOContext.DEFAULT);
+        assertEquals(Set.of("0.si", "0.cfs", "1.si", "1.cfs", "1.cfe"), remoteStoreRefreshListener.getUploadedSegments().keySet());
     }
 
-    public void testAfterRefreshOnlyDelete() throws IOException {
-        setup(new String[] { "0.si", "0.cfs" });
-
-        String[] localFiles = new String[] { "0.si" };
-        when(storeDirectory.listAll()).thenReturn(localFiles);
+    public void testAfterRefreshNoUpload() throws IOException {
+        setup(Set.of("0.si", "0.cfs"), Set.of("0.si"));
 
         remoteStoreRefreshListener.afterRefresh(true);
-        verify(storeDirectory).listAll();
+
         verify(remoteDirectory, times(0)).copyFrom(any(), any(), any(), any());
-        verify(remoteDirectory).deleteFile("0.cfs");
+        verify(remoteDirectory, times(0)).copyFrom(storeDirectory, REMOTE_SEGMENTS_METADATA, REMOTE_SEGMENTS_METADATA, IOContext.DEFAULT);
+        assertEquals(Set.of("0.si", "0.cfs"), remoteStoreRefreshListener.getUploadedSegments().keySet());
     }
 
-    public void testAfterRefreshTempLocalFile() throws IOException {
-        setup(new String[0]);
-
-        String[] localFiles = new String[] { "segments_1", "0.si", "0.cfs.tmp" };
-        when(storeDirectory.listAll()).thenReturn(localFiles);
-        doThrow(new NoSuchFileException("0.cfs.tmp")).when(remoteDirectory)
-            .copyFrom(storeDirectory, "0.cfs.tmp", "0.cfs.tmp", IOContext.DEFAULT);
-
-        remoteStoreRefreshListener.afterRefresh(true);
-        verify(storeDirectory).listAll();
-        verify(remoteDirectory).copyFrom(storeDirectory, "segments_1", "segments_1", IOContext.DEFAULT);
-        verify(remoteDirectory).copyFrom(storeDirectory, "0.si", "0.si", IOContext.DEFAULT);
-        verify(remoteDirectory, times(0)).deleteFile(any());
-    }
-
-    public void testAfterRefreshConsecutive() throws IOException {
-        setup(new String[0]);
-
-        String[] localFiles = new String[] { "segments_1", "0.si", "0.cfs", "0.cfe" };
-        when(storeDirectory.listAll()).thenReturn(localFiles);
-        doThrow(new IOException("0.cfs")).when(remoteDirectory).copyFrom(storeDirectory, "0.cfs", "0.cfe", IOContext.DEFAULT);
-        doThrow(new IOException("0.cfe")).when(remoteDirectory).copyFrom(storeDirectory, "0.cfe", "0.cfe", IOContext.DEFAULT);
-
-        remoteStoreRefreshListener.afterRefresh(true);
-        verify(storeDirectory).listAll();
-        verify(remoteDirectory).copyFrom(storeDirectory, "segments_1", "segments_1", IOContext.DEFAULT);
-        verify(remoteDirectory).copyFrom(storeDirectory, "0.si", "0.si", IOContext.DEFAULT);
-        verify(remoteDirectory).copyFrom(storeDirectory, "0.cfs", "0.cfs", IOContext.DEFAULT);
-        verify(remoteDirectory).copyFrom(storeDirectory, "0.cfe", "0.cfe", IOContext.DEFAULT);
-        verify(remoteDirectory, times(0)).deleteFile(any());
-
-        String[] localFilesSecondRefresh = new String[] { "segments_1", "0.cfs", "1.cfs", "1.cfe" };
-        when(storeDirectory.listAll()).thenReturn(localFilesSecondRefresh);
+    public void testAfterRefreshPartialUpload() throws IOException {
+        setup(Set.of("0.si", "0.cfs"), Set.of("0.si", "1.si", "1.cfs"));
 
         remoteStoreRefreshListener.afterRefresh(true);
 
-        verify(remoteDirectory).copyFrom(storeDirectory, "0.cfs", "0.cfs", IOContext.DEFAULT);
+        verify(remoteDirectory).copyFrom(storeDirectory, "1.si", "1.si", IOContext.DEFAULT);
         verify(remoteDirectory).copyFrom(storeDirectory, "1.cfs", "1.cfs", IOContext.DEFAULT);
-        verify(remoteDirectory).copyFrom(storeDirectory, "1.cfe", "1.cfe", IOContext.DEFAULT);
+        verify(remoteDirectory).copyFrom(storeDirectory, REMOTE_SEGMENTS_METADATA, REMOTE_SEGMENTS_METADATA, IOContext.DEFAULT);
+        assertEquals(Set.of("0.si", "0.cfs", "1.si", "1.cfs"), remoteStoreRefreshListener.getUploadedSegments().keySet());
+    }
+
+    public void testDeleteStaleSegmentsNoStale() throws IOException {
+        setup(Set.of("0.si", "0.cfs", REMOTE_SEGMENTS_METADATA), Set.of("0.si", "1.si", "0.cfs"));
+
+        remoteStoreRefreshListener.deleteStaleSegments(Set.of("0.si", "1.si", "0.cfs"));
+
+        verify(remoteDirectory, times(0)).deleteFile(any());
+        assertEquals(Set.of("0.si", "0.cfs", REMOTE_SEGMENTS_METADATA), remoteStoreRefreshListener.getUploadedSegments().keySet());
+    }
+
+    public void testDeleteStaleSegmentsFewStale() throws IOException {
+        setup(Set.of("0.si", "0.cfs"), Set.of("0.si", "1.si", "1.cfs"));
+
+        remoteStoreRefreshListener.deleteStaleSegments(Set.of("0.si", "1.si", "1.cfs"));
+
+        verify(remoteDirectory).deleteFile("0.cfs");
+        assertEquals(Set.of("0.si"), remoteStoreRefreshListener.getUploadedSegments().keySet());
+    }
+
+    public void testDeleteStaleSegmentsAllStale() throws IOException {
+        setup(Set.of("0.si", "0.cfs", REMOTE_SEGMENTS_METADATA), Set.of("2.si", "1.si", "1.cfs"));
+
+        remoteStoreRefreshListener.deleteStaleSegments(Set.of("2.si", "1.si", "1.cfs"));
+
+        verify(remoteDirectory).deleteFile("0.cfs");
         verify(remoteDirectory).deleteFile("0.si");
+        verify(remoteDirectory, times(0)).deleteFile(REMOTE_SEGMENTS_METADATA);
+        assertEquals(Set.of(REMOTE_SEGMENTS_METADATA), remoteStoreRefreshListener.getUploadedSegments().keySet());
+    }
+
+    public void testDeleteStaleSegmentsException() throws IOException {
+        setup(Set.of("0.si", "0.cfs", "0.cfe"), Set.of("2.si", "1.si", "1.cfs"));
+        doThrow(new IOException()).when(remoteDirectory).deleteFile("0.cfs");
+
+        remoteStoreRefreshListener.deleteStaleSegments(Set.of("2.si", "1.si", "1.cfs"));
+
+        verify(remoteDirectory).deleteFile("0.cfs");
+        verify(remoteDirectory).deleteFile("0.si");
+        verify(remoteDirectory).deleteFile("0.cfs");
+        assertEquals(Set.of("0.cfs"), remoteStoreRefreshListener.getUploadedSegments().keySet());
+    }
+
+    public void testSchedulerFlow() throws IOException {
+        setup(Set.of(), Set.of("0.si", "1.si", "2.si", "3.si", "4.si", "write.lock"));
+
+        // First Refresh
+        remoteStoreRefreshListener.afterRefresh(true);
+        verify(remoteDirectory).copyFrom(storeDirectory, "0.si", "0.si", IOContext.DEFAULT);
+        verify(remoteDirectory).copyFrom(storeDirectory, "1.si", "1.si", IOContext.DEFAULT);
+        verify(remoteDirectory).copyFrom(storeDirectory, "2.si", "2.si", IOContext.DEFAULT);
+        verify(remoteDirectory).copyFrom(storeDirectory, "3.si", "3.si", IOContext.DEFAULT);
+        verify(remoteDirectory).copyFrom(storeDirectory, "4.si", "4.si", IOContext.DEFAULT);
+        verify(remoteDirectory).copyFrom(storeDirectory, REMOTE_SEGMENTS_METADATA, REMOTE_SEGMENTS_METADATA, IOContext.DEFAULT);
+
+        assertEquals(Set.of("0.si", "1.si", "2.si", "3.si", "4.si"), remoteStoreRefreshListener.getUploadedSegments().keySet());
+        Map<String, StoreFileMetadata> metadata = remoteStoreRefreshListener.readRemoteSegmentsMetadata(storeDirectory);
+        assertEquals(Set.of("0.si", "1.si", "2.si", "3.si", "4.si"), metadata.keySet());
+
+        // Second Refresh
+        when(remoteDirectory.listAll()).thenReturn(remoteStoreRefreshListener.getUploadedSegments().keySet().toArray(new String[0]));
+        writeSegmentFilesToDir(Set.of("5.si", "6.si", "7.si"));
+        storeDirectory.deleteFile("0.si");
+        storeDirectory.deleteFile("1.si");
+        storeDirectory.deleteFile("2.si");
+
+        remoteStoreRefreshListener.afterRefresh(true);
+
+        verify(remoteDirectory).copyFrom(storeDirectory, "5.si", "5.si", IOContext.DEFAULT);
+        verify(remoteDirectory).copyFrom(storeDirectory, "6.si", "6.si", IOContext.DEFAULT);
+        verify(remoteDirectory).copyFrom(storeDirectory, "7.si", "7.si", IOContext.DEFAULT);
+
+        assertEquals(
+            Set.of("0.si", "1.si", "2.si", "3.si", "4.si", "5.si", "6.si", "7.si"),
+            remoteStoreRefreshListener.getUploadedSegments().keySet()
+        );
+        metadata = remoteStoreRefreshListener.readRemoteSegmentsMetadata(storeDirectory);
+        assertEquals(Set.of("3.si", "4.si", "5.si", "6.si", "7.si"), metadata.keySet());
+
+        // Schedule flow
+        when(remoteDirectory.listAll()).thenReturn(remoteStoreRefreshListener.getUploadedSegments().keySet().toArray(new String[0]));
+        writeSegmentFilesToDir(Set.of("8.si", "9.si", "10.si"));
+        storeDirectory.deleteFile("3.si");
+        storeDirectory.deleteFile("6.si");
+
+        Set<String> localFiles = Set.of("4.si", "5.si", "7.si", "8.si", "9.si", "10.si");
+
+        // Scheduler flow - upload new segments
+        remoteStoreRefreshListener.uploadNewSegments(localFiles);
+
+        verify(remoteDirectory).copyFrom(storeDirectory, "8.si", "8.si", IOContext.DEFAULT);
+        verify(remoteDirectory).copyFrom(storeDirectory, "9.si", "9.si", IOContext.DEFAULT);
+        verify(remoteDirectory).copyFrom(storeDirectory, "10.si", "10.si", IOContext.DEFAULT);
+        assertEquals(
+            Set.of("0.si", "1.si", "2.si", "3.si", "4.si", "5.si", "6.si", "7.si", "8.si", "9.si", "10.si"),
+            remoteStoreRefreshListener.getUploadedSegments().keySet()
+        );
+        metadata = remoteStoreRefreshListener.readRemoteSegmentsMetadata(storeDirectory);
+        assertEquals(Set.of("3.si", "4.si", "5.si", "6.si", "7.si"), metadata.keySet());
+
+        // Scheduler flow - delete stale segments
+        when(remoteDirectory.listAll()).thenReturn(remoteStoreRefreshListener.getUploadedSegments().keySet().toArray(new String[0]));
+        remoteStoreRefreshListener.deleteStaleSegments(localFiles);
+
+        verify(remoteDirectory).deleteFile("0.si");
+        verify(remoteDirectory).deleteFile("1.si");
+        verify(remoteDirectory).deleteFile("2.si");
+        verify(remoteDirectory).deleteFile("3.si");
+        verify(remoteDirectory).deleteFile("6.si");
+        assertEquals(Set.of("4.si", "5.si", "7.si", "8.si", "9.si", "10.si"), remoteStoreRefreshListener.getUploadedSegments().keySet());
+        metadata = remoteStoreRefreshListener.readRemoteSegmentsMetadata(storeDirectory);
+        assertEquals(Set.of("3.si", "4.si", "5.si", "6.si", "7.si"), metadata.keySet());
+
+        remoteStoreRefreshListener.uploadRemoteSegmentsMetadata(localFiles);
+
+        assertEquals(Set.of("4.si", "5.si", "7.si", "8.si", "9.si", "10.si"), remoteStoreRefreshListener.getUploadedSegments().keySet());
+        metadata = remoteStoreRefreshListener.readRemoteSegmentsMetadata(storeDirectory);
+        assertEquals(Set.of("4.si", "5.si", "7.si", "8.si", "9.si", "10.si"), metadata.keySet());
     }
 }

--- a/server/src/test/java/org/opensearch/index/store/RemoteDirectoryFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteDirectoryFactoryTests.java
@@ -27,6 +27,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.function.Supplier;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -35,13 +36,16 @@ import static org.mockito.Mockito.verify;
 
 public class RemoteDirectoryFactoryTests extends OpenSearchTestCase {
 
+    private Supplier<RepositoriesService> repositoriesServiceSupplier;
     private RepositoriesService repositoriesService;
     private RemoteDirectoryFactory remoteDirectoryFactory;
 
     @Before
     public void setup() {
+        repositoriesServiceSupplier = mock(Supplier.class);
         repositoriesService = mock(RepositoriesService.class);
-        remoteDirectoryFactory = new RemoteDirectoryFactory(repositoriesService);
+        when(repositoriesServiceSupplier.get()).thenReturn(repositoriesService);
+        remoteDirectoryFactory = new RemoteDirectoryFactory(repositoriesServiceSupplier);
     }
 
     public void testNewDirectory() throws IOException {

--- a/server/src/test/java/org/opensearch/index/store/RemoteIndexInputTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteIndexInputTests.java
@@ -37,6 +37,7 @@ public class RemoteIndexInputTests extends OpenSearchTestCase {
         when(inputStream.read()).thenReturn(10);
 
         assertEquals(10, remoteIndexInput.readByte());
+        assertEquals(1, remoteIndexInput.getFilePointer());
 
         verify(inputStream).read(any());
     }
@@ -45,9 +46,22 @@ public class RemoteIndexInputTests extends OpenSearchTestCase {
         when(inputStream.read(any())).thenThrow(new IOException("Error reading"));
 
         assertThrows(IOException.class, () -> remoteIndexInput.readByte());
+        assertEquals(0, remoteIndexInput.getFilePointer());
     }
 
     public void testReadBytes() throws IOException {
+        byte[] buffer = new byte[20];
+        when(inputStream.read(eq(buffer), anyInt(), anyInt())).thenReturn(10).thenReturn(3).thenReturn(6).thenReturn(-1);
+        remoteIndexInput.readBytes(buffer, 0, 20);
+
+        verify(inputStream).read(buffer, 0, 20);
+        verify(inputStream).read(buffer, 10, 10);
+        verify(inputStream).read(buffer, 13, 7);
+        verify(inputStream).read(buffer, 19, 1);
+        assertEquals(19, remoteIndexInput.getFilePointer());
+    }
+
+    public void testReadBytesMultipleIterations() throws IOException {
         byte[] buffer = new byte[10];
         remoteIndexInput.readBytes(buffer, 10, 20);
 
@@ -89,8 +103,11 @@ public class RemoteIndexInputTests extends OpenSearchTestCase {
         assertThrows(IOException.class, () -> remoteIndexInput.seek(10));
     }
 
-    public void testGetFilePointer() {
-        assertThrows(UnsupportedOperationException.class, () -> remoteIndexInput.getFilePointer());
+    public void testGetFilePointer() throws IOException {
+        when(inputStream.skip(10)).thenReturn(8L);
+        assertEquals(0, remoteIndexInput.getFilePointer());
+        remoteIndexInput.seek(10);
+        assertEquals(8, remoteIndexInput.getFilePointer());
     }
 
     public void testSlice() {

--- a/server/src/test/java/org/opensearch/indices/IndicesLifecycleListenerSingleNodeTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesLifecycleListenerSingleNodeTests.java
@@ -153,8 +153,7 @@ public class IndicesLifecycleListenerSingleNodeTests extends OpenSearchSingleNod
                 newRouting,
                 s -> {},
                 RetentionLeaseSyncer.EMPTY,
-                SegmentReplicationCheckpointPublisher.EMPTY,
-                null
+                SegmentReplicationCheckpointPublisher.EMPTY
             );
             IndexShardTestCase.updateRoutingEntry(shard, newRouting);
             assertEquals(5, counter.get());

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -1820,7 +1820,7 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     emptyMap(),
                     null,
                     emptyMap(),
-                    new RemoteDirectoryFactory(repositoriesService)
+                    new RemoteDirectoryFactory(() -> repositoriesService)
                 );
                 final RecoverySettings recoverySettings = new RecoverySettings(settings, clusterSettings);
                 snapshotShardsService = new SnapshotShardsService(

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -171,6 +171,7 @@ import org.opensearch.index.analysis.AnalysisRegistry;
 import org.opensearch.index.seqno.GlobalCheckpointSyncAction;
 import org.opensearch.index.seqno.RetentionLeaseSyncer;
 import org.opensearch.index.shard.PrimaryReplicaSyncer;
+import org.opensearch.index.store.RemoteDirectoryFactory;
 import org.opensearch.indices.IndicesModule;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.ShardLimitValidator;
@@ -1818,7 +1819,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     Collections.emptyList(),
                     emptyMap(),
                     null,
-                    emptyMap()
+                    emptyMap(),
+                    new RemoteDirectoryFactory(repositoriesService)
                 );
                 final RecoverySettings recoverySettings = new RecoverySettings(settings, clusterSettings);
                 snapshotShardsService = new SnapshotShardsService(


### PR DESCRIPTION
Signed-off-by: Sachin Kale <kalsac@amazon.com>

### Description
In this change, merged away segments are deleted from the remote segment store in async periodic flow. This will help in not blocking the refresh flow unnecessarily. 
To achieve this:
- After each refresh, we create and upload a metadata file named`remote_segments_metadata` to remote segment store.
- `remote_segments_metadata` keeps track of list of segment files at the time of refresh along with metadata including file length, checksum etc.
- A periodic thread reads deletes files that are not part of local directory or `remote_segments_metadata`. 
 
### Issues Resolved
- https://github.com/opensearch-project/OpenSearch/issues/3142
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
