### PR TITLE
Support for HTTP/2 (server-side) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added release notes for 1.3.5 ([#4343](https://github.com/opensearch-project/OpenSearch/pull/4343))
 - Added release notes for 2.2.1 ([#4344](https://github.com/opensearch-project/OpenSearch/pull/4344))
 - Label configuration for dependabot PRs ([#4348](https://github.com/opensearch-project/OpenSearch/pull/4348))
-- Support for HTTP/2 (server-side) (https://github.com/opensearch-project/OpenSearch/issues/3651)
+- Support for HTTP/2 (server-side) ([#3847](https://github.com/opensearch-project/OpenSearch/pull/3847))
 
 ### Changed
 - Dependency updates (httpcore, mockito, slf4j, httpasyncclient, commons-codec) ([#4308](https://github.com/opensearch-project/OpenSearch/pull/4308))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added release notes for 1.3.5 ([#4343](https://github.com/opensearch-project/OpenSearch/pull/4343))
 - Added release notes for 2.2.1 ([#4344](https://github.com/opensearch-project/OpenSearch/pull/4344))
 - Label configuration for dependabot PRs ([#4348](https://github.com/opensearch-project/OpenSearch/pull/4348))
+- Support for HTTP/2 (server-side) (https://github.com/opensearch-project/OpenSearch/issues/3651)
 
 ### Changed
 - Dependency updates (httpcore, mockito, slf4j, httpasyncclient, commons-codec) ([#4308](https://github.com/opensearch-project/OpenSearch/pull/4308))

--- a/modules/transport-netty4/build.gradle
+++ b/modules/transport-netty4/build.gradle
@@ -58,6 +58,7 @@ dependencies {
   api "io.netty:netty-buffer:${versions.netty}"
   api "io.netty:netty-codec:${versions.netty}"
   api "io.netty:netty-codec-http:${versions.netty}"
+  api "io.netty:netty-codec-http2:${versions.netty}"
   api "io.netty:netty-common:${versions.netty}"
   api "io.netty:netty-handler:${versions.netty}"
   api "io.netty:netty-resolver:${versions.netty}"

--- a/modules/transport-netty4/licenses/netty-codec-http2-4.1.79.Final.jar.sha1
+++ b/modules/transport-netty4/licenses/netty-codec-http2-4.1.79.Final.jar.sha1
@@ -1,0 +1,1 @@
+0eeffab0cd5efb699d5e4ab9b694d32fef6694b3

--- a/modules/transport-netty4/src/internalClusterTest/java/org/opensearch/http/netty4/Netty4Http2IT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/opensearch/http/netty4/Netty4Http2IT.java
@@ -6,30 +6,6 @@
  * compatible open source license.
  */
 
-/*
- * Licensed to Elasticsearch under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-/*
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
 package org.opensearch.http.netty4;
 
 import io.netty.handler.codec.http.FullHttpResponse;
@@ -42,10 +18,10 @@ import org.opensearch.test.OpenSearchIntegTestCase.Scope;
 
 import java.util.Collection;
 import java.util.Locale;
-import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 
 @ClusterScope(scope = Scope.TEST, supportsDedicatedMasters = false, numDataNodes = 1)
 public class Netty4Http2IT extends OpenSearchNetty4IntegTestCase {
@@ -80,9 +56,7 @@ public class Netty4Http2IT extends OpenSearchNetty4IntegTestCase {
         // and responses may come back at any order
         int i = 0;
         String msg = String.format(Locale.ROOT, "Expected list of opaque ids to be in any order, got [%s]", opaqueIds);
-        for (String opaqueId : opaqueIds.stream().sorted().collect(Collectors.toList())) {
-            assertThat(msg, opaqueId, is(String.valueOf(i++)));
-        }
+        assertThat(msg, opaqueIds, containsInAnyOrder(IntStream.range(0, 5).mapToObj(Integer::toString).toArray()));
     }
 
 }

--- a/modules/transport-netty4/src/internalClusterTest/java/org/opensearch/http/netty4/Netty4Http2IT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/opensearch/http/netty4/Netty4Http2IT.java
@@ -42,43 +42,45 @@ import org.opensearch.test.OpenSearchIntegTestCase.Scope;
 
 import java.util.Collection;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 @ClusterScope(scope = Scope.TEST, supportsDedicatedMasters = false, numDataNodes = 1)
-public class Netty4PipeliningIT extends OpenSearchNetty4IntegTestCase {
+public class Netty4Http2IT extends OpenSearchNetty4IntegTestCase {
 
     @Override
     protected boolean addMockHttpTransport() {
         return false; // enable http
     }
 
-    public void testThatNettyHttpServerSupportsPipelining() throws Exception {
+    public void testThatNettyHttpServerSupportsHttp2() throws Exception {
         String[] requests = new String[] { "/", "/_nodes/stats", "/", "/_cluster/state", "/" };
 
         HttpServerTransport httpServerTransport = internalCluster().getInstance(HttpServerTransport.class);
         TransportAddress[] boundAddresses = httpServerTransport.boundAddress().boundAddresses();
         TransportAddress transportAddress = randomFrom(boundAddresses);
 
-        try (Netty4HttpClient nettyHttpClient = Netty4HttpClient.http()) {
+        try (Netty4HttpClient nettyHttpClient = Netty4HttpClient.http2()) {
             Collection<FullHttpResponse> responses = nettyHttpClient.get(transportAddress.address(), requests);
             try {
                 assertThat(responses, hasSize(5));
 
                 Collection<String> opaqueIds = Netty4HttpClient.returnOpaqueIds(responses);
-                assertOpaqueIdsInOrder(opaqueIds);
+                assertOpaqueIdsInAnyOrder(opaqueIds);
             } finally {
                 responses.forEach(ReferenceCounted::release);
             }
         }
     }
 
-    private void assertOpaqueIdsInOrder(Collection<String> opaqueIds) {
-        // check if opaque ids are monotonically increasing
+    private void assertOpaqueIdsInAnyOrder(Collection<String> opaqueIds) {
+        // check if opaque ids are present in any order, since for HTTP/2 we use streaming (no head of line blocking)
+        // and responses may come back at any order
         int i = 0;
-        String msg = String.format(Locale.ROOT, "Expected list of opaque ids to be monotonically increasing, got [%s]", opaqueIds);
-        for (String opaqueId : opaqueIds) {
+        String msg = String.format(Locale.ROOT, "Expected list of opaque ids to be in any order, got [%s]", opaqueIds);
+        for (String opaqueId : opaqueIds.stream().sorted().collect(Collectors.toList())) {
             assertThat(msg, opaqueId, is(String.valueOf(i++)));
         }
     }

--- a/modules/transport-netty4/src/internalClusterTest/java/org/opensearch/http/netty4/Netty4HttpRequestSizeLimitIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/opensearch/http/netty4/Netty4HttpRequestSizeLimitIT.java
@@ -100,7 +100,7 @@ public class Netty4HttpRequestSizeLimitIT extends OpenSearchNetty4IntegTestCase 
         HttpServerTransport httpServerTransport = internalCluster().getInstance(HttpServerTransport.class);
         TransportAddress transportAddress = randomFrom(httpServerTransport.boundAddress().boundAddresses());
 
-        try (Netty4HttpClient nettyHttpClient = new Netty4HttpClient()) {
+        try (Netty4HttpClient nettyHttpClient = Netty4HttpClient.http()) {
             Collection<FullHttpResponse> singleResponse = nettyHttpClient.post(transportAddress.address(), requests.subList(0, 1));
             try {
                 assertThat(singleResponse, hasSize(1));
@@ -130,7 +130,7 @@ public class Netty4HttpRequestSizeLimitIT extends OpenSearchNetty4IntegTestCase 
         HttpServerTransport httpServerTransport = internalCluster().getInstance(HttpServerTransport.class);
         TransportAddress transportAddress = randomFrom(httpServerTransport.boundAddress().boundAddresses());
 
-        try (Netty4HttpClient nettyHttpClient = new Netty4HttpClient()) {
+        try (Netty4HttpClient nettyHttpClient = Netty4HttpClient.http()) {
             Collection<FullHttpResponse> responses = nettyHttpClient.put(transportAddress.address(), requestUris);
             try {
                 assertThat(responses, hasSize(requestUris.size()));

--- a/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpChannel.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpChannel.java
@@ -33,7 +33,10 @@
 package org.opensearch.http.netty4;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelPipeline;
+
 import org.opensearch.action.ActionListener;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.concurrent.CompletableContext;
 import org.opensearch.http.HttpChannel;
 import org.opensearch.http.HttpResponse;
@@ -45,9 +48,15 @@ public class Netty4HttpChannel implements HttpChannel {
 
     private final Channel channel;
     private final CompletableContext<Void> closeContext = new CompletableContext<>();
+    private final ChannelPipeline inboundPipeline;
 
     Netty4HttpChannel(Channel channel) {
+        this(channel, null);
+    }
+
+    Netty4HttpChannel(Channel channel, ChannelPipeline inboundPipeline) {
         this.channel = channel;
+        this.inboundPipeline = inboundPipeline;
         Netty4TcpChannel.addListener(this.channel.closeFuture(), closeContext);
     }
 
@@ -79,6 +88,10 @@ public class Netty4HttpChannel implements HttpChannel {
     @Override
     public void close() {
         channel.close();
+    }
+
+    public @Nullable ChannelPipeline inboundPipeline() {
+        return inboundPipeline;
     }
 
     public Channel getNettyChannel() {

--- a/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpServerTransport.java
@@ -40,18 +40,34 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.nio.NioChannelOption;
-import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.http.HttpContentCompressor;
 import io.netty.handler.codec.http.HttpContentDecompressor;
+import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpObjectAggregator;
-import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.HttpServerUpgradeHandler;
+import io.netty.handler.codec.http.HttpServerUpgradeHandler.UpgradeCodec;
+import io.netty.handler.codec.http.HttpServerUpgradeHandler.UpgradeCodecFactory;
+import io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler;
+import io.netty.handler.codec.http2.Http2CodecUtil;
+import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
+import io.netty.handler.codec.http2.Http2MultiplexHandler;
+import io.netty.handler.codec.http2.Http2ServerUpgradeCodec;
+import io.netty.handler.codec.http2.Http2StreamFrameToHttpObjectCodec;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.timeout.ReadTimeoutException;
 import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.util.AsciiString;
 import io.netty.util.AttributeKey;
+import io.netty.util.ReferenceCountUtil;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
@@ -335,31 +351,70 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
             this.responseCreator = new Netty4HttpResponseCreator();
         }
 
+        public ChannelHandler getRequestHandler() {
+            return requestHandler;
+        }
+
         @Override
         protected void initChannel(Channel ch) throws Exception {
             Netty4HttpChannel nettyHttpChannel = new Netty4HttpChannel(ch);
             ch.attr(HTTP_CHANNEL_KEY).set(nettyHttpChannel);
             ch.pipeline().addLast("byte_buf_sizer", byteBufSizer);
             ch.pipeline().addLast("read_timeout", new ReadTimeoutHandler(transport.readTimeoutMillis, TimeUnit.MILLISECONDS));
-            final HttpRequestDecoder decoder = new HttpRequestDecoder(
+
+            final UpgradeCodecFactory upgradeCodecFactory = new UpgradeCodecFactory() {
+                @Override
+                public UpgradeCodec newUpgradeCodec(CharSequence protocol) {
+                    if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
+                        return new Http2ServerUpgradeCodec(
+                            Http2FrameCodecBuilder.forServer().build(),
+                            new Http2MultiplexHandler(createHttp2ChannelInitializer())
+                        );
+                    } else {
+                        return null;
+                    }
+                }
+            };
+
+            final HttpServerCodec sourceCodec = new HttpServerCodec(
                 handlingSettings.getMaxInitialLineLength(),
                 handlingSettings.getMaxHeaderSize(),
                 handlingSettings.getMaxChunkSize()
             );
-            decoder.setCumulator(ByteToMessageDecoder.COMPOSITE_CUMULATOR);
-            ch.pipeline().addLast("decoder", decoder);
-            ch.pipeline().addLast("decoder_compress", new HttpContentDecompressor());
-            ch.pipeline().addLast("encoder", new HttpResponseEncoder());
-            final HttpObjectAggregator aggregator = new HttpObjectAggregator(handlingSettings.getMaxContentLength());
-            aggregator.setMaxCumulationBufferComponents(transport.maxCompositeBufferComponents);
-            ch.pipeline().addLast("aggregator", aggregator);
-            if (handlingSettings.isCompression()) {
-                ch.pipeline().addLast("encoder_compress", new HttpContentCompressor(handlingSettings.getCompressionLevel()));
-            }
-            ch.pipeline().addLast("request_creator", requestCreator);
-            ch.pipeline().addLast("response_creator", responseCreator);
-            ch.pipeline().addLast("pipelining", new Netty4HttpPipeliningHandler(logger, transport.pipeliningMaxEvents));
-            ch.pipeline().addLast("handler", requestHandler);
+
+            final HttpServerUpgradeHandler upgradeHandler = new HttpServerUpgradeHandler(sourceCodec, upgradeCodecFactory);
+            final CleartextHttp2ServerUpgradeHandler cleartextUpgradeHandler = new CleartextHttp2ServerUpgradeHandler(
+                sourceCodec,
+                upgradeHandler,
+                createHttp2ChannelInitializerPriorKnowledge()
+            );
+
+            ch.pipeline().addLast(cleartextUpgradeHandler).addLast(new SimpleChannelInboundHandler<HttpMessage>() {
+                @Override
+                protected void channelRead0(ChannelHandlerContext ctx, HttpMessage msg) throws Exception {
+                    final HttpObjectAggregator aggregator = new HttpObjectAggregator(handlingSettings.getMaxContentLength());
+                    aggregator.setMaxCumulationBufferComponents(transport.maxCompositeBufferComponents);
+
+                    // If this handler is hit then no upgrade has been attempted and the client is just talking HTTP
+                    final ChannelPipeline pipeline = ctx.pipeline();
+                    pipeline.addAfter(ctx.name(), "handler", getRequestHandler());
+                    pipeline.replace(this, "aggregator", aggregator);
+
+                    ch.pipeline().addLast("decoder_compress", new HttpContentDecompressor());
+                    ch.pipeline().addLast("encoder", new HttpResponseEncoder());
+                    if (handlingSettings.isCompression()) {
+                        ch.pipeline()
+                            .addAfter("aggregator", "encoder_compress", new HttpContentCompressor(handlingSettings.getCompressionLevel()));
+                    }
+                    ch.pipeline().addBefore("handler", "request_creator", requestCreator);
+                    ch.pipeline().addBefore("handler", "response_creator", responseCreator);
+                    ch.pipeline()
+                        .addBefore("handler", "pipelining", new Netty4HttpPipeliningHandler(logger, transport.pipeliningMaxEvents));
+
+                    ctx.fireChannelRead(ReferenceCountUtil.retain(msg));
+                }
+            });
+
             transport.serverAcceptedChannel(nettyHttpChannel);
         }
 
@@ -367,6 +422,52 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             ExceptionsHelper.maybeDieOnAnotherThread(cause);
             super.exceptionCaught(ctx, cause);
+        }
+
+        private void configureDefaultHttp2Pipeline(ChannelPipeline pipeline) {
+            pipeline.addLast(Http2FrameCodecBuilder.forServer().build())
+                .addLast(new Http2MultiplexHandler(createHttp2ChannelInitializer()));
+        }
+
+        private ChannelInitializer<Channel> createHttp2ChannelInitializerPriorKnowledge() {
+            return new ChannelInitializer<Channel>() {
+                @Override
+                protected void initChannel(Channel childChannel) throws Exception {
+                    configureDefaultHttp2Pipeline(childChannel.pipeline());
+                }
+            };
+        }
+
+        private ChannelInitializer<Channel> createHttp2ChannelInitializer() {
+            return new ChannelInitializer<Channel>() {
+                @Override
+                protected void initChannel(Channel childChannel) throws Exception {
+                    final Netty4HttpChannel nettyHttpChannel = new Netty4HttpChannel(childChannel);
+                    childChannel.attr(HTTP_CHANNEL_KEY).set(nettyHttpChannel);
+
+                    final HttpObjectAggregator aggregator = new HttpObjectAggregator(handlingSettings.getMaxContentLength());
+                    aggregator.setMaxCumulationBufferComponents(transport.maxCompositeBufferComponents);
+
+                    childChannel.pipeline()
+                        .addLast(new LoggingHandler(LogLevel.DEBUG))
+                        .addLast(new Http2StreamFrameToHttpObjectCodec(true))
+                        .addLast("byte_buf_sizer", byteBufSizer)
+                        .addLast("read_timeout", new ReadTimeoutHandler(transport.readTimeoutMillis, TimeUnit.MILLISECONDS))
+                        .addLast("decoder_decompress", new HttpContentDecompressor());
+
+                    if (handlingSettings.isCompression()) {
+                        childChannel.pipeline()
+                            .addLast("encoder_compress", new HttpContentCompressor(handlingSettings.getCompressionLevel()));
+                    }
+
+                    childChannel.pipeline()
+                        .addLast("aggregator", aggregator)
+                        .addLast("request_creator", requestCreator)
+                        .addLast("response_creator", responseCreator)
+                        .addLast("pipelining", new Netty4HttpPipeliningHandler(logger, transport.pipeliningMaxEvents))
+                        .addLast("handler", getRequestHandler());
+                }
+            };
         }
     }
 

--- a/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpServerTransport.java
@@ -364,7 +364,7 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
             ch.pipeline().addLast("byte_buf_sizer", byteBufSizer);
             ch.pipeline().addLast("read_timeout", new ReadTimeoutHandler(transport.readTimeoutMillis, TimeUnit.MILLISECONDS));
 
-            configureDefaultPipeline(ch);
+            configurePipeline(ch);
             transport.serverAcceptedChannel(nettyHttpChannel);
         }
 
@@ -374,7 +374,7 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
             super.exceptionCaught(ctx, cause);
         }
 
-        protected void configureDefaultPipeline(Channel ch) {
+        protected void configurePipeline(Channel ch) {
             final UpgradeCodecFactory upgradeCodecFactory = new UpgradeCodecFactory() {
                 @Override
                 public UpgradeCodec newUpgradeCodec(CharSequence protocol) {

--- a/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4BadRequestTests.java
+++ b/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4BadRequestTests.java
@@ -117,7 +117,7 @@ public class Netty4BadRequestTests extends OpenSearchTestCase {
             httpServerTransport.start();
             final TransportAddress transportAddress = randomFrom(httpServerTransport.boundAddress().boundAddresses());
 
-            try (Netty4HttpClient nettyHttpClient = new Netty4HttpClient()) {
+            try (Netty4HttpClient nettyHttpClient = Netty4HttpClient.http()) {
                 final Collection<FullHttpResponse> responses = nettyHttpClient.get(
                     transportAddress.address(),
                     "/_cluster/settings?pretty=%"

--- a/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpClient.java
+++ b/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpClient.java
@@ -37,14 +37,19 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpClientUpgradeHandler;
 import io.netty.handler.codec.http.HttpContentDecompressor;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
@@ -55,6 +60,17 @@ import io.netty.handler.codec.http.HttpRequestEncoder;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http2.DefaultHttp2Connection;
+import io.netty.handler.codec.http2.DelegatingDecompressorFrameListener;
+import io.netty.handler.codec.http2.Http2ClientUpgradeCodec;
+import io.netty.handler.codec.http2.Http2Connection;
+import io.netty.handler.codec.http2.Http2Settings;
+import io.netty.handler.codec.http2.HttpConversionUtil;
+import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler;
+import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandlerBuilder;
+import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapterBuilder;
+import io.netty.util.AttributeKey;
+
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.unit.ByteSizeUnit;
 import org.opensearch.common.unit.ByteSizeValue;
@@ -70,6 +86,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
@@ -97,11 +114,32 @@ class Netty4HttpClient implements Closeable {
     }
 
     private final Bootstrap clientBootstrap;
+    private final BiFunction<CountDownLatch, Collection<FullHttpResponse>, AwaitableChannelInitializer> handlerFactory;
 
-    Netty4HttpClient() {
-        clientBootstrap = new Bootstrap().channel(NettyAllocator.getChannelType())
-            .option(ChannelOption.ALLOCATOR, NettyAllocator.getAllocator())
-            .group(new NioEventLoopGroup(1));
+    Netty4HttpClient(
+        Bootstrap clientBootstrap,
+        BiFunction<CountDownLatch, Collection<FullHttpResponse>, AwaitableChannelInitializer> handlerFactory
+    ) {
+        this.clientBootstrap = clientBootstrap;
+        this.handlerFactory = handlerFactory;
+    }
+
+    static Netty4HttpClient http() {
+        return new Netty4HttpClient(
+            new Bootstrap().channel(NettyAllocator.getChannelType())
+                .option(ChannelOption.ALLOCATOR, NettyAllocator.getAllocator())
+                .group(new NioEventLoopGroup(1)),
+            CountDownLatchHandlerHttp::new
+        );
+    }
+
+    static Netty4HttpClient http2() {
+        return new Netty4HttpClient(
+            new Bootstrap().channel(NettyAllocator.getChannelType())
+                .option(ChannelOption.ALLOCATOR, NettyAllocator.getAllocator())
+                .group(new NioEventLoopGroup(1)),
+            CountDownLatchHandlerHttp2::new
+        );
     }
 
     public List<FullHttpResponse> get(SocketAddress remoteAddress, String... uris) throws InterruptedException {
@@ -110,6 +148,7 @@ class Netty4HttpClient implements Closeable {
             final HttpRequest httpRequest = new DefaultFullHttpRequest(HTTP_1_1, HttpMethod.GET, uris[i]);
             httpRequest.headers().add(HOST, "localhost");
             httpRequest.headers().add("X-Opaque-ID", String.valueOf(i));
+            httpRequest.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "http");
             requests.add(httpRequest);
         }
         return sendRequests(remoteAddress, requests);
@@ -143,6 +182,7 @@ class Netty4HttpClient implements Closeable {
             request.headers().add(HttpHeaderNames.HOST, "localhost");
             request.headers().add(HttpHeaderNames.CONTENT_LENGTH, content.readableBytes());
             request.headers().add(HttpHeaderNames.CONTENT_TYPE, "application/json");
+            request.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "http");
             requests.add(request);
         }
         return sendRequests(remoteAddress, requests);
@@ -153,12 +193,14 @@ class Netty4HttpClient implements Closeable {
         final CountDownLatch latch = new CountDownLatch(requests.size());
         final List<FullHttpResponse> content = Collections.synchronizedList(new ArrayList<>(requests.size()));
 
-        clientBootstrap.handler(new CountDownLatchHandler(latch, content));
+        final AwaitableChannelInitializer handler = handlerFactory.apply(latch, content);
+        clientBootstrap.handler(handler);
 
         ChannelFuture channelFuture = null;
         try {
             channelFuture = clientBootstrap.connect(remoteAddress);
             channelFuture.sync();
+            handler.await();
 
             for (HttpRequest request : requests) {
                 channelFuture.channel().writeAndFlush(request);
@@ -184,12 +226,12 @@ class Netty4HttpClient implements Closeable {
     /**
      * helper factory which adds returned data to a list and uses a count down latch to decide when done
      */
-    private static class CountDownLatchHandler extends ChannelInitializer<SocketChannel> {
+    private static class CountDownLatchHandlerHttp extends AwaitableChannelInitializer {
 
         private final CountDownLatch latch;
         private final Collection<FullHttpResponse> content;
 
-        CountDownLatchHandler(final CountDownLatch latch, final Collection<FullHttpResponse> content) {
+        CountDownLatchHandlerHttp(final CountDownLatch latch, final Collection<FullHttpResponse> content) {
             this.latch = latch;
             this.content = content;
         }
@@ -220,6 +262,147 @@ class Netty4HttpClient implements Closeable {
             });
         }
 
+    }
+
+    /**
+     * The channel initializer with the ability to await for initialization to be completed
+     *
+     */
+    private static abstract class AwaitableChannelInitializer extends ChannelInitializer<SocketChannel> {
+        void await() {
+            // do nothing
+        }
+    }
+
+    /**
+     * helper factory which adds returned data to a list and uses a count down latch to decide when done
+     */
+    private static class CountDownLatchHandlerHttp2 extends AwaitableChannelInitializer {
+
+        private final CountDownLatch latch;
+        private final Collection<FullHttpResponse> content;
+        private Http2SettingsHandler settingsHandler;
+
+        CountDownLatchHandlerHttp2(final CountDownLatch latch, final Collection<FullHttpResponse> content) {
+            this.latch = latch;
+            this.content = content;
+        }
+
+        @Override
+        protected void initChannel(SocketChannel ch) {
+            final int maxContentLength = new ByteSizeValue(100, ByteSizeUnit.MB).bytesAsInt();
+            final Http2Connection connection = new DefaultHttp2Connection(false);
+            settingsHandler = new Http2SettingsHandler(ch.newPromise());
+
+            final ChannelInboundHandler responseHandler = new SimpleChannelInboundHandler<HttpObject>() {
+                @Override
+                protected void channelRead0(ChannelHandlerContext ctx, HttpObject msg) {
+                    final FullHttpResponse response = (FullHttpResponse) msg;
+
+                    // this is upgrade request, skipping it over
+                    if (Boolean.TRUE.equals(ctx.channel().attr(AttributeKey.valueOf("upgrade")).getAndRemove())) {
+                        return;
+                    }
+
+                    // We copy the buffer manually to avoid a huge allocation on a pooled allocator. We have
+                    // a test that tracks huge allocations, so we want to avoid them in this test code.
+                    ByteBuf newContent = Unpooled.copiedBuffer(((FullHttpResponse) msg).content());
+                    content.add(response.replace(newContent));
+                    latch.countDown();
+                }
+
+                @Override
+                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                    super.exceptionCaught(ctx, cause);
+                    latch.countDown();
+                }
+            };
+
+            final HttpToHttp2ConnectionHandler connectionHandler = new HttpToHttp2ConnectionHandlerBuilder().connection(connection)
+                .frameListener(
+                    new DelegatingDecompressorFrameListener(
+                        connection,
+                        new InboundHttp2ToHttpAdapterBuilder(connection).maxContentLength(maxContentLength).propagateSettings(true).build()
+                    )
+                )
+                .build();
+
+            final HttpClientCodec sourceCodec = new HttpClientCodec();
+            final Http2ClientUpgradeCodec upgradeCodec = new Http2ClientUpgradeCodec(connectionHandler);
+            final HttpClientUpgradeHandler upgradeHandler = new HttpClientUpgradeHandler(sourceCodec, upgradeCodec, maxContentLength);
+
+            ch.pipeline().addLast(sourceCodec);
+            ch.pipeline().addLast(upgradeHandler);
+            ch.pipeline().addLast(new HttpContentDecompressor());
+            ch.pipeline().addLast(new UpgradeRequestHandler(settingsHandler, responseHandler));
+        }
+
+        @Override
+        void await() {
+            try {
+                // Await for HTTP/2 settings being sent over before moving on to sending the requests
+                settingsHandler.awaitSettings(5, TimeUnit.SECONDS);
+            } catch (final Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
+    /**
+     * A handler that triggers the cleartext upgrade to HTTP/2 (h2c) by sending an
+     * initial HTTP request.
+     */
+    private static class UpgradeRequestHandler extends ChannelInboundHandlerAdapter {
+        private final ChannelInboundHandler settingsHandler;
+        private final ChannelInboundHandler responseHandler;
+
+        UpgradeRequestHandler(final ChannelInboundHandler settingsHandler, final ChannelInboundHandler responseHandler) {
+            this.settingsHandler = settingsHandler;
+            this.responseHandler = responseHandler;
+        }
+
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+            // The first request is HTTP/2 protocol upgrade (since we support only h2c there)
+            final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+            request.headers().add(HttpHeaderNames.HOST, "localhost");
+            request.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "http");
+
+            ctx.channel().attr(AttributeKey.newInstance("upgrade")).set(true);
+            ctx.writeAndFlush(request);
+            ctx.fireChannelActive();
+
+            ctx.pipeline().remove(this);
+            ctx.pipeline().addLast(settingsHandler);
+            ctx.pipeline().addLast(responseHandler);
+        }
+    }
+
+    private static class Http2SettingsHandler extends SimpleChannelInboundHandler<Http2Settings> {
+        private ChannelPromise promise;
+
+        Http2SettingsHandler(ChannelPromise promise) {
+            this.promise = promise;
+        }
+
+        /**
+         * Wait for this handler to be added after the upgrade to HTTP/2, and for initial preface
+         * handshake to complete.
+         */
+        void awaitSettings(long timeout, TimeUnit unit) throws Exception {
+            if (!promise.awaitUninterruptibly(timeout, unit)) {
+                throw new IllegalStateException("Timed out waiting for HTTP/2 settings");
+            }
+            if (!promise.isSuccess()) {
+                throw new RuntimeException(promise.cause());
+            }
+        }
+
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx, Http2Settings msg) throws Exception {
+            promise.setSuccess();
+            ctx.pipeline().remove(this);
+        }
     }
 
 }

--- a/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpServerPipeliningTests.java
+++ b/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpServerPipeliningTests.java
@@ -109,7 +109,7 @@ public class Netty4HttpServerPipeliningTests extends OpenSearchTestCase {
                 }
             }
 
-            try (Netty4HttpClient nettyHttpClient = new Netty4HttpClient()) {
+            try (Netty4HttpClient nettyHttpClient = Netty4HttpClient.http()) {
                 Collection<FullHttpResponse> responses = nettyHttpClient.get(transportAddress.address(), requests.toArray(new String[] {}));
                 try {
                     Collection<String> responseBodies = Netty4HttpClient.returnHttpResponseBodies(responses);
@@ -163,9 +163,12 @@ public class Netty4HttpServerPipeliningTests extends OpenSearchTestCase {
         @Override
         protected void initChannel(Channel ch) throws Exception {
             super.initChannel(ch);
-            ch.pipeline().replace("handler", "handler", new PossiblySlowUpstreamHandler(executorService));
         }
 
+        @Override
+        public ChannelHandler getRequestHandler() {
+            return new PossiblySlowUpstreamHandler(executorService);
+        }
     }
 
     class PossiblySlowUpstreamHandler extends SimpleChannelInboundHandler<HttpPipelinedRequest> {

--- a/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -202,7 +202,7 @@ public class Netty4HttpServerTransportTests extends OpenSearchTestCase {
         ) {
             transport.start();
             final TransportAddress remoteAddress = randomFrom(transport.boundAddress().boundAddresses());
-            try (Netty4HttpClient client = new Netty4HttpClient()) {
+            try (Netty4HttpClient client = Netty4HttpClient.http()) {
                 final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
                 request.headers().set(HttpHeaderNames.EXPECT, expectation);
                 HttpUtil.setContentLength(request, contentLength);
@@ -322,7 +322,7 @@ public class Netty4HttpServerTransportTests extends OpenSearchTestCase {
             transport.start();
             final TransportAddress remoteAddress = randomFrom(transport.boundAddress().boundAddresses());
 
-            try (Netty4HttpClient client = new Netty4HttpClient()) {
+            try (Netty4HttpClient client = Netty4HttpClient.http()) {
                 final String url = "/" + new String(new byte[maxInitialLineLength], Charset.forName("UTF-8"));
                 final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, url);
 
@@ -384,7 +384,7 @@ public class Netty4HttpServerTransportTests extends OpenSearchTestCase {
             transport.start();
             final TransportAddress remoteAddress = randomFrom(transport.boundAddress().boundAddresses());
 
-            try (Netty4HttpClient client = new Netty4HttpClient()) {
+            try (Netty4HttpClient client = Netty4HttpClient.http()) {
                 DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, url);
                 request.headers().add(HttpHeaderNames.ACCEPT_ENCODING, randomFrom("deflate", "gzip"));
                 long numOfHugeAllocations = getHugeAllocationCount();
@@ -454,7 +454,7 @@ public class Netty4HttpServerTransportTests extends OpenSearchTestCase {
             final TransportAddress remoteAddress = randomFrom(transport.boundAddress().boundAddresses());
 
             // Test pre-flight request
-            try (Netty4HttpClient client = new Netty4HttpClient()) {
+            try (Netty4HttpClient client = Netty4HttpClient.http()) {
                 final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.OPTIONS, "/");
                 request.headers().add(CorsHandler.ORIGIN, "test-cors.org");
                 request.headers().add(CorsHandler.ACCESS_CONTROL_REQUEST_METHOD, "POST");
@@ -471,7 +471,7 @@ public class Netty4HttpServerTransportTests extends OpenSearchTestCase {
             }
 
             // Test short-circuited request
-            try (Netty4HttpClient client = new Netty4HttpClient()) {
+            try (Netty4HttpClient client = Netty4HttpClient.http()) {
                 final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
                 request.headers().add(CorsHandler.ORIGIN, "google.com");
 


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Support for HTTP/2. The initial pull request adds:
 - `h2c` support (HTTP/2 over clear text)
 - uses HTTP/2 to HTTP codecs to keep existing handlers working  

Here are couple of examples:
- normal HTTP/1.1 request / response processing

```
$ curl http://localhost:9200 -v

*   Trying 127.0.0.1:9200...
* Connected to localhost (127.0.0.1) port 9200 (#0)
> GET / HTTP/1.1
> Host: localhost:9200
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< content-type: application/json; charset=UTF-8
< content-length: 560
< 
{
  "name" : "runTask-0",
  "cluster_name" : "runTask",
  "cluster_uuid" : "oUex0RlaQ9GsNt_IemilMQ",
  "version" : {
    "distribution" : "opensearch",
    "number" : "3.0.0-SNAPSHOT",
    "build_type" : "tar",
    "build_hash" : "786b8d5dfbc0abf16826f26b0faea7722faa4dbb",
    "build_date" : "2022-07-11T14:37:47.288002Z",
    "build_snapshot" : true,
    "lucene_version" : "9.3.0",
    "minimum_wire_compatibility_version" : "2.2.0",
    "minimum_index_compatibility_version" : "2.0.0"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}
```

- HTTP/1.1 to HTTP/2 upgrade:

```
$ curl http://localhost:9200 -v --http2
*   Trying 127.0.0.1:9200...
* Connected to localhost (127.0.0.1) port 9200 (#0)
> GET / HTTP/1.1
> Host: localhost:9200
> User-Agent: curl/7.81.0
> Accept: */*
> Connection: Upgrade, HTTP2-Settings
> Upgrade: h2c
> HTTP2-Settings: AAMAAABkAAQCAAAAAAIAAAAA
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 101 Switching Protocols
< connection: upgrade
< upgrade: h2c
* Received 101
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Connection state changed (MAX_CONCURRENT_STREAMS == 4294967295)!
< HTTP/2 200 
< content-type: application/json; charset=UTF-8
< content-length: 560
< 
{
  "name" : "runTask-0",
  "cluster_name" : "runTask",
  "cluster_uuid" : "oUex0RlaQ9GsNt_IemilMQ",
  "version" : {
    "distribution" : "opensearch",
    "number" : "3.0.0-SNAPSHOT",
    "build_type" : "tar",
    "build_hash" : "786b8d5dfbc0abf16826f26b0faea7722faa4dbb",
    "build_date" : "2022-07-11T14:37:47.288002Z",
    "build_snapshot" : true,
    "lucene_version" : "9.3.0",
    "minimum_wire_compatibility_version" : "2.2.0",
    "minimum_index_compatibility_version" : "2.0.0"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}
```

- HTTP/2 prior knowledge:

```
$ curl http://localhost:9200 -v --http2-prior-knowledge
*   Trying 127.0.0.1:9200...
* Connected to localhost (127.0.0.1) port 9200 (#0)
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x5650a63e9e80)
> GET / HTTP/2
> Host: localhost:9200
> user-agent: curl/7.81.0
> accept: */*
> 
* Connection state changed (MAX_CONCURRENT_STREAMS == 4294967295)!
< HTTP/2 200 
< content-type: application/json; charset=UTF-8
< content-length: 560
< 
{
  "name" : "runTask-0",
  "cluster_name" : "runTask",
  "cluster_uuid" : "oUex0RlaQ9GsNt_IemilMQ",
  "version" : {
    "distribution" : "opensearch",
    "number" : "3.0.0-SNAPSHOT",
    "build_type" : "tar",
    "build_hash" : "786b8d5dfbc0abf16826f26b0faea7722faa4dbb",
    "build_date" : "2022-07-11T14:37:47.288002Z",
    "build_snapshot" : true,
    "lucene_version" : "9.3.0",
    "minimum_wire_compatibility_version" : "2.2.0",
    "minimum_index_compatibility_version" : "2.0.0"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}
```
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/3651
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
