### PR TITLE
Enable XML test reports for Jenkins integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -580,6 +580,11 @@ reporting {
   }
 }
 
+// Enable XML test reports for Jenkins integration
+tasks.withType(TestTaskReports).configureEach {
+  junitXml.enabled = true
+}
+
 tasks.named(JavaBasePlugin.CHECK_TASK_NAME) {
   dependsOn tasks.named('testAggregateTestReport', TestReport)
 }


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Enable XML test reports for Jenkins integration
 
### Issues Resolved
See please https://github.com/opensearch-project/opensearch-build/pull/2304
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
