### PR TITLE
Adding missing Java docs for new Translog implementation

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
@@ -285,9 +285,9 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
 
     /**
      * Reads operations from the translog
-     * @param location
+     * @param location location of translog
      * @return the translog operation
-     * @throws IOException
+     * @throws IOException throws an IO exception
      */
     @Override
     public Translog.Operation readOperation(Translog.Location location) throws IOException {
@@ -296,9 +296,9 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
 
     /**
      * Adds an operation to the translog
-     * @param operation
+     * @param operation operation to add to translog
      * @return the location in the translog
-     * @throws IOException
+     * @throws IOException throws an IO exception
      */
     @Override
     public Translog.Location add(Translog.Operation operation) throws IOException {
@@ -396,8 +396,8 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
 
     /**
      *
-     * @param localCheckpointOfLastCommit
-     * @param flushThreshold
+     * @param localCheckpointOfLastCommit local checkpoint reference of last commit to translog
+     * @param flushThreshold threshold to flush to translog
      * @return if the translog should be flushed
      */
     public boolean shouldPeriodicallyFlush(long localCheckpointOfLastCommit, long flushThreshold) {

--- a/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
@@ -98,15 +98,15 @@ public interface TranslogManager {
      * Reads operations for the translog
      * @param location the location in the translog
      * @return the translog operation
-     * @throws IOException
+     * @throws IOException throws an IO exception when reading the file fails
      */
     Translog.Operation readOperation(Translog.Location location) throws IOException;
 
     /**
      * Adds an operation to the translog
-     * @param operation
+     * @param operation to add to translog
      * @return the location in the translog
-     * @throws IOException
+     * @throws IOException throws an IO exception if adding an operation fails
      */
     Translog.Location add(Translog.Operation operation) throws IOException;
 


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Missing Java docs is causing failures on my local builds. 
Was trying to debug: https://github.com/opensearch-project/OpenSearch/pull/3935#issuecomment-1188047019

Seeing failures: Not sure why CI is not seeing this problem. Will take it as a follow up.
```
./gradlew ':server:test' --tests "org.opensearch.common.time.DateUtilsTests.testTimezoneIds" 

> Configure project :qa:os
Cannot add task 'destructiveDistroTest.docker' as a task with that name already exists.
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 7.5
  OS Info               : Linux 5.4.0-1037-aws (amd64)
  JDK Version           : 14 (Private Build JDK)
  JAVA_HOME             : /usr/lib/jvm/java-14-openjdk-amd64
  Random Testing Seed   : BB94918BD913A13B
  In FIPS 140 mode      : false
=======================================

> Task :server:compileJava
/home/ubuntu/joda-opensearch/server/src/main/java/org/opensearch/index/translog/TranslogManager.java:101: warning: no description for @throws
     * @throws IOException
       ^
/home/ubuntu/joda-opensearch/server/src/main/java/org/opensearch/index/translog/TranslogManager.java:107: warning: no description for @param
     * @param operation
       ^
/home/ubuntu/joda-opensearch/server/src/main/java/org/opensearch/index/translog/TranslogManager.java:109: warning: no description for @throws
     * @throws IOException
       ^
/home/ubuntu/joda-opensearch/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java:288: warning: no description for @param
     * @param location
       ^
/home/ubuntu/joda-opensearch/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java:290: warning: no description for @throws
     * @throws IOException
       ^
/home/ubuntu/joda-opensearch/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java:299: warning: no description for @param
     * @param operation
       ^
/home/ubuntu/joda-opensearch/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java:301: warning: no description for @throws
     * @throws IOException
       ^
/home/ubuntu/joda-opensearch/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java:399: warning: no description for @param
     * @param localCheckpointOfLastCommit
       ^
/home/ubuntu/joda-opensearch/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java:400: warning: no description for @param
     * @param flushThreshold
       ^
error: warnings found and -Werror specified
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 error
9 warnings

> Task :server:compileJava FAILED

FAILURE: Build failed with an exception.
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
