### PR TITLE
Revert renaming method onMaster() and offMaster() in interface LocalNodeMasterListener

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/LocalNodeMasterListener.java
+++ b/server/src/main/java/org/opensearch/cluster/LocalNodeMasterListener.java
@@ -42,21 +42,21 @@ public interface LocalNodeMasterListener extends ClusterStateListener {
     /**
      * Called when local node is elected to be the cluster-manager
      */
-    void onClusterManager();
+    void onMaster();
 
     /**
      * Called when the local node used to be the cluster-manager, a new cluster-manager was elected and it's no longer the local node.
      */
-    void offClusterManager();
+    void offMaster();
 
     @Override
     default void clusterChanged(ClusterChangedEvent event) {
         final boolean wasClusterManager = event.previousState().nodes().isLocalNodeElectedMaster();
         final boolean isClusterManager = event.localNodeMaster();
         if (wasClusterManager == false && isClusterManager) {
-            onClusterManager();
+            onMaster();
         } else if (wasClusterManager && isClusterManager == false) {
-            offClusterManager();
+            offMaster();
         }
     }
 }

--- a/server/src/main/java/org/opensearch/common/settings/ConsistentSettingsService.java
+++ b/server/src/main/java/org/opensearch/common/settings/ConsistentSettingsService.java
@@ -258,7 +258,7 @@ public final class ConsistentSettingsService {
         }
 
         @Override
