### PR TITLE
Reserve all methods with 'master' in the names in the package 'org.opensearch.action.support.clustermanager'

### DIFF
--- a/server/src/main/java/org/opensearch/action/support/clustermanager/ClusterManagerNodeOperationRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/support/clustermanager/ClusterManagerNodeOperationRequestBuilder.java
@@ -65,6 +65,17 @@ public abstract class ClusterManagerNodeOperationRequestBuilder<
 
     /**
      * Sets the cluster-manager node timeout in case the cluster-manager has not yet been discovered.
+     *
+     * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #setClusterManagerNodeTimeout(TimeValue)}
+     */
+    @SuppressWarnings("unchecked")
+    @Deprecated
+    public final RequestBuilder setMasterNodeTimeout(TimeValue timeout) {
+        return setClusterManagerNodeTimeout(timeout);
+    }
+
+    /**
+     * Sets the cluster-manager node timeout in case the cluster-manager has not yet been discovered.
      */
     @SuppressWarnings("unchecked")
     public final RequestBuilder setClusterManagerNodeTimeout(String timeout) {
@@ -72,4 +83,14 @@ public abstract class ClusterManagerNodeOperationRequestBuilder<
         return (RequestBuilder) this;
     }
 
+    /**
+     * Sets the cluster-manager node timeout in case the cluster-manager has not yet been discovered.
+     *
+     * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #setClusterManagerNodeTimeout(String)}
+     */
+    @SuppressWarnings("unchecked")
+    @Deprecated
+    public final RequestBuilder setMasterNodeTimeout(String timeout) {
+        return setClusterManagerNodeTimeout(timeout);
+    }
 }

--- a/server/src/main/java/org/opensearch/action/support/clustermanager/ClusterManagerNodeRequest.java
+++ b/server/src/main/java/org/opensearch/action/support/clustermanager/ClusterManagerNodeRequest.java
@@ -48,7 +48,15 @@ public abstract class ClusterManagerNodeRequest<Request extends ClusterManagerNo
 
     public static final TimeValue DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT = TimeValue.timeValueSeconds(30);
 
+    /** @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT} */
+    @Deprecated
+    public static final TimeValue DEFAULT_MASTER_NODE_TIMEOUT = DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT;
+
     protected TimeValue clusterManagerNodeTimeout = DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT;
+
+    /** @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #clusterManagerNodeTimeout} */
+    @Deprecated
+    protected TimeValue masterNodeTimeout = clusterManagerNodeTimeout;
 
     protected ClusterManagerNodeRequest() {}
 
@@ -74,6 +82,17 @@ public abstract class ClusterManagerNodeRequest<Request extends ClusterManagerNo
 
     /**
      * A timeout value in case the cluster-manager has not been discovered yet or disconnected.
+     *
+     * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #clusterManagerNodeTimeout(TimeValue)}
+     */
+    @SuppressWarnings("unchecked")
+    @Deprecated
+    public final Request masterNodeTimeout(TimeValue timeout) {
+        return clusterManagerNodeTimeout(timeout);
+    }
+
+    /**
+     * A timeout value in case the cluster-manager has not been discovered yet or disconnected.
      */
     public final Request clusterManagerNodeTimeout(String timeout) {
         return clusterManagerNodeTimeout(
@@ -81,11 +100,20 @@ public abstract class ClusterManagerNodeRequest<Request extends ClusterManagerNo
         );
     }
 
+    /**
+     * A timeout value in case the cluster-manager has not been discovered yet or disconnected.
+     *
+     * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #clusterManagerNodeTimeout(String)}
+     */
+    @Deprecated
+    public final Request masterNodeTimeout(String timeout) {
+        return clusterManagerNodeTimeout(timeout);
+    }
+
     public final TimeValue clusterManagerNodeTimeout() {
         return this.clusterManagerNodeTimeout;
     }
 
