### PR TITLE
Ignore backport / autocut / dependabot branches for gradle checks on push

### DIFF
--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -1,6 +1,10 @@
 name: Gradle Check (Jenkins)
 on:
   push:
+    branches-ignore:
+      - 'backport/*'
+      - 'create-pull-request/*'
+      - 'dependabot/*'
   pull_request_target:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Ignore backport / autocut / dependentbot branches for gradle checks.
These branches come and go and are not long-lived, thus no reason to even run gradle check on push.
They can run gradle check on pull_request_target event.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/851
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
