### PR TITLE
[2.x] Deprecate public methods and variables that contain 'master' terminology in 'client' directory (#3966)

### DIFF
--- a/client/rest-high-level/src/main/java/org/opensearch/client/ClusterRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/ClusterRequestConverters.java
@@ -105,7 +105,7 @@ final class ClusterRequestConverters {
             .build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
         RequestConverters.Params params = new RequestConverters.Params();
-        params.withMasterTimeout(putComponentTemplateRequest.masterNodeTimeout());
+        params.withMasterTimeout(putComponentTemplateRequest.clusterManagerNodeTimeout());
         if (putComponentTemplateRequest.create()) {
             params.putParam("create", Boolean.TRUE.toString());
         }
@@ -146,7 +146,7 @@ final class ClusterRequestConverters {
         String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_component_template").addPathPart(name).build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
         RequestConverters.Params params = new RequestConverters.Params();
-        params.withMasterTimeout(deleteComponentTemplateRequest.masterNodeTimeout());
+        params.withMasterTimeout(deleteComponentTemplateRequest.clusterManagerNodeTimeout());
         request.addParameters(params.asMap());
         return request;
     }

--- a/client/rest-high-level/src/main/java/org/opensearch/client/IndicesRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/IndicesRequestConverters.java
@@ -144,7 +144,7 @@ final class IndicesRequestConverters {
 
         RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(closeIndexRequest.timeout());
-        parameters.withMasterTimeout(closeIndexRequest.masterNodeTimeout());
+        parameters.withMasterTimeout(closeIndexRequest.clusterManagerNodeTimeout());
         parameters.withIndicesOptions(closeIndexRequest.indicesOptions());
         request.addParameters(parameters.asMap());
         return request;
@@ -156,7 +156,7 @@ final class IndicesRequestConverters {
 
         RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(createIndexRequest.timeout());
-        parameters.withMasterTimeout(createIndexRequest.masterNodeTimeout());
+        parameters.withMasterTimeout(createIndexRequest.clusterManagerNodeTimeout());
         parameters.withWaitForActiveShards(createIndexRequest.waitForActiveShards());
         request.addParameters(parameters.asMap());
         request.setEntity(RequestConverters.createEntity(createIndexRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
@@ -179,7 +179,7 @@ final class IndicesRequestConverters {
 
         RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(putMappingRequest.timeout());
-        parameters.withMasterTimeout(putMappingRequest.masterNodeTimeout());
+        parameters.withMasterTimeout(putMappingRequest.clusterManagerNodeTimeout());
         parameters.withIndicesOptions(putMappingRequest.indicesOptions());
         request.addParameters(parameters.asMap());
         request.setEntity(RequestConverters.createEntity(putMappingRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
@@ -192,7 +192,7 @@ final class IndicesRequestConverters {
         Request request = new Request(HttpGet.METHOD_NAME, RequestConverters.endpoint(indices, "_mapping"));
 
         RequestConverters.Params parameters = new RequestConverters.Params();
-        parameters.withMasterTimeout(getMappingsRequest.masterNodeTimeout());
+        parameters.withMasterTimeout(getMappingsRequest.clusterManagerNodeTimeout());
         parameters.withIndicesOptions(getMappingsRequest.indicesOptions());
         parameters.withLocal(getMappingsRequest.local());
         request.addParameters(parameters.asMap());
@@ -332,7 +332,7 @@ final class IndicesRequestConverters {
 
         RequestConverters.Params params = new RequestConverters.Params();
         params.withTimeout(resizeRequest.timeout());
-        params.withMasterTimeout(resizeRequest.masterNodeTimeout());
+        params.withMasterTimeout(resizeRequest.clusterManagerNodeTimeout());
         params.withWaitForActiveShards(resizeRequest.getWaitForActiveShards());
         request.addParameters(params.asMap());
         request.setEntity(RequestConverters.createEntity(resizeRequest, RequestConverters.REQUEST_BODY_CONTENT_TYPE));
@@ -365,7 +365,7 @@ final class IndicesRequestConverters {
 
         RequestConverters.Params params = new RequestConverters.Params();
         params.withTimeout(rolloverRequest.timeout());
-        params.withMasterTimeout(rolloverRequest.masterNodeTimeout());
+        params.withMasterTimeout(rolloverRequest.clusterManagerNodeTimeout());
         params.withWaitForActiveShards(rolloverRequest.getCreateIndexRequest().waitForActiveShards());
         if (rolloverRequest.isDryRun()) {
             params.putParam("dry_run", Boolean.TRUE.toString());
@@ -402,7 +402,7 @@ final class IndicesRequestConverters {
         params.withLocal(getIndexRequest.local());
         params.withIncludeDefaults(getIndexRequest.includeDefaults());
         params.withHuman(getIndexRequest.humanReadable());
-        params.withMasterTimeout(getIndexRequest.masterNodeTimeout());
+        params.withMasterTimeout(getIndexRequest.clusterManagerNodeTimeout());
         request.addParameters(params.asMap());
         return request;
     }
@@ -461,7 +461,7 @@ final class IndicesRequestConverters {
             .build();
         Request request = new Request(HttpPut.METHOD_NAME, endpoint);
         RequestConverters.Params params = new RequestConverters.Params();
-        params.withMasterTimeout(putIndexTemplateRequest.masterNodeTimeout());
+        params.withMasterTimeout(putIndexTemplateRequest.clusterManagerNodeTimeout());
         if (putIndexTemplateRequest.create()) {
             params.putParam("create", Boolean.TRUE.toString());
         }
@@ -479,7 +479,7 @@ final class IndicesRequestConverters {
             .build();
         Request request = new Request(HttpPost.METHOD_NAME, endpoint);
         RequestConverters.Params params = new RequestConverters.Params();
-        params.withMasterTimeout(simulateIndexTemplateRequest.masterNodeTimeout());
+        params.withMasterTimeout(simulateIndexTemplateRequest.clusterManagerNodeTimeout());
         PutComposableIndexTemplateRequest putComposableIndexTemplateRequest = simulateIndexTemplateRequest.indexTemplateV2Request();
         if (putComposableIndexTemplateRequest != null) {
             if (putComposableIndexTemplateRequest.create()) {
@@ -597,7 +597,7 @@ final class IndicesRequestConverters {
         String endpoint = new RequestConverters.EndpointBuilder().addPathPartAsIs("_index_template").addPathPart(name).build();
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
         RequestConverters.Params params = new RequestConverters.Params();
-        params.withMasterTimeout(deleteIndexTemplateRequest.masterNodeTimeout());
+        params.withMasterTimeout(deleteIndexTemplateRequest.clusterManagerNodeTimeout());
         request.addParameters(params.asMap());
         return request;
     }
@@ -610,7 +610,7 @@ final class IndicesRequestConverters {
         Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
         RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withTimeout(deleteAliasRequest.timeout());
-        parameters.withMasterTimeout(deleteAliasRequest.masterNodeTimeout());
+        parameters.withMasterTimeout(deleteAliasRequest.clusterManagerNodeTimeout());
         request.addParameters(parameters.asMap());
         return request;
     }

--- a/client/rest-high-level/src/main/java/org/opensearch/client/TimedRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/TimedRequest.java
@@ -44,10 +44,13 @@ import static org.opensearch.common.unit.TimeValue.timeValueSeconds;
 public abstract class TimedRequest implements Validatable {
 
     public static final TimeValue DEFAULT_ACK_TIMEOUT = timeValueSeconds(30);
-    public static final TimeValue DEFAULT_MASTER_NODE_TIMEOUT = TimeValue.timeValueSeconds(30);
+    public static final TimeValue DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT = TimeValue.timeValueSeconds(30);
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT} */
+    @Deprecated
+    public static final TimeValue DEFAULT_MASTER_NODE_TIMEOUT = DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT;
 
     private TimeValue timeout = DEFAULT_ACK_TIMEOUT;
-    private TimeValue clusterManagerTimeout = DEFAULT_MASTER_NODE_TIMEOUT;
+    private TimeValue clusterManagerTimeout = DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT;
 
     /**
      * Sets the timeout to wait for the all the nodes to acknowledge
@@ -61,8 +64,18 @@ public abstract class TimedRequest implements Validatable {
      * Sets the timeout to connect to the cluster-manager node
      * @param clusterManagerTimeout timeout as a {@link TimeValue}
      */
-    public void setMasterTimeout(TimeValue clusterManagerTimeout) {
+    public void setClusterManagerTimeout(TimeValue clusterManagerTimeout) {
         this.clusterManagerTimeout = clusterManagerTimeout;
+    }
+
+    /**
+     * Sets the timeout to connect to the cluster-manager node
+     * @param clusterManagerTimeout timeout as a {@link TimeValue}
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #setClusterManagerTimeout(TimeValue)}
+     */
+    @Deprecated
+    public void setMasterTimeout(TimeValue clusterManagerTimeout) {
+        setClusterManagerTimeout(clusterManagerTimeout);
     }
 
     /**
@@ -75,7 +88,16 @@ public abstract class TimedRequest implements Validatable {
     /**
      * Returns the timeout for the request to be completed on the cluster-manager node
      */
-    public TimeValue masterNodeTimeout() {
+    public TimeValue clusterManagerNodeTimeout() {
         return clusterManagerTimeout;
+    }
+
+    /**
+     * Returns the timeout for the request to be completed on the cluster-manager node
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #clusterManagerNodeTimeout()}
+     */
+    @Deprecated
+    public TimeValue masterNodeTimeout() {
+        return clusterManagerNodeTimeout();
     }
 }

--- a/client/rest-high-level/src/main/java/org/opensearch/client/indices/GetComponentTemplatesRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/indices/GetComponentTemplatesRequest.java
@@ -44,7 +44,7 @@ public class GetComponentTemplatesRequest implements Validatable {
 
     private final String name;
 
-    private TimeValue clusterManagerNodeTimeout = TimedRequest.DEFAULT_MASTER_NODE_TIMEOUT;
+    private TimeValue clusterManagerNodeTimeout = TimedRequest.DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT;
     private boolean local = false;
 
     /**
@@ -67,17 +67,41 @@ public class GetComponentTemplatesRequest implements Validatable {
     /**
      * @return the timeout for waiting for the cluster-manager node to respond
      */
-    public TimeValue getMasterNodeTimeout() {
+    public TimeValue getClusterManagerNodeTimeout() {
         return clusterManagerNodeTimeout;
     }
 
-    public void setMasterNodeTimeout(@Nullable TimeValue clusterManagerNodeTimeout) {
+    /**
+     * @return the timeout for waiting for the cluster-manager node to respond
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #getMasterNodeTimeout()}
+     */
+    @Deprecated
+    public TimeValue getMasterNodeTimeout() {
+        return getClusterManagerNodeTimeout();
+    }
+
+    public void setClusterManagerNodeTimeout(@Nullable TimeValue clusterManagerNodeTimeout) {
         this.clusterManagerNodeTimeout = clusterManagerNodeTimeout;
     }
 
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #setClusterManagerNodeTimeout(TimeValue)} */
+    @Deprecated
+    public void setMasterNodeTimeout(@Nullable TimeValue clusterManagerNodeTimeout) {
+        setClusterManagerNodeTimeout(clusterManagerNodeTimeout);
+    }
+
+    public void setClusterManagerNodeTimeout(String clusterManagerNodeTimeout) {
+        final TimeValue timeValue = TimeValue.parseTimeValue(
+            clusterManagerNodeTimeout,
+            getClass().getSimpleName() + ".clusterManagerNodeTimeout"
+        );
+        setClusterManagerNodeTimeout(timeValue);
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #setClusterManagerNodeTimeout(String)} */
+    @Deprecated
     public void setMasterNodeTimeout(String clusterManagerNodeTimeout) {
-        final TimeValue timeValue = TimeValue.parseTimeValue(clusterManagerNodeTimeout, getClass().getSimpleName() + ".masterNodeTimeout");
-        setMasterNodeTimeout(timeValue);
+        setClusterManagerNodeTimeout(clusterManagerNodeTimeout);
     }
 
     /**

--- a/client/rest-high-level/src/main/java/org/opensearch/client/indices/GetComposableIndexTemplateRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/indices/GetComposableIndexTemplateRequest.java
@@ -44,7 +44,7 @@ public class GetComposableIndexTemplateRequest implements Validatable {
 
     private final String name;
 
-    private TimeValue clusterManagerNodeTimeout = TimedRequest.DEFAULT_MASTER_NODE_TIMEOUT;
+    private TimeValue clusterManagerNodeTimeout = TimedRequest.DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT;
     private boolean local = false;
 
     /**
@@ -67,17 +67,41 @@ public class GetComposableIndexTemplateRequest implements Validatable {
     /**
      * @return the timeout for waiting for the cluster-manager node to respond
      */
-    public TimeValue getMasterNodeTimeout() {
+    public TimeValue getClusterManagerNodeTimeout() {
         return clusterManagerNodeTimeout;
     }
 
-    public void setMasterNodeTimeout(@Nullable TimeValue clusterManagerNodeTimeout) {
+    /**
+     * @return the timeout for waiting for the cluster-manager node to respond
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #getMasterNodeTimeout()}
+     */
+    @Deprecated
+    public TimeValue getMasterNodeTimeout() {
+        return getClusterManagerNodeTimeout();
+    }
+
+    public void setClusterManagerNodeTimeout(@Nullable TimeValue clusterManagerNodeTimeout) {
         this.clusterManagerNodeTimeout = clusterManagerNodeTimeout;
     }
 
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #setClusterManagerNodeTimeout(TimeValue)} */
+    @Deprecated
+    public void setMasterNodeTimeout(@Nullable TimeValue clusterManagerNodeTimeout) {
+        setClusterManagerNodeTimeout(clusterManagerNodeTimeout);
+    }
+
+    public void setClusterManagerNodeTimeout(String clusterManagerNodeTimeout) {
+        final TimeValue timeValue = TimeValue.parseTimeValue(
+            clusterManagerNodeTimeout,
+            getClass().getSimpleName() + ".clusterManagerNodeTimeout"
+        );
+        setClusterManagerNodeTimeout(timeValue);
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #setClusterManagerNodeTimeout(String)} */
+    @Deprecated
     public void setMasterNodeTimeout(String clusterManagerNodeTimeout) {
-        final TimeValue timeValue = TimeValue.parseTimeValue(clusterManagerNodeTimeout, getClass().getSimpleName() + ".masterNodeTimeout");
-        setMasterNodeTimeout(timeValue);
+        setClusterManagerNodeTimeout(clusterManagerNodeTimeout);
     }
 
     /**

--- a/client/rest-high-level/src/main/java/org/opensearch/client/indices/GetIndexTemplatesRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/indices/GetIndexTemplatesRequest.java
@@ -51,7 +51,7 @@ public class GetIndexTemplatesRequest implements Validatable {
 
     private final List<String> names;
 
-    private TimeValue clusterManagerNodeTimeout = TimedRequest.DEFAULT_MASTER_NODE_TIMEOUT;
+    private TimeValue clusterManagerNodeTimeout = TimedRequest.DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT;
     private boolean local = false;
 
     /**
@@ -86,17 +86,41 @@ public class GetIndexTemplatesRequest implements Validatable {
     /**
      * @return the timeout for waiting for the cluster-manager node to respond
      */
-    public TimeValue getMasterNodeTimeout() {
+    public TimeValue getClusterManagerNodeTimeout() {
         return clusterManagerNodeTimeout;
     }
 
-    public void setMasterNodeTimeout(@Nullable TimeValue clusterManagerNodeTimeout) {
+    /**
+     * @return the timeout for waiting for the cluster-manager node to respond
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #getMasterNodeTimeout()}
+     */
+    @Deprecated
+    public TimeValue getMasterNodeTimeout() {
+        return getClusterManagerNodeTimeout();
+    }
+
+    public void setClusterManagerNodeTimeout(@Nullable TimeValue clusterManagerNodeTimeout) {
         this.clusterManagerNodeTimeout = clusterManagerNodeTimeout;
     }
 
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #setClusterManagerNodeTimeout(TimeValue)} */
+    @Deprecated
+    public void setMasterNodeTimeout(@Nullable TimeValue clusterManagerNodeTimeout) {
+        setClusterManagerNodeTimeout(clusterManagerNodeTimeout);
+    }
+
+    public void setClusterManagerNodeTimeout(String clusterManagerNodeTimeout) {
+        final TimeValue timeValue = TimeValue.parseTimeValue(
+            clusterManagerNodeTimeout,
+            getClass().getSimpleName() + ".clusterManagerNodeTimeout"
+        );
+        setClusterManagerNodeTimeout(timeValue);
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #setClusterManagerNodeTimeout(String)} */
+    @Deprecated
     public void setMasterNodeTimeout(String clusterManagerNodeTimeout) {
-        final TimeValue timeValue = TimeValue.parseTimeValue(clusterManagerNodeTimeout, getClass().getSimpleName() + ".masterNodeTimeout");
-        setMasterNodeTimeout(timeValue);
+        setClusterManagerNodeTimeout(clusterManagerNodeTimeout);
     }
 
     /**

--- a/client/rest-high-level/src/test/java/org/opensearch/client/TimedRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/TimedRequestTests.java
@@ -41,7 +41,7 @@ public class TimedRequestTests extends OpenSearchTestCase {
         TimedRequest timedRequest = new TimedRequest() {
         };
         assertEquals(timedRequest.timeout(), TimedRequest.DEFAULT_ACK_TIMEOUT);
-        assertEquals(timedRequest.masterNodeTimeout(), TimedRequest.DEFAULT_MASTER_NODE_TIMEOUT);
+        assertEquals(timedRequest.clusterManagerNodeTimeout(), TimedRequest.DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT);
     }
 
     public void testNonDefaults() {
@@ -50,8 +50,8 @@ public class TimedRequestTests extends OpenSearchTestCase {
         TimeValue timeout = TimeValue.timeValueSeconds(randomIntBetween(0, 1000));
         TimeValue clusterManagerTimeout = TimeValue.timeValueSeconds(randomIntBetween(0, 1000));
         timedRequest.setTimeout(timeout);
-        timedRequest.setMasterTimeout(clusterManagerTimeout);
+        timedRequest.setClusterManagerTimeout(clusterManagerTimeout);
         assertEquals(timedRequest.timeout(), timeout);
-        assertEquals(timedRequest.masterNodeTimeout(), clusterManagerTimeout);
+        assertEquals(timedRequest.clusterManagerNodeTimeout(), clusterManagerTimeout);
     }
 }

--- a/client/rest-high-level/src/test/java/org/opensearch/client/documentation/ClusterClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/documentation/ClusterClientDocumentationIT.java
@@ -515,8 +515,8 @@ public class ClusterClientDocumentationIT extends OpenSearchRestHighLevelClientT
         // end::get-component-templates-request
 
         // tag::get-component-templates-request-masterTimeout
-        request.setMasterNodeTimeout(TimeValue.timeValueMinutes(1)); // <1>
-        request.setMasterNodeTimeout("1m"); // <2>
+        request.setClusterManagerNodeTimeout(TimeValue.timeValueMinutes(1)); // <1>
+        request.setClusterManagerNodeTimeout("1m"); // <2>
         // end::get-component-templates-request-masterTimeout
 
         // tag::get-component-templates-execute
@@ -603,7 +603,7 @@ public class ClusterClientDocumentationIT extends OpenSearchRestHighLevelClientT
             // end::put-component-template-request-create
 
             // tag::put-component-template-request-masterTimeout
-            request.setMasterTimeout(TimeValue.timeValueMinutes(1)); // <1>
+            request.setClusterManagerTimeout(TimeValue.timeValueMinutes(1)); // <1>
             // end::put-component-template-request-masterTimeout
 
             request.create(false); // make test happy
@@ -670,7 +670,7 @@ public class ClusterClientDocumentationIT extends OpenSearchRestHighLevelClientT
         // end::delete-component-template-request
 
         // tag::delete-component-template-request-masterTimeout
-        deleteRequest.setMasterTimeout(TimeValue.timeValueMinutes(1)); // <1>
+        deleteRequest.setClusterManagerTimeout(TimeValue.timeValueMinutes(1)); // <1>
         // end::delete-component-template-request-masterTimeout
 
         // tag::delete-component-template-execute

--- a/client/rest-high-level/src/test/java/org/opensearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/documentation/IndicesClientDocumentationIT.java
@@ -381,7 +381,7 @@ public class IndicesClientDocumentationIT extends OpenSearchRestHighLevelClientT
             request.setTimeout(TimeValue.timeValueMinutes(2)); // <1>
             // end::create-index-request-timeout
             // tag::create-index-request-masterTimeout
-            request.setMasterTimeout(TimeValue.timeValueMinutes(1)); // <1>
+            request.setClusterManagerTimeout(TimeValue.timeValueMinutes(1)); // <1>
             // end::create-index-request-masterTimeout
             // tag::create-index-request-waitForActiveShards
             request.waitForActiveShards(ActiveShardCount.from(2)); // <1>
@@ -526,7 +526,7 @@ public class IndicesClientDocumentationIT extends OpenSearchRestHighLevelClientT
             // end::put-mapping-request-timeout
 
             // tag::put-mapping-request-masterTimeout
-            request.setMasterTimeout(TimeValue.timeValueMinutes(1)); // <1>
+            request.setClusterManagerTimeout(TimeValue.timeValueMinutes(1)); // <1>
             // end::put-mapping-request-masterTimeout
 
             // tag::put-mapping-execute
@@ -597,7 +597,7 @@ public class IndicesClientDocumentationIT extends OpenSearchRestHighLevelClientT
             // end::get-mappings-request
 
             // tag::get-mappings-request-masterTimeout
-            request.setMasterTimeout(TimeValue.timeValueMinutes(1)); // <1>
+            request.setClusterManagerTimeout(TimeValue.timeValueMinutes(1)); // <1>
             // end::get-mappings-request-masterTimeout
 
             // tag::get-mappings-request-indicesOptions
@@ -1374,7 +1374,7 @@ public class IndicesClientDocumentationIT extends OpenSearchRestHighLevelClientT
             request.setTimeout(TimeValue.timeValueMinutes(2)); // <1>
             // end::close-index-request-timeout
             // tag::close-index-request-masterTimeout
-            request.setMasterTimeout(TimeValue.timeValueMinutes(1)); // <1>
+            request.setClusterManagerTimeout(TimeValue.timeValueMinutes(1)); // <1>
             // end::close-index-request-masterTimeout
 
             // tag::close-index-request-indicesOptions
@@ -1815,7 +1815,7 @@ public class IndicesClientDocumentationIT extends OpenSearchRestHighLevelClientT
         request.setTimeout(TimeValue.timeValueMinutes(2)); // <1>
         // end::rollover-index-request-timeout
         // tag::rollover-index-request-masterTimeout
-        request.setMasterTimeout(TimeValue.timeValueMinutes(1)); // <1>
+        request.setClusterManagerTimeout(TimeValue.timeValueMinutes(1)); // <1>
         // end::rollover-index-request-masterTimeout
         // tag::rollover-index-request-dryRun
         request.dryRun(true); // <1>
@@ -2231,8 +2231,8 @@ public class IndicesClientDocumentationIT extends OpenSearchRestHighLevelClientT
         // end::get-templates-request
 
         // tag::get-templates-request-masterTimeout
-        request.setMasterNodeTimeout(TimeValue.timeValueMinutes(1)); // <1>
-        request.setMasterNodeTimeout("1m"); // <2>
+        request.setClusterManagerNodeTimeout(TimeValue.timeValueMinutes(1)); // <1>
+        request.setClusterManagerNodeTimeout("1m"); // <2>
         // end::get-templates-request-masterTimeout
 
         // tag::get-templates-execute
@@ -2291,8 +2291,8 @@ public class IndicesClientDocumentationIT extends OpenSearchRestHighLevelClientT
         // end::get-index-templates-v2-request
 
         // tag::get-index-templates-v2-request-masterTimeout
-        request.setMasterNodeTimeout(TimeValue.timeValueMinutes(1)); // <1>
-        request.setMasterNodeTimeout("1m"); // <2>
+        request.setClusterManagerNodeTimeout(TimeValue.timeValueMinutes(1)); // <1>
+        request.setClusterManagerNodeTimeout("1m"); // <2>
         // end::get-index-templates-v2-request-masterTimeout
 
         // tag::get-index-templates-v2-execute
@@ -2450,7 +2450,7 @@ public class IndicesClientDocumentationIT extends OpenSearchRestHighLevelClientT
             // end::put-index-template-v2-request-create
 
             // tag::put-index-template-v2-request-masterTimeout
-            request.setMasterTimeout(TimeValue.timeValueMinutes(1)); // <1>
+            request.setClusterManagerTimeout(TimeValue.timeValueMinutes(1)); // <1>
             // end::put-index-template-v2-request-masterTimeout
 
             request.create(false); // make test happy
@@ -2511,7 +2511,7 @@ public class IndicesClientDocumentationIT extends OpenSearchRestHighLevelClientT
         // end::delete-index-template-v2-request
 
         // tag::delete-index-template-v2-request-masterTimeout
-        deleteRequest.setMasterTimeout(TimeValue.timeValueMinutes(1)); // <1>
+        deleteRequest.setClusterManagerTimeout(TimeValue.timeValueMinutes(1)); // <1>
         // end::delete-index-template-v2-request-masterTimeout
 
         // tag::delete-index-template-v2-execute
@@ -2644,8 +2644,8 @@ public class IndicesClientDocumentationIT extends OpenSearchRestHighLevelClientT
 
             // tag::templates-exist-request-optionals
             request.setLocal(true); // <1>
-            request.setMasterNodeTimeout(TimeValue.timeValueMinutes(1)); // <2>
-            request.setMasterNodeTimeout("1m"); // <3>
+            request.setClusterManagerNodeTimeout(TimeValue.timeValueMinutes(1)); // <2>
+            request.setClusterManagerNodeTimeout("1m"); // <3>
             // end::templates-exist-request-optionals
 
             // tag::templates-exist-execute
@@ -2973,7 +2973,7 @@ public class IndicesClientDocumentationIT extends OpenSearchRestHighLevelClientT
             request.setTimeout(TimeValue.timeValueMinutes(2)); // <1>
             // end::delete-alias-request-timeout
             // tag::delete-alias-request-masterTimeout
-            request.setMasterTimeout(TimeValue.timeValueMinutes(1)); // <1>
+            request.setClusterManagerTimeout(TimeValue.timeValueMinutes(1)); // <1>
             // end::delete-alias-request-masterTimeout
 
             // tag::delete-alias-execute

--- a/client/rest-high-level/src/test/java/org/opensearch/client/indices/CloseIndexRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/indices/CloseIndexRequestTests.java
@@ -75,15 +75,15 @@ public class CloseIndexRequestTests extends OpenSearchTestCase {
     public void testTimeout() {
         final CloseIndexRequest request = new CloseIndexRequest("index");
         assertEquals(request.timeout(), TimedRequest.DEFAULT_ACK_TIMEOUT);
-        assertEquals(request.masterNodeTimeout(), TimedRequest.DEFAULT_MASTER_NODE_TIMEOUT);
+        assertEquals(request.clusterManagerNodeTimeout(), TimedRequest.DEFAULT_CLUSTER_MANAGER_NODE_TIMEOUT);
 
         final TimeValue timeout = TimeValue.timeValueSeconds(randomIntBetween(0, 1000));
         request.setTimeout(timeout);
 
         final TimeValue clusterManagerTimeout = TimeValue.timeValueSeconds(randomIntBetween(0, 1000));
-        request.setMasterTimeout(clusterManagerTimeout);
+        request.setClusterManagerTimeout(clusterManagerTimeout);
 
         assertEquals(request.timeout(), timeout);
-        assertEquals(request.masterNodeTimeout(), clusterManagerTimeout);
+        assertEquals(request.clusterManagerNodeTimeout(), clusterManagerTimeout);
     }
 }

--- a/client/rest/src/main/java/org/opensearch/client/Node.java
+++ b/client/rest/src/main/java/org/opensearch/client/Node.java
@@ -212,8 +212,17 @@ public class Node {
         /**
          * Returns whether or not the node <strong>could</strong> be elected cluster-manager.
          */
-        public boolean isMasterEligible() {
+        public boolean isClusterManagerEligible() {
             return roles.contains("master") || roles.contains("cluster_manager");
+        }
+
+        /**
+         * Returns whether or not the node <strong>could</strong> be elected cluster-manager.
+         * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #isClusterManagerEligible()}
+         */
+        @Deprecated
+        public boolean isMasterEligible() {
+            return isClusterManagerEligible();
         }
 
         /**

--- a/client/rest/src/main/java/org/opensearch/client/NodeSelector.java
+++ b/client/rest/src/main/java/org/opensearch/client/NodeSelector.java
@@ -89,7 +89,9 @@ public interface NodeSelector {
             for (Iterator<Node> itr = nodes.iterator(); itr.hasNext();) {
                 Node node = itr.next();
                 if (node.getRoles() == null) continue;
-                if (node.getRoles().isMasterEligible() && false == node.getRoles().isData() && false == node.getRoles().isIngest()) {
+                if (node.getRoles().isClusterManagerEligible()
+                    && false == node.getRoles().isData()
+                    && false == node.getRoles().isIngest()) {
                     itr.remove();
                 }
             }
@@ -97,7 +99,7 @@ public interface NodeSelector {
 
         @Override
         public String toString() {
-            return "SKIP_DEDICATED_MASTERS";
+            return "SKIP_DEDICATED_CLUSTER_MANAGERS";
         }
     };
 }

--- a/client/sniffer/src/test/java/org/opensearch/client/sniff/OpenSearchNodesSnifferTests.java
+++ b/client/sniffer/src/test/java/org/opensearch/client/sniff/OpenSearchNodesSnifferTests.java
@@ -287,7 +287,7 @@ public class OpenSearchNodesSnifferTests extends RestClientTestCase {
             Collections.shuffle(roles, getRandom());
             generator.writeArrayFieldStart("roles");
             for (String role : roles) {
-                if ("cluster_manager".equals(role) && node.getRoles().isMasterEligible()) {
+                if ("cluster_manager".equals(role) && node.getRoles().isClusterManagerEligible()) {
                     generator.writeString("cluster_manager");
                 }
                 if ("data".equals(role) && node.getRoles().isData()) {


### PR DESCRIPTION
### Description
Backport PR https://github.com/opensearch-project/OpenSearch/pull/3966 / commit https://github.com/opensearch-project/OpenSearch/commit/ccf1d15618770acd54be9b3f37e731612a42e2d6 to `2.x` branch
 
### Issues Resolved
To support inclusive language, the `master` terminology is going to be replaced by `cluster manager` in the code base.
This PR deprecate public and protected methods/variable that contains `master` terminology in the name in `client` directory, and create alternatives.

List of public methods to be renamed in `client` directory:
```
public void setMasterTimeout(TimeValue clusterManagerTimeout)
public TimeValue masterNodeTimeout()
public TimeValue getMasterNodeTimeout()
public void setMasterNodeTimeout(@Nullable TimeValue clusterManagerNodeTimeout)
public void setMasterNodeTimeout(String clusterManagerNodeTimeout)
public boolean isMasterEligible()
```

List of public variables to be renamed in `client` directory:
```
public static final TimeValue DEFAULT_MASTER_NODE_TIMEOUT
```

Other changes:
- 1 String type usage:
https://github.com/opensearch-project/OpenSearch/blob/31f4b7aac8aa95db1e6ca146ba42fa6fdf3b18b0/client/rest/src/main/java/org/opensearch/client/NodeSelector.java#L102

The method `Params withMasterTimeout(TimeValue masterTimeout)` remains not changed, because `master_timeout` parameter of the REST APIs is not deprecated in version `2.x`
https://github.com/opensearch-project/OpenSearch/blob/79cabafebc74e8379f7c854657693ca3b03a3247/client/rest-high-level/src/main/java/org/opensearch/client/RequestConverters.java#L894

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
