### PR TITLE
Changing default  no_master_block from write to metadata_write

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/discovery/ClusterManagerDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/ClusterManagerDisruptionIT.java
@@ -227,7 +227,7 @@ public class ClusterManagerDisruptionIT extends AbstractDisruptionTestCase {
         // continuously ping until network failures have been resolved. However
         // It may a take a bit before the node detects it has been cut off from the elected cluster-manager
         logger.info("waiting for isolated node [{}] to have no cluster-manager", isolatedNode);
-        assertNoClusterManager(isolatedNode, NoMasterBlockService.NO_MASTER_BLOCK_WRITES, TimeValue.timeValueSeconds(30));
+        assertNoClusterManager(isolatedNode, NoMasterBlockService.NO_MASTER_BLOCK_METADATA_WRITES, TimeValue.timeValueSeconds(30));
 
         logger.info("wait until elected cluster-manager has been removed and a new 2 node cluster was from (via [{}])", isolatedNode);
         ensureStableCluster(2, nonIsolatedNode);

--- a/server/src/main/java/org/opensearch/cluster/coordination/NoMasterBlockService.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/NoMasterBlockService.java
@@ -78,7 +78,7 @@ public class NoMasterBlockService {
 
     public static final Setting<ClusterBlock> NO_MASTER_BLOCK_SETTING = new Setting<>(
         "cluster.no_master_block",
-        "write",
+        "metadata_write",
         NoMasterBlockService::parseNoClusterManagerBlock,
         Property.Dynamic,
         Property.NodeScope,

--- a/server/src/test/java/org/opensearch/cluster/coordination/NoMasterBlockServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/NoMasterBlockServiceTests.java
@@ -61,7 +61,7 @@ public class NoMasterBlockServiceTests extends OpenSearchTestCase {
 
     public void testBlocksWritesByDefault() {
         createService(Settings.EMPTY);
-        assertThat(noClusterManagerBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_WRITES));
+        assertThat(noClusterManagerBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_METADATA_WRITES));
     }
 
     public void testBlocksWritesIfConfiguredBySetting() {


### PR DESCRIPTION
Signed-off-by: Gaurav Bafna <gbbafna@amazon.com>

### Description
When there is no master in the cluster, or a node is partitioned off the cluster all writes see a 5xx, this leads to availability drop espl when there is a master quorum loss(writes do not need a quorum to succeed)

We can switch the default to only fail metadata writes as a part of index creation/dynamic mapping updates but let other writes succeed. 
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/3045
 
### Check List
- [] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
