### PR TITLE
[Remote Store] Add remote store restore API implementation

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequest.java
@@ -1,0 +1,211 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.remotestore.restore;
+
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.ToXContentObject;
+import org.opensearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.opensearch.action.ValidateActions.addValidationError;
+
+/**
+ * Restore remote store request
+ *
+ * @opensearch.internal
+ */
+public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<RestoreRemoteStoreRequest> implements ToXContentObject {
+
+    private String[] indices = Strings.EMPTY_ARRAY;
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
+    private boolean waitForCompletion;
+
+    public RestoreRemoteStoreRequest() {}
+
+    public RestoreRemoteStoreRequest(StreamInput in) throws IOException {
+        super(in);
+        indices = in.readStringArray();
+        indicesOptions = IndicesOptions.readIndicesOptions(in);
+        waitForCompletion = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeStringArray(indices);
+        indicesOptions.writeIndicesOptions(out);
+        out.writeBoolean(waitForCompletion);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (indices == null || indices.length == 0) {
+            validationException = addValidationError("indices are missing", validationException);
+        }
+        return validationException;
+    }
+
+    /**
+     * Sets the list of indices that should be restored from the remote store
+     * <p>
+     * The list of indices supports multi-index syntax. For example: "+test*" ,"-test42" will index all indices with
+     * prefix "test" except index "test42". Aliases are not supported. An empty list or {"_all"} will restore all open
+     * indices in the cluster.
+     *
+     * @param indices list of indices
+     * @return this request
+     */
+    public RestoreRemoteStoreRequest indices(String... indices) {
+        this.indices = indices;
+        return this;
+    }
+
+    /**
+     * Sets the list of indices that should be restored from the remote store
+     * <p>
+     * The list of indices supports multi-index syntax. For example: "+test*" ,"-test42" will index all indices with
+     * prefix "test" except index "test42". Aliases are not supported. An empty list or {"_all"} will restore all open
+     * indices in the cluster.
+     *
+     * @param indices list of indices
+     * @return this request
+     */
+    public RestoreRemoteStoreRequest indices(List<String> indices) {
+        this.indices = indices.toArray(new String[indices.size()]);
+        return this;
+    }
+
+    /**
+     * Returns list of indices that should be restored from the remote store
+     */
+    public String[] indices() {
+        return indices;
+    }
+
+    /**
+     * Specifies what type of requested indices to ignore and how to deal with wildcard expressions.
+     * For example indices that don't exist.
+     *
+     * @return the desired behaviour regarding indices to ignore and wildcard indices expression
+     */
+    public IndicesOptions indicesOptions() {
+        return indicesOptions;
+    }
+
+    /**
+     * Specifies what type of requested indices to ignore and how to deal with wildcard expressions.
+     * For example indices that don't exist.
+     *
+     * @param indicesOptions the desired behaviour regarding indices to ignore and wildcard indices expressions
+     * @return this request
+     */
+    public RestoreRemoteStoreRequest indicesOptions(IndicesOptions indicesOptions) {
+        this.indicesOptions = indicesOptions;
+        return this;
+    }
+
+    /**
+     * If this parameter is set to true the operation will wait for completion of restore process before returning.
+     *
+     * @param waitForCompletion if true the operation will wait for completion
+     * @return this request
+     */
+    public RestoreRemoteStoreRequest waitForCompletion(boolean waitForCompletion) {
+        this.waitForCompletion = waitForCompletion;
+        return this;
+    }
+
+    /**
+     * Returns wait for completion setting
+     *
+     * @return true if the operation will wait for completion
+     */
+    public boolean waitForCompletion() {
+        return waitForCompletion;
+    }
+
+    /**
+     * Parses restore definition
+     *
+     * @param source restore definition
+     * @return this request
+     */
+    @SuppressWarnings("unchecked")
+    public RestoreRemoteStoreRequest source(Map<String, Object> source) {
+        for (Map.Entry<String, Object> entry : source.entrySet()) {
+            String name = entry.getKey();
+            if (name.equals("indices")) {
+                if (entry.getValue() instanceof String) {
+                    indices(Strings.splitStringByCommaToArray((String) entry.getValue()));
+                } else if (entry.getValue() instanceof ArrayList) {
+                    indices((ArrayList<String>) entry.getValue());
+                } else {
+                    throw new IllegalArgumentException("malformed indices section, should be an array of strings");
+                }
+            } else {
+                if (IndicesOptions.isIndicesOptions(name) == false) {
+                    throw new IllegalArgumentException("Unknown parameter " + name);
+                }
+            }
+        }
+        indicesOptions(IndicesOptions.fromMap(source, indicesOptions));
+        return this;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.startArray("indices");
+        for (String index : indices) {
+            builder.value(index);
+        }
+        builder.endArray();
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public String getDescription() {
+        return "remote_store";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RestoreRemoteStoreRequest that = (RestoreRemoteStoreRequest) o;
+        return waitForCompletion == that.waitForCompletion
+            && Arrays.equals(indices, that.indices)
+            && Objects.equals(indicesOptions, that.indicesOptions);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(indicesOptions, waitForCompletion);
+        result = 31 * result + Arrays.hashCode(indices);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequest.java
@@ -34,24 +34,21 @@ import static org.opensearch.action.ValidateActions.addValidationError;
 public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<RestoreRemoteStoreRequest> implements ToXContentObject {
 
     private String[] indices = Strings.EMPTY_ARRAY;
-    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
-    private boolean waitForCompletion;
+    private Boolean waitForCompletion;
 
     public RestoreRemoteStoreRequest() {}
 
     public RestoreRemoteStoreRequest(StreamInput in) throws IOException {
         super(in);
         indices = in.readStringArray();
-        indicesOptions = IndicesOptions.readIndicesOptions(in);
-        waitForCompletion = in.readBoolean();
+        waitForCompletion = in.readOptionalBoolean();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeStringArray(indices);
-        indicesOptions.writeIndicesOptions(out);
-        out.writeBoolean(waitForCompletion);
+        out.writeOptionalBoolean(waitForCompletion);
     }
 
     @Override
@@ -101,28 +98,6 @@ public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<Restore
     }
 
     /**
-     * Specifies what type of requested indices to ignore and how to deal with wildcard expressions.
-     * For example indices that don't exist.
-     *
-     * @return the desired behaviour regarding indices to ignore and wildcard indices expression
-     */
-    public IndicesOptions indicesOptions() {
-        return indicesOptions;
-    }
-
-    /**
-     * Specifies what type of requested indices to ignore and how to deal with wildcard expressions.
-     * For example indices that don't exist.
-     *
-     * @param indicesOptions the desired behaviour regarding indices to ignore and wildcard indices expressions
-     * @return this request
-     */
-    public RestoreRemoteStoreRequest indicesOptions(IndicesOptions indicesOptions) {
-        this.indicesOptions = indicesOptions;
-        return this;
-    }
-
-    /**
      * If this parameter is set to true the operation will wait for completion of restore process before returning.
      *
      * @param waitForCompletion if true the operation will wait for completion
@@ -166,7 +141,6 @@ public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<Restore
                 }
             }
         }
-        indicesOptions(IndicesOptions.fromMap(source, indicesOptions));
         return this;
     }
 
@@ -192,14 +166,12 @@ public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<Restore
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         RestoreRemoteStoreRequest that = (RestoreRemoteStoreRequest) o;
-        return waitForCompletion == that.waitForCompletion
-            && Arrays.equals(indices, that.indices)
-            && Objects.equals(indicesOptions, that.indicesOptions);
+        return waitForCompletion == that.waitForCompletion && Arrays.equals(indices, that.indices);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(indicesOptions, waitForCompletion);
+        int result = Objects.hash(waitForCompletion);
         result = 31 * result + Arrays.hashCode(indices);
         return result;
     }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/package-info.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Restore Snapshot transport handler. */
+package org.opensearch.action.admin.cluster.remotestore.restore;

--- a/server/src/main/java/org/opensearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/IndexRoutingTable.java
@@ -45,6 +45,7 @@ import org.opensearch.cluster.routing.RecoverySource.ExistingStoreRecoverySource
 import org.opensearch.cluster.routing.RecoverySource.LocalShardsRecoverySource;
 import org.opensearch.cluster.routing.RecoverySource.PeerRecoverySource;
 import org.opensearch.cluster.routing.RecoverySource.SnapshotRecoverySource;
+import org.opensearch.cluster.routing.RecoverySource.RemoteStoreRecoverySource;
 import org.opensearch.common.Randomness;
 import org.opensearch.common.collect.ImmutableOpenIntMap;
 import org.opensearch.common.io.stream.StreamInput;
@@ -445,11 +446,28 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
         }
 
         /**
+         * Initializes an existing index, to be restored from remote store
+         */
+        public Builder initializeAsRemoteStoreRestore(IndexMetadata indexMetadata, RemoteStoreRecoverySource recoverySource) {
+            final UnassignedInfo unassignedInfo = new UnassignedInfo(
+                UnassignedInfo.Reason.EXISTING_INDEX_RESTORED,
+                "restore_source[remote_store]"
+            );
+            for (int shardNumber = 0; shardNumber < indexMetadata.getNumberOfShards(); shardNumber++) {
+                ShardId shardId = new ShardId(index, shardNumber);
+                IndexShardRoutingTable.Builder indexShardRoutingBuilder = new IndexShardRoutingTable.Builder(shardId);
+                indexShardRoutingBuilder.addShard(ShardRouting.newUnassigned(shardId, true, recoverySource, unassignedInfo));
+                shards.put(shardNumber, indexShardRoutingBuilder.build());
+            }
+            return this;
+        }
+
+        /**
          * Initializes an index, to be restored from snapshot
          */
         private Builder initializeAsRestore(
             IndexMetadata indexMetadata,
-            SnapshotRecoverySource recoverySource,
+            RecoverySource recoverySource,
             IntSet ignoreShards,
             boolean asNew,
             UnassignedInfo unassignedInfo

--- a/server/src/main/java/org/opensearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/IndexRoutingTable.java
@@ -453,6 +453,10 @@ public class IndexRoutingTable extends AbstractDiffable<IndexRoutingTable> imple
                 UnassignedInfo.Reason.EXISTING_INDEX_RESTORED,
                 "restore_source[remote_store]"
             );
+            assert indexMetadata.getIndex().equals(index);
+            if (!shards.isEmpty()) {
+                throw new IllegalStateException("trying to initialize an index with fresh shards, but already has shards created");
+            }
             for (int shardNumber = 0; shardNumber < indexMetadata.getNumberOfShards(); shardNumber++) {
                 ShardId shardId = new ShardId(index, shardNumber);
                 IndexShardRoutingTable.Builder indexShardRoutingBuilder = new IndexShardRoutingTable.Builder(shardId);

--- a/server/src/main/java/org/opensearch/cluster/routing/RecoverySource.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RecoverySource.java
@@ -88,6 +88,8 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
                 return new SnapshotRecoverySource(in);
             case LOCAL_SHARDS:
                 return LocalShardsRecoverySource.INSTANCE;
+            case REMOTE_STORE:
+                return new RemoteStoreRecoverySource(in);
             default:
                 throw new IllegalArgumentException("unknown recovery type: " + type.name());
         }
@@ -116,7 +118,8 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
         EXISTING_STORE,
         PEER,
         SNAPSHOT,
-        LOCAL_SHARDS
+        LOCAL_SHARDS,
+        REMOTE_STORE
     }
 
     public abstract Type getType();
@@ -345,6 +348,97 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
         @Override
         public int hashCode() {
             return Objects.hash(restoreUUID, snapshot, index, version);
+        }
+
+    }
+
+    /**
+     * Recovery from remote store
+     *
+     * @opensearch.internal
+     */
+    public static class RemoteStoreRecoverySource extends RecoverySource {
+
+        private final String restoreUUID;
+        private final IndexId index;
+        private final Version version;
+
+        public RemoteStoreRecoverySource(String restoreUUID, Version version, IndexId indexId) {
+            this.restoreUUID = restoreUUID;
+            this.version = Objects.requireNonNull(version);
+            this.index = Objects.requireNonNull(indexId);
+        }
+
+        RemoteStoreRecoverySource(StreamInput in) throws IOException {
+            restoreUUID = in.readString();
+            version = Version.readVersion(in);
+            if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
+                index = new IndexId(in);
+            } else {
+                index = new IndexId(in.readString(), IndexMetadata.INDEX_UUID_NA_VALUE);
+            }
+        }
+
+        public String restoreUUID() {
+            return restoreUUID;
+        }
+
+        /**
+         * Gets the {@link IndexId} of the recovery source. May contain {@link IndexMetadata#INDEX_UUID_NA_VALUE} as the index uuid if it
+         * was created by an older version cluster-manager in a mixed version cluster.
+         *
+         * @return IndexId
+         */
+        public IndexId index() {
+            return index;
+        }
+
+        public Version version() {
+            return version;
+        }
+
+        @Override
+        protected void writeAdditionalFields(StreamOutput out) throws IOException {
+            out.writeString(restoreUUID);
+            Version.writeVersion(version, out);
+            if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
+                index.writeTo(out);
+            } else {
+                out.writeString(index.getName());
+            }
+        }
+
+        @Override
+        public Type getType() {
+            return Type.REMOTE_STORE;
+        }
+
+        @Override
+        public void addAdditionalFields(XContentBuilder builder, ToXContent.Params params) throws IOException {
+            builder.field("version", version.toString()).field("index", index.getName()).field("restoreUUID", restoreUUID);
+        }
+
+        @Override
+        public String toString() {
+            return "remote store recovery [" + restoreUUID + "]";
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            RemoteStoreRecoverySource that = (RemoteStoreRecoverySource) o;
+            return restoreUUID.equals(that.restoreUUID) && index.equals(that.index) && version.equals(that.version);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(restoreUUID, index, version);
         }
 
     }

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
@@ -41,6 +41,7 @@ import org.opensearch.cluster.DiffableUtils;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.routing.RecoverySource.SnapshotRecoverySource;
+import org.opensearch.cluster.routing.RecoverySource.RemoteStoreRecoverySource;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.io.stream.StreamInput;
@@ -562,6 +563,13 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
             IndexRoutingTable.Builder indexRoutingBuilder = new IndexRoutingTable.Builder(indexMetadata.getIndex())
                 .initializeAsFromOpenToClose(indexMetadata);
             return add(indexRoutingBuilder);
