### PR TITLE
PR coverage requirement and default settings

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        target: 70%    # the required coverage value
+        threshold: 1%  # the leniency in hitting the target


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Add PR code coverage requirement and default settings. Used `70%` coverage based on existing coverage which is just above 70%. 

As an improvement, project specific status checks can be added. For e.g. `server/` which contains the core logic should have strict rules and separate status checks. 
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/1324


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
