### PR TITLE
[Feature/extensions] Adding support to register settings dynamically

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
@@ -121,7 +121,7 @@ public abstract class AbstractScopedSettings {
                 keySettings.putIfAbsent(setting.getKey(), setting);
             }
         }
-        this.complexMatchers = Collections.unmodifiableMap(complexMatchers);
+        this.complexMatchers = complexMatchers;
         this.keySettings = keySettings;
     }
 

--- a/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
@@ -144,12 +144,12 @@ public abstract class AbstractScopedSettings {
         settingUpdaters.addAll(other.settingUpdaters);
     }
 
-    protected void registerSetting(Setting<?> setting) {
+    protected boolean registerSetting(Setting<?> setting) {
         validateSettingKey(setting);
         if (setting.hasComplexMatcher()) {
-            complexMatchers.putIfAbsent(setting.getKey(), setting);
+            return setting != complexMatchers.putIfAbsent(setting.getKey(), setting);
         } else {
-            keySettings.putIfAbsent(setting.getKey(), setting);
+            return setting != keySettings.putIfAbsent(setting.getKey(), setting);
         }
     }
 

--- a/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
@@ -122,7 +122,7 @@ public abstract class AbstractScopedSettings {
             }
         }
         this.complexMatchers = Collections.unmodifiableMap(complexMatchers);