+        }
+
+        public Builder addAsRemoteStoreRestore(IndexMetadata indexMetadata, RemoteStoreRecoverySource recoverySource) {
+            IndexRoutingTable.Builder indexRoutingBuilder = new IndexRoutingTable.Builder(indexMetadata.getIndex())
+                .initializeAsRemoteStoreRestore(indexMetadata, recoverySource);
+            add(indexRoutingBuilder);
+            return this;
         }
 
         public Builder addAsRestore(IndexMetadata indexMetadata, SnapshotRecoverySource recoverySource) {

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -514,13 +514,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                     this.indexSettings,
                     path
                 );
-                remoteStore = new Store(
-                    shardId,
-                    this.indexSettings,
-                    remoteDirectory,
-                    lock,
-                    new StoreCloseListener(shardId, () -> eventListener.onStoreClosed(shardId))
-                );
+                remoteStore = new Store(shardId, this.indexSettings, remoteDirectory, lock, Store.OnClose.EMPTY);
             }
 
             Directory directory = directoryFactory.newDirectory(this.indexSettings, path);

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -469,10 +469,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return this.shardFieldData;
     }
 
-    public RemoteStoreRefreshListener getRemoteStoreRefreshListener() {
-        return this.remoteStoreRefreshListener;
-    }
-
     public boolean isSystem() {
         return indexSettings.getIndexMetadata().isSystem();
     }

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -39,6 +39,10 @@ public class RemoteStoreRefreshListener implements ReferenceManager.RefreshListe
         this.filesUploadedToRemoteStore = new HashSet<>(Arrays.asList(remoteDirectory.listAll()));
     }
 
