### PR TITLE
[2.x] Rename and deprecate public methods that contains 'master' in the name in 'server' directory (#3647)

### DIFF
--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/RetryTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/RetryTests.java
@@ -123,7 +123,7 @@ public class RetryTests extends OpenSearchIntegTestCase {
              */
             NodeInfo clusterManagerNode = null;
             for (NodeInfo candidate : client.admin().cluster().prepareNodesInfo().get().getNodes()) {
-                if (candidate.getNode().isMasterNode()) {
+                if (candidate.getNode().isClusterManagerNode()) {
                     clusterManagerNode = candidate;
                 }
             }

--- a/plugins/discovery-azure-classic/src/internalClusterTest/java/org/opensearch/discovery/azure/classic/AzureSimpleTests.java
+++ b/plugins/discovery-azure-classic/src/internalClusterTest/java/org/opensearch/discovery/azure/classic/AzureSimpleTests.java
@@ -51,7 +51,7 @@ public class AzureSimpleTests extends AbstractAzureComputeServiceTestCase {
         final String node1 = internalCluster().startNode(settings);
         registerAzureNode(node1);
         assertNotNull(
-            client().admin().cluster().prepareState().setClusterManagerNodeTimeout("1s").get().getState().nodes().getMasterNodeId()
+            client().admin().cluster().prepareState().setClusterManagerNodeTimeout("1s").get().getState().nodes().getClusterManagerNodeId()
         );
 
         // We expect having 1 node as part of the cluster, let's test that
@@ -66,7 +66,7 @@ public class AzureSimpleTests extends AbstractAzureComputeServiceTestCase {
         final String node1 = internalCluster().startNode(settings);
         registerAzureNode(node1);
         assertNotNull(
-            client().admin().cluster().prepareState().setClusterManagerNodeTimeout("1s").get().getState().nodes().getMasterNodeId()
+            client().admin().cluster().prepareState().setClusterManagerNodeTimeout("1s").get().getState().nodes().getClusterManagerNodeId()
         );
 
         // We expect having 1 node as part of the cluster, let's test that

--- a/plugins/discovery-azure-classic/src/internalClusterTest/java/org/opensearch/discovery/azure/classic/AzureTwoStartedNodesTests.java
+++ b/plugins/discovery-azure-classic/src/internalClusterTest/java/org/opensearch/discovery/azure/classic/AzureTwoStartedNodesTests.java
@@ -54,14 +54,14 @@ public class AzureTwoStartedNodesTests extends AbstractAzureComputeServiceTestCa
         final String node1 = internalCluster().startNode(settings);
         registerAzureNode(node1);
         assertNotNull(
-            client().admin().cluster().prepareState().setClusterManagerNodeTimeout("1s").get().getState().nodes().getMasterNodeId()
+            client().admin().cluster().prepareState().setClusterManagerNodeTimeout("1s").get().getState().nodes().getClusterManagerNodeId()
         );
 
         logger.info("--> start another node");
         final String node2 = internalCluster().startNode(settings);
         registerAzureNode(node2);
         assertNotNull(
-            client().admin().cluster().prepareState().setClusterManagerNodeTimeout("1s").get().getState().nodes().getMasterNodeId()
+            client().admin().cluster().prepareState().setClusterManagerNodeTimeout("1s").get().getState().nodes().getClusterManagerNodeId()
         );
 
         // We expect having 2 nodes as part of the cluster, let's test that

--- a/plugins/discovery-gce/src/internalClusterTest/java/org/opensearch/discovery/gce/GceDiscoverTests.java
+++ b/plugins/discovery-gce/src/internalClusterTest/java/org/opensearch/discovery/gce/GceDiscoverTests.java
@@ -96,7 +96,7 @@ public class GceDiscoverTests extends OpenSearchIntegTestCase {
             .clear()
             .setNodes(true)
             .get();
-        assertNotNull(clusterStateResponse.getState().nodes().getMasterNodeId());
+        assertNotNull(clusterStateResponse.getState().nodes().getClusterManagerNodeId());
 
         // start another node
         final String secondNode = internalCluster().startNode();
@@ -109,7 +109,7 @@ public class GceDiscoverTests extends OpenSearchIntegTestCase {
             .setNodes(true)
             .setLocal(true)
             .get();
-        assertNotNull(clusterStateResponse.getState().nodes().getMasterNodeId());
+        assertNotNull(clusterStateResponse.getState().nodes().getClusterManagerNodeId());
 
         // wait for the cluster to form
         assertNoTimeout(client().admin().cluster().prepareHealth().setWaitForNodes(Integer.toString(2)).get());

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/state/TransportClusterStateActionDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/state/TransportClusterStateActionDisruptionIT.java
@@ -82,7 +82,10 @@ public class TransportClusterStateActionDisruptionIT extends OpenSearchIntegTest
             } catch (ClusterManagerNotDiscoveredException e) {
                 return; // ok, we hit the disconnected node
             }
-            assertNotNull("should always contain a cluster-manager node", clusterStateResponse.getState().nodes().getMasterNodeId());
+            assertNotNull(
+                "should always contain a cluster-manager node",
+                clusterStateResponse.getState().nodes().getClusterManagerNodeId()
+            );
         });
     }
 
@@ -134,7 +137,7 @@ public class TransportClusterStateActionDisruptionIT extends OpenSearchIntegTest
             }
             if (clusterStateResponse.isWaitForTimedOut() == false) {
                 final ClusterState state = clusterStateResponse.getState();
-                assertNotNull("should always contain a cluster-manager node", state.nodes().getMasterNodeId());
+                assertNotNull("should always contain a cluster-manager node", state.nodes().getClusterManagerNodeId());
                 assertThat("waited for metadata version", state.metadata().version(), greaterThanOrEqualTo(waitForMetadataVersion));
             }
         });

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/MinimumClusterManagerNodesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/MinimumClusterManagerNodesIT.java
@@ -168,7 +168,7 @@ public class MinimumClusterManagerNodesIT extends OpenSearchIntegTestCase {
         assertThat(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
         // verify that both nodes are still in the cluster state but there is no cluster-manager
         assertThat(state.nodes().getSize(), equalTo(2));
-        assertThat(state.nodes().getMasterNode(), equalTo(null));
+        assertThat(state.nodes().getClusterManagerNode(), equalTo(null));
 
         logger.info("--> starting the previous cluster-manager node again...");
         node2Name = internalCluster().startNode(Settings.builder().put(settings).put(clusterManagerDataPathSettings).build());
@@ -387,7 +387,7 @@ public class MinimumClusterManagerNodesIT extends OpenSearchIntegTestCase {
         assertThat(failure.get(), instanceOf(FailedToCommitClusterStateException.class));
 
         logger.debug("--> check that there is no cluster-manager in minor partition");
-        assertBusy(() -> assertThat(clusterManagerClusterService.state().nodes().getMasterNode(), nullValue()));
+        assertBusy(() -> assertThat(clusterManagerClusterService.state().nodes().getClusterManagerNode(), nullValue()));
 
         // let major partition to elect new cluster-manager, to ensure that old cluster-manager is not elected once partition is restored,
         // otherwise persistent setting (which is a part of accepted state on old cluster-manager) will be propagated to other nodes
@@ -401,7 +401,7 @@ public class MinimumClusterManagerNodesIT extends OpenSearchIntegTestCase {
                 .actionGet()
                 .getState()
                 .nodes()
-                .getMasterNode();
+                .getClusterManagerNode();
             assertThat(clusterManagerNode, notNullValue());
             assertThat(clusterManagerNode.getName(), not(equalTo(clusterManager)));
         });

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/SimpleClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/SimpleClusterStateIT.java
@@ -473,7 +473,7 @@ public class SimpleClusterStateIT extends OpenSearchIntegTestCase {
                     return;
                 }
 
-                if (state.nodes().isLocalNodeElectedMaster()) {
+                if (state.nodes().isLocalNodeElectedClusterManager()) {
                     if (state.custom("test") == null) {
                         if (installed.compareAndSet(false, true)) {
                             clusterService.submitStateUpdateTask("install-metadata-custom", new ClusterStateUpdateTask(Priority.URGENT) {

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/SpecificClusterManagerNodesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/SpecificClusterManagerNodesIT.java
@@ -69,7 +69,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
                     .actionGet()
                     .getState()
                     .nodes()
-                    .getMasterNodeId(),
+                    .getClusterManagerNodeId(),
                 nullValue()
             );
             fail("should not be able to find cluster-manager");
@@ -87,7 +87,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
                 .actionGet()
                 .getState()
                 .nodes()
-                .getMasterNode()
+                .getClusterManagerNode()
                 .getName(),
             equalTo(clusterManagerNodeName)
         );
@@ -100,7 +100,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
                 .actionGet()
                 .getState()
                 .nodes()
-                .getMasterNode()
+                .getClusterManagerNode()
                 .getName(),
             equalTo(clusterManagerNodeName)
         );
@@ -119,7 +119,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
                     .actionGet()
                     .getState()
                     .nodes()
-                    .getMasterNodeId(),
+                    .getClusterManagerNodeId(),
                 nullValue()
             );
             fail("should not be able to find cluster-manager");
@@ -140,7 +140,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
                 .actionGet()
                 .getState()
                 .nodes()
-                .getMasterNode()
+                .getClusterManagerNode()
                 .getName(),
             equalTo(nextClusterManagerEligibleNodeName)
         );
@@ -153,7 +153,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
                 .actionGet()
                 .getState()
                 .nodes()
-                .getMasterNode()
+                .getClusterManagerNode()
                 .getName(),
             equalTo(nextClusterManagerEligibleNodeName)
         );
@@ -173,7 +173,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
                     .actionGet()
                     .getState()
                     .nodes()
-                    .getMasterNodeId(),
+                    .getClusterManagerNodeId(),
                 nullValue()
             );
             fail("should not be able to find cluster-manager");
@@ -191,7 +191,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
                 .actionGet()
                 .getState()
                 .nodes()
-                .getMasterNode()
+                .getClusterManagerNode()
                 .getName(),
             equalTo(clusterManagerNodeName)
         );
@@ -204,7 +204,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
                 .actionGet()
                 .getState()
                 .nodes()
-                .getMasterNode()
+                .getClusterManagerNode()
                 .getName(),
             equalTo(clusterManagerNodeName)
         );
@@ -220,7 +220,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
                 .actionGet()
                 .getState()
                 .nodes()
-                .getMasterNode()
+                .getClusterManagerNode()
                 .getName(),
             equalTo(clusterManagerNodeName)
         );
@@ -233,7 +233,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
                 .actionGet()
                 .getState()
                 .nodes()
-                .getMasterNode()
+                .getClusterManagerNode()
                 .getName(),
             equalTo(clusterManagerNodeName)
         );
@@ -246,7 +246,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
                 .actionGet()
                 .getState()
                 .nodes()
-                .getMasterNode()
+                .getClusterManagerNode()
                 .getName(),
             equalTo(clusterManagerNodeName)
         );
@@ -264,7 +264,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
                     .actionGet()
                     .getState()
                     .nodes()
-                    .getMasterNode()
+                    .getClusterManagerNode()
                     .getName(),
                 equalTo(nextClusterManagerEligableNodeName)
             );
@@ -277,7 +277,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
                     .actionGet()
                     .getState()
                     .nodes()
-                    .getMasterNode()
+                    .getClusterManagerNode()
                     .getName(),
                 equalTo(nextClusterManagerEligableNodeName)
             );
@@ -292,7 +292,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
                 .actionGet()
                 .getState()
                 .nodes()
-                .getMasterNode()
+                .getClusterManagerNode()
                 .getName(),
             equalTo(nextClusterManagerEligableNodeName)
         );
@@ -305,7 +305,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
                 .actionGet()
                 .getState()
                 .nodes()