-    // Preserve the method so that classes implements AcknowledgedRequest don't need to override it for backwards compatibility.
     /** @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #clusterManagerNodeTimeout()} */
     @Deprecated
     public final TimeValue masterNodeTimeout() {

--- a/server/src/main/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeAction.java
@@ -120,8 +120,7 @@ public abstract class TransportClusterManagerNodeAction<Request extends ClusterM
     protected abstract void clusterManagerOperation(Request request, ClusterState state, ActionListener<Response> listener)
         throws Exception;
 
-    // Preserve the method so that o.o.action.support.master.info.TransportClusterInfoAction class
-    // can override masterOperation() for backwards compatibility.
+    // Change the method to be concrete after deprecation so that existing class can override it while new class don't have to.
     /** @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #clusterManagerOperation(ClusterManagerNodeRequest, ClusterState, ActionListener)} */
     @Deprecated
     protected void masterOperation(Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
@@ -134,6 +133,16 @@ public abstract class TransportClusterManagerNodeAction<Request extends ClusterM
     protected void clusterManagerOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener)
         throws Exception {
         clusterManagerOperation(request, state, listener);
+    }
+
+    /**
+     * Override this operation if access to the task parameter is needed
+     *
+     * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #clusterManagerOperation(Task, ClusterManagerNodeRequest, ClusterState, ActionListener)}
+     */
+    @Deprecated
+    protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
+        clusterManagerOperation(task, request, state, listener);
     }
 
     protected boolean localExecute(Request request) {
@@ -302,5 +311,16 @@ public abstract class TransportClusterManagerNodeAction<Request extends ClusterM
      */
     protected String getClusterManagerActionName(DiscoveryNode node) {
         return actionName;
+    }
+
+    /**
+     * Allows to conditionally return a different cluster-manager node action name in the case an action gets renamed.
+     * This mainly for backwards compatibility should be used rarely
+     *
+     * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #getClusterManagerActionName(DiscoveryNode)}
+     */
+    @Deprecated
+    protected String getMasterActionName(DiscoveryNode node) {
+        return getClusterManagerActionName(node);
     }
 }

--- a/server/src/main/java/org/opensearch/action/support/clustermanager/info/TransportClusterInfoAction.java
+++ b/server/src/main/java/org/opensearch/action/support/clustermanager/info/TransportClusterInfoAction.java
@@ -82,10 +82,24 @@ public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequ
         doClusterManagerOperation(request, concreteIndices, state, listener);
     }
 
+    /** @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #clusterManagerOperation(ClusterInfoRequest, ClusterState, ActionListener)} */
+    @Deprecated
+    @Override
+    protected final void masterOperation(final Request request, final ClusterState state, final ActionListener<Response> listener) {
+        clusterManagerOperation(request, state, listener);
+    }
+
     protected abstract void doClusterManagerOperation(
         Request request,
         String[] concreteIndices,
         ClusterState state,
         ActionListener<Response> listener
     );
+
+    // Change the method to be concrete after deprecation so that existing class can override it while new class don't have to.
+    /** @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #doClusterManagerOperation(ClusterInfoRequest, String[], ClusterState, ActionListener)} */
+    @Deprecated
+    protected void doMasterOperation(Request request, String[] concreteIndices, ClusterState state, ActionListener<Response> listener) {
+        doClusterManagerOperation(request, concreteIndices, state, listener);
+    }
 }

--- a/server/src/main/java/org/opensearch/action/support/master/MasterNodeOperationRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/support/master/MasterNodeOperationRequestBuilder.java
@@ -37,7 +37,6 @@ import org.opensearch.action.ActionResponse;
 import org.opensearch.action.support.clustermanager.ClusterManagerNodeOperationRequestBuilder;
 import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
 import org.opensearch.client.OpenSearchClient;
-import org.opensearch.common.unit.TimeValue;
 
 /**
  * Base request builder for cluster-manager node operations
@@ -54,23 +53,5 @@ public abstract class MasterNodeOperationRequestBuilder<
 
     protected MasterNodeOperationRequestBuilder(OpenSearchClient client, ActionType<Response> action, Request request) {
         super(client, action, request);
-    }
-
-    /**
-     * Sets the cluster-manager node timeout in case the cluster-manager has not yet been discovered.
-     */
-    @SuppressWarnings("unchecked")
-    @Deprecated
-    public final RequestBuilder setMasterNodeTimeout(TimeValue timeout) {
-        return setClusterManagerNodeTimeout(timeout);
-    }
-
-    /**
-     * Sets the cluster-manager node timeout in case the cluster-manager has not yet been discovered.
-     */
-    @SuppressWarnings("unchecked")
-    @Deprecated
-    public final RequestBuilder setMasterNodeTimeout(String timeout) {
-        return setClusterManagerNodeTimeout(timeout);
     }
 }