-        this.keySettings = Collections.unmodifiableMap(keySettings);
+        this.keySettings = keySettings;
     }
 
     protected void validateSettingKey(Setting<?> setting) {
@@ -142,6 +142,24 @@ public abstract class AbstractScopedSettings {
         keySettings = other.keySettings;
         settingUpgraders = Collections.unmodifiableMap(new HashMap<>(other.settingUpgraders));
         settingUpdaters.addAll(other.settingUpdaters);
+    }
+
+    protected void registerSetting(Setting<?> setting) {
+        if (setting.hasComplexMatcher()) {
+            Setting<?> overlappingSetting = findOverlappingSetting(setting, complexMatchers);
+            if (overlappingSetting != null) {
+                throw new IllegalArgumentException(
+                    "complex setting key: ["
+                        + setting.getKey()
+                        + "] overlaps existing setting key: ["
+                        + overlappingSetting.getKey()
+                        + "]"
+                );
+            }
+            complexMatchers.putIfAbsent(setting.getKey(), setting);
+        } else {
+            keySettings.putIfAbsent(setting.getKey(), setting);
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
@@ -149,11 +149,7 @@ public abstract class AbstractScopedSettings {
             Setting<?> overlappingSetting = findOverlappingSetting(setting, complexMatchers);
             if (overlappingSetting != null) {
                 throw new IllegalArgumentException(
-                    "complex setting key: ["
-                        + setting.getKey()
-                        + "] overlaps existing setting key: ["
-                        + overlappingSetting.getKey()
-                        + "]"
+                    "complex setting key: [" + setting.getKey() + "] overlaps existing setting key: [" + overlappingSetting.getKey() + "]"
                 );
             }
             complexMatchers.putIfAbsent(setting.getKey(), setting);

--- a/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
@@ -145,6 +145,7 @@ public abstract class AbstractScopedSettings {
     }
 
     protected void registerSetting(Setting<?> setting) {
+        validateSettingKey(setting);
         if (setting.hasComplexMatcher()) {
             Setting<?> overlappingSetting = findOverlappingSetting(setting, complexMatchers);
             if (overlappingSetting != null) {

--- a/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
@@ -147,12 +147,6 @@ public abstract class AbstractScopedSettings {
     protected void registerSetting(Setting<?> setting) {
         validateSettingKey(setting);
         if (setting.hasComplexMatcher()) {
-            Setting<?> overlappingSetting = findOverlappingSetting(setting, complexMatchers);
-            if (overlappingSetting != null) {
-                throw new IllegalArgumentException(
-                    "complex setting key: [" + setting.getKey() + "] overlaps existing setting key: [" + overlappingSetting.getKey() + "]"
-                );
-            }
             complexMatchers.putIfAbsent(setting.getKey(), setting);
         } else {
             keySettings.putIfAbsent(setting.getKey(), setting);

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -162,6 +162,10 @@ public final class ClusterSettings extends AbstractScopedSettings {
         addSettingsUpdater(new LoggingSettingUpdater(nodeSettings));
     }
 
+    public void registerSetting(Setting<?> setting) {
+        super.registerSetting(setting);
+    }
+
     private static final class LoggingSettingUpdater implements SettingUpdater<Settings> {
         final Predicate<String> loggerPredicate = Loggers.LOG_LEVEL_SETTING::match;
         private final Settings settings;

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -162,8 +162,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
         addSettingsUpdater(new LoggingSettingUpdater(nodeSettings));
     }
 
-    public void registerSetting(Setting<?> setting) {
-        super.registerSetting(setting);
+    public boolean registerSetting(Setting<?> setting) {
+        return super.registerSetting(setting);
     }
 
     private static final class LoggingSettingUpdater implements SettingUpdater<Settings> {

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -236,6 +236,11 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         return new IndexScopedSettings(settings, this, metadata);
     }
 
+    public void registerSetting(Setting<?> setting) {
+        validateSettingKey(setting);
+        super.registerSetting(setting);
+    }
+
     @Override
     protected void validateSettingKey(Setting setting) {
         if (setting.getKey().startsWith("index.") == false) {

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -236,9 +236,9 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         return new IndexScopedSettings(settings, this, metadata);
     }
 
-    public void registerSetting(Setting<?> setting) {
+    public boolean registerSetting(Setting<?> setting) {
         validateSettingKey(setting);
-        super.registerSetting(setting);
+        return super.registerSetting(setting);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/common/settings/SettingsModule.java
+++ b/server/src/main/java/org/opensearch/common/settings/SettingsModule.java
@@ -179,6 +179,11 @@ public class SettingsModule implements Module {
         binder.bind(IndexScopedSettings.class).toInstance(indexScopedSettings);
     }
 
+    /**
+     * Dynamically registers a new Setting at Runtime. This method is mostly used by plugins/extensions
+     * to register new settings at runtime. Settings can be of Node Scope or Index Scope.
+     * @param setting which is being registered in the cluster.
+     */
     public void registerDynamicSetting(Setting<?> setting) {
         try {
             registerSetting(setting);
@@ -191,6 +196,7 @@ public class SettingsModule implements Module {
             logger.info("Registered new Setting: " + setting.getKey() + " successfully ");
         } catch (Exception e) {
             logger.error("Could not register setting " + setting.getKey());
+            throw new SettingsException("Could not register setting:" + setting.getKey());
         }
     }
 

--- a/server/src/main/java/org/opensearch/common/settings/SettingsModule.java
+++ b/server/src/main/java/org/opensearch/common/settings/SettingsModule.java
@@ -179,6 +179,21 @@ public class SettingsModule implements Module {
         binder.bind(IndexScopedSettings.class).toInstance(indexScopedSettings);
     }
 
+    public void registerDynamicSetting(Setting<?> setting) {
+        try {
+            registerSetting(setting);
+            if (setting.hasNodeScope()) {
+                clusterSettings.registerSetting(setting);
+            }
+            if(setting.hasIndexScope()) {
+                indexScopedSettings.registerSetting(setting);
+            }
+            logger.info("Registered new Setting: " + setting.getKey() +  " successfully ");
+        } catch(Exception e) {
+            logger.error("Could not register setting " + setting.getKey());
+        }
+    }
+
     /**
      * Registers a new setting. This method should be used by plugins in order to expose any custom settings the plugin defines.
      * Unless a setting is registered the setting is unusable. If a setting is never the less specified the node will reject

--- a/server/src/main/java/org/opensearch/common/settings/SettingsModule.java
+++ b/server/src/main/java/org/opensearch/common/settings/SettingsModule.java
@@ -185,11 +185,11 @@ public class SettingsModule implements Module {
             if (setting.hasNodeScope()) {
                 clusterSettings.registerSetting(setting);
             }
-            if(setting.hasIndexScope()) {
+            if (setting.hasIndexScope()) {
                 indexScopedSettings.registerSetting(setting);
             }
-            logger.info("Registered new Setting: " + setting.getKey() +  " successfully ");
-        } catch(Exception e) {
+            logger.info("Registered new Setting: " + setting.getKey() + " successfully ");
+        } catch (Exception e) {
             logger.error("Could not register setting " + setting.getKey());
         }
     }

--- a/server/src/main/java/org/opensearch/common/settings/SettingsModule.java
+++ b/server/src/main/java/org/opensearch/common/settings/SettingsModule.java
@@ -183,21 +183,23 @@ public class SettingsModule implements Module {
      * Dynamically registers a new Setting at Runtime. This method is mostly used by plugins/extensions
      * to register new settings at runtime. Settings can be of Node Scope or Index Scope.
      * @param setting which is being registered in the cluster.
+     * @return boolean value is set to true when successfully registered, else returns false
      */
-    public void registerDynamicSetting(Setting<?> setting) {
+    public boolean registerDynamicSetting(Setting<?> setting) {
         try {
             registerSetting(setting);
             if (setting.hasNodeScope()) {
-                clusterSettings.registerSetting(setting);
+                return clusterSettings.registerSetting(setting);
             }
             if (setting.hasIndexScope()) {
-                indexScopedSettings.registerSetting(setting);
+                return indexScopedSettings.registerSetting(setting);
             }
             logger.info("Registered new Setting: " + setting.getKey() + " successfully ");
         } catch (Exception e) {
             logger.error("Could not register setting " + setting.getKey());
             throw new SettingsException("Could not register setting:" + setting.getKey());
         }
+        return false;
     }
 
     /**

--- a/server/src/test/java/org/opensearch/common/settings/SettingsModuleTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/SettingsModuleTests.java
@@ -246,7 +246,7 @@ public class SettingsModuleTests extends ModuleTestCase {
         assertNull(module.getClusterSettings().get("some.custom.setting2"));
         assertInstanceBinding(module, Settings.class, (s) -> s == settings);
 
-        module.registerDynamicSetting(Setting.floatSetting("some.custom.setting2", 1.0f, Property.NodeScope));
+        assertTrue(module.registerDynamicSetting(Setting.floatSetting("some.custom.setting2", 1.0f, Property.NodeScope)));
         assertNotNull(module.getClusterSettings().get("some.custom.setting2"));
 
         // verify if some.custom.setting still exists
@@ -267,7 +267,7 @@ public class SettingsModuleTests extends ModuleTestCase {
         assertNull(module.getIndexScopedSettings().get("index.custom.setting2"));
         assertInstanceBinding(module, Settings.class, (s) -> s == settings);
 
-        module.registerDynamicSetting(Setting.floatSetting("index.custom.setting2", 1.0f, Property.IndexScope));
+        assertTrue(module.registerDynamicSetting(Setting.floatSetting("index.custom.setting2", 1.0f, Property.IndexScope)));
         assertNotNull(module.getIndexScopedSettings().get("index.custom.setting2"));
 
         // verify if some.custom.setting still exists

--- a/server/src/test/java/org/opensearch/common/settings/SettingsModuleTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/SettingsModuleTests.java
@@ -248,6 +248,15 @@ public class SettingsModuleTests extends ModuleTestCase {
 
         module.registerDynamicSetting(Setting.floatSetting("some.custom.setting2", 1.0f, Property.NodeScope));
         assertNotNull(module.getClusterSettings().get("some.custom.setting2"));
+
+        // verify if some.custom.setting still exists
+        assertNotNull(module.getClusterSettings().get("some.custom.setting"));
+
+        // verify exception is thrown when setting registration fails
+        expectThrows(
+            SettingsException.class,
+            () -> module.registerDynamicSetting(Setting.floatSetting("some.custom.setting", 1.0f, Property.NodeScope))
+        );
     }
 
     public void testDynamicIndexSettingsRegistration() {
@@ -260,5 +269,14 @@ public class SettingsModuleTests extends ModuleTestCase {
 
         module.registerDynamicSetting(Setting.floatSetting("index.custom.setting2", 1.0f, Property.IndexScope));
         assertNotNull(module.getIndexScopedSettings().get("index.custom.setting2"));
+
+        // verify if some.custom.setting still exists
+        assertNotNull(module.getClusterSettings().get("some.custom.setting"));
+
+        // verify exception is thrown when setting registration fails
+        expectThrows(
+            SettingsException.class,
+            () -> module.registerDynamicSetting(Setting.floatSetting("index.custom.setting2", 1.0f, Property.IndexScope))
+        );
     }
 }

--- a/server/src/test/java/org/opensearch/common/settings/SettingsModuleTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/SettingsModuleTests.java
@@ -237,4 +237,28 @@ public class SettingsModuleTests extends ModuleTestCase {
             ex.getMessage()
         );
     }
+
+    public void testDynamicNodeSettingsRegistration() {
+        Settings settings = Settings.builder().put("some.custom.setting", "2.0").build();
+        SettingsModule module = new SettingsModule(settings, Setting.floatSetting("some.custom.setting", 1.0f, Property.NodeScope));
+        assertNotNull(module.getClusterSettings().get("some.custom.setting"));
+        // For unregistered setting the value is expected to be null
+        assertNull(module.getClusterSettings().get("some.custom.setting2"));
+        assertInstanceBinding(module, Settings.class, (s) -> s == settings);
+
+        module.registerDynamicSetting(Setting.floatSetting("some.custom.setting2", 1.0f, Property.NodeScope));
+        assertNotNull(module.getClusterSettings().get("some.custom.setting2"));
+    }
+
+    public void testDynamicIndexSettingsRegistration() {
+        Settings settings = Settings.builder().put("some.custom.setting", "2.0").build();
+        SettingsModule module = new SettingsModule(settings, Setting.floatSetting("some.custom.setting", 1.0f, Property.NodeScope));
+        assertNotNull(module.getClusterSettings().get("some.custom.setting"));
+        // For unregistered setting the value is expected to be null
+        assertNull(module.getIndexScopedSettings().get("index.custom.setting2"));
+        assertInstanceBinding(module, Settings.class, (s) -> s == settings);
+
+        module.registerDynamicSetting(Setting.floatSetting("index.custom.setting2", 1.0f, Property.IndexScope));
+        assertNotNull(module.getIndexScopedSettings().get("index.custom.setting2"));
+    }
 }


### PR DESCRIPTION
### Description
Adding support to register dynamic settings. 
For plugins/extensions, they can define their own settings which are propagated across the cluster. 
This PR adds support to register `Node` Scope or `Index` Scope settings at anytime. 
This feature support unlocks a part of extensions hot swap.  

This is a recreate of PR: https://github.com/opensearch-project/OpenSearch/pull/3529
 
### Issues Resolved
#3434 
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