-                .getMasterNode()
+                .getClusterManagerNode()
                 .getName(),
             equalTo(nextClusterManagerEligableNodeName)
         );

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/RareClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/RareClusterStateIT.java
@@ -244,13 +244,13 @@ public class RareClusterStateIT extends OpenSearchIntegTestCase {
 
         // Check routing tables
         ClusterState state = client().admin().cluster().prepareState().get().getState();
-        assertEquals(clusterManager, state.nodes().getMasterNode().getName());
+        assertEquals(clusterManager, state.nodes().getClusterManagerNode().getName());
         List<ShardRouting> shards = state.routingTable().allShards("index");
         assertThat(shards, hasSize(1));
         for (ShardRouting shard : shards) {
             if (shard.primary()) {
                 // primary must not be on the cluster-manager node
-                assertFalse(state.nodes().getMasterNodeId().equals(shard.currentNodeId()));
+                assertFalse(state.nodes().getClusterManagerNodeId().equals(shard.currentNodeId()));
             } else {
                 fail(); // only primaries
             }
@@ -336,13 +336,13 @@ public class RareClusterStateIT extends OpenSearchIntegTestCase {
 
         // Check routing tables
         ClusterState state = client().admin().cluster().prepareState().get().getState();
-        assertEquals(clusterManager, state.nodes().getMasterNode().getName());
+        assertEquals(clusterManager, state.nodes().getClusterManagerNode().getName());
         List<ShardRouting> shards = state.routingTable().allShards("index");
         assertThat(shards, hasSize(2));
         for (ShardRouting shard : shards) {
             if (shard.primary()) {
                 // primary must be on the cluster-manager
-                assertEquals(state.nodes().getMasterNodeId(), shard.currentNodeId());
+                assertEquals(state.nodes().getClusterManagerNodeId(), shard.currentNodeId());
             } else {
                 assertTrue(shard.active());
             }

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/VotingConfigurationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/VotingConfigurationIT.java
@@ -105,7 +105,7 @@ public class VotingConfigurationIT extends OpenSearchIntegTestCase {
         final Set<String> votingConfiguration = clusterState.getLastCommittedConfiguration().getNodeIds();
         assertThat(votingConfiguration, hasSize(3));
         assertThat(clusterState.nodes().getSize(), equalTo(4));
-        assertThat(votingConfiguration, hasItem(clusterState.nodes().getMasterNodeId()));
+        assertThat(votingConfiguration, hasItem(clusterState.nodes().getClusterManagerNodeId()));
         for (DiscoveryNode discoveryNode : clusterState.nodes()) {
             if (votingConfiguration.contains(discoveryNode.getId()) == false) {
                 assertThat(excludedNodeName, nullValue());
@@ -155,7 +155,10 @@ public class VotingConfigurationIT extends OpenSearchIntegTestCase {
             .setMetadata(true)
             .get()
             .getState();
-        assertThat(newClusterState.nodes().getMasterNode().getName(), equalTo(excludedNodeName));
-        assertThat(newClusterState.getLastCommittedConfiguration().getNodeIds(), hasItem(newClusterState.nodes().getMasterNodeId()));
+        assertThat(newClusterState.nodes().getClusterManagerNode().getName(), equalTo(excludedNodeName));
+        assertThat(
+            newClusterState.getLastCommittedConfiguration().getNodeIds(),
+            hasItem(newClusterState.nodes().getClusterManagerNodeId())
+        );
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/ClusterManagerDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/ClusterManagerDisruptionIT.java
@@ -171,7 +171,11 @@ public class ClusterManagerDisruptionIT extends AbstractDisruptionTestCase {
                 try {
                     assertEquals("unequal versions", state.version(), nodeState.version());
                     assertEquals("unequal node count", state.nodes().getSize(), nodeState.nodes().getSize());
-                    assertEquals("different cluster-managers ", state.nodes().getMasterNodeId(), nodeState.nodes().getMasterNodeId());
+                    assertEquals(
+                        "different cluster-managers ",
+                        state.nodes().getClusterManagerNodeId(),
+                        nodeState.nodes().getClusterManagerNodeId()
+                    );
                     assertEquals("different meta data version", state.metadata().version(), nodeState.metadata().version());
                     assertEquals("different routing", state.routingTable().toString(), nodeState.routingTable().toString());
                 } catch (AssertionError t) {
@@ -238,7 +242,7 @@ public class ClusterManagerDisruptionIT extends AbstractDisruptionTestCase {
         for (String node : partitions.getMajoritySide()) {
             ClusterState nodeState = getNodeClusterState(node);
             boolean success = true;
-            if (nodeState.nodes().getMasterNode() == null) {
+            if (nodeState.nodes().getClusterManagerNode() == null) {
                 success = false;
             }
             if (!nodeState.blocks().global().isEmpty()) {

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/DiscoveryDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/DiscoveryDisruptionIT.java
@@ -71,7 +71,7 @@ public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
 
         TransportService clusterManagerTranspotService = internalCluster().getInstance(
             TransportService.class,
-            discoveryNodes.getMasterNode().getName()
+            discoveryNodes.getClusterManagerNode().getName()
         );
 
         logger.info("blocking requests from non cluster-manager [{}] to cluster-manager [{}]", nonClusterManagerNode, clusterManagerNode);

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/StableClusterManagerDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/StableClusterManagerDisruptionIT.java
@@ -129,7 +129,7 @@ public class StableClusterManagerDisruptionIT extends OpenSearchIntegTestCase {
     private void ensureNoMaster(String node) throws Exception {
         assertBusy(
             () -> assertNull(
-                client(node).admin().cluster().state(new ClusterStateRequest().local(true)).get().getState().nodes().getMasterNode()
+                client(node).admin().cluster().state(new ClusterStateRequest().local(true)).get().getState().nodes().getClusterManagerNode()
             )
         );
     }
@@ -220,8 +220,8 @@ public class StableClusterManagerDisruptionIT extends OpenSearchIntegTestCase {
         for (final String node : majoritySide) {
             clusterManagers.put(node, new ArrayList<>());
             internalCluster().getInstance(ClusterService.class, node).addListener(event -> {
-                DiscoveryNode previousClusterManager = event.previousState().nodes().getMasterNode();
-                DiscoveryNode currentClusterManager = event.state().nodes().getMasterNode();
+                DiscoveryNode previousClusterManager = event.previousState().nodes().getClusterManagerNode();
+                DiscoveryNode currentClusterManager = event.state().nodes().getClusterManagerNode();
                 if (!Objects.equals(previousClusterManager, currentClusterManager)) {
                     logger.info(
                         "--> node {} received new cluster state: {} \n and had previous cluster state: {}",
@@ -238,7 +238,7 @@ public class StableClusterManagerDisruptionIT extends OpenSearchIntegTestCase {
 
         final CountDownLatch oldClusterManagerNodeSteppedDown = new CountDownLatch(1);
         internalCluster().getInstance(ClusterService.class, oldClusterManagerNode).addListener(event -> {
-            if (event.state().nodes().getMasterNodeId() == null) {
+            if (event.state().nodes().getClusterManagerNodeId() == null) {
                 oldClusterManagerNodeSteppedDown.countDown();
             }
         });

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/single/SingleNodeDiscoveryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/single/SingleNodeDiscoveryIT.java
@@ -112,7 +112,7 @@ public class SingleNodeDiscoveryIT extends OpenSearchIntegTestCase {
             final ClusterState second = other.getInstance(ClusterService.class).state();
             assertThat(first.nodes().getSize(), equalTo(1));
             assertThat(second.nodes().getSize(), equalTo(1));
-            assertThat(first.nodes().getMasterNodeId(), not(equalTo(second.nodes().getMasterNodeId())));
+            assertThat(first.nodes().getClusterManagerNodeId(), not(equalTo(second.nodes().getClusterManagerNodeId())));
             assertThat(first.metadata().clusterUUID(), not(equalTo(second.metadata().clusterUUID())));
         }
     }

--- a/server/src/internalClusterTest/java/org/opensearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/recovery/IndexRecoveryIT.java
@@ -1510,7 +1510,7 @@ public class IndexRecoveryIT extends OpenSearchIntegTestCase {
             );
             phase1ReadyBlocked.await();
             internalCluster().restartNode(
-                clusterService().state().nodes().getMasterNode().getName(),
+                clusterService().state().nodes().getClusterManagerNode().getName(),
                 new InternalTestCluster.RestartCallback()
             );
             internalCluster().ensureAtLeastNumDataNodes(3);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequest.java
@@ -132,7 +132,7 @@ public class AddVotingConfigExclusionsRequest extends ClusterManagerNodeRequest<
         if (nodeDescriptions.length >= 1) {
             newVotingConfigExclusions = Arrays.stream(allNodes.resolveNodes(nodeDescriptions))
                 .map(allNodes::get)
-                .filter(DiscoveryNode::isMasterNode)
+                .filter(DiscoveryNode::isClusterManagerNode)
                 .map(VotingConfigExclusion::new)
                 .collect(Collectors.toSet());
 
@@ -147,7 +147,7 @@ public class AddVotingConfigExclusionsRequest extends ClusterManagerNodeRequest<
             for (String nodeId : nodeIds) {
                 if (allNodes.nodeExists(nodeId)) {
                     DiscoveryNode discoveryNode = allNodes.get(nodeId);
-                    if (discoveryNode.isMasterNode()) {
+                    if (discoveryNode.isClusterManagerNode()) {
                         newVotingConfigExclusions.add(new VotingConfigExclusion(discoveryNode));
                     }
                 } else {
@@ -162,7 +162,7 @@ public class AddVotingConfigExclusionsRequest extends ClusterManagerNodeRequest<
             for (String nodeName : nodeNames) {
                 if (existingNodes.containsKey(nodeName)) {
                     DiscoveryNode discoveryNode = existingNodes.get(nodeName);
-                    if (discoveryNode.isMasterNode()) {
+                    if (discoveryNode.isClusterManagerNode()) {
                         newVotingConfigExclusions.add(new VotingConfigExclusion(discoveryNode));
                     }
                 } else {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponse.java
@@ -284,8 +284,14 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
         return clusterStateHealth.getNumberOfDataNodes();
     }
 
+    public boolean hasDiscoveredClusterManager() {
+        return clusterStateHealth.hasDiscoveredClusterManager();
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #hasDiscoveredClusterManager()} */
+    @Deprecated
     public boolean hasDiscoveredMaster() {
-        return clusterStateHealth.hasDiscoveredMaster();
+        return hasDiscoveredClusterManager();
     }
 
     public int getNumberOfPendingTasks() {
@@ -385,8 +391,8 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
         builder.field(TIMED_OUT, isTimedOut());
         builder.field(NUMBER_OF_NODES, getNumberOfNodes());
         builder.field(NUMBER_OF_DATA_NODES, getNumberOfDataNodes());
-        builder.field(DISCOVERED_MASTER, hasDiscoveredMaster());  // the field will be removed in a future major version
-        builder.field(DISCOVERED_CLUSTER_MANAGER, hasDiscoveredMaster());
+        builder.field(DISCOVERED_MASTER, hasDiscoveredClusterManager());  // the field will be removed in a future major version
+        builder.field(DISCOVERED_CLUSTER_MANAGER, hasDiscoveredClusterManager());
         builder.field(ACTIVE_PRIMARY_SHARDS, getActivePrimaryShards());
         builder.field(ACTIVE_SHARDS, getActiveShards());
         builder.field(RELOCATING_SHARDS, getRelocatingShards());

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -221,7 +221,7 @@ public class TransportClusterHealthAction extends TransportClusterManagerNodeRea
                     }
 
                     @Override
-                    public void onNoLongerMaster(String source) {
+                    public void onNoLongerClusterManager(String source) {
                         logger.trace(
                             "stopped being cluster-manager while waiting for events with priority [{}]. retrying.",
                             request.waitForEvents()

--- a/server/src/main/java/org/opensearch/action/admin/cluster/repositories/cleanup/TransportCleanupRepositoryAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/repositories/cleanup/TransportCleanupRepositoryAction.java
@@ -126,14 +126,14 @@ public final class TransportCleanupRepositoryAction extends TransportClusterMana
         // We add a state applier that will remove any dangling repository cleanup actions on cluster-manager failover.
         // This is safe to do since cleanups will increment the repository state id before executing any operations to prevent concurrent
         // operations from corrupting the repository. This is the same safety mechanism used by snapshot deletes.
-        if (DiscoveryNode.isMasterNode(clusterService.getSettings())) {
+        if (DiscoveryNode.isClusterManagerNode(clusterService.getSettings())) {
             addClusterStateApplier(clusterService);
         }
     }
 
     private static void addClusterStateApplier(ClusterService clusterService) {
         clusterService.addStateApplier(event -> {
-            if (event.localNodeMaster() && event.previousState().nodes().isLocalNodeElectedMaster() == false) {
+            if (event.localNodeClusterManager() && event.previousState().nodes().isLocalNodeElectedClusterManager() == false) {
                 final RepositoryCleanupInProgress repositoryCleanupInProgress = event.state()
                     .custom(RepositoryCleanupInProgress.TYPE, RepositoryCleanupInProgress.EMPTY);
                 if (repositoryCleanupInProgress.hasCleanupInProgress() == false) {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -163,7 +163,7 @@ public class TransportClusterUpdateSettingsAction extends TransportClusterManage
                     // We're about to send a second update task, so we need to check if we're still the elected cluster-manager
                     // For example the minimum_master_node could have been breached and we're no longer elected cluster-manager,
                     // so we should *not* execute the reroute.
-                    if (!clusterService.state().nodes().isLocalNodeElectedMaster()) {
+                    if (!clusterService.state().nodes().isLocalNodeElectedClusterManager()) {
                         logger.debug("Skipping reroute after cluster update settings, because node is no longer cluster-manager");
                         listener.onResponse(
                             new ClusterUpdateSettingsResponse(
@@ -201,7 +201,7 @@ public class TransportClusterUpdateSettingsAction extends TransportClusterManage
                             }
 
                             @Override
-                            public void onNoLongerMaster(String source) {
+                            public void onNoLongerClusterManager(String source) {
                                 logger.debug(
                                     "failed to preform reroute after cluster settings were updated - current node is no longer a cluster-manager"
                                 );

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/ClusterStateResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/ClusterStateResponse.java
@@ -129,7 +129,7 @@ public class ClusterStateResponse extends ActionResponse {
         }
         DiscoveryNodes nodes = clusterState.getNodes();
         if (nodes != null) {
-            return nodes.getMasterNodeId();
+            return nodes.getClusterManagerNodeId();
         } else {
             return null;
         }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -127,7 +127,7 @@ public class TransportClusterStateAction extends TransportClusterManagerNodeRead
 
         final Predicate<ClusterState> acceptableClusterStateOrNotMasterPredicate = request.local()
             ? acceptableClusterStatePredicate
-            : acceptableClusterStatePredicate.or(clusterState -> clusterState.nodes().isLocalNodeElectedMaster() == false);
+            : acceptableClusterStatePredicate.or(clusterState -> clusterState.nodes().isLocalNodeElectedClusterManager() == false);
 
         if (acceptableClusterStatePredicate.test(state)) {
             ActionListener.completeWith(listener, () -> buildResponse(request, state));

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -197,7 +197,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<
         }
 
         ClusterHealthStatus clusterStatus = null;
-        if (clusterService.state().nodes().isLocalNodeElectedMaster()) {
+        if (clusterService.state().nodes().isLocalNodeElectedClusterManager()) {
             clusterStatus = new ClusterStateHealth(clusterService.state()).getStatus();
         }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/delete/TransportDeleteIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/delete/TransportDeleteIndexTemplateAction.java
@@ -108,7 +108,7 @@ public class TransportDeleteIndexTemplateAction extends TransportClusterManagerN
         final ActionListener<AcknowledgedResponse> listener
     ) {
         indexTemplateService.removeTemplates(
-            new MetadataIndexTemplateService.RemoveRequest(request.name()).masterTimeout(request.clusterManagerNodeTimeout()),
+            new MetadataIndexTemplateService.RemoveRequest(request.name()).clusterManagerTimeout(request.clusterManagerNodeTimeout()),
             new MetadataIndexTemplateService.RemoveListener() {
                 @Override
                 public void onResponse(MetadataIndexTemplateService.RemoveResponse response) {

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
@@ -125,7 +125,7 @@ public class TransportPutIndexTemplateAction extends TransportClusterManagerNode
                 .mappings(request.mappings())
                 .aliases(request.aliases())
                 .create(request.create())
-                .masterTimeout(request.clusterManagerNodeTimeout())
+                .clusterManagerTimeout(request.clusterManagerNodeTimeout())
                 .version(request.version()),
 
             new MetadataIndexTemplateService.PutListener() {

--- a/server/src/main/java/org/opensearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/opensearch/action/bulk/TransportShardBulkAction.java
@@ -169,7 +169,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
         performOnPrimary(request, primary, updateHelper, threadPool::absoluteTimeInMillis, (update, shardId, mappingListener) -> {
             assert update != null;
             assert shardId != null;
-            mappingUpdatedAction.updateMappingOnMaster(shardId.getIndex(), update, mappingListener);
+            mappingUpdatedAction.updateMappingOnClusterManager(shardId.getIndex(), update, mappingListener);
         }, mappingUpdateListener -> observer.waitForNextChange(new ClusterStateObserver.Listener() {
             @Override
             public void onNewClusterState(ClusterState state) {
@@ -626,7 +626,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
         }
         if (result.getResultType() == Engine.Result.Type.MAPPING_UPDATE_REQUIRED) {
             // Even though the primary waits on all nodes to ack the mapping changes to the cluster-manager
-            // (see MappingUpdatedAction.updateMappingOnMaster) we still need to protect against missing mappings
+            // (see MappingUpdatedAction.updateMappingOnClusterManager) we still need to protect against missing mappings
             // and wait for them. The reason is concurrent requests. Request r1 which has new field f triggers a
             // mapping update. Assume that that update is first applied on the primary, and only later on the replica
             // (it’s happening concurrently). Request r2, which now arrives on the primary and which also has the new

--- a/server/src/main/java/org/opensearch/cluster/ClusterChangedEvent.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterChangedEvent.java
@@ -213,8 +213,18 @@ public class ClusterChangedEvent {
     /**
      * Returns <code>true</code> iff the local node is the mater node of the cluster.
      */
+    public boolean localNodeClusterManager() {
+        return state.nodes().isLocalNodeElectedClusterManager();
+    }
+
+    /**
+     * Returns <code>true</code> iff the local node is the mater node of the cluster.
+     *
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #localNodeClusterManager()}
+     */
+    @Deprecated
     public boolean localNodeMaster() {
-        return state.nodes().isLocalNodeElectedMaster();
+        return localNodeClusterManager();
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/ClusterManagerNodeChangePredicate.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterManagerNodeChangePredicate.java
@@ -53,10 +53,10 @@ public final class ClusterManagerNodeChangePredicate {
      */
     public static Predicate<ClusterState> build(ClusterState currentState) {
         final long currentVersion = currentState.version();
-        final DiscoveryNode clusterManagerNode = currentState.nodes().getMasterNode();
+        final DiscoveryNode clusterManagerNode = currentState.nodes().getClusterManagerNode();
         final String currentMasterId = clusterManagerNode == null ? null : clusterManagerNode.getEphemeralId();
         return newState -> {
-            final DiscoveryNode newClusterManager = newState.nodes().getMasterNode();
+            final DiscoveryNode newClusterManager = newState.nodes().getClusterManagerNode();
             final boolean accept;
             if (newClusterManager == null) {
                 accept = false;

--- a/server/src/main/java/org/opensearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterState.java
@@ -404,8 +404,8 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
      * In essence that means that all the changes from the other cluster state are also reflected by the current one
      */
     public boolean supersedes(ClusterState other) {
-        return this.nodes().getMasterNodeId() != null
-            && this.nodes().getMasterNodeId().equals(other.nodes().getMasterNodeId())
+        return this.nodes().getClusterManagerNodeId() != null
+            && this.nodes().getClusterManagerNodeId().equals(other.nodes().getClusterManagerNodeId())
             && this.version() > other.version();
 
     }
@@ -485,12 +485,12 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
         }
 
         if (metrics.contains(Metric.MASTER_NODE)) {
-            builder.field("master_node", nodes().getMasterNodeId());
+            builder.field("master_node", nodes().getClusterManagerNodeId());
         }
 
         // Value of the field is identical with the above, and aims to replace the above field.
         if (metrics.contains(Metric.CLUSTER_MANAGER_NODE)) {
-            builder.field("cluster_manager_node", nodes().getMasterNodeId());
+            builder.field("cluster_manager_node", nodes().getClusterManagerNodeId());
         }
 
         if (metrics.contains(Metric.BLOCKS)) {

--- a/server/src/main/java/org/opensearch/cluster/ClusterStateObserver.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterStateObserver.java
@@ -311,7 +311,7 @@ public class ClusterStateObserver {
         private final long version;
 
         StoredState(ClusterState clusterState) {
-            this.clusterManagerNodeId = clusterState.nodes().getMasterNodeId();
+            this.clusterManagerNodeId = clusterState.nodes().getClusterManagerNodeId();
             this.version = clusterState.version();
         }
 
@@ -320,7 +320,7 @@ public class ClusterStateObserver {
          * */
         public boolean isOlderOrDifferentClusterManager(ClusterState clusterState) {
             return version < clusterState.version()
-                || Objects.equals(clusterManagerNodeId, clusterState.nodes().getMasterNodeId()) == false;
+                || Objects.equals(clusterManagerNodeId, clusterState.nodes().getClusterManagerNodeId()) == false;
         }
     }
 

--- a/server/src/main/java/org/opensearch/cluster/ClusterStateTaskExecutor.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterStateTaskExecutor.java
@@ -52,8 +52,18 @@ public interface ClusterStateTaskExecutor<T> {
     /**
      * indicates whether this executor should only run if the current node is cluster-manager
      */
-    default boolean runOnlyOnMaster() {
+    default boolean runOnlyOnClusterManager() {
         return true;
+    }
+
+    /**
+     * indicates whether this executor should only run if the current node is cluster-manager
+     *
+     * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #runOnlyOnClusterManager()}
+     */
+    @Deprecated
+    default boolean runOnlyOnMaster() {
+        return runOnlyOnClusterManager();
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/ClusterStateTaskListener.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterStateTaskListener.java
@@ -51,8 +51,19 @@ public interface ClusterStateTaskListener {
      * called when the task was rejected because the local node is no longer cluster-manager.
      * Used only for tasks submitted to {@link MasterService}.
      */
-    default void onNoLongerMaster(String source) {
+    default void onNoLongerClusterManager(String source) {
         onFailure(source, new NotClusterManagerException("no longer cluster-manager. source: [" + source + "]"));
+    }
+
+    /**
+     * called when the task was rejected because the local node is no longer cluster-manager.
+     * Used only for tasks submitted to {@link MasterService}.
+     *
+     * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #onNoLongerClusterManager(String)}
+     */
+    @Deprecated
+    default void onNoLongerMaster(String source) {
+        onNoLongerClusterManager(source);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/ClusterStateUpdateTask.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterStateUpdateTask.java
@@ -107,7 +107,7 @@ public abstract class ClusterStateUpdateTask
      * For local requests, use {@link LocalClusterUpdateTask} instead.
      */
     @Override
-    public final boolean runOnlyOnMaster() {
+    public final boolean runOnlyOnClusterManager() {
         return true;
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/opensearch/cluster/InternalClusterInfoService.java
@@ -151,14 +151,14 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
-        if (event.localNodeMaster() && refreshAndRescheduleRunnable.get() == null) {
+        if (event.localNodeClusterManager() && refreshAndRescheduleRunnable.get() == null) {
             logger.trace("elected as cluster-manager, scheduling cluster info update tasks");
             executeRefresh(event.state(), "became cluster-manager");
 
             final RefreshAndRescheduleRunnable newRunnable = new RefreshAndRescheduleRunnable();
             refreshAndRescheduleRunnable.set(newRunnable);
             threadPool.scheduleUnlessShuttingDown(updateFrequency, REFRESH_EXECUTOR, newRunnable);
-        } else if (event.localNodeMaster() == false) {
+        } else if (event.localNodeClusterManager() == false) {
             refreshAndRescheduleRunnable.set(null);
             return;
         }

--- a/server/src/main/java/org/opensearch/cluster/LocalClusterUpdateTask.java
+++ b/server/src/main/java/org/opensearch/cluster/LocalClusterUpdateTask.java
@@ -91,7 +91,7 @@ public abstract class LocalClusterUpdateTask
     }
 
     @Override
-    public final boolean runOnlyOnMaster() {
+    public final boolean runOnlyOnClusterManager() {
         return false;
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/LocalNodeClusterManagerListener.java
+++ b/server/src/main/java/org/opensearch/cluster/LocalNodeClusterManagerListener.java
@@ -51,8 +51,8 @@ public interface LocalNodeClusterManagerListener extends ClusterStateListener {
 
     @Override
     default void clusterChanged(ClusterChangedEvent event) {
-        final boolean wasClusterManager = event.previousState().nodes().isLocalNodeElectedMaster();
-        final boolean isClusterManager = event.localNodeMaster();
+        final boolean wasClusterManager = event.previousState().nodes().isLocalNodeElectedClusterManager();
+        final boolean isClusterManager = event.localNodeClusterManager();
         if (wasClusterManager == false && isClusterManager) {
             onMaster();
         } else if (wasClusterManager && isClusterManager == false) {

--- a/server/src/main/java/org/opensearch/cluster/action/index/MappingUpdatedAction.java
+++ b/server/src/main/java/org/opensearch/cluster/action/index/MappingUpdatedAction.java
@@ -111,7 +111,7 @@ public class MappingUpdatedAction {
      * {@code timeout} is the cluster-manager node timeout ({@link ClusterManagerNodeRequest#clusterManagerNodeTimeout()}),
      * potentially waiting for a cluster-manager node to be available.
      */
-    public void updateMappingOnMaster(Index index, Mapping mappingUpdate, ActionListener<Void> listener) {
+    public void updateMappingOnClusterManager(Index index, Mapping mappingUpdate, ActionListener<Void> listener) {
 
         final RunOnce release = new RunOnce(() -> semaphore.release());
         try {
@@ -130,6 +130,19 @@ public class MappingUpdatedAction {
                 release.run();
             }
         }
+    }
+
+    /**
+     * Update mappings on the cluster-manager node, waiting for the change to be committed,
+     * but not for the mapping update to be applied on all nodes. The timeout specified by
+     * {@code timeout} is the cluster-manager node timeout ({@link ClusterManagerNodeRequest#clusterManagerNodeTimeout()}),
+     * potentially waiting for a cluster-manager node to be available.
+     *
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #updateMappingOnClusterManager(Index, Mapping, ActionListener)}
+     */
+    @Deprecated
+    public void updateMappingOnMaster(Index index, Mapping mappingUpdate, ActionListener<Void> listener) {
+        updateMappingOnClusterManager(index, mappingUpdate, listener);
     }
 
     // used by tests

--- a/server/src/main/java/org/opensearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/opensearch/cluster/action/shard/ShardStateAction.java
@@ -39,12 +39,12 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.ActionListener;
 import org.opensearch.cluster.ClusterChangedEvent;
+import org.opensearch.cluster.ClusterManagerNodeChangePredicate;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterStateObserver;
 import org.opensearch.cluster.ClusterStateTaskConfig;
 import org.opensearch.cluster.ClusterStateTaskExecutor;
 import org.opensearch.cluster.ClusterStateTaskListener;
-import org.opensearch.cluster.ClusterManagerNodeChangePredicate;
 import org.opensearch.cluster.NotClusterManagerException;
 import org.opensearch.cluster.coordination.FailedToCommitClusterStateException;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -182,7 +182,7 @@ public class ShardStateAction {
         final ActionListener<Void> listener
     ) {
         ClusterStateObserver observer = new ClusterStateObserver(currentState, clusterService, null, logger, threadPool.getThreadContext());
-        DiscoveryNode clusterManagerNode = currentState.nodes().getMasterNode();
+        DiscoveryNode clusterManagerNode = currentState.nodes().getClusterManagerNode();
         Predicate<ClusterState> changePredicate = ClusterManagerNodeChangePredicate.build(currentState);
         if (clusterManagerNode == null) {
             logger.warn("no cluster-manager known for action [{}] for shard entry [{}]", actionName, request);
@@ -385,7 +385,7 @@ public class ShardStateAction {
                     }
 
                     @Override
-                    public void onNoLongerMaster(String source) {
+                    public void onNoLongerClusterManager(String source) {
                         logger.error("{} no longer cluster-manager while failing shard [{}]", request.shardId, request);
                         try {
                             channel.sendResponse(new NotClusterManagerException(source));

--- a/server/src/main/java/org/opensearch/cluster/coordination/ClusterBootstrapService.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/ClusterBootstrapService.java
@@ -134,7 +134,7 @@ public class ClusterBootstrapService {
                         + "]"
                 );
             }
-            if (DiscoveryNode.isMasterNode(settings) == false) {
+            if (DiscoveryNode.isClusterManagerNode(settings) == false) {
                 throw new IllegalArgumentException(
                     "node with ["
                         + DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey()
@@ -176,7 +176,7 @@ public class ClusterBootstrapService {
     void onFoundPeersUpdated() {
         final Set<DiscoveryNode> nodes = getDiscoveredNodes();
         if (bootstrappingPermitted.get()
-            && transportService.getLocalNode().isMasterNode()
+            && transportService.getLocalNode().isClusterManagerNode()
             && bootstrapRequirements.isEmpty() == false
             && isBootstrappedSupplier.getAsBoolean() == false
             && nodes.stream().noneMatch(Coordinator::isZen1Node)) {
@@ -219,7 +219,7 @@ public class ClusterBootstrapService {
             return;
         }
 
-        if (transportService.getLocalNode().isMasterNode() == false) {
+        if (transportService.getLocalNode().isClusterManagerNode() == false) {
             return;
         }
 
@@ -257,7 +257,7 @@ public class ClusterBootstrapService {
     }
 
     private void startBootstrap(Set<DiscoveryNode> discoveryNodes, List<String> unsatisfiedRequirements) {
-        assert discoveryNodes.stream().allMatch(DiscoveryNode::isMasterNode) : discoveryNodes;
+        assert discoveryNodes.stream().allMatch(DiscoveryNode::isClusterManagerNode) : discoveryNodes;
         assert discoveryNodes.stream().noneMatch(Coordinator::isZen1Node) : discoveryNodes;
         assert unsatisfiedRequirements.size() < discoveryNodes.size() : discoveryNodes + " smaller than " + unsatisfiedRequirements;
         if (bootstrappingPermitted.compareAndSet(true, false)) {
@@ -277,7 +277,7 @@ public class ClusterBootstrapService {
     }
 
     private void doBootstrap(VotingConfiguration votingConfiguration) {
-        assert transportService.getLocalNode().isMasterNode();
+        assert transportService.getLocalNode().isClusterManagerNode();
 
         try {
             votingConfigurationConsumer.accept(votingConfiguration);

--- a/server/src/main/java/org/opensearch/cluster/coordination/ClusterFormationFailureHelper.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/ClusterFormationFailureHelper.java
@@ -184,9 +184,10 @@ public class ClusterFormationFailureHelper {
             if (statusInfo.getStatus() == UNHEALTHY) {
                 return String.format(Locale.ROOT, "this node is unhealthy: %s", statusInfo.getInfo());
             }
-            final List<String> clusterStateNodes = StreamSupport.stream(clusterState.nodes().getMasterNodes().values().spliterator(), false)
-                .map(n -> n.value.toString())
-                .collect(Collectors.toList());
+            final List<String> clusterStateNodes = StreamSupport.stream(
+                clusterState.nodes().getClusterManagerNodes().values().spliterator(),
+                false
+            ).map(n -> n.value.toString()).collect(Collectors.toList());
 
             final String discoveryWillContinueDescription = String.format(
                 Locale.ROOT,
@@ -206,7 +207,7 @@ public class ClusterFormationFailureHelper {
                 discoveryWillContinueDescription
             );
 
-            if (clusterState.nodes().getLocalNode().isMasterNode() == false) {
+            if (clusterState.nodes().getLocalNode().isClusterManagerNode() == false) {
                 return String.format(Locale.ROOT, "cluster-manager not discovered yet: %s", discoveryStateIgnoringQuorum);
             }
 

--- a/server/src/main/java/org/opensearch/cluster/coordination/CoordinationState.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/CoordinationState.java
@@ -413,7 +413,7 @@ public class CoordinationState {
         }
         if (clusterState.term() == getLastAcceptedTerm() && clusterState.version() <= getLastAcceptedVersion()) {
             if (clusterState.term() == ZEN1_BWC_TERM
-                && clusterState.nodes().getMasterNode().equals(getLastAcceptedState().nodes().getMasterNode()) == false) {
+                && clusterState.nodes().getClusterManagerNode().equals(getLastAcceptedState().nodes().getClusterManagerNode()) == false) {
                 logger.debug(
                     "handling publish request in compatibility mode despite version mismatch (expected: >[{}], actual: [{}])",
                     getLastAcceptedVersion(),
@@ -652,7 +652,7 @@ public class CoordinationState {
         private final Set<Join> joins;
 
         public boolean addVote(DiscoveryNode sourceNode) {
-            return sourceNode.isMasterNode() && nodes.put(sourceNode.getId(), sourceNode) == null;
+            return sourceNode.isClusterManagerNode() && nodes.put(sourceNode.getId(), sourceNode) == null;
         }
 
         public boolean addJoinVote(Join join) {

--- a/server/src/main/java/org/opensearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/FollowersChecker.java
@@ -168,7 +168,7 @@ public class FollowersChecker {
             followerCheckers.keySet().removeIf(isUnknownNode);
             faultyNodes.removeIf(isUnknownNode);
 
-            discoveryNodes.mastersFirstStream().forEach(discoveryNode -> {
+            discoveryNodes.clusterManagersFirstStream().forEach(discoveryNode -> {
                 if (discoveryNode.equals(discoveryNodes.getLocalNode()) == false
                     && followerCheckers.containsKey(discoveryNode) == false
                     && faultyNodes.contains(discoveryNode) == false) {

--- a/server/src/main/java/org/opensearch/cluster/coordination/JoinTaskExecutor.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/JoinTaskExecutor.java
@@ -103,8 +103,14 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
             return node != null ? node + " " + reason : reason;
         }
 
-        public boolean isBecomeMasterTask() {
+        public boolean isBecomeClusterManagerTask() {
             return reason.equals(BECOME_MASTER_TASK_REASON) || reason.equals(BECOME_CLUSTER_MANAGER_TASK_REASON);
+        }
+
+        /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #isBecomeClusterManagerTask()} */
+        @Deprecated
+        public boolean isBecomeMasterTask() {
+            return isBecomeClusterManagerTask();
         }
 
         public boolean isFinishElectionTask() {
@@ -143,7 +149,7 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
 
         if (joiningNodes.size() == 1 && joiningNodes.get(0).isFinishElectionTask()) {
             return results.successes(joiningNodes).build(currentState);
-        } else if (currentNodes.getMasterNode() == null && joiningNodes.stream().anyMatch(Task::isBecomeMasterTask)) {
+        } else if (currentNodes.getClusterManagerNode() == null && joiningNodes.stream().anyMatch(Task::isBecomeClusterManagerTask)) {
             assert joiningNodes.stream().anyMatch(Task::isFinishElectionTask) : "becoming a cluster-manager but election is not finished "
                 + joiningNodes;
             // use these joins to try and become the cluster-manager.
@@ -151,10 +157,10 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
             // during the cluster state publishing guarantees that we have enough
             newState = becomeClusterManagerAndTrimConflictingNodes(currentState, joiningNodes);
             nodesChanged = true;
-        } else if (currentNodes.isLocalNodeElectedMaster() == false) {
+        } else if (currentNodes.isLocalNodeElectedClusterManager() == false) {
             logger.trace(
                 "processing node joins, but we are not the cluster-manager. current cluster-manager: {}",
-                currentNodes.getMasterNode()
+                currentNodes.getClusterManagerNode()
             );
             throw new NotClusterManagerException("Node [" + currentNodes.getLocalNode() + "] not cluster-manager for join request");
         } else {
@@ -163,7 +169,7 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
 
         DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(newState.nodes());
 
-        assert nodesBuilder.isLocalNodeElectedMaster();
+        assert nodesBuilder.isLocalNodeElectedClusterManager();
 
         Version minClusterNodeVersion = newState.nodes().getMinNodeVersion();
         Version maxClusterNodeVersion = newState.nodes().getMaxNodeVersion();
@@ -172,7 +178,7 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
         // processing any joins
         Map<String, String> joiniedNodeNameIds = new HashMap<>();
         for (final Task joinTask : joiningNodes) {
-            if (joinTask.isBecomeMasterTask() || joinTask.isFinishElectionTask()) {
+            if (joinTask.isBecomeClusterManagerTask() || joinTask.isFinishElectionTask()) {
                 // noop
             } else if (currentNodes.nodeExistsWithSameRoles(joinTask.node()) && !currentNodes.nodeExistsWithBWCVersion(joinTask.node())) {
                 logger.debug("received a join request for an existing node [{}]", joinTask.node());
@@ -190,7 +196,7 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
                     nodesChanged = true;
                     minClusterNodeVersion = Version.min(minClusterNodeVersion, node.getVersion());
                     maxClusterNodeVersion = Version.max(maxClusterNodeVersion, node.getVersion());
-                    if (node.isMasterNode()) {
+                    if (node.isClusterManagerNode()) {
                         joiniedNodeNameIds.put(node.getName(), node.getId());
                     }
                 } catch (IllegalArgumentException | IllegalStateException e) {
@@ -245,13 +251,13 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
     }
 
     protected ClusterState.Builder becomeClusterManagerAndTrimConflictingNodes(ClusterState currentState, List<Task> joiningNodes) {
-        assert currentState.nodes().getMasterNodeId() == null : currentState;
+        assert currentState.nodes().getClusterManagerNodeId() == null : currentState;
         DiscoveryNodes currentNodes = currentState.nodes();
         DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(currentNodes);
-        nodesBuilder.masterNodeId(currentState.nodes().getLocalNodeId());
+        nodesBuilder.clusterManagerNodeId(currentState.nodes().getLocalNodeId());
 
         for (final Task joinTask : joiningNodes) {
-            if (joinTask.isBecomeMasterTask()) {
+            if (joinTask.isBecomeClusterManagerTask()) {
                 refreshDiscoveryNodeVersionAfterUpgrade(currentNodes, nodesBuilder);
             } else if (joinTask.isFinishElectionTask()) {
                 // no-op
@@ -343,7 +349,7 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
     }
 
     @Override
-    public boolean runOnlyOnMaster() {
+    public boolean runOnlyOnClusterManager() {
         // we validate that we are allowed to change the cluster state during cluster state processing
         return false;
     }
@@ -366,7 +372,7 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
 
     /**
      * a task that is used to signal the election is stopped and we should process pending joins.
-     * it may be used in combination with {@link JoinTaskExecutor#newBecomeMasterTask()}
+     * it may be used in combination with {@link JoinTaskExecutor#newBecomeClusterManagerTask()}
      */
     public static Task newFinishElectionTask() {
         return new Task(null, Task.FINISH_ELECTION_TASK_REASON);

--- a/server/src/main/java/org/opensearch/cluster/coordination/LeaderChecker.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/LeaderChecker.java
@@ -193,7 +193,7 @@ public class LeaderChecker {
 
     // For assertions
     boolean currentNodeIsClusterManager() {
-        return discoveryNodes.isLocalNodeElectedMaster();
+        return discoveryNodes.isLocalNodeElectedClusterManager();
     }
 
     private void handleLeaderCheck(LeaderCheckRequest request) {
@@ -209,7 +209,7 @@ public class LeaderChecker {
                 + "]";
             logger.debug(message);
             throw new NodeHealthCheckFailureException(message);
-        } else if (discoveryNodes.isLocalNodeElectedMaster() == false) {
+        } else if (discoveryNodes.isLocalNodeElectedClusterManager() == false) {
             logger.debug("rejecting leader check on non-cluster-manager {}", request);
             throw new CoordinationStateRejectedException(
                 "rejecting leader check from [" + request.getSender() + "] sent to a node that is no longer the cluster-manager"

--- a/server/src/main/java/org/opensearch/cluster/coordination/NodeRemovalClusterStateTaskExecutor.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/NodeRemovalClusterStateTaskExecutor.java
@@ -136,7 +136,7 @@ public class NodeRemovalClusterStateTaskExecutor
     }
 
     @Override
-    public void onNoLongerMaster(String source) {
+    public void onNoLongerClusterManager(String source) {
         logger.debug("no longer cluster-manager while processing node removal [{}]", source);
     }
 

--- a/server/src/main/java/org/opensearch/cluster/coordination/PeersResponse.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/PeersResponse.java
@@ -76,8 +76,17 @@ public class PeersResponse extends TransportResponse {
     /**
      * @return the node that is currently leading, according to the responding node.
      */
-    public Optional<DiscoveryNode> getMasterNode() {
+    public Optional<DiscoveryNode> getClusterManagerNode() {
         return clusterManagerNode;
+    }
+
+    /**
+     * @return the node that is currently leading, according to the responding node.
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #getClusterManagerNode()}
+     */
+    @Deprecated
+    public Optional<DiscoveryNode> getMasterNode() {
+        return getClusterManagerNode();
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/coordination/Publication.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/Publication.java
@@ -78,7 +78,10 @@ public abstract class Publication {
         startTime = currentTimeSupplier.getAsLong();
         applyCommitRequest = Optional.empty();
         publicationTargets = new ArrayList<>(publishRequest.getAcceptedState().getNodes().getNodes().size());
-        publishRequest.getAcceptedState().getNodes().mastersFirstStream().forEach(n -> publicationTargets.add(new PublicationTarget(n)));
+        publishRequest.getAcceptedState()
+            .getNodes()
+            .clusterManagersFirstStream()
+            .forEach(n -> publicationTargets.add(new PublicationTarget(n)));
     }
 
     public void start(Set<DiscoveryNode> faultyNodes) {

--- a/server/src/main/java/org/opensearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/PublicationTransportHandler.java
@@ -232,7 +232,7 @@ public class PublicationTransportHandler {
 
     private PublishWithJoinResponse acceptState(ClusterState incomingState) {
         // if the state is coming from the current node, use original request instead (see currentPublishRequestToSelf for explanation)
-        if (transportService.getLocalNode().equals(incomingState.nodes().getMasterNode())) {
+        if (transportService.getLocalNode().equals(incomingState.nodes().getClusterManagerNode())) {
             final PublishRequest publishRequest = currentPublishRequestToSelf.get();
             if (publishRequest == null || publishRequest.getAcceptedState().stateUUID().equals(incomingState.stateUUID()) == false) {
                 throw new IllegalStateException("publication to self failed for " + publishRequest);

--- a/server/src/main/java/org/opensearch/cluster/coordination/Reconfigurator.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/Reconfigurator.java
@@ -125,14 +125,14 @@ public class Reconfigurator {
         );
 
         final Set<String> liveNodeIds = liveNodes.stream()
-            .filter(DiscoveryNode::isMasterNode)
+            .filter(DiscoveryNode::isClusterManagerNode)
             .map(DiscoveryNode::getId)
             .collect(Collectors.toSet());
         final Set<String> currentConfigNodeIds = currentConfig.getNodeIds();
 
         final Set<VotingConfigNode> orderedCandidateNodes = new TreeSet<>();
         liveNodes.stream()
-            .filter(DiscoveryNode::isMasterNode)
+            .filter(DiscoveryNode::isClusterManagerNode)
             .filter(n -> retiredNodeIds.contains(n.getId()) == false)
             .forEach(
                 n -> orderedCandidateNodes.add(

--- a/server/src/main/java/org/opensearch/cluster/coordination/UnsafeBootstrapClusterManagerCommand.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/UnsafeBootstrapClusterManagerCommand.java
@@ -98,7 +98,7 @@ public class UnsafeBootstrapClusterManagerCommand extends OpenSearchNodeCommand 
     protected boolean validateBeforeLock(Terminal terminal, Environment env) {
         Settings settings = env.settings();
         terminal.println(Terminal.Verbosity.VERBOSE, "Checking node.roles setting");
-        Boolean clusterManager = DiscoveryNode.isMasterNode(settings);
+        Boolean clusterManager = DiscoveryNode.isClusterManagerNode(settings);
         if (clusterManager == false) {
             throw new OpenSearchException(NOT_CLUSTER_MANAGER_NODE_MSG);
         }

--- a/server/src/main/java/org/opensearch/cluster/health/ClusterStateHealth.java
+++ b/server/src/main/java/org/opensearch/cluster/health/ClusterStateHealth.java
@@ -86,7 +86,7 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
     public ClusterStateHealth(final ClusterState clusterState, final String[] concreteIndices) {
         numberOfNodes = clusterState.nodes().getSize();
         numberOfDataNodes = clusterState.nodes().getDataNodes().size();
-        hasDiscoveredClusterManager = clusterState.nodes().getMasterNodeId() != null;
+        hasDiscoveredClusterManager = clusterState.nodes().getClusterManagerNodeId() != null;
         indices = new HashMap<>();
         for (String index : concreteIndices) {
             IndexRoutingTable indexRoutingTable = clusterState.routingTable().index(index);
@@ -238,8 +238,14 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
         return activeShardsPercent;
     }
 
-    public boolean hasDiscoveredMaster() {
+    public boolean hasDiscoveredClusterManager() {
         return hasDiscoveredClusterManager;
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #hasDiscoveredClusterManager()} */
+    @Deprecated
+    public boolean hasDiscoveredMaster() {
+        return hasDiscoveredClusterManager();
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -132,7 +132,7 @@ public class MetadataIndexTemplateService {
 
             @Override
             public TimeValue timeout() {
-                return request.masterTimeout;
+                return request.clusterManagerTimeout;
             }
 
             @Override
@@ -860,7 +860,7 @@ public class MetadataIndexTemplateService {
 
                 @Override
                 public TimeValue timeout() {
-                    return request.masterTimeout;
+                    return request.clusterManagerTimeout;
                 }
 
                 @Override
@@ -1526,6 +1526,10 @@ public class MetadataIndexTemplateService {
         String mappings = null;
         List<Alias> aliases = new ArrayList<>();
 
+        TimeValue clusterManagerTimeout = ClusterManagerNodeRequest.DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT;
+
+        /** @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #clusterManagerTimeout} */
+        @Deprecated
         TimeValue masterTimeout = ClusterManagerNodeRequest.DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT;
 
         public PutRequest(String cause, String name) {
@@ -1563,9 +1567,15 @@ public class MetadataIndexTemplateService {
             return this;
         }
 
-        public PutRequest masterTimeout(TimeValue masterTimeout) {
-            this.masterTimeout = masterTimeout;
+        public PutRequest clusterManagerTimeout(TimeValue clusterManagerTimeout) {
+            this.clusterManagerTimeout = clusterManagerTimeout;
             return this;
+        }
+
+        /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #clusterManagerTimeout(TimeValue)} */
+        @Deprecated
+        public PutRequest masterTimeout(TimeValue masterTimeout) {
+            return clusterManagerTimeout(masterTimeout);
         }
 
         public PutRequest version(Integer version) {
@@ -1598,15 +1608,25 @@ public class MetadataIndexTemplateService {
      */
     public static class RemoveRequest {
         final String name;
+        TimeValue clusterManagerTimeout = ClusterManagerNodeRequest.DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT;
+
+        /** @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #clusterManagerTimeout} */
+        @Deprecated
         TimeValue masterTimeout = ClusterManagerNodeRequest.DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT;
 
         public RemoveRequest(String name) {
             this.name = name;
         }
 
-        public RemoveRequest masterTimeout(TimeValue masterTimeout) {
-            this.masterTimeout = masterTimeout;
+        public RemoveRequest clusterManagerTimeout(TimeValue clusterManagerTimeout) {
+            this.clusterManagerTimeout = clusterManagerTimeout;
             return this;
+        }
+
+        /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #clusterManagerTimeout} */
+        @Deprecated
+        public RemoveRequest masterTimeout(TimeValue masterTimeout) {
+            return clusterManagerTimeout(masterTimeout);
         }
     }
 

--- a/server/src/main/java/org/opensearch/cluster/metadata/SystemIndexMetadataUpgradeService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/SystemIndexMetadataUpgradeService.java
@@ -70,8 +70,8 @@ public class SystemIndexMetadataUpgradeService implements ClusterStateListener {
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
-        if (event.localNodeMaster() != clusterManager) {
-            this.clusterManager = event.localNodeMaster();
+        if (event.localNodeClusterManager() != clusterManager) {
+            this.clusterManager = event.localNodeClusterManager();
         }
 
         if (clusterManager && updateTaskPending == false) {

--- a/server/src/main/java/org/opensearch/cluster/metadata/TemplateUpgradeService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/TemplateUpgradeService.java
@@ -109,7 +109,7 @@ public class TemplateUpgradeService implements ClusterStateListener {
             }
             return upgradedTemplates;
         };
-        if (DiscoveryNode.isMasterNode(clusterService.getSettings())) {
+        if (DiscoveryNode.isClusterManagerNode(clusterService.getSettings())) {
             clusterService.addListener(this);
         }
     }
@@ -117,7 +117,7 @@ public class TemplateUpgradeService implements ClusterStateListener {
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
         ClusterState state = event.state();
-        if (state.nodes().isLocalNodeElectedMaster() == false) {
+        if (state.nodes().isLocalNodeElectedClusterManager() == false) {
             return;
         }
         if (state.blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)) {

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -74,7 +74,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
 
     public static boolean nodeRequiresLocalStorage(Settings settings) {
         boolean localStorageEnable = Node.NODE_LOCAL_STORAGE_SETTING.get(settings);
-        if (localStorageEnable == false && (isDataNode(settings) || isMasterNode(settings))) {
+        if (localStorageEnable == false && (isDataNode(settings) || isClusterManagerNode(settings))) {
             // TODO: make this a proper setting validation logic, requiring multi-settings validation
             throw new IllegalArgumentException("storage can not be disabled for cluster-manager and data nodes");
         }
@@ -96,8 +96,14 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         }
     }
 
-    public static boolean isMasterNode(Settings settings) {
+    public static boolean isClusterManagerNode(Settings settings) {
         return hasRole(settings, DiscoveryNodeRole.MASTER_ROLE) || hasRole(settings, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE);
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #isClusterManagerNode(Settings)} */
+    @Deprecated
+    public static boolean isMasterNode(Settings settings) {
+        return isClusterManagerNode(settings);
     }
 
     /**
@@ -462,8 +468,18 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
     /**
      * Can this node become cluster-manager or not.
      */
-    public boolean isMasterNode() {
+    public boolean isClusterManagerNode() {
         return roles.contains(DiscoveryNodeRole.MASTER_ROLE) || roles.contains(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE);
+    }
+
+    /**
+     * Can this node become cluster-manager or not.
+     *
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #isClusterManagerNode()}
+     */
+    @Deprecated
+    public boolean isMasterNode() {
+        return isClusterManagerNode();
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodes.java
@@ -114,12 +114,22 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
     /**
      * Returns {@code true} if the local node is the elected cluster-manager node.
      */
-    public boolean isLocalNodeElectedMaster() {
+    public boolean isLocalNodeElectedClusterManager() {
         if (localNodeId == null) {
             // we don't know yet the local node id, return false
             return false;
         }
         return localNodeId.equals(clusterManagerNodeId);
+    }
+
+    /**
+     * Returns {@code true} if the local node is the elected cluster-manager node.
+     *
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #isLocalNodeElectedClusterManager()}
+     */
+    @Deprecated
+    public boolean isLocalNodeElectedMaster() {
+        return isLocalNodeElectedClusterManager();
     }
 
     /**
@@ -154,8 +164,19 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
      *
      * @return {@link Map} of the discovered cluster-manager nodes arranged by their ids
      */
-    public ImmutableOpenMap<String, DiscoveryNode> getMasterNodes() {
+    public ImmutableOpenMap<String, DiscoveryNode> getClusterManagerNodes() {
         return this.clusterManagerNodes;
+    }
+
+    /**
+     * Get a {@link Map} of the discovered cluster-manager nodes arranged by their ids
+     *
+     * @return {@link Map} of the discovered cluster-manager nodes arranged by their ids
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #getClusterManagerNodes()}
+     */
+    @Deprecated
+    public ImmutableOpenMap<String, DiscoveryNode> getMasterNodes() {
+        return getClusterManagerNodes();
     }
 
     /**
@@ -170,10 +191,21 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
      *
      * @return {@link Map} of the discovered cluster-manager and data nodes arranged by their ids
      */
-    public ImmutableOpenMap<String, DiscoveryNode> getMasterAndDataNodes() {
+    public ImmutableOpenMap<String, DiscoveryNode> getClusterManagerAndDataNodes() {
         ImmutableOpenMap.Builder<String, DiscoveryNode> nodes = ImmutableOpenMap.builder(dataNodes);
         nodes.putAll(clusterManagerNodes);
         return nodes.build();
+    }
+
+    /**
+     * Get a {@link Map} of the discovered cluster-manager and data nodes arranged by their ids
+     *
+     * @return {@link Map} of the discovered cluster-manager and data nodes arranged by their ids
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #getClusterManagerAndDataNodes()}
+     */
+    @Deprecated
+    public ImmutableOpenMap<String, DiscoveryNode> getMasterAndDataNodes() {
+        return getClusterManagerAndDataNodes();
     }
 
     /**
@@ -192,11 +224,21 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
     /**
      * Returns a stream of all nodes, with cluster-manager nodes at the front
      */
-    public Stream<DiscoveryNode> mastersFirstStream() {
+    public Stream<DiscoveryNode> clusterManagersFirstStream() {
         return Stream.concat(
             StreamSupport.stream(clusterManagerNodes.spliterator(), false).map(cur -> cur.value),
-            StreamSupport.stream(this.spliterator(), false).filter(n -> n.isMasterNode() == false)
+            StreamSupport.stream(this.spliterator(), false).filter(n -> n.isClusterManagerNode() == false)
         );
+    }
+
+    /**
+     * Returns a stream of all nodes, with cluster-manager nodes at the front
+     *
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #clusterManagersFirstStream()}
+     */
+    @Deprecated
+    public Stream<DiscoveryNode> mastersFirstStream() {
+        return clusterManagersFirstStream();
     }
 
     /**
@@ -256,8 +298,19 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
      *
      * @return id of the cluster-manager
      */
-    public String getMasterNodeId() {
+    public String getClusterManagerNodeId() {
         return this.clusterManagerNodeId;
+    }
+
+    /**
+     * Get the id of the cluster-manager node
+     *
+     * @return id of the cluster-manager
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #getClusterManagerNodeId()}
+     */
+    @Deprecated
+    public String getMasterNodeId() {
+        return getClusterManagerNodeId();
     }
 
     /**
@@ -282,11 +335,22 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
      * Returns the cluster-manager node, or {@code null} if there is no cluster-manager node
      */
     @Nullable
-    public DiscoveryNode getMasterNode() {
+    public DiscoveryNode getClusterManagerNode() {
         if (clusterManagerNodeId != null) {
             return nodes.get(clusterManagerNodeId);
         }
         return null;
+    }
+
+    /**
+     * Returns the cluster-manager node, or {@code null} if there is no cluster-manager node
+     *
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #getClusterManagerNode()}
+     */
+    @Deprecated
+    @Nullable
+    public DiscoveryNode getMasterNode() {
+        return getClusterManagerNode();
     }
 
     /**
@@ -396,7 +460,7 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
                         resolvedNodesIds.add(localNodeId);
                     }
                 } else if (nodeId.equals("_master") || nodeId.equals("_cluster_manager")) {
-                    String clusterManagerNodeId = getMasterNodeId();
+                    String clusterManagerNodeId = getClusterManagerNodeId();
                     if (clusterManagerNodeId != null) {
                         resolvedNodesIds.add(clusterManagerNodeId);
                     }
@@ -490,8 +554,8 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
         }
 
         return new Delta(
-            other.getMasterNode(),
-            getMasterNode(),
+            other.getClusterManagerNode(),
+            getClusterManagerNode(),
             localNodeId,
             Collections.unmodifiableList(removed),
             Collections.unmodifiableList(added)
@@ -507,7 +571,7 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
             if (node == getLocalNode()) {
                 sb.append(", local");
             }
-            if (node == getMasterNode()) {
+            if (node == getClusterManagerNode()) {
                 sb.append(", cluster-manager");
             }
             sb.append("\n");
@@ -545,11 +609,17 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
         }
 
         public boolean hasChanges() {
-            return masterNodeChanged() || !removed.isEmpty() || !added.isEmpty();
+            return clusterManagerNodeChanged() || !removed.isEmpty() || !added.isEmpty();
         }
 
-        public boolean masterNodeChanged() {
+        public boolean clusterManagerNodeChanged() {
             return Objects.equals(newClusterManagerNode, previousClusterManagerNode) == false;
+        }
+
+        /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #clusterManagerNodeChanged()} */
+        @Deprecated
+        public boolean masterNodeChanged() {
+            return clusterManagerNodeChanged();
         }
 
         @Nullable
@@ -557,9 +627,23 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
             return previousClusterManagerNode;
         }
 
+        /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #previousClusterManagerNode()} */
+        @Deprecated
+        @Nullable
+        public DiscoveryNode previousMasterNode() {
+            return previousClusterManagerNode();
+        }
+
+        @Nullable
+        public DiscoveryNode newClusterManagerNode() {
+            return newClusterManagerNode;
+        }
+
+        /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #newClusterManagerNode()} */
+        @Deprecated
         @Nullable
         public DiscoveryNode newMasterNode() {
-            return newClusterManagerNode;
+            return newClusterManagerNode();
         }
 
         public boolean removed() {
@@ -580,14 +664,14 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
 
         public String shortSummary() {
             final StringBuilder summary = new StringBuilder();
-            if (masterNodeChanged()) {
+            if (clusterManagerNodeChanged()) {
                 summary.append("cluster-manager node changed {previous [");
                 if (previousClusterManagerNode() != null) {
                     summary.append(previousClusterManagerNode());
                 }
                 summary.append("], current [");
-                if (newMasterNode() != null) {
-                    summary.append(newMasterNode());
+                if (newClusterManagerNode() != null) {
+                    summary.append(newClusterManagerNode());
                 }
                 summary.append("]}");
             }
@@ -631,7 +715,7 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
     public static DiscoveryNodes readFrom(StreamInput in, DiscoveryNode localNode) throws IOException {
         Builder builder = new Builder();
         if (in.readBoolean()) {
-            builder.masterNodeId(in.readString());
+            builder.clusterManagerNodeId(in.readString());
         }
         if (localNode != null) {
             builder.localNodeId(localNode.getId());
@@ -679,7 +763,7 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
         }
 
         public Builder(DiscoveryNodes nodes) {
-            this.clusterManagerNodeId = nodes.getMasterNodeId();
+            this.clusterManagerNodeId = nodes.getClusterManagerNodeId();
             this.localNodeId = nodes.getLocalNodeId();
             this.nodes = ImmutableOpenMap.builder(nodes.getNodes());
         }
@@ -724,9 +808,15 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
             return this;
         }
 
-        public Builder masterNodeId(String clusterManagerNodeId) {
+        public Builder clusterManagerNodeId(String clusterManagerNodeId) {
             this.clusterManagerNodeId = clusterManagerNodeId;
             return this;
+        }
+
+        /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #clusterManagerNodeId} */
+        @Deprecated
+        public Builder masterNodeId(String clusterManagerNodeId) {
+            return clusterManagerNodeId(clusterManagerNodeId);
         }
 
         public Builder localNodeId(String localNodeId) {
@@ -761,7 +851,7 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
 
         public DiscoveryNodes build() {
             ImmutableOpenMap.Builder<String, DiscoveryNode> dataNodesBuilder = ImmutableOpenMap.builder();
-            ImmutableOpenMap.Builder<String, DiscoveryNode> masterNodesBuilder = ImmutableOpenMap.builder();
+            ImmutableOpenMap.Builder<String, DiscoveryNode> clusterManagerNodesBuilder = ImmutableOpenMap.builder();
             ImmutableOpenMap.Builder<String, DiscoveryNode> ingestNodesBuilder = ImmutableOpenMap.builder();
             Version minNodeVersion = null;
             Version maxNodeVersion = null;
@@ -771,11 +861,11 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
                 if (nodeEntry.value.isDataNode()) {
                     dataNodesBuilder.put(nodeEntry.key, nodeEntry.value);
                 }
-                if (nodeEntry.value.isMasterNode()) {
-                    masterNodesBuilder.put(nodeEntry.key, nodeEntry.value);
+                if (nodeEntry.value.isClusterManagerNode()) {
+                    clusterManagerNodesBuilder.put(nodeEntry.key, nodeEntry.value);
                 }
                 final Version version = nodeEntry.value.getVersion();
-                if (nodeEntry.value.isDataNode() || nodeEntry.value.isMasterNode()) {
+                if (nodeEntry.value.isDataNode() || nodeEntry.value.isClusterManagerNode()) {
                     if (minNonClientNodeVersion == null) {
                         minNonClientNodeVersion = version;
                         maxNonClientNodeVersion = version;
@@ -794,7 +884,7 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
             return new DiscoveryNodes(
                 nodes.build(),
                 dataNodesBuilder.build(),
-                masterNodesBuilder.build(),
+                clusterManagerNodesBuilder.build(),
                 ingestNodesBuilder.build(),
                 clusterManagerNodeId,
                 localNodeId,
@@ -805,8 +895,14 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
             );
         }
 
-        public boolean isLocalNodeElectedMaster() {
+        public boolean isLocalNodeElectedClusterManager() {
             return clusterManagerNodeId != null && clusterManagerNodeId.equals(localNodeId);
+        }
+
+        /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #isLocalNodeElectedClusterManager()} */
+        @Deprecated
+        public boolean isLocalNodeElectedMaster() {
+            return isLocalNodeElectedClusterManager();
         }
     }
 

--- a/server/src/main/java/org/opensearch/cluster/routing/BatchedRerouteService.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/BatchedRerouteService.java
@@ -141,7 +141,7 @@ public class BatchedRerouteService implements RerouteService {
                 }
 
                 @Override
-                public void onNoLongerMaster(String source) {
+                public void onNoLongerClusterManager(String source) {
                     synchronized (mutex) {
                         if (pendingRerouteListeners == currentListeners) {
                             pendingRerouteListeners = null;

--- a/server/src/main/java/org/opensearch/cluster/service/ClusterApplierService.java
+++ b/server/src/main/java/org/opensearch/cluster/service/ClusterApplierService.java
@@ -42,6 +42,7 @@ import org.opensearch.cluster.ClusterStateListener;
 import org.opensearch.cluster.ClusterStateObserver;
 import org.opensearch.cluster.ClusterStateTaskConfig;
 import org.opensearch.cluster.LocalNodeClusterManagerListener;
+import org.opensearch.cluster.LocalNodeMasterListener;
 import org.opensearch.cluster.NodeConnectionsService;
 import org.opensearch.cluster.TimeoutClusterStateListener;
 import org.opensearch.cluster.metadata.ProcessClusterEventTimeoutException;
@@ -277,8 +278,17 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
     /**
      * Add a listener for on/off local node cluster-manager events
      */
-    public void addLocalNodeMasterListener(LocalNodeClusterManagerListener listener) {
+    public void addLocalNodeClusterManagerListener(LocalNodeClusterManagerListener listener) {
         addListener(listener);
+    }
+
+    /**
+     * Add a listener for on/off local node cluster-manager events
+     * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #addLocalNodeClusterManagerListener}
+     */
+    @Deprecated
+    public void addLocalNodeMasterListener(LocalNodeMasterListener listener) {
+        addLocalNodeClusterManagerListener(listener);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/service/ClusterService.java
+++ b/server/src/main/java/org/opensearch/cluster/service/ClusterService.java
@@ -40,6 +40,7 @@ import org.opensearch.cluster.ClusterStateTaskConfig;
 import org.opensearch.cluster.ClusterStateTaskExecutor;
 import org.opensearch.cluster.ClusterStateTaskListener;
 import org.opensearch.cluster.LocalNodeClusterManagerListener;
+import org.opensearch.cluster.LocalNodeMasterListener;
 import org.opensearch.cluster.NodeConnectionsService;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.OperationRouting;
@@ -214,8 +215,17 @@ public class ClusterService extends AbstractLifecycleComponent {
     /**
      * Add a listener for on/off local node cluster-manager events
      */
-    public void addLocalNodeMasterListener(LocalNodeClusterManagerListener listener) {
-        clusterApplierService.addLocalNodeMasterListener(listener);
+    public void addLocalNodeClusterManagerListener(LocalNodeClusterManagerListener listener) {
+        clusterApplierService.addLocalNodeClusterManagerListener(listener);
+    }
+
+    /**
+     * Add a listener for on/off local node cluster-manager events
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #addLocalNodeClusterManagerListener}
+     */
+    @Deprecated
+    public void addLocalNodeMasterListener(LocalNodeMasterListener listener) {
+        addLocalNodeClusterManagerListener(listener);
     }
 
     public MasterService getMasterService() {
@@ -240,11 +250,17 @@ public class ClusterService extends AbstractLifecycleComponent {
         return clusterApplierService;
     }
 
-    public static boolean assertClusterOrMasterStateThread() {
+    public static boolean assertClusterOrClusterManagerStateThread() {
         assert Thread.currentThread().getName().contains(ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME)
             || Thread.currentThread().getName().contains(MasterService.MASTER_UPDATE_THREAD_NAME)
             : "not called from the master/cluster state update thread";
         return true;
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #assertClusterOrClusterManagerStateThread} */
+    @Deprecated
+    public static boolean assertClusterOrMasterStateThread() {
+        return assertClusterOrClusterManagerStateThread();
     }
 
     public ClusterName getClusterName() {

--- a/server/src/main/java/org/opensearch/common/settings/ConsistentSettingsService.java
+++ b/server/src/main/java/org/opensearch/common/settings/ConsistentSettingsService.java
@@ -123,7 +123,7 @@ public final class ConsistentSettingsService {
                     "no published hash for the consistent secure setting [{}] but it exists on the local node",
                     concreteSecureSetting.getKey()
                 );
-                if (state.nodes().isLocalNodeElectedMaster()) {
+                if (state.nodes().isLocalNodeElectedClusterManager()) {
                     throw new IllegalStateException(
                         "Master node cannot validate consistent setting. No published hash for ["
                             + concreteSecureSetting.getKey()
@@ -162,7 +162,7 @@ public final class ConsistentSettingsService {
                         concreteSecureSetting.getKey(),
                         computedSaltedHash
                     );
-                    if (state.nodes().isLocalNodeElectedMaster()) {
+                    if (state.nodes().isLocalNodeElectedClusterManager()) {
                         throw new IllegalStateException(
                             "Master node cannot validate consistent setting. The published hash ["
                                 + publishedHash

--- a/server/src/main/java/org/opensearch/discovery/HandshakingTransportAddressConnector.java
+++ b/server/src/main/java/org/opensearch/discovery/HandshakingTransportAddressConnector.java
@@ -141,7 +141,7 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
 
                                         if (remoteNode.equals(transportService.getLocalNode())) {
                                             listener.onFailure(new ConnectTransportException(remoteNode, "local node found"));
-                                        } else if (remoteNode.isMasterNode() == false) {
+                                        } else if (remoteNode.isClusterManagerNode() == false) {
                                             listener.onFailure(
                                                 new ConnectTransportException(remoteNode, "non-cluster-manager-eligible node found")
                                             );

--- a/server/src/main/java/org/opensearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/opensearch/env/NodeEnvironment.java
@@ -354,12 +354,12 @@ public final class NodeEnvironment implements Closeable {
             applySegmentInfosTrace(settings);
             assertCanWrite();
 
-            if (DiscoveryNode.isMasterNode(settings) || DiscoveryNode.isDataNode(settings)) {
+            if (DiscoveryNode.isClusterManagerNode(settings) || DiscoveryNode.isDataNode(settings)) {
                 ensureAtomicMoveSupported(nodePaths);
             }
 
             if (DiscoveryNode.isDataNode(settings) == false) {
-                if (DiscoveryNode.isMasterNode(settings) == false) {
+                if (DiscoveryNode.isClusterManagerNode(settings) == false) {
                     ensureNoIndexMetadata(nodePaths);
                 }
 

--- a/server/src/main/java/org/opensearch/env/NodeRepurposeCommand.java
+++ b/server/src/main/java/org/opensearch/env/NodeRepurposeCommand.java
@@ -96,7 +96,7 @@ public class NodeRepurposeCommand extends OpenSearchNodeCommand {
         throws IOException {
         assert DiscoveryNode.isDataNode(env.settings()) == false;
 
-        if (DiscoveryNode.isMasterNode(env.settings()) == false) {
+        if (DiscoveryNode.isClusterManagerNode(env.settings()) == false) {
             processNoClusterManagerNoDataNode(terminal, dataPaths, env);
         } else {
             processClusterManagerNoDataNode(terminal, dataPaths, env);

--- a/server/src/main/java/org/opensearch/gateway/Gateway.java
+++ b/server/src/main/java/org/opensearch/gateway/Gateway.java
@@ -70,7 +70,7 @@ public class Gateway {
     }
 
     public void performStateRecovery(final GatewayStateRecoveredListener listener) throws GatewayException {
-        final String[] nodesIds = clusterService.state().nodes().getMasterNodes().keys().toArray(String.class);
+        final String[] nodesIds = clusterService.state().nodes().getClusterManagerNodes().keys().toArray(String.class);
         logger.trace("performing state recovery from {}", Arrays.toString(nodesIds));
         final TransportNodesListGatewayMetaState.NodesGatewayMetaState nodesState = listGatewayMetaState.list(nodesIds, null).actionGet();
 

--- a/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
@@ -127,7 +127,7 @@ public class GatewayMetaState implements Closeable {
     ) {
         assert persistedState.get() == null : "should only start once, but already have " + persistedState.get();
 
-        if (DiscoveryNode.isMasterNode(settings) || DiscoveryNode.isDataNode(settings)) {
+        if (DiscoveryNode.isClusterManagerNode(settings) || DiscoveryNode.isDataNode(settings)) {
             try {
                 final PersistedClusterStateService.OnDiskState onDiskState = persistedClusterStateService.loadBestOnDiskState();
 
@@ -158,7 +158,7 @@ public class GatewayMetaState implements Closeable {
                             .build()
                     );
 
-                    if (DiscoveryNode.isMasterNode(settings)) {
+                    if (DiscoveryNode.isClusterManagerNode(settings)) {
                         persistedState = new LucenePersistedState(persistedClusterStateService, currentTerm, clusterState);
                     } else {
                         persistedState = new AsyncLucenePersistedState(

--- a/server/src/main/java/org/opensearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/opensearch/gateway/LocalAllocateDangledIndices.java
@@ -108,7 +108,7 @@ public class LocalAllocateDangledIndices {
 
     public void allocateDangled(Collection<IndexMetadata> indices, ActionListener<AllocateDangledResponse> listener) {
         ClusterState clusterState = clusterService.state();
-        DiscoveryNode clusterManagerNode = clusterState.nodes().getMasterNode();
+        DiscoveryNode clusterManagerNode = clusterState.nodes().getClusterManagerNode();
         if (clusterManagerNode == null) {
             listener.onFailure(new ClusterManagerNotDiscoveredException("no cluster-manager to send allocate dangled request"));
             return;
@@ -165,7 +165,7 @@ public class LocalAllocateDangledIndices {
                                 indexMetadata.getIndex(),
                                 request.fromNode,
                                 indexMetadata.getCreationVersion(),
-                                currentState.getNodes().getMasterNode().getVersion()
+                                currentState.getNodes().getClusterManagerNode().getVersion()
                             );
                             continue;
                         }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -513,7 +513,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             }
 
             if (newRouting.primary()) {
-                replicationTracker.updateFromMaster(applyingClusterStateVersion, inSyncAllocationIds, routingTable);
+                replicationTracker.updateFromClusterManager(applyingClusterStateVersion, inSyncAllocationIds, routingTable);
             }
 
             if (state == IndexShardState.POST_RECOVERY && newRouting.active()) {

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -728,7 +728,7 @@ public class Node implements Closeable {
                 systemIndices,
                 scriptService
             );
-            if (DiscoveryNode.isMasterNode(settings)) {
+            if (DiscoveryNode.isClusterManagerNode(settings)) {
                 clusterService.addListener(new SystemIndexMetadataUpgradeService(systemIndices, clusterService));
             }
             new TemplateUpgradeService(client, clusterService, threadPool, indexTemplateMetadataUpgraders);
@@ -1122,7 +1122,7 @@ public class Node implements Closeable {
             ClusterState clusterState = clusterService.state();
             ClusterStateObserver observer = new ClusterStateObserver(clusterState, clusterService, null, logger, thread.getThreadContext());
 
-            if (clusterState.nodes().getMasterNodeId() == null) {
+            if (clusterState.nodes().getClusterManagerNodeId() == null) {
                 logger.debug("waiting to join the cluster. timeout [{}]", initialStateTimeout);
                 final CountDownLatch latch = new CountDownLatch(1);
                 observer.waitForNextChange(new ClusterStateObserver.Listener() {
@@ -1141,7 +1141,7 @@ public class Node implements Closeable {
                         logger.warn("timed out while waiting for initial discovery state - timeout: {}", initialStateTimeout);
                         latch.countDown();
                     }
-                }, state -> state.nodes().getMasterNodeId() != null, initialStateTimeout);
+                }, state -> state.nodes().getClusterManagerNodeId() != null, initialStateTimeout);
 
                 try {
                     latch.await();
@@ -1464,7 +1464,7 @@ public class Node implements Closeable {
         NodeClient client
     ) {
         final InternalClusterInfoService service = new InternalClusterInfoService(settings, clusterService, threadPool, client);
-        if (DiscoveryNode.isMasterNode(settings)) {
+        if (DiscoveryNode.isClusterManagerNode(settings)) {
             // listen for state changes (this node starts/stops being the elected cluster manager, or new nodes are added)
             clusterService.addListener(service);
         }

--- a/server/src/main/java/org/opensearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoriesService.java
@@ -126,7 +126,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
         this.threadPool = threadPool;
         // Doesn't make sense to maintain repositories on non-master and non-data nodes
         // Nothing happens there anyway
-        if (DiscoveryNode.isDataNode(settings) || DiscoveryNode.isMasterNode(settings)) {
+        if (DiscoveryNode.isDataNode(settings) || DiscoveryNode.isClusterManagerNode(settings)) {
             if (isDedicatedVotingOnlyNode(DiscoveryNode.getRolesFromSettings(settings)) == false) {
                 clusterService.addHighPriorityApplier(this);
             }
@@ -238,7 +238,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
                 @Override
                 public boolean mustAck(DiscoveryNode discoveryNode) {
                     // repository is created on both cluster-manager and data nodes
-                    return discoveryNode.isMasterNode() || discoveryNode.isDataNode();
+                    return discoveryNode.isClusterManagerNode() || discoveryNode.isDataNode();
                 }
             }
         );
@@ -293,7 +293,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
                 @Override
                 public boolean mustAck(DiscoveryNode discoveryNode) {
                     // repository was created on both cluster-manager and data nodes
-                    return discoveryNode.isMasterNode() || discoveryNode.isDataNode();
+                    return discoveryNode.isClusterManagerNode() || discoveryNode.isDataNode();
                 }
             }
         );

--- a/server/src/main/java/org/opensearch/repositories/VerifyNodeRepositoryAction.java
+++ b/server/src/main/java/org/opensearch/repositories/VerifyNodeRepositoryAction.java
@@ -96,7 +96,7 @@ public class VerifyNodeRepositoryAction {
         final DiscoveryNodes discoNodes = clusterService.state().nodes();
         final DiscoveryNode localNode = discoNodes.getLocalNode();
 
-        final ObjectContainer<DiscoveryNode> masterAndDataNodes = discoNodes.getMasterAndDataNodes().values();
+        final ObjectContainer<DiscoveryNode> masterAndDataNodes = discoNodes.getClusterManagerAndDataNodes().values();
         final List<DiscoveryNode> nodes = new ArrayList<>();
         for (ObjectCursor<DiscoveryNode> cursor : masterAndDataNodes) {
             DiscoveryNode node = cursor.value;

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestClusterManagerAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestClusterManagerAction.java
@@ -113,7 +113,7 @@ public class RestClusterManagerAction extends AbstractCatAction {
         DiscoveryNodes nodes = state.getState().nodes();
 
         table.startRow();
-        DiscoveryNode clusterManager = nodes.get(nodes.getMasterNodeId());
+        DiscoveryNode clusterManager = nodes.get(nodes.getClusterManagerNodeId());
         if (clusterManager == null) {
             table.addCell("-");
             table.addCell("-");

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestHealthAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestHealthAction.java
@@ -119,7 +119,7 @@ public class RestHealthAction extends AbstractCatAction {
         t.addCell(health.getStatus().name().toLowerCase(Locale.ROOT));
         t.addCell(health.getNumberOfNodes());
         t.addCell(health.getNumberOfDataNodes());
-        t.addCell(health.hasDiscoveredMaster());
+        t.addCell(health.hasDiscoveredClusterManager());
         t.addCell(health.getActiveShards());
         t.addCell(health.getActivePrimaryShards());
         t.addCell(health.getRelocatingShards());

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestNodesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestNodesAction.java
@@ -343,7 +343,7 @@ public class RestNodesAction extends AbstractCatAction {
     ) {
 
         DiscoveryNodes nodes = state.getState().nodes();
-        String clusterManagerId = nodes.getMasterNodeId();
+        String clusterManagerId = nodes.getClusterManagerNodeId();
         Table table = getTableWithHeader(req);
 
         for (DiscoveryNode node : nodes) {

--- a/server/src/main/java/org/opensearch/snapshots/InternalSnapshotsInfoService.java
+++ b/server/src/main/java/org/opensearch/snapshots/InternalSnapshotsInfoService.java
@@ -130,7 +130,7 @@ public class InternalSnapshotsInfoService implements ClusterStateListener, Snaps
         this.maxConcurrentFetches = INTERNAL_SNAPSHOT_INFO_MAX_CONCURRENT_FETCHES_SETTING.get(settings);
         final ClusterSettings clusterSettings = clusterService.getClusterSettings();
         clusterSettings.addSettingsUpdateConsumer(INTERNAL_SNAPSHOT_INFO_MAX_CONCURRENT_FETCHES_SETTING, this::setMaxConcurrentFetches);
-        if (DiscoveryNode.isMasterNode(settings)) {
+        if (DiscoveryNode.isClusterManagerNode(settings)) {
             clusterService.addListener(this);
         }
     }
@@ -155,7 +155,7 @@ public class InternalSnapshotsInfoService implements ClusterStateListener, Snaps
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
-        if (event.localNodeMaster()) {
+        if (event.localNodeClusterManager()) {
             final Set<SnapshotShard> onGoingSnapshotRecoveries = listOfSnapshotShards(event.state());
 
             int unknownShards = 0;
@@ -180,7 +180,7 @@ public class InternalSnapshotsInfoService implements ClusterStateListener, Snaps
                 fetchNextSnapshotShard();
             }
 
-        } else if (event.previousState().nodes().isLocalNodeElectedMaster()) {
+        } else if (event.previousState().nodes().isLocalNodeElectedClusterManager()) {
             // TODO Maybe just clear out non-ongoing snapshot recoveries is the node is cluster-manager eligible, so that we don't
             // have to repopulate the data over and over in an unstable cluster-manager situation?
             synchronized (mutex) {

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -189,7 +189,7 @@ public class RestoreService implements ClusterStateApplier {
         this.allocationService = allocationService;
         this.createIndexService = createIndexService;
         this.metadataIndexUpgradeService = metadataIndexUpgradeService;
-        if (DiscoveryNode.isMasterNode(clusterService.getSettings())) {
+        if (DiscoveryNode.isClusterManagerNode(clusterService.getSettings())) {
             clusterService.addStateApplier(this);
         }
         this.clusterSettings = clusterService.getClusterSettings();
@@ -969,7 +969,7 @@ public class RestoreService implements ClusterStateApplier {
         }
 
         @Override
-        public void onNoLongerMaster(String source) {
+        public void onNoLongerClusterManager(String source) {
             logger.debug("no longer cluster-manager while processing restore state update [{}]", source);
         }
 
@@ -1119,7 +1119,7 @@ public class RestoreService implements ClusterStateApplier {
     @Override
     public void applyClusterState(ClusterChangedEvent event) {
         try {
-            if (event.localNodeMaster()) {
+            if (event.localNodeClusterManager()) {
                 cleanupRestoreState(event);
             }
         } catch (Exception t) {

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotShardsService.java
@@ -150,8 +150,8 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                 }
             }
 
-            String previousClusterManagerNodeId = event.previousState().nodes().getMasterNodeId();
-            String currentMasterNodeId = event.state().nodes().getMasterNodeId();
+            String previousClusterManagerNodeId = event.previousState().nodes().getClusterManagerNodeId();
+            String currentMasterNodeId = event.state().nodes().getClusterManagerNodeId();
             if (currentMasterNodeId != null && currentMasterNodeId.equals(previousClusterManagerNodeId) == false) {
                 syncShardStatsOnNewMaster(event);
             }

--- a/server/src/main/java/org/opensearch/transport/ConnectionProfile.java
+++ b/server/src/main/java/org/opensearch/transport/ConnectionProfile.java
@@ -103,7 +103,10 @@ public final class ConnectionProfile {
         builder.addConnections(connectionsPerNodeBulk, TransportRequestOptions.Type.BULK);
         builder.addConnections(connectionsPerNodePing, TransportRequestOptions.Type.PING);
         // if we are not cluster-manager eligible we don't need a dedicated channel to publish the state
-        builder.addConnections(DiscoveryNode.isMasterNode(settings) ? connectionsPerNodeState : 0, TransportRequestOptions.Type.STATE);
+        builder.addConnections(
+            DiscoveryNode.isClusterManagerNode(settings) ? connectionsPerNodeState : 0,
+            TransportRequestOptions.Type.STATE
+        );
         // if we are not a data-node we don't need any dedicated channels for recovery
         builder.addConnections(DiscoveryNode.isDataNode(settings) ? connectionsPerNodeRecovery : 0, TransportRequestOptions.Type.RECOVERY);
         builder.addConnections(connectionsPerNodeReg, TransportRequestOptions.Type.REG);

--- a/server/src/main/java/org/opensearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/opensearch/transport/SniffConnectionStrategy.java
@@ -141,7 +141,7 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
     static final int CHANNELS_PER_CONNECTION = 6;
 
     private static final Predicate<DiscoveryNode> DEFAULT_NODE_PREDICATE = (node) -> Version.CURRENT.isCompatible(node.getVersion())
-        && (node.isMasterNode() == false || node.isDataNode() || node.isIngestNode());
+        && (node.isClusterManagerNode() == false || node.isDataNode() || node.isIngestNode());
 
     private final List<String> configuredSeedNodes;
     private final List<Supplier<DiscoveryNode>> seedNodes;

--- a/server/src/test/java/org/opensearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
@@ -175,7 +175,7 @@ public class TransportAddVotingConfigExclusionsActionTests extends OpenSearchTes
                     .add(otherNode2)
                     .add(otherDataNode)
                     .localNodeId(localNode.getId())
-                    .masterNodeId(localNode.getId())
+                    .clusterManagerNodeId(localNode.getId())
             )
                 .metadata(
                     Metadata.builder()

--- a/server/src/test/java/org/opensearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsActionTests.java
@@ -126,7 +126,11 @@ public class TransportClearVotingConfigExclusionsActionTests extends OpenSearchT
         transportService.acceptIncomingRequests();
 
         final ClusterState.Builder builder = builder(new ClusterName("cluster")).nodes(
-            new Builder().add(localNode).add(otherNode1).add(otherNode2).localNodeId(localNode.getId()).masterNodeId(localNode.getId())
+            new Builder().add(localNode)
+                .add(otherNode1)
+                .add(otherNode2)
+                .localNodeId(localNode.getId())
+                .clusterManagerNodeId(localNode.getId())
         );
         builder.metadata(
             Metadata.builder()

--- a/server/src/test/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponsesTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponsesTests.java
@@ -116,7 +116,7 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
         DiscoveryNode localNode = new DiscoveryNode("node", OpenSearchTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
         // set the node information to verify cluster_manager_node discovery in ClusterHealthResponse
         ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
-            .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()).masterNodeId(localNode.getId()))
+            .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()).clusterManagerNodeId(localNode.getId()))
             .build();
         int pendingTasks = randomIntBetween(0, 200);
         int inFlight = randomIntBetween(0, 200);
@@ -132,7 +132,7 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
             pendingTaskInQueueTime
         );
         clusterHealth = maybeSerialize(clusterHealth);
-        assertThat(clusterHealth.getClusterStateHealth().hasDiscoveredMaster(), Matchers.equalTo(true));
+        assertThat(clusterHealth.getClusterStateHealth().hasDiscoveredClusterManager(), Matchers.equalTo(true));
         assertClusterHealth(clusterHealth);
     }
 
@@ -146,7 +146,7 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
         assertThat(clusterHealth.getUnassignedShards(), Matchers.equalTo(clusterStateHealth.getUnassignedShards()));
         assertThat(clusterHealth.getNumberOfNodes(), Matchers.equalTo(clusterStateHealth.getNumberOfNodes()));
         assertThat(clusterHealth.getNumberOfDataNodes(), Matchers.equalTo(clusterStateHealth.getNumberOfDataNodes()));
-        assertThat(clusterHealth.hasDiscoveredMaster(), Matchers.equalTo(clusterStateHealth.hasDiscoveredMaster()));
+        assertThat(clusterHealth.hasDiscoveredClusterManager(), Matchers.equalTo(clusterStateHealth.hasDiscoveredClusterManager()));
     }
 
     public void testVersionCompatibleSerialization() throws IOException {
@@ -240,7 +240,7 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
             assertNotNull(clusterHealth);
             assertThat(clusterHealth.getClusterName(), Matchers.equalTo("535799904437:7-1-3-node"));
             assertThat(clusterHealth.getNumberOfNodes(), Matchers.equalTo(6));
-            assertThat(clusterHealth.hasDiscoveredMaster(), Matchers.equalTo(true));
+            assertThat(clusterHealth.hasDiscoveredClusterManager(), Matchers.equalTo(true));
         }
     }
 
@@ -261,7 +261,7 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
             assertNotNull(clusterHealth);
             assertThat(clusterHealth.getClusterName(), Matchers.equalTo("535799904437:7-1-3-node"));
             assertThat(clusterHealth.getNumberOfNodes(), Matchers.equalTo(6));
-            assertThat(clusterHealth.hasDiscoveredMaster(), Matchers.equalTo(false));
+            assertThat(clusterHealth.hasDiscoveredClusterManager(), Matchers.equalTo(false));
         }
     }
 
@@ -283,7 +283,7 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
             )
         ) {
             ClusterHealthResponse clusterHealth = ClusterHealthResponse.fromXContent(parser);
-            assertThat(clusterHealth.hasDiscoveredMaster(), Matchers.equalTo(true));
+            assertThat(clusterHealth.hasDiscoveredClusterManager(), Matchers.equalTo(true));
         }
 
         try (
@@ -299,7 +299,7 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
             )
         ) {
             ClusterHealthResponse clusterHealth = ClusterHealthResponse.fromXContent(parser);
-            assertThat(clusterHealth.hasDiscoveredMaster(), Matchers.equalTo(true));
+            assertThat(clusterHealth.hasDiscoveredClusterManager(), Matchers.equalTo(true));
         }
     }
 
@@ -449,7 +449,7 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
                     state.getUnassignedShards(),
                     state.getNumberOfNodes(),
                     state.getNumberOfDataNodes(),
-                    state.hasDiscoveredMaster(),
+                    state.hasDiscoveredClusterManager(),
                     state.getActiveShardsPercent(),
                     state.getStatus(),
                     state.getIndices()

--- a/server/src/test/java/org/opensearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
@@ -61,7 +61,7 @@ public class ClusterRerouteResponseTests extends OpenSearchTestCase {
 
     public void testToXContent() throws IOException {
         DiscoveryNode node0 = new DiscoveryNode("node0", new TransportAddress(TransportAddress.META_ADDRESS, 9000), Version.CURRENT);
-        DiscoveryNodes nodes = new DiscoveryNodes.Builder().add(node0).masterNodeId(node0.getId()).build();
+        DiscoveryNodes nodes = new DiscoveryNodes.Builder().add(node0).clusterManagerNodeId(node0.getId()).build();
         IndexMetadata indexMetadata = IndexMetadata.builder("index")
             .settings(
                 Settings.builder()

--- a/server/src/test/java/org/opensearch/action/admin/cluster/state/ClusterStateResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/state/ClusterStateResponseTests.java
@@ -49,7 +49,7 @@ public class ClusterStateResponseTests extends AbstractWireSerializingTestCase<C
         if (randomBoolean()) {
             ClusterState.Builder clusterStateBuilder = ClusterState.builder(clusterName).version(randomNonNegativeLong());
             if (randomBoolean()) {
-                clusterStateBuilder.nodes(DiscoveryNodes.builder().masterNodeId(randomAlphaOfLength(4)).build());
+                clusterStateBuilder.nodes(DiscoveryNodes.builder().clusterManagerNodeId(randomAlphaOfLength(4)).build());
             }
             clusterState = clusterStateBuilder.build();
         }

--- a/server/src/test/java/org/opensearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
@@ -284,7 +284,7 @@ public class TransportBroadcastByNodeActionTests extends OpenSearchTestCase {
             }
         }
         discoBuilder.localNodeId(newNode(0).getId());
-        discoBuilder.masterNodeId(newNode(numberOfNodes - 1).getId());
+        discoBuilder.clusterManagerNodeId(newNode(numberOfNodes - 1).getId());
         ClusterState.Builder stateBuilder = ClusterState.builder(new ClusterName(TEST_CLUSTER));
         stateBuilder.nodes(discoBuilder);
         final IndexMetadata.Builder indexMetadata = IndexMetadata.builder(index)
@@ -374,7 +374,7 @@ public class TransportBroadcastByNodeActionTests extends OpenSearchTestCase {
         Request request = new Request(new String[] { TEST_INDEX });
         PlainActionFuture<Response> listener = new PlainActionFuture<>();
 
-        DiscoveryNode clusterManagerNode = clusterService.state().nodes().getMasterNode();
+        DiscoveryNode clusterManagerNode = clusterService.state().nodes().getClusterManagerNode();
         DiscoveryNodes.Builder builder = DiscoveryNodes.builder(clusterService.state().getNodes());
         builder.remove(clusterManagerNode.getId());
 
@@ -460,10 +460,10 @@ public class TransportBroadcastByNodeActionTests extends OpenSearchTestCase {
         final boolean simulateFailedClusterManagerNode = rarely();
         DiscoveryNode failedClusterManagerNode = null;
         if (simulateFailedClusterManagerNode) {
-            failedClusterManagerNode = clusterService.state().nodes().getMasterNode();
+            failedClusterManagerNode = clusterService.state().nodes().getClusterManagerNode();
             DiscoveryNodes.Builder builder = DiscoveryNodes.builder(clusterService.state().getNodes());
             builder.remove(failedClusterManagerNode.getId());
-            builder.masterNodeId(null);
+            builder.clusterManagerNodeId(null);
 
             setState(clusterService, ClusterState.builder(clusterService.state()).nodes(builder));
         }

--- a/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeActionTests.java
@@ -405,7 +405,7 @@ public class TransportClusterManagerNodeActionTests extends OpenSearchTestCase {
 
         assertThat(transport.capturedRequests().length, equalTo(1));
         CapturingTransport.CapturedRequest capturedRequest = transport.capturedRequests()[0];
-        assertTrue(capturedRequest.node.isMasterNode());
+        assertTrue(capturedRequest.node.isClusterManagerNode());
         assertThat(capturedRequest.request, equalTo(request));
         assertThat(capturedRequest.action, equalTo("internal:testAction"));
 
@@ -432,7 +432,7 @@ public class TransportClusterManagerNodeActionTests extends OpenSearchTestCase {
         CapturingTransport.CapturedRequest[] capturedRequests = transport.getCapturedRequestsAndClear();
         assertThat(capturedRequests.length, equalTo(1));
         CapturingTransport.CapturedRequest capturedRequest = capturedRequests[0];
-        assertTrue(capturedRequest.node.isMasterNode());
+        assertTrue(capturedRequest.node.isClusterManagerNode());
         assertThat(capturedRequest.request, equalTo(request));
         assertThat(capturedRequest.action, equalTo("internal:testAction"));
 
@@ -447,14 +447,14 @@ public class TransportClusterManagerNodeActionTests extends OpenSearchTestCase {
             if (randomBoolean()) {
                 // simulate cluster-manager node removal
                 final DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(clusterService.state().nodes());
-                nodesBuilder.masterNodeId(null);
+                nodesBuilder.clusterManagerNodeId(null);
                 setState(clusterService, ClusterState.builder(clusterService.state()).nodes(nodesBuilder));
             }
             if (randomBoolean()) {
                 // reset the same state to increment a version simulating a join of an existing node
                 // simulating use being disconnected
                 final DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(clusterService.state().nodes());
-                nodesBuilder.masterNodeId(clusterManagerNode.getId());
+                nodesBuilder.clusterManagerNodeId(clusterManagerNode.getId());
                 setState(clusterService, ClusterState.builder(clusterService.state()).nodes(nodesBuilder));
             } else {
                 // simulate cluster-manager restart followed by a state recovery - this will reset the cluster state version
@@ -466,7 +466,7 @@ public class TransportClusterManagerNodeActionTests extends OpenSearchTestCase {
                     clusterManagerNode.getVersion()
                 );
                 nodesBuilder.add(clusterManagerNode);
-                nodesBuilder.masterNodeId(clusterManagerNode.getId());
+                nodesBuilder.clusterManagerNodeId(clusterManagerNode.getId());
                 final ClusterState.Builder builder = ClusterState.builder(clusterService.state()).nodes(nodesBuilder);
                 setState(clusterService, builder.version(0));
             }
@@ -474,7 +474,7 @@ public class TransportClusterManagerNodeActionTests extends OpenSearchTestCase {
             capturedRequests = transport.getCapturedRequestsAndClear();
             assertThat(capturedRequests.length, equalTo(1));
             capturedRequest = capturedRequests[0];
-            assertTrue(capturedRequest.node.isMasterNode());
+            assertTrue(capturedRequest.node.isClusterManagerNode());
             assertThat(capturedRequest.request, equalTo(request));
             assertThat(capturedRequest.action, equalTo("internal:testAction"));
         } else if (failsWithConnectTransportException) {
@@ -524,7 +524,7 @@ public class TransportClusterManagerNodeActionTests extends OpenSearchTestCase {
 
         assertThat(transport.capturedRequests().length, equalTo(1));
         CapturingTransport.CapturedRequest capturedRequest = transport.capturedRequests()[0];
-        assertTrue(capturedRequest.node.isMasterNode());
+        assertTrue(capturedRequest.node.isClusterManagerNode());
         assertThat(capturedRequest.request, equalTo(request));
         assertThat(capturedRequest.action, equalTo("internal:testAction"));
 
@@ -559,7 +559,7 @@ public class TransportClusterManagerNodeActionTests extends OpenSearchTestCase {
 
         assertThat(transport.capturedRequests().length, equalTo(1));
         CapturingTransport.CapturedRequest capturedRequest = transport.capturedRequests()[0];
-        assertTrue(capturedRequest.node.isMasterNode());
+        assertTrue(capturedRequest.node.isClusterManagerNode());
         assertThat(capturedRequest.request, equalTo(request));
         assertThat(capturedRequest.action, equalTo("internal:testAction"));
 

--- a/server/src/test/java/org/opensearch/action/support/nodes/TransportNodesActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/nodes/TransportNodesActionTests.java
@@ -226,7 +226,7 @@ public class TransportNodesActionTests extends OpenSearchTestCase {
             discoveryNodes.add(node);
         }
         discoBuilder.localNodeId(randomFrom(discoveryNodes).getId());
-        discoBuilder.masterNodeId(randomFrom(discoveryNodes).getId());
+        discoBuilder.clusterManagerNodeId(randomFrom(discoveryNodes).getId());
         ClusterState.Builder stateBuilder = ClusterState.builder(clusterService.getClusterName());
         stateBuilder.nodes(discoBuilder);
         ClusterState clusterState = stateBuilder.build();

--- a/server/src/test/java/org/opensearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
@@ -142,7 +142,7 @@ public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTe
         Set<DiscoveryNodeRole> roles = new HashSet<>(DiscoveryNodeRole.BUILT_IN_ROLES);
         DiscoveryNode node1 = new DiscoveryNode("_name1", "_node1", buildNewFakeTransportAddress(), emptyMap(), roles, Version.CURRENT);
         DiscoveryNode node2 = new DiscoveryNode("_name2", "_node2", buildNewFakeTransportAddress(), emptyMap(), roles, Version.CURRENT);
-        state.nodes(DiscoveryNodes.builder().add(node1).add(node2).localNodeId(node1.getId()).masterNodeId(node1.getId()));
+        state.nodes(DiscoveryNodes.builder().add(node1).add(node2).localNodeId(node1.getId()).clusterManagerNodeId(node1.getId()));
 
         shardId = new ShardId("index", UUID.randomUUID().toString(), 0);
         ShardRouting shardRouting = newShardRouting(

--- a/server/src/test/java/org/opensearch/cluster/ClusterChangedEventTests.java
+++ b/server/src/test/java/org/opensearch/cluster/ClusterChangedEventTests.java
@@ -115,11 +115,11 @@ public class ClusterChangedEventTests extends OpenSearchTestCase {
         ClusterState previousState = createSimpleClusterState();
         ClusterState newState = createState(numNodesInCluster, true, initialIndices);
         ClusterChangedEvent event = new ClusterChangedEvent("_na_", newState, previousState);
-        assertTrue("local node should be cluster-manager", event.localNodeMaster());
+        assertTrue("local node should be cluster-manager", event.localNodeClusterManager());
 
         newState = createState(numNodesInCluster, false, initialIndices);
         event = new ClusterChangedEvent("_na_", newState, previousState);
-        assertFalse("local node should not be cluster-manager", event.localNodeMaster());
+        assertFalse("local node should not be cluster-manager", event.localNodeClusterManager());
     }
 
     /**
@@ -319,10 +319,10 @@ public class ClusterChangedEventTests extends OpenSearchTestCase {
         final DiscoveryNodes.Builder builderLocalIsMaster = DiscoveryNodes.builder();
         final DiscoveryNode node0 = newNode("node_0", Set.of(DiscoveryNodeRole.MASTER_ROLE));
         final DiscoveryNode node1 = newNode("node_1", Set.of(DiscoveryNodeRole.DATA_ROLE));
-        builderLocalIsMaster.add(node0).add(node1).masterNodeId(node0.getId()).localNodeId(node0.getId());
+        builderLocalIsMaster.add(node0).add(node1).clusterManagerNodeId(node0.getId()).localNodeId(node0.getId());
 
         final DiscoveryNodes.Builder builderLocalNotMaster = DiscoveryNodes.builder();
-        builderLocalNotMaster.add(node0).add(node1).masterNodeId(node0.getId()).localNodeId(node1.getId());
+        builderLocalNotMaster.add(node0).add(node1).clusterManagerNodeId(node0.getId()).localNodeId(node1.getId());
 
         ClusterState previousState = createSimpleClusterState();
         final Metadata metadata = createMetadata(initialIndices);
@@ -332,7 +332,7 @@ public class ClusterChangedEventTests extends OpenSearchTestCase {
             .routingTable(createRoutingTable(1, metadata))
             .build();
         ClusterChangedEvent event = new ClusterChangedEvent("_na_", newState, previousState);
-        assertTrue("local node should be master", event.localNodeMaster());
+        assertTrue("local node should be master", event.localNodeClusterManager());
 
         newState = ClusterState.builder(TEST_CLUSTER_NAME)
             .nodes(builderLocalNotMaster.build())
@@ -340,7 +340,7 @@ public class ClusterChangedEventTests extends OpenSearchTestCase {
             .routingTable(createRoutingTable(1, metadata))
             .build();
         event = new ClusterChangedEvent("_na_", newState, previousState);
-        assertFalse("local node should not be master", event.localNodeMaster());
+        assertFalse("local node should not be master", event.localNodeClusterManager());
     }
 
     private static class CustomMetadata2 extends TestCustomMetadata {
@@ -476,7 +476,7 @@ public class ClusterChangedEventTests extends OpenSearchTestCase {
             Set<DiscoveryNodeRole> roles = new HashSet<>();
             if (i == 0) {
                 // the cluster-manager node
-                builder.masterNodeId(nodeId);
+                builder.clusterManagerNodeId(nodeId);
                 roles.add(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE);
             } else if (i == 1) {
                 // the alternate cluster-manager node

--- a/server/src/test/java/org/opensearch/cluster/ClusterStateTests.java
+++ b/server/src/test/java/org/opensearch/cluster/ClusterStateTests.java
@@ -90,15 +90,15 @@ public class ClusterStateTests extends OpenSearchTestCase {
         ClusterState noClusterManager2 = ClusterState.builder(name).version(randomInt(5)).nodes(nodes).build();
         ClusterState withClusterManager1a = ClusterState.builder(name)
             .version(randomInt(5))
-            .nodes(DiscoveryNodes.builder(nodes).masterNodeId(node1.getId()))
+            .nodes(DiscoveryNodes.builder(nodes).clusterManagerNodeId(node1.getId()))
             .build();
         ClusterState withClusterManager1b = ClusterState.builder(name)
             .version(randomInt(5))
-            .nodes(DiscoveryNodes.builder(nodes).masterNodeId(node1.getId()))
+            .nodes(DiscoveryNodes.builder(nodes).clusterManagerNodeId(node1.getId()))
             .build();
         ClusterState withClusterManager2 = ClusterState.builder(name)
             .version(randomInt(5))
-            .nodes(DiscoveryNodes.builder(nodes).masterNodeId(node2.getId()))
+            .nodes(DiscoveryNodes.builder(nodes).clusterManagerNodeId(node2.getId()))
             .build();
 
         // states with no cluster-manager should never supersede anything
@@ -871,7 +871,7 @@ public class ClusterStateTests extends OpenSearchTestCase {
             .stateUUID("stateUUID")
             .nodes(
                 DiscoveryNodes.builder()
-                    .masterNodeId("clusterManagerNodeId")
+                    .clusterManagerNodeId("clusterManagerNodeId")
                     .add(new DiscoveryNode("nodeId1", new TransportAddress(InetAddress.getByName("127.0.0.1"), 111), Version.CURRENT))
                     .build()
             )

--- a/server/src/test/java/org/opensearch/cluster/InternalClusterInfoServiceSchedulingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/InternalClusterInfoServiceSchedulingTests.java
@@ -69,7 +69,9 @@ public class InternalClusterInfoServiceSchedulingTests extends OpenSearchTestCas
     public void testScheduling() {
         final DiscoveryNode discoveryNode = new DiscoveryNode("test", buildNewFakeTransportAddress(), Version.CURRENT);
         final DiscoveryNodes noClusterManager = DiscoveryNodes.builder().add(discoveryNode).localNodeId(discoveryNode.getId()).build();
-        final DiscoveryNodes localClusterManager = DiscoveryNodes.builder(noClusterManager).masterNodeId(discoveryNode.getId()).build();
+        final DiscoveryNodes localClusterManager = DiscoveryNodes.builder(noClusterManager)
+            .clusterManagerNodeId(discoveryNode.getId())
+            .build();
 
         final Settings.Builder settingsBuilder = Settings.builder().put(Node.NODE_NAME_SETTING.getKey(), discoveryNode.getName());
         if (randomBoolean()) {

--- a/server/src/test/java/org/opensearch/cluster/action/index/MappingUpdatedActionTests.java
+++ b/server/src/test/java/org/opensearch/cluster/action/index/MappingUpdatedActionTests.java
@@ -130,13 +130,13 @@ public class MappingUpdatedActionTests extends OpenSearchTestCase {
         };
 
         PlainActionFuture<Void> fut1 = new PlainActionFuture<>();
-        mua.updateMappingOnMaster(null, null, fut1);
+        mua.updateMappingOnClusterManager(null, null, fut1);
         assertEquals(1, inFlightListeners.size());
         assertEquals(0, mua.blockedThreads());
 
         PlainActionFuture<Void> fut2 = new PlainActionFuture<>();
         Thread thread = new Thread(() -> {
-            mua.updateMappingOnMaster(null, null, fut2); // blocked
+            mua.updateMappingOnClusterManager(null, null, fut2); // blocked
         });
         thread.start();
         assertBusy(() -> assertEquals(1, mua.blockedThreads()));

--- a/server/src/test/java/org/opensearch/cluster/action/shard/ShardStateActionTests.java
+++ b/server/src/test/java/org/opensearch/cluster/action/shard/ShardStateActionTests.java
@@ -197,7 +197,7 @@ public class ShardStateActionTests extends OpenSearchTestCase {
         assertEquals(shardEntry.shardId, shardRouting.shardId());
         assertEquals(shardEntry.allocationId, shardRouting.allocationId().getId());
         // sent to the cluster-manager
-        assertEquals(clusterService.state().nodes().getMasterNode().getId(), capturedRequests[0].node.getId());
+        assertEquals(clusterService.state().nodes().getClusterManagerNode().getId(), capturedRequests[0].node.getId());
 
         transport.handleResponse(capturedRequests[0].requestId, TransportResponse.Empty.INSTANCE);
 
@@ -211,7 +211,7 @@ public class ShardStateActionTests extends OpenSearchTestCase {
         setState(clusterService, ClusterStateCreationUtils.stateWithActivePrimary(index, true, randomInt(5)));
 
         DiscoveryNodes.Builder noClusterManagerBuilder = DiscoveryNodes.builder(clusterService.state().nodes());
-        noClusterManagerBuilder.masterNodeId(null);
+        noClusterManagerBuilder.clusterManagerNodeId(null);
         setState(clusterService, ClusterState.builder(clusterService.state()).nodes(noClusterManagerBuilder));
 
         CountDownLatch latch = new CountDownLatch(1);
@@ -504,7 +504,9 @@ public class ShardStateActionTests extends OpenSearchTestCase {
     ) {
         shardStateAction.setOnBeforeWaitForNewClusterManagerAndRetry(() -> {
             DiscoveryNodes.Builder clusterManagerBuilder = DiscoveryNodes.builder(clusterService.state().nodes());
-            clusterManagerBuilder.masterNodeId(clusterService.state().nodes().getMasterNodes().iterator().next().value.getId());
+            clusterManagerBuilder.clusterManagerNodeId(
+                clusterService.state().nodes().getClusterManagerNodes().iterator().next().value.getId()
+            );
             setState(clusterService, ClusterState.builder(clusterService.state()).nodes(clusterManagerBuilder));
         });
 

--- a/server/src/test/java/org/opensearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/CoordinatorTests.java
@@ -170,7 +170,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             cluster.stabilise();
 
             final ClusterNode leader = cluster.getAnyLeader();
-            assertTrue(leader.getLocalNode().isMasterNode());
+            assertTrue(leader.getLocalNode().isClusterManagerNode());
         }
     }
 
@@ -1729,7 +1729,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             final ClusterNode leader = cluster.getAnyLeader();
             final long expectedTerm = leader.coordinator.getCurrentTerm();
 
-            if (cluster.clusterNodes.stream().filter(n -> n.getLocalNode().isMasterNode()).count() == 2) {
+            if (cluster.clusterNodes.stream().filter(n -> n.getLocalNode().isClusterManagerNode()).count() == 2) {
                 // in the 2-node case, auto-shrinking the voting configuration is required to reduce the voting configuration down to just
                 // the leader, otherwise restarting the other cluster-manager-eligible node triggers an election
                 leader.submitSetAutoShrinkVotingConfiguration(true);

--- a/server/src/test/java/org/opensearch/cluster/coordination/FollowersCheckerTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/FollowersCheckerTests.java
@@ -713,7 +713,7 @@ public class FollowersCheckerTests extends OpenSearchTestCase {
             .map(cr -> cr.node)
             .collect(Collectors.toList());
         List<DiscoveryNode> sortedFollowerTargets = new ArrayList<>(followerTargets);
-        Collections.sort(sortedFollowerTargets, Comparator.comparing(n -> n.isMasterNode() == false));
+        Collections.sort(sortedFollowerTargets, Comparator.comparing(n -> n.isClusterManagerNode() == false));
         assertEquals(sortedFollowerTargets, followerTargets);
     }
 

--- a/server/src/test/java/org/opensearch/cluster/coordination/JoinTaskExecutorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/JoinTaskExecutorTests.java
@@ -189,7 +189,7 @@ public class JoinTaskExecutorTests extends OpenSearchTestCase {
                 DiscoveryNodes.builder()
                     .add(clusterManagerNode)
                     .localNodeId(clusterManagerNode.getId())
-                    .masterNodeId(clusterManagerNode.getId())
+                    .clusterManagerNodeId(clusterManagerNode.getId())
                     .add(bwcNode)
             )
             .build();
@@ -282,12 +282,12 @@ public class JoinTaskExecutorTests extends OpenSearchTestCase {
     }
 
     /**
-     * Validate isBecomeMasterTask() can identify "become cluster manager task" properly
+     * Validate isBecomeClusterManagerTask() can identify "become cluster manager task" properly
      */
     public void testIsBecomeClusterManagerTask() {
         JoinTaskExecutor.Task joinTaskOfMaster = JoinTaskExecutor.newBecomeMasterTask();
-        assertThat(joinTaskOfMaster.isBecomeMasterTask(), is(true));
+        assertThat(joinTaskOfMaster.isBecomeClusterManagerTask(), is(true));
         JoinTaskExecutor.Task joinTaskOfClusterManager = JoinTaskExecutor.newBecomeClusterManagerTask();
-        assertThat(joinTaskOfClusterManager.isBecomeMasterTask(), is(true));
+        assertThat(joinTaskOfClusterManager.isBecomeClusterManagerTask(), is(true));
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/coordination/LeaderCheckerTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/LeaderCheckerTests.java
@@ -453,7 +453,7 @@ public class LeaderCheckerTests extends OpenSearchTestCase {
         final DiscoveryNodes discoveryNodes = DiscoveryNodes.builder()
             .add(localNode)
             .localNodeId(localNode.getId())
-            .masterNodeId(localNode.getId())
+            .clusterManagerNodeId(localNode.getId())
             .build();
 
         {
@@ -498,7 +498,7 @@ public class LeaderCheckerTests extends OpenSearchTestCase {
         }
 
         {
-            leaderChecker.setCurrentNodes(DiscoveryNodes.builder(discoveryNodes).add(otherNode).masterNodeId(null).build());
+            leaderChecker.setCurrentNodes(DiscoveryNodes.builder(discoveryNodes).add(otherNode).clusterManagerNodeId(null).build());
 
             final CapturingTransportResponseHandler handler = new CapturingTransportResponseHandler();
             transportService.sendRequest(localNode, LEADER_CHECK_ACTION_NAME, new LeaderCheckRequest(otherNode), handler);

--- a/server/src/test/java/org/opensearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/NodeJoinTests.java
@@ -336,17 +336,17 @@ public class NodeJoinTests extends OpenSearchTestCase {
             () -> new StatusInfo(HEALTHY, "healthy-info")
         );
         assertFalse(isLocalNodeElectedMaster());
-        assertNull(coordinator.getStateForClusterManagerService().nodes().getMasterNodeId());
+        assertNull(coordinator.getStateForClusterManagerService().nodes().getClusterManagerNodeId());
         long newTerm = initialTerm + randomLongBetween(1, 10);
         SimpleFuture fut = joinNodeAsync(
             new JoinRequest(node1, newTerm, Optional.of(new Join(node1, node0, newTerm, initialTerm, initialVersion)))
         );
         assertEquals(Coordinator.Mode.LEADER, coordinator.getMode());
-        assertNull(coordinator.getStateForClusterManagerService().nodes().getMasterNodeId());
+        assertNull(coordinator.getStateForClusterManagerService().nodes().getClusterManagerNodeId());
         deterministicTaskQueue.runAllRunnableTasks();
         assertTrue(fut.isDone());
         assertTrue(isLocalNodeElectedMaster());
-        assertTrue(coordinator.getStateForClusterManagerService().nodes().isLocalNodeElectedMaster());
+        assertTrue(coordinator.getStateForClusterManagerService().nodes().isLocalNodeElectedClusterManager());
     }
 
     public void testJoinWithHigherTermButBetterStateGetsRejected() {

--- a/server/src/test/java/org/opensearch/cluster/coordination/PublicationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/PublicationTests.java
@@ -462,7 +462,7 @@ public class PublicationTests extends OpenSearchTestCase {
 
         List<DiscoveryNode> publicationTargets = new ArrayList<>(publication.pendingPublications.keySet());
         List<DiscoveryNode> sortedPublicationTargets = new ArrayList<>(publicationTargets);
-        Collections.sort(sortedPublicationTargets, Comparator.comparing(n -> n.isMasterNode() == false));
+        Collections.sort(sortedPublicationTargets, Comparator.comparing(n -> n.isClusterManagerNode() == false));
         assertEquals(sortedPublicationTargets, publicationTargets);
     }
 

--- a/server/src/test/java/org/opensearch/cluster/health/ClusterStateHealthTests.java
+++ b/server/src/test/java/org/opensearch/cluster/health/ClusterStateHealthTests.java
@@ -144,7 +144,7 @@ public class ClusterStateHealthTests extends OpenSearchTestCase {
         setState(
             clusterService,
             ClusterState.builder(clusterService.state())
-                .nodes(DiscoveryNodes.builder(clusterService.state().nodes()).masterNodeId(null))
+                .nodes(DiscoveryNodes.builder(clusterService.state().nodes()).clusterManagerNodeId(null))
                 .build()
         );
 
@@ -163,7 +163,7 @@ public class ClusterStateHealthTests extends OpenSearchTestCase {
             .onNewClusterState(
                 "restore cluster-manager",
                 () -> ClusterState.builder(currentState)
-                    .nodes(DiscoveryNodes.builder(currentState.nodes()).masterNodeId(currentState.nodes().getLocalNodeId()))
+                    .nodes(DiscoveryNodes.builder(currentState.nodes()).clusterManagerNodeId(currentState.nodes().getLocalNodeId()))
                     .build(),
                 (source, e) -> {}
             );
@@ -219,7 +219,10 @@ public class ClusterStateHealthTests extends OpenSearchTestCase {
         ClusterStateHealth clusterStateHealth = new ClusterStateHealth(clusterState, concreteIndices);
         logger.info("cluster status: {}, expected {}", clusterStateHealth.getStatus(), counter.status());
         clusterStateHealth = maybeSerialize(clusterStateHealth);
-        assertThat(clusterStateHealth.hasDiscoveredMaster(), equalTo(clusterService.state().nodes().getMasterNodeId() != null));
+        assertThat(
+            clusterStateHealth.hasDiscoveredClusterManager(),
+            equalTo(clusterService.state().nodes().getClusterManagerNodeId() != null)
+        );
         assertClusterHealth(clusterStateHealth, counter);
     }
 

--- a/server/src/test/java/org/opensearch/cluster/metadata/AutoExpandReplicasTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/AutoExpandReplicasTests.java
@@ -190,7 +190,7 @@ public class AutoExpandReplicasTests extends OpenSearchTestCase {
                 assertThat(postTable.toString(), postTable.getAllAllocationIds(), everyItem(is(in(preTable.getAllAllocationIds()))));
             } else {
                 // fake an election where conflicting nodes are removed and readded
-                state = ClusterState.builder(state).nodes(DiscoveryNodes.builder(state.nodes()).masterNodeId(null).build()).build();
+                state = ClusterState.builder(state).nodes(DiscoveryNodes.builder(state.nodes()).clusterManagerNodeId(null).build()).build();
 
                 List<DiscoveryNode> conflictingNodes = randomSubsetOf(2, dataNodes);
                 unchangedNodeIds = dataNodes.stream()
@@ -215,7 +215,7 @@ public class AutoExpandReplicasTests extends OpenSearchTestCase {
                     nodesToAdd.add(createNode(DiscoveryNodeRole.DATA_ROLE));
                 }
 
-                state = cluster.joinNodesAndBecomeMaster(state, nodesToAdd);
+                state = cluster.joinNodesAndBecomeClusterManager(state, nodesToAdd);
                 postTable = state.routingTable().index("index").shard(0);
             }
 

--- a/server/src/test/java/org/opensearch/cluster/metadata/TemplateUpgradeServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/TemplateUpgradeServiceTests.java
@@ -367,7 +367,7 @@ public class TemplateUpgradeServiceTests extends OpenSearchTestCase {
                         new DiscoveryNode("node1", "node1", buildNewFakeTransportAddress(), emptyMap(), MASTER_DATA_ROLES, Version.CURRENT)
                     )
                     .localNodeId("node1")
-                    .masterNodeId("node1")
+                    .clusterManagerNodeId("node1")
                     .build()
             )
             .metadata(metadata)

--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeRoleSettingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeRoleSettingTests.java
@@ -58,11 +58,11 @@ public class DiscoveryNodeRoleSettingTests extends OpenSearchTestCase {
     public void testIsMasterNode() {
         // It's used to add MASTER_ROLE into 'roleMap', because MASTER_ROLE is removed from DiscoveryNodeRole.BUILT_IN_ROLES in 2.0.
         DiscoveryNode.setAdditionalRoles(Collections.emptySet());
-        runRoleTest(DiscoveryNode::isMasterNode, DiscoveryNodeRole.MASTER_ROLE);
+        runRoleTest(DiscoveryNode::isClusterManagerNode, DiscoveryNodeRole.MASTER_ROLE);
     }
 
     public void testIsClusterManagerNode() {
-        runRoleTest(DiscoveryNode::isMasterNode, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE);
+        runRoleTest(DiscoveryNode::isClusterManagerNode, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE);
     }
 
     public void testIsRemoteClusterClient() {

--- a/server/src/test/java/org/opensearch/cluster/routing/BatchedRerouteServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/BatchedRerouteServiceTests.java
@@ -237,7 +237,10 @@ public class BatchedRerouteServiceTests extends OpenSearchTestCase {
                 clusterService.getClusterApplierService().onNewClusterState("simulated", () -> {
                     ClusterState state = clusterService.state();
                     return ClusterState.builder(state)
-                        .nodes(DiscoveryNodes.builder(state.nodes()).masterNodeId(randomBoolean() ? null : state.nodes().getLocalNodeId()))
+                        .nodes(
+                            DiscoveryNodes.builder(state.nodes())
+                                .clusterManagerNodeId(randomBoolean() ? null : state.nodes().getLocalNodeId())
+                        )
                         .build();
                 }, (source, e) -> {});
             }

--- a/server/src/test/java/org/opensearch/cluster/routing/DelayedAllocationServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/DelayedAllocationServiceTests.java
@@ -108,7 +108,7 @@ public class DelayedAllocationServiceTests extends OpenSearchAllocationTestCase 
             .routingTable(RoutingTable.builder().addAsNew(metadata.index("test")).build())
             .build();
         clusterState = ClusterState.builder(clusterState)
-            .nodes(DiscoveryNodes.builder().add(newNode("node1")).add(newNode("node2")).localNodeId("node1").masterNodeId("node1"))
+            .nodes(DiscoveryNodes.builder().add(newNode("node1")).add(newNode("node2")).localNodeId("node1").clusterManagerNodeId("node1"))
             .build();
         clusterState = allocationService.reroute(clusterState, "reroute");
         // starting primaries
@@ -154,7 +154,7 @@ public class DelayedAllocationServiceTests extends OpenSearchAllocationTestCase 
             .routingTable(RoutingTable.builder().addAsNew(metadata.index("test")).build())
             .build();
         clusterState = ClusterState.builder(clusterState)
-            .nodes(DiscoveryNodes.builder().add(newNode("node1")).add(newNode("node2")).localNodeId("node1").masterNodeId("node1"))
+            .nodes(DiscoveryNodes.builder().add(newNode("node1")).add(newNode("node2")).localNodeId("node1").clusterManagerNodeId("node1"))
             .build();
         final long baseTimestampNanos = System.nanoTime();
         allocationService.setNanoTimeOverride(baseTimestampNanos);
@@ -264,7 +264,7 @@ public class DelayedAllocationServiceTests extends OpenSearchAllocationTestCase 
                 DiscoveryNodes.builder()
                     .add(newNode("node0", singleton(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE)))
                     .localNodeId("node0")
-                    .masterNodeId("node0")
+                    .clusterManagerNodeId("node0")
                     .add(newNode("node1"))
                     .add(newNode("node2"))
                     .add(newNode("node3"))
@@ -449,7 +449,7 @@ public class DelayedAllocationServiceTests extends OpenSearchAllocationTestCase 
                     .add(newNode("node3"))
                     .add(newNode("node4"))
                     .localNodeId("node1")
-                    .masterNodeId("node1")
+                    .clusterManagerNodeId("node1")
             )
             .build();
         final long nodeLeftTimestampNanos = System.nanoTime();
@@ -556,7 +556,7 @@ public class DelayedAllocationServiceTests extends OpenSearchAllocationTestCase 
         }
 
         @Override
-        protected void assertClusterOrMasterStateThread() {
+        protected void assertClusterOrClusterManagerStateThread() {
             // do not check this in the unit tests
         }
 

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
@@ -201,7 +201,7 @@ public class RestoreInProgressAllocationDeciderTests extends OpenSearchAllocatio
         DiscoveryNodes discoveryNodes = DiscoveryNodes.builder()
             .add(newNode("cluster-manager", Collections.singleton(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE)))
             .localNodeId("cluster-manager")
-            .masterNodeId("cluster-manager")
+            .clusterManagerNodeId("cluster-manager")
             .build();
 
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
@@ -230,7 +230,7 @@ public class RestoreInProgressAllocationDeciderTests extends OpenSearchAllocatio
         if (randomBoolean()) {
             decision = decider.canAllocate(shardRouting, allocation);
         } else {
-            DiscoveryNode node = clusterState.getNodes().getMasterNode();
+            DiscoveryNode node = clusterState.getNodes().getClusterManagerNode();
             decision = decider.canAllocate(shardRouting, new RoutingNode(node.getId(), node), allocation);
         }
         return decision;

--- a/server/src/test/java/org/opensearch/cluster/serialization/ClusterSerializationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/serialization/ClusterSerializationTests.java
@@ -85,7 +85,7 @@ public class ClusterSerializationTests extends OpenSearchAllocationTestCase {
             .add(newNode("node2"))
             .add(newNode("node3"))
             .localNodeId("node1")
-            .masterNodeId("node2")
+            .clusterManagerNodeId("node2")
             .build();
 
         ClusterState clusterState = ClusterState.builder(new ClusterName("clusterName1"))

--- a/server/src/test/java/org/opensearch/cluster/serialization/ClusterStateToStringTests.java
+++ b/server/src/test/java/org/opensearch/cluster/serialization/ClusterStateToStringTests.java
@@ -67,7 +67,7 @@ public class ClusterStateToStringTests extends OpenSearchAllocationTestCase {
         DiscoveryNodes nodes = DiscoveryNodes.builder()
             .add(new DiscoveryNode("node_foo", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT))
             .localNodeId("node_foo")
-            .masterNodeId("node_foo")
+            .clusterManagerNodeId("node_foo")
             .build();
 
         ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))

--- a/server/src/test/java/org/opensearch/cluster/service/ClusterApplierServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/service/ClusterApplierServiceTests.java
@@ -119,7 +119,7 @@ public class ClusterApplierServiceTests extends OpenSearchTestCase {
                     DiscoveryNodes.builder()
                         .add(localNode)
                         .localNodeId(localNode.getId())
-                        .masterNodeId(makeClusterManager ? localNode.getId() : null)
+                        .clusterManagerNodeId(makeClusterManager ? localNode.getId() : null)
                 )
                 .blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK)
                 .build()
@@ -297,7 +297,7 @@ public class ClusterApplierServiceTests extends OpenSearchTestCase {
         TimedClusterApplierService timedClusterApplierService = createTimedClusterService(false);
 
         AtomicBoolean isClusterManager = new AtomicBoolean();
-        timedClusterApplierService.addLocalNodeMasterListener(new LocalNodeClusterManagerListener() {
+        timedClusterApplierService.addLocalNodeClusterManagerListener(new LocalNodeClusterManagerListener() {
             @Override
             public void onMaster() {
                 isClusterManager.set(true);
@@ -311,20 +311,20 @@ public class ClusterApplierServiceTests extends OpenSearchTestCase {
 
         ClusterState state = timedClusterApplierService.state();
         DiscoveryNodes nodes = state.nodes();
-        DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(nodes).masterNodeId(nodes.getLocalNodeId());
+        DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(nodes).clusterManagerNodeId(nodes.getLocalNodeId());
         state = ClusterState.builder(state).blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK).nodes(nodesBuilder).build();
         setState(timedClusterApplierService, state);
         assertThat(isClusterManager.get(), is(true));
 
         nodes = state.nodes();
-        nodesBuilder = DiscoveryNodes.builder(nodes).masterNodeId(null);
+        nodesBuilder = DiscoveryNodes.builder(nodes).clusterManagerNodeId(null);
         state = ClusterState.builder(state)
             .blocks(ClusterBlocks.builder().addGlobalBlock(NoClusterManagerBlockService.NO_MASTER_BLOCK_WRITES))
             .nodes(nodesBuilder)
             .build();
         setState(timedClusterApplierService, state);
         assertThat(isClusterManager.get(), is(false));
-        nodesBuilder = DiscoveryNodes.builder(nodes).masterNodeId(nodes.getLocalNodeId());
+        nodesBuilder = DiscoveryNodes.builder(nodes).clusterManagerNodeId(nodes.getLocalNodeId());
         state = ClusterState.builder(state).blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK).nodes(nodesBuilder).build();
         setState(timedClusterApplierService, state);
         assertThat(isClusterManager.get(), is(true));

--- a/server/src/test/java/org/opensearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/service/MasterServiceTests.java
@@ -136,7 +136,7 @@ public class MasterServiceTests extends OpenSearchTestCase {
                 DiscoveryNodes.builder()
                     .add(localNode)
                     .localNodeId(localNode.getId())
-                    .masterNodeId(makeClusterManager ? localNode.getId() : null)
+                    .clusterManagerNodeId(makeClusterManager ? localNode.getId() : null)
             )
             .blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK)
             .build();

--- a/server/src/test/java/org/opensearch/discovery/AbstractDisruptionTestCase.java
+++ b/server/src/test/java/org/opensearch/discovery/AbstractDisruptionTestCase.java
@@ -167,7 +167,10 @@ public abstract class AbstractDisruptionTestCase extends OpenSearchIntegTestCase
         assertBusy(() -> {
             ClusterState state = getNodeClusterState(node);
             final DiscoveryNodes nodes = state.nodes();
-            assertNull("node [" + node + "] still has [" + nodes.getMasterNode() + "] as cluster-manager", nodes.getMasterNode());
+            assertNull(
+                "node [" + node + "] still has [" + nodes.getClusterManagerNode() + "] as cluster-manager",
+                nodes.getClusterManagerNode()
+            );
             if (expectedBlocks != null) {
                 for (ClusterBlockLevel level : expectedBlocks.levels()) {
                     assertTrue(
@@ -183,10 +186,10 @@ public abstract class AbstractDisruptionTestCase extends OpenSearchIntegTestCase
         assertBusy(() -> {
             ClusterState state = getNodeClusterState(node);
             String clusterManagerNode = null;
-            if (state.nodes().getMasterNode() != null) {
-                clusterManagerNode = state.nodes().getMasterNode().getName();
+            if (state.nodes().getClusterManagerNode() != null) {
+                clusterManagerNode = state.nodes().getClusterManagerNode().getName();
             }
-            logger.trace("[{}] cluster-manager is [{}]", node, state.nodes().getMasterNode());
+            logger.trace("[{}] cluster-manager is [{}]", node, state.nodes().getClusterManagerNode());
             assertThat(
                 "node [" + node + "] still has [" + clusterManagerNode + "] as cluster-manager",
                 oldClusterManagerNode,
@@ -201,7 +204,9 @@ public abstract class AbstractDisruptionTestCase extends OpenSearchIntegTestCase
                 ClusterState state = getNodeClusterState(node);
                 String failMsgSuffix = "cluster_state:\n" + state;
                 assertThat("wrong node count on [" + node + "]. " + failMsgSuffix, state.nodes().getSize(), equalTo(nodes.size()));
-                String otherClusterManagerNodeName = state.nodes().getMasterNode() != null ? state.nodes().getMasterNode().getName() : null;
+                String otherClusterManagerNodeName = state.nodes().getClusterManagerNode() != null
+                    ? state.nodes().getClusterManagerNode().getName()
+                    : null;
                 assertThat(
                     "wrong cluster-manager on node [" + node + "]. " + failMsgSuffix,
                     otherClusterManagerNodeName,

--- a/server/src/test/java/org/opensearch/discovery/PeerFinderMessagesTests.java
+++ b/server/src/test/java/org/opensearch/discovery/PeerFinderMessagesTests.java
@@ -97,12 +97,12 @@ public class PeerFinderMessagesTests extends OpenSearchTestCase {
                 final long term = in.getTerm();
                 if (randomBoolean()) {
                     return new PeersResponse(
-                        in.getMasterNode(),
+                        in.getClusterManagerNode(),
                         in.getKnownPeers(),
                         randomValueOtherThan(term, OpenSearchTestCase::randomNonNegativeLong)
                     );
                 } else {
-                    if (in.getMasterNode().isPresent()) {
+                    if (in.getClusterManagerNode().isPresent()) {
                         if (randomBoolean()) {
                             return new PeersResponse(Optional.of(createNode(randomAlphaOfLength(10))), in.getKnownPeers(), term);
                         } else {
@@ -112,7 +112,7 @@ public class PeerFinderMessagesTests extends OpenSearchTestCase {
                         if (randomBoolean()) {
                             return new PeersResponse(Optional.of(createNode(randomAlphaOfLength(10))), emptyList(), term);
                         } else {
-                            return new PeersResponse(in.getMasterNode(), modifyDiscoveryNodesList(in.getKnownPeers(), false), term);
+                            return new PeersResponse(in.getClusterManagerNode(), modifyDiscoveryNodesList(in.getKnownPeers(), false), term);
                         }
                     }
                 }

--- a/server/src/test/java/org/opensearch/discovery/PeerFinderTests.java
+++ b/server/src/test/java/org/opensearch/discovery/PeerFinderTests.java
@@ -140,7 +140,7 @@ public class PeerFinderTests extends OpenSearchTestCase {
                     for (final Map.Entry<TransportAddress, DiscoveryNode> addressAndNode : reachableNodes.entrySet()) {
                         if (addressAndNode.getKey().equals(transportAddress)) {
                             final DiscoveryNode discoveryNode = addressAndNode.getValue();
-                            if (discoveryNode.isMasterNode()) {
+                            if (discoveryNode.isClusterManagerNode()) {
                                 disconnectedNodes.remove(discoveryNode);
                                 connectedNodes.add(discoveryNode);
                                 assertTrue(inFlightConnectionAttempts.remove(transportAddress));
@@ -477,7 +477,7 @@ public class PeerFinderTests extends OpenSearchTestCase {
 
         peerFinder.activate(lastAcceptedNodes);
         final PeersResponse peersResponse1 = peerFinder.handlePeersRequest(new PeersRequest(sourceNode, Collections.emptyList()));
-        assertFalse(peersResponse1.getMasterNode().isPresent());
+        assertFalse(peersResponse1.getClusterManagerNode().isPresent());
         assertThat(peersResponse1.getKnownPeers(), empty()); // sourceNode is not yet known
         assertThat(peersResponse1.getTerm(), is(0L));
 
@@ -488,7 +488,7 @@ public class PeerFinderTests extends OpenSearchTestCase {
         final long updatedTerm = randomNonNegativeLong();
         peerFinder.setCurrentTerm(updatedTerm);
         final PeersResponse peersResponse2 = peerFinder.handlePeersRequest(new PeersRequest(sourceNode, Collections.emptyList()));
-        assertFalse(peersResponse2.getMasterNode().isPresent());
+        assertFalse(peersResponse2.getClusterManagerNode().isPresent());
         assertThat(peersResponse2.getKnownPeers(), contains(sourceNode));
         assertThat(peersResponse2.getTerm(), is(updatedTerm));
     }
@@ -531,7 +531,7 @@ public class PeerFinderTests extends OpenSearchTestCase {
                 @Override
                 public void handleResponse(PeersResponse response) {
                     assertTrue(responseReceived.compareAndSet(false, true));
-                    assertFalse(response.getMasterNode().isPresent());
+                    assertFalse(response.getClusterManagerNode().isPresent());
                     assertThat(response.getKnownPeers(), empty()); // sourceNode is not yet known
                     assertThat(response.getTerm(), is(0L));
                 }

--- a/server/src/test/java/org/opensearch/gateway/GatewayServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/GatewayServiceTests.java
@@ -135,7 +135,7 @@ public class GatewayServiceTests extends OpenSearchTestCase {
             nodeId
         );
         ClusterState stateWithBlock = ClusterState.builder(ClusterName.DEFAULT)
-            .nodes(DiscoveryNodes.builder().localNodeId(nodeId).masterNodeId(nodeId).add(clusterManagerNode).build())
+            .nodes(DiscoveryNodes.builder().localNodeId(nodeId).clusterManagerNodeId(nodeId).add(clusterManagerNode).build())
             .blocks(ClusterBlocks.builder().addGlobalBlock(STATE_NOT_RECOVERED_BLOCK).build())
             .build();
 

--- a/server/src/test/java/org/opensearch/gateway/IncrementalClusterStateWriterTests.java
+++ b/server/src/test/java/org/opensearch/gateway/IncrementalClusterStateWriterTests.java
@@ -188,7 +188,7 @@ public class IncrementalClusterStateWriterTests extends OpenSearchAllocationTest
             .add(newNode("node1", clusterManagerEligible ? CLUSTER_MANAGER_DATA_ROLES : dataOnlyRoles))
             .add(newNode("cluster_manager_node", CLUSTER_MANAGER_DATA_ROLES))
             .localNodeId("node1")
-            .masterNodeId(clusterManagerEligible ? "node1" : "cluster_manager_node");
+            .clusterManagerNodeId(clusterManagerEligible ? "node1" : "cluster_manager_node");
     }
 
     private IndexMetadata createIndexMetadata(String name) {

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -2654,7 +2654,7 @@ public class InternalEngineTests extends EngineTestCase {
             );
 
             ReplicationTracker gcpTracker = (ReplicationTracker) initialEngine.config().getGlobalCheckpointSupplier();
-            gcpTracker.updateFromMaster(
+            gcpTracker.updateFromClusterManager(
                 1L,
                 new HashSet<>(Collections.singletonList(primary.allocationId().getId())),
                 new IndexShardRoutingTable.Builder(shardId).addShard(primary).build()
@@ -2669,7 +2669,7 @@ public class InternalEngineTests extends EngineTestCase {
                 );
                 countDownLatch.await();
             }
-            gcpTracker.updateFromMaster(
+            gcpTracker.updateFromClusterManager(
                 2L,
                 new HashSet<>(Collections.singletonList(primary.allocationId().getId())),
                 new IndexShardRoutingTable.Builder(shardId).addShard(primary).addShard(initializingReplica).build()
@@ -2677,7 +2677,7 @@ public class InternalEngineTests extends EngineTestCase {
             gcpTracker.initiateTracking(initializingReplica.allocationId().getId());
             gcpTracker.markAllocationIdAsInSync(initializingReplica.allocationId().getId(), replicaLocalCheckpoint);
             final ShardRouting replica = initializingReplica.moveToStarted();
-            gcpTracker.updateFromMaster(
+            gcpTracker.updateFromClusterManager(
                 3L,
                 new HashSet<>(Arrays.asList(primary.allocationId().getId(), replica.allocationId().getId())),
                 new IndexShardRoutingTable.Builder(shardId).addShard(primary).addShard(replica).build()

--- a/server/src/test/java/org/opensearch/index/engine/NoOpEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/NoOpEngineTests.java
@@ -99,7 +99,7 @@ public class NoOpEngineTests extends EngineTestCase {
             allocationId
         );
         IndexShardRoutingTable table = new IndexShardRoutingTable.Builder(shardId).addShard(routing).build();
-        tracker.updateFromMaster(1L, Collections.singleton(allocationId.getId()), table);
+        tracker.updateFromClusterManager(1L, Collections.singleton(allocationId.getId()), table);
         tracker.activatePrimaryMode(SequenceNumbers.NO_OPS_PERFORMED);
         for (int i = 0; i < docs; i++) {
             ParsedDocument doc = testParsedDocument("" + i, null, testDocumentWithTextField(), B_1, null);
@@ -203,7 +203,7 @@ public class NoOpEngineTests extends EngineTestCase {
             allocationId
         );
         IndexShardRoutingTable table = new IndexShardRoutingTable.Builder(shardId).addShard(routing).build();
-        tracker.updateFromMaster(1L, Collections.singleton(allocationId.getId()), table);
+        tracker.updateFromClusterManager(1L, Collections.singleton(allocationId.getId()), table);
         tracker.activatePrimaryMode(SequenceNumbers.NO_OPS_PERFORMED);
         engine.onSettingsChanged(TimeValue.MINUS_ONE, ByteSizeValue.ZERO, randomNonNegativeLong());
         final int numDocs = scaledRandomIntBetween(10, 3000);

--- a/server/src/test/java/org/opensearch/index/seqno/PeerRecoveryRetentionLeaseExpiryTests.java
+++ b/server/src/test/java/org/opensearch/index/seqno/PeerRecoveryRetentionLeaseExpiryTests.java
@@ -95,7 +95,7 @@ public class PeerRecoveryRetentionLeaseExpiryTests extends ReplicationTrackerTes
             (leases, listener) -> {},
             () -> safeCommitInfo
         );
-        replicationTracker.updateFromMaster(
+        replicationTracker.updateFromClusterManager(
             1L,
             Collections.singleton(primaryAllocationId.getId()),
             routingTable(Collections.emptySet(), primaryAllocationId)
@@ -107,7 +107,7 @@ public class PeerRecoveryRetentionLeaseExpiryTests extends ReplicationTrackerTes
             Collections.singleton(replicaAllocationId),
             primaryAllocationId
         );
-        replicationTracker.updateFromMaster(2L, Collections.singleton(primaryAllocationId.getId()), routingTableWithReplica);
+        replicationTracker.updateFromClusterManager(2L, Collections.singleton(primaryAllocationId.getId()), routingTableWithReplica);
         replicationTracker.addPeerRecoveryRetentionLease(
             routingTableWithReplica.getByAllocationId(replicaAllocationId.getId()).currentNodeId(),
             randomCheckpoint(),
@@ -127,7 +127,7 @@ public class PeerRecoveryRetentionLeaseExpiryTests extends ReplicationTrackerTes
         final IndexShardRoutingTable.Builder builder = new IndexShardRoutingTable.Builder(replicationTracker.routingTable);
         builder.removeShard(replicaShardRouting);
         builder.addShard(replicaShardRouting.moveToStarted());
-        replicationTracker.updateFromMaster(
+        replicationTracker.updateFromClusterManager(
             replicationTracker.appliedClusterStateVersion + 1,
             replicationTracker.routingTable.shards().stream().map(sr -> sr.allocationId().getId()).collect(Collectors.toSet()),
             builder.build()

--- a/server/src/test/java/org/opensearch/index/seqno/ReplicationTrackerRetentionLeaseTests.java
+++ b/server/src/test/java/org/opensearch/index/seqno/ReplicationTrackerRetentionLeaseTests.java
@@ -86,7 +86,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             (leases, listener) -> {},
             OPS_BASED_RECOVERY_ALWAYS_REASONABLE
         );
-        replicationTracker.updateFromMaster(
+        replicationTracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(allocationId.getId()),
             routingTable(Collections.emptySet(), allocationId)
@@ -134,7 +134,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             (leases, listener) -> {},
             OPS_BASED_RECOVERY_ALWAYS_REASONABLE
         );
-        replicationTracker.updateFromMaster(
+        replicationTracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(allocationId.getId()),
             routingTable(Collections.emptySet(), allocationId)
@@ -166,7 +166,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             (leases, listener) -> {},
             OPS_BASED_RECOVERY_ALWAYS_REASONABLE
         );
-        replicationTracker.updateFromMaster(
+        replicationTracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(allocationId.getId()),
             routingTable(Collections.emptySet(), allocationId)
@@ -205,7 +205,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             OPS_BASED_RECOVERY_ALWAYS_REASONABLE
         );
         reference.set(replicationTracker);
-        replicationTracker.updateFromMaster(
+        replicationTracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(allocationId.getId()),
             routingTable(Collections.emptySet(), allocationId)
@@ -243,7 +243,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             (leases, listener) -> {},
             OPS_BASED_RECOVERY_ALWAYS_REASONABLE
         );
-        replicationTracker.updateFromMaster(
+        replicationTracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(allocationId.getId()),
             routingTable(Collections.emptySet(), allocationId)
@@ -308,7 +308,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             OPS_BASED_RECOVERY_ALWAYS_REASONABLE
         );
         replicationTrackerRef.set(replicationTracker);
-        replicationTracker.updateFromMaster(
+        replicationTracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(allocationId.getId()),
             routingTable(Collections.emptySet(), allocationId)
@@ -353,7 +353,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             (leases, listener) -> {},
             OPS_BASED_RECOVERY_ALWAYS_REASONABLE
         );
-        replicationTracker.updateFromMaster(
+        replicationTracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(allocationId.getId()),
             routingTable(Collections.emptySet(), allocationId)
@@ -382,7 +382,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             (leases, listener) -> {},
             OPS_BASED_RECOVERY_ALWAYS_REASONABLE
         );
-        replicationTracker.updateFromMaster(
+        replicationTracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(allocationId.getId()),
             routingTable(Collections.emptySet(), allocationId)
@@ -415,7 +415,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             (leases, listener) -> {},
             OPS_BASED_RECOVERY_ALWAYS_REASONABLE
         );
-        replicationTracker.updateFromMaster(
+        replicationTracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(allocationId.getId()),
             routingTable(Collections.emptySet(), allocationId)
@@ -454,7 +454,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             OPS_BASED_RECOVERY_ALWAYS_REASONABLE
         );
         reference.set(replicationTracker);
-        replicationTracker.updateFromMaster(
+        replicationTracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(allocationId.getId()),
             routingTable(Collections.emptySet(), allocationId)
@@ -506,7 +506,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             (leases, listener) -> {},
             OPS_BASED_RECOVERY_ALWAYS_REASONABLE
         );
-        replicationTracker.updateFromMaster(
+        replicationTracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(allocationId.getId()),
             routingTable(Collections.emptySet(), allocationId)
@@ -585,7 +585,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             (leases, listener) -> {},
             OPS_BASED_RECOVERY_ALWAYS_REASONABLE
         );
-        replicationTracker.updateFromMaster(
+        replicationTracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(allocationId.getId()),
             routingTable(Collections.emptySet(), allocationId)
@@ -638,7 +638,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             (leases, listener) -> {},
             OPS_BASED_RECOVERY_ALWAYS_REASONABLE
         );
-        replicationTracker.updateFromMaster(
+        replicationTracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(allocationId.getId()),
             routingTable(Collections.emptySet(), allocationId)
@@ -673,7 +673,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             (leases, listener) -> {},
             OPS_BASED_RECOVERY_ALWAYS_REASONABLE
         );
-        replicationTracker.updateFromMaster(
+        replicationTracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(allocationId.getId()),
             routingTable(Collections.emptySet(), allocationId)
@@ -726,7 +726,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             (leases, listener) -> {},
             OPS_BASED_RECOVERY_ALWAYS_REASONABLE
         );
-        replicationTracker.updateFromMaster(
+        replicationTracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(allocationId.getId()),
             routingTable(Collections.emptySet(), allocationId)
@@ -790,7 +790,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             (leases, listener) -> {},
             OPS_BASED_RECOVERY_ALWAYS_REASONABLE
         );
-        replicationTracker.updateFromMaster(
+        replicationTracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(allocationId.getId()),
             routingTable(Collections.emptySet(), allocationId)

--- a/server/src/test/java/org/opensearch/index/seqno/ReplicationTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/seqno/ReplicationTrackerTests.java
@@ -137,7 +137,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
             logger.info("  - [{}], local checkpoint [{}], [{}]", aId, allocations.get(aId), type);
         });
 
-        tracker.updateFromMaster(initialClusterStateVersion, ids(active), routingTable(initializing, primaryId));
+        tracker.updateFromClusterManager(initialClusterStateVersion, ids(active), routingTable(initializing, primaryId));
         tracker.activatePrimaryMode(NO_OPS_PERFORMED);
         assertThat(tracker.getReplicationGroup().getReplicationTargets().size(), equalTo(1));
         initializing.forEach(aId -> markAsTrackingAndInSyncQuietly(tracker, aId.getId(), NO_OPS_PERFORMED));
@@ -167,7 +167,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
 
         Set<AllocationId> newInitializing = new HashSet<>(initializing);
         newInitializing.add(extraId);
-        tracker.updateFromMaster(initialClusterStateVersion + 1, ids(active), routingTable(newInitializing, primaryId));
+        tracker.updateFromClusterManager(initialClusterStateVersion + 1, ids(active), routingTable(newInitializing, primaryId));
 
         addPeerRecoveryRetentionLease(tracker, extraId);
         tracker.initiateTracking(extraId.getId());
@@ -208,7 +208,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
         final AllocationId primaryId = active.iterator().next();
         final AllocationId replicaId = initializing.iterator().next();
         final ReplicationTracker tracker = newTracker(primaryId);
-        tracker.updateFromMaster(initialClusterStateVersion, ids(active), routingTable(initializing, primaryId));
+        tracker.updateFromClusterManager(initialClusterStateVersion, ids(active), routingTable(initializing, primaryId));
         final long localCheckpoint = randomLongBetween(0, Long.MAX_VALUE - 1);
         tracker.activatePrimaryMode(localCheckpoint);
         addPeerRecoveryRetentionLease(tracker, replicaId);
@@ -249,7 +249,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
         assigned.putAll(initializing);
         AllocationId primaryId = active.keySet().iterator().next();
         final ReplicationTracker tracker = newTracker(primaryId);
-        tracker.updateFromMaster(randomNonNegativeLong(), ids(active.keySet()), routingTable(initializing.keySet(), primaryId));
+        tracker.updateFromClusterManager(randomNonNegativeLong(), ids(active.keySet()), routingTable(initializing.keySet(), primaryId));
         tracker.activatePrimaryMode(NO_OPS_PERFORMED);
         randomSubsetOf(initializing.keySet()).forEach(k -> markAsTrackingAndInSyncQuietly(tracker, k.getId(), NO_OPS_PERFORMED));
         final AllocationId missingActiveID = randomFrom(active.keySet());
@@ -275,7 +275,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
 
         AllocationId primaryId = active.keySet().iterator().next();
         final ReplicationTracker tracker = newTracker(primaryId);
-        tracker.updateFromMaster(randomNonNegativeLong(), ids(active.keySet()), routingTable(initializing.keySet(), primaryId));
+        tracker.updateFromClusterManager(randomNonNegativeLong(), ids(active.keySet()), routingTable(initializing.keySet(), primaryId));
         tracker.activatePrimaryMode(NO_OPS_PERFORMED);
         randomSubsetOf(randomIntBetween(1, initializing.size() - 1), initializing.keySet()).forEach(
             aId -> markAsTrackingAndInSyncQuietly(tracker, aId.getId(), NO_OPS_PERFORMED)
@@ -298,7 +298,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
         final Map<AllocationId, Long> nonApproved = randomAllocationsWithLocalCheckpoints(1, 5);
         final AllocationId primaryId = active.keySet().iterator().next();
         final ReplicationTracker tracker = newTracker(primaryId);
-        tracker.updateFromMaster(randomNonNegativeLong(), ids(active.keySet()), routingTable(initializing.keySet(), primaryId));
+        tracker.updateFromClusterManager(randomNonNegativeLong(), ids(active.keySet()), routingTable(initializing.keySet(), primaryId));
         tracker.activatePrimaryMode(NO_OPS_PERFORMED);
         initializing.keySet().forEach(k -> markAsTrackingAndInSyncQuietly(tracker, k.getId(), NO_OPS_PERFORMED));
         nonApproved.keySet()
@@ -335,7 +335,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
             allocations.putAll(initializingToBeRemoved);
         }
         final ReplicationTracker tracker = newTracker(primaryId);
-        tracker.updateFromMaster(initialClusterStateVersion, ids(active), routingTable(initializing, primaryId));
+        tracker.updateFromClusterManager(initialClusterStateVersion, ids(active), routingTable(initializing, primaryId));
         tracker.activatePrimaryMode(NO_OPS_PERFORMED);
         if (randomBoolean()) {
             initializingToStay.keySet().forEach(k -> markAsTrackingAndInSyncQuietly(tracker, k.getId(), NO_OPS_PERFORMED));
@@ -348,7 +348,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
 
         // now remove shards
         if (randomBoolean()) {
-            tracker.updateFromMaster(
+            tracker.updateFromClusterManager(
                 initialClusterStateVersion + 1,
                 ids(activeToStay.keySet()),
                 routingTable(initializingToStay.keySet(), primaryId)
@@ -356,7 +356,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
             allocations.forEach((aid, ckp) -> updateLocalCheckpoint(tracker, aid.getId(), ckp + 10L));
         } else {
             allocations.forEach((aid, ckp) -> updateLocalCheckpoint(tracker, aid.getId(), ckp + 10L));
-            tracker.updateFromMaster(
+            tracker.updateFromClusterManager(
                 initialClusterStateVersion + 2,
                 ids(activeToStay.keySet()),
                 routingTable(initializingToStay.keySet(), primaryId)
@@ -378,7 +378,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
         final AllocationId trackingAllocationId = AllocationId.newInitializing();
         final ReplicationTracker tracker = newTracker(inSyncAllocationId);
         final long clusterStateVersion = randomNonNegativeLong();
-        tracker.updateFromMaster(
+        tracker.updateFromClusterManager(
             clusterStateVersion,
             Collections.singleton(inSyncAllocationId.getId()),
             routingTable(Collections.singleton(trackingAllocationId), inSyncAllocationId)
@@ -422,7 +422,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
             assertTrue(tracker.getTrackedLocalCheckpointForShard(trackingAllocationId.getId()).inSync);
         } else {
             // cluster-manager changes its mind and cancels the allocation
-            tracker.updateFromMaster(
+            tracker.updateFromClusterManager(
                 clusterStateVersion + 1,
                 Collections.singleton(inSyncAllocationId.getId()),
                 routingTable(emptySet(), inSyncAllocationId)
@@ -449,7 +449,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
         final AllocationId inSyncAllocationId = AllocationId.newInitializing();
         final AllocationId trackingAllocationId = AllocationId.newInitializing();
         final ReplicationTracker tracker = newTracker(inSyncAllocationId);
-        tracker.updateFromMaster(
+        tracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(inSyncAllocationId.getId()),
             routingTable(Collections.singleton(trackingAllocationId), inSyncAllocationId)
@@ -505,7 +505,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
         AllocationId primaryId = activeAllocationIds.iterator().next();
         IndexShardRoutingTable routingTable = routingTable(initializingIds, primaryId);
         final ReplicationTracker tracker = newTracker(primaryId);
-        tracker.updateFromMaster(initialClusterStateVersion, ids(activeAllocationIds), routingTable);
+        tracker.updateFromClusterManager(initialClusterStateVersion, ids(activeAllocationIds), routingTable);
         tracker.activatePrimaryMode(NO_OPS_PERFORMED);
         assertThat(tracker.getReplicationGroup().getInSyncAllocationIds(), equalTo(ids(activeAllocationIds)));
         assertThat(tracker.getReplicationGroup().getRoutingTable(), equalTo(routingTable));
@@ -539,7 +539,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
             .filter(a -> !removingInitializingAllocationIds.contains(a))
             .collect(Collectors.toSet());
         routingTable = routingTable(newInitializingAllocationIds, primaryId);
-        tracker.updateFromMaster(initialClusterStateVersion + 1, ids(newActiveAllocationIds), routingTable);
+        tracker.updateFromClusterManager(initialClusterStateVersion + 1, ids(newActiveAllocationIds), routingTable);
         assertTrue(newActiveAllocationIds.stream().allMatch(a -> tracker.getTrackedLocalCheckpointForShard(a.getId()).inSync));
         assertTrue(removingActiveAllocationIds.stream().allMatch(a -> tracker.getTrackedLocalCheckpointForShard(a.getId()) == null));
         assertTrue(newInitializingAllocationIds.stream().noneMatch(a -> tracker.getTrackedLocalCheckpointForShard(a.getId()).inSync));
@@ -555,7 +555,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
          * than we have been using above ensures that we can not collide with a previous allocation ID
          */
         newInitializingAllocationIds.add(AllocationId.newInitializing());
-        tracker.updateFromMaster(
+        tracker.updateFromClusterManager(
             initialClusterStateVersion + 2,
             ids(newActiveAllocationIds),
             routingTable(newInitializingAllocationIds, primaryId)
@@ -607,7 +607,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
         // using a different length than we have been using above ensures that we can not collide with a previous allocation ID
         final AllocationId newSyncingAllocationId = AllocationId.newInitializing();
         newInitializingAllocationIds.add(newSyncingAllocationId);
-        tracker.updateFromMaster(
+        tracker.updateFromClusterManager(
             initialClusterStateVersion + 3,
             ids(newActiveAllocationIds),
             routingTable(newInitializingAllocationIds, primaryId)
@@ -649,7 +649,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
          * the in-sync set even if we receive a cluster state update that does not reflect this.
          *
          */
-        tracker.updateFromMaster(
+        tracker.updateFromClusterManager(
             initialClusterStateVersion + 4,
             ids(newActiveAllocationIds),
             routingTable(newInitializingAllocationIds, primaryId)
@@ -678,7 +678,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
 
         final int activeLocalCheckpoint = randomIntBetween(0, Integer.MAX_VALUE - 1);
         final ReplicationTracker tracker = newTracker(active);
-        tracker.updateFromMaster(
+        tracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(active.getId()),
             routingTable(Collections.singleton(initializing), active)
@@ -907,7 +907,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
         final AllocationId active = AllocationId.newInitializing();
         final AllocationId initializing = AllocationId.newInitializing();
         final ReplicationTracker tracker = newTracker(active);
-        tracker.updateFromMaster(
+        tracker.updateFromClusterManager(
             randomNonNegativeLong(),
             Collections.singleton(active.getId()),
             routingTable(Collections.singleton(initializing), active)
@@ -938,7 +938,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
         }
 
         public void apply(ReplicationTracker gcp) {
-            gcp.updateFromMaster(version, ids(inSyncIds), routingTable);
+            gcp.updateFromClusterManager(version, ids(inSyncIds), routingTable);
         }
     }
 
@@ -1114,7 +1114,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
         tracker.updateRetentionLeasesOnReplica(new RetentionLeases(randomNonNegativeLong(), randomNonNegativeLong(), initialLeases));
 
         IndexShardRoutingTable routingTable = routingTable(initializingAllocationIds, primaryId);
-        tracker.updateFromMaster(initialClusterStateVersion, ids(activeAllocationIds), routingTable);
+        tracker.updateFromClusterManager(initialClusterStateVersion, ids(activeAllocationIds), routingTable);
         tracker.activatePrimaryMode(NO_OPS_PERFORMED);
         assertTrue(
             "primary's retention lease should exist",
@@ -1184,7 +1184,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
         routingTable = routingTableBuilder.build();
         activeAllocationIds.addAll(initializingAllocationIds);
 
-        tracker.updateFromMaster(initialClusterStateVersion + randomLongBetween(1, 10), ids(activeAllocationIds), routingTable);
+        tracker.updateFromClusterManager(initialClusterStateVersion + randomLongBetween(1, 10), ids(activeAllocationIds), routingTable);
 
         assertAsTimePasses.accept(() -> {
             // Leases still don't expire

--- a/server/src/test/java/org/opensearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/opensearch/indices/cluster/ClusterStateChanges.java
@@ -397,13 +397,19 @@ public class ClusterStateChanges {
         );
     }
 
-    public ClusterState joinNodesAndBecomeMaster(ClusterState clusterState, List<DiscoveryNode> nodes) {
+    public ClusterState joinNodesAndBecomeClusterManager(ClusterState clusterState, List<DiscoveryNode> nodes) {
         List<JoinTaskExecutor.Task> joinNodes = new ArrayList<>();
-        joinNodes.add(JoinTaskExecutor.newBecomeMasterTask());
+        joinNodes.add(JoinTaskExecutor.newBecomeClusterManagerTask());
         joinNodes.add(JoinTaskExecutor.newFinishElectionTask());
         joinNodes.addAll(nodes.stream().map(node -> new JoinTaskExecutor.Task(node, "dummy reason")).collect(Collectors.toList()));
 
         return runTasks(joinTaskExecutor, clusterState, joinNodes);
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #joinNodesAndBecomeClusterManager(ClusterState, List)} */
+    @Deprecated
+    public ClusterState joinNodesAndBecomeMaster(ClusterState clusterState, List<DiscoveryNode> nodes) {
+        return joinNodesAndBecomeClusterManager(clusterState, nodes);
     }
 
     public ClusterState removeNodes(ClusterState clusterState, List<DiscoveryNode> nodes) {

--- a/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
+++ b/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
@@ -494,7 +494,7 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
                 // remove node
                 if (state.nodes().getDataNodes().size() > 3) {
                     DiscoveryNode discoveryNode = randomFrom(state.nodes().getNodes().values().toArray(DiscoveryNode.class));
-                    if (discoveryNode.equals(state.nodes().getMasterNode()) == false) {
+                    if (discoveryNode.equals(state.nodes().getClusterManagerNode()) == false) {
                         state = cluster.removeNodes(state, Collections.singletonList(discoveryNode));
                         updateNodes(state, clusterStateServiceMap, indicesServiceSupplier);
                     }

--- a/server/src/test/java/org/opensearch/persistent/PersistentTasksClusterServiceTests.java
+++ b/server/src/test/java/org/opensearch/persistent/PersistentTasksClusterServiceTests.java
@@ -153,7 +153,7 @@ public class PersistentTasksClusterServiceTests extends OpenSearchTestCase {
         DiscoveryNodes nodes = DiscoveryNodes.builder()
             .add(new DiscoveryNode("_node", buildNewFakeTransportAddress(), Version.CURRENT))
             .localNodeId("_node")
-            .masterNodeId("_node")
+            .clusterManagerNodeId("_node")
             .build();
 
         boolean unassigned = randomBoolean();
@@ -536,7 +536,7 @@ public class PersistentTasksClusterServiceTests extends OpenSearchTestCase {
         builder = ClusterState.builder(clusterState);
         nodes = DiscoveryNodes.builder(clusterState.nodes());
         nodes.add(DiscoveryNode.createLocal(Settings.EMPTY, buildNewFakeTransportAddress(), "a_new_cluster_manager_node"));
-        nodes.masterNodeId("a_new_cluster_manager_node");
+        nodes.clusterManagerNodeId("a_new_cluster_manager_node");
         ClusterState nonMasterClusterState = builder.nodes(nodes).build();
         event = new ClusterChangedEvent("test", nonMasterClusterState, clusterState);
         service.clusterChanged(event);
@@ -554,7 +554,7 @@ public class PersistentTasksClusterServiceTests extends OpenSearchTestCase {
         DiscoveryNodes.Builder nodes = DiscoveryNodes.builder()
             .add(new DiscoveryNode("_node_1", buildNewFakeTransportAddress(), Version.CURRENT))
             .localNodeId("_node_1")
-            .masterNodeId("_node_1")
+            .clusterManagerNodeId("_node_1")
             .add(new DiscoveryNode("_node_2", buildNewFakeTransportAddress(), Version.CURRENT));
 
         String unassignedId = addTask(tasks, "unassign", "_node_2");
@@ -579,7 +579,7 @@ public class PersistentTasksClusterServiceTests extends OpenSearchTestCase {
         DiscoveryNodes.Builder nodes = DiscoveryNodes.builder()
             .add(new DiscoveryNode("_node_1", buildNewFakeTransportAddress(), Version.CURRENT))
             .localNodeId("_node_1")
-            .masterNodeId("_node_1")
+            .clusterManagerNodeId("_node_1")
             .add(new DiscoveryNode("_node_2", buildNewFakeTransportAddress(), Version.CURRENT));
 
         Metadata.Builder metadata = Metadata.builder(clusterState.metadata()).putCustom(PersistentTasksCustomMetadata.TYPE, tasks.build());
@@ -902,7 +902,7 @@ public class PersistentTasksClusterServiceTests extends OpenSearchTestCase {
         DiscoveryNodes.Builder nodes = DiscoveryNodes.builder();
         nodes.add(DiscoveryNode.createLocal(Settings.EMPTY, buildNewFakeTransportAddress(), "this_node"));
         nodes.localNodeId("this_node");
-        nodes.masterNodeId("this_node");
+        nodes.clusterManagerNodeId("this_node");
 
         return ClusterState.builder(ClusterName.DEFAULT).nodes(nodes).metadata(metadata).routingTable(routingTable.build()).build();
     }

--- a/server/src/test/java/org/opensearch/persistent/PersistentTasksCustomMetadataTests.java
+++ b/server/src/test/java/org/opensearch/persistent/PersistentTasksCustomMetadataTests.java
@@ -330,7 +330,7 @@ public class PersistentTasksCustomMetadataTests extends AbstractDiffableSerializ
         DiscoveryNodes nodes = DiscoveryNodes.builder()
             .add(new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT))
             .localNodeId("node1")
-            .masterNodeId("node1")
+            .clusterManagerNodeId("node1")
             .build();
 
         String taskName = "test/task";
@@ -358,7 +358,7 @@ public class PersistentTasksCustomMetadataTests extends AbstractDiffableSerializ
         DiscoveryNodes nodes = DiscoveryNodes.builder()
             .add(new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT))
             .localNodeId("node1")
-            .masterNodeId("node1")
+            .clusterManagerNodeId("node1")
             .build();
 
         String taskName = "test/task";

--- a/server/src/test/java/org/opensearch/snapshots/InternalSnapshotsInfoServiceTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/InternalSnapshotsInfoServiceTests.java
@@ -495,7 +495,7 @@ public class InternalSnapshotsInfoServiceTests extends OpenSearchTestCase {
         assertThat(currentState.nodes().get(node.getId()), nullValue());
 
         return ClusterState.builder(currentState)
-            .nodes(DiscoveryNodes.builder(currentState.nodes()).add(node).masterNodeId(node.getId()))
+            .nodes(DiscoveryNodes.builder(currentState.nodes()).add(node).clusterManagerNodeId(node.getId()))
             .build();
     }
 

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -1340,13 +1340,13 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
             testClusterNodes.nodes.values()
                 .stream()
                 .map(n -> n.node)
-                .filter(DiscoveryNode::isMasterNode)
+                .filter(DiscoveryNode::isClusterManagerNode)
                 .map(DiscoveryNode::getId)
                 .collect(Collectors.toSet())
         );
         testClusterNodes.nodes.values()
             .stream()
-            .filter(n -> n.node.isMasterNode())
+            .filter(n -> n.node.isClusterManagerNode())
             .forEach(testClusterNode -> testClusterNode.coordinator.setInitialConfiguration(votingConfiguration));
         // Connect all nodes to each other
         testClusterNodes.nodes.values()
@@ -1375,7 +1375,7 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                 .map(node -> node.clusterService.state())
                 .collect(Collectors.toList());
             final Set<String> clusterManagerNodeIds = clusterStates.stream()
-                .map(clusterState -> clusterState.nodes().getMasterNodeId())
+                .map(clusterState -> clusterState.nodes().getClusterManagerNodeId())
                 .collect(Collectors.toSet());
             final Set<Long> terms = clusterStates.stream().map(ClusterState::term).collect(Collectors.toSet());
             final List<Long> versions = clusterStates.stream().map(ClusterState::version).distinct().collect(Collectors.toList());
@@ -1535,7 +1535,7 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
             // Select from sorted list of data-nodes here to not have deterministic behaviour
             final List<TestClusterNode> clusterManagerNodes = testClusterNodes.nodes.values()
                 .stream()
-                .filter(n -> n.node.isMasterNode())
+                .filter(n -> n.node.isClusterManagerNode())
                 .filter(n -> disconnectedNodes.contains(n.node.getName()) == false)
                 .sorted(Comparator.comparing(n -> n.node.getName()))
                 .collect(Collectors.toList());
@@ -1606,9 +1606,9 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
          * @return Cluster Manager Node
          */
         public TestClusterNode currentClusterManager(ClusterState state) {
-            TestClusterNode clusterManager = nodes.get(state.nodes().getMasterNode().getName());
+            TestClusterNode clusterManager = nodes.get(state.nodes().getClusterManagerNode().getName());
             assertNotNull(clusterManager);
-            assertTrue(clusterManager.node.isMasterNode());
+            assertTrue(clusterManager.node.isClusterManagerNode());
             return clusterManager;
         }
 
@@ -2200,7 +2200,7 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     () -> persistedState,
                     hostsResolver -> nodes.values()
                         .stream()
-                        .filter(n -> n.node.isMasterNode())
+                        .filter(n -> n.node.isClusterManagerNode())
                         .map(n -> n.node.getAddress())
                         .collect(Collectors.toList()),
                     clusterService.getClusterApplierService(),

--- a/test/framework/src/main/java/org/opensearch/action/support/replication/ClusterStateCreationUtils.java
+++ b/test/framework/src/main/java/org/opensearch/action/support/replication/ClusterStateCreationUtils.java
@@ -107,7 +107,7 @@ public class ClusterStateCreationUtils {
             unassignedNodes.add(node.getId());
         }
         discoBuilder.localNodeId(newNode(0).getId());
-        discoBuilder.masterNodeId(newNode(1).getId()); // we need a non-local cluster-manager to test shard failures
+        discoBuilder.clusterManagerNodeId(newNode(1).getId()); // we need a non-local cluster-manager to test shard failures
         final int primaryTerm = 1 + randomInt(200);
         IndexMetadata indexMetadata = IndexMetadata.builder(index)
             .settings(
@@ -198,7 +198,7 @@ public class ClusterStateCreationUtils {
             nodes.add(node.getId());
         }
         discoBuilder.localNodeId(newNode(0).getId());
-        discoBuilder.masterNodeId(randomFrom(nodes));
+        discoBuilder.clusterManagerNodeId(randomFrom(nodes));
         IndexMetadata indexMetadata = IndexMetadata.builder(index)
             .settings(
                 Settings.builder()
@@ -240,7 +240,7 @@ public class ClusterStateCreationUtils {
             nodes.add(node.getId());
         }
         discoBuilder.localNodeId(newNode(0).getId());
-        discoBuilder.masterNodeId(newNode(0).getId());
+        discoBuilder.clusterManagerNodeId(newNode(0).getId());
         Metadata.Builder metadata = Metadata.builder();
         RoutingTable.Builder routingTable = RoutingTable.builder();
         List<String> nodesList = new ArrayList<>(nodes);
@@ -291,7 +291,7 @@ public class ClusterStateCreationUtils {
             discoBuilder = discoBuilder.add(node);
         }
         discoBuilder.localNodeId(newNode(0).getId());
-        discoBuilder.masterNodeId(newNode(1).getId()); // we need a non-local cluster-manager to test shard failures
+        discoBuilder.clusterManagerNodeId(newNode(1).getId()); // we need a non-local cluster-manager to test shard failures
         IndexMetadata indexMetadata = IndexMetadata.builder(index)
             .settings(
                 Settings.builder()
@@ -332,7 +332,7 @@ public class ClusterStateCreationUtils {
             discoBuilder = discoBuilder.add(node);
         }
         discoBuilder.localNodeId(newNode(0).getId());
-        discoBuilder.masterNodeId(newNode(numberOfDataNodes + 1).getId());
+        discoBuilder.clusterManagerNodeId(newNode(numberOfDataNodes + 1).getId());
         ClusterState.Builder state = ClusterState.builder(new ClusterName("test"));
         state.nodes(discoBuilder);
         Builder routingTableBuilder = RoutingTable.builder();
@@ -417,7 +417,7 @@ public class ClusterStateCreationUtils {
     public static ClusterState stateWithNoShard() {
         DiscoveryNodes.Builder discoBuilder = DiscoveryNodes.builder();
         discoBuilder.localNodeId(newNode(0).getId());
-        discoBuilder.masterNodeId(newNode(1).getId());
+        discoBuilder.clusterManagerNodeId(newNode(1).getId());
         ClusterState.Builder state = ClusterState.builder(new ClusterName("test"));
         state.nodes(discoBuilder);
         state.metadata(Metadata.builder().generateClusterUuidIfNeeded());
@@ -439,7 +439,7 @@ public class ClusterStateCreationUtils {
             discoBuilder.add(node);
         }
         if (clusterManagerNode != null) {
-            discoBuilder.masterNodeId(clusterManagerNode.getId());
+            discoBuilder.clusterManagerNodeId(clusterManagerNode.getId());
         }
         discoBuilder.localNodeId(localNode.getId());
 

--- a/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -311,7 +311,7 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                     nodeHealthService
                 );
                 clusterNodes.add(clusterNode);
-                if (clusterNode.getLocalNode().isMasterNode()) {
+                if (clusterNode.getLocalNode().isClusterManagerNode()) {
                     clusterManagerEligibleNodeIds.add(clusterNode.getId());
                 }
             }
@@ -617,7 +617,7 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                     assertTrue(nodeId + " has been bootstrapped", clusterNode.coordinator.isInitialConfigurationSet());
                     assertThat(
                         nodeId + " has correct cluster-manager",
-                        clusterNode.getLastAppliedClusterState().nodes().getMasterNode(),
+                        clusterNode.getLastAppliedClusterState().nodes().getClusterManagerNode(),
                         equalTo(leader.getLocalNode())
                     );
                     assertThat(
@@ -634,7 +634,7 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                     assertThat(nodeId + " is not following " + leaderId, clusterNode.coordinator.getMode(), is(CANDIDATE));
                     assertThat(
                         nodeId + " has no cluster-manager",
-                        clusterNode.getLastAppliedClusterState().nodes().getMasterNode(),
+                        clusterNode.getLastAppliedClusterState().nodes().getClusterManagerNode(),
                         nullValue()
                     );
                     assertThat(
@@ -784,7 +784,7 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
         ClusterNode getAnyBootstrappableNode() {
             return randomFrom(
                 clusterNodes.stream()
-                    .filter(n -> n.getLocalNode().isMasterNode())
+                    .filter(n -> n.getLocalNode().isClusterManagerNode())
                     .filter(n -> initialConfiguration.getNodeIds().contains(n.getLocalNode().getId()))
                     .collect(Collectors.toList())
             );
@@ -899,7 +899,8 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                         final long persistedCurrentTerm;
 
                         if ( // node is cluster-manager-ineligible either before or after the restart ...
-                        (oldState.getLastAcceptedState().nodes().getLocalNode().isMasterNode() && newLocalNode.isMasterNode()) == false
+                        (oldState.getLastAcceptedState().nodes().getLocalNode().isClusterManagerNode()
+                            && newLocalNode.isClusterManagerNode()) == false
                             // ... and it's accepted some non-initial state so we can roll back ...
                             && (oldState.getLastAcceptedState().term() > 0L || oldState.getLastAcceptedState().version() > 0L)
                             // ... and we're feeling lucky ...
@@ -1194,7 +1195,9 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                     address.getAddress(),
                     address,
                     Collections.emptyMap(),
-                    localNode.isMasterNode() && DiscoveryNode.isMasterNode(nodeSettings) ? DiscoveryNodeRole.BUILT_IN_ROLES : emptySet(),
+                    localNode.isClusterManagerNode() && DiscoveryNode.isClusterManagerNode(nodeSettings)
+                        ? DiscoveryNodeRole.BUILT_IN_ROLES
+                        : emptySet(),
                     Version.CURRENT
                 );
                 return new ClusterNode(
@@ -1291,7 +1294,7 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                     }
 
                     @Override
-                    public void onNoLongerMaster(String source) {
+                    public void onNoLongerClusterManager(String source) {
                         // in this case, we know for sure that event was not processed by the system and will not change history
                         // remove event to help avoid bloated history and state space explosion in linearizability checker
                         history.remove(eventId);
@@ -1346,9 +1349,9 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                         }
 
                         @Override
-                        public void onNoLongerMaster(String source) {
+                        public void onNoLongerClusterManager(String source) {
                             logger.trace("no longer cluster-manager: [{}]", source);
-                            taskListener.onNoLongerMaster(source);
+                            taskListener.onNoLongerClusterManager(source);
                         }
 
                         @Override
@@ -1427,7 +1430,7 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
             }
 
             private boolean isNotUsefullyBootstrapped() {
-                return getLocalNode().isMasterNode() == false || coordinator.isInitialConfigurationSet() == false;
+                return getLocalNode().isClusterManagerNode() == false || coordinator.isInitialConfigurationSet() == false;
             }
 
             void allowClusterStateApplicationFailure() {

--- a/test/framework/src/main/java/org/opensearch/cluster/coordination/CoordinationStateTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/coordination/CoordinationStateTestCluster.java
@@ -148,7 +148,7 @@ public class CoordinationStateTestCluster {
         }
 
         void reboot() {
-            if (localNode.isMasterNode() == false && rarely()) {
+            if (localNode.isClusterManagerNode() == false && rarely()) {
                 // cluster-manager-ineligible nodes can't be trusted to persist the cluster state properly,
                 // but will not lose the fact that they were bootstrapped
                 final CoordinationMetadata.VotingConfiguration votingConfiguration = persistedState.getLastAcceptedState()

--- a/test/framework/src/main/java/org/opensearch/repositories/blobstore/BlobStoreTestUtil.java
+++ b/test/framework/src/main/java/org/opensearch/repositories/blobstore/BlobStoreTestUtil.java
@@ -414,7 +414,9 @@ public final class BlobStoreTestUtil {
         final DiscoveryNode localNode = new DiscoveryNode("", buildNewFakeTransportAddress(), Version.CURRENT);
         final AtomicReference<ClusterState> currentState = new AtomicReference<>(
             ClusterState.builder(initialState)
-                .nodes(DiscoveryNodes.builder().add(localNode).masterNodeId(localNode.getId()).localNodeId(localNode.getId()).build())
+                .nodes(
+                    DiscoveryNodes.builder().add(localNode).clusterManagerNodeId(localNode.getId()).localNodeId(localNode.getId()).build()
+                )
                 .build()
         );
         when(clusterService.state()).then(invocationOnMock -> currentState.get());

--- a/test/framework/src/main/java/org/opensearch/test/ClusterServiceUtils.java
+++ b/test/framework/src/main/java/org/opensearch/test/ClusterServiceUtils.java
@@ -79,7 +79,7 @@ public class ClusterServiceUtils {
 
     public static MasterService createMasterService(ThreadPool threadPool, DiscoveryNode localNode) {
         ClusterState initialClusterState = ClusterState.builder(new ClusterName(ClusterServiceUtils.class.getSimpleName()))
-            .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()).masterNodeId(localNode.getId()))
+            .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()).clusterManagerNodeId(localNode.getId()))
             .blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK)
             .build();
         return createMasterService(threadPool, initialClusterState);
@@ -160,7 +160,7 @@ public class ClusterServiceUtils {
         ClusterService clusterService = new ClusterService(settings, clusterSettings, threadPool);
         clusterService.setNodeConnectionsService(createNoOpNodeConnectionsService());
         ClusterState initialClusterState = ClusterState.builder(new ClusterName(ClusterServiceUtils.class.getSimpleName()))
-            .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()).masterNodeId(localNode.getId()))
+            .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()).clusterManagerNodeId(localNode.getId()))
             .blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK)
             .build();
         clusterService.getClusterApplierService().setInitialState(initialClusterState);

--- a/test/framework/src/main/java/org/opensearch/test/ExternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/ExternalTestCluster.java
@@ -148,7 +148,7 @@ public final class ExternalTestCluster extends TestCluster {
                 if (DiscoveryNode.isDataNode(nodeInfo.getSettings())) {
                     dataNodes++;
                     clusterManagerAndDataNodes++;
-                } else if (DiscoveryNode.isMasterNode(nodeInfo.getSettings())) {
+                } else if (DiscoveryNode.isClusterManagerNode(nodeInfo.getSettings())) {
                     clusterManagerAndDataNodes++;
                 }
             }

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -1100,7 +1100,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
             clusterManagerClusterState = ClusterState.Builder.fromBytes(masterClusterStateBytes, null, namedWriteableRegistry);
             Map<String, Object> clusterManagerStateMap = convertToMap(clusterManagerClusterState);
             int clusterManagerClusterStateSize = clusterManagerClusterState.toString().length();
-            String clusterManagerId = clusterManagerClusterState.nodes().getMasterNodeId();
+            String clusterManagerId = clusterManagerClusterState.nodes().getClusterManagerNodeId();
             for (Client client : cluster().getClients()) {
                 ClusterState localClusterState = client.admin().cluster().prepareState().all().setLocal(true).get().getState();
                 byte[] localClusterStateBytes = ClusterState.Builder.toBytes(localClusterState);
@@ -1112,7 +1112,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
                 // that the cluster-manager node matches the cluster-manager (otherwise there is no requirement for the cluster state to
                 // match)
                 if (clusterManagerClusterState.version() == localClusterState.version()
-                    && clusterManagerId.equals(localClusterState.nodes().getMasterNodeId())) {
+                    && clusterManagerId.equals(localClusterState.nodes().getClusterManagerNodeId())) {
                     try {
                         assertEquals(
                             "cluster state UUID does not match",

--- a/test/framework/src/test/java/org/opensearch/test/test/InternalTestClusterTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/test/InternalTestClusterTests.java
@@ -439,7 +439,7 @@ public class InternalTestClusterTests extends OpenSearchTestCase {
             for (String name : cluster.getNodeNames()) {
                 DiscoveryNode node = cluster.getInstance(ClusterService.class, name).localNode();
                 List<String> paths = Arrays.stream(getNodePaths(cluster, name)).map(Path::toString).collect(Collectors.toList());
-                if (node.isMasterNode()) {
+                if (node.isClusterManagerNode()) {
                     result.computeIfAbsent(clusterManagerRole, k -> new HashSet<>()).addAll(paths);
                 } else if (node.isDataNode()) {
                     result.computeIfAbsent(DiscoveryNodeRole.DATA_ROLE, k -> new HashSet<>()).addAll(paths);


### PR DESCRIPTION
### Description
Backport PR https://github.com/opensearch-project/OpenSearch/pull/3647 / commit https://github.com/opensearch-project/OpenSearch/commit/1510b942bc05a89928e576300119f62871e5a1fd into `2.x` branch.

To support inclusive language, the `master` terminology is going to be replaced by `cluster manager` in the code base.
This PR deprecate public and protected methods that contains `master` terminology in the name in `server` directory, except those covered by issue https://github.com/opensearch-project/OpenSearch/issues/3542 and https://github.com/opensearch-project/OpenSearch/issues/3543.

List of public methods that contain `master` in name that will be deprecated in this PR:
```
In directory - OpenSearch.server.main  (totally 27 class definitions)
public boolean hasDiscoveredMaster() {
public boolean localNodeMaster() {
public void updateMappingOnMaster(Index index, Mapping mappingUpdate, ActionListener<Void> listener) {
public boolean isBecomeMasterTask() {
public Optional<DiscoveryNode> getMasterNode() {
public PutRequest masterTimeout(TimeValue masterTimeout) {
public RemoveRequest masterTimeout(TimeValue masterTimeout) {
public static boolean isMasterNode(Settings settings) {
public boolean isMasterNode() {
public boolean isLocalNodeElectedMaster() {
public ImmutableOpenMap<String, DiscoveryNode> getMasterNodes() {
public ImmutableOpenMap<String, DiscoveryNode> getMasterAndDataNodes() {
public Stream<DiscoveryNode> mastersFirstStream() {
public String getMasterNodeId() {
public DiscoveryNode getMasterNode() {
public boolean masterNodeChanged() {
public DiscoveryNode previousMasterNode() {
public DiscoveryNode newMasterNode() {
public Builder masterNodeId(String clusterManagerNodeId) {
public boolean isLocalNodeElectedMaster() {
protected void assertClusterOrMasterStateThread() {
public void addLocalNodeMasterListener(LocalNodeMasterListener listener) {
public MasterService getMasterService() { (not changed in this PR)
public static boolean assertClusterOrMasterStateThread() {
void connectToRemoteMasterNode(TransportAddress transportAddress, ActionListener<DiscoveryNode> listener); (in interface, and not changed in this PR)
public synchronized void updateFromMaster(
public ClusterState joinNodesAndBecomeMaster(ClusterState clusterState, List<DiscoveryNode> nodes) {
```

The below test classes will not be renamed, because they are used to test the deprecated master node behavior.
```
public void testDoesNothingByDefaultIfMasterNodesConfigured() {
public void testDoesNotBootstrapsOnNonMasterNode() {
public void testDoesNotBootstrapsIfLocalNodeNotInInitialMasterNodes() {
public void testFailBootstrapWithBothSingleNodeDiscoveryAndInitialMasterNodes() {
public void testFailBootstrapNonMasterEligibleNodeWithSingleNodeDiscovery() {
public void testIsMasterNode() {
```

Other changes:
- Changed 2 references of `JoinTaskExecutor.newBecomeMasterTask()` to use `JoinTaskExecutor.newBecomeClusterManagerTask()`
 
### Issues Resolved
A part of issue https://github.com/opensearch-project/OpenSearch/issues/3544
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
