### PR TITLE
Fix random gradle check failure issue 3584.

### DIFF
--- a/server/src/test/java/org/opensearch/index/engine/NRTReplicationEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/NRTReplicationEngineTests.java
@@ -110,8 +110,9 @@ public class NRTReplicationEngineTests extends EngineTestCase {
 
             engine.refresh("test");
 
-            nrtEngine.updateSegments(engine.getLatestSegmentInfos(), engine.getProcessedLocalCheckpoint());
-            assertMatchingSegmentsAndCheckpoints(nrtEngine);
+            final SegmentInfos latestPrimaryInfos = engine.getLatestSegmentInfos();
+            nrtEngine.updateSegments(latestPrimaryInfos, engine.getProcessedLocalCheckpoint());
+            assertMatchingSegmentsAndCheckpoints(nrtEngine, latestPrimaryInfos);
 
             // assert a doc from the operations exists.
             final ParsedDocument parsedDoc = createParsedDoc(operations.stream().findFirst().get().id(), null);
@@ -139,8 +140,9 @@ public class NRTReplicationEngineTests extends EngineTestCase {
                 );
             }
 
-            nrtEngine.updateSegments(engine.getLastCommittedSegmentInfos(), engine.getProcessedLocalCheckpoint());
-            assertMatchingSegmentsAndCheckpoints(nrtEngine);
+            final SegmentInfos primaryInfos = engine.getLastCommittedSegmentInfos();
+            nrtEngine.updateSegments(primaryInfos, engine.getProcessedLocalCheckpoint());
+            assertMatchingSegmentsAndCheckpoints(nrtEngine, primaryInfos);
 
             assertEquals(
                 nrtEngine.getTranslog().getGeneration().translogFileGeneration,
@@ -196,14 +198,14 @@ public class NRTReplicationEngineTests extends EngineTestCase {
         }
     }
 
-    private void assertMatchingSegmentsAndCheckpoints(NRTReplicationEngine nrtEngine) throws IOException {
+    private void assertMatchingSegmentsAndCheckpoints(NRTReplicationEngine nrtEngine, SegmentInfos expectedSegmentInfos)
+        throws IOException {
         assertEquals(engine.getPersistedLocalCheckpoint(), nrtEngine.getPersistedLocalCheckpoint());
         assertEquals(engine.getProcessedLocalCheckpoint(), nrtEngine.getProcessedLocalCheckpoint());
         assertEquals(engine.getLocalCheckpointTracker().getMaxSeqNo(), nrtEngine.getLocalCheckpointTracker().getMaxSeqNo());
-        assertEquals(engine.getLatestSegmentInfos().files(true), nrtEngine.getLatestSegmentInfos().files(true));
-        assertEquals(engine.getLatestSegmentInfos().getUserData(), nrtEngine.getLatestSegmentInfos().getUserData());
-        assertEquals(engine.getLatestSegmentInfos().getVersion(), nrtEngine.getLatestSegmentInfos().getVersion());
-        assertEquals(engine.segments(true), nrtEngine.segments(true));
+        assertEquals(expectedSegmentInfos.files(true), nrtEngine.getLatestSegmentInfos().files(true));
+        assertEquals(expectedSegmentInfos.getUserData(), nrtEngine.getLatestSegmentInfos().getUserData());
+        assertEquals(expectedSegmentInfos.getVersion(), nrtEngine.getLatestSegmentInfos().getVersion());
     }
 
     private void assertSearcherHits(Engine engine, int hits) {


### PR DESCRIPTION


Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
This changes NRTReplicationEngineTests to assert against the exact version of
SegmentInfos passed from the primary to replicas.  Under certain conditions a primary
can perform a merge while the replica is updating, making its latest segmentInfos differ
from what was passed to the replica.  It also removes the assertion against engine.segments(),
because that is always computed from the `lastCommittedSegmentInfos`, which will differ after a merge.
 
### Issues Resolved
closes #3584 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