+    public Directory getRemoteDirectory() {
+        return this.remoteDirectory;
+    }
+
     @Override
     public void beforeRefresh() throws IOException {
         // Do Nothing

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -39,10 +39,6 @@ public class RemoteStoreRefreshListener implements ReferenceManager.RefreshListe
         this.filesUploadedToRemoteStore = new HashSet<>(Arrays.asList(remoteDirectory.listAll()));
     }
 
-    public Directory getRemoteDirectory() {
-        return this.remoteDirectory;
-    }
-
     @Override
     public void beforeRefresh() throws IOException {
         // Do Nothing

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -463,8 +463,11 @@ final class StoreRecovery {
             for (String file : remoteDirectory.listAll()) {
                 storeDirectory.copyFrom(remoteDirectory, file, file, IOContext.DEFAULT);
             }
-            indexShard.recoveryState().getIndex().setFileDetailsComplete();
+            // This creates empty trans-log for now
             // ToDo: Add code to restore remote trans-log
+            bootstrap(indexShard, store);
+            assert indexShard.shardRouting.primary() : "only primary shards can recover from store";
+            indexShard.recoveryState().getIndex().setFileDetailsComplete();
             indexShard.openEngineAndRecoverFromTranslog();
             indexShard.getEngine().fillSeqNoGaps(indexShard.getPendingPrimaryTerm());
             indexShard.finalizeRecovery();

--- a/server/src/main/java/org/opensearch/index/store/RemoteIndexInput.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteIndexInput.java
@@ -43,7 +43,12 @@ public class RemoteIndexInput extends IndexInput {
 
     @Override
     public void readBytes(byte[] b, int offset, int len) throws IOException {
-        inputStream.read(b, offset, len);
+        int bytesRead = inputStream.read(b, offset, len);
+        while (bytesRead > 0 && bytesRead < len) {
+            len -= bytesRead;
+            offset += bytesRead;
+            bytesRead = inputStream.read(b, offset, len);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -227,6 +227,14 @@ public class RestoreService implements ClusterStateApplier {
                         logger.warn("Remote store restore is not supported for non-existent index. Skipping: {}", index);
                         continue;
                     }
+                    if (currentIndexMetadata.getState() != IndexMetadata.State.CLOSE) {
+                        throw new IllegalStateException(
+                            "cannot restore index ["
+                                + index
+                                + "] because an open index "
+                                + "with same name already exists in the cluster. Close the existing index"
+                        );
+                    }
                     if (currentIndexMetadata.getSettings().getAsBoolean(SETTING_REMOTE_STORE, false)) {
                         IndexId indexId = new IndexId(index, currentIndexMetadata.getIndexUUID());
 
@@ -239,7 +247,7 @@ public class RestoreService implements ClusterStateApplier {
                         indicesToBeRestored.add(index);
                         totalShards += currentIndexMetadata.getNumberOfShards();
                     } else {
-                        logger.warn("Remote store is not enable for index: {}", index);
+                        logger.warn("Remote store is not enabled for index: {}", index);
                     }
                 }
 

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -42,6 +42,7 @@ import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.StepListener;
+import org.opensearch.action.admin.cluster.remotestore.restore.RestoreRemoteStoreRequest;
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.cluster.ClusterChangedEvent;
@@ -68,6 +69,7 @@ import org.opensearch.cluster.metadata.RepositoriesMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.RecoverySource;
 import org.opensearch.cluster.routing.RecoverySource.SnapshotRecoverySource;
+import org.opensearch.cluster.routing.RecoverySource.RemoteStoreRecoverySource;
 import org.opensearch.cluster.routing.RoutingChangesObserver;
 import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
@@ -114,6 +116,7 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_RE
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_VERSION_UPGRADED;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_STORE;
 import static org.opensearch.common.util.set.Sets.newHashSet;
 import static org.opensearch.snapshots.SnapshotUtils.filterIndices;
 
@@ -194,6 +197,76 @@ public class RestoreService implements ClusterStateApplier {
         }
         this.clusterSettings = clusterService.getClusterSettings();
         this.shardLimitValidator = shardLimitValidator;
+    }
+
+    /**
+     * Restores data from remote store for indices specified in the restore request.
+     *
+     * @param request  restore request
+     * @param listener restore listener
+     */
+    public void restoreFromRemoteStore(RestoreRemoteStoreRequest request, final ActionListener<RestoreCompletionResponse> listener) {
+        clusterService.submitStateUpdateTask("restore[remote_store]", new ClusterStateUpdateTask() {
+            final String restoreUUID = UUIDs.randomBase64UUID();
+            RestoreInfo restoreInfo = null;
+
+            @Override
+            public ClusterState execute(ClusterState currentState) {
+                // Updating cluster state
+                ClusterState.Builder builder = ClusterState.builder(currentState);
+                Metadata.Builder mdBuilder = Metadata.builder(currentState.metadata());
+                ClusterBlocks.Builder blocks = ClusterBlocks.builder().blocks(currentState.blocks());
+                RoutingTable.Builder rtBuilder = RoutingTable.builder(currentState.routingTable());
+
+                List<String> indicesToBeRestored = new ArrayList<>();
+                int totalShards = 0;
+                for (String index : request.indices()) {
+                    IndexMetadata currentIndexMetadata = currentState.metadata().index(index);
+                    if (currentIndexMetadata == null) {
+                        // ToDo: Handle index metadata does not exist case. (GitHub #3457)
+                        logger.warn("Remote store restore is not supported for non-existent index. Skipping: {}", index);
+                        continue;
+                    }
+                    if (currentIndexMetadata.getSettings().getAsBoolean(SETTING_REMOTE_STORE, false)) {
+                        IndexId indexId = new IndexId(index, currentIndexMetadata.getIndexUUID());
+
+                        RemoteStoreRecoverySource recoverySource = new RemoteStoreRecoverySource(
+                            restoreUUID,
+                            currentIndexMetadata.getCreationVersion(),
+                            indexId
+                        );
+                        rtBuilder.addAsRemoteStoreRestore(currentIndexMetadata, recoverySource);
+                        indicesToBeRestored.add(index);
+                        totalShards += currentIndexMetadata.getNumberOfShards();
+                    } else {
+                        logger.warn("Remote store is not enable for index: {}", index);
+                    }
+                }
+
+                restoreInfo = new RestoreInfo("remote_store", indicesToBeRestored, totalShards, totalShards);
+
+                RoutingTable rt = rtBuilder.build();
+                ClusterState updatedState = builder.metadata(mdBuilder).blocks(blocks).routingTable(rt).build();
+                return allocationService.reroute(updatedState, "restored from remote store");
+            }
+
+            @Override
+            public void onFailure(String source, Exception e) {
+                logger.warn("failed to restore from remote store", e);
+                listener.onFailure(e);
+            }
+
+            @Override
+            public TimeValue timeout() {
+                return request.masterNodeTimeout();
+            }
+
+            @Override
+            public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                listener.onResponse(new RestoreCompletionResponse(restoreUUID, null, restoreInfo));
+            }
+        });
+
     }
 
     /**

--- a/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequestTests.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.remotestore.restore;
+
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.test.AbstractWireSerializingTestCase;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Collections;
+
+public class RestoreRemoteStoreRequestTests extends AbstractWireSerializingTestCase<RestoreRemoteStoreRequest> {
+    private RestoreRemoteStoreRequest randomState(RestoreRemoteStoreRequest instance) {
+        if (randomBoolean()) {
+            List<String> indices = new ArrayList<>();
+            int count = randomInt(3) + 1;
+
+            for (int i = 0; i < count; ++i) {
+                indices.add(randomAlphaOfLength(randomInt(3) + 2));
+            }
+
+            instance.indices(indices);
+        }
+        if (randomBoolean()) {
+            Collection<IndicesOptions.WildcardStates> wildcardStates = randomSubsetOf(
+                Arrays.asList(IndicesOptions.WildcardStates.values())
+            );
+            Collection<IndicesOptions.Option> options = randomSubsetOf(
+                Arrays.asList(IndicesOptions.Option.ALLOW_NO_INDICES, IndicesOptions.Option.IGNORE_UNAVAILABLE)
+            );
+
+            instance.indicesOptions(
+                new IndicesOptions(
+                    options.isEmpty() ? IndicesOptions.Option.NONE : EnumSet.copyOf(options),
+                    wildcardStates.isEmpty() ? IndicesOptions.WildcardStates.NONE : EnumSet.copyOf(wildcardStates)
+                )
+            );
+        }
+
+        instance.waitForCompletion(randomBoolean());
+
+        if (randomBoolean()) {
+            instance.masterNodeTimeout(randomTimeValue());
+        }
+
+        return instance;
+    }
+
+    @Override
+    protected RestoreRemoteStoreRequest createTestInstance() {
+        return randomState(new RestoreRemoteStoreRequest());
+    }
+
+    @Override
+    protected Writeable.Reader<RestoreRemoteStoreRequest> instanceReader() {
+        return RestoreRemoteStoreRequest::new;
+    }
+
+    @Override
+    protected RestoreRemoteStoreRequest mutateInstance(RestoreRemoteStoreRequest instance) throws IOException {
+        RestoreRemoteStoreRequest copy = copyInstance(instance);
+        // ensure that at least one property is different
+        List<String> indices = new ArrayList<>(List.of(instance.indices()));
+        indices.add("copied");
+        copy.indices(indices);
+        return randomState(copy);
+    }
+
+    public void testSource() throws IOException {
+        RestoreRemoteStoreRequest original = createTestInstance();
+        XContentBuilder builder = original.toXContent(XContentFactory.jsonBuilder(), new ToXContent.MapParams(Collections.emptyMap()));
+        XContentParser parser = XContentType.JSON.xContent()
+            .createParser(NamedXContentRegistry.EMPTY, null, BytesReference.bytes(builder).streamInput());
+        Map<String, Object> map = parser.mapOrdered();
+
+        RestoreRemoteStoreRequest processed = new RestoreRemoteStoreRequest();
+        processed.masterNodeTimeout(original.masterNodeTimeout());
+        processed.waitForCompletion(original.waitForCompletion());
+        processed.indicesOptions(original.indicesOptions());
+        processed.source(map);
+
+        assertEquals(original, processed);
+    }
+}

--- a/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequestTests.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.action.admin.cluster.remotestore.restore;
 
-import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.xcontent.ToXContent;
@@ -22,9 +21,6 @@ import org.opensearch.test.AbstractWireSerializingTestCase;
 import java.io.IOException;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.Map;
 import java.util.Collections;
 
@@ -39,21 +35,6 @@ public class RestoreRemoteStoreRequestTests extends AbstractWireSerializingTestC
             }
 
             instance.indices(indices);
-        }
-        if (randomBoolean()) {
-            Collection<IndicesOptions.WildcardStates> wildcardStates = randomSubsetOf(
-                Arrays.asList(IndicesOptions.WildcardStates.values())
-            );
-            Collection<IndicesOptions.Option> options = randomSubsetOf(
-                Arrays.asList(IndicesOptions.Option.ALLOW_NO_INDICES, IndicesOptions.Option.IGNORE_UNAVAILABLE)
-            );
-
-            instance.indicesOptions(
-                new IndicesOptions(
-                    options.isEmpty() ? IndicesOptions.Option.NONE : EnumSet.copyOf(options),
-                    wildcardStates.isEmpty() ? IndicesOptions.WildcardStates.NONE : EnumSet.copyOf(wildcardStates)
-                )
-            );
         }
 
         instance.waitForCompletion(randomBoolean());
@@ -95,7 +76,6 @@ public class RestoreRemoteStoreRequestTests extends AbstractWireSerializingTestC
         RestoreRemoteStoreRequest processed = new RestoreRemoteStoreRequest();
         processed.masterNodeTimeout(original.masterNodeTimeout());
         processed.waitForCompletion(original.waitForCompletion());
-        processed.indicesOptions(original.indicesOptions());
         processed.source(map);
 
         assertEquals(original, processed);

--- a/server/src/test/java/org/opensearch/cluster/routing/RecoverySourceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/RecoverySourceTests.java
@@ -32,7 +32,10 @@
 
 package org.opensearch.cluster.routing;
 
+import org.opensearch.Version;
+import org.opensearch.common.UUIDs;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.repositories.IndexId;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -57,10 +60,25 @@ public class RecoverySourceTests extends OpenSearchTestCase {
         assertEquals(RecoverySource.Type.PEER.ordinal(), 2);
         assertEquals(RecoverySource.Type.SNAPSHOT.ordinal(), 3);
         assertEquals(RecoverySource.Type.LOCAL_SHARDS.ordinal(), 4);
+        assertEquals(RecoverySource.Type.REMOTE_STORE.ordinal(), 5);
         // check exhaustiveness
         for (RecoverySource.Type type : RecoverySource.Type.values()) {
             assertThat(type.ordinal(), greaterThanOrEqualTo(0));
-            assertThat(type.ordinal(), lessThanOrEqualTo(4));
+            assertThat(type.ordinal(), lessThanOrEqualTo(5));
         }
+    }
+
+    public void testSerializationRemoteStoreRecoverySource() throws IOException {
+        RecoverySource recoverySource = new RecoverySource.RemoteStoreRecoverySource(
+            UUIDs.randomBase64UUID(),
+            Version.CURRENT,
+            new IndexId("some_index", UUIDs.randomBase64UUID(random()))
+        );
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        recoverySource.writeTo(out);
+        RecoverySource serializedRecoverySource = RecoverySource.readFrom(out.bytes().streamInput());
+        assertEquals(recoverySource.getType(), serializedRecoverySource.getType());
+        assertEquals(recoverySource, serializedRecoverySource);
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/routing/RoutingTableTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/RoutingTableTests.java
@@ -60,6 +60,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
+import org.opensearch.cluster.routing.RecoverySource.RemoteStoreRecoverySource;
+import org.opensearch.repositories.IndexId;
+
 public class RoutingTableTests extends OpenSearchAllocationTestCase {
 
     private static final String TEST_INDEX_1 = "test1";
@@ -490,6 +493,20 @@ public class RoutingTableTests extends OpenSearchAllocationTestCase {
             assertThat(routingTable.allShards(TEST_INDEX_1).size(), is(this.shardsPerIndex));
             assertThat(routingTable.index(TEST_INDEX_1).shardsWithState(UNASSIGNED).size(), is(this.shardsPerIndex));
         }
+    }
+
+    public void testAddAsRemoteStoreRestore() {
+        final IndexMetadata indexMetadata = createIndexMetadata(TEST_INDEX_1).state(IndexMetadata.State.OPEN).build();
+        final RemoteStoreRecoverySource remoteStoreRecoverySource = new RemoteStoreRecoverySource(
+            "restore_uuid",
+            Version.CURRENT,
+            new IndexId(TEST_INDEX_1, "1")
+        );
+        final RoutingTable routingTable = new RoutingTable.Builder().addAsRemoteStoreRestore(indexMetadata, remoteStoreRecoverySource)
+            .build();
+        assertTrue(routingTable.hasIndex(TEST_INDEX_1));
+        assertEquals(this.numberOfShards, routingTable.allShards(TEST_INDEX_1).size());
+        assertEquals(this.numberOfShards, routingTable.index(TEST_INDEX_1).shardsWithState(UNASSIGNED).size());
     }
 
     /** reverse engineer the in sync aid based on the given indexRoutingTable **/

--- a/server/src/test/java/org/opensearch/index/engine/NoOpEngineRecoveryTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/NoOpEngineRecoveryTests.java
@@ -58,7 +58,8 @@ public class NoOpEngineRecoveryTests extends IndexShardTestCase {
             initWithSameId(shardRouting, ExistingStoreRecoverySource.INSTANCE),
             indexShard.indexSettings().getIndexMetadata(),
             NoOpEngine::new,
-            new EngineConfigFactory(indexShard.indexSettings())
+            new EngineConfigFactory(indexShard.indexSettings()),
+            null
         );
         recoverShardFromStore(primary);
         assertEquals(primary.seqNoStats().getMaxSeqNo(), primary.getMaxSeqNoOfUpdatesOrDeletes());

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -44,6 +44,7 @@ import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.store.IOContext;
+import org.apache.lucene.tests.store.BaseDirectoryWrapper;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Constants;
 import org.junit.Assert;
@@ -1217,7 +1218,8 @@ public class IndexShardTests extends IndexShardTestCase {
             null,
             new InternalEngineFactory(),
             () -> synced.set(true),
-            RetentionLeaseSyncer.EMPTY
+            RetentionLeaseSyncer.EMPTY,
+            null
         );
         // add a replica
         recoverShardFromStore(primaryShard);
@@ -1291,7 +1293,8 @@ public class IndexShardTests extends IndexShardTestCase {
             null,
             new InternalEngineFactory(),
             () -> synced.set(true),
-            RetentionLeaseSyncer.EMPTY
+            RetentionLeaseSyncer.EMPTY,
+            null
         );
         recoverShardFromStore(primaryShard);
         IndexShard replicaShard = newShard(shardId, false);
@@ -1701,7 +1704,8 @@ public class IndexShardTests extends IndexShardTestCase {
                 new EngineConfigFactory(new IndexSettings(metadata, metadata.getSettings())),
                 () -> {},
                 RetentionLeaseSyncer.EMPTY,
-                EMPTY_EVENT_LISTENER
+                EMPTY_EVENT_LISTENER,
+                null
             );
             AtomicBoolean failureCallbackTriggered = new AtomicBoolean(false);
             shard.addShardFailureCallback((ig) -> failureCallbackTriggered.set(true));
@@ -2549,7 +2553,8 @@ public class IndexShardTests extends IndexShardTestCase {
             shard.getEngineConfigFactory(),
             shard.getGlobalCheckpointSyncer(),
             shard.getRetentionLeaseSyncer(),
-            EMPTY_EVENT_LISTENER
+            EMPTY_EVENT_LISTENER,
+            null
         );
         DiscoveryNode localNode = new DiscoveryNode("foo", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT);
         newShard.markAsRecovering("store", new RecoveryState(newShard.routingEntry(), localNode, null));
@@ -2651,6 +2656,55 @@ public class IndexShardTests extends IndexShardTestCase {
         closeShards(target);
     }
 
+    public void testRestoreShardFromRemoteStore() throws IOException {
+        IndexShard target = newStartedShard(
+            true,
+            Settings.builder().put(IndexMetadata.SETTING_REMOTE_STORE, true).build(),
+            new InternalEngineFactory()
+        );
+
+        indexDoc(target, "_doc", "1");
+        indexDoc(target, "_doc", "2");
+        target.refresh("test");
+        assertDocs(target, "1", "2");
+        flushShard(target);
+
+        ShardRouting routing = ShardRoutingHelper.initWithSameId(
+            target.routingEntry(),
+            RecoverySource.ExistingStoreRecoverySource.INSTANCE
+        );
+        routing = ShardRoutingHelper.newWithRestoreSource(
+            routing,
+            new RecoverySource.RemoteStoreRecoverySource(
+                UUIDs.randomBase64UUID(),
+                Version.CURRENT,
+                new IndexId("test", UUIDs.randomBase64UUID(random()))
+            )
+        );
+
+        // Delete files in store directory to restore from remote directory
+        Directory storeDirectory = target.store().directory();
+        for (String file : storeDirectory.listAll()) {
+            storeDirectory.deleteFile(file);
+        }
+
+        target = reinitShard(target, routing);
+
+        DiscoveryNode localNode = new DiscoveryNode("foo", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT);
+        target.markAsRecovering("remote_store", new RecoveryState(routing, localNode, null));
+        final PlainActionFuture<Boolean> future = PlainActionFuture.newFuture();
+        target.restoreFromRemoteStore(future);
+        assertTrue(future.actionGet());
+
+        assertDocs(target, "1", "2");
+
+        ((BaseDirectoryWrapper) target.getRemoteStoreRefreshListener().getRemoteDirectory()).setCheckIndexOnClose(false);
+        storeDirectory = ((FilterDirectory) ((FilterDirectory) target.store().directory()).getDelegate()).getDelegate();
+        ((BaseDirectoryWrapper) storeDirectory).setCheckIndexOnClose(false);
+        target.getRemoteStoreRefreshListener().getRemoteDirectory().close();
+        closeShards(target);
+    }
+
     public void testReaderWrapperIsUsed() throws IOException {
         IndexShard shard = newStartedShard(true);
         indexDoc(shard, "_doc", "0", "{\"foo\" : \"bar\"}");
@@ -2679,7 +2733,8 @@ public class IndexShardTests extends IndexShardTestCase {
             shard.getEngineConfigFactory(),
             () -> {},
             RetentionLeaseSyncer.EMPTY,
-            EMPTY_EVENT_LISTENER
+            EMPTY_EVENT_LISTENER,
+            null
         );
 
         recoverShardFromStore(newShard);
@@ -2829,7 +2884,8 @@ public class IndexShardTests extends IndexShardTestCase {
             shard.getEngineConfigFactory(),
             () -> {},
             RetentionLeaseSyncer.EMPTY,
-            EMPTY_EVENT_LISTENER
+            EMPTY_EVENT_LISTENER,
+            null
         );
 
         recoverShardFromStore(newShard);
@@ -3494,7 +3550,8 @@ public class IndexShardTests extends IndexShardTestCase {
             () -> {},
             RetentionLeaseSyncer.EMPTY,
             EMPTY_EVENT_LISTENER,
-            checkpointPublisher
+            checkpointPublisher,
+            null
         );
     }
 
@@ -3550,7 +3607,8 @@ public class IndexShardTests extends IndexShardTestCase {
             indexShard.engineConfigFactory,
             indexShard.getGlobalCheckpointSyncer(),
             indexShard.getRetentionLeaseSyncer(),
-            EMPTY_EVENT_LISTENER
+            EMPTY_EVENT_LISTENER,
+            null
         );
 
         final IndexShardRecoveryException indexShardRecoveryException = expectThrows(
@@ -3607,7 +3665,8 @@ public class IndexShardTests extends IndexShardTestCase {
             indexShard.engineConfigFactory,
             indexShard.getGlobalCheckpointSyncer(),
             indexShard.getRetentionLeaseSyncer(),
-            EMPTY_EVENT_LISTENER
+            EMPTY_EVENT_LISTENER,
+            null
         );
 
         final IndexShardRecoveryException exception1 = expectThrows(
@@ -3641,7 +3700,8 @@ public class IndexShardTests extends IndexShardTestCase {
             indexShard.engineConfigFactory,
             indexShard.getGlobalCheckpointSyncer(),
             indexShard.getRetentionLeaseSyncer(),
-            EMPTY_EVENT_LISTENER
+            EMPTY_EVENT_LISTENER,
+            null
         );
 
         final IndexShardRecoveryException exception2 = expectThrows(
@@ -3695,7 +3755,8 @@ public class IndexShardTests extends IndexShardTestCase {
             indexShard.engineConfigFactory,
             indexShard.getGlobalCheckpointSyncer(),
             indexShard.getRetentionLeaseSyncer(),
-            EMPTY_EVENT_LISTENER
+            EMPTY_EVENT_LISTENER,
+            null
         );
 
         Store.MetadataSnapshot storeFileMetadatas = newShard.snapshotStoreMetadata();
@@ -4437,7 +4498,8 @@ public class IndexShardTests extends IndexShardTestCase {
                     // just like a following shard, we need to skip this check for now.
                 }
             },
-            shard.getEngineConfigFactory()
+            shard.getEngineConfigFactory(),
+            null
         );
         DiscoveryNode localNode = new DiscoveryNode("foo", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT);
         readonlyShard.markAsRecovering("store", new RecoveryState(readonlyShard.routingEntry(), localNode, null));

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -44,6 +44,7 @@ import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.store.IOContext;
+import org.apache.lucene.tests.mockfile.ExtrasFS;
 import org.apache.lucene.tests.store.BaseDirectoryWrapper;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Constants;
@@ -2691,8 +2692,10 @@ public class IndexShardTests extends IndexShardTestCase {
         Directory remoteDirectory = ((FilterDirectory) ((FilterDirectory) target.remoteStore().directory()).getDelegate()).getDelegate();
         ((BaseDirectoryWrapper) remoteDirectory).setCheckIndexOnClose(false);
 
+        // extra0 file is added as a part of https://lucene.apache.org/core/7_2_1/test-framework/org/apache/lucene/mockfile/ExtrasFS.html
+        // Safe to remove without impacting the test
         for (String file : remoteDirectory.listAll()) {
-            if (file.equals("extra0")) {
+            if (ExtrasFS.isExtra(file)) {
                 remoteDirectory.deleteFile(file);
             }
         }

--- a/server/src/test/java/org/opensearch/index/shard/RemoveCorruptedShardDataCommandTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoveCorruptedShardDataCommandTests.java
@@ -174,7 +174,8 @@ public class RemoveCorruptedShardDataCommandTests extends IndexShardTestCase {
                 new EngineConfigFactory(new IndexSettings(indexMetadata, settings)),
                 () -> {},
                 RetentionLeaseSyncer.EMPTY,
-                EMPTY_EVENT_LISTENER
+                EMPTY_EVENT_LISTENER,
+                null
             ),
             true
         );
@@ -550,7 +551,8 @@ public class RemoveCorruptedShardDataCommandTests extends IndexShardTestCase {
             indexShard.getEngineConfigFactory(),
             indexShard.getGlobalCheckpointSyncer(),
             indexShard.getRetentionLeaseSyncer(),
-            EMPTY_EVENT_LISTENER
+            EMPTY_EVENT_LISTENER,
+            null
         );
     }
 

--- a/server/src/test/java/org/opensearch/index/store/RemoteIndexInputTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteIndexInputTests.java
@@ -54,6 +54,17 @@ public class RemoteIndexInputTests extends OpenSearchTestCase {
         verify(inputStream).read(buffer, 10, 20);
     }
 
+    public void testReadBytesMultipleIterations() throws IOException {
+        byte[] buffer = new byte[20];
+        when(inputStream.read(eq(buffer), anyInt(), anyInt())).thenReturn(10).thenReturn(3).thenReturn(6).thenReturn(-1);
+        remoteIndexInput.readBytes(buffer, 0, 20);
+
+        verify(inputStream).read(buffer, 0, 20);
+        verify(inputStream).read(buffer, 10, 10);
+        verify(inputStream).read(buffer, 13, 7);
+        verify(inputStream).read(buffer, 19, 1);
+    }
+
     public void testReadBytesIOException() throws IOException {
         byte[] buffer = new byte[10];
         when(inputStream.read(buffer, 10, 20)).thenThrow(new IOException("Error reading"));

--- a/server/src/test/java/org/opensearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -317,7 +317,8 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
             ShardRoutingHelper.initWithSameId(shard.routingEntry(), RecoverySource.PeerRecoverySource.INSTANCE),
             indexMetadata,
             NoOpEngine::new,
-            new EngineConfigFactory(shard.indexSettings())
+            new EngineConfigFactory(shard.indexSettings()),
+            null
         );
         replica.markAsRecovering("for testing", new RecoveryState(replica.routingEntry(), localNode, localNode));
         replica.prepareForIndexRecovery();

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
@@ -140,7 +140,8 @@ public class BlobStoreRepositoryRestoreTests extends IndexShardTestCase {
                 new EngineConfigFactory(shard.indexSettings()),
                 () -> {},
                 RetentionLeaseSyncer.EMPTY,
-                EMPTY_EVENT_LISTENER
+                EMPTY_EVENT_LISTENER,
+                null
             );
 
             // restore the shard

--- a/test/framework/src/main/java/org/opensearch/cluster/routing/ShardRoutingHelper.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/routing/ShardRoutingHelper.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.cluster.routing;
 
-import org.opensearch.cluster.routing.RecoverySource.SnapshotRecoverySource;
-
 /**
  * A helper class that allows access to package private APIs for testing.
  */
@@ -77,7 +75,7 @@ public class ShardRoutingHelper {
         return routing.moveToUnassigned(info);
     }
 
-    public static ShardRouting newWithRestoreSource(ShardRouting routing, SnapshotRecoverySource recoverySource) {
+    public static ShardRouting newWithRestoreSource(ShardRouting routing, RecoverySource recoverySource) {
         return new ShardRouting(
             routing.shardId(),
             routing.currentNodeId(),

--- a/test/framework/src/main/java/org/opensearch/index/replication/OpenSearchIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/replication/OpenSearchIndexLevelReplicationTestCase.java
@@ -218,7 +218,7 @@ public abstract class OpenSearchIndexLevelReplicationTestCase extends IndexShard
 
         protected ReplicationGroup(final IndexMetadata indexMetadata) throws IOException {
             final ShardRouting primaryRouting = this.createShardRouting("s0", true);
-            primary = newShard(primaryRouting, indexMetadata, null, getEngineFactory(primaryRouting), () -> {}, retentionLeaseSyncer);
+            primary = newShard(primaryRouting, indexMetadata, null, getEngineFactory(primaryRouting), () -> {}, retentionLeaseSyncer, null);
             replicas = new CopyOnWriteArrayList<>();
             this.indexMetadata = indexMetadata;
             updateAllocationIDsOnPrimary();
@@ -345,7 +345,8 @@ public abstract class OpenSearchIndexLevelReplicationTestCase extends IndexShard
                 null,
                 getEngineFactory(replicaRouting),
                 () -> {},
-                retentionLeaseSyncer
+                retentionLeaseSyncer,
+                null
             );
             addReplica(replica);
             return replica;
@@ -386,7 +387,8 @@ public abstract class OpenSearchIndexLevelReplicationTestCase extends IndexShard
                 getEngineConfigFactory(new IndexSettings(indexMetadata, indexMetadata.getSettings())),
                 () -> {},
                 retentionLeaseSyncer,
-                EMPTY_EVENT_LISTENER
+                EMPTY_EVENT_LISTENER,
+                null
             );
             replicas.add(newReplica);
             if (replicationTargets != null) {

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -284,7 +284,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
             .settings(indexSettings)
             .primaryTerm(0, primaryTerm)
             .putMapping("{ \"properties\": {} }");
-        return newShard(shardRouting, metadata.build(), null, engineFactory, () -> {}, RetentionLeaseSyncer.EMPTY, listeners);
+        return newShard(shardRouting, metadata.build(), null, engineFactory, () -> {}, RetentionLeaseSyncer.EMPTY, null, listeners);
     }
 
     /**
@@ -353,7 +353,8 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
             readerWrapper,
             new InternalEngineFactory(),
             globalCheckpointSyncer,
-            RetentionLeaseSyncer.EMPTY
+            RetentionLeaseSyncer.EMPTY,
+            null
         );
     }
 
@@ -372,7 +373,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
         EngineFactory engineFactory,
         IndexingOperationListener... listeners
     ) throws IOException {
-        return newShard(routing, indexMetadata, indexReaderWrapper, engineFactory, () -> {}, RetentionLeaseSyncer.EMPTY, listeners);
+        return newShard(routing, indexMetadata, indexReaderWrapper, engineFactory, () -> {}, RetentionLeaseSyncer.EMPTY, null, listeners);
     }
 
     /**
@@ -391,6 +392,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
         @Nullable EngineFactory engineFactory,
         Runnable globalCheckpointSyncer,
         RetentionLeaseSyncer retentionLeaseSyncer,
+        RemoteStoreRefreshListener remoteStoreRefreshListener,
         IndexingOperationListener... listeners
     ) throws IOException {
         // add node id as name to settings for proper logging
@@ -408,6 +410,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
             globalCheckpointSyncer,
             retentionLeaseSyncer,
             EMPTY_EVENT_LISTENER,
+            remoteStoreRefreshListener,
             listeners
         );
     }
@@ -435,6 +438,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
         Runnable globalCheckpointSyncer,
         RetentionLeaseSyncer retentionLeaseSyncer,
         IndexEventListener indexEventListener,
+        RemoteStoreRefreshListener remoteStoreRefreshListener,
         IndexingOperationListener... listeners
     ) throws IOException {
         return newShard(
@@ -449,6 +453,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
             retentionLeaseSyncer,
             indexEventListener,
             SegmentReplicationCheckpointPublisher.EMPTY,
+            remoteStoreRefreshListener,
             listeners
         );
     }
@@ -477,6 +482,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
         RetentionLeaseSyncer retentionLeaseSyncer,
         IndexEventListener indexEventListener,
         SegmentReplicationCheckpointPublisher checkpointPublisher,
+        @Nullable RemoteStoreRefreshListener remoteStoreRefreshListener,
         IndexingOperationListener... listeners
     ) throws IOException {
         final Settings nodeSettings = Settings.builder().put("node.name", routing.currentNodeId()).build();
@@ -504,6 +510,13 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                 Collections.emptyList(),
                 clusterSettings
             );
+            if (remoteStoreRefreshListener == null && indexSettings.isRemoteStoreEnabled()) {
+                ShardId shardId = shardPath.getShardId();
+                NodeEnvironment.NodePath remoteNodePath = new NodeEnvironment.NodePath(createTempDir());
+                ShardPath remoteShardPath = new ShardPath(false, remoteNodePath.resolve(shardId), remoteNodePath.resolve(shardId), shardId);
+                Directory remoteDirectory = newFSDirectory(remoteShardPath.resolveIndex());
+                remoteStoreRefreshListener = new RemoteStoreRefreshListener(store.directory(), remoteDirectory);
+            }
             indexShard = new IndexShard(
                 routing,
                 indexSettings,
@@ -526,7 +539,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                 retentionLeaseSyncer,
                 breakerService,
                 checkpointPublisher,
-                null
+                remoteStoreRefreshListener
             );
             indexShard.addShardFailureCallback(DEFAULT_SHARD_FAILURE_HANDLER);
             success = true;
@@ -568,6 +581,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
             current.indexSettings.getIndexMetadata(),
             current.engineFactory,
             current.engineConfigFactory,
+            current.getRemoteStoreRefreshListener(),
             listeners
         );
     }
@@ -586,6 +600,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
         IndexMetadata indexMetadata,
         EngineFactory engineFactory,
         EngineConfigFactory engineConfigFactory,
+        RemoteStoreRefreshListener remoteStoreRefreshListener,
         IndexingOperationListener... listeners
     ) throws IOException {
         closeShards(current);
@@ -600,6 +615,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
             current.getGlobalCheckpointSyncer(),
             current.getRetentionLeaseSyncer(),
             EMPTY_EVENT_LISTENER,
+            remoteStoreRefreshListener,
             listeners
         );
     }


### PR DESCRIPTION
Signed-off-by: Sachin Kale <kalsac@amazon.com>

### Description
- This change adds implementation for the remote store restore API.
- Currently, only segment restore is supported. Once remote translog support is added, we need to modify implementation of this API to restore data from remote translog as well.
- API endpoint is added as part of this PR: https://github.com/opensearch-project/OpenSearch/pull/3576
- This will be followed by integ tests PR which will cover end-to-end flow of segment upload and restore.
 
### Issues Resolved
- https://github.com/opensearch-project/OpenSearch/issues/3145
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
