### PR TITLE
[Feature/extensions] Added unit test for createComponent workflow

### DIFF
--- a/server/src/main/java/org/opensearch/extensions/ExtensionsOrchestrator.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsOrchestrator.java
@@ -107,10 +107,14 @@ public class ExtensionsOrchestrator implements ReportingService<PluginsAndModule
 
     public void setTransportService(TransportService transportService) {
         this.transportService = transportService;
+        registerRequestHandler();
     }
 
     public void setClusterService(ClusterService clusterService) {
         this.clusterService = clusterService;
+    }
+
+    private void registerRequestHandler() {
         transportService.registerRequestHandler(
             REQUEST_EXTENSION_CLUSTER_STATE,
             ThreadPool.Names.GENERIC,
@@ -244,7 +248,7 @@ public class ExtensionsOrchestrator implements ReportingService<PluginsAndModule
         }
     }
 
-    TransportResponse handleExtensionRequest(ExtensionRequest extensionRequest) {
+    TransportResponse handleExtensionRequest(ExtensionRequest extensionRequest) throws Exception {
         // Read enum
         if (extensionRequest.getRequestType() == RequestType.REQUEST_EXTENSION_CLUSTER_STATE) {
             ClusterStateResponse clusterStateResponse = new ClusterStateResponse(
@@ -260,7 +264,7 @@ public class ExtensionsOrchestrator implements ReportingService<PluginsAndModule
             ClusterSettingsResponse clusterSettingsResponse = new ClusterSettingsResponse(clusterService);
             return clusterSettingsResponse;
         }
-        return null;
+        throw new Exception("Handler not present for the provided request");
     }
 
     public void onIndexModule(IndexModule indexModule) throws UnknownHostException {


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Added Unit tests for registerHandler of ClusterState, ClusterSettings and LocalNode
 
### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-sdk/issues/25
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
