### PR TITLE
Deprecate public methods and variables that contain 'master' terminology in 'test/framework' directory 

### DIFF
--- a/modules/ingest-common/src/internalClusterTest/java/org/opensearch/ingest/common/IngestRestartIT.java
+++ b/modules/ingest-common/src/internalClusterTest/java/org/opensearch/ingest/common/IngestRestartIT.java
@@ -166,7 +166,7 @@ public class IngestRestartIT extends OpenSearchIntegTestCase {
         checkPipelineExists.accept(pipelineIdWithScript);
         checkPipelineExists.accept(pipelineIdWithoutScript);
 
-        internalCluster().restartNode(internalCluster().getMasterName(), new InternalTestCluster.RestartCallback() {
+        internalCluster().restartNode(internalCluster().getClusterManagerName(), new InternalTestCluster.RestartCallback() {
 
             @Override
             public Settings onNodeStopped(String nodeName) {

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/DeleteByQueryBasicTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/DeleteByQueryBasicTests.java
@@ -274,9 +274,9 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
                 InternalTestCluster internalTestCluster = internalCluster();
                 InternalClusterInfoService infoService = (InternalClusterInfoService) internalTestCluster.getInstance(
                     ClusterInfoService.class,
-                    internalTestCluster.getMasterName()
+                    internalTestCluster.getClusterManagerName()
                 );
-                ThreadPool threadPool = internalTestCluster.getInstance(ThreadPool.class, internalTestCluster.getMasterName());
+                ThreadPool threadPool = internalTestCluster.getInstance(ThreadPool.class, internalTestCluster.getClusterManagerName());
                 // Refresh the cluster info after a random delay to check the disk threshold and release the block on the index
                 threadPool.schedule(infoService::refresh, TimeValue.timeValueMillis(randomIntBetween(1, 100)), ThreadPool.Names.MANAGEMENT);
                 // The delete by query request will be executed successfully because the block will be released

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/RetryTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/RetryTests.java
@@ -206,7 +206,7 @@ public class RetryTests extends OpenSearchIntegTestCase {
         assertFalse(initialBulkResponse.buildFailureMessage(), initialBulkResponse.hasFailures());
         client().admin().indices().prepareRefresh("source").get();
 
-        AbstractBulkByScrollRequestBuilder<?, ?> builder = request.apply(internalCluster().masterClient());
+        AbstractBulkByScrollRequestBuilder<?, ?> builder = request.apply(internalCluster().clusterManagerClient());
         // Make sure we use more than one batch so we have to scroll
         builder.source().setSize(DOC_COUNT / randomIntBetween(2, 10));
 

--- a/plugins/repository-gcs/src/internalClusterTest/java/org/opensearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/plugins/repository-gcs/src/internalClusterTest/java/org/opensearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -130,7 +130,7 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends OpenSearchMockAP
 
     public void testDeleteSingleItem() {
         final String repoName = createRepository(randomName());
-        final RepositoriesService repositoriesService = internalCluster().getMasterNodeInstance(RepositoriesService.class);
+        final RepositoriesService repositoriesService = internalCluster().getClusterManagerNodeInstance(RepositoriesService.class);
         final BlobStoreRepository repository = (BlobStoreRepository) repositoriesService.repository(repoName);
         PlainActionFuture.get(
             f -> repository.threadPool()

--- a/plugins/repository-s3/src/internalClusterTest/java/org/opensearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/plugins/repository-s3/src/internalClusterTest/java/org/opensearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -172,7 +172,7 @@ public class S3BlobStoreRepositoryTests extends OpenSearchMockAPIBasedRepository
             .get()
             .getSnapshotInfo()
             .snapshotId();
-        final RepositoriesService repositoriesService = internalCluster().getCurrentMasterNodeInstance(RepositoriesService.class);
+        final RepositoriesService repositoriesService = internalCluster().getCurrentClusterManagerNodeInstance(RepositoriesService.class);
         final BlobStoreRepository repository = (BlobStoreRepository) repositoriesService.repository(repoName);
         final RepositoryData repositoryData = getRepositoryData(repository);
         final RepositoryData modifiedRepositoryData = repositoryData.withVersions(

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -158,14 +158,14 @@ public class TasksIT extends OpenSearchIntegTestCase {
         registerTaskManagerListeners(ClusterHealthAction.NAME);
 
         // First run the health on the cluster-manager node - should produce only one task on the cluster-manager node
-        internalCluster().masterClient().admin().cluster().prepareHealth().get();
+        internalCluster().clusterManagerClient().admin().cluster().prepareHealth().get();
         assertEquals(1, numberOfEvents(ClusterHealthAction.NAME, Tuple::v1)); // counting only registration events
         assertEquals(1, numberOfEvents(ClusterHealthAction.NAME, event -> event.v1() == false)); // counting only unregistration events
 
         resetTaskManagerListeners(ClusterHealthAction.NAME);
 
         // Now run the health on a non-cluster-manager node - should produce one task on cluster-manager and one task on another node
-        internalCluster().nonMasterClient().admin().cluster().prepareHealth().get();
+        internalCluster().nonClusterManagerClient().admin().cluster().prepareHealth().get();
         assertEquals(2, numberOfEvents(ClusterHealthAction.NAME, Tuple::v1)); // counting only registration events
         assertEquals(2, numberOfEvents(ClusterHealthAction.NAME, event -> event.v1() == false)); // counting only unregistration events
         List<TaskInfo> tasks = findEvents(ClusterHealthAction.NAME, Tuple::v1);

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/state/TransportClusterStateActionDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/state/TransportClusterStateActionDisruptionIT.java
@@ -194,7 +194,7 @@ public class TransportClusterStateActionDisruptionIT extends OpenSearchIntegTest
             )
         );
 
-        final String clusterManagerName = internalCluster().getMasterName();
+        final String clusterManagerName = internalCluster().getClusterManagerName();
 
         final AtomicBoolean shutdown = new AtomicBoolean();
         final Thread assertingThread = new Thread(() -> {
@@ -245,7 +245,7 @@ public class TransportClusterStateActionDisruptionIT extends OpenSearchIntegTest
                 clusterManagerName,
                 () -> randomFrom(internalCluster().getNodeNames())
             );
-            final String claimedClusterManagerName = internalCluster().getMasterName(nonClusterManagerNode);
+            final String claimedClusterManagerName = internalCluster().getClusterManagerName(nonClusterManagerNode);
             assertThat(claimedClusterManagerName, not(equalTo(clusterManagerName)));
         });
 

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/CreateIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/CreateIndexIT.java
@@ -340,7 +340,7 @@ public class CreateIndexIT extends OpenSearchIntegTestCase {
             IllegalStateException.class
         );
 
-        IndicesService indicesService = internalCluster().getInstance(IndicesService.class, internalCluster().getMasterName());
+        IndicesService indicesService = internalCluster().getInstance(IndicesService.class, internalCluster().getClusterManagerName());
         for (IndexService indexService : indicesService) {
             assertThat(indexService.index().getName(), not("test-idx-2"));
         }

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/ShrinkIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/ShrinkIndexIT.java
@@ -496,7 +496,7 @@ public class ShrinkIndexIT extends OpenSearchIntegTestCase {
 
         final InternalClusterInfoService infoService = (InternalClusterInfoService) internalCluster().getInstance(
             ClusterInfoService.class,
-            internalCluster().getMasterName()
+            internalCluster().getClusterManagerName()
         );
         infoService.refresh();
         // kick off a retry and wait until it's done!

--- a/server/src/internalClusterTest/java/org/opensearch/action/support/clustermanager/IndexingClusterManagerFailoverIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/support/clustermanager/IndexingClusterManagerFailoverIT.java
@@ -67,7 +67,7 @@ public class IndexingClusterManagerFailoverIT extends OpenSearchIntegTestCase {
 
         internalCluster().setBootstrapClusterManagerNodeIndex(2);
 
-        internalCluster().startMasterOnlyNodes(3, Settings.EMPTY);
+        internalCluster().startClusterManagerOnlyNodes(3, Settings.EMPTY);
 
         String dataNode = internalCluster().startDataOnlyNode(Settings.EMPTY);
 

--- a/server/src/internalClusterTest/java/org/opensearch/action/support/replication/TransportReplicationActionRetryOnClosedNodeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/support/replication/TransportReplicationActionRetryOnClosedNodeIT.java
@@ -203,7 +203,7 @@ public class TransportReplicationActionRetryOnClosedNodeIT extends OpenSearchInt
     }
 
     public void testRetryOnStoppedTransportService() throws Exception {
-        internalCluster().startMasterOnlyNodes(2);
+        internalCluster().startClusterManagerOnlyNodes(2);
         String primary = internalCluster().startDataOnlyNode();
         assertAcked(
             prepareCreate("test").setSettings(

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterHealthIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterHealthIT.java
@@ -307,7 +307,10 @@ public class ClusterHealthIT extends OpenSearchIntegTestCase {
             .execute();
 
         final AtomicBoolean keepSubmittingTasks = new AtomicBoolean(true);
-        final ClusterService clusterService = internalCluster().getInstance(ClusterService.class, internalCluster().getMasterName());
+        final ClusterService clusterService = internalCluster().getInstance(
+            ClusterService.class,
+            internalCluster().getClusterManagerName()
+        );
         final PlainActionFuture<Void> completionFuture = new PlainActionFuture<>();
         clusterService.submitStateUpdateTask("looping task", new ClusterStateUpdateTask(Priority.LOW) {
             @Override
@@ -377,7 +380,7 @@ public class ClusterHealthIT extends OpenSearchIntegTestCase {
                     .setClusterManagerNodeTimeout(TimeValue.timeValueMinutes(2))
                     .execute()
             );
-            internalCluster().restartNode(internalCluster().getMasterName(), InternalTestCluster.EMPTY_CALLBACK);
+            internalCluster().restartNode(internalCluster().getClusterManagerName(), InternalTestCluster.EMPTY_CALLBACK);
         }
         if (withIndex) {
             assertAcked(
@@ -396,7 +399,10 @@ public class ClusterHealthIT extends OpenSearchIntegTestCase {
 
     public void testWaitForEventsTimesOutIfClusterManagerBusy() {
         final AtomicBoolean keepSubmittingTasks = new AtomicBoolean(true);
-        final ClusterService clusterService = internalCluster().getInstance(ClusterService.class, internalCluster().getMasterName());
+        final ClusterService clusterService = internalCluster().getInstance(
+            ClusterService.class,
+            internalCluster().getClusterManagerName()
+        );
         final PlainActionFuture<Void> completionFuture = new PlainActionFuture<>();
         clusterService.submitStateUpdateTask("looping task", new ClusterStateUpdateTask(Priority.LOW) {
             @Override

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterInfoServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterInfoServiceIT.java
@@ -169,7 +169,7 @@ public class ClusterInfoServiceIT extends OpenSearchIntegTestCase {
         // Get the cluster info service on the cluster-manager node
         final InternalClusterInfoService infoService = (InternalClusterInfoService) internalTestCluster.getInstance(
             ClusterInfoService.class,
-            internalTestCluster.getMasterName()
+            internalTestCluster.getClusterManagerName()
         );
         infoService.setUpdateFrequency(TimeValue.timeValueMillis(200));
         ClusterInfo info = infoService.refresh();
@@ -193,7 +193,7 @@ public class ClusterInfoServiceIT extends OpenSearchIntegTestCase {
             logger.info("--> shard size: {}", size.value);
             assertThat("shard size is greater than 0", size.value, greaterThanOrEqualTo(0L));
         }
-        ClusterService clusterService = internalTestCluster.getInstance(ClusterService.class, internalTestCluster.getMasterName());
+        ClusterService clusterService = internalTestCluster.getInstance(ClusterService.class, internalTestCluster.getClusterManagerName());
         ClusterState state = clusterService.state();
         for (ShardRouting shard : state.routingTable().allShards()) {
             String dataPath = info.getDataPath(shard);
@@ -221,7 +221,7 @@ public class ClusterInfoServiceIT extends OpenSearchIntegTestCase {
         InternalTestCluster internalTestCluster = internalCluster();
         InternalClusterInfoService infoService = (InternalClusterInfoService) internalTestCluster.getInstance(
             ClusterInfoService.class,
-            internalTestCluster.getMasterName()
+            internalTestCluster.getClusterManagerName()
         );
         // get one healthy sample
         ClusterInfo info = infoService.refresh();
@@ -231,7 +231,7 @@ public class ClusterInfoServiceIT extends OpenSearchIntegTestCase {
 
         MockTransportService mockTransportService = (MockTransportService) internalCluster().getInstance(
             TransportService.class,
-            internalTestCluster.getMasterName()
+            internalTestCluster.getClusterManagerName()
         );
 
         final AtomicBoolean timeout = new AtomicBoolean(false);
@@ -272,7 +272,7 @@ public class ClusterInfoServiceIT extends OpenSearchIntegTestCase {
 
         // now we cause an exception
         timeout.set(false);
-        ActionFilters actionFilters = internalTestCluster.getInstance(ActionFilters.class, internalTestCluster.getMasterName());
+        ActionFilters actionFilters = internalTestCluster.getInstance(ActionFilters.class, internalTestCluster.getClusterManagerName());
         BlockingActionFilter blockingActionFilter = null;
         for (ActionFilter filter : actionFilters.filters()) {
             if (filter instanceof BlockingActionFilter) {

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/MinimumClusterManagerNodesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/MinimumClusterManagerNodesIT.java
@@ -151,7 +151,7 @@ public class MinimumClusterManagerNodesIT extends OpenSearchIntegTestCase {
             );
         }
 
-        String clusterManagerNode = internalCluster().getMasterName();
+        String clusterManagerNode = internalCluster().getClusterManagerName();
         String otherNode = node1Name.equals(clusterManagerNode) ? node2Name : node1Name;
         logger.info("--> add voting config exclusion for non-cluster-manager node, to be sure it's not elected");
         client().execute(AddVotingConfigExclusionsAction.INSTANCE, new AddVotingConfigExclusionsRequest(otherNode)).get();
@@ -204,7 +204,7 @@ public class MinimumClusterManagerNodesIT extends OpenSearchIntegTestCase {
         clearRequest.setWaitForRemoval(false);
         client().execute(ClearVotingConfigExclusionsAction.INSTANCE, clearRequest).get();
 
-        clusterManagerNode = internalCluster().getMasterName();
+        clusterManagerNode = internalCluster().getClusterManagerName();
         otherNode = node1Name.equals(clusterManagerNode) ? node2Name : node1Name;
         logger.info("--> add voting config exclusion for cluster-manager node, to be sure it's not elected");
         client().execute(AddVotingConfigExclusionsAction.INSTANCE, new AddVotingConfigExclusionsRequest(clusterManagerNode)).get();
@@ -310,12 +310,15 @@ public class MinimumClusterManagerNodesIT extends OpenSearchIntegTestCase {
         }
 
         List<String> nonClusterManagerNodes = new ArrayList<>(
-            Sets.difference(Sets.newHashSet(internalCluster().getNodeNames()), Collections.singleton(internalCluster().getMasterName()))
+            Sets.difference(
+                Sets.newHashSet(internalCluster().getNodeNames()),
+                Collections.singleton(internalCluster().getClusterManagerName())
+            )
         );
         Settings nonClusterManagerDataPathSettings1 = internalCluster().dataPathSettings(nonClusterManagerNodes.get(0));
         Settings nonClusterManagerDataPathSettings2 = internalCluster().dataPathSettings(nonClusterManagerNodes.get(1));
-        internalCluster().stopRandomNonMasterNode();
-        internalCluster().stopRandomNonMasterNode();
+        internalCluster().stopRandomNonClusterManagerNode();
+        internalCluster().stopRandomNonClusterManagerNode();
 
         logger.info("--> verify that there is no cluster-manager anymore on remaining node");
         // spin here to wait till the state is set
@@ -347,7 +350,7 @@ public class MinimumClusterManagerNodesIT extends OpenSearchIntegTestCase {
         internalCluster().startNodes(3, settings);
         ensureStableCluster(3);
 
-        final String clusterManager = internalCluster().getMasterName();
+        final String clusterManager = internalCluster().getClusterManagerName();
         Set<String> otherNodes = new HashSet<>(Arrays.asList(internalCluster().getNodeNames()));
         otherNodes.remove(clusterManager);
         NetworkDisruption partition = isolateClusterManagerDisruption(NetworkDisruption.DISCONNECT);

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/SpecificClusterManagerNodesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/SpecificClusterManagerNodesIT.java
@@ -38,7 +38,6 @@ import org.opensearch.action.admin.cluster.configuration.AddVotingConfigExclusio
 import org.opensearch.common.settings.Settings;
 import org.opensearch.discovery.ClusterManagerNotDiscoveredException;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
 import org.opensearch.test.OpenSearchIntegTestCase.Scope;
@@ -46,6 +45,7 @@ import org.opensearch.test.InternalTestCluster;
 
 import java.io.IOException;
 
+import static org.opensearch.test.NodeRoles.clusterManagerNode;
 import static org.opensearch.test.NodeRoles.dataOnlyNode;
 import static org.opensearch.test.NodeRoles.nonDataNode;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
@@ -129,7 +129,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
 
         logger.info("--> start previous cluster-manager node again");
         final String nextClusterManagerEligibleNodeName = internalCluster().startNode(
-            Settings.builder().put(nonDataNode(NodeRoles.clusterManagerNode())).put(clusterManagerDataPathSettings)
+            Settings.builder().put(nonDataNode(clusterManagerNode())).put(clusterManagerDataPathSettings)
         );
         assertThat(
             internalCluster().nonClusterManagerClient()

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/SpecificClusterManagerNodesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/SpecificClusterManagerNodesIT.java
@@ -38,6 +38,7 @@ import org.opensearch.action.admin.cluster.configuration.AddVotingConfigExclusio
 import org.opensearch.common.settings.Settings;
 import org.opensearch.discovery.ClusterManagerNotDiscoveredException;
 import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
 import org.opensearch.test.OpenSearchIntegTestCase.Scope;
@@ -46,7 +47,6 @@ import org.opensearch.test.InternalTestCluster;
 import java.io.IOException;
 
 import static org.opensearch.test.NodeRoles.dataOnlyNode;
-import static org.opensearch.test.NodeRoles.masterNode;
 import static org.opensearch.test.NodeRoles.nonDataNode;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
@@ -129,7 +129,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
 
         logger.info("--> start previous cluster-manager node again");
         final String nextClusterManagerEligibleNodeName = internalCluster().startNode(
-            Settings.builder().put(nonDataNode(masterNode())).put(clusterManagerDataPathSettings)
+            Settings.builder().put(nonDataNode(NodeRoles.clusterManagerNode())).put(clusterManagerDataPathSettings)
         );
         assertThat(
             internalCluster().nonMasterClient()

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/SpecificClusterManagerNodesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/SpecificClusterManagerNodesIT.java
@@ -79,7 +79,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
         logger.info("--> start cluster-manager node");
         final String clusterManagerNodeName = internalCluster().startClusterManagerOnlyNode();
         assertThat(
-            internalCluster().nonMasterClient()
+            internalCluster().nonClusterManagerClient()
                 .admin()
                 .cluster()
                 .prepareState()
@@ -92,7 +92,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
             equalTo(clusterManagerNodeName)
         );
         assertThat(
-            internalCluster().masterClient()
+            internalCluster().clusterManagerClient()
                 .admin()
                 .cluster()
                 .prepareState()
@@ -106,8 +106,8 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
         );
 
         logger.info("--> stop cluster-manager node");
-        Settings clusterManagerDataPathSettings = internalCluster().dataPathSettings(internalCluster().getMasterName());
-        internalCluster().stopCurrentMasterNode();
+        Settings clusterManagerDataPathSettings = internalCluster().dataPathSettings(internalCluster().getClusterManagerName());
+        internalCluster().stopCurrentClusterManagerNode();
 
         try {
             assertThat(
@@ -132,7 +132,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
             Settings.builder().put(nonDataNode(NodeRoles.clusterManagerNode())).put(clusterManagerDataPathSettings)
         );
         assertThat(
-            internalCluster().nonMasterClient()
+            internalCluster().nonClusterManagerClient()
                 .admin()
                 .cluster()
                 .prepareState()
@@ -145,7 +145,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
             equalTo(nextClusterManagerEligibleNodeName)
         );
         assertThat(
-            internalCluster().masterClient()
+            internalCluster().clusterManagerClient()
                 .admin()
                 .cluster()
                 .prepareState()
@@ -183,7 +183,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
         logger.info("--> start cluster-manager node (1)");
         final String clusterManagerNodeName = internalCluster().startClusterManagerOnlyNode();
         assertThat(
-            internalCluster().nonMasterClient()
+            internalCluster().nonClusterManagerClient()
                 .admin()
                 .cluster()
                 .prepareState()
@@ -196,7 +196,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
             equalTo(clusterManagerNodeName)
         );
         assertThat(
-            internalCluster().masterClient()
+            internalCluster().clusterManagerClient()
                 .admin()
                 .cluster()
                 .prepareState()
@@ -212,7 +212,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
         logger.info("--> start cluster-manager node (2)");
         final String nextClusterManagerEligableNodeName = internalCluster().startClusterManagerOnlyNode();
         assertThat(
-            internalCluster().nonMasterClient()
+            internalCluster().nonClusterManagerClient()
                 .admin()
                 .cluster()
                 .prepareState()
@@ -225,7 +225,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
             equalTo(clusterManagerNodeName)
         );
         assertThat(
-            internalCluster().nonMasterClient()
+            internalCluster().nonClusterManagerClient()
                 .admin()
                 .cluster()
                 .prepareState()
@@ -238,7 +238,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
             equalTo(clusterManagerNodeName)
         );
         assertThat(
-            internalCluster().masterClient()
+            internalCluster().clusterManagerClient()
                 .admin()
                 .cluster()
                 .prepareState()
@@ -256,7 +256,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
         // removing the cluster-manager from the voting configuration immediately triggers the cluster-manager to step down
         assertBusy(() -> {
             assertThat(
-                internalCluster().nonMasterClient()
+                internalCluster().nonClusterManagerClient()
                     .admin()
                     .cluster()
                     .prepareState()
@@ -269,7 +269,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
                 equalTo(nextClusterManagerEligableNodeName)
             );
             assertThat(
-                internalCluster().masterClient()
+                internalCluster().clusterManagerClient()
                     .admin()
                     .cluster()
                     .prepareState()
@@ -284,7 +284,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
         });
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(clusterManagerNodeName));
         assertThat(
-            internalCluster().nonMasterClient()
+            internalCluster().nonClusterManagerClient()
                 .admin()
                 .cluster()
                 .prepareState()
@@ -297,7 +297,7 @@ public class SpecificClusterManagerNodesIT extends OpenSearchIntegTestCase {
             equalTo(nextClusterManagerEligableNodeName)
         );
         assertThat(
-            internalCluster().masterClient()
+            internalCluster().clusterManagerClient()
                 .admin()
                 .cluster()
                 .prepareState()

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/UpdateSettingsValidationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/UpdateSettingsValidationIT.java
@@ -35,18 +35,18 @@ package org.opensearch.cluster;
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.opensearch.common.Priority;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
 import org.opensearch.test.OpenSearchIntegTestCase.Scope;
 
 import static org.opensearch.test.NodeRoles.nonDataNode;
-import static org.opensearch.test.NodeRoles.nonMasterNode;
 import static org.hamcrest.Matchers.equalTo;
 
 @ClusterScope(scope = Scope.TEST, numDataNodes = 0)
 public class UpdateSettingsValidationIT extends OpenSearchIntegTestCase {
     public void testUpdateSettingsValidation() throws Exception {
-        internalCluster().startNodes(nonDataNode(), nonMasterNode(), nonMasterNode());
+        internalCluster().startNodes(nonDataNode(), NodeRoles.nonClusterManagerNode(), NodeRoles.nonClusterManagerNode());
 
         createIndex("test");
         NumShards test = getNumShards("test");

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/UpdateSettingsValidationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/UpdateSettingsValidationIT.java
@@ -35,18 +35,18 @@ package org.opensearch.cluster;
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.opensearch.common.Priority;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
 import org.opensearch.test.OpenSearchIntegTestCase.Scope;
 
+import static org.opensearch.test.NodeRoles.nonClusterManagerNode;
 import static org.opensearch.test.NodeRoles.nonDataNode;
 import static org.hamcrest.Matchers.equalTo;
 
 @ClusterScope(scope = Scope.TEST, numDataNodes = 0)
 public class UpdateSettingsValidationIT extends OpenSearchIntegTestCase {
     public void testUpdateSettingsValidation() throws Exception {
-        internalCluster().startNodes(nonDataNode(), NodeRoles.nonClusterManagerNode(), NodeRoles.nonClusterManagerNode());
+        internalCluster().startNodes(nonDataNode(), nonClusterManagerNode(), nonClusterManagerNode());
 
         createIndex("test");
         NumShards test = getNumShards("test");

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/action/shard/ShardStateActionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/action/shard/ShardStateActionIT.java
@@ -123,7 +123,7 @@ public class ShardStateActionIT extends OpenSearchIntegTestCase {
         final AtomicBoolean stopSpammingClusterManager = new AtomicBoolean();
         final ClusterService clusterManagerClusterService = internalCluster().getInstance(
             ClusterService.class,
-            internalCluster().getMasterName()
+            internalCluster().getClusterManagerName()
         );
         clusterManagerClusterService.submitStateUpdateTask("spam", new ClusterStateUpdateTask(Priority.HIGH) {
             @Override

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/RareClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/RareClusterStateIT.java
@@ -105,7 +105,7 @@ public class RareClusterStateIT extends OpenSearchIntegTestCase {
         // close to have some unassigned started shards shards..
         client().admin().indices().prepareClose(index).get();
 
-        final String clusterManagerName = internalCluster().getMasterName();
+        final String clusterManagerName = internalCluster().getClusterManagerName();
         final ClusterService clusterService = internalCluster().clusterService(clusterManagerName);
         final AllocationService allocationService = internalCluster().getInstance(AllocationService.class, clusterManagerName);
         clusterService.submitStateUpdateTask("test-inject-node-and-reroute", new ClusterStateUpdateTask() {
@@ -159,7 +159,7 @@ public class RareClusterStateIT extends OpenSearchIntegTestCase {
     ) throws Exception {
         // Wait for no publication in progress to not accidentally cancel a publication different from the one triggered by the given
         // request.
-        final Coordinator clusterManagerCoordinator = (Coordinator) internalCluster().getCurrentMasterNodeInstance(Discovery.class);
+        final Coordinator clusterManagerCoordinator = (Coordinator) internalCluster().getCurrentClusterManagerNodeInstance(Discovery.class);
         assertBusy(() -> {
             assertFalse(clusterManagerCoordinator.publicationInProgress());
             final long applierVersion = clusterManagerCoordinator.getApplierState().version();
@@ -202,7 +202,9 @@ public class RareClusterStateIT extends OpenSearchIntegTestCase {
         ensureGreen(TimeValue.timeValueMinutes(30), "test");
         // due to publish_timeout of 0, wait for data node to have cluster state fully applied
         assertBusy(() -> {
-            long clusterManagerClusterStateVersion = internalCluster().clusterService(internalCluster().getMasterName()).state().version();
+            long clusterManagerClusterStateVersion = internalCluster().clusterService(internalCluster().getClusterManagerName())
+                .state()
+                .version();
             long dataClusterStateVersion = internalCluster().clusterService(dataNode).state().version();
             assertThat(clusterManagerClusterStateVersion, equalTo(dataClusterStateVersion));
         });
@@ -220,7 +222,7 @@ public class RareClusterStateIT extends OpenSearchIntegTestCase {
         final List<String> nodeNames = internalCluster().startNodes(2);
         assertFalse(client().admin().cluster().prepareHealth().setWaitForNodes("2").get().isTimedOut());
 
-        final String clusterManager = internalCluster().getMasterName();
+        final String clusterManager = internalCluster().getClusterManagerName();
         assertThat(nodeNames, hasItem(clusterManager));
         String otherNode = null;
         for (String node : nodeNames) {
@@ -308,7 +310,7 @@ public class RareClusterStateIT extends OpenSearchIntegTestCase {
         final List<String> nodeNames = internalCluster().startNodes(2);
         assertFalse(client().admin().cluster().prepareHealth().setWaitForNodes("2").get().isTimedOut());
 
-        final String clusterManager = internalCluster().getMasterName();
+        final String clusterManager = internalCluster().getClusterManagerName();
         assertThat(nodeNames, hasItem(clusterManager));
         String otherNode = null;
         for (String node : nodeNames) {

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
@@ -238,7 +238,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
         String node = internalCluster().startNode();
         Settings dataPathSettings = internalCluster().dataPathSettings(node);
         ensureStableCluster(1);
-        NodeEnvironment nodeEnvironment = internalCluster().getMasterNodeInstance(NodeEnvironment.class);
+        NodeEnvironment nodeEnvironment = internalCluster().getClusterManagerNodeInstance(NodeEnvironment.class);
         internalCluster().stopRandomDataNode();
         Environment environment = TestEnvironment.newEnvironment(
             Settings.builder().put(internalCluster().getDefaultSettings()).put(dataPathSettings).build()
@@ -253,7 +253,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
         String node = internalCluster().startNode();
         Settings dataPathSettings = internalCluster().dataPathSettings(node);
         ensureStableCluster(1);
-        NodeEnvironment nodeEnvironment = internalCluster().getMasterNodeInstance(NodeEnvironment.class);
+        NodeEnvironment nodeEnvironment = internalCluster().getClusterManagerNodeInstance(NodeEnvironment.class);
         internalCluster().stopRandomDataNode();
         Environment environment = TestEnvironment.newEnvironment(
             Settings.builder().put(internalCluster().getDefaultSettings()).put(dataPathSettings).build()
@@ -306,7 +306,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
         ); // node ordinal 1
 
         logger.info("--> start 2nd and 3rd cluster-manager-eligible nodes and bootstrap");
-        clusterManagerNodes.addAll(internalCluster().startMasterOnlyNodes(2)); // node ordinals 2 and 3
+        clusterManagerNodes.addAll(internalCluster().startClusterManagerOnlyNodes(2)); // node ordinals 2 and 3
 
         logger.info("--> wait for all nodes to join the cluster");
         ensureStableCluster(4);
@@ -351,7 +351,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
         );
 
         logger.info("--> stop 1st cluster-manager-eligible node and data-only node");
-        NodeEnvironment nodeEnvironment = internalCluster().getMasterNodeInstance(NodeEnvironment.class);
+        NodeEnvironment nodeEnvironment = internalCluster().getClusterManagerNodeInstance(NodeEnvironment.class);
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(clusterManagerNodes.get(0)));
         assertBusy(() -> internalCluster().getInstance(GatewayMetaState.class, dataNode).allPendingAsyncStatesWritten());
         internalCluster().stopRandomDataNode();
@@ -492,7 +492,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
         internalCluster().setBootstrapClusterManagerNodeIndex(0);
         String clusterManagerNode = internalCluster().startClusterManagerOnlyNode();
         Settings clusterManagerNodeDataPathSettings = internalCluster().dataPathSettings(clusterManagerNode);
-        internalCluster().stopCurrentMasterNode();
+        internalCluster().stopCurrentClusterManagerNode();
 
         final Environment environment = TestEnvironment.newEnvironment(
             Settings.builder().put(internalCluster().getDefaultSettings()).put(clusterManagerNodeDataPathSettings).build()
@@ -527,7 +527,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
 
         ensureReadOnlyBlock(false, clusterManagerNode);
 
-        internalCluster().stopCurrentMasterNode();
+        internalCluster().stopCurrentClusterManagerNode();
 
         final Environment environment = TestEnvironment.newEnvironment(
             Settings.builder().put(internalCluster().getDefaultSettings()).put(clusterManagerNodeDataPathSettings).build()
@@ -557,7 +557,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
 
         ensureReadOnlyBlock(false, clusterManagerNode);
 
-        internalCluster().stopCurrentMasterNode();
+        internalCluster().stopCurrentClusterManagerNode();
 
         final Environment environment = TestEnvironment.newEnvironment(
             Settings.builder().put(internalCluster().getDefaultSettings()).put(clusterManagerNodeDataPathSettings).build()

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
@@ -62,7 +62,7 @@ import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE
 import static org.opensearch.gateway.DanglingIndicesState.AUTO_IMPORT_DANGLING_INDICES_SETTING;
 import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
 import static org.opensearch.indices.recovery.RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING;
-import static org.opensearch.test.NodeRoles.nonMasterNode;
+import static org.opensearch.test.NodeRoles.nonClusterManagerNode;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 
@@ -175,7 +175,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
 
     public void testBootstrapNotClusterManagerEligible() {
         final Environment environment = TestEnvironment.newEnvironment(
-            Settings.builder().put(nonMasterNode(internalCluster().getDefaultSettings())).build()
+            Settings.builder().put(nonClusterManagerNode(internalCluster().getDefaultSettings())).build()
         );
         expectThrows(() -> unsafeBootstrap(environment), UnsafeBootstrapClusterManagerCommand.NOT_CLUSTER_MANAGER_NODE_MSG);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/VotingConfigurationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/VotingConfigurationIT.java
@@ -64,12 +64,12 @@ public class VotingConfigurationIT extends OpenSearchIntegTestCase {
     public void testAbdicateAfterVotingConfigExclusionAdded() throws ExecutionException, InterruptedException {
         internalCluster().setBootstrapClusterManagerNodeIndex(0);
         internalCluster().startNodes(2);
-        final String originalClusterManager = internalCluster().getMasterName();
+        final String originalClusterManager = internalCluster().getClusterManagerName();
 
         logger.info("--> excluding cluster-manager node {}", originalClusterManager);
         client().execute(AddVotingConfigExclusionsAction.INSTANCE, new AddVotingConfigExclusionsRequest(originalClusterManager)).get();
         client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).get();
-        assertNotEquals(originalClusterManager, internalCluster().getMasterName());
+        assertNotEquals(originalClusterManager, internalCluster().getClusterManagerName());
     }
 
     public void testElectsNodeNotInVotingConfiguration() throws Exception {
@@ -134,7 +134,7 @@ public class VotingConfigurationIT extends OpenSearchIntegTestCase {
             }
         }
 
-        internalCluster().stopCurrentMasterNode();
+        internalCluster().stopCurrentClusterManagerNode();
         assertFalse(
             internalCluster().client()
                 .admin()

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/ZenDiscoveryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/ZenDiscoveryIT.java
@@ -91,10 +91,10 @@ public class ZenDiscoveryIT extends OpenSearchIntegTestCase {
         RecoveryResponse r = client().admin().indices().prepareRecoveries("test").get();
         int numRecoveriesBeforeNewClusterManager = r.shardRecoveryStates().get("test").size();
 
-        final String oldClusterManager = internalCluster().getMasterName();
-        internalCluster().stopCurrentMasterNode();
+        final String oldClusterManager = internalCluster().getClusterManagerName();
+        internalCluster().stopCurrentClusterManagerNode();
         assertBusy(() -> {
-            String current = internalCluster().getMasterName();
+            String current = internalCluster().getClusterManagerName();
             assertThat(current, notNullValue());
             assertThat(current, not(equalTo(oldClusterManager)));
         });
@@ -170,7 +170,7 @@ public class ZenDiscoveryIT extends OpenSearchIntegTestCase {
         ensureGreen(); // ensures that all events are processed (in particular state recovery fully completed)
         assertBusy(
             () -> assertThat(
-                internalCluster().clusterService(internalCluster().getMasterName()).getMasterService().numberOfPendingTasks(),
+                internalCluster().clusterService(internalCluster().getClusterManagerName()).getMasterService().numberOfPendingTasks(),
                 equalTo(0)
             )
         ); // see https://github.com/elastic/elasticsearch/issues/24388

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -160,10 +160,9 @@ public class DiskThresholdDeciderIT extends OpenSearchIntegTestCase {
         final String dataNodeName = internalCluster().startDataOnlyNode();
         ensureStableCluster(3);
 
-        final InternalClusterInfoService clusterInfoService = (InternalClusterInfoService) internalCluster().getCurrentMasterNodeInstance(
-            ClusterInfoService.class
-        );
-        internalCluster().getCurrentMasterNodeInstance(ClusterService.class).addListener(event -> clusterInfoService.refresh());
+        final InternalClusterInfoService clusterInfoService = (InternalClusterInfoService) internalCluster()
+            .getCurrentClusterManagerNodeInstance(ClusterInfoService.class);
+        internalCluster().getCurrentClusterManagerNodeInstance(ClusterService.class).addListener(event -> clusterInfoService.refresh());
 
         final String dataNode0Id = internalCluster().getInstance(NodeEnvironment.class, dataNodeName).nodeId();
         final Path dataNode0Path = internalCluster().getInstance(Environment.class, dataNodeName).dataFiles()[0];
@@ -203,10 +202,9 @@ public class DiskThresholdDeciderIT extends OpenSearchIntegTestCase {
                 .setSettings(Settings.builder().put("location", randomRepoPath()).put("compress", randomBoolean()))
         );
 
-        final InternalClusterInfoService clusterInfoService = (InternalClusterInfoService) internalCluster().getCurrentMasterNodeInstance(
-            ClusterInfoService.class
-        );
-        internalCluster().getCurrentMasterNodeInstance(ClusterService.class).addListener(event -> clusterInfoService.refresh());
+        final InternalClusterInfoService clusterInfoService = (InternalClusterInfoService) internalCluster()
+            .getCurrentClusterManagerNodeInstance(ClusterInfoService.class);
+        internalCluster().getCurrentClusterManagerNodeInstance(ClusterService.class).addListener(event -> clusterInfoService.refresh());
 
         final String dataNode0Id = internalCluster().getInstance(NodeEnvironment.class, dataNodeName).nodeId();
         final Path dataNode0Path = internalCluster().getInstance(Environment.class, dataNodeName).dataFiles()[0];
@@ -330,7 +328,7 @@ public class DiskThresholdDeciderIT extends OpenSearchIntegTestCase {
     }
 
     private void refreshDiskUsage() {
-        final ClusterInfoService clusterInfoService = internalCluster().getCurrentMasterNodeInstance(ClusterInfoService.class);
+        final ClusterInfoService clusterInfoService = internalCluster().getCurrentClusterManagerNodeInstance(ClusterInfoService.class);
         ((InternalClusterInfoService) clusterInfoService).refresh();
         // if the nodes were all under the low watermark already (but unbalanced) then a change in the disk usage doesn't trigger a reroute
         // even though it's now possible to achieve better balance, so we have to do an explicit reroute. TODO fix this?

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/MockDiskUsagesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/MockDiskUsagesIT.java
@@ -270,7 +270,7 @@ public class MockDiskUsagesIT extends OpenSearchIntegTestCase {
         final MockInternalClusterInfoService clusterInfoService = getMockInternalClusterInfoService();
 
         final AtomicReference<ClusterState> clusterManagerAppliedClusterState = new AtomicReference<>();
-        internalCluster().getCurrentMasterNodeInstance(ClusterService.class).addListener(event -> {
+        internalCluster().getCurrentClusterManagerNodeInstance(ClusterService.class).addListener(event -> {
             clusterManagerAppliedClusterState.set(event.state());
             clusterInfoService.refresh(); // so that a subsequent reroute sees disk usage according to the current state
         });
@@ -358,7 +358,7 @@ public class MockDiskUsagesIT extends OpenSearchIntegTestCase {
             false
         ).map(RoutingNode::nodeId).collect(Collectors.toList());
 
-        internalCluster().getCurrentMasterNodeInstance(ClusterService.class).addListener(event -> {
+        internalCluster().getCurrentClusterManagerNodeInstance(ClusterService.class).addListener(event -> {
             assertThat(event.state().getRoutingNodes().node(nodeIds.get(2)).size(), lessThanOrEqualTo(1));
             clusterManagerAppliedClusterState.set(event.state());
             clusterInfoService.refresh(); // so that a subsequent reroute sees disk usage according to the current state
@@ -544,7 +544,7 @@ public class MockDiskUsagesIT extends OpenSearchIntegTestCase {
     }
 
     private MockInternalClusterInfoService getMockInternalClusterInfoService() {
-        return (MockInternalClusterInfoService) internalCluster().getCurrentMasterNodeInstance(ClusterInfoService.class);
+        return (MockInternalClusterInfoService) internalCluster().getCurrentClusterManagerNodeInstance(ClusterInfoService.class);
     }
 
 }

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/ClusterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/ClusterDisruptionIT.java
@@ -338,7 +338,7 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
     // simulate handling of sending shard failure during an isolation
     public void testSendingShardFailure() throws Exception {
         List<String> nodes = startCluster(3);
-        String clusterManagerNode = internalCluster().getMasterName();
+        String clusterManagerNode = internalCluster().getClusterManagerName();
         List<String> nonClusterManagerNodes = nodes.stream().filter(node -> !node.equals(clusterManagerNode)).collect(Collectors.toList());
         String nonClusterManagerNode = randomFrom(nonClusterManagerNodes);
         assertAcked(
@@ -463,12 +463,12 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
      */
     public void testIndicesDeleted() throws Exception {
         final String idxName = "test";
-        final List<String> allClusterManagerEligibleNodes = internalCluster().startMasterOnlyNodes(2);
+        final List<String> allClusterManagerEligibleNodes = internalCluster().startClusterManagerOnlyNodes(2);
         final String dataNode = internalCluster().startDataOnlyNode();
         ensureStableCluster(3);
         assertAcked(prepareCreate("test"));
 
-        final String clusterManagerNode1 = internalCluster().getMasterName();
+        final String clusterManagerNode1 = internalCluster().getClusterManagerName();
         NetworkDisruption networkDisruption = new NetworkDisruption(
             new TwoPartitions(clusterManagerNode1, dataNode),
             NetworkDisruption.UNRESPONSIVE

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/ClusterManagerDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/ClusterManagerDisruptionIT.java
@@ -71,7 +71,7 @@ public class ClusterManagerDisruptionIT extends AbstractDisruptionTestCase {
     public void testClusterManagerNodeGCs() throws Exception {
         List<String> nodes = startCluster(3);
 
-        String oldClusterManagerNode = internalCluster().getMasterName();
+        String oldClusterManagerNode = internalCluster().getClusterManagerName();
         // a very long GC, but it's OK as we remove the disruption when it has had an effect
         SingleNodeDisruption clusterManagerNodeDisruption = new IntermittentLongGCDisruption(
             random(),
@@ -105,7 +105,7 @@ public class ClusterManagerDisruptionIT extends AbstractDisruptionTestCase {
         ensureStableCluster(3, waitTime, false, oldNonClusterManagerNodes.get(0));
 
         // make sure all nodes agree on cluster-manager
-        String newClusterManager = internalCluster().getMasterName();
+        String newClusterManager = internalCluster().getClusterManagerName();
         assertThat(newClusterManager, not(equalTo(oldClusterManagerNode)));
         assertClusterManager(newClusterManager, nodes);
     }
@@ -126,7 +126,7 @@ public class ClusterManagerDisruptionIT extends AbstractDisruptionTestCase {
         );
 
         ensureGreen();
-        String isolatedNode = internalCluster().getMasterName();
+        String isolatedNode = internalCluster().getClusterManagerName();
         TwoPartitions partitions = isolateNode(isolatedNode);
         NetworkDisruption networkDisruption = addRandomDisruptionType(partitions);
         networkDisruption.startDisrupting();
@@ -296,7 +296,7 @@ public class ClusterManagerDisruptionIT extends AbstractDisruptionTestCase {
             Settings.builder()
                 .put("index.number_of_shards", 1)
                 .put("index.number_of_replicas", 1)
-                .put("index.routing.allocation.exclude._name", internalCluster().getMasterName())
+                .put("index.routing.allocation.exclude._name", internalCluster().getClusterManagerName())
                 .build()
         );
 

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/DiscoveryDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/DiscoveryDisruptionIT.java
@@ -136,7 +136,7 @@ public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
 
         // shutting down the nodes, to avoid the leakage check tripping
         // on the states associated with the commit requests we may have dropped
-        internalCluster().stopRandomNonMasterNode();
+        internalCluster().stopRandomNonClusterManagerNode();
     }
 
     public void testClusterFormingWithASlowNode() {
@@ -170,7 +170,7 @@ public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
         }
         internalCluster().clearDisruptionScheme();
         ensureStableCluster(3);
-        final String preferredClusterManagerName = internalCluster().getMasterName();
+        final String preferredClusterManagerName = internalCluster().getClusterManagerName();
         final DiscoveryNode preferredClusterManager = internalCluster().clusterService(preferredClusterManagerName).localNode();
 
         logger.info("--> preferred cluster-manager is {}", preferredClusterManager);
@@ -214,7 +214,7 @@ public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
     public void testNodeNotReachableFromClusterManager() throws Exception {
         startCluster(3);
 
-        String clusterManagerNode = internalCluster().getMasterName();
+        String clusterManagerNode = internalCluster().getClusterManagerName();
         String nonClusterManagerNode = null;
         while (nonClusterManagerNode == null) {
             nonClusterManagerNode = randomFrom(internalCluster().getNodeNames());

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/SnapshotDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/SnapshotDisruptionIT.java
@@ -212,7 +212,7 @@ public class SnapshotDisruptionIT extends AbstractSnapshotIntegTestCase {
         index(idxName, "type", JsonXContent.contentBuilder().startObject().field("foo", "bar").endObject());
 
         logger.info("--> run a snapshot that fails to finalize but succeeds on the data node");
-        blockMasterFromFinalizingSnapshotOnIndexFile(repoName);
+        blockClusterManagerFromFinalizingSnapshotOnIndexFile(repoName);
         final ActionFuture<CreateSnapshotResponse> snapshotFuture = client(clusterManagerNode).admin()
             .cluster()
             .prepareCreateSnapshot(repoName, "snapshot-2")

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/SnapshotDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/SnapshotDisruptionIT.java
@@ -86,7 +86,7 @@ public class SnapshotDisruptionIT extends AbstractSnapshotIntegTestCase {
 
     public void testDisruptionAfterFinalization() throws Exception {
         final String idxName = "test";
-        internalCluster().startMasterOnlyNodes(3);
+        internalCluster().startClusterManagerOnlyNodes(3);
         final String dataNode = internalCluster().startDataOnlyNode();
         ensureStableCluster(4);
 
@@ -94,7 +94,7 @@ public class SnapshotDisruptionIT extends AbstractSnapshotIntegTestCase {
 
         createRepository("test-repo", "fs");
 
-        final String clusterManagerNode1 = internalCluster().getMasterName();
+        final String clusterManagerNode1 = internalCluster().getClusterManagerName();
 
         NetworkDisruption networkDisruption = isolateClusterManagerDisruption(NetworkDisruption.UNRESPONSIVE);
         internalCluster().setDisruptionScheme(networkDisruption);
@@ -168,7 +168,7 @@ public class SnapshotDisruptionIT extends AbstractSnapshotIntegTestCase {
 
     public void testDisruptionAfterShardFinalization() throws Exception {
         final String idxName = "test";
-        internalCluster().startMasterOnlyNodes(1);
+        internalCluster().startClusterManagerOnlyNodes(1);
         internalCluster().startDataOnlyNode();
         ensureStableCluster(2);
         createIndex(idxName);
@@ -177,7 +177,7 @@ public class SnapshotDisruptionIT extends AbstractSnapshotIntegTestCase {
         final String repoName = "test-repo";
         createRepository(repoName, "mock");
 
-        final String clusterManagerNode = internalCluster().getMasterName();
+        final String clusterManagerNode = internalCluster().getClusterManagerName();
 
         blockAllDataNodes(repoName);
 
@@ -236,7 +236,7 @@ public class SnapshotDisruptionIT extends AbstractSnapshotIntegTestCase {
     }
 
     public void testClusterManagerFailOverDuringShardSnapshots() throws Exception {
-        internalCluster().startMasterOnlyNodes(3);
+        internalCluster().startClusterManagerOnlyNodes(3);
         final String dataNode = internalCluster().startDataOnlyNode();
         ensureStableCluster(4);
         final String repoName = "test-repo";
@@ -249,7 +249,7 @@ public class SnapshotDisruptionIT extends AbstractSnapshotIntegTestCase {
         blockDataNode(repoName, dataNode);
 
         logger.info("--> create snapshot via cluster-manager node client");
-        final ActionFuture<CreateSnapshotResponse> snapshotResponse = internalCluster().masterClient()
+        final ActionFuture<CreateSnapshotResponse> snapshotResponse = internalCluster().clusterManagerClient()
             .admin()
             .cluster()
             .prepareCreateSnapshot(repoName, "test-snap")

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/StableClusterManagerDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/StableClusterManagerDisruptionIT.java
@@ -92,7 +92,7 @@ public class StableClusterManagerDisruptionIT extends OpenSearchIntegTestCase {
         ensureStableCluster(3);
 
         // Figure out what is the elected cluster-manager node
-        final String clusterManagerNode = internalCluster().getMasterName();
+        final String clusterManagerNode = internalCluster().getClusterManagerName();
         logger.info("---> legit elected cluster-manager node={}", clusterManagerNode);
 
         // Pick a node that isn't the elected cluster-manager.
@@ -123,7 +123,7 @@ public class StableClusterManagerDisruptionIT extends OpenSearchIntegTestCase {
         ensureStableCluster(3);
 
         // The elected cluster-manager shouldn't have changed, since the unlucky node never could have elected itself as cluster-manager
-        assertThat(internalCluster().getMasterName(), equalTo(clusterManagerNode));
+        assertThat(internalCluster().getClusterManagerName(), equalTo(clusterManagerNode));
     }
 
     private void ensureNoMaster(String node) throws Exception {
@@ -162,11 +162,11 @@ public class StableClusterManagerDisruptionIT extends OpenSearchIntegTestCase {
         ensureStableCluster(4);
 
         logger.info("--> stopping current cluster-manager");
-        internalCluster().stopCurrentMasterNode();
+        internalCluster().stopCurrentClusterManagerNode();
 
         ensureStableCluster(3);
 
-        final String clusterManager = internalCluster().getMasterName();
+        final String clusterManager = internalCluster().getClusterManagerName();
         final List<String> nonClusterManagers = Arrays.stream(internalCluster().getNodeNames())
             .filter(n -> clusterManager.equals(n) == false)
             .collect(Collectors.toList());
@@ -205,7 +205,7 @@ public class StableClusterManagerDisruptionIT extends OpenSearchIntegTestCase {
         ensureStableCluster(3);
 
         // Save the current cluster-manager node as old cluster-manager node, because that node will get frozen
-        final String oldClusterManagerNode = internalCluster().getMasterName();
+        final String oldClusterManagerNode = internalCluster().getClusterManagerName();
 
         // Simulating a painful gc by suspending all threads for a long time on the current elected cluster-manager node.
         SingleNodeDisruption clusterManagerNodeDisruption = new LongGCDisruption(random(), oldClusterManagerNode);
@@ -274,7 +274,7 @@ public class StableClusterManagerDisruptionIT extends OpenSearchIntegTestCase {
             });
 
         // Save the new elected cluster-manager node
-        final String newClusterManagerNode = internalCluster().getMasterName(majoritySide.get(0));
+        final String newClusterManagerNode = internalCluster().getClusterManagerName(majoritySide.get(0));
         logger.info("--> new detected cluster-manager node [{}]", newClusterManagerNode);
 
         // Stop disruption

--- a/server/src/internalClusterTest/java/org/opensearch/index/mapper/DynamicMappingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/mapper/DynamicMappingIT.java
@@ -148,7 +148,7 @@ public class DynamicMappingIT extends OpenSearchIntegTestCase {
         final CountDownLatch clusterManagerBlockedLatch = new CountDownLatch(1);
         final CountDownLatch indexingCompletedLatch = new CountDownLatch(1);
 
-        internalCluster().getInstance(ClusterService.class, internalCluster().getMasterName())
+        internalCluster().getInstance(ClusterService.class, internalCluster().getClusterManagerName())
             .submitStateUpdateTask("block-state-updates", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {

--- a/server/src/internalClusterTest/java/org/opensearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/recovery/IndexRecoveryIT.java
@@ -775,7 +775,7 @@ public class IndexRecoveryIT extends OpenSearchIntegTestCase {
         logger.info("--> request recoveries");
         RecoveryResponse response = client().admin().indices().prepareRecoveries(INDEX_NAME).execute().actionGet();
 
-        Repository repository = internalCluster().getMasterNodeInstance(RepositoriesService.class).repository(REPO_NAME);
+        Repository repository = internalCluster().getClusterManagerNodeInstance(RepositoriesService.class).repository(REPO_NAME);
         final RepositoryData repositoryData = PlainActionFuture.get(repository::getRepositoryData);
         for (Map.Entry<String, List<RecoveryState>> indexRecoveryStates : response.shardRecoveryStates().entrySet()) {
 

--- a/server/src/internalClusterTest/java/org/opensearch/indices/recovery/ReplicaToPrimaryPromotionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/recovery/ReplicaToPrimaryPromotionIT.java
@@ -80,7 +80,7 @@ public class ReplicaToPrimaryPromotionIT extends OpenSearchIntegTestCase {
         }
 
         // pick up a data node that contains a random primary shard
-        ClusterState state = client(internalCluster().getMasterName()).admin().cluster().prepareState().get().getState();
+        ClusterState state = client(internalCluster().getClusterManagerName()).admin().cluster().prepareState().get().getState();
         final int numShards = state.metadata().index(indexName).getNumberOfShards();
         final ShardRouting primaryShard = state.routingTable().index(indexName).shard(randomIntBetween(0, numShards - 1)).primaryShard();
         final DiscoveryNode randomNode = state.nodes().resolveNode(primaryShard.currentNodeId());
@@ -89,7 +89,7 @@ public class ReplicaToPrimaryPromotionIT extends OpenSearchIntegTestCase {
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(randomNode.getName()));
         ensureYellowAndNoInitializingShards(indexName);
 
-        state = client(internalCluster().getMasterName()).admin().cluster().prepareState().get().getState();
+        state = client(internalCluster().getClusterManagerName()).admin().cluster().prepareState().get().getState();
         for (IndexShardRoutingTable shardRoutingTable : state.routingTable().index(indexName)) {
             for (ShardRouting shardRouting : shardRoutingTable.activeShards()) {
                 assertThat(shardRouting + " should be promoted as a primary", shardRouting.primary(), is(true));

--- a/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateSettingsIT.java
@@ -836,7 +836,7 @@ public class UpdateSettingsIT extends OpenSearchIntegTestCase {
 
     public void testNoopUpdate() {
         internalCluster().ensureAtLeastNumDataNodes(2);
-        final ClusterService clusterService = internalCluster().getMasterNodeInstance(ClusterService.class);
+        final ClusterService clusterService = internalCluster().getClusterManagerNodeInstance(ClusterService.class);
         assertAcked(
             client().admin()
                 .indices()

--- a/server/src/internalClusterTest/java/org/opensearch/indices/state/CloseWhileRelocatingShardsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/state/CloseWhileRelocatingShardsIT.java
@@ -150,7 +150,10 @@ public class CloseWhileRelocatingShardsIT extends OpenSearchIntegTestCase {
         ensureClusterSizeConsistency(); // wait for the cluster-manager to finish processing join.
 
         try {
-            final ClusterService clusterService = internalCluster().getInstance(ClusterService.class, internalCluster().getMasterName());
+            final ClusterService clusterService = internalCluster().getInstance(
+                ClusterService.class,
+                internalCluster().getClusterManagerName()
+            );
             final ClusterState state = clusterService.state();
             final CountDownLatch latch = new CountDownLatch(indices.length);
             final CountDownLatch release = new CountDownLatch(indices.length);

--- a/server/src/internalClusterTest/java/org/opensearch/indices/state/ReopenWhileClosingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/state/ReopenWhileClosingIT.java
@@ -150,7 +150,7 @@ public class ReopenWhileClosingIT extends OpenSearchIntegTestCase {
     private Releasable interceptVerifyShardBeforeCloseActions(final String indexPattern, final Runnable onIntercept) {
         final MockTransportService mockTransportService = (MockTransportService) internalCluster().getInstance(
             TransportService.class,
-            internalCluster().getMasterName()
+            internalCluster().getClusterManagerName()
         );
 
         final CountDownLatch release = new CountDownLatch(1);

--- a/server/src/internalClusterTest/java/org/opensearch/indices/store/IndicesStoreIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/store/IndicesStoreIntegrationIT.java
@@ -460,7 +460,7 @@ public class IndicesStoreIntegrationIT extends OpenSearchIntegTestCase {
     public void testShardActiveElseWhere() throws Exception {
         List<String> nodes = internalCluster().startNodes(2);
 
-        final String clusterManagerNode = internalCluster().getMasterName();
+        final String clusterManagerNode = internalCluster().getClusterManagerName();
         final String nonClusterManagerNode = nodes.get(0).equals(clusterManagerNode) ? nodes.get(1) : nodes.get(0);
 
         final String clusterManagerId = internalCluster().clusterService(clusterManagerNode).localNode().getId();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/store/IndicesStoreIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/store/IndicesStoreIntegrationIT.java
@@ -59,7 +59,6 @@ import org.opensearch.index.shard.ShardId;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.recovery.PeerRecoveryTargetService;
 import org.opensearch.plugins.Plugin;
-import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
 import org.opensearch.test.OpenSearchIntegTestCase.Scope;
@@ -112,8 +111,8 @@ public class IndicesStoreIntegrationIT extends OpenSearchIntegTestCase {
 
     public void testIndexCleanup() throws Exception {
         internalCluster().startNode(nonDataNode());
-        final String node_1 = internalCluster().startNode(NodeRoles.nonClusterManagerNode());
-        final String node_2 = internalCluster().startNode(NodeRoles.nonClusterManagerNode());
+        final String node_1 = internalCluster().startNode(nonClusterManagerNode());
+        final String node_2 = internalCluster().startNode(nonClusterManagerNode());
         logger.info("--> creating index [test] with one shard and on replica");
         assertAcked(
             prepareCreate("test").setSettings(
@@ -134,7 +133,7 @@ public class IndicesStoreIntegrationIT extends OpenSearchIntegTestCase {
         assertThat(Files.exists(indexDirectory(node_2, index)), equalTo(true));
 
         logger.info("--> starting node server3");
-        final String node_3 = internalCluster().startNode(NodeRoles.nonClusterManagerNode());
+        final String node_3 = internalCluster().startNode(nonClusterManagerNode());
         logger.info("--> running cluster_health");
         ClusterHealthResponse clusterHealth = client().admin()
             .cluster()

--- a/server/src/internalClusterTest/java/org/opensearch/indices/store/IndicesStoreIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/store/IndicesStoreIntegrationIT.java
@@ -59,6 +59,7 @@ import org.opensearch.index.shard.ShardId;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.recovery.PeerRecoveryTargetService;
 import org.opensearch.plugins.Plugin;
+import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
 import org.opensearch.test.OpenSearchIntegTestCase.Scope;
@@ -80,7 +81,7 @@ import java.util.concurrent.TimeUnit;
 
 import static java.lang.Thread.sleep;
 import static org.opensearch.test.NodeRoles.nonDataNode;
-import static org.opensearch.test.NodeRoles.nonMasterNode;
+import static org.opensearch.test.NodeRoles.nonClusterManagerNode;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -111,8 +112,8 @@ public class IndicesStoreIntegrationIT extends OpenSearchIntegTestCase {
 
     public void testIndexCleanup() throws Exception {
         internalCluster().startNode(nonDataNode());
-        final String node_1 = internalCluster().startNode(nonMasterNode());
-        final String node_2 = internalCluster().startNode(nonMasterNode());
+        final String node_1 = internalCluster().startNode(NodeRoles.nonClusterManagerNode());
+        final String node_2 = internalCluster().startNode(NodeRoles.nonClusterManagerNode());
         logger.info("--> creating index [test] with one shard and on replica");
         assertAcked(
             prepareCreate("test").setSettings(
@@ -133,7 +134,7 @@ public class IndicesStoreIntegrationIT extends OpenSearchIntegTestCase {
         assertThat(Files.exists(indexDirectory(node_2, index)), equalTo(true));
 
         logger.info("--> starting node server3");
-        final String node_3 = internalCluster().startNode(nonMasterNode());
+        final String node_3 = internalCluster().startNode(NodeRoles.nonClusterManagerNode());
         logger.info("--> running cluster_health");
         ClusterHealthResponse clusterHealth = client().admin()
             .cluster()

--- a/server/src/internalClusterTest/java/org/opensearch/persistent/PersistentTasksExecutorIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/persistent/PersistentTasksExecutorIT.java
@@ -224,7 +224,7 @@ public class PersistentTasksExecutorIT extends OpenSearchIntegTestCase {
     public void testPersistentActionWithNonClusterStateCondition() throws Exception {
         PersistentTasksClusterService persistentTasksClusterService = internalCluster().getInstance(
             PersistentTasksClusterService.class,
-            internalCluster().getMasterName()
+            internalCluster().getClusterManagerName()
         );
         // Speed up rechecks to a rate that is quicker than what settings would allow
         persistentTasksClusterService.setRecheckInterval(TimeValue.timeValueMillis(1));
@@ -384,7 +384,7 @@ public class PersistentTasksExecutorIT extends OpenSearchIntegTestCase {
     public void testUnassignRunningPersistentTask() throws Exception {
         PersistentTasksClusterService persistentTasksClusterService = internalCluster().getInstance(
             PersistentTasksClusterService.class,
-            internalCluster().getMasterName()
+            internalCluster().getClusterManagerName()
         );
         // Speed up rechecks to a rate that is quicker than what settings would allow
         persistentTasksClusterService.setRecheckInterval(TimeValue.timeValueMillis(1));

--- a/server/src/internalClusterTest/java/org/opensearch/persistent/decider/EnableAssignmentDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/persistent/decider/EnableAssignmentDeciderIT.java
@@ -87,7 +87,7 @@ public class EnableAssignmentDeciderIT extends OpenSearchIntegTestCase {
         }
         latch.await();
 
-        ClusterService clusterService = internalCluster().clusterService(internalCluster().getMasterName());
+        ClusterService clusterService = internalCluster().clusterService(internalCluster().getClusterManagerName());
         PersistentTasksCustomMetadata tasks = clusterService.state().getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
         assertEquals(numberOfTasks, tasks.tasks().stream().filter(t -> TestPersistentTasksExecutor.NAME.equals(t.getTaskName())).count());
 

--- a/server/src/internalClusterTest/java/org/opensearch/repositories/RepositoriesServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/repositories/RepositoriesServiceIT.java
@@ -65,7 +65,9 @@ public class RepositoriesServiceIT extends OpenSearchIntegTestCase {
         final String repositoryName = "test-repo";
 
         final Client client = client();
-        final RepositoriesService repositoriesService = cluster.getDataOrMasterNodeInstances(RepositoriesService.class).iterator().next();
+        final RepositoriesService repositoriesService = cluster.getDataOrClusterManagerNodeInstances(RepositoriesService.class)
+            .iterator()
+            .next();
 
         final Settings.Builder repoSettings = Settings.builder().put("location", randomRepoPath());
 

--- a/server/src/internalClusterTest/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryCleanupIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryCleanupIT.java
@@ -56,7 +56,7 @@ public class BlobStoreRepositoryCleanupIT extends AbstractSnapshotIntegTestCase 
 
         final int nodeCount = internalCluster().numDataAndMasterNodes();
         logger.info("-->  stopping cluster-manager node");
-        internalCluster().stopCurrentMasterNode();
+        internalCluster().stopCurrentClusterManagerNode();
 
         ensureStableCluster(nodeCount - 1);
 
@@ -92,7 +92,7 @@ public class BlobStoreRepositoryCleanupIT extends AbstractSnapshotIntegTestCase 
 
     private String startBlockedCleanup(String repoName) throws Exception {
         logger.info("-->  starting two cluster-manager nodes and one data node");
-        internalCluster().startMasterOnlyNodes(2);
+        internalCluster().startClusterManagerOnlyNodes(2);
         internalCluster().startDataOnlyNodes(1);
 
         createRepository(repoName, "mock");
@@ -100,7 +100,10 @@ public class BlobStoreRepositoryCleanupIT extends AbstractSnapshotIntegTestCase 
         logger.info("-->  snapshot");
         client().admin().cluster().prepareCreateSnapshot(repoName, "test-snap").setWaitForCompletion(true).get();
 
-        final RepositoriesService service = internalCluster().getInstance(RepositoriesService.class, internalCluster().getMasterName());
+        final RepositoriesService service = internalCluster().getInstance(
+            RepositoriesService.class,
+            internalCluster().getClusterManagerName()
+        );
         final BlobStoreRepository repository = (BlobStoreRepository) service.repository(repoName);
 
         logger.info("--> creating a garbage data blob");
@@ -146,7 +149,10 @@ public class BlobStoreRepositoryCleanupIT extends AbstractSnapshotIntegTestCase 
             assertThat(createSnapshotResponse.getSnapshotInfo().state(), is(SnapshotState.SUCCESS));
         }
 
-        final RepositoriesService service = internalCluster().getInstance(RepositoriesService.class, internalCluster().getMasterName());
+        final RepositoriesService service = internalCluster().getInstance(
+            RepositoriesService.class,
+            internalCluster().getClusterManagerName()
+        );
         final BlobStoreRepository repository = (BlobStoreRepository) service.repository(repoName);
 
         logger.info("--> write two outdated index-N blobs");

--- a/server/src/internalClusterTest/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryCleanupIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryCleanupIT.java
@@ -117,7 +117,7 @@ public class BlobStoreRepositoryCleanupIT extends AbstractSnapshotIntegTestCase 
             );
         garbageFuture.get();
 
-        final String clusterManagerNode = blockMasterFromFinalizingSnapshotOnIndexFile(repoName);
+        final String clusterManagerNode = blockClusterManagerFromFinalizingSnapshotOnIndexFile(repoName);
 
         logger.info("--> starting repository cleanup");
         client().admin().cluster().prepareCleanupRepository(repoName).execute();

--- a/server/src/internalClusterTest/java/org/opensearch/search/scroll/SearchScrollWithFailingNodesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/scroll/SearchScrollWithFailingNodesIT.java
@@ -97,7 +97,7 @@ public class SearchScrollWithFailingNodesIT extends OpenSearchIntegTestCase {
         assertThat(numHits, equalTo(100L));
         clearScroll("_all");
 
-        internalCluster().stopRandomNonMasterNode();
+        internalCluster().stopRandomNonClusterManagerNode();
 
         searchResponse = client().prepareSearch().setQuery(matchAllQuery()).setSize(10).setScroll(TimeValue.timeValueMinutes(1)).get();
         assertThat(searchResponse.getSuccessfulShards(), lessThan(searchResponse.getTotalShards()));

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/CloneSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/CloneSnapshotIT.java
@@ -91,7 +91,7 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         final String sourceSnapshot = "source-snapshot";
         final SnapshotInfo sourceSnapshotInfo = createFullSnapshot(repoName, sourceSnapshot);
 
-        final BlobStoreRepository repository = (BlobStoreRepository) internalCluster().getCurrentMasterNodeInstance(
+        final BlobStoreRepository repository = (BlobStoreRepository) internalCluster().getCurrentClusterManagerNodeInstance(
             RepositoriesService.class
         ).repository(repoName);
         final RepositoryData repositoryData = getRepositoryData(repoName);
@@ -378,7 +378,7 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
     }
 
     public void testClusterManagerFailoverDuringCloneStep1() throws Exception {
-        internalCluster().startMasterOnlyNodes(3);
+        internalCluster().startClusterManagerOnlyNodes(3);
         internalCluster().startDataOnlyNode();
         final String repoName = "test-repo";
         createRepository(repoName, "mock");
@@ -392,7 +392,7 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         final String cloneName = "target-snapshot";
         final ActionFuture<AcknowledgedResponse> cloneFuture = startCloneFromDataNode(repoName, sourceSnapshot, cloneName, testIndex);
         awaitNumberOfSnapshotsInProgress(1);
-        final String clusterManagerNode = internalCluster().getMasterName();
+        final String clusterManagerNode = internalCluster().getClusterManagerName();
         waitForBlock(clusterManagerNode, repoName, TimeValue.timeValueSeconds(30L));
         internalCluster().restartNode(clusterManagerNode);
         boolean cloneSucceeded = false;
@@ -404,7 +404,7 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
             // snapshot on disconnect slowly enough for it to work out
         }
 
-        awaitNoMoreRunningOperations(internalCluster().getMasterName());
+        awaitNoMoreRunningOperations(internalCluster().getClusterManagerName());
 
         // Check if the clone operation worked out by chance as a result of the clone request being retried
         // because of the cluster-manager failover
@@ -433,7 +433,7 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
 
     public void testClusterManagerFailoverDuringCloneStep2() throws Exception {
         // large snapshot pool so blocked snapshot threads from cloning don't prevent concurrent snapshot finalizations
-        internalCluster().startMasterOnlyNodes(3, LARGE_SNAPSHOT_POOL_SETTINGS);
+        internalCluster().startClusterManagerOnlyNodes(3, LARGE_SNAPSHOT_POOL_SETTINGS);
         internalCluster().startDataOnlyNode();
         final String repoName = "test-repo";
         createRepository(repoName, "mock");
@@ -447,18 +447,18 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         blockClusterManagerOnShardClone(repoName);
         final ActionFuture<AcknowledgedResponse> cloneFuture = startCloneFromDataNode(repoName, sourceSnapshot, targetSnapshot, testIndex);
         awaitNumberOfSnapshotsInProgress(1);
-        final String clusterManagerNode = internalCluster().getMasterName();
+        final String clusterManagerNode = internalCluster().getClusterManagerName();
         waitForBlock(clusterManagerNode, repoName, TimeValue.timeValueSeconds(30L));
         internalCluster().restartNode(clusterManagerNode);
         expectThrows(SnapshotException.class, cloneFuture::actionGet);
-        awaitNoMoreRunningOperations(internalCluster().getMasterName());
+        awaitNoMoreRunningOperations(internalCluster().getClusterManagerName());
 
         assertAllSnapshotsSuccessful(getRepositoryData(repoName), 2);
     }
 
     public void testExceptionDuringShardClone() throws Exception {
         // large snapshot pool so blocked snapshot threads from cloning don't prevent concurrent snapshot finalizations
-        internalCluster().startMasterOnlyNodes(3, LARGE_SNAPSHOT_POOL_SETTINGS);
+        internalCluster().startClusterManagerOnlyNodes(3, LARGE_SNAPSHOT_POOL_SETTINGS);
         internalCluster().startDataOnlyNode();
         final String repoName = "test-repo";
         createRepository(repoName, "mock");
@@ -472,11 +472,11 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         blockClusterManagerFromFinalizingSnapshotOnSnapFile(repoName);
         final ActionFuture<AcknowledgedResponse> cloneFuture = startCloneFromDataNode(repoName, sourceSnapshot, targetSnapshot, testIndex);
         awaitNumberOfSnapshotsInProgress(1);
-        final String clusterManagerNode = internalCluster().getMasterName();
+        final String clusterManagerNode = internalCluster().getClusterManagerName();
         waitForBlock(clusterManagerNode, repoName, TimeValue.timeValueSeconds(30L));
         unblockNode(repoName, clusterManagerNode);
         expectThrows(SnapshotException.class, cloneFuture::actionGet);
-        awaitNoMoreRunningOperations(internalCluster().getMasterName());
+        awaitNoMoreRunningOperations(internalCluster().getClusterManagerName());
         assertAllSnapshotsSuccessful(getRepositoryData(repoName), 1);
         assertAcked(startDeleteSnapshot(repoName, sourceSnapshot).get());
     }
@@ -491,7 +491,7 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         final String sourceSnapshot = "source-snapshot";
         blockDataNode(repoName, dataNode);
-        final Client clusterManagerClient = internalCluster().masterClient();
+        final Client clusterManagerClient = internalCluster().clusterManagerClient();
         final ActionFuture<CreateSnapshotResponse> sourceSnapshotFuture = clusterManagerClient.admin()
             .cluster()
             .prepareCreateSnapshot(repoName, sourceSnapshot)
@@ -643,12 +643,12 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
     }
 
     private void blockClusterManagerOnReadIndexMeta(String repoName) {
-        ((MockRepository) internalCluster().getCurrentMasterNodeInstance(RepositoriesService.class).repository(repoName))
+        ((MockRepository) internalCluster().getCurrentClusterManagerNodeInstance(RepositoriesService.class).repository(repoName))
             .setBlockOnReadIndexMeta();
     }
 
     private void blockClusterManagerOnShardClone(String repoName) {
-        ((MockRepository) internalCluster().getCurrentMasterNodeInstance(RepositoriesService.class).repository(repoName))
+        ((MockRepository) internalCluster().getCurrentClusterManagerNodeInstance(RepositoriesService.class).repository(repoName))
             .setBlockOnWriteShardLevelMeta();
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/CloneSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/CloneSnapshotIT.java
@@ -469,7 +469,7 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         createFullSnapshot(repoName, sourceSnapshot);
 
         final String targetSnapshot = "target-snapshot";
-        blockMasterFromFinalizingSnapshotOnSnapFile(repoName);
+        blockClusterManagerFromFinalizingSnapshotOnSnapFile(repoName);
         final ActionFuture<AcknowledgedResponse> cloneFuture = startCloneFromDataNode(repoName, sourceSnapshot, targetSnapshot, testIndex);
         awaitNumberOfSnapshotsInProgress(1);
         final String clusterManagerNode = internalCluster().getMasterName();
@@ -528,7 +528,7 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         final String sourceSnapshot = "source-snapshot";
         createFullSnapshot(repoName, sourceSnapshot);
 
-        blockMasterOnWriteIndexFile(repoName);
+        blockClusterManagerOnWriteIndexFile(repoName);
         final String cloneName = "clone-blocked";
         final ActionFuture<AcknowledgedResponse> blockedClone = startClone(repoName, sourceSnapshot, cloneName, indexName);
         waitForBlock(clusterManagerName, repoName, TimeValue.timeValueSeconds(30L));
@@ -558,7 +558,7 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         final String sourceSnapshot = "source-snapshot";
         createFullSnapshot(repoName, sourceSnapshot);
 
-        blockMasterOnWriteIndexFile(repoName);
+        blockClusterManagerOnWriteIndexFile(repoName);
         final String cloneName = "clone-blocked";
         final ActionFuture<AcknowledgedResponse> blockedClone = startClone(repoName, sourceSnapshot, cloneName, indexName);
         waitForBlock(clusterManagerName, repoName, TimeValue.timeValueSeconds(30L));
@@ -588,7 +588,7 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         final String sourceSnapshot = "source-snapshot";
         createFullSnapshot(repoName, sourceSnapshot);
 
-        blockMasterOnWriteIndexFile(repoName);
+        blockClusterManagerOnWriteIndexFile(repoName);
         final ActionFuture<CreateSnapshotResponse> blockedSnapshot = startFullSnapshot(repoName, "snap-blocked");
         waitForBlock(clusterManagerName, repoName, TimeValue.timeValueSeconds(30L));
         awaitNumberOfSnapshotsInProgress(1);

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/ConcurrentSnapshotsIT.java
@@ -312,7 +312,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         final String firstSnapshot = "first-snapshot";
         createFullSnapshot(repoName, firstSnapshot);
 
-        blockMasterFromFinalizingSnapshotOnIndexFile(repoName);
+        blockClusterManagerFromFinalizingSnapshotOnIndexFile(repoName);
         final ActionFuture<AcknowledgedResponse> deleteFuture = startDeleteSnapshot(repoName, firstSnapshot);
         waitForBlock(clusterManagerNode, repoName, TimeValue.timeValueSeconds(30L));
 
@@ -591,7 +591,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         createIndexWithContent("index-one");
         createNSnapshots(repoName, randomIntBetween(2, 5));
 
-        blockMasterFromFinalizingSnapshotOnIndexFile(repoName);
+        blockClusterManagerFromFinalizingSnapshotOnIndexFile(repoName);
         final ActionFuture<AcknowledgedResponse> firstDeleteFuture = startDeleteSnapshot(repoName, "*");
         waitForBlock(clusterManagerNode, repoName, TimeValue.timeValueSeconds(30L));
 
@@ -718,7 +718,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         final NetworkDisruption networkDisruption = isolateClusterManagerDisruption(NetworkDisruption.DISCONNECT);
         internalCluster().setDisruptionScheme(networkDisruption);
 
-        blockMasterFromFinalizingSnapshotOnIndexFile(repoName);
+        blockClusterManagerFromFinalizingSnapshotOnIndexFile(repoName);
         final ActionFuture<CreateSnapshotResponse> firstFailedSnapshotFuture = startFullSnapshotFromClusterManagerClient(
             repoName,
             "failing-snapshot-1"
@@ -819,7 +819,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         final long generation = getRepositoryData(repoName).getGenId();
         final String clusterManagerNode = internalCluster().getMasterName();
-        blockMasterFromFinalizingSnapshotOnIndexFile(repoName);
+        blockClusterManagerFromFinalizingSnapshotOnIndexFile(repoName);
         final ActionFuture<CreateSnapshotResponse> snapshotThree = startFullSnapshotFromNonClusterManagerClient(repoName, "snapshot-three");
         waitForBlock(clusterManagerNode, repoName, TimeValue.timeValueSeconds(30L));
 
@@ -1044,7 +1044,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         createIndexWithContent("index-test");
         createNSnapshots(repoName, randomIntBetween(1, 5));
         final String snapshotName = "snap-name";
-        blockMasterFromDeletingIndexNFile(repoName);
+        blockClusterManagerFromDeletingIndexNFile(repoName);
         final ActionFuture<CreateSnapshotResponse> snapshotFuture = startFullSnapshot(repoName, snapshotName);
         waitForBlock(clusterManagerName, repoName, TimeValue.timeValueSeconds(30L));
         final ActionFuture<AcknowledgedResponse> deleteFuture = startDeleteSnapshot(repoName, snapshotName);
@@ -1091,7 +1091,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         final List<String> snapshotNames = createNSnapshots(repoName, randomIntBetween(2, 5));
         final String clusterManagerName = internalCluster().getMasterName();
-        blockMasterFromDeletingIndexNFile(repoName);
+        blockClusterManagerFromDeletingIndexNFile(repoName);
         final ActionFuture<CreateSnapshotResponse> snapshotThree = startFullSnapshotFromClusterManagerClient(repoName, "snap-other");
         waitForBlock(clusterManagerName, repoName, TimeValue.timeValueSeconds(30L));
 
@@ -1210,8 +1210,8 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         corruptIndexN(repoPath, getRepositoryData(repoName).getGenId());
 
-        blockMasterFromFinalizingSnapshotOnIndexFile(repoName);
-        blockMasterFromFinalizingSnapshotOnIndexFile(otherRepoName);
+        blockClusterManagerFromFinalizingSnapshotOnIndexFile(repoName);
+        blockClusterManagerFromFinalizingSnapshotOnIndexFile(otherRepoName);
 
         client().admin().cluster().prepareCreateSnapshot(repoName, "snapshot-blocked-1").setWaitForCompletion(false).get();
         client().admin().cluster().prepareCreateSnapshot(repoName, "snapshot-blocked-2").setWaitForCompletion(false).get();
@@ -1338,7 +1338,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         final String clusterManagerNode = internalCluster().startClusterManagerOnlyNode();
         final String repoName = "test-repo";
         createRepository(repoName, "mock");
-        blockMasterFromFinalizingSnapshotOnIndexFile(repoName);
+        blockClusterManagerFromFinalizingSnapshotOnIndexFile(repoName);
         final String snapshotName = "snap-1";
         final ActionFuture<CreateSnapshotResponse> snapshotFuture = startFullSnapshot(repoName, snapshotName);
         waitForBlock(clusterManagerNode, repoName, TimeValue.timeValueSeconds(30L));
@@ -1386,7 +1386,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         createIndexWithContent("test-idx");
         createFullSnapshot(repoName, "first-snapshot");
 
-        blockMasterOnWriteIndexFile(repoName);
+        blockClusterManagerOnWriteIndexFile(repoName);
         final ActionFuture<CreateSnapshotResponse> blockedSnapshot = startFullSnapshot(repoName, "snap-blocked");
         waitForBlock(clusterManagerName, repoName, TimeValue.timeValueSeconds(30L));
         awaitNumberOfSnapshotsInProgress(1);
@@ -1510,7 +1510,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
     private ActionFuture<CreateSnapshotResponse> startAndBlockFailingFullSnapshot(String blockedRepoName, String snapshotName)
         throws InterruptedException {
-        blockMasterFromFinalizingSnapshotOnIndexFile(blockedRepoName);
+        blockClusterManagerFromFinalizingSnapshotOnIndexFile(blockedRepoName);
         final ActionFuture<CreateSnapshotResponse> fut = startFullSnapshot(blockedRepoName, snapshotName);
         waitForBlock(internalCluster().getMasterName(), blockedRepoName, TimeValue.timeValueSeconds(30L));
         return fut;

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/ConcurrentSnapshotsIT.java
@@ -224,7 +224,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
             .setWaitForCompletion(false)
             .get();
 
-        unblockNode(blockedRepoName, internalCluster().getMasterName());
+        unblockNode(blockedRepoName, internalCluster().getClusterManagerName());
         expectThrows(SnapshotException.class, createSlowFuture::actionGet);
 
         assertBusy(() -> assertThat(currentSnapshots(otherRepoName), empty()), 30L, TimeUnit.SECONDS);
@@ -448,7 +448,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
     }
 
     public void testClusterManagerFailOverWithQueuedDeletes() throws Exception {
-        internalCluster().startMasterOnlyNodes(3);
+        internalCluster().startClusterManagerOnlyNodes(3);
         final String dataNode = internalCluster().startDataOnlyNode();
         final String repoName = "test-repo";
         createRepository(repoName, "mock");
@@ -513,7 +513,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         }, 30L, TimeUnit.SECONDS);
 
         logger.info("--> stopping current cluster-manager node");
-        internalCluster().stopCurrentMasterNode();
+        internalCluster().stopCurrentClusterManagerNode();
 
         unblockNode(repoName, dataNode);
         unblockNode(repoName, dataNode2);
@@ -641,7 +641,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
     }
 
     public void testQueuedOperationsOnClusterManagerRestart() throws Exception {
-        internalCluster().startMasterOnlyNodes(3);
+        internalCluster().startClusterManagerOnlyNodes(3);
         internalCluster().startDataOnlyNode();
         final String repoName = "test-repo";
         createRepository(repoName, "mock");
@@ -655,21 +655,21 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         startDeleteSnapshot(repoName, "*");
         awaitNDeletionsInProgress(2);
 
-        internalCluster().stopCurrentMasterNode();
+        internalCluster().stopCurrentClusterManagerNode();
         ensureStableCluster(3);
 
         awaitNoMoreRunningOperations();
     }
 
     public void testQueuedOperationsOnClusterManagerDisconnect() throws Exception {
-        internalCluster().startMasterOnlyNodes(3);
+        internalCluster().startClusterManagerOnlyNodes(3);
         final String dataNode = internalCluster().startDataOnlyNode();
         final String repoName = "test-repo";
         createRepository(repoName, "mock");
         createIndexWithContent("index-one");
         createNSnapshots(repoName, randomIntBetween(2, 5));
 
-        final String clusterManagerNode = internalCluster().getMasterName();
+        final String clusterManagerNode = internalCluster().getClusterManagerName();
         final NetworkDisruption networkDisruption = isolateClusterManagerDisruption(NetworkDisruption.DISCONNECT);
         internalCluster().setDisruptionScheme(networkDisruption);
 
@@ -707,14 +707,14 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
     }
 
     public void testQueuedOperationsOnClusterManagerDisconnectAndRepoFailure() throws Exception {
-        internalCluster().startMasterOnlyNodes(3);
+        internalCluster().startClusterManagerOnlyNodes(3);
         final String dataNode = internalCluster().startDataOnlyNode();
         final String repoName = "test-repo";
         createRepository(repoName, "mock");
         createIndexWithContent("index-one");
         createNSnapshots(repoName, randomIntBetween(2, 5));
 
-        final String clusterManagerNode = internalCluster().getMasterName();
+        final String clusterManagerNode = internalCluster().getClusterManagerName();
         final NetworkDisruption networkDisruption = isolateClusterManagerDisruption(NetworkDisruption.DISCONNECT);
         internalCluster().setDisruptionScheme(networkDisruption);
 
@@ -752,7 +752,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
     public void testQueuedOperationsAndBrokenRepoOnClusterManagerFailOver() throws Exception {
         disableRepoConsistencyCheck("This test corrupts the repository on purpose");
 
-        internalCluster().startMasterOnlyNodes(3);
+        internalCluster().startClusterManagerOnlyNodes(3);
         internalCluster().startDataOnlyNode();
         final String repoName = "test-repo";
         final Path repoPath = randomRepoPath();
@@ -771,7 +771,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         final ActionFuture<AcknowledgedResponse> deleteFuture = startDeleteFromNonClusterManagerClient(repoName, "*");
         awaitNDeletionsInProgress(2);
 
-        internalCluster().stopCurrentMasterNode();
+        internalCluster().stopCurrentClusterManagerNode();
         ensureStableCluster(3);
 
         awaitNoMoreRunningOperations();
@@ -781,7 +781,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
     public void testQueuedSnapshotOperationsAndBrokenRepoOnClusterManagerFailOver() throws Exception {
         disableRepoConsistencyCheck("This test corrupts the repository on purpose");
 
-        internalCluster().startMasterOnlyNodes(3);
+        internalCluster().startClusterManagerOnlyNodes(3);
         internalCluster().startDataOnlyNode();
         final String repoName = "test-repo";
         final Path repoPath = randomRepoPath();
@@ -790,7 +790,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         createNSnapshots(repoName, randomIntBetween(2, 5));
 
         final long generation = getRepositoryData(repoName).getGenId();
-        final String clusterManagerNode = internalCluster().getMasterName();
+        final String clusterManagerNode = internalCluster().getClusterManagerName();
         blockNodeOnAnyFiles(repoName, clusterManagerNode);
         final ActionFuture<CreateSnapshotResponse> snapshotThree = startFullSnapshotFromNonClusterManagerClient(repoName, "snapshot-three");
         waitForBlock(clusterManagerNode, repoName, TimeValue.timeValueSeconds(30L));
@@ -798,7 +798,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         corruptIndexN(repoPath, generation);
 
         final ActionFuture<CreateSnapshotResponse> snapshotFour = startFullSnapshotFromNonClusterManagerClient(repoName, "snapshot-four");
-        internalCluster().stopCurrentMasterNode();
+        internalCluster().stopCurrentClusterManagerNode();
         ensureStableCluster(3);
 
         awaitNoMoreRunningOperations();
@@ -809,7 +809,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
     public void testQueuedSnapshotOperationsAndBrokenRepoOnClusterManagerFailOver2() throws Exception {
         disableRepoConsistencyCheck("This test corrupts the repository on purpose");
 
-        internalCluster().startMasterOnlyNodes(3);
+        internalCluster().startClusterManagerOnlyNodes(3);
         final String dataNode = internalCluster().startDataOnlyNode();
         final String repoName = "test-repo";
         final Path repoPath = randomRepoPath();
@@ -818,7 +818,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         createNSnapshots(repoName, randomIntBetween(2, 5));
 
         final long generation = getRepositoryData(repoName).getGenId();
-        final String clusterManagerNode = internalCluster().getMasterName();
+        final String clusterManagerNode = internalCluster().getClusterManagerName();
         blockClusterManagerFromFinalizingSnapshotOnIndexFile(repoName);
         final ActionFuture<CreateSnapshotResponse> snapshotThree = startFullSnapshotFromNonClusterManagerClient(repoName, "snapshot-three");
         waitForBlock(clusterManagerNode, repoName, TimeValue.timeValueSeconds(30L));
@@ -842,7 +842,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
     public void testQueuedSnapshotOperationsAndBrokenRepoOnClusterManagerFailOverMultipleRepos() throws Exception {
         disableRepoConsistencyCheck("This test corrupts the repository on purpose");
 
-        internalCluster().startMasterOnlyNodes(3, LARGE_SNAPSHOT_POOL_SETTINGS);
+        internalCluster().startClusterManagerOnlyNodes(3, LARGE_SNAPSHOT_POOL_SETTINGS);
         internalCluster().startDataOnlyNode();
         final String repoName = "test-repo";
         final Path repoPath = randomRepoPath();
@@ -850,7 +850,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         createIndexWithContent("index-one");
         createNSnapshots(repoName, randomIntBetween(2, 5));
 
-        final String clusterManagerNode = internalCluster().getMasterName();
+        final String clusterManagerNode = internalCluster().getClusterManagerName();
 
         final String blockedRepoName = "repo-blocked";
         createRepository(blockedRepoName, "mock");
@@ -875,7 +875,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         final ActionFuture<CreateSnapshotResponse> snapshotFour = startFullSnapshotFromNonClusterManagerClient(repoName, "snapshot-four");
         awaitNumberOfSnapshotsInProgress(3);
-        internalCluster().stopCurrentMasterNode();
+        internalCluster().stopCurrentClusterManagerNode();
         ensureStableCluster(3);
 
         awaitNoMoreRunningOperations();
@@ -1014,7 +1014,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
     }
 
     public void testQueuedOperationsAfterFinalizationFailure() throws Exception {
-        internalCluster().startMasterOnlyNodes(3);
+        internalCluster().startClusterManagerOnlyNodes(3);
         internalCluster().startDataOnlyNode();
         final String repoName = "test-repo";
         createRepository(repoName, "mock");
@@ -1024,7 +1024,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         final ActionFuture<CreateSnapshotResponse> snapshotThree = startAndBlockFailingFullSnapshot(repoName, "snap-other");
 
-        final String clusterManagerName = internalCluster().getMasterName();
+        final String clusterManagerName = internalCluster().getClusterManagerName();
 
         final String snapshotOne = snapshotNames.get(0);
         final ActionFuture<AcknowledgedResponse> deleteSnapshotOne = startDeleteSnapshot(repoName, snapshotOne);
@@ -1081,7 +1081,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
     }
 
     public void testClusterManagerFailoverOnFinalizationLoop() throws Exception {
-        internalCluster().startMasterOnlyNodes(3);
+        internalCluster().startClusterManagerOnlyNodes(3);
         final String dataNode = internalCluster().startDataOnlyNode();
         final String repoName = "test-repo";
         createRepository(repoName, "mock");
@@ -1090,7 +1090,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         internalCluster().setDisruptionScheme(networkDisruption);
 
         final List<String> snapshotNames = createNSnapshots(repoName, randomIntBetween(2, 5));
-        final String clusterManagerName = internalCluster().getMasterName();
+        final String clusterManagerName = internalCluster().getClusterManagerName();
         blockClusterManagerFromDeletingIndexNFile(repoName);
         final ActionFuture<CreateSnapshotResponse> snapshotThree = startFullSnapshotFromClusterManagerClient(repoName, "snap-other");
         waitForBlock(clusterManagerName, repoName, TimeValue.timeValueSeconds(30L));
@@ -1196,7 +1196,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
     public void testClusterManagerFailoverAndMultipleQueuedUpSnapshotsAcrossTwoRepos() throws Exception {
         disableRepoConsistencyCheck("This test corrupts the repository on purpose");
 
-        internalCluster().startMasterOnlyNodes(3, LARGE_SNAPSHOT_POOL_SETTINGS);
+        internalCluster().startClusterManagerOnlyNodes(3, LARGE_SNAPSHOT_POOL_SETTINGS);
         final String dataNode = internalCluster().startDataOnlyNode();
         final String repoName = "test-repo";
         final String otherRepoName = "other-test-repo";
@@ -1219,11 +1219,11 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         client().admin().cluster().prepareCreateSnapshot(otherRepoName, "snapshot-other-blocked-2").setWaitForCompletion(false).get();
 
         awaitNumberOfSnapshotsInProgress(4);
-        final String initialClusterManager = internalCluster().getMasterName();
+        final String initialClusterManager = internalCluster().getClusterManagerName();
         waitForBlock(initialClusterManager, repoName, TimeValue.timeValueSeconds(30L));
         waitForBlock(initialClusterManager, otherRepoName, TimeValue.timeValueSeconds(30L));
 
-        internalCluster().stopCurrentMasterNode();
+        internalCluster().stopCurrentClusterManagerNode();
         ensureStableCluster(3, dataNode);
         awaitNoMoreRunningOperations();
 
@@ -1431,12 +1431,12 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
     private ActionFuture<AcknowledgedResponse> startDeleteFromNonClusterManagerClient(String repoName, String snapshotName) {
         logger.info("--> deleting snapshot [{}] from repo [{}] from non cluster-manager client", snapshotName, repoName);
-        return internalCluster().nonMasterClient().admin().cluster().prepareDeleteSnapshot(repoName, snapshotName).execute();
+        return internalCluster().nonClusterManagerClient().admin().cluster().prepareDeleteSnapshot(repoName, snapshotName).execute();
     }
 
     private ActionFuture<CreateSnapshotResponse> startFullSnapshotFromNonClusterManagerClient(String repoName, String snapshotName) {
         logger.info("--> creating full snapshot [{}] to repo [{}] from non cluster-manager client", snapshotName, repoName);
-        return internalCluster().nonMasterClient()
+        return internalCluster().nonClusterManagerClient()
             .admin()
             .cluster()
             .prepareCreateSnapshot(repoName, snapshotName)
@@ -1446,7 +1446,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
     private ActionFuture<CreateSnapshotResponse> startFullSnapshotFromClusterManagerClient(String repoName, String snapshotName) {
         logger.info("--> creating full snapshot [{}] to repo [{}] from cluster-manager client", snapshotName, repoName);
-        return internalCluster().masterClient()
+        return internalCluster().clusterManagerClient()
             .admin()
             .cluster()
             .prepareCreateSnapshot(repoName, snapshotName)
@@ -1501,7 +1501,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
     private ActionFuture<AcknowledgedResponse> startAndBlockOnDeleteSnapshot(String repoName, String snapshotName)
         throws InterruptedException {
-        final String clusterManagerName = internalCluster().getMasterName();
+        final String clusterManagerName = internalCluster().getClusterManagerName();
         blockNodeOnAnyFiles(repoName, clusterManagerName);
         final ActionFuture<AcknowledgedResponse> fut = startDeleteSnapshot(repoName, snapshotName);
         waitForBlock(clusterManagerName, repoName, TimeValue.timeValueSeconds(30L));
@@ -1512,7 +1512,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         throws InterruptedException {
         blockClusterManagerFromFinalizingSnapshotOnIndexFile(blockedRepoName);
         final ActionFuture<CreateSnapshotResponse> fut = startFullSnapshot(blockedRepoName, snapshotName);
-        waitForBlock(internalCluster().getMasterName(), blockedRepoName, TimeValue.timeValueSeconds(30L));
+        waitForBlock(internalCluster().getClusterManagerName(), blockedRepoName, TimeValue.timeValueSeconds(30L));
         return fut;
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/CorruptedBlobStoreRepositoryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/CorruptedBlobStoreRepositoryIT.java
@@ -205,7 +205,7 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
             equalTo(createSnapshotResponse.getSnapshotInfo().totalShards())
         );
 
-        final Repository repository = internalCluster().getMasterNodeInstance(RepositoriesService.class).repository(repoName);
+        final Repository repository = internalCluster().getClusterManagerNodeInstance(RepositoriesService.class).repository(repoName);
 
         logger.info("--> move index-N blob to next generation");
         final RepositoryData repositoryData = getRepositoryData(repository);
@@ -215,7 +215,7 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         logger.info("--> verify index-N blob is found at the new location");
         assertThat(getRepositoryData(repository).getGenId(), is(beforeMoveGen + 1));
 
-        final SnapshotsService snapshotsService = internalCluster().getCurrentMasterNodeInstance(SnapshotsService.class);
+        final SnapshotsService snapshotsService = internalCluster().getCurrentClusterManagerNodeInstance(SnapshotsService.class);
         logger.info("--> wait for all listeners on snapshots service to be resolved to avoid snapshot task batching causing a conflict");
         assertBusy(() -> assertTrue(snapshotsService.assertAllListenersResolved()));
 
@@ -267,7 +267,8 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
             equalTo(createSnapshotResponse.getSnapshotInfo().totalShards())
         );
 
-        final Repository repository = internalCluster().getCurrentMasterNodeInstance(RepositoriesService.class).repository(repoName);
+        final Repository repository = internalCluster().getCurrentClusterManagerNodeInstance(RepositoriesService.class)
+            .repository(repoName);
 
         logger.info("--> move index-N blob to next generation");
         final RepositoryData repositoryData = getRepositoryData(repoName);
@@ -367,8 +368,8 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         );
 
         logger.info("--> verify that repo is assumed in old metadata format");
-        final SnapshotsService snapshotsService = internalCluster().getCurrentMasterNodeInstance(SnapshotsService.class);
-        final ThreadPool threadPool = internalCluster().getCurrentMasterNodeInstance(ThreadPool.class);
+        final SnapshotsService snapshotsService = internalCluster().getCurrentClusterManagerNodeInstance(SnapshotsService.class);
+        final ThreadPool threadPool = internalCluster().getCurrentClusterManagerNodeInstance(ThreadPool.class);
         assertThat(
             PlainActionFuture.get(
                 f -> threadPool.generic()
@@ -435,7 +436,8 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         );
 
         logger.info("--> corrupt index-N blob");
-        final Repository repository = internalCluster().getCurrentMasterNodeInstance(RepositoriesService.class).repository(repoName);
+        final Repository repository = internalCluster().getCurrentClusterManagerNodeInstance(RepositoriesService.class)
+            .repository(repoName);
         final RepositoryData repositoryData = getRepositoryData(repoName);
         Files.write(repo.resolve("index-" + repositoryData.getGenId()), randomByteArrayOfLength(randomIntBetween(1, 100)));
 
@@ -444,7 +446,8 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
 
         final String otherRepoName = "other-repo";
         createRepository(otherRepoName, "fs", Settings.builder().put("location", repo).put("compress", false));
-        final Repository otherRepo = internalCluster().getCurrentMasterNodeInstance(RepositoriesService.class).repository(otherRepoName);
+        final Repository otherRepo = internalCluster().getCurrentClusterManagerNodeInstance(RepositoriesService.class)
+            .repository(otherRepoName);
 
         logger.info("--> verify loading repository data from newly mounted repository throws RepositoryException");
         expectThrows(RepositoryException.class, () -> getRepositoryData(otherRepo));

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -837,7 +837,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
     public void testClusterManagerShutdownDuringSnapshot() throws Exception {
         logger.info("-->  starting two cluster-manager nodes and two data nodes");
-        internalCluster().startMasterOnlyNodes(2);
+        internalCluster().startClusterManagerOnlyNodes(2);
         internalCluster().startDataOnlyNodes(2);
 
         final Path repoPath = randomRepoPath();
@@ -860,7 +860,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
             .get();
 
         logger.info("--> stopping cluster-manager node");
-        internalCluster().stopCurrentMasterNode();
+        internalCluster().stopCurrentClusterManagerNode();
 
         logger.info("--> wait until the snapshot is done");
 
@@ -875,7 +875,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
     public void testClusterManagerAndDataShutdownDuringSnapshot() throws Exception {
         logger.info("-->  starting three cluster-manager nodes and two data nodes");
-        internalCluster().startMasterOnlyNodes(3);
+        internalCluster().startClusterManagerOnlyNodes(3);
         internalCluster().startDataOnlyNodes(2);
 
         final Path repoPath = randomRepoPath();
@@ -903,7 +903,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         logger.info("--> stopping data node {}", dataNode);
         stopNode(dataNode);
         logger.info("--> stopping cluster-manager node {} ", clusterManagerNode);
-        internalCluster().stopCurrentMasterNode();
+        internalCluster().stopCurrentClusterManagerNode();
 
         logger.info("--> wait until the snapshot is done");
 
@@ -1159,7 +1159,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         logger.info("-->  snapshot");
         ServiceDisruptionScheme disruption = new BusyMasterServiceDisruption(random(), Priority.HIGH);
         setDisruptionScheme(disruption);
-        client(internalCluster().getMasterName()).admin()
+        client(internalCluster().getClusterManagerName()).admin()
             .cluster()
             .prepareCreateSnapshot("test-repo", "test-snap")
             .setWaitForCompletion(false)
@@ -1213,7 +1213,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
         blockAllDataNodes("test-repo");
         logger.info("-->  snapshot");
-        client(internalCluster().getMasterName()).admin()
+        client(internalCluster().getClusterManagerName()).admin()
             .cluster()
             .prepareCreateSnapshot("test-repo", "test-snap")
             .setWaitForCompletion(false)
@@ -1399,7 +1399,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         createRepository(repoName, "fs");
         createIndex("some-index");
 
-        final SnapshotsService snapshotsService = internalCluster().getMasterNodeInstance(SnapshotsService.class);
+        final SnapshotsService snapshotsService = internalCluster().getClusterManagerNodeInstance(SnapshotsService.class);
         final Snapshot snapshot1 = PlainActionFuture.get(
             f -> snapshotsService.createSnapshotLegacy(new CreateSnapshotRequest(repoName, "snap-1"), f)
         );

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -90,7 +90,6 @@ import org.opensearch.rest.RestStatus;
 import org.opensearch.rest.action.admin.cluster.RestClusterStateAction;
 import org.opensearch.rest.action.admin.cluster.RestGetRepositoriesAction;
 import org.opensearch.snapshots.mockstore.MockRepository;
-import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
 import org.opensearch.test.OpenSearchIntegTestCase.Scope;
 import org.opensearch.test.InternalTestCluster;
@@ -125,6 +124,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static org.opensearch.index.seqno.RetentionLeaseActions.RETAIN_ALL;
+import static org.opensearch.test.NodeRoles.nonClusterManagerNode;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertFutureThrows;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertRequestBuilderThrows;
@@ -760,7 +760,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         internalCluster().startNode();
         logger.info("--> start second node");
         // Make sure the first node is elected as cluster-manager
-        internalCluster().startNode(NodeRoles.nonClusterManagerNode());
+        internalCluster().startNode(nonClusterManagerNode());
         // Register mock repositories
         for (int i = 0; i < 5; i++) {
             clusterAdmin().preparePutRepository("test-repo" + i)

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -90,6 +90,7 @@ import org.opensearch.rest.RestStatus;
 import org.opensearch.rest.action.admin.cluster.RestClusterStateAction;
 import org.opensearch.rest.action.admin.cluster.RestGetRepositoriesAction;
 import org.opensearch.snapshots.mockstore.MockRepository;
+import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
 import org.opensearch.test.OpenSearchIntegTestCase.Scope;
 import org.opensearch.test.InternalTestCluster;
@@ -124,7 +125,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static org.opensearch.index.seqno.RetentionLeaseActions.RETAIN_ALL;
-import static org.opensearch.test.NodeRoles.nonMasterNode;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertFutureThrows;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertRequestBuilderThrows;
@@ -760,7 +760,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         internalCluster().startNode();
         logger.info("--> start second node");
         // Make sure the first node is elected as cluster-manager
-        internalCluster().startNode(nonMasterNode());
+        internalCluster().startNode(NodeRoles.nonClusterManagerNode());
         // Register mock repositories
         for (int i = 0; i < 5; i++) {
             clusterAdmin().preparePutRepository("test-repo" + i)

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -890,7 +890,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         final int numberOfShards = getNumShards("test-idx").numPrimaries;
         logger.info("number of shards: {}", numberOfShards);
 
-        final String clusterManagerNode = blockMasterFromFinalizingSnapshotOnSnapFile("test-repo");
+        final String clusterManagerNode = blockClusterManagerFromFinalizingSnapshotOnSnapFile("test-repo");
         final String dataNode = blockNodeWithIndex("test-repo", "test-idx");
 
         dataNodeClient().admin()

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/MetadataLoadingDuringSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/MetadataLoadingDuringSnapshotRestoreIT.java
@@ -198,7 +198,7 @@ public class MetadataLoadingDuringSnapshotRestoreIT extends AbstractSnapshotInte
     }
 
     private CountingMockRepository getCountingMockRepository() {
-        String clusterManager = internalCluster().getMasterName();
+        String clusterManager = internalCluster().getClusterManagerName();
         RepositoriesService repositoriesService = internalCluster().getInstance(RepositoriesService.class, clusterManager);
         Repository repository = repositoriesService.repository("repository");
         assertThat(repository, instanceOf(CountingMockRepository.class));

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/RepositoriesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/RepositoriesIT.java
@@ -157,7 +157,7 @@ public class RepositoriesIT extends AbstractSnapshotIntegTestCase {
         createFullSnapshot(repositoryName, snapshotToBeDeletedLastName);
 
         // Create more snapshots to be deleted in bulk
-        int maxThreadsForSnapshotDeletion = internalCluster().getMasterNodeInstance(ThreadPool.class)
+        int maxThreadsForSnapshotDeletion = internalCluster().getClusterManagerNodeInstance(ThreadPool.class)
             .info(ThreadPool.Names.SNAPSHOT)
             .getMax();
         for (int i = 1; i <= maxThreadsForSnapshotDeletion + 1; i++) {
@@ -177,7 +177,7 @@ public class RepositoriesIT extends AbstractSnapshotIntegTestCase {
 
         // Make repository to throw exception when trying to delete stale indices
         // This will make sure stale indices stays in repository after snapshot delete
-        String clusterManagerNode = internalCluster().getMasterName();
+        String clusterManagerNode = internalCluster().getClusterManagerName();
         ((MockRepository) internalCluster().getInstance(RepositoriesService.class, clusterManagerNode).repository("test-repo"))
             .setThrowExceptionWhileDelete(true);
 

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/RepositoryFilterUserMetadataIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/RepositoryFilterUserMetadataIT.java
@@ -70,7 +70,7 @@ public class RepositoryFilterUserMetadataIT extends OpenSearchIntegTestCase {
     }
 
     public void testFilteredRepoMetadataIsUsed() {
-        final String clusterManagerName = internalCluster().getMasterName();
+        final String clusterManagerName = internalCluster().getClusterManagerName();
         final String repoName = "test-repo";
         assertAcked(
             client().admin()

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -1916,7 +1916,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         waitForBlock(blockedNode, repo, TimeValue.timeValueSeconds(10));
 
         logger.info("--> removing primary shard that is being snapshotted");
-        ClusterState clusterState = internalCluster().clusterService(internalCluster().getMasterName()).state();
+        ClusterState clusterState = internalCluster().clusterService(internalCluster().getClusterManagerName()).state();
         IndexRoutingTable indexRoutingTable = clusterState.getRoutingTable().index(index);
         String nodeWithPrimary = clusterState.nodes().get(indexRoutingTable.shard(0).primaryShard().currentNodeId()).getName();
         assertNotNull("should be at least one node with a primary shard", nodeWithPrimary);
@@ -2368,7 +2368,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         final String repoName = "test-repo";
         final Path repoPath = randomRepoPath();
         createRepository(repoName, "mock", repoPath);
-        final MockRepository repository = (MockRepository) internalCluster().getCurrentMasterNodeInstance(RepositoriesService.class)
+        final MockRepository repository = (MockRepository) internalCluster().getCurrentClusterManagerNodeInstance(RepositoriesService.class)
             .repository(repoName);
         repository.setFailOnIndexLatest(true);
         createFullSnapshot(repoName, "snapshot-1");

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SnapshotStatusApisIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SnapshotStatusApisIT.java
@@ -238,7 +238,7 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
 
         final String snapshotOne = "snap-1";
         // restarting a data node below so using a cluster-manager client here
-        final ActionFuture<CreateSnapshotResponse> responseSnapshotOne = internalCluster().masterClient()
+        final ActionFuture<CreateSnapshotResponse> responseSnapshotOne = internalCluster().clusterManagerClient()
             .admin()
             .cluster()
             .prepareCreateSnapshot(repoName, snapshotOne)

--- a/server/src/test/java/org/opensearch/cluster/coordination/ClusterBootstrapServiceDeprecatedMasterTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/ClusterBootstrapServiceDeprecatedMasterTests.java
@@ -37,6 +37,7 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.discovery.DiscoveryModule;
+import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.transport.MockTransport;
 import org.opensearch.transport.TransportRequest;
@@ -56,7 +57,6 @@ import static org.opensearch.cluster.coordination.ClusterBootstrapService.INITIA
 import static org.opensearch.cluster.coordination.ClusterBootstrapService.UNCONFIGURED_BOOTSTRAP_TIMEOUT_SETTING;
 import static org.opensearch.common.settings.Settings.builder;
 import static org.opensearch.node.Node.NODE_NAME_SETTING;
-import static org.opensearch.test.NodeRoles.nonMasterNode;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -298,7 +298,7 @@ public class ClusterBootstrapServiceDeprecatedMasterTests extends OpenSearchTest
         final Settings.Builder settings = Settings.builder()
             .put(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey(), DiscoveryModule.SINGLE_NODE_DISCOVERY_TYPE)
             .put(NODE_NAME_SETTING.getKey(), localNode.getName())
-            .put(nonMasterNode());
+            .put(NodeRoles.nonClusterManagerNode());
 
         assertThat(
             expectThrows(

--- a/server/src/test/java/org/opensearch/cluster/coordination/ClusterBootstrapServiceDeprecatedMasterTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/ClusterBootstrapServiceDeprecatedMasterTests.java
@@ -37,7 +37,6 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.discovery.DiscoveryModule;
-import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.transport.MockTransport;
 import org.opensearch.transport.TransportRequest;
@@ -57,6 +56,7 @@ import static org.opensearch.cluster.coordination.ClusterBootstrapService.INITIA
 import static org.opensearch.cluster.coordination.ClusterBootstrapService.UNCONFIGURED_BOOTSTRAP_TIMEOUT_SETTING;
 import static org.opensearch.common.settings.Settings.builder;
 import static org.opensearch.node.Node.NODE_NAME_SETTING;
+import static org.opensearch.test.NodeRoles.nonClusterManagerNode;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -298,7 +298,7 @@ public class ClusterBootstrapServiceDeprecatedMasterTests extends OpenSearchTest
         final Settings.Builder settings = Settings.builder()
             .put(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey(), DiscoveryModule.SINGLE_NODE_DISCOVERY_TYPE)
             .put(NODE_NAME_SETTING.getKey(), localNode.getName())
-            .put(NodeRoles.nonClusterManagerNode());
+            .put(nonClusterManagerNode());
 
         assertThat(
             expectThrows(

--- a/server/src/test/java/org/opensearch/cluster/coordination/ClusterBootstrapServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/ClusterBootstrapServiceTests.java
@@ -37,7 +37,6 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.discovery.DiscoveryModule;
-import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.transport.MockTransport;
 import org.opensearch.transport.TransportRequest;
@@ -64,6 +63,7 @@ import static org.opensearch.common.settings.Settings.builder;
 import static org.opensearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING;
 import static org.opensearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 import static org.opensearch.node.Node.NODE_NAME_SETTING;
+import static org.opensearch.test.NodeRoles.nonClusterManagerNode;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -680,7 +680,7 @@ public class ClusterBootstrapServiceTests extends OpenSearchTestCase {
         final Settings.Builder settings = Settings.builder()
             .put(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey(), DiscoveryModule.SINGLE_NODE_DISCOVERY_TYPE)
             .put(NODE_NAME_SETTING.getKey(), localNode.getName())
-            .put(NodeRoles.nonClusterManagerNode());
+            .put(nonClusterManagerNode());
 
         assertThat(
             expectThrows(

--- a/server/src/test/java/org/opensearch/cluster/coordination/ClusterBootstrapServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/ClusterBootstrapServiceTests.java
@@ -37,6 +37,7 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.discovery.DiscoveryModule;
+import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.transport.MockTransport;
 import org.opensearch.transport.TransportRequest;
@@ -63,7 +64,6 @@ import static org.opensearch.common.settings.Settings.builder;
 import static org.opensearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING;
 import static org.opensearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 import static org.opensearch.node.Node.NODE_NAME_SETTING;
-import static org.opensearch.test.NodeRoles.nonMasterNode;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -680,7 +680,7 @@ public class ClusterBootstrapServiceTests extends OpenSearchTestCase {
         final Settings.Builder settings = Settings.builder()
             .put(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey(), DiscoveryModule.SINGLE_NODE_DISCOVERY_TYPE)
             .put(NODE_NAME_SETTING.getKey(), localNode.getName())
-            .put(nonMasterNode());
+            .put(NodeRoles.nonClusterManagerNode());
 
         assertThat(
             expectThrows(

--- a/server/src/test/java/org/opensearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/CoordinatorTests.java
@@ -57,7 +57,6 @@ import org.opensearch.discovery.DiscoveryModule;
 import org.opensearch.gateway.GatewayService;
 import org.opensearch.monitor.StatusInfo;
 import org.opensearch.test.MockLogAppender;
-import org.opensearch.test.NodeRoles;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -91,6 +90,7 @@ import static org.opensearch.cluster.coordination.Reconfigurator.CLUSTER_AUTO_SH
 import static org.opensearch.discovery.PeerFinder.DISCOVERY_FIND_PEERS_INTERVAL_SETTING;
 import static org.opensearch.monitor.StatusInfo.Status.HEALTHY;
 import static org.opensearch.monitor.StatusInfo.Status.UNHEALTHY;
+import static org.opensearch.test.NodeRoles.nonClusterManagerNode;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
@@ -1702,7 +1702,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
 
             chosenNode.close();
             cluster.clusterNodes.replaceAll(
-                cn -> cn == chosenNode ? cn.restartedNode(Function.identity(), Function.identity(), NodeRoles.nonClusterManagerNode()) : cn
+                cn -> cn == chosenNode ? cn.restartedNode(Function.identity(), Function.identity(), nonClusterManagerNode()) : cn
             );
             cluster.stabilise();
 

--- a/server/src/test/java/org/opensearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/CoordinatorTests.java
@@ -57,6 +57,7 @@ import org.opensearch.discovery.DiscoveryModule;
 import org.opensearch.gateway.GatewayService;
 import org.opensearch.monitor.StatusInfo;
 import org.opensearch.test.MockLogAppender;
+import org.opensearch.test.NodeRoles;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -90,7 +91,6 @@ import static org.opensearch.cluster.coordination.Reconfigurator.CLUSTER_AUTO_SH
 import static org.opensearch.discovery.PeerFinder.DISCOVERY_FIND_PEERS_INTERVAL_SETTING;
 import static org.opensearch.monitor.StatusInfo.Status.HEALTHY;
 import static org.opensearch.monitor.StatusInfo.Status.UNHEALTHY;
-import static org.opensearch.test.NodeRoles.nonMasterNode;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
@@ -1702,7 +1702,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
 
             chosenNode.close();
             cluster.clusterNodes.replaceAll(
-                cn -> cn == chosenNode ? cn.restartedNode(Function.identity(), Function.identity(), nonMasterNode()) : cn
+                cn -> cn == chosenNode ? cn.restartedNode(Function.identity(), Function.identity(), NodeRoles.nonClusterManagerNode()) : cn
             );
             cluster.stabilise();
 

--- a/server/src/test/java/org/opensearch/cluster/routing/MovePrimaryFirstTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/MovePrimaryFirstTests.java
@@ -56,7 +56,7 @@ public class MovePrimaryFirstTests extends OpenSearchIntegTestCase {
      * enabled, cluster should not become red and zone2 nodes have all the primaries
      */
     public void testClusterGreenAfterPartialRelocation() throws InterruptedException {
-        internalCluster().startMasterOnlyNodes(1);
+        internalCluster().startClusterManagerOnlyNodes(1);
         final String z1 = "zone-1", z2 = "zone-2";
         final int primaryShardCount = 6;
         assertTrue("Primary shard count must be even for equal distribution across two nodes", primaryShardCount % 2 == 0);

--- a/server/src/test/java/org/opensearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/opensearch/env/NodeEnvironmentTests.java
@@ -66,7 +66,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.opensearch.test.NodeRoles.nonDataNode;
-import static org.opensearch.test.NodeRoles.nonMasterNode;
+import static org.opensearch.test.NodeRoles.nonClusterManagerNode;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
@@ -473,7 +473,7 @@ public class NodeEnvironmentTests extends OpenSearchTestCase {
     public void testNodeIdNotPersistedAtInitialization() throws IOException {
         NodeEnvironment env = newNodeEnvironment(
             new String[0],
-            nonMasterNode(nonDataNode(Settings.builder().put("node.local_storage", false).build()))
+            nonClusterManagerNode(nonDataNode(Settings.builder().put("node.local_storage", false).build()))
         );
         String nodeID = env.nodeId();
         env.close();
@@ -566,7 +566,7 @@ public class NodeEnvironmentTests extends OpenSearchTestCase {
         verifyFailsOnMetadata(noDataNoClusterManagerSettings, indexPath);
 
         // build settings using same path.data as original but without cluster-manager role
-        Settings noClusterManagerSettings = nonMasterNode(settings);
+        Settings noClusterManagerSettings = nonClusterManagerNode(settings);
 
         // test that we can create cluster_manager=false env regardless of data.
         newNodeEnvironment(noClusterManagerSettings).close();

--- a/server/src/test/java/org/opensearch/env/NodeRepurposeCommandTests.java
+++ b/server/src/test/java/org/opensearch/env/NodeRepurposeCommandTests.java
@@ -64,9 +64,9 @@ import java.util.stream.Stream;
 import static org.opensearch.env.NodeRepurposeCommand.NO_CLEANUP;
 import static org.opensearch.env.NodeRepurposeCommand.NO_DATA_TO_CLEAN_UP_FOUND;
 import static org.opensearch.env.NodeRepurposeCommand.NO_SHARD_DATA_TO_CLEAN_UP_FOUND;
-import static org.opensearch.test.NodeRoles.masterNode;
+import static org.opensearch.test.NodeRoles.clusterManagerNode;
 import static org.opensearch.test.NodeRoles.nonDataNode;
-import static org.opensearch.test.NodeRoles.nonMasterNode;
+import static org.opensearch.test.NodeRoles.nonClusterManagerNode;
 import static org.opensearch.test.NodeRoles.removeRoles;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -102,13 +102,13 @@ public class NodeRepurposeCommandTests extends OpenSearchTestCase {
                 writer.writeFullStateAndCommit(1L, ClusterState.EMPTY_STATE);
             }
         }
-        dataNoClusterManagerSettings = nonMasterNode(dataClusterManagerSettings);
+        dataNoClusterManagerSettings = nonClusterManagerNode(dataClusterManagerSettings);
         noDataNoClusterManagerSettings = removeRoles(
             dataClusterManagerSettings,
             Collections.unmodifiableSet(new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE)))
         );
 
-        noDataClusterManagerSettings = masterNode(nonDataNode(dataClusterManagerSettings));
+        noDataClusterManagerSettings = clusterManagerNode(nonDataNode(dataClusterManagerSettings));
     }
 
     public void testEarlyExitNoCleanup() throws Exception {

--- a/server/src/test/java/org/opensearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/opensearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -60,7 +60,6 @@ import org.opensearch.env.NodeEnvironment;
 import org.opensearch.env.TestEnvironment;
 import org.opensearch.indices.breaker.NoneCircuitBreakerService;
 import org.opensearch.node.Node;
-import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
@@ -76,6 +75,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.opensearch.test.NodeRoles.nonClusterManagerNode;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
@@ -405,7 +405,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
             );
             Settings settings = Settings.builder()
                 .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), clusterName.value())
-                .put(NodeRoles.nonClusterManagerNode())
+                .put(nonClusterManagerNode())
                 .put(Node.NODE_NAME_SETTING.getKey(), "test")
                 .build();
             final MockGatewayMetaState gateway = new MockGatewayMetaState(localNode, bigArrays);

--- a/server/src/test/java/org/opensearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/opensearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -60,6 +60,7 @@ import org.opensearch.env.NodeEnvironment;
 import org.opensearch.env.TestEnvironment;
 import org.opensearch.indices.breaker.NoneCircuitBreakerService;
 import org.opensearch.node.Node;
+import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
@@ -75,7 +76,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.opensearch.test.NodeRoles.nonMasterNode;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
@@ -405,7 +405,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
             );
             Settings settings = Settings.builder()
                 .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), clusterName.value())
-                .put(nonMasterNode())
+                .put(NodeRoles.nonClusterManagerNode())
                 .put(Node.NODE_NAME_SETTING.getKey(), "test")
                 .build();
             final MockGatewayMetaState gateway = new MockGatewayMetaState(localNode, bigArrays);

--- a/server/src/test/java/org/opensearch/gateway/GatewayServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/GatewayServiceTests.java
@@ -53,6 +53,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.snapshots.EmptySnapshotsInfoService;
+import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.gateway.TestGatewayAllocator;
 import org.hamcrest.Matchers;
@@ -61,7 +62,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 
 import static org.opensearch.gateway.GatewayService.STATE_NOT_RECOVERED_BLOCK;
-import static org.opensearch.test.NodeRoles.masterNode;
+import static org.opensearch.test.NodeRoles.clusterManagerNode;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.hasItem;
 
@@ -130,7 +131,7 @@ public class GatewayServiceTests extends OpenSearchTestCase {
         ClusterStateUpdateTask clusterStateUpdateTask = service.new RecoverStateUpdateTask();
         String nodeId = randomAlphaOfLength(10);
         DiscoveryNode clusterManagerNode = DiscoveryNode.createLocal(
-            settings(Version.CURRENT).put(masterNode()).build(),
+            settings(Version.CURRENT).put(NodeRoles.clusterManagerNode()).build(),
             new TransportAddress(TransportAddress.META_ADDRESS, 9300),
             nodeId
         );

--- a/server/src/test/java/org/opensearch/gateway/GatewayServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/GatewayServiceTests.java
@@ -53,7 +53,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.snapshots.EmptySnapshotsInfoService;
-import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.gateway.TestGatewayAllocator;
 import org.hamcrest.Matchers;
@@ -131,7 +130,7 @@ public class GatewayServiceTests extends OpenSearchTestCase {
         ClusterStateUpdateTask clusterStateUpdateTask = service.new RecoverStateUpdateTask();
         String nodeId = randomAlphaOfLength(10);
         DiscoveryNode clusterManagerNode = DiscoveryNode.createLocal(
-            settings(Version.CURRENT).put(NodeRoles.clusterManagerNode()).build(),
+            settings(Version.CURRENT).put(clusterManagerNode()).build(),
             new TransportAddress(TransportAddress.META_ADDRESS, 9300),
             nodeId
         );

--- a/server/src/test/java/org/opensearch/transport/ConnectionProfileTests.java
+++ b/server/src/test/java/org/opensearch/transport/ConnectionProfileTests.java
@@ -34,6 +34,7 @@ package org.opensearch.transport;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchTestCase;
 import org.hamcrest.Matchers;
 
@@ -45,7 +46,6 @@ import java.util.HashSet;
 import java.util.List;
 
 import static org.opensearch.test.NodeRoles.nonDataNode;
-import static org.opensearch.test.NodeRoles.nonMasterNode;
 import static org.opensearch.test.NodeRoles.removeRoles;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -240,7 +240,7 @@ public class ConnectionProfileTests extends OpenSearchTestCase {
         assertEquals(TransportSettings.TRANSPORT_COMPRESS.get(Settings.EMPTY), profile.getCompressionEnabled());
         assertEquals(TransportSettings.PING_SCHEDULE.get(Settings.EMPTY), profile.getPingInterval());
 
-        profile = ConnectionProfile.buildDefaultConnectionProfile(nonMasterNode());
+        profile = ConnectionProfile.buildDefaultConnectionProfile(NodeRoles.nonClusterManagerNode());
         assertEquals(12, profile.getNumConnections());
         assertEquals(1, profile.getNumConnectionsPerType(TransportRequestOptions.Type.PING));
         assertEquals(6, profile.getNumConnectionsPerType(TransportRequestOptions.Type.REG));

--- a/server/src/test/java/org/opensearch/transport/ConnectionProfileTests.java
+++ b/server/src/test/java/org/opensearch/transport/ConnectionProfileTests.java
@@ -34,7 +34,6 @@ package org.opensearch.transport;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchTestCase;
 import org.hamcrest.Matchers;
 
@@ -45,6 +44,7 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 
+import static org.opensearch.test.NodeRoles.nonClusterManagerNode;
 import static org.opensearch.test.NodeRoles.nonDataNode;
 import static org.opensearch.test.NodeRoles.removeRoles;
 import static org.hamcrest.Matchers.equalTo;
@@ -240,7 +240,7 @@ public class ConnectionProfileTests extends OpenSearchTestCase {
         assertEquals(TransportSettings.TRANSPORT_COMPRESS.get(Settings.EMPTY), profile.getCompressionEnabled());
         assertEquals(TransportSettings.PING_SCHEDULE.get(Settings.EMPTY), profile.getPingInterval());
 
-        profile = ConnectionProfile.buildDefaultConnectionProfile(NodeRoles.nonClusterManagerNode());
+        profile = ConnectionProfile.buildDefaultConnectionProfile(nonClusterManagerNode());
         assertEquals(12, profile.getNumConnections());
         assertEquals(1, profile.getNumConnectionsPerType(TransportRequestOptions.Type.PING));
         assertEquals(6, profile.getNumConnectionsPerType(TransportRequestOptions.Type.REG));

--- a/server/src/test/java/org/opensearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/opensearch/transport/RemoteClusterServiceTests.java
@@ -44,6 +44,7 @@ import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.internal.io.IOUtils;
+import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.transport.MockTransportService;
 import org.opensearch.threadpool.TestThreadPool;
@@ -63,7 +64,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 import static org.opensearch.test.NodeRoles.clusterManagerOnlyNode;
-import static org.opensearch.test.NodeRoles.nonMasterNode;
 import static org.opensearch.test.NodeRoles.removeRoles;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
@@ -552,7 +552,7 @@ public class RemoteClusterServiceTests extends OpenSearchTestCase {
     public void testRemoteNodeRoles() throws IOException, InterruptedException {
         final Settings settings = Settings.EMPTY;
         final List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
-        final Settings data = nonMasterNode();
+        final Settings data = NodeRoles.nonClusterManagerNode();
         final Settings dedicatedClusterManager = clusterManagerOnlyNode();
         try (
             MockTransportService c1N1 = startTransport("cluster_1_node_1", knownNodes, Version.CURRENT, dedicatedClusterManager);

--- a/server/src/test/java/org/opensearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/opensearch/transport/RemoteClusterServiceTests.java
@@ -44,7 +44,6 @@ import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.internal.io.IOUtils;
-import org.opensearch.test.NodeRoles;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.transport.MockTransportService;
 import org.opensearch.threadpool.TestThreadPool;
@@ -64,6 +63,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 import static org.opensearch.test.NodeRoles.clusterManagerOnlyNode;
+import static org.opensearch.test.NodeRoles.nonClusterManagerNode;
 import static org.opensearch.test.NodeRoles.removeRoles;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
@@ -552,7 +552,7 @@ public class RemoteClusterServiceTests extends OpenSearchTestCase {
     public void testRemoteNodeRoles() throws IOException, InterruptedException {
         final Settings settings = Settings.EMPTY;
         final List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
-        final Settings data = NodeRoles.nonClusterManagerNode();
+        final Settings data = nonClusterManagerNode();
         final Settings dedicatedClusterManager = clusterManagerOnlyNode();
         try (
             MockTransportService c1N1 = startTransport("cluster_1_node_1", knownNodes, Version.CURRENT, dedicatedClusterManager);

--- a/test/framework/src/main/java/org/opensearch/repositories/blobstore/BlobStoreTestUtil.java
+++ b/test/framework/src/main/java/org/opensearch/repositories/blobstore/BlobStoreTestUtil.java
@@ -105,7 +105,7 @@ import static org.mockito.Mockito.when;
 public final class BlobStoreTestUtil {
 
     public static void assertRepoConsistency(InternalTestCluster testCluster, String repoName) {
-        final BlobStoreRepository repo = (BlobStoreRepository) testCluster.getCurrentMasterNodeInstance(RepositoriesService.class)
+        final BlobStoreRepository repo = (BlobStoreRepository) testCluster.getCurrentClusterManagerNodeInstance(RepositoriesService.class)
             .repository(repoName);
         BlobStoreTestUtil.assertConsistency(repo, repo.threadPool().executor(ThreadPool.Names.GENERIC));
     }

--- a/test/framework/src/main/java/org/opensearch/repositories/blobstore/OpenSearchBlobStoreRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/repositories/blobstore/OpenSearchBlobStoreRepositoryIntegTestCase.java
@@ -107,7 +107,7 @@ public abstract class OpenSearchBlobStoreRepositoryIntegTestCase extends OpenSea
             client().admin().cluster().preparePutRepository(name).setType(repositoryType()).setVerify(verify).setSettings(settings)
         );
 
-        internalCluster().getDataOrMasterNodeInstances(RepositoriesService.class).forEach(repositories -> {
+        internalCluster().getDataOrClusterManagerNodeInstances(RepositoriesService.class).forEach(repositories -> {
             assertThat(repositories.repository(name), notNullValue());
             assertThat(repositories.repository(name), instanceOf(BlobStoreRepository.class));
             assertThat(repositories.repository(name).isReadOnly(), is(false));
@@ -280,7 +280,7 @@ public abstract class OpenSearchBlobStoreRepositoryIntegTestCase extends OpenSea
 
     protected BlobStore newBlobStore() {
         final String repository = createRepository(randomName());
-        final BlobStoreRepository blobStoreRepository = (BlobStoreRepository) internalCluster().getMasterNodeInstance(
+        final BlobStoreRepository blobStoreRepository = (BlobStoreRepository) internalCluster().getClusterManagerNodeInstance(
             RepositoriesService.class
         ).repository(repository);
         return PlainActionFuture.get(
@@ -470,8 +470,11 @@ public abstract class OpenSearchBlobStoreRepositoryIntegTestCase extends OpenSea
         assertAcked(client().admin().cluster().prepareDeleteSnapshot(repoName, "test-snap").get());
 
         logger.info("--> verify index folder deleted from blob container");
-        RepositoriesService repositoriesSvc = internalCluster().getInstance(RepositoriesService.class, internalCluster().getMasterName());
-        ThreadPool threadPool = internalCluster().getInstance(ThreadPool.class, internalCluster().getMasterName());
+        RepositoriesService repositoriesSvc = internalCluster().getInstance(
+            RepositoriesService.class,
+            internalCluster().getClusterManagerName()
+        );
+        ThreadPool threadPool = internalCluster().getInstance(ThreadPool.class, internalCluster().getClusterManagerName());
         BlobStoreRepository repository = (BlobStoreRepository) repositoriesSvc.repository(repoName);
 
         final SetOnce<BlobContainer> indicesBlobContainer = new SetOnce<>();

--- a/test/framework/src/main/java/org/opensearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -251,31 +251,55 @@ public abstract class AbstractSnapshotIntegTestCase extends OpenSearchIntegTestC
         return null;
     }
 
-    public static String blockMasterFromFinalizingSnapshotOnIndexFile(final String repositoryName) {
+    public static String blockClusterManagerFromFinalizingSnapshotOnIndexFile(final String repositoryName) {
         final String clusterManagerName = internalCluster().getMasterName();
         ((MockRepository) internalCluster().getInstance(RepositoriesService.class, clusterManagerName).repository(repositoryName))
             .setBlockAndFailOnWriteIndexFile();
         return clusterManagerName;
     }
 
-    public static String blockMasterOnWriteIndexFile(final String repositoryName) {
+    public static String blockClusterManagerOnWriteIndexFile(final String repositoryName) {
         final String clusterManagerName = internalCluster().getMasterName();
         ((MockRepository) internalCluster().getMasterNodeInstance(RepositoriesService.class).repository(repositoryName))
             .setBlockOnWriteIndexFile();
         return clusterManagerName;
     }
 
-    public static void blockMasterFromDeletingIndexNFile(String repositoryName) {
+    public static void blockClusterManagerFromDeletingIndexNFile(String repositoryName) {
         final String clusterManagerName = internalCluster().getMasterName();
         ((MockRepository) internalCluster().getInstance(RepositoriesService.class, clusterManagerName).repository(repositoryName))
             .setBlockOnDeleteIndexFile();
     }
 
-    public static String blockMasterFromFinalizingSnapshotOnSnapFile(final String repositoryName) {
+    public static String blockClusterManagerFromFinalizingSnapshotOnSnapFile(final String repositoryName) {
         final String clusterManagerName = internalCluster().getMasterName();
         ((MockRepository) internalCluster().getInstance(RepositoriesService.class, clusterManagerName).repository(repositoryName))
             .setBlockAndFailOnWriteSnapFiles(true);
         return clusterManagerName;
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #blockClusterManagerFromFinalizingSnapshotOnIndexFile(String)} */
+    @Deprecated
+    public static String blockMasterFromFinalizingSnapshotOnIndexFile(final String repositoryName) {
+        return blockClusterManagerFromFinalizingSnapshotOnIndexFile(repositoryName);
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #blockClusterManagerOnWriteIndexFile(String)} */
+    @Deprecated
+    public static String blockMasterOnWriteIndexFile(final String repositoryName) {
+        return blockClusterManagerOnWriteIndexFile(repositoryName);
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #blockClusterManagerFromDeletingIndexNFile(String)} */
+    @Deprecated
+    public static void blockMasterFromDeletingIndexNFile(String repositoryName) {
+        blockClusterManagerFromDeletingIndexNFile(repositoryName);
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #blockClusterManagerFromFinalizingSnapshotOnSnapFile(String)} */
+    @Deprecated
+    public static String blockMasterFromFinalizingSnapshotOnSnapFile(final String repositoryName) {
+        return blockClusterManagerFromFinalizingSnapshotOnSnapFile(repositoryName);
     }
 
     public static String blockNodeWithIndex(final String repositoryName, final String indexName) {
@@ -638,5 +662,11 @@ public abstract class AbstractSnapshotIntegTestCase extends OpenSearchIntegTestC
                 }
             }
         });
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #awaitClusterManagerFinishRepoOperations()} */
+    @Deprecated
+    protected void awaitMasterFinishRepoOperations() throws Exception {
+        awaitClusterManagerFinishRepoOperations();
     }
 }

--- a/test/framework/src/main/java/org/opensearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -166,7 +166,7 @@ public abstract class AbstractSnapshotIntegTestCase extends OpenSearchIntegTestC
     }
 
     protected RepositoryData getRepositoryData(String repository) {
-        return getRepositoryData(internalCluster().getCurrentMasterNodeInstance(RepositoriesService.class).repository(repository));
+        return getRepositoryData(internalCluster().getCurrentClusterManagerNodeInstance(RepositoriesService.class).repository(repository));
     }
 
     protected RepositoryData getRepositoryData(Repository repository) {
@@ -175,7 +175,7 @@ public abstract class AbstractSnapshotIntegTestCase extends OpenSearchIntegTestC
 
     public static long getFailureCount(String repository) {
         long failureCount = 0;
-        for (RepositoriesService repositoriesService : internalCluster().getDataOrMasterNodeInstances(RepositoriesService.class)) {
+        for (RepositoriesService repositoriesService : internalCluster().getDataOrClusterManagerNodeInstances(RepositoriesService.class)) {
             MockRepository mockRepository = (MockRepository) repositoriesService.repository(repository);
             failureCount += mockRepository.getFailureCount();
         }
@@ -252,27 +252,27 @@ public abstract class AbstractSnapshotIntegTestCase extends OpenSearchIntegTestC
     }
 
     public static String blockClusterManagerFromFinalizingSnapshotOnIndexFile(final String repositoryName) {
-        final String clusterManagerName = internalCluster().getMasterName();
+        final String clusterManagerName = internalCluster().getClusterManagerName();
         ((MockRepository) internalCluster().getInstance(RepositoriesService.class, clusterManagerName).repository(repositoryName))
             .setBlockAndFailOnWriteIndexFile();
         return clusterManagerName;
     }
 
     public static String blockClusterManagerOnWriteIndexFile(final String repositoryName) {
-        final String clusterManagerName = internalCluster().getMasterName();
-        ((MockRepository) internalCluster().getMasterNodeInstance(RepositoriesService.class).repository(repositoryName))
+        final String clusterManagerName = internalCluster().getClusterManagerName();
+        ((MockRepository) internalCluster().getClusterManagerNodeInstance(RepositoriesService.class).repository(repositoryName))
             .setBlockOnWriteIndexFile();
         return clusterManagerName;
     }
 
     public static void blockClusterManagerFromDeletingIndexNFile(String repositoryName) {
-        final String clusterManagerName = internalCluster().getMasterName();
+        final String clusterManagerName = internalCluster().getClusterManagerName();
         ((MockRepository) internalCluster().getInstance(RepositoriesService.class, clusterManagerName).repository(repositoryName))
             .setBlockOnDeleteIndexFile();
     }
 
     public static String blockClusterManagerFromFinalizingSnapshotOnSnapFile(final String repositoryName) {
-        final String clusterManagerName = internalCluster().getMasterName();
+        final String clusterManagerName = internalCluster().getClusterManagerName();
         ((MockRepository) internalCluster().getInstance(RepositoriesService.class, clusterManagerName).repository(repositoryName))
             .setBlockAndFailOnWriteSnapFiles(true);
         return clusterManagerName;
@@ -503,7 +503,7 @@ public abstract class AbstractSnapshotIntegTestCase extends OpenSearchIntegTestC
             initialRepoMetadata.generation(),
             is(RepositoryData.UNKNOWN_REPO_GEN)
         );
-        final Repository repo = internalCluster().getCurrentMasterNodeInstance(RepositoriesService.class).repository(repoName);
+        final Repository repo = internalCluster().getCurrentClusterManagerNodeInstance(RepositoriesService.class).repository(repoName);
         final SnapshotId snapshotId = new SnapshotId(snapshotName, UUIDs.randomBase64UUID(random()));
         logger.info("--> adding old version FAILED snapshot [{}] to repository [{}]", snapshotId, repoName);
         final SnapshotInfo snapshotInfo = new SnapshotInfo(
@@ -535,7 +535,7 @@ public abstract class AbstractSnapshotIntegTestCase extends OpenSearchIntegTestC
     }
 
     protected void awaitNoMoreRunningOperations() throws Exception {
-        awaitNoMoreRunningOperations(internalCluster().getMasterName());
+        awaitNoMoreRunningOperations(internalCluster().getClusterManagerName());
     }
 
     protected void awaitNoMoreRunningOperations(String viaNode) throws Exception {
@@ -548,7 +548,7 @@ public abstract class AbstractSnapshotIntegTestCase extends OpenSearchIntegTestC
     }
 
     protected void awaitClusterState(Predicate<ClusterState> statePredicate) throws Exception {
-        awaitClusterState(internalCluster().getMasterName(), statePredicate);
+        awaitClusterState(internalCluster().getClusterManagerName(), statePredicate);
     }
 
     protected void awaitClusterState(String viaNode, Predicate<ClusterState> statePredicate) throws Exception {
@@ -625,7 +625,7 @@ public abstract class AbstractSnapshotIntegTestCase extends OpenSearchIntegTestC
 
     protected void updateClusterState(final Function<ClusterState, ClusterState> updater) throws Exception {
         final PlainActionFuture<Void> future = PlainActionFuture.newFuture();
-        final ClusterService clusterService = internalCluster().getCurrentMasterNodeInstance(ClusterService.class);
+        final ClusterService clusterService = internalCluster().getCurrentClusterManagerNodeInstance(ClusterService.class);
         clusterService.submitStateUpdateTask("test", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
@@ -653,7 +653,7 @@ public abstract class AbstractSnapshotIntegTestCase extends OpenSearchIntegTestC
 
     protected void awaitClusterManagerFinishRepoOperations() throws Exception {
         logger.info("--> waiting for cluster-manager to finish all repo operations on its SNAPSHOT pool");
-        final ThreadPool clusterManagerThreadPool = internalCluster().getMasterNodeInstance(ThreadPool.class);
+        final ThreadPool clusterManagerThreadPool = internalCluster().getClusterManagerNodeInstance(ThreadPool.class);
         assertBusy(() -> {
             for (ThreadPoolStats.Stats stat : clusterManagerThreadPool.stats()) {
                 if (ThreadPool.Names.SNAPSHOT.equals(stat.getName())) {

--- a/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
@@ -207,8 +207,15 @@ public final class InternalTestCluster extends TestCluster {
         nodeAndClient.node.settings()
     );
 
-    public static final int DEFAULT_LOW_NUM_MASTER_NODES = 1;
-    public static final int DEFAULT_HIGH_NUM_MASTER_NODES = 3;
+    public static final int DEFAULT_LOW_NUM_CLUSTER_MANAGER_NODES = 1;
+    public static final int DEFAULT_HIGH_NUM_CLUSTER_MANAGER_NODES = 3;
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #DEFAULT_LOW_NUM_CLUSTER_MANAGER_NODES} */
+    @Deprecated
+    public static final int DEFAULT_LOW_NUM_MASTER_NODES = DEFAULT_LOW_NUM_CLUSTER_MANAGER_NODES;
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #DEFAULT_HIGH_NUM_CLUSTER_MANAGER_NODES} */
+    @Deprecated
+    public static final int DEFAULT_HIGH_NUM_MASTER_NODES = DEFAULT_HIGH_NUM_CLUSTER_MANAGER_NODES;
 
     static final int DEFAULT_MIN_NUM_DATA_NODES = 1;
     static final int DEFAULT_MAX_NUM_DATA_NODES = TEST_NIGHTLY ? 6 : 3;
@@ -341,9 +348,9 @@ public final class InternalTestCluster extends TestCluster {
             if (useDedicatedClusterManagerNodes) {
                 if (random.nextBoolean()) {
                     // use a dedicated cluster-manager, but only low number to reduce overhead to tests
-                    this.numSharedDedicatedClusterManagerNodes = DEFAULT_LOW_NUM_MASTER_NODES;
+                    this.numSharedDedicatedClusterManagerNodes = DEFAULT_LOW_NUM_CLUSTER_MANAGER_NODES;
                 } else {
-                    this.numSharedDedicatedClusterManagerNodes = DEFAULT_HIGH_NUM_MASTER_NODES;
+                    this.numSharedDedicatedClusterManagerNodes = DEFAULT_HIGH_NUM_CLUSTER_MANAGER_NODES;
                 }
             } else {
                 this.numSharedDedicatedClusterManagerNodes = 0;
@@ -921,7 +928,10 @@ public final class InternalTestCluster extends TestCluster {
         }
     }
 
-    public static final int REMOVED_MINIMUM_MASTER_NODES = Integer.MAX_VALUE;
+    public static final int REMOVED_MINIMUM_CLUSTER_MANAGER_NODES = Integer.MAX_VALUE;
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #REMOVED_MINIMUM_CLUSTER_MANAGER_NODES} */
+    @Deprecated
+    public static final int REMOVED_MINIMUM_MASTER_NODES = REMOVED_MINIMUM_CLUSTER_MANAGER_NODES;
 
     private final class NodeAndClient implements Closeable {
         private MockNode node;

--- a/test/framework/src/main/java/org/opensearch/test/NodeRoles.java
+++ b/test/framework/src/main/java/org/opensearch/test/NodeRoles.java
@@ -168,11 +168,11 @@ public class NodeRoles {
         return removeRoles(settings, Collections.singleton(DiscoveryNodeRole.INGEST_ROLE));
     }
 
-    public static Settings masterNode() {
-        return masterNode(Settings.EMPTY);
+    public static Settings clusterManagerNode() {
+        return clusterManagerNode(Settings.EMPTY);
     }
 
-    public static Settings masterNode(final Settings settings) {
+    public static Settings clusterManagerNode(final Settings settings) {
         return addRoles(settings, Collections.singleton(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE));
     }
 
@@ -184,12 +184,48 @@ public class NodeRoles {
         return onlyRole(settings, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE);
     }
 
-    public static Settings nonMasterNode() {
-        return nonMasterNode(Settings.EMPTY);
+    public static Settings nonClusterManagerNode() {
+        return nonClusterManagerNode(Settings.EMPTY);
     }
 
-    public static Settings nonMasterNode(final Settings settings) {
+    public static Settings nonClusterManagerNode(final Settings settings) {
         return removeRoles(settings, Collections.singleton(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE));
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #clusterManagerNode()} */
+    @Deprecated
+    public static Settings masterNode() {
+        return clusterManagerNode();
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #clusterManagerNode(Settings)} */
+    @Deprecated
+    public static Settings masterNode(final Settings settings) {
+        return clusterManagerNode(settings);
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #clusterManagerOnlyNode()} */
+    @Deprecated
+    public static Settings masterOnlyNode() {
+        return clusterManagerOnlyNode();
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #clusterManagerOnlyNode(Settings)} */
+    @Deprecated
+    public static Settings masterOnlyNode(final Settings settings) {
+        return clusterManagerOnlyNode(settings);
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #nonClusterManagerNode()} */
+    @Deprecated
+    public static Settings nonMasterNode() {
+        return nonClusterManagerNode();
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #nonClusterManagerNode(Settings)} */
+    @Deprecated
+    public static Settings nonMasterNode(final Settings settings) {
+        return nonClusterManagerNode(settings);
     }
 
     public static Settings remoteClusterClientNode() {

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -713,7 +713,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
      * @return disruption
      */
     protected static NetworkDisruption isolateClusterManagerDisruption(NetworkDisruption.NetworkLinkDisruptionType disruptionType) {
-        final String clusterManagerNode = internalCluster().getMasterName();
+        final String clusterManagerNode = internalCluster().getClusterManagerName();
         return new NetworkDisruption(
             new NetworkDisruption.TwoPartitions(
                 Collections.singleton(clusterManagerNode),

--- a/test/framework/src/main/java/org/opensearch/test/disruption/BlockMasterServiceOnMaster.java
+++ b/test/framework/src/main/java/org/opensearch/test/disruption/BlockMasterServiceOnMaster.java
@@ -53,7 +53,7 @@ public class BlockMasterServiceOnMaster extends SingleNodeDisruption {
 
     @Override
     public void startDisrupting() {
-        disruptedNode = cluster.getMasterName();
+        disruptedNode = cluster.getClusterManagerName();
         final String disruptionNodeCopy = disruptedNode;
         if (disruptionNodeCopy == null) {
             return;

--- a/test/framework/src/main/java/org/opensearch/test/disruption/BusyMasterServiceDisruption.java
+++ b/test/framework/src/main/java/org/opensearch/test/disruption/BusyMasterServiceDisruption.java
@@ -52,7 +52,7 @@ public class BusyMasterServiceDisruption extends SingleNodeDisruption {
 
     @Override
     public void startDisrupting() {
-        disruptedNode = cluster.getMasterName();
+        disruptedNode = cluster.getClusterManagerName();
         final String disruptionNodeCopy = disruptedNode;
         if (disruptionNodeCopy == null) {
             return;

--- a/test/framework/src/main/java/org/opensearch/test/rest/yaml/ClientYamlTestClient.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/yaml/ClientYamlTestClient.java
@@ -105,6 +105,12 @@ public class ClientYamlTestClient implements Closeable {
         return clusterManagerVersion;
     }
 
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #getClusterManagerVersion()} */
+    @Deprecated
+    public Version getMasterVersion() {
+        return getClusterManagerVersion();
+    }
+
     /**
      * Calls an api with the provided parameters and body
      */

--- a/test/framework/src/main/java/org/opensearch/test/rest/yaml/ClientYamlTestExecutionContext.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/yaml/ClientYamlTestExecutionContext.java
@@ -227,8 +227,14 @@ public class ClientYamlTestExecutionContext {
         return clientYamlTestClient.getEsVersion();
     }
 
-    public Version masterVersion() {
+    public Version clusterManagerVersion() {
         return clientYamlTestClient.getClusterManagerVersion();
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #clusterManagerVersion()} */
+    @Deprecated
+    public Version masterVersion() {
+        return clusterManagerVersion();
     }
 
 }

--- a/test/framework/src/main/java/org/opensearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/yaml/section/DoSection.java
@@ -321,7 +321,7 @@ public class DoSection implements ExecutableSection {
                 }
                 fail(formatStatusCodeMessage(response, catchStatusCode));
             }
-            checkWarningHeaders(response.getWarningHeaders(), executionContext.masterVersion());
+            checkWarningHeaders(response.getWarningHeaders(), executionContext.clusterManagerVersion());
         } catch (ClientYamlTestResponseException e) {
             ClientYamlTestResponse restTestResponse = e.getRestTestResponse();
             if (!Strings.hasLength(catchParam)) {

--- a/test/framework/src/test/java/org/opensearch/test/test/InternalTestClusterTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/test/InternalTestClusterTests.java
@@ -304,13 +304,13 @@ public class InternalTestClusterTests extends OpenSearchTestCase {
         );
         try {
             cluster.beforeTest(random());
-            final int originalClusterManagerCount = cluster.numMasterNodes();
+            final int originalClusterManagerCount = cluster.numClusterManagerNodes();
             final Map<String, Path[]> shardNodePaths = new HashMap<>();
             for (String name : cluster.getNodeNames()) {
                 shardNodePaths.put(name, getNodePaths(cluster, name));
             }
             String poorNode = randomValueOtherThanMany(
-                n -> originalClusterManagerCount == 1 && n.equals(cluster.getMasterName()),
+                n -> originalClusterManagerCount == 1 && n.equals(cluster.getClusterManagerName()),
                 () -> randomFrom(cluster.getNodeNames())
             );
             Path dataPath = getNodePaths(cluster, poorNode)[0];


### PR DESCRIPTION
### Description
To support inclusive language, the `master` terminology is going to be replaced by `cluster manager` in the code base.
This PR deprecate public and protected methods/variable that contains `master` terminology in the name in `test/framework` directory, and create alternatives.

List of public methods in `test/framework` directory that renamed in this PR:
```
public static String blockMasterFromFinalizingSnapshotOnIndexFile(final String repositoryName) {
public static String blockMasterOnWriteIndexFile(final String repositoryName) {
public static void blockMasterFromDeletingIndexNFile(String repositoryName) {
public static String blockMasterFromFinalizingSnapshotOnSnapFile(final String repositoryName) {
public Client masterClient() {
public Client nonMasterClient() {
public boolean isMasterEligible() {
public synchronized <T> T getCurrentMasterNodeInstance(Class<T> clazz) {
public <T> Iterable<T> getDataOrMasterNodeInstances(Class<T> clazz) {
public <T> T getMasterNodeInstance(Class<T> clazz) {
public synchronized void stopCurrentMasterNode() throws IOException {
public synchronized void stopRandomNonMasterNode() throws IOException {
public String getMasterName() {
public String getMasterName(@Nullable String viaNode) {
public List<String> startMasterOnlyNodes(int numNodes) {
public List<String> startMasterOnlyNodes(int numNodes, Settings settings) {
public int numMasterNodes() {
public static Settings masterNode()
public static Settings masterNode(final Settings settings)
public static Settings masterOnlyNode()
public static Settings masterOnlyNode(final Settings settings)
public static Settings nonMasterNode()
public static Settings nonMasterNode(final Settings settings)
public Version masterVersion()
```

List of public variables in `test/framework` directory that renamed in this PR:
(all in `org.opensearch.test.InternalTestCluster`)
```
public static final int DEFAULT_LOW_NUM_MASTER_NODES
public static final int DEFAULT_HIGH_NUM_MASTER_NODES
public static final int REMOVED_MINIMUM_MASTER_NODES
```
 
public that not renamed in this PR:
```
public static MasterService createMasterService(ThreadPool threadPool, ClusterState initialClusterState)
public static MasterService createMasterService(ThreadPool threadPool, DiscoveryNode localNode)
public abstract int numDataAndMasterNodes();
```
Reason for the above are not deprecated and renamed:
1. The class `MasterService` is not deprecated, and needs to find a solution to deal with deprecating this class in the return value.
2. abstract methods will be deprecated in a separate PR.
 
### Issues Resolved
A part of issue https://github.com/opensearch-project/OpenSearch/issues/3544
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
