### PR TITLE
Fix for failing segment replication delete integration test

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -105,7 +105,7 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
 
         createIndex(INDEX_NAME);
         ensureGreen(INDEX_NAME);
-        final int initialDocCount = 1;
+        final int initialDocCount = scaledRandomIntBetween(0, 100);
         try (
             BackgroundIndexer indexer = new BackgroundIndexer(
                 INDEX_NAME,
@@ -126,7 +126,7 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
             assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
             assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
 
-            final int additionalDocCount = 3;
+            final int additionalDocCount = scaledRandomIntBetween(0, 100);
             final int expectedHitCount = initialDocCount + additionalDocCount;
             indexer.start(additionalDocCount);
             waitForDocs(expectedHitCount, indexer);

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -1,0 +1,267 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import org.junit.Assert;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.admin.indices.segments.IndexShardSegments;
+import org.opensearch.action.admin.indices.segments.IndicesSegmentResponse;
+import org.opensearch.action.admin.indices.segments.IndicesSegmentsRequest;
+import org.opensearch.action.admin.indices.segments.ShardSegments;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexModule;
+import org.opensearch.index.engine.Segment;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.test.BackgroundIndexer;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class SegmentReplicationIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX_NAME = "test-idx-1";
+    private static final int SHARD_COUNT = 1;
+    private static final int REPLICA_COUNT = 1;
+
+    @Override
+    public Settings indexSettings() {
+        return Settings.builder()
+            .put(super.indexSettings())
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, SHARD_COUNT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, REPLICA_COUNT)
+            .put(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.getKey(), false)
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .build();
+    }
+
+    @Override
+    protected boolean addMockInternalEngine() {
+        return false;
+    }
+
+    public void testReplicationAfterPrimaryRefreshAndFlush() throws Exception {
+        final String nodeA = internalCluster().startNode();
+        final String nodeB = internalCluster().startNode();
+        createIndex(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        final int initialDocCount = scaledRandomIntBetween(0, 200);
+        try (
+            BackgroundIndexer indexer = new BackgroundIndexer(
+                INDEX_NAME,
+                "_doc",
+                client(),
+                -1,
+                RandomizedTest.scaledRandomIntBetween(2, 5),
+                false,
+                random()
+            )
+        ) {
+            indexer.start(initialDocCount);
+            waitForDocs(initialDocCount, indexer);
+            refresh(INDEX_NAME);
+
+            // wait a short amount of time to give replication a chance to complete.
+            Thread.sleep(1000);
+            assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
+            assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
+
+            final int additionalDocCount = scaledRandomIntBetween(0, 200);
+            final int expectedHitCount = initialDocCount + additionalDocCount;
+            indexer.start(additionalDocCount);
+            waitForDocs(expectedHitCount, indexer);
+
+            flushAndRefresh(INDEX_NAME);
+            Thread.sleep(1000);
+            assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount);
+            assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount);
+
+            ensureGreen(INDEX_NAME);
+            assertSegmentStats(REPLICA_COUNT);
+        }
+    }
+
+    public void testDeleteOperations() {
+        final String nodeA = internalCluster().startNode();
+        final String nodeB = internalCluster().startNode();
+
+        createIndex(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+        client().prepareIndex(INDEX_NAME).setId("1").setSource("foo", "bar").setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL).get();
+
+        assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 1);
+        assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 1);
+
+        client().prepareIndex(INDEX_NAME)
+            .setId("2")
+            .setSource("fooo", "baar")
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL)
+            .get();
+
+        assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 2);
+        assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 2);
+
+        // Now delete with blockUntilRefresh
+        client().prepareDelete(INDEX_NAME, "1").setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL).get();
+        assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 1);
+        assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 1);
+
+        client().prepareDelete(INDEX_NAME, "2").setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL).get();
+        assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 0);
+        assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 0);
+    }
+
+    public void testReplicationAfterForceMerge() throws Exception {
+        final String nodeA = internalCluster().startNode();
+        final String nodeB = internalCluster().startNode();
+        createIndex(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        final int initialDocCount = scaledRandomIntBetween(0, 200);
+        try (
+            BackgroundIndexer indexer = new BackgroundIndexer(
+                INDEX_NAME,
+                "_doc",
+                client(),
+                -1,
+                RandomizedTest.scaledRandomIntBetween(2, 5),
+                false,
+                random()
+            )
+        ) {
+            indexer.start(initialDocCount);
+            waitForDocs(initialDocCount, indexer);
+
+            flush(INDEX_NAME);
+            // wait a short amount of time to give replication a chance to complete.
+            Thread.sleep(1000);
+            assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
+            assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
+
+            final int additionalDocCount = scaledRandomIntBetween(0, 200);
+            final int expectedHitCount = initialDocCount + additionalDocCount;
+
+            // Index a second set of docs so we can merge into one segment.
+            indexer.start(additionalDocCount);
+            waitForDocs(expectedHitCount, indexer);
+
+            // Force a merge here so that the in memory SegmentInfos does not reference old segments on disk.
+            // This case tests that replicas preserve these files so the local store is not corrupt.
+            client().admin().indices().prepareForceMerge(INDEX_NAME).setMaxNumSegments(1).setFlush(false).get();
+            Thread.sleep(1000);
+            refresh(INDEX_NAME);
+            Thread.sleep(1000);
+            assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount);
+            assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount);
+
+            ensureGreen(INDEX_NAME);
+            assertSegmentStats(REPLICA_COUNT);
+        }
+    }
+
+    public void testReplicaSetupAfterPrimaryIndexesDocs() {
+        final String nodeA = internalCluster().startNode();
+        createIndex(INDEX_NAME, Settings.builder().put(indexSettings()).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).build());
+        ensureGreen(INDEX_NAME);
+
+        // Index a doc to create the first set of segments. _s1.si
+        client().prepareIndex(INDEX_NAME).setId("1").setSource("foo", "bar").setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL).get();
+        // Flush segments to disk and create a new commit point (Primary: segments_3, _s1.si)
+        flushAndRefresh(INDEX_NAME);
+        assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 1);
+
+        // Index to create another segment
+        client().prepareIndex(INDEX_NAME).setId("2").setSource("foo", "bar").setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL).get();
+
+        // Force a merge here so that the in memory SegmentInfos does not reference old segments on disk.
+        // This case tests that we are still sending these older segments to replicas so the index on disk is not corrupt.
+        client().admin().indices().prepareForceMerge(INDEX_NAME).setMaxNumSegments(1).setFlush(false).get();
+        refresh(INDEX_NAME);
+
+        final String nodeB = internalCluster().startNode();
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareUpdateSettings(INDEX_NAME)
+                .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1))
+        );
+        ensureGreen(INDEX_NAME);
+        assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 2);
+        assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 2);
+        assertSegmentStats(REPLICA_COUNT);
+    }
+
+    private void assertSegmentStats(int numberOfReplicas) {
+        client().admin().indices().segments(new IndicesSegmentsRequest(), new ActionListener<>() {
+            @Override
+            public void onResponse(IndicesSegmentResponse indicesSegmentResponse) {
+
+                List<ShardSegments[]> segmentsByIndex = indicesSegmentResponse.getIndices()
+                    .values()
+                    .stream() // get list of IndexSegments
+                    .flatMap(is -> is.getShards().values().stream()) // Map to shard replication group
+                    .map(IndexShardSegments::getShards) // get list of segments across replication group
+                    .collect(Collectors.toList());
+
+                // There will be an entry in the list for each index.
+                for (ShardSegments[] replicationGroupSegments : segmentsByIndex) {
+
+                    // Separate Primary & replica shards ShardSegments.
+                    final Map<Boolean, List<ShardSegments>> segmentListMap = Arrays.stream(replicationGroupSegments)
+                        .collect(Collectors.groupingBy(s -> s.getShardRouting().primary()));
+                    final List<ShardSegments> primaryShardSegmentsList = segmentListMap.get(true);
+                    final List<ShardSegments> replicaShardSegments = segmentListMap.get(false);
+
+                    assertEquals("There should only be one primary in the replicationGroup", primaryShardSegmentsList.size(), 1);
+                    final ShardSegments primaryShardSegments = primaryShardSegmentsList.stream().findFirst().get();
+
+                    // create a map of the primary's segments keyed by segment name, allowing us to compare the same segment found on
+                    // replicas.
+                    final Map<String, Segment> primarySegmentsMap = primaryShardSegments.getSegments()
+                        .stream()
+                        .collect(Collectors.toMap(Segment::getName, Function.identity()));
+                    // For every replica, ensure that its segments are in the same state as on the primary.
+                    // It is possible the primary has not cleaned up old segments that are not required on replicas, so we can't do a
+                    // list comparison.
+                    // This equality check includes search/committed properties on the Segment. Combined with docCount checks,
+                    // this ensures the replica has correctly copied the latest segments and has all segments referenced by the latest
+                    // commit point, even if they are not searchable.
+                    assertEquals(
+                        "There should be a ShardSegment entry for each replica in the replicationGroup",
+                        numberOfReplicas,
+                        replicaShardSegments.size()
+                    );
+
+                    for (ShardSegments shardSegment : replicaShardSegments) {
+                        for (Segment replicaSegment : shardSegment.getSegments()) {
+                            final Segment primarySegment = primarySegmentsMap.get(replicaSegment.getName());
+                            assertEquals("Replica's segment should be identical to primary's version", replicaSegment, primarySegment);
+                        }
+                    }
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                Assert.fail("Error fetching segment stats");
+            }
+        });
+    }
+}

