### PR TITLE
Add getHistoryOperationsFromTranslog method to fetch the history snapshot from translogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Plugin ZIP publication groupId value is configurable ([#4156](https://github.com/opensearch-project/OpenSearch/pull/4156))
 - Add index specific setting for remote repository ([#4253](https://github.com/opensearch-project/OpenSearch/pull/4253))
 - [Segment Replication] Update replicas to commit SegmentInfos instead of relying on SIS files from primary shards. ([#4402](https://github.com/opensearch-project/OpenSearch/pull/4402))
+- [CCR] Add getHistoryOperationsFromTranslog method to fetch the history snapshot from translogs ([#3948](https://github.com/opensearch-project/OpenSearch/pull/3948))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -2358,6 +2358,16 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     /**
+     * Creates a new history snapshot from the translog instead of the lucene index. Required for cross cluster replication.
+     * Use the recommended {@link #getHistoryOperations(String, long, long, boolean)} method for other cases.
+     * Depending on how translog durability is configured, this method might/might not return the snapshot. For e.g,
+     * If the translog has been configured with no-durability, it'll return UnsupportedOperationException.
+     */
+    public Translog.Snapshot getHistoryOperationsFromTranslog(long startingSeqNo, long endSeqNo) throws IOException {
+        return getEngine().translogManager().newChangesSnapshot(startingSeqNo, endSeqNo, true);
+    }
+
+    /**
      * Checks if we have a completed history of operations since the given starting seqno (inclusive).
      * This method should be called after acquiring the retention lock; See {@link #acquireHistoryRetentionLock()}
      */

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -2363,7 +2363,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * This method should only be invoked if Segment Replication or Remote Store is not enabled.
      */
     public Translog.Snapshot getHistoryOperationsFromTranslog(long startingSeqNo, long endSeqNo) throws IOException {
-        assert !(indexSettings.isSegRepEnabled() || indexSettings.isRemoteStoreEnabled())
+        assert (indexSettings.isSegRepEnabled() || indexSettings.isRemoteStoreEnabled()) == false
             : "unsupported operation for segment replication enabled indices or remote store backed indices";
         return getEngine().translogManager().newChangesSnapshot(startingSeqNo, endSeqNo, true);
     }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -2360,10 +2360,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     /**
      * Creates a new history snapshot from the translog instead of the lucene index. Required for cross cluster replication.
      * Use the recommended {@link #getHistoryOperations(String, long, long, boolean)} method for other cases.
-     * Depending on how translog durability is configured, this method might/might not return the snapshot. For e.g,
-     * If the translog has been configured with no-durability, it'll return UnsupportedOperationException.
+     * This method should only be invoked if Segment Replication or Remote Store is not enabled.
      */
     public Translog.Snapshot getHistoryOperationsFromTranslog(long startingSeqNo, long endSeqNo) throws IOException {
+        assert !(indexSettings.isSegRepEnabled() || indexSettings.isRemoteStoreEnabled())
+            : "unsupported operation for segment replication enabled indices or remote store backed indices";
         return getEngine().translogManager().newChangesSnapshot(startingSeqNo, endSeqNo, true);
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
@@ -98,6 +98,11 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
         }
     }
 
+    @Override
+    public Translog.Snapshot newChangesSnapshot(long fromSeqNo, long toSeqNo, boolean requiredFullRange) throws IOException {
+        return translog.newSnapshot(fromSeqNo, toSeqNo, requiredFullRange);
+    }
+
     /**
      * Performs recovery from the transaction log up to {@code recoverUpToSeqNo} (inclusive).
      * This operation will close the engine if the recovery fails.

--- a/server/src/main/java/org/opensearch/index/translog/NoOpTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/NoOpTranslogManager.java
@@ -112,4 +112,9 @@ public class NoOpTranslogManager implements TranslogManager {
     public Translog.Location add(Translog.Operation operation) throws IOException {
         return new Translog.Location(0, 0, 0);
     }
+
+    @Override
+    public Translog.Snapshot newChangesSnapshot(long fromSeqNo, long toSeqNo, boolean requiredFullRange) throws IOException {
+        throw new UnsupportedOperationException("Translog snapshot unsupported with no-op translogs");
+    }
 }

--- a/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
@@ -34,6 +34,11 @@ public interface TranslogManager {
     int recoverFromTranslog(TranslogRecoveryRunner translogRecoveryRunner, long localCheckpoint, long recoverUpToSeqNo) throws IOException;
 
     /**
+     * Creates a new history snapshot from the translog file instead of the lucene index.
+     */
+    Translog.Snapshot newChangesSnapshot(long fromSeqNo, long toSeqNo, boolean requiredFullRange) throws IOException;
+
+    /**
      * Checks if the underlying storage sync is required.
      */
     boolean isTranslogSyncNeeded();

--- a/server/src/main/java/org/opensearch/index/translog/WriteOnlyTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/WriteOnlyTranslogManager.java
@@ -68,4 +68,9 @@ public class WriteOnlyTranslogManager extends InternalTranslogManager {
     public void skipTranslogRecovery() {
         // Do nothing.
     }
+
+    @Override
+    public Translog.Snapshot newChangesSnapshot(long fromSeqNo, long toSeqNo, boolean requiredFullRange) throws IOException {
+        throw new UnsupportedOperationException("Translog snapshot unsupported with no-op translogs");
+    }
 }


### PR DESCRIPTION
### Description
Add getHistoryOperationsFromTranslog method to fetch the hostory snapshot from translogs

Original issue for reference: https://github.com/opensearch-project/OpenSearch/issues/2482
 
### Issues Resolved
[375](https://github.com/opensearch-project/cross-cluster-replication/issues/375)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
