### PR TITLE
Move gradle-check code to its own scripts and upload codecov

### DIFF
--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -23,12 +23,10 @@ jobs:
           ref: main
 
       - name: Trigger jenkins workflow to run gradle check
-        run: bash scripts/gradle/gradle-check.sh ${{ secrets.JENKINS_GRADLE_CHECK_GENERIC_WEBHOOK_TOKEN }} | tee -a gradle-check.log
-
-      - name: Upload Coverage Report
-        uses: codecov/codecov-action@v2
-        with:
-          files: ./codeCoverage.xml
+        run: |
+            set -e
+            set -o pipefail
+            bash scripts/gradle/gradle-check.sh ${{ secrets.JENKINS_GRADLE_CHECK_GENERIC_WEBHOOK_TOKEN }} | tee -a gradle-check.log
 
       - name: Setup Result Status
         if: always()
@@ -38,11 +36,26 @@ jobs:
             echo "workflow_url=$WORKFLOW_URL" >> $GITHUB_ENV
             echo "result=$RESULT" >> $GITHUB_ENV
 
-      - name: Create comment
-        if: always()
+      - name: Upload Coverage Report
+        if: success()
+        uses: codecov/codecov-action@v2
+        with:
+          files: ./codeCoverage.xml
+
+      - name: Create Comment Success
+        if: success()
         uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ env.pr_number }}
           body: |
-              Gradle Check (Jenkins) Completed with ${{ env.result }}: ${{ env.workflow_url }}
+              Gradle Check (Jenkins) Completed with **RESULT: ${{ env.result }}** :white_check_mark: : ${{ env.workflow_url }}
+              (Re-commit to this PR or restart github action to run gradle check again)
+
+      - name: Create Comment Failure
+        if: failure()
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ env.pr_number }}
+          body: |
+              Gradle Check (Jenkins) Completed with **RESULT: ${{ env.result }}** :x: : ${{ env.workflow_url }}
               (Re-commit to this PR or restart github action to run gradle check again)

--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -48,8 +48,10 @@ jobs:
         with:
           issue-number: ${{ env.pr_number }}
           body: |
-              Gradle Check (Jenkins) Completed with **RESULT: ${{ env.result }}** :white_check_mark: : ${{ env.workflow_url }}
-              (Re-commit to this PR or restart github action to run gradle check again)
+              ### Gradle Check (Jenkins) Run Completed with:
+              * **RESULT:** ${{ env.result }} :white_check_mark:
+              * **URL:** ${{ env.workflow_url }}
+              * **CommitID:** ${{ env.pr_from_sha }}
 
       - name: Create Comment Failure
         if: failure()
@@ -57,5 +59,7 @@ jobs:
         with:
           issue-number: ${{ env.pr_number }}
           body: |
-              Gradle Check (Jenkins) Completed with **RESULT: ${{ env.result }}** :x: : ${{ env.workflow_url }}
-              (Re-commit to this PR or restart github action to run gradle check again)
+              ### Gradle Check (Jenkins) Run Completed with:
+              * **RESULT:** ${{ env.result }} :x:
+              * **URL:** ${{ env.workflow_url }}
+              * **CommitID:** ${{ env.pr_from_sha }}

--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -16,58 +16,33 @@ jobs:
             echo "pr_title=$(jq --raw-output .pull_request.title $GITHUB_EVENT_PATH)" >> $GITHUB_ENV
             echo "pr_number=$(jq --raw-output .pull_request.number $GITHUB_EVENT_PATH)" >> $GITHUB_ENV
 
+      - name: Checkout opensearch-build repo
+        uses: actions/checkout@v2
+        with:
+          repository: opensearch-project/opensearch-build
+          ref: main
+
       - name: Trigger jenkins workflow to run gradle check
+        run: bash scripts/gradle/gradle-check.sh ${{ secrets.JENKINS_GRADLE_CHECK_GENERIC_WEBHOOK_TOKEN }} | tee -a gradle-check.log
+
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v2
+        with:
+          files: ./codeCoverage.xml
+
+      - name: Setup Result Status
+        if: always()
         run: |
