### PR TITLE
fix for bug: https://github.com/opensearch-project/OpenSearch/issues/…

### DIFF
--- a/client/rest/src/main/java/org/opensearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClient.java
@@ -954,6 +954,41 @@ public class RestClient implements Closeable {
             }
             return out.asInput();
         }
+
+        /**
+         * A gzip compressing enrity doesn't worked with chunked encoding with sigv4
+         *
+         * @return false
+         */
+        @Override
+        public boolean isChunked() {
+            return false;
+        }
+
+        /**
+         * A gzip entity require to content length in http headers
+         * as it doesn't work with chunked encoding for sigv4
+         *
+         * @return content lenght of gzip entity
+         */
+        @Override
+        public long getContentLength() {
+            long size = 0;
+            int chunk = 0;
+            byte[] buffer = new byte[1024];
+
+            try {
+                InputStream is = getContent();
+
+                while ((chunk = is.read(buffer)) != -1) {
+                    size += chunk;
+                }
+            } catch (Exception ex) {
+                throw new RuntimeException("failed to get compressed content lenght: " + ex.getMessage());
+            }
+
+            return size;
+        }
     }
 
     /**

--- a/client/rest/src/main/java/org/opensearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClient.java
@@ -36,6 +36,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.http.ConnectionClosedException;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
+import org.apache.http.entity.HttpEntityWrapper;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
@@ -644,6 +645,8 @@ public class RestClient implements Closeable {
                     } else {
                         entity = new ContentCompressingEntity(entity);
                     }
+                } else if (chunkedTransferEncodingEnabled) {
+                    entity = new ChunkedHttpEntity(entity);
                 }
                 ((HttpEntityEnclosingRequestBase) httpRequest).setEntity(entity);
             } else {
@@ -1042,6 +1045,28 @@ public class RestClient implements Closeable {
             }
 
             return size;
+        }
+    }
+
+    public static class ChunkedHttpEntity extends HttpEntityWrapper {
+        /**
+         * Creates a {@link ChunkedHttpEntity} instance with the provided HTTP entity.
+         *
+         * @param entity the HTTP entity.
+         */
+        public ChunkedHttpEntity(HttpEntity entity) {
+            super(entity);
+        }
+
+        /**
+         * A chunked entity requires transfer-encoding:chunked in http headers
+         * which requires isChunked to be true
+         *
+         * @return true
+         */
+        @Override
+        public boolean isChunked() {
+            return true;
         }
     }
 

--- a/client/rest/src/main/java/org/opensearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClient.java
@@ -956,7 +956,7 @@ public class RestClient implements Closeable {
         }
 
         /**
-         * A gzip compressing enrity doesn't worked with chunked encoding with sigv4
+         * A gzip compressing entity doesn't work with chunked encoding with sigv4
          *
          * @return false
          */
