### PR TITLE
Correct class definitions in deprecated package org.opensearch.actionsupport.master

### DIFF
--- a/server/src/main/java/org/opensearch/action/support/master/AcknowledgedRequest.java
+++ b/server/src/main/java/org/opensearch/action/support/master/AcknowledgedRequest.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.action.support.master;
 
-import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
 import org.opensearch.common.io.stream.StreamInput;
 
 import java.io.IOException;
@@ -42,7 +41,7 @@ import java.io.IOException;
  *
  * @opensearch.internal
  */
-public abstract class AcknowledgedRequest<Request extends ClusterManagerNodeRequest<Request>> extends
+public abstract class AcknowledgedRequest<Request extends AcknowledgedRequest<Request>> extends
     org.opensearch.action.support.clustermanager.AcknowledgedRequest<Request> {
 
     protected AcknowledgedRequest() {

--- a/server/src/main/java/org/opensearch/action/support/master/AcknowledgedRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/support/master/AcknowledgedRequestBuilder.java
@@ -32,8 +32,6 @@
 package org.opensearch.action.support.master;
 
 import org.opensearch.action.ActionType;
-import org.opensearch.action.support.clustermanager.AcknowledgedRequest;
-import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.client.OpenSearchClient;
 
 /**

--- a/server/src/main/java/org/opensearch/action/support/master/MasterNodeOperationRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/support/master/MasterNodeOperationRequestBuilder.java
@@ -35,7 +35,6 @@ package org.opensearch.action.support.master;
 import org.opensearch.action.ActionType;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.action.support.clustermanager.ClusterManagerNodeOperationRequestBuilder;
-import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
 import org.opensearch.client.OpenSearchClient;
 import org.opensearch.common.unit.TimeValue;
 
@@ -47,7 +46,7 @@ import org.opensearch.common.unit.TimeValue;
  */
 @Deprecated
 public abstract class MasterNodeOperationRequestBuilder<
-    Request extends ClusterManagerNodeRequest<Request>,
+    Request extends MasterNodeRequest<Request>,
     Response extends ActionResponse,
     RequestBuilder extends MasterNodeOperationRequestBuilder<Request, Response, RequestBuilder>> extends
     ClusterManagerNodeOperationRequestBuilder<Request, Response, RequestBuilder> {

--- a/server/src/main/java/org/opensearch/action/support/master/MasterNodeReadOperationRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/support/master/MasterNodeReadOperationRequestBuilder.java
@@ -34,9 +34,7 @@ package org.opensearch.action.support.master;
 
 import org.opensearch.action.ActionType;
 import org.opensearch.action.ActionResponse;
-import org.opensearch.action.support.clustermanager.ClusterManagerNodeOperationRequestBuilder;
 import org.opensearch.action.support.clustermanager.ClusterManagerNodeReadOperationRequestBuilder;
-import org.opensearch.action.support.clustermanager.ClusterManagerNodeReadRequest;
 import org.opensearch.client.OpenSearchClient;
 
 /**
@@ -47,10 +45,10 @@ import org.opensearch.client.OpenSearchClient;
  */
 @Deprecated
 public abstract class MasterNodeReadOperationRequestBuilder<
-    Request extends ClusterManagerNodeReadRequest<Request>,
+    Request extends MasterNodeReadRequest<Request>,
     Response extends ActionResponse,
-    RequestBuilder extends ClusterManagerNodeReadOperationRequestBuilder<Request, Response, RequestBuilder>> extends
-    ClusterManagerNodeOperationRequestBuilder<Request, Response, RequestBuilder> {
+    RequestBuilder extends MasterNodeReadOperationRequestBuilder<Request, Response, RequestBuilder>> extends
+    ClusterManagerNodeReadOperationRequestBuilder<Request, Response, RequestBuilder> {
 
     protected MasterNodeReadOperationRequestBuilder(OpenSearchClient client, ActionType<Response> action, Request request) {
         super(client, action, request);

--- a/server/src/main/java/org/opensearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/master/TransportMasterNodeAction.java
@@ -35,7 +35,6 @@ package org.opensearch.action.support.master;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.action.support.ActionFilters;
-import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
 import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
@@ -50,7 +49,7 @@ import org.opensearch.transport.TransportService;
  * A base class for operations that needs to be performed on the cluster-manager node.
  *
  * @opensearch.internal
- * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link ClusterManagerNodeRequest}
+ * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link TransportClusterManagerNodeAction}
  */
 @Deprecated
 public abstract class TransportMasterNodeAction<Request extends MasterNodeRequest<Request>, Response extends ActionResponse> extends

--- a/server/src/main/java/org/opensearch/action/support/master/TransportMasterNodeReadAction.java
+++ b/server/src/main/java/org/opensearch/action/support/master/TransportMasterNodeReadAction.java
@@ -34,7 +34,6 @@ package org.opensearch.action.support.master;
 
 import org.opensearch.action.ActionResponse;
 import org.opensearch.action.support.ActionFilters;
-import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
 import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeReadAction;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
@@ -47,7 +46,7 @@ import org.opensearch.transport.TransportService;
  * Can also be executed on the local node if needed.
  *
  * @opensearch.internal
- * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link ClusterManagerNodeRequest}
+ * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link TransportClusterManagerNodeReadAction}
  */
 @Deprecated
 public abstract class TransportMasterNodeReadAction<Request extends MasterNodeReadRequest<Request>, Response extends ActionResponse> extends

--- a/server/src/main/java/org/opensearch/action/support/master/info/ClusterInfoRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/support/master/info/ClusterInfoRequestBuilder.java
@@ -33,7 +33,6 @@ package org.opensearch.action.support.master.info;
 
 import org.opensearch.action.ActionType;
 import org.opensearch.action.ActionResponse;
-import org.opensearch.action.support.clustermanager.info.ClusterInfoRequest;
 import org.opensearch.client.OpenSearchClient;
 
 /**


### PR DESCRIPTION
### Description
Correct the class definitions in the deprecated package `org.opensearch.actionsupport.master`
For reference, the original package before deprecation is: https://github.com/opensearch-project/OpenSearch/tree/2.0.1/server/src/main/java/org/opensearch/action/support/master
The package is deprecated in the PR https://github.com/opensearch-project/OpenSearch/pull/3593 / commit https://github.com/opensearch-project/OpenSearch/commit/223d472e6d8ea4454cb05fba7271d213430a1a4e

- Use classes in the same package for inheritance (after `extends`) to keep original behavior
- Correct the class name in the Javadoc `replaced by {@link #...}`
 
### Issues Resolved
Related to issue #3542
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