-        public void onClusterManager() {
+        public void onMaster() {
             clusterService.submitStateUpdateTask("publish-secure-settings-hashes", new ClusterStateUpdateTask(Priority.URGENT) {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
@@ -284,7 +284,7 @@ public final class ConsistentSettingsService {
         }
 
         @Override
-        public void offClusterManager() {
+        public void offMaster() {
             logger.trace("I am no longer master, nothing to do");
         }
     }

--- a/server/src/test/java/org/opensearch/cluster/service/ClusterApplierServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/service/ClusterApplierServiceTests.java
@@ -298,12 +298,12 @@ public class ClusterApplierServiceTests extends OpenSearchTestCase {
         AtomicBoolean isClusterManager = new AtomicBoolean();
         timedClusterApplierService.addLocalNodeMasterListener(new LocalNodeMasterListener() {
             @Override
-            public void onClusterManager() {
+            public void onMaster() {
                 isClusterManager.set(true);
             }
 
             @Override
-            public void offClusterManager() {
+            public void offMaster() {
                 isClusterManager.set(false);
             }
         });

--- a/server/src/test/java/org/opensearch/common/settings/ConsistentSettingsServiceTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/ConsistentSettingsServiceTests.java
@@ -75,7 +75,7 @@ public class ConsistentSettingsServiceTests extends OpenSearchTestCase {
         // hashes not yet published
         assertThat(new ConsistentSettingsService(settings, clusterService, Arrays.asList(stringSetting)).areAllConsistent(), is(false));
         // publish
-        new ConsistentSettingsService(settings, clusterService, Arrays.asList(stringSetting)).newHashPublisher().onClusterManager();
+        new ConsistentSettingsService(settings, clusterService, Arrays.asList(stringSetting)).newHashPublisher().onMaster();
         ConsistentSettingsService consistentService = new ConsistentSettingsService(settings, clusterService, Arrays.asList(stringSetting));
         assertThat(consistentService.areAllConsistent(), is(true));
         // change value
@@ -83,7 +83,7 @@ public class ConsistentSettingsServiceTests extends OpenSearchTestCase {
         assertThat(consistentService.areAllConsistent(), is(false));
         assertThat(new ConsistentSettingsService(settings, clusterService, Arrays.asList(stringSetting)).areAllConsistent(), is(false));
         // publish change
-        new ConsistentSettingsService(settings, clusterService, Arrays.asList(stringSetting)).newHashPublisher().onClusterManager();
+        new ConsistentSettingsService(settings, clusterService, Arrays.asList(stringSetting)).newHashPublisher().onMaster();
         assertThat(consistentService.areAllConsistent(), is(true));
         assertThat(new ConsistentSettingsService(settings, clusterService, Arrays.asList(stringSetting)).areAllConsistent(), is(true));
     }
@@ -108,7 +108,7 @@ public class ConsistentSettingsServiceTests extends OpenSearchTestCase {
             is(false)
         );
         // publish
-        new ConsistentSettingsService(settings, clusterService, Arrays.asList(affixStringSetting)).newHashPublisher().onClusterManager();
+        new ConsistentSettingsService(settings, clusterService, Arrays.asList(affixStringSetting)).newHashPublisher().onMaster();
         ConsistentSettingsService consistentService = new ConsistentSettingsService(
             settings,
             clusterService,
@@ -123,7 +123,7 @@ public class ConsistentSettingsServiceTests extends OpenSearchTestCase {
             is(false)
         );
         // publish change
-        new ConsistentSettingsService(settings, clusterService, Arrays.asList(affixStringSetting)).newHashPublisher().onClusterManager();
+        new ConsistentSettingsService(settings, clusterService, Arrays.asList(affixStringSetting)).newHashPublisher().onMaster();
         assertThat(consistentService.areAllConsistent(), is(true));
         assertThat(new ConsistentSettingsService(settings, clusterService, Arrays.asList(affixStringSetting)).areAllConsistent(), is(true));
         // add value
@@ -136,7 +136,7 @@ public class ConsistentSettingsServiceTests extends OpenSearchTestCase {
             is(false)
         );
         // publish
-        new ConsistentSettingsService(settings, clusterService, Arrays.asList(affixStringSetting)).newHashPublisher().onClusterManager();
+        new ConsistentSettingsService(settings, clusterService, Arrays.asList(affixStringSetting)).newHashPublisher().onMaster();
         assertThat(new ConsistentSettingsService(settings, clusterService, Arrays.asList(affixStringSetting)).areAllConsistent(), is(true));
         // remove value
         secureSettings = new MockSecureSettings();
@@ -173,7 +173,7 @@ public class ConsistentSettingsServiceTests extends OpenSearchTestCase {
             is(false)
         );
         // publish only the simple string setting
-        new ConsistentSettingsService(settings, clusterService, Arrays.asList(stringSetting)).newHashPublisher().onClusterManager();
+        new ConsistentSettingsService(settings, clusterService, Arrays.asList(stringSetting)).newHashPublisher().onMaster();
         assertThat(new ConsistentSettingsService(settings, clusterService, Arrays.asList(stringSetting)).areAllConsistent(), is(true));
         assertThat(
             new ConsistentSettingsService(settings, clusterService, Arrays.asList(affixStringSetting)).areAllConsistent(),
@@ -184,7 +184,7 @@ public class ConsistentSettingsServiceTests extends OpenSearchTestCase {
             is(false)
         );
         // publish only the affix string setting
-        new ConsistentSettingsService(settings, clusterService, Arrays.asList(affixStringSetting)).newHashPublisher().onClusterManager();
+        new ConsistentSettingsService(settings, clusterService, Arrays.asList(affixStringSetting)).newHashPublisher().onMaster();
         assertThat(new ConsistentSettingsService(settings, clusterService, Arrays.asList(stringSetting)).areAllConsistent(), is(false));
         assertThat(new ConsistentSettingsService(settings, clusterService, Arrays.asList(affixStringSetting)).areAllConsistent(), is(true));
         assertThat(
@@ -193,7 +193,7 @@ public class ConsistentSettingsServiceTests extends OpenSearchTestCase {
         );
         // publish both settings
         new ConsistentSettingsService(settings, clusterService, Arrays.asList(stringSetting, affixStringSetting)).newHashPublisher()
-            .onClusterManager();
+            .onMaster();
         assertThat(new ConsistentSettingsService(settings, clusterService, Arrays.asList(stringSetting)).areAllConsistent(), is(true));
         assertThat(new ConsistentSettingsService(settings, clusterService, Arrays.asList(affixStringSetting)).areAllConsistent(), is(true));
         assertThat(


### PR DESCRIPTION
### Description
Revert renaming method `onMaster()` and `offMaster()` in interface `LocalNodeMasterListener`

I didn't realize that the `onMaster()` and `offMaster()` is exposed to the public, then renamed it directly to make the method name inclusive. The classes that implement the interface need to implement the method in new name, so it breaks backwards compatibility.
The original file: https://github.com/opensearch-project/OpenSearch/blob/2.0.1/server/src/main/java/org/opensearch/cluster/LocalNodeMasterListener.java
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/3688
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
