### PR TITLE
Update github action gradle-check to use pull_request_target for accessing token

### DIFF
--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -1,4 +1,4 @@
-name: Jenkins Gradle Check
+name: Gradle Check (Jenkins)
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -1,5 +1,7 @@
 name: Jenkins Gradle Check
-on: [pull_request]
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 jobs:
   gradle-check:


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Update github action gradle-check to use pull_request_target for accessing token
Since Jenkins workflow needs to be triggered through github workflow with a token, `pull_request` does not allow fork repo to read secret just to be safe, therefore change to use `pull_request_target` for this access.

https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

`Workflows triggered via pull_request_target have write permission to the target repository. They also have access to target repository secrets. The same is true for workflows triggered on pull_request from a branch in the same repository, but not from external forks. The reasoning behind the latter is that it is safe to share the repository secrets if the user creating the PR has write permission to the target repository already.`
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/851
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
