### PR TITLE
Mute testHighWatermarkNotExceeded

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -153,6 +153,7 @@ public class DiskThresholdDeciderIT extends OpenSearchIntegTestCase {
         return Collections.singletonList(InternalSettingsPlugin.class);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/pull/3561")
     public void testHighWatermarkNotExceeded() throws Exception {
         internalCluster().startClusterManagerOnlyNode();
         internalCluster().startDataOnlyNode();


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
testHighWatermarkNotExceeded is failing with > 50% failure rate. There is already a [fix](https://github.com/opensearch-project/OpenSearch/pull/3561) in place, muting till the fix is merged. 

Related
https://github.com/opensearch-project/OpenSearch/issues/3579

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
