### PR TITLE
Build performance improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -320,7 +320,7 @@ allprojects {
     task.reproducibleFileOrder = true
     if (task instanceof SymbolicLinkPreservingTar) {
       // Replace file timestamps with latest Git revision date (if available)
-      task.lastModifiedTimestamp = gitRevisionDate 
+      task.lastModifiedTimestamp = gitRevisionDate
     }
   }
 
@@ -359,7 +359,8 @@ allprojects {
           project.javadoc.dependsOn "${upstreamProject.path}:javadoc"
           String externalLinkName = upstreamProject.archivesBaseName
           String artifactPath = dep.group.replaceAll('\\.', '/') + '/' + externalLinkName.replaceAll('\\.', '/') + '/' + dep.version
-          project.javadoc.options.linksOffline artifactsHost + "/javadoc/" + artifactPath, "${upstreamProject.buildDir}/docs/javadoc/"
+          String projectRelativePath = project.relativePath(upstreamProject.buildDir)
+          project.javadoc.options.linksOffline artifactsHost + "/javadoc/" + artifactPath, "${projectRelativePath}/docs/javadoc/"
         }
       }
       boolean hasShadow = project.plugins.hasPlugin(ShadowPlugin)

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -392,7 +392,7 @@ tasks.register('buildRpm', Rpm) {
 }
 
 tasks.register('buildNoJdkRpm', Rpm) {
-  configure(commonRpmConfig(true, 'x64'))
+  configure(commonRpmConfig(false, 'x64'))
 }
 
 Closure dpkgExists = { it -> new File('/bin/dpkg-deb').exists() || new File('/usr/bin/dpkg-deb').exists() || new File('/usr/local/bin/dpkg-deb').exists() }

--- a/gradle/missing-javadoc.gradle
+++ b/gradle/missing-javadoc.gradle
@@ -70,7 +70,7 @@ allprojects {
       classpath = sourceSets.main.compileClasspath
       srcDirSet = sourceSets.main.java
 
-      outputDir = project.javadoc.destinationDir
+      outputDir = file("${project.buildDir}/tmp/missingJavadoc/")
     }
   }
 }
@@ -183,6 +183,7 @@ configure(project(":server")) {
   }
 }
 
+@CacheableTask
 class MissingJavadocTask extends DefaultTask {
   @InputFiles
   @SkipWhenEmpty
@@ -227,7 +228,8 @@ class MissingJavadocTask extends DefaultTask {
   @Input
   def executable
 
-  @Input
+  @InputFiles
+  @PathSensitive(PathSensitivity.RELATIVE)
   def taskResources
 
   /** Utility method to recursively collect all tasks with same name like this one that we depend on */


### PR DESCRIPTION
### Description
This Pull Request proposes small improvements to the build script logic to improve performance and cache hit ratio in the project.
 
### Issues Resolved
* Fixed compilation avoidance for tasks `buildNoJdkRpm` and `buildRpm` #3927
* Makes `missingJavadoc` task cacheable
* `javadoc` outputs are reusable between different environments

### Build improvements 

#### Compilation avoidance
The configuration of the task `buildNoJdkRpm` is:
```
tasks.register('buildNoJdkRpm', Rpm) {
  configure(commonRpmConfig(true, 'x64'))
}
```
The current configuration was setting the incorrect parameter `jdk` to true. This configuration was causing in incremental build scenarios the execution of the tasks. After setting the correct parameter tasks are UP-TO-DATE.
Results:
Main branch: https://scans.gradle.com/s/2wvwfoybovs3e
This PR: https://scans.gradle.com/s/jdjx4vxwgqy4w

#### MissingJavadoc cacheable
Caching was not enabled for the task. We are updating the task definition with:
```
@CacheableTask
class MissingJavadocTask extends DefaultTask {
```
Additionally, we are avoiding the potential [overlapping outputs](https://docs.gradle.org/current/userguide/build_cache_concepts.html#concepts_overlapping_outputs) issue setting the output of the task in a different folder.
Results:
Main branch: https://scans.gradle.com/s/lpchzshhoe5iy/performance/build-cache
This PR: https://scans.gradle.com/s/x65oz7h3l7xks/performance/build-cache
 
#### Javadoc output reusable in different environments
When we are building from different environments(CI, different local paths), javadoc tasks were not cacheable. This was caused by the usage of the absolute path in the property `javadoc.options.linksOffline`:
```
project.javadoc.options.linksOffline artifactsHost + "/javadoc/" + artifactPath, "${upstreamProject.buildDir}/docs/javadoc/"
```
This PR updates the configuration to use a relative path in the property.
Results:
Main: https://scans.gradle.com/s/mpbt2xbmg3ety/performance/build-cache
This PR: https://scans.gradle.com/s/vkxooiwndw3sq/performance/build-cache


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