--- a/server/src/main/java/org/opensearch/action/support/master/MasterNodeRequest.java
+++ b/server/src/main/java/org/opensearch/action/support/master/MasterNodeRequest.java
@@ -34,7 +34,6 @@ package org.opensearch.action.support.master;
 
 import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
 import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.unit.TimeValue;
 
 import java.io.IOException;
 
@@ -47,30 +46,7 @@ import java.io.IOException;
 @Deprecated
 public abstract class MasterNodeRequest<Request extends MasterNodeRequest<Request>> extends ClusterManagerNodeRequest<Request> {
 
-    @Deprecated
-    public static final TimeValue DEFAULT_MASTER_NODE_TIMEOUT = DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT;
-
-    @Deprecated
-    protected TimeValue masterNodeTimeout = clusterManagerNodeTimeout;
-
     protected MasterNodeRequest(StreamInput in) throws IOException {
         super(in);
-    }
-
-    /**
-     * A timeout value in case the cluster-manager has not been discovered yet or disconnected.
-     */
-    @SuppressWarnings("unchecked")
-    @Deprecated
-    public final Request masterNodeTimeout(TimeValue timeout) {
-        return clusterManagerNodeTimeout(timeout);
-    }
-
-    /**
-     * A timeout value in case the cluster-manager has not been discovered yet or disconnected.
-     */
-    @Deprecated
-    public final Request masterNodeTimeout(String timeout) {
-        return clusterManagerNodeTimeout(timeout);
     }
 }

--- a/server/src/main/java/org/opensearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/master/TransportMasterNodeAction.java
@@ -39,10 +39,8 @@ import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
 import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
-import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.io.stream.Writeable;
-import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
@@ -93,20 +91,4 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
     @Deprecated
     protected abstract void masterOperation(Request request, ClusterState state, ActionListener<Response> listener) throws Exception;
 
-    /**
-     * Override this operation if access to the task parameter is needed
-     */
-    @Deprecated
-    protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
-        clusterManagerOperation(task, request, state, listener);
-    }
-
-    /**
-     * Allows to conditionally return a different cluster-manager node action name in the case an action gets renamed.
-     * This mainly for backwards compatibility should be used rarely
-     */
-    @Deprecated
-    protected String getMasterActionName(DiscoveryNode node) {
-        return getClusterManagerActionName(node);
-    }
 }

--- a/server/src/main/java/org/opensearch/action/support/master/info/TransportClusterInfoAction.java
+++ b/server/src/main/java/org/opensearch/action/support/master/info/TransportClusterInfoAction.java
@@ -62,11 +62,6 @@ public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequ
     }
 
     @Deprecated
-    protected final void masterOperation(final Request request, final ClusterState state, final ActionListener<Response> listener) {
-        clusterManagerOperation(request, state, listener);
-    }
-
-    @Deprecated
     protected abstract void doMasterOperation(
         Request request,
         String[] concreteIndices,


### PR DESCRIPTION
### Description
This is a follow up PR for the previous PR https://github.com/opensearch-project/OpenSearch/pull/3617 to fix the backwards compatibility.

In the PR #3617, I renamed public methods with "master" word in the new package `org.opensearch.action.support.clustermanager`, and preserved those methods by their old names in the classes of the old package `org.opensearch.action.support.master`.
This will break the compatibility in a case.

For example:
Before the class renaming: 
The class `ClusterHealthRequest` extends `MasterNodeReadRequest` extends `MasterNodeRequest`.
Class `MasterNodeRequest` has got a method `masterNodeTimeout(TimeValue)`.
Then the class `ClusterHealthRequest` can access the method `masterNodeTimeout(TimeValue)`.

After the class renaming: 
The class `ClusterHealthRequest` extends `MasterNodeReadRequest` extends `ClusterManagerNodeReadRequest` extends `ClusterManagerNodeRequest`.
Class `ClusterManagerNodeRequest` has got the method `clusterManagerNodeTimeout(TimeValue)`.
Class `MasterNodeRequest` has got the method `masterNodeTimeout(TimeValue)`.
But the class `ClusterHealthRequest` can not access the method `masterNodeTimeout(TimeValue)` any more.

In this PR, I added all the deprecated methods that with `master` word into the classes of package `org.opensearch.action.support.clustermanager` to keep the backwards compatibility.

### Issues Resolved
A part of issue #3542 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
