### PR TITLE
Parallelize stale blobs deletion during snapshot delete

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/RepositoriesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/RepositoriesIT.java
@@ -345,7 +345,9 @@ public class RepositoriesIT extends AbstractSnapshotIntegTestCase {
         createRepository(
             "test-repo",
             "mock",
-            Settings.builder().put("location", repositoryPath).put(BlobStoreRepository.MAX_SHARD_BLOB_DELETE_BATCH_SIZE.getKey(), maxShardBlobDeleteBatchSize)
+            Settings.builder()
+                .put("location", repositoryPath)
+                .put(BlobStoreRepository.MAX_SHARD_BLOB_DELETE_BATCH_SIZE.getKey(), maxShardBlobDeleteBatchSize)
         );
 
         logger.info("--> creating index-0 and ingest data");
@@ -397,7 +399,9 @@ public class RepositoriesIT extends AbstractSnapshotIntegTestCase {
         createRepository(
             "test-repo",
             "mock",
-            Settings.builder().put("location", repositoryPath).put(BlobStoreRepository.MAX_SHARD_BLOB_DELETE_BATCH_SIZE.getKey(), maxShardBlobDeleteBatchSize)
+            Settings.builder()
+                .put("location", repositoryPath)
+                .put(BlobStoreRepository.MAX_SHARD_BLOB_DELETE_BATCH_SIZE.getKey(), maxShardBlobDeleteBatchSize)
         );
 
         logger.info("--> creating index-0 and ingest data");

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/RepositoriesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/RepositoriesIT.java
@@ -347,7 +347,7 @@ public class RepositoriesIT extends AbstractSnapshotIntegTestCase {
             "mock",
             Settings.builder()
                 .put("location", repositoryPath)
-                .put(BlobStoreRepository.MAX_SHARD_BLOB_DELETE_BATCH_SIZE.getKey(), maxShardBlobDeleteBatchSize)
+                .put(BlobStoreRepository.MAX_SNAPSHOT_SHARD_BLOB_DELETE_BATCH_SIZE.getKey(), maxShardBlobDeleteBatchSize)
         );
 
         logger.info("--> creating index-0 and ingest data");
@@ -401,7 +401,7 @@ public class RepositoriesIT extends AbstractSnapshotIntegTestCase {
             "mock",
             Settings.builder()
                 .put("location", repositoryPath)
-                .put(BlobStoreRepository.MAX_SHARD_BLOB_DELETE_BATCH_SIZE.getKey(), maxShardBlobDeleteBatchSize)
+                .put(BlobStoreRepository.MAX_SNAPSHOT_SHARD_BLOB_DELETE_BATCH_SIZE.getKey(), maxShardBlobDeleteBatchSize)
         );
 
         logger.info("--> creating index-0 and ingest data");

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -960,7 +960,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     l.onResponse(null);
                 } catch (Exception e) {
                     logger.warn(() -> new ParameterizedMessage("{} Failed to delete blobs during snapshot delete", metadata.name()), e);
-                    throw e;
+                    l.onFailure(e);
                 }
                 executeStaleShardDelete(staleFilesToDeleteInBatch, listener);
             }));

--- a/test/framework/src/main/java/org/opensearch/snapshots/mockstore/MockRepository.java
+++ b/test/framework/src/main/java/org/opensearch/snapshots/mockstore/MockRepository.java
@@ -474,6 +474,9 @@ public class MockRepository extends FsRepository {
                 if (blockOnDeleteIndexN && blobNames.stream().anyMatch(name -> name.startsWith(BlobStoreRepository.INDEX_FILE_PREFIX))) {
                     blockExecutionAndMaybeWait("index-{N}");
                 }
+                if (setThrowExceptionWhileDelete) {
+                    throw new IOException("Random exception");
+                }
                 super.deleteBlobsIgnoringIfNotExists(blobNames);
             }
 


### PR DESCRIPTION
Signed-off-by: Piyush Daftary <pdaftary@amazon.com>


### Description
Currently during snapshot delete, deletion of [unlinked shard level blob ](https://github.com/opensearch-project/OpenSearch/blob/b9ff91d591ce4b0a23d48b291e689ca906b6ab3b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java#L892)is single threaded using SNAPSHOT threadpool. Hence if there is huge number of unlinked shard level blob flies, it will take considerable amount of time to clean them.

Hence I propose to make unlinked shard level blob deletion multi threaded delete the same way we do for cleaning up of [stale indices](https://github.com/opensearch-project/OpenSearch/blob/b9ff91d591ce4b0a23d48b291e689ca906b6ab3b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java#L1237), to speedup the overall snapshot deletion process.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/2156
 
### Check List
- [Y] New functionality includes testing.
  - [Y] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [Y] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
