### PR TITLE
Fixing implausibly old time stamp 1970-01-01 00:00:00 by using the timestamp from the Git revision instead of default 0 value

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -289,6 +289,7 @@ allprojects {
     task.preserveFileTimestamps = false
     task.reproducibleFileOrder = true
     if (task instanceof SymbolicLinkPreservingTar) {
+      // Replace file timestamps with latest Git revision date (if available)
       task.lastModifiedTimestamp = BuildParams.getGitRevisionDate(project) 
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@
  * under the License.
  */
 
+import java.nio.charset.StandardCharsets;
+import java.io.ByteArrayOutputStream;
+
 import com.avast.gradle.dockercompose.tasks.ComposePull
 import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
 import de.thetaphi.forbiddenapis.gradle.ForbiddenApisPlugin
@@ -41,8 +44,11 @@ import org.opensearch.gradle.tar.SymbolicLinkPreservingTar
 import org.gradle.plugins.ide.eclipse.model.AccessRule
 import org.gradle.plugins.ide.eclipse.model.EclipseJdt
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
+import org.gradle.api.Project;
+import org.gradle.process.ExecResult;
 import org.gradle.util.DistributionLocator
 import org.gradle.util.GradleVersion
+
 import static org.opensearch.gradle.util.GradleUtils.maybeConfigure
 
 plugins {
@@ -150,6 +156,30 @@ Map<String, String> buildMetadataMap = buildMetadataValue.tokenize(';').collectE
   def (String key, String value) = it.split('=')
   return [key, value]
 }
+
+    /**
+     * Using 'git' command line (if available), tries to fetch the commit date of the current revision
+     * @return commit date of the current revision or 0 if it is not available
+     */
+long gitRevisionDate = {
+  // Try to get last commit date as Unix timestamp
+  try (ByteArrayOutputStream stdout = new ByteArrayOutputStream()) {
+     ExecResult result = project.exec(spec -> {
+        spec.setIgnoreExitValue(true);
+        spec.setStandardOutput(stdout);
+        spec.commandLine("git", "log", "-1", "--format=%ct");
+     });
+
+    if (result.getExitValue() == 0) {
+      return Long.parseLong(stdout.toString(StandardCharsets.UTF_8).replaceAll("\\s", "")) * 1000; /* seconds to millis */
+    }
+  } catch (IOException | GradleException | NumberFormatException ex) {
+    /* fall back to default Unix epoch timestamp */
+  }
+
+  return 0;
+}()
+
 
 // injecting groovy property variables into all projects
 allprojects {
@@ -290,7 +320,7 @@ allprojects {
     task.reproducibleFileOrder = true
     if (task instanceof SymbolicLinkPreservingTar) {
       // Replace file timestamps with latest Git revision date (if available)
-      task.lastModifiedTimestamp = BuildParams.getGitRevisionDate(project) 
+      task.lastModifiedTimestamp = gitRevisionDate 
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ import org.opensearch.gradle.Version
 import org.opensearch.gradle.VersionProperties
 import org.opensearch.gradle.info.BuildParams
 import org.opensearch.gradle.plugin.PluginBuildPlugin
+import org.opensearch.gradle.tar.SymbolicLinkPreservingTar
 import org.gradle.plugins.ide.eclipse.model.AccessRule
 import org.gradle.plugins.ide.eclipse.model.EclipseJdt
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
@@ -282,11 +283,14 @@ allprojects {
   }
 
   // support for reproducible builds
-  tasks.withType(AbstractArchiveTask).configureEach {
+  tasks.withType(AbstractArchiveTask).configureEach { task ->
     // ignore file timestamps
     // be consistent in archive file order
-    preserveFileTimestamps = false
-    reproducibleFileOrder = true
+    task.preserveFileTimestamps = false
+    task.reproducibleFileOrder = true
+    if (task instanceof SymbolicLinkPreservingTar) {
+      task.lastModifiedTimestamp = BuildParams.getGitRevisionDate(project) 
+    }
   }
 
   project.afterEvaluate {

--- a/buildSrc/src/main/java/org/opensearch/gradle/info/BuildParams.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/info/BuildParams.java
@@ -33,14 +33,9 @@ package org.opensearch.gradle.info;
 
 import org.opensearch.gradle.BwcVersions;
 import org.gradle.api.JavaVersion;
-import org.gradle.api.Project;
-import org.gradle.process.ExecResult;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.Modifier;
-import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -150,29 +145,6 @@ public class BuildParams {
 
     public static boolean isSnapshotBuild() {
         return value(BuildParams.isSnapshotBuild);
-    }
-
-    /**
-     * Using 'git' command line (if available), tries to fetch the commit date of the current revision
-     * @return commit date of the current revision or 0 if it is not available
-     */
-    public static long getGitRevisionDate(Project project) {
-        // Try to get last commit date as Unix timestamp
-        try (ByteArrayOutputStream stdout = new ByteArrayOutputStream()) {
-            final ExecResult result = project.exec(spec -> {
-                spec.setIgnoreExitValue(true);
-                spec.setStandardOutput(stdout);
-                spec.commandLine("git", "log", "-1", "--format=%ct");
-            });
-
-            if (result.getExitValue() == 0) {
-                return Long.parseLong(stdout.toString(StandardCharsets.UTF_8).replaceAll("\\s", "")) * 1000; /* seconds to millis */
-            }
-        } catch (IOException | NumberFormatException ex) {
-            /* fall back to default Unix epoch timestamp */
-        }
-
-        return 0;
     }
 
     private static <T> T value(T object) {

--- a/buildSrc/src/main/java/org/opensearch/gradle/info/BuildParams.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/info/BuildParams.java
@@ -166,8 +166,7 @@ public class BuildParams {
             });
 
             if (result.getExitValue() == 0) {
-                return Long.parseLong(new String(stdout.toByteArray(), StandardCharsets.UTF_8).replaceAll("\\s", ""))
-                    * 1000; /* seconds to millis */
+                return Long.parseLong(stdout.toString(StandardCharsets.UTF_8).replaceAll("\\s", "")) * 1000; /* seconds to millis */
             }
         } catch (IOException | NumberFormatException ex) {
             /* fall back to default Unix epoch timestamp */

--- a/buildSrc/src/main/java/org/opensearch/gradle/info/BuildParams.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/info/BuildParams.java
@@ -33,9 +33,14 @@ package org.opensearch.gradle.info;
 
 import org.opensearch.gradle.BwcVersions;
 import org.gradle.api.JavaVersion;
+import org.gradle.api.Project;
+import org.gradle.process.ExecResult;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -145,6 +150,30 @@ public class BuildParams {
 
     public static boolean isSnapshotBuild() {
         return value(BuildParams.isSnapshotBuild);
+    }
+
+    /**
+     * Using 'git' command line (if available), tries to fetch the commit date of the current revision
+     * @return commit date of the current revision or 0 if it is not available
+     */
+    public static long getGitRevisionDate(Project project) {
+        // Try to get last commit date as Unix timestamp
+        try (ByteArrayOutputStream stdout = new ByteArrayOutputStream()) {
+            final ExecResult result = project.exec(spec -> {
+                spec.setIgnoreExitValue(true);
+                spec.setStandardOutput(stdout);
+                spec.commandLine("git", "log", "-1", "--format=%ct");
+            });
+
+            if (result.getExitValue() == 0) {
+                return Long.parseLong(new String(stdout.toByteArray(), StandardCharsets.UTF_8).replaceAll("\\s", ""))
+                    * 1000; /* seconds to millis */
+            }
+        } catch (IOException | NumberFormatException ex) {
+            /* fall back to default Unix epoch timestamp */
+        }
+
+        return 0;
     }
 
     private static <T> T value(T object) {

--- a/buildSrc/src/main/java/org/opensearch/gradle/tar/SymbolicLinkPreservingTar.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/tar/SymbolicLinkPreservingTar.java
@@ -65,6 +65,11 @@ import java.util.Set;
  * This task is necessary because the built-in task {@link org.gradle.api.tasks.bundling.Tar} does not preserve symbolic links.
  */
 public class SymbolicLinkPreservingTar extends Tar {
+    private long lastModifiedTimestamp = 0;
+
+    public void setLastModifiedTimestamp(long lastModifiedTimestamp) {
+        this.lastModifiedTimestamp = lastModifiedTimestamp;
+    }
 
     @Override
     protected CopyAction createCopyAction() {
@@ -80,7 +85,7 @@ public class SymbolicLinkPreservingTar extends Tar {
                 compressor = new SimpleCompressor();
                 break;
         }
-        return new SymbolicLinkPreservingTarCopyAction(getArchiveFile(), compressor, isPreserveFileTimestamps());
+        return new SymbolicLinkPreservingTarCopyAction(getArchiveFile(), compressor, isPreserveFileTimestamps(), lastModifiedTimestamp);
     }
 
     private static class SymbolicLinkPreservingTarCopyAction implements CopyAction {
@@ -88,15 +93,18 @@ public class SymbolicLinkPreservingTar extends Tar {
         private final Provider<RegularFile> tarFile;
         private final ArchiveOutputStreamFactory compressor;
         private final boolean isPreserveFileTimestamps;
+        private final long lastModifiedTimestamp;
 
         SymbolicLinkPreservingTarCopyAction(
             final Provider<RegularFile> tarFile,
             final ArchiveOutputStreamFactory compressor,
-            final boolean isPreserveFileTimestamps
+            final boolean isPreserveFileTimestamps,
+            final long lastModifiedTimestamp
         ) {
             this.tarFile = tarFile;
             this.compressor = compressor;
             this.isPreserveFileTimestamps = isPreserveFileTimestamps;
+            this.lastModifiedTimestamp = lastModifiedTimestamp;
         }
 
         @Override
@@ -219,7 +227,7 @@ public class SymbolicLinkPreservingTar extends Tar {
         }
 
         private long getModTime(final FileCopyDetails details) {
-            return isPreserveFileTimestamps ? details.getLastModified() : 0;
+            return isPreserveFileTimestamps ? details.getLastModified() : lastModifiedTimestamp;
         }
 
     }


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Fixing implausibly old time stamp 1970-01-01 00:00:00 by using the timestamp from the Git revision instead of default 0 value.
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/2412
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
