### PR TITLE
Add coverage, gha, jenkins server, documentation and forum badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
+<img src="https://opensearch.org/assets/img/opensearch-logo-themed.svg" height="64px">
+
+[![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://forum.opensearch.org/c/opensearch/)
+[![Documentation](https://img.shields.io/badge/documentation-reference-blue)](https://opensearch.org/docs/latest/opensearch/index/)
 [![codecov](https://codecov.io/gh/opensearch-project/OpenSearch/branch/2.0/graph/badge.svg)](https://codecov.io/gh/opensearch-project/OpenSearch)
 [![GHA gradle check](https://github.com/opensearch-project/OpenSearch/actions/workflows/gradle-check.yml/badge.svg)](https://github.com/opensearch-project/OpenSearch/actions/workflows/gradle-check.yml)
 [![GHA validate pull request](https://github.com/opensearch-project/OpenSearch/actions/workflows/wrapper.yml/badge.svg)](https://github.com/opensearch-project/OpenSearch/actions/workflows/wrapper.yml)
 [![GHA precommit](https://github.com/opensearch-project/OpenSearch/actions/workflows/precommit.yml/badge.svg)](https://github.com/opensearch-project/OpenSearch/actions/workflows/precommit.yml)
 [![Jenkins gradle check job](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fbuild.ci.opensearch.org%2Fjob%2Fgradle-check%2F&label=Jenkins%20Gradle%20Check)](https://build.ci.opensearch.org/job/gradle-check/)
-[![Documentation](https://img.shields.io/badge/doc-reference-blue)](https://opensearch.org/docs/latest/opensearch/index/)
-[![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://forum.opensearch.org/c/opensearch/)
-
-<img src="https://opensearch.org/assets/img/opensearch-logo-themed.svg" height="64px">
 
 - [Welcome!](#welcome)
 - [Project Resources](#project-resources)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+[![codecov](https://codecov.io/gh/opensearch-project/OpenSearch/branch/2.0/graph/badge.svg)](https://codecov.io/gh/opensearch-project/OpenSearch)
+[![GHA gradle check](https://github.com/opensearch-project/OpenSearch/actions/workflows/gradle-check.yml/badge.svg)](https://github.com/opensearch-project/OpenSearch/actions/workflows/gradle-check.yml)
+[![GHA validate pull request](https://github.com/opensearch-project/OpenSearch/actions/workflows/wrapper.yml/badge.svg)](https://github.com/opensearch-project/OpenSearch/actions/workflows/wrapper.yml)
+[![GHA precommit](https://github.com/opensearch-project/OpenSearch/actions/workflows/precommit.yml/badge.svg)](https://github.com/opensearch-project/OpenSearch/actions/workflows/precommit.yml)
+[![Jenkins gradle check job](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fbuild.ci.opensearch.org%2Fjob%2Fgradle-check%2F&label=Jenkins%20Gradle%20Check)](https://build.ci.opensearch.org/job/gradle-check/)
+[![Documentation](https://img.shields.io/badge/doc-reference-blue)](https://opensearch.org/docs/latest/opensearch/index/)
+[![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://forum.opensearch.org/c/opensearch/)
+
 <img src="https://opensearch.org/assets/img/opensearch-logo-themed.svg" height="64px">
 
 - [Welcome!](#welcome)


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Adds badges to readme for different jobs listed below

1. GHA gradle check
2. GHA precommit
3. GHA validate pull request
4. Public jenkins gradle check
5. Documentation
6. Forum

### Issues Resolved
#1323 

### Related
#850 

<img width="843" alt="Screen Shot 2022-07-13 at 11 10 43 AM" src="https://user-images.githubusercontent.com/79435743/178802137-457b815a-eb36-486c-b89a-ad09370e3d64.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