--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -35,6 +35,7 @@ public class FeatureFlags {
      * and false otherwise.
      */
     public static boolean isEnabled(String featureFlagName) {
-        return "true".equalsIgnoreCase(System.getProperty(featureFlagName));
+        return true;
+        // return "true".equalsIgnoreCase(System.getProperty(featureFlagName));
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
@@ -214,7 +214,29 @@ public class NRTReplicationEngine extends Engine {
         boolean requiredFullRange,
         boolean accurateCount
     ) throws IOException {
-        throw new UnsupportedOperationException("Not implemented");
+        ensureOpen();
+        Searcher searcher = acquireSearcher(source, SearcherScope.INTERNAL);
+        try {
+            LuceneChangesSnapshot snapshot = new LuceneChangesSnapshot(
+                searcher,
+                LuceneChangesSnapshot.DEFAULT_BATCH_SIZE,
+                fromSeqNo,
+                toSeqNo,
+                requiredFullRange,
+                accurateCount
+            );
+            searcher = null;
+            return snapshot;
+        } catch (Exception e) {
+            try {
+                maybeFailEngine("acquire changes snapshot", e);
+            } catch (Exception inner) {
+                e.addSuppressed(inner);
+            }
+            throw e;
+        } finally {
+            IOUtils.close(searcher);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/store/Store.java
+++ b/server/src/main/java/org/opensearch/index/store/Store.java
@@ -1003,7 +1003,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
                     // version is written since 3.1+: we should have already hit IndexFormatTooOld.
                     throw new IllegalArgumentException("expected valid version value: " + info.info.toString());
                 }
-                if (version.onOrAfter(maxVersion)) {
+                if (maxVersion == null || version.onOrAfter(maxVersion)) {
                     maxVersion = version;
                 }
                 for (String file : info.files()) {

--- a/server/src/main/java/org/opensearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/opensearch/indices/cluster/IndicesClusterStateService.java
@@ -80,6 +80,7 @@ import org.opensearch.indices.recovery.PeerRecoverySourceService;
 import org.opensearch.indices.recovery.PeerRecoveryTargetService;
 import org.opensearch.indices.recovery.RecoveryListener;
 import org.opensearch.indices.recovery.RecoveryState;
+import org.opensearch.indices.replication.SegmentReplicationTargetService;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.indices.replication.common.ReplicationState;
 import org.opensearch.repositories.RepositoriesService;
@@ -120,6 +121,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
     private final ClusterService clusterService;
     private final ThreadPool threadPool;
     private final PeerRecoveryTargetService recoveryTargetService;
+    private final SegmentReplicationTargetService segmentReplicationTargetService;
     private final ShardStateAction shardStateAction;
     private final NodeMappingRefreshAction nodeMappingRefreshAction;
 
@@ -148,6 +150,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         final ClusterService clusterService,
         final ThreadPool threadPool,
         final PeerRecoveryTargetService recoveryTargetService,
+        final SegmentReplicationTargetService segmentReplicationTargetService,
         final ShardStateAction shardStateAction,
         final NodeMappingRefreshAction nodeMappingRefreshAction,
         final RepositoriesService repositoriesService,
@@ -166,6 +169,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             threadPool,
             checkpointPublisher,
             recoveryTargetService,
+            segmentReplicationTargetService,
             shardStateAction,
             nodeMappingRefreshAction,
             repositoriesService,
@@ -186,6 +190,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         final ThreadPool threadPool,
         final SegmentReplicationCheckpointPublisher checkpointPublisher,
         final PeerRecoveryTargetService recoveryTargetService,
+        final SegmentReplicationTargetService segmentReplicationTargetService,
         final ShardStateAction shardStateAction,
         final NodeMappingRefreshAction nodeMappingRefreshAction,
         final RepositoriesService repositoriesService,
@@ -198,11 +203,18 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
     ) {
         this.settings = settings;
         this.checkpointPublisher = checkpointPublisher;
-        this.buildInIndexListener = Arrays.asList(peerRecoverySourceService, recoveryTargetService, searchService, snapshotShardsService);
+        this.buildInIndexListener = Arrays.asList(
+            peerRecoverySourceService,
+            recoveryTargetService,
+            segmentReplicationTargetService,
+            searchService,
+            snapshotShardsService
+        );
         this.indicesService = indicesService;
         this.clusterService = clusterService;
         this.threadPool = threadPool;
         this.recoveryTargetService = recoveryTargetService;
+        this.segmentReplicationTargetService = segmentReplicationTargetService;
         this.shardStateAction = shardStateAction;
         this.nodeMappingRefreshAction = nodeMappingRefreshAction;
         this.repositoriesService = repositoriesService;
@@ -634,6 +646,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                 checkpointPublisher,
                 recoveryTargetService,
                 new RecoveryListener(shardRouting, primaryTerm, this),
+                segmentReplicationTargetService,
                 repositoriesService,
                 failedShardHandler,
                 globalCheckpointSyncer,
@@ -992,6 +1005,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             SegmentReplicationCheckpointPublisher checkpointPublisher,
             PeerRecoveryTargetService recoveryTargetService,
             RecoveryListener recoveryListener,
+            SegmentReplicationTargetService segmentReplicationTargetService,
             RepositoriesService repositoriesService,
             Consumer<IndexShard.ShardFailure> onShardFailure,
             Consumer<ShardId> globalCheckpointSyncer,

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
@@ -544,7 +544,7 @@ public class RecoverySourceHandler {
                 // Generate a "diff" of all the identical, different, and missing
                 // segment files on the target node, using the existing files on
                 // the source node
-                final Store.RecoveryDiff diff = recoverySourceMetadata.recoveryDiff(request.metadataSnapshot());
+                final Store.RecoveryDiff diff = recoverySourceMetadata.recoveryDiff(request.metadataSnapshot(), false);
                 for (StoreFileMetadata md : diff.identical) {
                     phase1ExistingFileNames.add(md.name());
                     phase1ExistingFileSizes.add(md.length());

--- a/server/src/main/java/org/opensearch/indices/replication/PrepareShardRequest.java
+++ b/server/src/main/java/org/opensearch/indices/replication/PrepareShardRequest.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.transport.TransportRequest;
+
+import java.io.IOException;
+
+public class PrepareShardRequest extends TransportRequest {
+
+    private final ShardId shardId;
+
+    protected PrepareShardRequest(ShardId shardId) {
+        this.shardId = shardId;
+    }
+
+    protected PrepareShardRequest(StreamInput in) throws IOException {
+        super(in);
+        shardId = new ShardId(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        shardId.writeTo(out);
+    }
+
+    public ShardId getShardId() {
+        return shardId;
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/replication/PrepareShardResponse.java
+++ b/server/src/main/java/org/opensearch/indices/replication/PrepareShardResponse.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportResponse;
+
+import java.io.IOException;
+
+public class PrepareShardResponse extends TransportResponse {
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    private final String uuid;
+
+    public PrepareShardResponse(String uuid) {
+        this.uuid = uuid;
+    }
+
+    public PrepareShardResponse(StreamInput in) throws IOException {
+        uuid = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(uuid);
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceFactory.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceFactory.java
@@ -39,11 +39,11 @@ public class SegmentReplicationSourceFactory {
 
     public SegmentReplicationSource get(IndexShard shard) {
         return new PrimaryShardReplicationSource(
-            clusterService.localNode(),
+            shard.recoveryState().getTargetNode(),
             shard.routingEntry().allocationId().getId(),
             transportService,
             recoverySettings,
-            getPrimaryNode(shard.shardId())
+            shard.recoveryState().getSourceNode()
         );
     }
 

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.index.IndexCommit;
 import org.opensearch.action.StepListener;
-import org.opensearch.action.admin.indices.flush.FlushRequest;
 import org.opensearch.action.support.ChannelActionListener;
 import org.opensearch.action.support.ThreadedActionListener;
 import org.opensearch.action.support.replication.ReplicationResponse;

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
@@ -165,7 +165,7 @@ public class SegmentReplicationTarget extends ReplicationTarget {
         throws IOException {
         final Store.MetadataSnapshot snapshot = checkpointInfo.getSnapshot();
         Store.MetadataSnapshot localMetadata = getMetadataSnapshot();
-        final Store.RecoveryDiff diff = snapshot.recoveryDiff(localMetadata);
+        final Store.RecoveryDiff diff = snapshot.recoveryDiff(localMetadata, true);
         logger.debug("Replication diff {}", diff);
         // Segments are immutable. So if the replica has any segments with the same name that differ from the one in the incoming snapshot
         // from

--- a/server/src/main/java/org/opensearch/indices/replication/common/CopyState.java
+++ b/server/src/main/java/org/opensearch/indices/replication/common/CopyState.java
@@ -62,7 +62,7 @@ public class CopyState extends AbstractRefCounted {
         // This ensures that the store on replicas is in sync with the store on primaries.
         this.commitRef = shard.acquireLastIndexCommit(false);
         Store.MetadataSnapshot metadata = shard.store().getMetadata(this.commitRef.get());
-        final Store.RecoveryDiff diff = metadata.recoveryDiff(this.metadataSnapshot);
+        final Store.RecoveryDiff diff = metadata.recoveryDiff(this.metadataSnapshot, false);
         this.pendingDeleteFiles = new HashSet<>(diff.missing);
         if (this.pendingDeleteFiles.isEmpty()) {
             // If there are no additional files we can release the last commit immediately.

--- a/server/src/main/java/org/opensearch/repositories/blobstore/FileRestoreContext.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/FileRestoreContext.java
@@ -130,7 +130,7 @@ public abstract class FileRestoreContext {
                 throw new IndexShardRestoreFailedException(shardId, "Snapshot has no segments file");
             }
 
-            final Store.RecoveryDiff diff = sourceMetadata.recoveryDiff(recoveryTargetMetadata);
+            final Store.RecoveryDiff diff = sourceMetadata.recoveryDiff(recoveryTargetMetadata, false);
             for (StoreFileMetadata md : diff.identical) {
                 BlobStoreIndexShardSnapshot.FileInfo fileInfo = fileInfos.get(md.name());
                 recoveryState.getIndex().addFileDetail(fileInfo.physicalName(), fileInfo.length(), true);

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -3412,9 +3412,9 @@ public class IndexShardTests extends IndexShardTestCase {
             while (stop.get() == false) {
                 try {
                     Store.MetadataSnapshot readMeta = newShard.snapshotStoreMetadata();
-                    assertEquals(0, storeFileMetadatas.recoveryDiff(readMeta).different.size());
-                    assertEquals(0, storeFileMetadatas.recoveryDiff(readMeta).missing.size());
-                    assertEquals(storeFileMetadatas.size(), storeFileMetadatas.recoveryDiff(readMeta).identical.size());
+                    assertEquals(0, storeFileMetadatas.recoveryDiff(readMeta, false).different.size());
+                    assertEquals(0, storeFileMetadatas.recoveryDiff(readMeta, false).missing.size());
+                    assertEquals(storeFileMetadatas.size(), storeFileMetadatas.recoveryDiff(readMeta, false).identical.size());
                 } catch (IOException e) {
                     throw new AssertionError(e);
                 }
@@ -3708,9 +3708,9 @@ public class IndexShardTests extends IndexShardTestCase {
                 try {
                     Store.MetadataSnapshot readMeta = newShard.snapshotStoreMetadata();
                     assertThat(readMeta.getNumDocs(), equalTo(numDocs));
-                    assertThat(storeFileMetadatas.recoveryDiff(readMeta).different.size(), equalTo(0));
-                    assertThat(storeFileMetadatas.recoveryDiff(readMeta).missing.size(), equalTo(0));
-                    assertThat(storeFileMetadatas.recoveryDiff(readMeta).identical.size(), equalTo(storeFileMetadatas.size()));
+                    assertThat(storeFileMetadatas.recoveryDiff(readMeta, false).different.size(), equalTo(0));
+                    assertThat(storeFileMetadatas.recoveryDiff(readMeta, false).missing.size(), equalTo(0));
+                    assertThat(storeFileMetadatas.recoveryDiff(readMeta, false).identical.size(), equalTo(storeFileMetadatas.size()));
                 } catch (IOException e) {
                     throw new AssertionError(e);
                 }

--- a/server/src/test/java/org/opensearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/opensearch/index/store/StoreTests.java
@@ -583,7 +583,7 @@ public class StoreTests extends OpenSearchTestCase {
             writer.close();
             second = store.getMetadata();
         }
-        Store.RecoveryDiff diff = first.recoveryDiff(second);
+        Store.RecoveryDiff diff = first.recoveryDiff(second, false);
         assertThat(first.size(), equalTo(second.size()));
         for (StoreFileMetadata md : first) {
             assertThat(second.get(md.name()), notNullValue());
@@ -595,7 +595,7 @@ public class StoreTests extends OpenSearchTestCase {
         assertThat(diff.missing, empty());
 
         // check the self diff
-        Store.RecoveryDiff selfDiff = first.recoveryDiff(first);
+        Store.RecoveryDiff selfDiff = first.recoveryDiff(first, false);
         assertThat(selfDiff.identical.size(), equalTo(first.size()));
         assertThat(selfDiff.different, empty());
         assertThat(selfDiff.missing, empty());
@@ -618,7 +618,7 @@ public class StoreTests extends OpenSearchTestCase {
                 break;
             }
         }
-        Store.RecoveryDiff afterDeleteDiff = metadata.recoveryDiff(second);
+        Store.RecoveryDiff afterDeleteDiff = metadata.recoveryDiff(second, false);
         if (delFile != null) {
             assertThat(afterDeleteDiff.identical.size(), equalTo(metadata.size() - 2)); // segments_N + del file
             assertThat(afterDeleteDiff.different.size(), equalTo(0));
@@ -631,7 +631,7 @@ public class StoreTests extends OpenSearchTestCase {
         }
 
         // check the self diff
-        selfDiff = metadata.recoveryDiff(metadata);
+        selfDiff = metadata.recoveryDiff(metadata, false);
         assertThat(selfDiff.identical.size(), equalTo(metadata.size()));
         assertThat(selfDiff.different, empty());
         assertThat(selfDiff.missing, empty());
@@ -646,7 +646,7 @@ public class StoreTests extends OpenSearchTestCase {
         writer.close();
 
         Store.MetadataSnapshot newCommitMetadata = store.getMetadata();
-        Store.RecoveryDiff newCommitDiff = newCommitMetadata.recoveryDiff(metadata);
+        Store.RecoveryDiff newCommitDiff = newCommitMetadata.recoveryDiff(metadata, false);
         if (delFile != null) {
             assertThat(newCommitDiff.identical.size(), equalTo(newCommitMetadata.size() - 5)); // segments_N, del file, cfs, cfe, si for the
                                                                                                // new segment

--- a/server/src/test/java/org/opensearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
+++ b/server/src/test/java/org/opensearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
@@ -59,6 +59,7 @@ import org.opensearch.indices.cluster.IndicesClusterStateService.Shard;
 import org.opensearch.indices.recovery.PeerRecoveryTargetService;
 import org.opensearch.indices.recovery.RecoveryListener;
 import org.opensearch.indices.recovery.RecoveryState;
+import org.opensearch.indices.replication.SegmentReplicationTargetService;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.test.OpenSearchTestCase;
@@ -257,6 +258,7 @@ public abstract class AbstractIndicesClusterStateServiceTestCase extends OpenSea
             final SegmentReplicationCheckpointPublisher checkpointPublisher,
             final PeerRecoveryTargetService recoveryTargetService,
             final RecoveryListener recoveryListener,
+            final SegmentReplicationTargetService segmentReplicationTargetService,
             final RepositoriesService repositoriesService,
             final Consumer<IndexShard.ShardFailure> onShardFailure,
             final Consumer<ShardId> globalCheckpointSyncer,

--- a/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
+++ b/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
@@ -66,6 +66,8 @@ import org.opensearch.index.seqno.RetentionLeaseSyncer;
 import org.opensearch.index.shard.PrimaryReplicaSyncer;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.indices.recovery.PeerRecoveryTargetService;
+import org.opensearch.indices.replication.SegmentReplicationSourceFactory;
+import org.opensearch.indices.replication.SegmentReplicationTargetService;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.threadpool.TestThreadPool;
@@ -556,6 +558,12 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
             null,
             clusterService
         );
+        final SegmentReplicationTargetService segmentReplicationTargetService = new SegmentReplicationTargetService(
+            threadPool,
+            null,
+            transportService,
+            new SegmentReplicationSourceFactory(transportService, null, clusterService)
+        );
         final ShardStateAction shardStateAction = mock(ShardStateAction.class);
         final PrimaryReplicaSyncer primaryReplicaSyncer = mock(PrimaryReplicaSyncer.class);
         return new IndicesClusterStateService(
@@ -565,6 +573,7 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
             threadPool,
             SegmentReplicationCheckpointPublisher.EMPTY,
             recoveryTargetService,
+            segmentReplicationTargetService,
             shardStateAction,
             null,
             repositoriesService,

--- a/server/src/test/java/org/opensearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -170,7 +170,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         cleanFilesFuture.actionGet();
         recoveryTarget.decRef();
         Store.MetadataSnapshot targetSnapshot = targetShard.snapshotStoreMetadata();
-        Store.RecoveryDiff diff = sourceSnapshot.recoveryDiff(targetSnapshot);
+        Store.RecoveryDiff diff = sourceSnapshot.recoveryDiff(targetSnapshot, false);
         assertThat(diff.different, empty());
         closeShards(sourceShard, targetShard);
     }

--- a/server/src/test/java/org/opensearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -228,7 +228,7 @@ public class RecoverySourceHandlerTests extends OpenSearchTestCase {
         handler.sendFiles(store, metas.toArray(new StoreFileMetadata[0]), () -> 0, sendFilesFuture);
         sendFilesFuture.actionGet();
         Store.MetadataSnapshot targetStoreMetadata = targetStore.getMetadata();
-        Store.RecoveryDiff recoveryDiff = targetStoreMetadata.recoveryDiff(metadata);
+        Store.RecoveryDiff recoveryDiff = targetStoreMetadata.recoveryDiff(metadata, false);
         assertEquals(metas.size(), recoveryDiff.identical.size());
         assertEquals(0, recoveryDiff.different.size());
         assertEquals(0, recoveryDiff.missing.size());

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -1845,6 +1845,7 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     clusterService,
                     threadPool,
                     new PeerRecoveryTargetService(threadPool, transportService, recoverySettings, clusterService),
+                    null,
                     shardStateAction,
                     new NodeMappingRefreshAction(transportService, metadataMappingService),
                     repositoriesService,


### PR DESCRIPTION
### Description
The delete operation integration test was failing due to the calculation of recoveryDiff used by the getFiles method to get the files needed as specified by the checkpoints.
 
### Issues Resolved
Resolves #3787 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
