### PR TITLE
Don't run EmptyDirTaskTests in a Docker container

### DIFF
--- a/buildSrc/src/test/java/org/opensearch/gradle/EmptyDirTaskTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/EmptyDirTaskTests.java
@@ -37,11 +37,12 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 import org.apache.tools.ant.taskdefs.condition.Os;
+import org.opensearch.gradle.test.GradleUnitTestCase;
+import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.opensearch.gradle.test.GradleUnitTestCase;
-
-import com.carrotsearch.randomizedtesting.RandomizedTest;
 
 public class EmptyDirTaskTests extends GradleUnitTestCase {
 

--- a/buildSrc/src/test/java/org/opensearch/gradle/EmptyDirTaskTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/EmptyDirTaskTests.java
@@ -37,11 +37,11 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 
-import com.carrotsearch.randomizedtesting.RandomizedTest;
 import org.apache.tools.ant.taskdefs.condition.Os;
-import org.opensearch.gradle.test.GradleUnitTestCase;
-import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
+import org.opensearch.gradle.test.GradleUnitTestCase;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 
 public class EmptyDirTaskTests extends GradleUnitTestCase {
 
@@ -67,7 +67,10 @@ public class EmptyDirTaskTests extends GradleUnitTestCase {
     }
 
     public void testCreateEmptyDirNoPermissions() throws Exception {
-        RandomizedTest.assumeFalse("Functionality is Unix specific", Os.isFamily(Os.FAMILY_WINDOWS));
+        // Test depends on Posix file permissions
+        RandomizedTest.assumeFalse("Functionality is Unix-like OS specific", Os.isFamily(Os.FAMILY_WINDOWS));
+        // Java's Files.setPosixFilePermissions is a NOOP inside a Docker container as
+        // files are created by default with UID and GID = 0 (root).
         RandomizedTest.assumeFalse("Functionality doesn't work in Docker", isRunningInDocker());
 
         Project project = ProjectBuilder.builder().build();

--- a/buildSrc/src/test/java/org/opensearch/gradle/EmptyDirTaskTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/EmptyDirTaskTests.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import org.apache.tools.ant.taskdefs.condition.Os;
@@ -108,8 +107,7 @@ public class EmptyDirTaskTests extends GradleUnitTestCase {
                 return true;
             }
             // Backup 2: look for 'docker' in overlay fs
-            return Files.lines(Path.of("/proc/1/mounts"))
-                    .anyMatch(line -> line.startsWith("overlay") && line.contains("docker"));
+            return Files.lines(Path.of("/proc/1/mounts")).anyMatch(line -> line.startsWith("overlay") && line.contains("docker"));
         } catch (InvalidPathException | IOException e) {
             return false;
         }

--- a/buildSrc/src/test/java/org/opensearch/gradle/EmptyDirTaskTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/EmptyDirTaskTests.java
@@ -42,7 +42,6 @@ import org.apache.tools.ant.taskdefs.condition.Os;
 import org.opensearch.gradle.test.GradleUnitTestCase;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
-import org.opensearch.gradle.test.GradleUnitTestCase;
 
 public class EmptyDirTaskTests extends GradleUnitTestCase {
 


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description
Docker doesn't provide the permissions to test EmptyDirTask. Similar to the Windows OS, the test should not run if it detects that environment.

The primary/reliable/consistent test of whether in a Docker container is the presence of a `.dockerenv` file in the root directory. There was mention in 2016 that this could in theory be removed in the future but it's still present 6 years later and other proposed alternatives are not consistently valid in 2022. I added two potential backup tests.
 
### Issues Resolved
Fixes #3674 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
