### PR TITLE
[2.x] Deprecate public class names with master terminology (#3871)

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/LocalNodeMasterListener.java
+++ b/server/src/main/java/org/opensearch/cluster/LocalNodeMasterListener.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.cluster;
+
+/**
+ * Enables listening to cluster-manager changes events of the local node (when the local node becomes the cluster-manager, and when the local
+ * node cease being a cluster-manager).
+ *
+ * @opensearch.internal
+ * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link LocalNodeClusterManagerListener}
+ */
+@Deprecated
+public interface LocalNodeMasterListener extends LocalNodeClusterManagerListener {
+
+}

--- a/server/src/main/java/org/opensearch/cluster/MasterNodeChangePredicate.java
+++ b/server/src/main/java/org/opensearch/cluster/MasterNodeChangePredicate.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.cluster;
+
+import java.util.function.Predicate;
+
+/**
+ * Utility class to build a predicate that accepts cluster state changes
+ *
+ * @opensearch.internal
+ * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link ClusterManagerNodeChangePredicate}
+ */
+@Deprecated
+public final class MasterNodeChangePredicate {
+
+    private MasterNodeChangePredicate() {
+
+    }
+
+    public static Predicate<ClusterState> build(ClusterState currentState) {
+        return ClusterManagerNodeChangePredicate.build(currentState);
+    }
+}

--- a/server/src/main/java/org/opensearch/cluster/NotMasterException.java
+++ b/server/src/main/java/org/opensearch/cluster/NotMasterException.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.cluster;
+
+import org.opensearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * Thrown when a node join request or a cluster-manager ping reaches a node which is not
+ * currently acting as a cluster-manager or when a cluster state update task is to be executed
+ * on a node that is no longer cluster-manager.
+ *
+ * @opensearch.internal
+ * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link NotClusterManagerException}
+ */
+@Deprecated
+public class NotMasterException extends NotClusterManagerException {
+
+    public NotMasterException(String msg) {
+        super(msg);
+    }
+
+    public NotMasterException(StreamInput in) throws IOException {
+        super(in);
+    }
+
+}

--- a/server/src/main/java/org/opensearch/cluster/coordination/NoMasterBlockService.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/NoMasterBlockService.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.cluster.coordination;
+
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+
+/**
+ * Service to block the master node
+ *
+ * @opensearch.internal
+ * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link NoClusterManagerBlockService}
+ */
+@Deprecated
+public class NoMasterBlockService extends NoClusterManagerBlockService {
+
+    public NoMasterBlockService(Settings settings, ClusterSettings clusterSettings) {
+        super(settings, clusterSettings);
+    }
+
+}

--- a/server/src/main/java/org/opensearch/cluster/coordination/UnsafeBootstrapMasterCommand.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/UnsafeBootstrapMasterCommand.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.cluster.coordination;
+
+/**
+ * Tool to run an unsafe bootstrap
+ *
+ * @opensearch.internal
+ * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link UnsafeBootstrapClusterManagerCommand}
+ */
+@Deprecated
+public class UnsafeBootstrapMasterCommand extends UnsafeBootstrapClusterManagerCommand {
+
+    UnsafeBootstrapMasterCommand() {
+        super();
+    }
+
+}

--- a/server/src/main/java/org/opensearch/common/settings/ConsistentSettingsService.java
+++ b/server/src/main/java/org/opensearch/common/settings/ConsistentSettingsService.java
@@ -36,7 +36,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterStateUpdateTask;
-import org.opensearch.cluster.LocalNodeClusterManagerListener;
+import org.opensearch.cluster.LocalNodeMasterListener;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Priority;
@@ -88,10 +88,10 @@ public final class ConsistentSettingsService {
     }
 
     /**
-     * Returns a {@link LocalNodeClusterManagerListener} that will publish hashes of all the settings passed in the constructor. These hashes are
+     * Returns a {@link LocalNodeMasterListener} that will publish hashes of all the settings passed in the constructor. These hashes are
      * published by the cluster-manager node only. Note that this is not designed for {@link SecureSettings} implementations that are mutable.
      */
