### PR TITLE
Optimize Gradle builds by enabling local build caching

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,8 @@
 # GitHub history for details.
 #
 
+# Enable build caching
+org.gradle.caching=true
 org.gradle.warning.mode=none
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Xss2m \

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,13 @@ plugins {
   id "com.gradle.enterprise" version "3.10.1"
 }
 
+buildCache {
+  local {
+    enabled = true
+    removeUnusedEntriesAfterDays = 14
+  }
+}
+
 rootProject.name = "OpenSearch"
 
 include 'doc-tools'


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
The Gradle build cache is a cache mechanism that aims to save time by reusing outputs produced by other builds. The build cache works by storing (locally or remotely) build outputs and allowing builds to fetch these outputs from the cache when it is determined that inputs have not changed, avoiding the expensive work of regenerating them [1].

Even when used by a single developer only, the build cache can be very useful. Gradle’s incremental build feature helps to avoid work that is already done, but once you re-execute a task, any previous results are forgotten. When you are switching branches back and forth, the local results get rebuilt over and over again, even if you are building something that has already been built before. The build cache remembers the earlier build results, and greatly reduces the need to rebuild things when they have already been built locally. [2]

[1] https://docs.gradle.org/current/userguide/build_cache.html
[2] https://docs.gradle.org/current/userguide/build_cache_use_cases.html#use_cases_cache
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
