### PR TITLE
[Backport 2.0] [BUG] opensearch crashes on closed client connection before search reply

### DIFF
--- a/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
@@ -456,7 +456,11 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
         }
         final int totalOps = this.totalOps.incrementAndGet();
         if (totalOps == expectedTotalOps) {
-            onPhaseDone();
+            try {
+                onPhaseDone();
+            } catch (final Exception ex) {
+                onPhaseFailure(this, "The phase has failed", ex);
+            }
         } else if (totalOps > expectedTotalOps) {
             throw new AssertionError(
                 "unexpected higher total ops [" + totalOps + "] compared to expected [" + expectedTotalOps + "]",
@@ -561,7 +565,11 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
         }
         final int xTotalOps = totalOps.addAndGet(remainingOpsOnIterator);
         if (xTotalOps == expectedTotalOps) {
-            onPhaseDone();
+            try {
+                onPhaseDone();
+            } catch (final Exception ex) {
+                onPhaseFailure(this, "The phase has failed", ex);
+            }
         } else if (xTotalOps > expectedTotalOps) {
             throw new AssertionError(
                 "unexpected higher total ops [" + xTotalOps + "] compared to expected [" + expectedTotalOps + "]",


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Backport https://github.com/opensearch-project/OpenSearch/commit/3dba46ecd14c5b1eb18500357400d6cefafc2836 from https://github.com/opensearch-project/OpenSearch/pull/3626
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/3557
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