-    public LocalNodeClusterManagerListener newHashPublisher() {
+    public LocalNodeMasterListener newHashPublisher() {
         // eagerly compute hashes to be published
         final Map<String, String> computedHashesOfConsistentSettings = computeHashesOfConsistentSecureSettings();
         return new HashesPublisher(computedHashesOfConsistentSettings, clusterService);
@@ -246,7 +246,7 @@ public final class ConsistentSettingsService {
         }
     }
 
-    static final class HashesPublisher implements LocalNodeClusterManagerListener {
+    static final class HashesPublisher implements LocalNodeMasterListener {
 
         // eagerly compute hashes to be published
         final Map<String, String> computedHashesOfConsistentSettings;

--- a/server/src/main/java/org/opensearch/discovery/MasterNotDiscoveredException.java
+++ b/server/src/main/java/org/opensearch/discovery/MasterNotDiscoveredException.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.discovery;
+
+import org.opensearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * Exception when the cluster-manager is not discovered
+ *
+ * @opensearch.internal
+ * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link ClusterManagerNotDiscoveredException}
+ */
+@Deprecated
+public class MasterNotDiscoveredException extends ClusterManagerNotDiscoveredException {
+
+    public MasterNotDiscoveredException() {
+        super();
+    }
+
+    public MasterNotDiscoveredException(Throwable cause) {
+        super(cause);
+    }
+
+    public MasterNotDiscoveredException(String message) {
+        super(message);
+    }
+
+    public MasterNotDiscoveredException(StreamInput in) throws IOException {
+        super(in);
+    }
+}

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestMasterAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestMasterAction.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.rest.action.cat;
+
+/**
+ * _cat API action to list cluster_manager information
+ *
+ * @opensearch.api
+ * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link RestClusterManagerAction}
+ */
+@Deprecated
+public class RestMasterAction extends RestClusterManagerAction {
+
+}

--- a/server/src/test/java/org/opensearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/opensearch/ExceptionSerializationTests.java
@@ -44,6 +44,7 @@ import org.opensearch.action.search.SearchPhaseExecutionException;
 import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.action.support.replication.ReplicationOperation;
 import org.opensearch.client.AbstractClientHeadersTestCase;
+import org.opensearch.cluster.NotMasterException;
 import org.opensearch.cluster.action.shard.ShardStateAction;
 import org.opensearch.cluster.block.ClusterBlockException;
 import org.opensearch.cluster.coordination.CoordinationStateRejectedException;
@@ -69,6 +70,7 @@ import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.common.util.CancellableThreadsTests;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.common.xcontent.XContentLocation;
+import org.opensearch.discovery.MasterNotDiscoveredException;
 import org.opensearch.env.ShardLockObtainFailedException;
 import org.opensearch.index.Index;
 import org.opensearch.index.engine.RecoveryEngineException;
@@ -234,6 +236,9 @@ public class ExceptionSerializationTests extends OpenSearchTestCase {
         Files.walkFileTree(testStartPath, visitor);
         assertTrue(notRegistered.remove(TestException.class));
         assertTrue(notRegistered.remove(UnknownHeaderException.class));
+        // Remove the deprecated exception classes from the unregistered list.
+        assertTrue(notRegistered.remove(NotMasterException.class));
+        assertTrue(notRegistered.remove(MasterNotDiscoveredException.class));
         assertTrue("Classes subclassing OpenSearchException must be registered \n" + notRegistered.toString(), notRegistered.isEmpty());
         assertTrue(registered.removeAll(OpenSearchException.getRegisteredKeys())); // check
         assertEquals(registered.toString(), 0, registered.size());

--- a/server/src/test/java/org/opensearch/action/RenamedTimeoutRequestParameterTests.java
+++ b/server/src/test/java/org/opensearch/action/RenamedTimeoutRequestParameterTests.java
@@ -66,6 +66,7 @@ import org.opensearch.rest.action.admin.cluster.RestDeleteStoredScriptAction;
 import org.opensearch.rest.action.admin.cluster.RestGetStoredScriptAction;
 import org.opensearch.rest.action.admin.cluster.RestPutStoredScriptAction;
 import org.opensearch.rest.action.cat.RestAllocationAction;
+import org.opensearch.rest.action.cat.RestMasterAction;
 import org.opensearch.rest.action.cat.RestRepositoriesAction;
 import org.opensearch.rest.action.cat.RestThreadPoolAction;
 import org.opensearch.rest.action.cat.RestClusterManagerAction;
@@ -135,6 +136,12 @@ public class RenamedTimeoutRequestParameterTests extends OpenSearchTestCase {
 
     public void testCatClusterManager() {
         RestClusterManagerAction action = new RestClusterManagerAction();
+        Exception e = assertThrows(OpenSearchParseException.class, () -> action.doCatRequest(getRestRequestWithBothParams(), client));
+        assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
+    }
+
+    public void testCatMaster() {
+        RestMasterAction action = new RestMasterAction();
         Exception e = assertThrows(OpenSearchParseException.class, () -> action.doCatRequest(getRestRequestWithBothParams(), client));
         assertThat(e.getMessage(), containsString(DUPLICATE_PARAMETER_ERROR_MESSAGE));
     }


### PR DESCRIPTION
### Description
Backport PR https://github.com/opensearch-project/OpenSearch/pull/3871 / commit https://github.com/opensearch-project/OpenSearch/commit/0e96a878a5ab1ffec3ee04f15fe976d34c9905dc

- Add back the usage of old names for some classes for backwards compatibility. Those public classes were renamed from "master" to "cluster manager" In PR https://github.com/opensearch-project/OpenSearch/pull/3619 / commit https://github.com/opensearch-project/OpenSearch/commit/a7e113a67a9d8c4dd7298956174ff2f666a2c2b7.
 - Add a unit test to validate the backwards compatibility of interface `LocalNodeMasterListener` remains.

**List of classes that renamed in previous PR:**
In this PR, the usages of the old names should all be restored.
`sever` directory:
interface LocalNodeMasterListener -> LocalNodeClusterManagerListener
final class MasterNodeChangePredicate -> ClusterManagerNodeChangePredicate
NotMasterException -> NotClusterManagerException
NoMasterBlockService -> NoClusterManagerBlockService
UnsafeBootstrapMasterCommand - UnsafeBootstrapClusterManagerCommand
MasterNotDiscoveredException -> ClusterManagerNotDiscoveredException
RestMasterAction -> RestClusterManagerAction

**List of classes that was not renamed:**
`sever` directory:
MasterService
`test/framework` directory:
FakeThreadPoolMasterService
BlockMasterServiceOnMaster
BusyMasterServiceDisruption
 
### Issues Resolved
The second step to resolve issue https://github.com/opensearch-project/OpenSearch/issues/3543
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
