### PR TITLE
[BUG] Custom POM configuration for ZIP publication produces duplicit tags (url, scm)

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/PublishPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/PublishPlugin.java
@@ -36,7 +36,6 @@ import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin;
 import com.github.jengelman.gradle.plugins.shadow.ShadowExtension;
 import groovy.util.Node;
 import groovy.util.NodeList;
-import groovy.xml.QName;
 
 import org.opensearch.gradle.info.BuildParams;
 import org.opensearch.gradle.precommit.PomValidationPrecommitPlugin;
@@ -57,6 +56,9 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.util.concurrent.Callable;
 
 import static org.opensearch.gradle.util.GradleUtils.maybeConfigure;
@@ -153,16 +155,29 @@ public class PublishPlugin implements Plugin<Project> {
         for (final Object child : root.children()) {
             if (child instanceof Node) {
                 final Node node = (Node) child;
-                if (node.name() instanceof QName) {
-                    final QName qname = (QName) node.name();
-                    if (qname.matches("url")) {
-                        url = node;
-                    } else if (qname.matches("scm")) {
-                        scm = node;
+                final Object name = node.name();
+
+                try {
+                    // For Gradle 6.8 and below, the class is groovy.xml.QName
+                    // For Gradle 7.4 and above, the class is groovy.namespace.QName
+                    if (name != null && name.getClass().getSimpleName().equals("QName")) {
+                        final MethodHandle handle = MethodHandles.publicLookup()
+                            .findVirtual(name.getClass(), "matches", MethodType.methodType(boolean.class, Object.class))
+                            .bindTo(name);
+
+                        if ((boolean) handle.invoke("url")) {
+                            url = node;
+                        } else if ((boolean) handle.invoke("scm")) {
+                            scm = node;
+                        }
                     }
-                } else if ("url".equals(node.name())) {
+                } catch (final Throwable ex) {
+                    // Not a suitable QName type we could use ...
+                }
+
+                if ("url".equals(name)) {
                     url = node;
-                } else if ("scm".equals(node.name())) {
+                } else if ("scm".equals(name)) {
                     scm = node;
                 }
             }


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Only create SCM and URL sections if those are not provided.
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/3649
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