@@ -966,25 +966,18 @@ public class RestClient implements Closeable {
         }
 
         /**
-         * A gzip entity require to content length in http headers
+         * A gzip entity requires content length in http headers
          * as it doesn't work with chunked encoding for sigv4
          *
-         * @return content lenght of gzip entity
+         * @return content length of gzip entity
          */
         @Override
         public long getContentLength() {
-            long size = 0;
-            int chunk = 0;
-            byte[] buffer = new byte[1024];
-
-            try {
-                InputStream is = getContent();
-
-                while ((chunk = is.read(buffer)) != -1) {
-                    size += chunk;
-                }
-            } catch (Exception ex) {
-                throw new RuntimeException("failed to get compressed content lenght: " + ex.getMessage());
+            long size;
+            try (InputStream is = getContent()) {
+                size = is.readAllBytes().length;
+            } catch (IOException ex) {
+                size = -1L;
             }
 
             return size;

--- a/client/rest/src/main/java/org/opensearch/client/RestClientBuilder.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClientBuilder.java
@@ -84,6 +84,7 @@ public final class RestClientBuilder {
     private NodeSelector nodeSelector = NodeSelector.ANY;
     private boolean strictDeprecationMode = false;
     private boolean compressionEnabled = false;
+    private boolean chunkedTransferEncodingEnabled = true;
 
     /**
      * Creates a new builder instance and sets the hosts that the client will send requests to.
@@ -239,6 +240,16 @@ public final class RestClientBuilder {
     }
 
     /**
+     * Whether the REST client should use Transfer-Encoding: chunked for compress requests"
+     *
+     * @param chunkedTransferEncodingEnabled flag for enabling Transfer-Encoding: chunked
+     */
+    public RestClientBuilder setChunkedTransferEncodingEnabled(boolean chunkedTransferEncodingEnabled) {
+        this.chunkedTransferEncodingEnabled = chunkedTransferEncodingEnabled;
+        return this;
+    }
+
+    /**
      * Creates a new {@link RestClient} based on the provided configuration.
      */
     public RestClient build() {
@@ -256,7 +267,8 @@ public final class RestClientBuilder {
             failureListener,
             nodeSelector,
             strictDeprecationMode,
-            compressionEnabled
+            compressionEnabled,
+            chunkedTransferEncodingEnabled
         );
         httpClient.start();
         return restClient;

--- a/client/rest/src/main/java/org/opensearch/client/RestClientBuilder.java
+++ b/client/rest/src/main/java/org/opensearch/client/RestClientBuilder.java
@@ -240,7 +240,7 @@ public final class RestClientBuilder {
     }
 
     /**
-     * Whether the REST client should use Transfer-Encoding: chunked for compress requests"
+     * Whether the REST client should use Transfer-Encoding: chunked for requests or not"
      *
      * @param chunkedTransferEncodingEnabled flag for enabling Transfer-Encoding: chunked
      */

--- a/client/rest/src/test/java/org/opensearch/client/RestClientCompressionTests.java
+++ b/client/rest/src/test/java/org/opensearch/client/RestClientCompressionTests.java
@@ -6,11 +6,6 @@
  * compatible open source license.
  */
 
-/*
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
 package org.opensearch.client;
 
 import com.sun.net.httpserver.HttpExchange;

--- a/client/rest/src/test/java/org/opensearch/client/RestClientCompressionTests.java
+++ b/client/rest/src/test/java/org/opensearch/client/RestClientCompressionTests.java
@@ -92,7 +92,9 @@ public class RestClientCompressionTests extends RestClientTestCase {
         }
     }
 
-    /** Read all bytes of an input stream and close it. */
+    /**
+     * Read all bytes of an input stream and close it.
+     */
     private static byte[] readAll(InputStream in) throws IOException {
         byte[] buffer = new byte[1024];
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -104,15 +106,16 @@ public class RestClientCompressionTests extends RestClientTestCase {
         return bos.toByteArray();
     }
 
-    private RestClient createClient(boolean enableCompression) {
+    private RestClient createClient(boolean enableCompression, boolean chunkedEnabled) {
         InetSocketAddress address = httpServer.getAddress();
         return RestClient.builder(new HttpHost(address.getHostString(), address.getPort(), "http"))
             .setCompressionEnabled(enableCompression)
+            .setChunkedTransferEncodingEnabled(chunkedEnabled)
             .build();
     }
 
     public void testCompressingClientWithContentLengthSync() throws Exception {
-        RestClient restClient = createClient(true);
+        RestClient restClient = createClient(true, false);
 
         Request request = new Request("POST", "/");
         request.setEntity(new StringEntity("compressing client", ContentType.TEXT_PLAIN));
@@ -129,9 +132,7 @@ public class RestClientCompressionTests extends RestClientTestCase {
 
     public void testCompressingClientContentLengthAsync() throws Exception {
         InetSocketAddress address = httpServer.getAddress();
-        RestClient restClient = RestClient.builder(new HttpHost(address.getHostString(), address.getPort(), "http"))
-            .setCompressionEnabled(true)
-            .build();
+        RestClient restClient = createClient(true, false);
 
         Request request = new Request("POST", "/");
         request.setEntity(new StringEntity("compressing client", ContentType.TEXT_PLAIN));

--- a/client/rest/src/test/java/org/opensearch/client/RestClientCompressionTests.java
+++ b/client/rest/src/test/java/org/opensearch/client/RestClientCompressionTests.java
@@ -7,25 +7,6 @@
  */
 
 /*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-/*
  * Modifications Copyright OpenSearch Contributors. See
  * GitHub history for details.
  */

--- a/client/rest/src/test/java/org/opensearch/client/RestClientCompressionTests.java
+++ b/client/rest/src/test/java/org/opensearch/client/RestClientCompressionTests.java
@@ -1,0 +1,188 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.client;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class RestClientCompressionTests extends RestClientTestCase {
+
+    private static HttpServer httpServer;
+
+    @BeforeClass
+    public static void startHttpServer() throws Exception {
+        httpServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        httpServer.createContext("/", new GzipResponseHandler());
+        httpServer.start();
+    }
+
+    @AfterClass
+    public static void stopHttpServers() throws IOException {
+        httpServer.stop(0);
+        httpServer = null;
+    }
+
+    /**
+     * A response handler that accepts gzip-encoded data and replies request and response encoding values
+     * followed by the request body. The response is compressed if "Accept-Encoding" is "gzip".
+     */
+    private static class GzipResponseHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+
+            // Decode body (if any)
+            String contentEncoding = exchange.getRequestHeaders().getFirst("Content-Encoding");
+            String contentLength = exchange.getRequestHeaders().getFirst("Content-Length");
+            InputStream body = exchange.getRequestBody();
+            boolean compressedRequest = false;
+            if ("gzip".equals(contentEncoding)) {
+                body = new GZIPInputStream(body);
+                compressedRequest = true;
+            }
+            byte[] bytes = readAll(body);
+            boolean compress = "gzip".equals(exchange.getRequestHeaders().getFirst("Accept-Encoding"));
+            if (compress) {
+                exchange.getResponseHeaders().add("Content-Encoding", "gzip");
+            }
+
+            exchange.sendResponseHeaders(200, 0);
+
+            // Encode response if needed
+            OutputStream out = exchange.getResponseBody();
+            if (compress) {
+                out = new GZIPOutputStream(out);
+            }
+
+            // Outputs <request-encoding|null>#<response-encoding|null>#<request-body>
+            out.write(String.valueOf(contentEncoding).getBytes(StandardCharsets.UTF_8));
+            out.write('#');
+            out.write((compress ? "gzip" : "null").getBytes(StandardCharsets.UTF_8));
+            out.write('#');
+            out.write((compressedRequest ? contentLength : "null").getBytes(StandardCharsets.UTF_8));
+            out.write('#');
+            out.write(bytes);
+            out.close();
+
+            exchange.close();
+        }
+    }
+
+    /** Read all bytes of an input stream and close it. */
+    private static byte[] readAll(InputStream in) throws IOException {
+        byte[] buffer = new byte[1024];
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        int len = 0;
+        while ((len = in.read(buffer)) > 0) {
+            bos.write(buffer, 0, len);
+        }
+        in.close();
+        return bos.toByteArray();
+    }
+
+    private RestClient createClient(boolean enableCompression) {
+        InetSocketAddress address = httpServer.getAddress();
+        return RestClient.builder(new HttpHost(address.getHostString(), address.getPort(), "http"))
+            .setCompressionEnabled(enableCompression)
+            .build();
+    }
+
+    public void testCompressingClientWithContentLengthSync() throws Exception {
+        RestClient restClient = createClient(true);
+
+        Request request = new Request("POST", "/");
+        request.setEntity(new StringEntity("compressing client", ContentType.TEXT_PLAIN));
+
+        Response response = restClient.performRequest(request);
+
+        HttpEntity entity = response.getEntity();
+        String content = new String(readAll(entity.getContent()), StandardCharsets.UTF_8);
+        // Content-Encoding#Accept-Encoding#Content-Length#Content
+        Assert.assertEquals("gzip#gzip#38#compressing client", content);
+
+        restClient.close();
+    }
+
+    public void testCompressingClientContentLengthAsync() throws Exception {
+        InetSocketAddress address = httpServer.getAddress();
+        RestClient restClient = RestClient.builder(new HttpHost(address.getHostString(), address.getPort(), "http"))
+            .setCompressionEnabled(true)
+            .build();
+
+        Request request = new Request("POST", "/");
+        request.setEntity(new StringEntity("compressing client", ContentType.TEXT_PLAIN));
+
+        FutureResponse futureResponse = new FutureResponse();
+        restClient.performRequestAsync(request, futureResponse);
+        Response response = futureResponse.get();
+
+        // Server should report it had a compressed request and sent back a compressed response
+        HttpEntity entity = response.getEntity();
+        String content = new String(readAll(entity.getContent()), StandardCharsets.UTF_8);
+
+        // Content-Encoding#Accept-Encoding#Content-Length#Content
+        Assert.assertEquals("gzip#gzip#38#compressing client", content);
+
+        restClient.close();
+    }
+
+    public static class FutureResponse extends CompletableFuture<Response> implements ResponseListener {
+        @Override
+        public void onSuccess(Response response) {
+            this.complete(response);
+        }
+
+        @Override
+        public void onFailure(Exception exception) {
+            this.completeExceptionally(exception);
+        }
+    }
+}


### PR DESCRIPTION
### Description
Overriding isChunked method from GzipCompressingEntity to false as it didn't worked with SIGV4 AuthN/AuthZ,
to preserve data Overriding getContentLength from GzipCompressingEntity to return content length of gzip entity
which will be added in http header.
 
### Issues Resolved
 https://github.com/opensearch-project/OpenSearch/issues/3640
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
