### PR TITLE
Adding workflow to automatically publish releases after a tag is pushed

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,22 @@
+name: Releases
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+      - uses: actions/checkout@v2
+      - uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          bodyFile: release-notes/opensearch.release-notes-${{steps.tag.outputs.tag}}.md


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Release tags are automatically published by https://github.com/opensearch-project/opensearch-build.
Github releases [1] are not published and are manually published after every release. 

This workflow automates publishing github releases.
It automatically includes the release notes. 
 
I've tested this manually on my fork: 
Release: https://github.com/saratvemulapalli/OpenSearch/releases/tag/5.4.6
Workflow: https://github.com/saratvemulapalli/OpenSearch/actions/runs/2632146820

[1] https://github.com/opensearch-project/OpenSearch/releases
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
