### PR TITLE
Fixing flaky test testThreeZoneOneReplicaWithForceZoneValueAndLoadAwareness

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/allocation/AwarenessAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/allocation/AwarenessAllocationIT.java
@@ -366,16 +366,19 @@ public class AwarenessAllocationIT extends OpenSearchIntegTestCase {
             .put("cluster.routing.allocation.load_awareness.provisioned_capacity", Integer.toString(nodeCountPerAZ * 3))
             .build();
 
+        logger.info("--> starting a dedicated cluster manager node");
+        internalCluster().startClusterManagerOnlyNode();
+
         logger.info("--> starting 15 nodes on zones 'a' & 'b' & 'c'");
-        List<String> nodes_in_zone_a = internalCluster().startNodes(
+        List<String> nodes_in_zone_a = internalCluster().startDataOnlyNodes(
             nodeCountPerAZ,
             Settings.builder().put(commonSettings).put("node.attr.zone", "a").build()
         );
-        List<String> nodes_in_zone_b = internalCluster().startNodes(
+        List<String> nodes_in_zone_b = internalCluster().startDataOnlyNodes(
             nodeCountPerAZ,
             Settings.builder().put(commonSettings).put("node.attr.zone", "b").build()
         );
-        List<String> nodes_in_zone_c = internalCluster().startNodes(
+        List<String> nodes_in_zone_c = internalCluster().startDataOnlyNodes(
             nodeCountPerAZ,
             Settings.builder().put(commonSettings).put("node.attr.zone", "c").build()
         );
@@ -395,7 +398,7 @@ public class AwarenessAllocationIT extends OpenSearchIntegTestCase {
             .setIndices("test-1")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
-            .setWaitForNodes(Integer.toString(nodeCountPerAZ * 3))
+            .setWaitForNodes(Integer.toString(nodeCountPerAZ * 3 + 1))
             .setWaitForNoRelocatingShards(true)
             .setWaitForNoInitializingShards(true)
             .execute()
@@ -431,7 +434,7 @@ public class AwarenessAllocationIT extends OpenSearchIntegTestCase {
             .prepareHealth()
             .setIndices("test-1")
             .setWaitForEvents(Priority.LANGUID)
-            .setWaitForNodes(Integer.toString(nodeCountPerAZ * 3 - nodesToStop))
+            .setWaitForNodes(Integer.toString(nodeCountPerAZ * 3 - nodesToStop + 1))
             .setWaitForNoRelocatingShards(true)
             .setWaitForNoInitializingShards(true)
             .execute()
@@ -452,7 +455,7 @@ public class AwarenessAllocationIT extends OpenSearchIntegTestCase {
             .prepareHealth()
             .setIndices("test-1", "test-2")
             .setWaitForEvents(Priority.LANGUID)
-            .setWaitForNodes(Integer.toString(nodeCountPerAZ * 3 - nodesToStop))
+            .setWaitForNodes(Integer.toString(nodeCountPerAZ * 3 - nodesToStop + 1))
             .setWaitForNoRelocatingShards(true)
             .setWaitForNoInitializingShards(true)
             .execute()
@@ -477,7 +480,7 @@ public class AwarenessAllocationIT extends OpenSearchIntegTestCase {
             .prepareHealth()
             .setIndices("test-1", "test-2")
             .setWaitForEvents(Priority.LANGUID)
-            .setWaitForNodes(Integer.toString(nodeCountPerAZ * 3))
+            .setWaitForNodes(Integer.toString(nodeCountPerAZ * 3 + 1))
             .setWaitForGreenStatus()
             .setWaitForActiveShards(2 * numOfShards * (numOfReplica + 1))
             .setWaitForNoRelocatingShards(true)

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/allocation/AwarenessAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/allocation/AwarenessAllocationIT.java
@@ -364,6 +364,7 @@ public class AwarenessAllocationIT extends OpenSearchIntegTestCase {
             .put("cluster.routing.allocation.awareness.force.zone.values", "a,b,c")
             .put("cluster.routing.allocation.load_awareness.skew_factor", "0.0")
             .put("cluster.routing.allocation.load_awareness.provisioned_capacity", Integer.toString(nodeCountPerAZ * 3))
+            .put("cluster.routing.allocation.allow_rebalance", "indices_primaries_active")
             .build();
 
         logger.info("--> starting a dedicated cluster manager node");


### PR DESCRIPTION
Signed-off-by: Rishab Nahata <rnnahata@amazon.com>

### Description
Caused by #3563 

```
org.opensearch.cluster.allocation.AwarenessAllocationIT > testThreeZoneOneReplicaWithForceZoneValueAndLoadAwareness FAILED
    java.lang.AssertionError: unexpected
        at org.opensearch.test.InternalTestCluster.removeExclusions(InternalTestCluster.java:1912)
        at org.opensearch.test.InternalTestCluster.stopNodesAndClients(InternalTestCluster.java:1777)
        at org.opensearch.test.InternalTestCluster.stopNodesAndClient(InternalTestCluster.java:1764)
        at org.opensearch.test.InternalTestCluster.stopRandomNode(InternalTestCluster.java:1672)
        at org.opensearch.cluster.allocation.AwarenessAllocationIT.testThreeZoneOneReplicaWithForceZoneValueAndLoadAwareness(AwarenessAllocationIT.java:425)

        Caused by:
        java.util.concurrent.ExecutionException: MasterNotDiscoveredException[null]
            at org.opensearch.common.util.concurrent.BaseFuture$Sync.getValue(BaseFuture.java:286)
            at org.opensearch.common.util.concurrent.BaseFuture$Sync.get(BaseFuture.java:273)
            at org.opensearch.common.util.concurrent.BaseFuture.get(BaseFuture.java:104)
            at org.opensearch.test.InternalTestCluster.removeExclusions(InternalTestCluster.java:1910)
            ... 4 more

            Caused by:
            MasterNotDiscoveredException[null]
                at app//org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction$AsyncSingleAction$2.onTimeout(TransportClusterManagerNodeAction.java:282)
                at app//org.opensearch.cluster.ClusterStateObserver$ContextPreservingListener.onTimeout(ClusterStateObserver.java:394)
                at app//org.opensearch.cluster.ClusterStateObserver$ObserverClusterStateListener.onTimeout(ClusterStateObserver.java:294)
                at app//org.opensearch.cluster.service.ClusterApplierService$NotifyTimeout.run(ClusterApplierService.java:697)
                at app//org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:739)
                at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
                at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
                at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)

    MasterNotDiscoveredException[null]
        at app//org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction$AsyncSingleAction$2.onTimeout(TransportClusterManagerNodeAction.java:282)
        at app//org.opensearch.cluster.ClusterStateObserver$ContextPreservingListener.onTimeout(ClusterStateObserver.java:394)
        at app//org.opensearch.cluster.ClusterStateObserver$ObserverClusterStateListener.onTimeout(ClusterStateObserver.java:294)
        at app//org.opensearch.cluster.service.ClusterApplierService$NotifyTimeout.run(ClusterApplierService.java:697)
        at app//org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:739)
        at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base@17.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base@17.0.3/java.lang.Thread.run(Thread.java:833)
```
 
### Issues Resolved
#3603 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