-            echo "${{ env.pr_to_clone_url }} PR: ${{ env.pr_number }}"
-            echo "Raise from ${{ env.pr_from_clone_url }} ${{ env.pr_from_sha }}"
-            echo "PR Title: ${{ env.pr_title }}"
-            JENKINS_URL="https://build.ci.opensearch.org"
-            TIMEPASS=0
-            TIMEOUT=7200
-            RESULT="null"
+            WORKFLOW_URL=`cat gradle-check.log | grep 'WORKFLOW_URL' | awk '{print $2}'`
+            RESULT=`cat gradle-check.log | grep 'Result:' | awk '{print $2}'`
+            echo "workflow_url=$WORKFLOW_URL" >> $GITHUB_ENV
+            echo "result=$RESULT" >> $GITHUB_ENV
 
-            echo "Trigger Jenkins workflows"
-            JENKINS_REQ=$(curl -s -XPOST \
-                 -H "Authorization: Bearer ${{ secrets.JENKINS_GRADLE_CHECK_GENERIC_WEBHOOK_TOKEN }}" \
-                 -H "Content-Type: application/json" \
-                 --data '{"pr_from_sha": "${{ env.pr_from_sha }}", "pr_from_clone_url": "${{ env.pr_from_clone_url }}", "pr_to_clone_url": "${{ env.pr_to_clone_url }}", "pr_title": "${{ env.pr_title }}", "pr_number": "${{ env.pr_number }}"}' \
-                 'https://build.ci.opensearch.org/generic-webhook-trigger/invoke')
-
-            QUEUE_URL=$(echo $JENKINS_REQ | jq --raw-output '.jobs."gradle-check".url')
-            echo QUEUE_URL $QUEUE_URL
-            echo "wait for jenkins to start workflow" && sleep 15
-
-            echo "Check if queue exist in Jenkins after triggering"
-            if [ -z "$QUEUE_URL" ] || [ "$QUEUE_URL" != "null" ]; then
-                WORKFLOW_URL=$(curl -s -XGET ${JENKINS_URL}/${QUEUE_URL}api/json | jq --raw-output .executable.url)
-                echo WORKFLOW_URL $WORKFLOW_URL
-
-                echo "Use queue information to find build number in Jenkins if available"
-                if [ -z "$WORKFLOW_URL" ] || [ "$WORKFLOW_URL" != "null" ]; then
-
-                    RUNNING="true"
-
-                    echo "Waiting for Jenkins to complete the run"
-                    while [ "$RUNNING" = "true" ] && [ "$TIMEPASS" -le "$TIMEOUT" ]; do
-                        echo "Still running, wait for another 30 seconds before checking again, max timeout $TIMEOUT"
-                        echo "Jenkins Workflow Url: $WORKFLOW_URL"
-                        TIMEPASS=$(( TIMEPASS + 30 )) && echo time pass: $TIMEPASS
-                        sleep 30
-                        RUNNING=$(curl -s -XGET ${WORKFLOW_URL}api/json | jq --raw-output .building)
-                    done
-
-                    echo "Complete the run, checking results now......"
-                    RESULT=$(curl -s -XGET ${WORKFLOW_URL}api/json | jq --raw-output .result)
-
-                fi
-            fi
-
-            echo "Please check jenkins url for logs: $WORKFLOW_URL"
-
-            if [ "$RESULT" != "SUCCESS" ]; then
-                echo "Result: $RESULT"
-                exit 1
-            else
-                echo "Result: $RESULT"
-                echo 0
-            fi
+      - name: Create comment
+        if: always()
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ env.pr_number }}
+          body: |
+              Gradle Check (Jenkins) Completed with ${{ env.result }}: ${{ env.workflow_url }}
+              (Re-commit to this PR or restart github action to run gradle check again)


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Move gradle-check code to its own scripts.
It is not easy to keep updating all the branches with any workflow changes in code.
Therefore, move the gradle check code to its own scripts.
This also attempt to upload codecoverage xml to codecov if gradle check success.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2193
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
