### PR TITLE
Add support for ppc64, ppc64le and riscv64 architectures

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/Architecture.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/Architecture.java
@@ -42,6 +42,9 @@ public enum Architecture {
         switch (architecture) {
             case "amd64":
             case "x86_64":
+            case "ppc64":
+            case "ppc64le":
+            case "riscv64":
                 return X64;
             case "aarch64":
                 return ARM64;

--- a/buildSrc/src/main/java/org/opensearch/gradle/Architecture.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/Architecture.java
@@ -35,19 +35,23 @@ package org.opensearch.gradle;
 public enum Architecture {
 
     X64,
-    ARM64;
+    ARM64,
+    PPC,
+    RISCV;
 
     public static Architecture current() {
         final String architecture = System.getProperty("os.arch", "");
         switch (architecture) {
             case "amd64":
             case "x86_64":
-            case "ppc64":
-            case "ppc64le":
-            case "riscv64":
                 return X64;
             case "aarch64":
                 return ARM64;
+            case "ppc64":
+            case "ppc64le":
+                return PPC;
+            case "riscv64":
+                return RISCV;
             default:
                 throw new IllegalArgumentException("can not determine architecture from [" + architecture + "]");
         }

--- a/buildSrc/src/test/java/org/opensearch/gradle/ArchitectureTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/ArchitectureTests.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gradle;
+
+import org.opensearch.gradle.test.GradleUnitTestCase;
+
+public class ArchitectureTests extends GradleUnitTestCase {
+
+    final String architecture = System.getProperty("os.arch", "");
+
+    public void testCurrentArchitecture() {
+        assertEquals(Architecture.X64, currentArchitecture("amd64"));
+        assertEquals(Architecture.X64, currentArchitecture("x86_64"));
+        assertEquals(Architecture.X64, currentArchitecture("ppc64"));
+        assertEquals(Architecture.X64, currentArchitecture("ppc64le"));
+        assertEquals(Architecture.X64, currentArchitecture("riscv64"));
+
+        assertEquals(Architecture.ARM64, currentArchitecture("aarch64"));
+    }
+
+    public void testInvalidCurrentArchitecture() {
+        assertThrows(
+            "can not determine architecture from [",
+            IllegalArgumentException.class,
+            () -> currentArchitecture("fooBar64")
+        );
+    }
+
+    /**
+     * Determines the return value of {@link Architecture#current()} based on a string representing a potential OS Architecture.
+     *
+     * @param osArchToTest  An expected value of the {@code os.arch} system property on another architecture.
+     * @return the value of the {@link Architecture} enum which would have resulted with the given value.
+     * @throws IllegalArgumentException if the string is not mapped to a value of the {@link Architecture} enum.
+     */
+    private Architecture currentArchitecture(String osArchToTest) throws IllegalArgumentException {
+        // Test new architecture
+        System.setProperty("os.arch", osArchToTest);
+        try {
+            return Architecture.current();
+        } finally {
+            // Restore actual architecture property value
+            System.setProperty("os.arch", this.architecture);
+        }
+    }
+}

--- a/buildSrc/src/test/java/org/opensearch/gradle/ArchitectureTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/ArchitectureTests.java
@@ -25,11 +25,7 @@ public class ArchitectureTests extends GradleUnitTestCase {
     }
 
     public void testInvalidCurrentArchitecture() {
-        assertThrows(
-            "can not determine architecture from [",
-            IllegalArgumentException.class,
-            () -> currentArchitecture("fooBar64")
-        );
+        assertThrows("can not determine architecture from [", IllegalArgumentException.class, () -> currentArchitecture("fooBar64"));
     }
 
     /**

--- a/buildSrc/src/test/java/org/opensearch/gradle/ArchitectureTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/ArchitectureTests.java
@@ -17,11 +17,10 @@ public class ArchitectureTests extends GradleUnitTestCase {
     public void testCurrentArchitecture() {
         assertEquals(Architecture.X64, currentArchitecture("amd64"));
         assertEquals(Architecture.X64, currentArchitecture("x86_64"));
-        assertEquals(Architecture.X64, currentArchitecture("ppc64"));
-        assertEquals(Architecture.X64, currentArchitecture("ppc64le"));
-        assertEquals(Architecture.X64, currentArchitecture("riscv64"));
-
         assertEquals(Architecture.ARM64, currentArchitecture("aarch64"));
+        assertEquals(Architecture.PPC, currentArchitecture("ppc64"));
+        assertEquals(Architecture.PPC, currentArchitecture("ppc64le"));
+        assertEquals(Architecture.RISCV, currentArchitecture("riscv64"));
     }
 
     public void testInvalidCurrentArchitecture() {


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description
Properly parses the Architecture enum when building for ppc64, ppc64le, and RISC-V 64 architectures.
 
### Issues Resolved
Fixes #1303.  Fixes #2341.  Supersedes PR #3435.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
