### PR TITLE
Deprecate public methods and variables that contain 'master' terminology in class 'NoMasterBlockService' and 'MasterService'

### DIFF
--- a/modules/rank-eval/src/test/java/org/opensearch/index/rankeval/RankEvalResponseTests.java
+++ b/modules/rank-eval/src/test/java/org/opensearch/index/rankeval/RankEvalResponseTests.java
@@ -76,7 +76,7 @@ import static org.hamcrest.Matchers.instanceOf;
 public class RankEvalResponseTests extends OpenSearchTestCase {
 
     private static final Exception[] RANDOM_EXCEPTIONS = new Exception[] {
-        new ClusterBlockException(singleton(NoClusterManagerBlockService.NO_MASTER_BLOCK_WRITES)),
+        new ClusterBlockException(singleton(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_WRITES)),
         new CircuitBreakingException("Data too large", 123, 456, CircuitBreaker.Durability.PERMANENT),
         new SearchParseException(SHARD_TARGET, "Parse failure", new XContentLocation(12, 98)),
         new IllegalArgumentException("Closed resource", new RuntimeException("Resource")),

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterStateDiffIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterStateDiffIT.java
@@ -396,9 +396,9 @@ public class ClusterStateDiffIT extends OpenSearchIntegTestCase {
     private ClusterBlock randomGlobalBlock() {
         switch (randomInt(2)) {
             case 0:
-                return NoClusterManagerBlockService.NO_MASTER_BLOCK_ALL;
+                return NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ALL;
             case 1:
-                return NoClusterManagerBlockService.NO_MASTER_BLOCK_WRITES;
+                return NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_WRITES;
             default:
                 return GatewayService.STATE_NOT_RECOVERED_BLOCK;
         }

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/MinimumClusterManagerNodesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/MinimumClusterManagerNodesIT.java
@@ -93,7 +93,7 @@ public class MinimumClusterManagerNodesIT extends OpenSearchIntegTestCase {
 
         logger.info("--> should be blocked, no cluster-manager...");
         ClusterState state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
+        assertThat(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID), equalTo(true));
         assertThat(state.nodes().getSize(), equalTo(1)); // verify that we still see the local node in the cluster state
 
         logger.info("--> start second node, cluster should be formed");
@@ -109,9 +109,9 @@ public class MinimumClusterManagerNodesIT extends OpenSearchIntegTestCase {
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
+        assertThat(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID), equalTo(false));
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
+        assertThat(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID), equalTo(false));
 
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
         assertThat(state.nodes().getSize(), equalTo(2));
@@ -161,11 +161,11 @@ public class MinimumClusterManagerNodesIT extends OpenSearchIntegTestCase {
 
         assertBusy(() -> {
             ClusterState clusterState = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-            assertTrue(clusterState.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID));
+            assertTrue(clusterState.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID));
         });
 
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
+        assertThat(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID), equalTo(true));
         // verify that both nodes are still in the cluster state but there is no cluster-manager
         assertThat(state.nodes().getSize(), equalTo(2));
         assertThat(state.nodes().getClusterManagerNode(), equalTo(null));
@@ -184,9 +184,9 @@ public class MinimumClusterManagerNodesIT extends OpenSearchIntegTestCase {
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
+        assertThat(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID), equalTo(false));
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
+        assertThat(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID), equalTo(false));
 
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
         assertThat(state.nodes().getSize(), equalTo(2));
@@ -214,7 +214,7 @@ public class MinimumClusterManagerNodesIT extends OpenSearchIntegTestCase {
 
         assertBusy(() -> {
             ClusterState state1 = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-            assertThat(state1.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
+            assertThat(state1.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID), equalTo(true));
         });
 
         logger.info("--> starting the previous cluster-manager node again...");
@@ -232,9 +232,9 @@ public class MinimumClusterManagerNodesIT extends OpenSearchIntegTestCase {
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
+        assertThat(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID), equalTo(false));
         state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertThat(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
+        assertThat(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID), equalTo(false));
 
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
         assertThat(state.nodes().getSize(), equalTo(2));
@@ -262,7 +262,7 @@ public class MinimumClusterManagerNodesIT extends OpenSearchIntegTestCase {
         assertBusy(() -> {
             for (Client client : clients()) {
                 ClusterState state1 = client.admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-                assertThat(state1.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
+                assertThat(state1.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID), equalTo(true));
             }
         });
 
@@ -324,7 +324,7 @@ public class MinimumClusterManagerNodesIT extends OpenSearchIntegTestCase {
         // spin here to wait till the state is set
         assertBusy(() -> {
             ClusterState st = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-            assertThat(st.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
+            assertThat(st.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID), equalTo(true));
         });
 
         logger.info("--> start back the 2 nodes ");

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/NoClusterManagerNodeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/NoClusterManagerNodeIT.java
@@ -117,7 +117,7 @@ public class NoClusterManagerNodeIT extends OpenSearchIntegTestCase {
                 .execute()
                 .actionGet()
                 .getState();
-            assertTrue(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID));
+            assertTrue(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID));
         });
 
         assertRequestBuilderThrows(
@@ -288,7 +288,7 @@ public class NoClusterManagerNodeIT extends OpenSearchIntegTestCase {
 
         assertBusy(() -> {
             ClusterState state = clientToClusterManagerlessNode.admin().cluster().prepareState().setLocal(true).get().getState();
-            assertTrue(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID));
+            assertTrue(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID));
         });
 
         GetResponse getResponse = clientToClusterManagerlessNode.prepareGet("test1", "1").get();
@@ -387,7 +387,7 @@ public class NoClusterManagerNodeIT extends OpenSearchIntegTestCase {
         assertBusy(() -> {
             for (String node : nodesWithShards) {
                 ClusterState state = client(node).admin().cluster().prepareState().setLocal(true).get().getState();
-                assertTrue(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID));
+                assertTrue(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID));
             }
         });
 

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
@@ -220,7 +220,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
         );
         assertBusy(() -> {
             ClusterState state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-            assertTrue(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID));
+            assertTrue(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID));
         });
 
         Settings dataPathSettings = internalCluster().dataPathSettings(node);
@@ -338,7 +338,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
                 .execute()
                 .actionGet()
                 .getState();
-            assertTrue(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID));
+            assertTrue(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID));
         });
 
         logger.info("--> try to unsafely bootstrap 1st cluster-manager-eligible node, while node lock is held");
@@ -394,7 +394,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
                 .execute()
                 .actionGet()
                 .getState();
-            assertFalse(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID));
+            assertFalse(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID));
             assertTrue(
                 state.metadata().persistentSettings().getAsBoolean(UnsafeBootstrapClusterManagerCommand.UNSAFE_BOOTSTRAP.getKey(), false)
             );
@@ -508,7 +508,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends OpenSearchIntegTestCase {
         );
 
         ClusterState state = internalCluster().client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
-        assertTrue(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID));
+        assertTrue(state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID));
 
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(node));
     }

--- a/server/src/internalClusterTest/java/org/opensearch/discovery/ClusterManagerDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/ClusterManagerDisruptionIT.java
@@ -234,7 +234,11 @@ public class ClusterManagerDisruptionIT extends AbstractDisruptionTestCase {
         // continuously ping until network failures have been resolved. However
         // It may a take a bit before the node detects it has been cut off from the elected cluster-manager
         logger.info("waiting for isolated node [{}] to have no cluster-manager", isolatedNode);
-        assertNoClusterManager(isolatedNode, NoClusterManagerBlockService.NO_MASTER_BLOCK_METADATA_WRITES, TimeValue.timeValueSeconds(30));
+        assertNoClusterManager(
+            isolatedNode,
+            NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_METADATA_WRITES,
+            TimeValue.timeValueSeconds(30)
+        );
 
         logger.info("wait until elected cluster-manager has been removed and a new 2 node cluster was from (via [{}])", isolatedNode);
         ensureStableCluster(2, nonIsolatedNode);
@@ -280,7 +284,7 @@ public class ClusterManagerDisruptionIT extends AbstractDisruptionTestCase {
         // continuously ping until network failures have been resolved. However
         // It may a take a bit before the node detects it has been cut off from the elected cluster-manager
         logger.info("waiting for isolated node [{}] to have no cluster-manager", isolatedNode);
-        assertNoClusterManager(isolatedNode, NoClusterManagerBlockService.NO_MASTER_BLOCK_ALL, TimeValue.timeValueSeconds(30));
+        assertNoClusterManager(isolatedNode, NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ALL, TimeValue.timeValueSeconds(30));
 
         // make sure we have stable cluster & cross partition recoveries are canceled by the removal of the missing node
         // the unresponsive partition causes recoveries to only time out after 15m (default) and these will cause

--- a/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java
@@ -105,7 +105,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_MASTER_BLOCK_ID;
+import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID;
 import static org.opensearch.gateway.ClusterStateUpdaters.hideStateIfNotRecovered;
 import static org.opensearch.gateway.GatewayService.STATE_NOT_RECOVERED_BLOCK;
 import static org.opensearch.monitor.StatusInfo.Status.UNHEALTHY;
@@ -839,7 +839,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                 .blocks(
                     ClusterBlocks.builder()
                         .addGlobalBlock(STATE_NOT_RECOVERED_BLOCK)
-                        .addGlobalBlock(noClusterManagerBlockService.getNoMasterBlock())
+                        .addGlobalBlock(noClusterManagerBlockService.getNoClusterManagerBlock())
                 )
                 .nodes(DiscoveryNodes.builder().add(getLocalNode()).localNodeId(getLocalNode().getId()))
                 .build();
@@ -886,7 +886,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
             assert followersChecker.getFastResponseState().term == getCurrentTerm() : followersChecker.getFastResponseState();
             assert followersChecker.getFastResponseState().mode == getMode() : followersChecker.getFastResponseState();
             assert (applierState.nodes().getClusterManagerNodeId() == null) == applierState.blocks()
-                .hasGlobalBlockWithId(NO_MASTER_BLOCK_ID);
+                .hasGlobalBlockWithId(NO_CLUSTER_MANAGER_BLOCK_ID);
             assert preVoteCollector.getPreVoteResponse().equals(getPreVoteResponse()) : preVoteCollector + " vs " + getPreVoteResponse();
 
             assert lagDetector.getTrackedNodes().contains(getLocalNode()) == false : lagDetector.getTrackedNodes();
@@ -1221,11 +1221,11 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
     private ClusterState clusterStateWithNoClusterManagerBlock(ClusterState clusterState) {
         if (clusterState.nodes().getClusterManagerNodeId() != null) {
             // remove block if it already exists before adding new one
-            assert clusterState.blocks().hasGlobalBlockWithId(NO_MASTER_BLOCK_ID) == false
+            assert clusterState.blocks().hasGlobalBlockWithId(NO_CLUSTER_MANAGER_BLOCK_ID) == false
                 : "NO_MASTER_BLOCK should only be added by Coordinator";
             final ClusterBlocks clusterBlocks = ClusterBlocks.builder()
                 .blocks(clusterState.blocks())
-                .addGlobalBlock(noClusterManagerBlockService.getNoMasterBlock())
+                .addGlobalBlock(noClusterManagerBlockService.getNoClusterManagerBlock())
                 .build();
             final DiscoveryNodes discoveryNodes = new DiscoveryNodes.Builder(clusterState.nodes()).clusterManagerNodeId(null).build();
             return ClusterState.builder(clusterState).blocks(clusterBlocks).nodes(discoveryNodes).build();

--- a/server/src/main/java/org/opensearch/cluster/coordination/JoinTaskExecutor.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/JoinTaskExecutor.java
@@ -285,7 +285,9 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
         ClusterState tmpState = ClusterState.builder(currentState)
             .nodes(nodesBuilder)
             .blocks(
-                ClusterBlocks.builder().blocks(currentState.blocks()).removeGlobalBlock(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID)
+                ClusterBlocks.builder()
+                    .blocks(currentState.blocks())
+                    .removeGlobalBlock(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID)
             )
             .build();
         logger.trace("becomeClusterManagerAndTrimConflictingNodes: {}", tmpState.nodes());

--- a/server/src/main/java/org/opensearch/cluster/coordination/NoClusterManagerBlockService.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/NoClusterManagerBlockService.java
@@ -47,9 +47,9 @@ import java.util.EnumSet;
  * @opensearch.internal
  */
 public class NoClusterManagerBlockService {
-    public static final int NO_MASTER_BLOCK_ID = 2;
-    public static final ClusterBlock NO_MASTER_BLOCK_WRITES = new ClusterBlock(
-        NO_MASTER_BLOCK_ID,
+    public static final int NO_CLUSTER_MANAGER_BLOCK_ID = 2;
+    public static final ClusterBlock NO_CLUSTER_MANAGER_BLOCK_WRITES = new ClusterBlock(
+        NO_CLUSTER_MANAGER_BLOCK_ID,
         "no cluster-manager",
         true,
         false,
@@ -57,8 +57,8 @@ public class NoClusterManagerBlockService {
         RestStatus.SERVICE_UNAVAILABLE,
         EnumSet.of(ClusterBlockLevel.WRITE, ClusterBlockLevel.METADATA_WRITE)
     );
-    public static final ClusterBlock NO_MASTER_BLOCK_ALL = new ClusterBlock(
-        NO_MASTER_BLOCK_ID,
+    public static final ClusterBlock NO_CLUSTER_MANAGER_BLOCK_ALL = new ClusterBlock(
+        NO_CLUSTER_MANAGER_BLOCK_ID,
         "no cluster-manager",
         true,
         true,
@@ -66,8 +66,8 @@ public class NoClusterManagerBlockService {
         RestStatus.SERVICE_UNAVAILABLE,
         ClusterBlockLevel.ALL
     );
-    public static final ClusterBlock NO_MASTER_BLOCK_METADATA_WRITES = new ClusterBlock(
-        NO_MASTER_BLOCK_ID,
+    public static final ClusterBlock NO_CLUSTER_MANAGER_BLOCK_METADATA_WRITES = new ClusterBlock(
+        NO_CLUSTER_MANAGER_BLOCK_ID,
         "no cluster-manager",
         true,
         false,
@@ -75,6 +75,19 @@ public class NoClusterManagerBlockService {
         RestStatus.SERVICE_UNAVAILABLE,
         EnumSet.of(ClusterBlockLevel.METADATA_WRITE)
     );
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #NO_CLUSTER_MANAGER_BLOCK_ID} */
+    @Deprecated
+    public static final int NO_MASTER_BLOCK_ID = NO_CLUSTER_MANAGER_BLOCK_ID;
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #NO_CLUSTER_MANAGER_BLOCK_WRITES} */
+    @Deprecated
+    public static final ClusterBlock NO_MASTER_BLOCK_WRITES = NO_CLUSTER_MANAGER_BLOCK_WRITES;
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #NO_CLUSTER_MANAGER_BLOCK_ALL} */
+    @Deprecated
+    public static final ClusterBlock NO_MASTER_BLOCK_ALL = NO_CLUSTER_MANAGER_BLOCK_ALL;
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #NO_CLUSTER_MANAGER_BLOCK_METADATA_WRITES} */
+    @Deprecated
+    public static final ClusterBlock NO_MASTER_BLOCK_METADATA_WRITES = NO_CLUSTER_MANAGER_BLOCK_METADATA_WRITES;
 
     public static final Setting<ClusterBlock> NO_MASTER_BLOCK_SETTING = new Setting<>(
         "cluster.no_master_block",
@@ -98,17 +111,17 @@ public class NoClusterManagerBlockService {
 
     public NoClusterManagerBlockService(Settings settings, ClusterSettings clusterSettings) {
         this.noClusterManagerBlock = NO_CLUSTER_MANAGER_BLOCK_SETTING.get(settings);
-        clusterSettings.addSettingsUpdateConsumer(NO_CLUSTER_MANAGER_BLOCK_SETTING, this::setNoMasterBlock);
+        clusterSettings.addSettingsUpdateConsumer(NO_CLUSTER_MANAGER_BLOCK_SETTING, this::setNoClusterManagerBlock);
     }
 
     private static ClusterBlock parseNoClusterManagerBlock(String value) {
         switch (value) {
             case "all":
-                return NO_MASTER_BLOCK_ALL;
+                return NO_CLUSTER_MANAGER_BLOCK_ALL;
             case "write":
-                return NO_MASTER_BLOCK_WRITES;
+                return NO_CLUSTER_MANAGER_BLOCK_WRITES;
             case "metadata_write":
-                return NO_MASTER_BLOCK_METADATA_WRITES;
+                return NO_CLUSTER_MANAGER_BLOCK_METADATA_WRITES;
             default:
                 throw new IllegalArgumentException(
                     "invalid no-cluster-manager block [" + value + "], must be one of [all, write, metadata_write]"
@@ -116,11 +129,17 @@ public class NoClusterManagerBlockService {
         }
     }
 
+    public ClusterBlock getNoClusterManagerBlock() {
+        return noClusterManagerBlock;
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #getNoClusterManagerBlock()} */
+    @Deprecated
     public ClusterBlock getNoMasterBlock() {
         return noClusterManagerBlock;
     }
 
-    private void setNoMasterBlock(ClusterBlock noClusterManagerBlock) {
+    private void setNoClusterManagerBlock(ClusterBlock noClusterManagerBlock) {
         this.noClusterManagerBlock = noClusterManagerBlock;
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/service/ClusterService.java
+++ b/server/src/main/java/org/opensearch/cluster/service/ClusterService.java
@@ -252,7 +252,7 @@ public class ClusterService extends AbstractLifecycleComponent {
 
     public static boolean assertClusterOrClusterManagerStateThread() {
         assert Thread.currentThread().getName().contains(ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME)
-            || Thread.currentThread().getName().contains(MasterService.MASTER_UPDATE_THREAD_NAME)
+            || Thread.currentThread().getName().contains(MasterService.CLUSTER_MANAGER_UPDATE_THREAD_NAME)
             : "not called from the master/cluster state update thread";
         return true;
     }

--- a/server/src/main/java/org/opensearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/opensearch/cluster/service/MasterService.java
@@ -228,22 +228,34 @@ public class MasterService extends AbstractLifecycleComponent {
         return clusterStateSupplier.get();
     }
 
-    private static boolean isMasterUpdateThread() {
+    private static boolean isClusterManagerUpdateThread() {
         return Thread.currentThread().getName().contains(MASTER_UPDATE_THREAD_NAME);
     }
 
-    public static boolean assertMasterUpdateThread() {
-        assert isMasterUpdateThread() : "not called from the cluster-manager service thread";
+    public static boolean assertClusterManagerUpdateThread() {
+        assert isClusterManagerUpdateThread() : "not called from the cluster-manager service thread";
         return true;
     }
 
-    public static boolean assertNotMasterUpdateThread(String reason) {
-        assert isMasterUpdateThread() == false : "Expected current thread ["
+    public static boolean assertNotClusterManagerUpdateThread(String reason) {
+        assert isClusterManagerUpdateThread() == false : "Expected current thread ["
             + Thread.currentThread()
-            + "] to not be the cluster-maanger service thread. Reason: ["
+            + "] to not be the cluster-manager service thread. Reason: ["
             + reason
             + "]";
         return true;
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #assertClusterManagerUpdateThread()} */
+    @Deprecated
+    public static boolean assertMasterUpdateThread() {
+        return assertClusterManagerUpdateThread();
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #assertNotClusterManagerUpdateThread(String)} */
+    @Deprecated
+    public static boolean assertNotMasterUpdateThread(String reason) {
+        return assertNotClusterManagerUpdateThread(reason);
     }
 
     private void runTasks(TaskInputs taskInputs) {
@@ -314,7 +326,7 @@ public class MasterService extends AbstractLifecycleComponent {
         final PlainActionFuture<Void> fut = new PlainActionFuture<Void>() {
             @Override
             protected boolean blockingAllowed() {
-                return isMasterUpdateThread() || super.blockingAllowed();
+                return isClusterManagerUpdateThread() || super.blockingAllowed();
             }
         };
         clusterStatePublisher.publish(clusterChangedEvent, fut, taskOutputs.createAckListener(threadPool, clusterChangedEvent.state()));

--- a/server/src/main/java/org/opensearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/opensearch/cluster/service/MasterService.java
@@ -107,6 +107,10 @@ public class MasterService extends AbstractLifecycleComponent {
         Setting.Property.NodeScope
     );
 
+    static final String CLUSTER_MANAGER_UPDATE_THREAD_NAME = "clusterManagerService#updateTask";
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #CLUSTER_MANAGER_UPDATE_THREAD_NAME} */
+    @Deprecated
     static final String MASTER_UPDATE_THREAD_NAME = "masterService#updateTask";
 
     ClusterStatePublisher clusterStatePublisher;
@@ -156,8 +160,8 @@ public class MasterService extends AbstractLifecycleComponent {
 
     protected PrioritizedOpenSearchThreadPoolExecutor createThreadPoolExecutor() {
         return OpenSearchExecutors.newSinglePrioritizing(
-            nodeName + "/" + MASTER_UPDATE_THREAD_NAME,
-            daemonThreadFactory(nodeName, MASTER_UPDATE_THREAD_NAME),
+            nodeName + "/" + CLUSTER_MANAGER_UPDATE_THREAD_NAME,
+            daemonThreadFactory(nodeName, CLUSTER_MANAGER_UPDATE_THREAD_NAME),
             threadPool.getThreadContext(),
             threadPool.scheduler()
         );
@@ -229,7 +233,8 @@ public class MasterService extends AbstractLifecycleComponent {
     }
 
     private static boolean isClusterManagerUpdateThread() {
-        return Thread.currentThread().getName().contains(MASTER_UPDATE_THREAD_NAME);
+        return Thread.currentThread().getName().contains(CLUSTER_MANAGER_UPDATE_THREAD_NAME)
+            || Thread.currentThread().getName().contains(MASTER_UPDATE_THREAD_NAME);
     }
 
     public static boolean assertClusterManagerUpdateThread() {

--- a/server/src/main/java/org/opensearch/common/util/concurrent/BaseFuture.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/BaseFuture.java
@@ -109,7 +109,7 @@ public abstract class BaseFuture<V> implements Future<V> {
         return Transports.assertNotTransportThread(BLOCKING_OP_REASON)
             && ThreadPool.assertNotScheduleThread(BLOCKING_OP_REASON)
             && ClusterApplierService.assertNotClusterStateUpdateThread(BLOCKING_OP_REASON)
-            && MasterService.assertNotMasterUpdateThread(BLOCKING_OP_REASON);
+            && MasterService.assertNotClusterManagerUpdateThread(BLOCKING_OP_REASON);
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/opensearch/ExceptionSerializationTests.java
@@ -516,9 +516,11 @@ public class ExceptionSerializationTests extends OpenSearchTestCase {
     }
 
     public void testClusterBlockException() throws IOException {
-        ClusterBlockException ex = serialize(new ClusterBlockException(singleton(NoClusterManagerBlockService.NO_MASTER_BLOCK_WRITES)));
+        ClusterBlockException ex = serialize(
+            new ClusterBlockException(singleton(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_WRITES))
+        );
         assertEquals("blocked by: [SERVICE_UNAVAILABLE/2/no cluster-manager];", ex.getMessage());
-        assertTrue(ex.blocks().contains(NoClusterManagerBlockService.NO_MASTER_BLOCK_WRITES));
+        assertTrue(ex.blocks().contains(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_WRITES));
         assertEquals(1, ex.blocks().size());
     }
 

--- a/server/src/test/java/org/opensearch/OpenSearchExceptionTests.java
+++ b/server/src/test/java/org/opensearch/OpenSearchExceptionTests.java
@@ -478,7 +478,10 @@ public class OpenSearchExceptionTests extends OpenSearchTestCase {
             "foo",
             new OpenSearchException(
                 "bar",
-                new OpenSearchException("baz", new ClusterBlockException(singleton(NoClusterManagerBlockService.NO_MASTER_BLOCK_WRITES)))
+                new OpenSearchException(
+                    "baz",
+                    new ClusterBlockException(singleton(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_WRITES))
+                )
             )
         );
         e.addHeader("foo_0", "0");
@@ -1032,7 +1035,7 @@ public class OpenSearchExceptionTests extends OpenSearchTestCase {
         int type = randomIntBetween(0, 5);
         switch (type) {
             case 0:
-                actual = new ClusterBlockException(singleton(NoClusterManagerBlockService.NO_MASTER_BLOCK_WRITES));
+                actual = new ClusterBlockException(singleton(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_WRITES));
                 expected = new OpenSearchException(
                     "OpenSearch exception [type=cluster_block_exception, "
                         + "reason=blocked by: [SERVICE_UNAVAILABLE/2/no cluster-manager];]"

--- a/server/src/test/java/org/opensearch/action/resync/TransportResyncReplicationActionTests.java
+++ b/server/src/test/java/org/opensearch/action/resync/TransportResyncReplicationActionTests.java
@@ -116,7 +116,7 @@ public class TransportResyncReplicationActionTests extends OpenSearchTestCase {
                 ClusterState.builder(clusterService.state())
                     .blocks(
                         ClusterBlocks.builder()
-                            .addGlobalBlock(NoClusterManagerBlockService.NO_MASTER_BLOCK_ALL)
+                            .addGlobalBlock(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ALL)
                             .addIndexBlock(indexName, IndexMetadata.INDEX_WRITE_BLOCK)
                     )
             );

--- a/server/src/test/java/org/opensearch/cluster/InternalClusterInfoServiceSchedulingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/InternalClusterInfoServiceSchedulingTests.java
@@ -210,7 +210,9 @@ public class InternalClusterInfoServiceSchedulingTests extends OpenSearchTestCas
                 requestCount++;
                 // ClusterInfoService handles ClusterBlockExceptions quietly, so we invent such an exception to avoid excess logging
                 listener.onFailure(
-                    new ClusterBlockException(org.opensearch.common.collect.Set.of(NoClusterManagerBlockService.NO_MASTER_BLOCK_ALL))
+                    new ClusterBlockException(
+                        org.opensearch.common.collect.Set.of(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ALL)
+                    )
                 );
             } else {
                 fail("unexpected action: " + action.name());

--- a/server/src/test/java/org/opensearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/CoordinatorTests.java
@@ -82,10 +82,10 @@ import static org.opensearch.cluster.coordination.FollowersChecker.FOLLOWER_CHEC
 import static org.opensearch.cluster.coordination.LeaderChecker.LEADER_CHECK_INTERVAL_SETTING;
 import static org.opensearch.cluster.coordination.LeaderChecker.LEADER_CHECK_RETRY_COUNT_SETTING;
 import static org.opensearch.cluster.coordination.LeaderChecker.LEADER_CHECK_TIMEOUT_SETTING;
-import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_MASTER_BLOCK_ALL;
-import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_MASTER_BLOCK_METADATA_WRITES;
+import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ALL;
+import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_METADATA_WRITES;
 import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_SETTING;
-import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_MASTER_BLOCK_WRITES;
+import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_WRITES;
 import static org.opensearch.cluster.coordination.Reconfigurator.CLUSTER_AUTO_SHRINK_VOTING_CONFIGURATION;
 import static org.opensearch.discovery.PeerFinder.DISCOVERY_FIND_PEERS_INTERVAL_SETTING;
 import static org.opensearch.monitor.StatusInfo.Status.HEALTHY;
@@ -1122,19 +1122,19 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
     }
 
     public void testAppliesNoClusterManagerBlockWritesByDefault() {
-        testAppliesNoClusterManagerBlock(null, NO_MASTER_BLOCK_WRITES);
+        testAppliesNoClusterManagerBlock(null, NO_CLUSTER_MANAGER_BLOCK_WRITES);
     }
 
     public void testAppliesNoClusterManagerBlockWritesIfConfigured() {
-        testAppliesNoClusterManagerBlock("write", NO_MASTER_BLOCK_WRITES);
+        testAppliesNoClusterManagerBlock("write", NO_CLUSTER_MANAGER_BLOCK_WRITES);
     }
 
     public void testAppliesNoClusterManagerBlockAllIfConfigured() {
-        testAppliesNoClusterManagerBlock("all", NO_MASTER_BLOCK_ALL);
+        testAppliesNoClusterManagerBlock("all", NO_CLUSTER_MANAGER_BLOCK_ALL);
     }
 
     public void testAppliesNoClusterManagerBlockMetadataWritesIfConfigured() {
-        testAppliesNoClusterManagerBlock("metadata_write", NO_MASTER_BLOCK_METADATA_WRITES);
+        testAppliesNoClusterManagerBlock("metadata_write", NO_CLUSTER_MANAGER_BLOCK_METADATA_WRITES);
     }
 
     private void testAppliesNoClusterManagerBlock(String noClusterManagerBlockSetting, ClusterBlock expectedBlock) {

--- a/server/src/test/java/org/opensearch/cluster/coordination/NoClusterManagerBlockServiceRenamedSettingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/NoClusterManagerBlockServiceRenamedSettingTests.java
@@ -56,7 +56,7 @@ public class NoClusterManagerBlockServiceRenamedSettingTests extends OpenSearchT
     public void testSettingGetValue() {
         Settings settings = Settings.builder().put("cluster.no_cluster_manager_block", "all").build();
         assertEquals(
-            NoClusterManagerBlockService.NO_MASTER_BLOCK_ALL,
+            NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ALL,
             NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_SETTING.get(settings)
         );
         assertEquals(
@@ -71,7 +71,7 @@ public class NoClusterManagerBlockServiceRenamedSettingTests extends OpenSearchT
     public void testSettingGetValueWithFallback() {
         Settings settings = Settings.builder().put("cluster.no_master_block", "metadata_write").build();
         assertEquals(
-            NoClusterManagerBlockService.NO_MASTER_BLOCK_METADATA_WRITES,
+            NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_METADATA_WRITES,
             NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_SETTING.get(settings)
         );
         assertSettingDeprecationsAndWarnings(new Setting<?>[] { NoClusterManagerBlockService.NO_MASTER_BLOCK_SETTING });
@@ -86,11 +86,11 @@ public class NoClusterManagerBlockServiceRenamedSettingTests extends OpenSearchT
             .put("cluster.no_master_block", "metadata_write")
             .build();
         assertEquals(
-            NoClusterManagerBlockService.NO_MASTER_BLOCK_ALL,
+            NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ALL,
             NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_SETTING.get(settings)
         );
         assertEquals(
-            NoClusterManagerBlockService.NO_MASTER_BLOCK_METADATA_WRITES,
+            NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_METADATA_WRITES,
             NoClusterManagerBlockService.NO_MASTER_BLOCK_SETTING.get(settings)
         );
         assertSettingDeprecationsAndWarnings(new Setting<?>[] { NoClusterManagerBlockService.NO_MASTER_BLOCK_SETTING });

--- a/server/src/test/java/org/opensearch/cluster/coordination/NoClusterManagerBlockServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/NoClusterManagerBlockServiceTests.java
@@ -35,10 +35,10 @@ import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 
-import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_MASTER_BLOCK_ALL;
-import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_MASTER_BLOCK_METADATA_WRITES;
+import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ALL;
+import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_METADATA_WRITES;
 import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_SETTING;
-import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_MASTER_BLOCK_WRITES;
+import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_WRITES;
 import static org.opensearch.common.settings.ClusterSettings.BUILT_IN_CLUSTER_SETTINGS;
 import static org.hamcrest.Matchers.sameInstance;
 
@@ -61,22 +61,22 @@ public class NoClusterManagerBlockServiceTests extends OpenSearchTestCase {
 
     public void testBlocksWritesByDefault() {
         createService(Settings.EMPTY);
-        assertThat(noClusterManagerBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_METADATA_WRITES));
+        assertThat(noClusterManagerBlockService.getNoClusterManagerBlock(), sameInstance(NO_CLUSTER_MANAGER_BLOCK_METADATA_WRITES));
     }
 
     public void testBlocksWritesIfConfiguredBySetting() {
         createService(Settings.builder().put(NO_CLUSTER_MANAGER_BLOCK_SETTING.getKey(), "write").build());
-        assertThat(noClusterManagerBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_WRITES));
+        assertThat(noClusterManagerBlockService.getNoClusterManagerBlock(), sameInstance(NO_CLUSTER_MANAGER_BLOCK_WRITES));
     }
 
     public void testBlocksAllIfConfiguredBySetting() {
         createService(Settings.builder().put(NO_CLUSTER_MANAGER_BLOCK_SETTING.getKey(), "all").build());
-        assertThat(noClusterManagerBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_ALL));
+        assertThat(noClusterManagerBlockService.getNoClusterManagerBlock(), sameInstance(NO_CLUSTER_MANAGER_BLOCK_ALL));
     }
 
     public void testBlocksMetadataWritesIfConfiguredBySetting() {
         createService(Settings.builder().put(NO_CLUSTER_MANAGER_BLOCK_SETTING.getKey(), "metadata_write").build());
-        assertThat(noClusterManagerBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_METADATA_WRITES));
+        assertThat(noClusterManagerBlockService.getNoClusterManagerBlock(), sameInstance(NO_CLUSTER_MANAGER_BLOCK_METADATA_WRITES));
     }
 
     public void testRejectsInvalidSetting() {
@@ -88,12 +88,12 @@ public class NoClusterManagerBlockServiceTests extends OpenSearchTestCase {
 
     public void testSettingCanBeUpdated() {
         createService(Settings.builder().put(NO_CLUSTER_MANAGER_BLOCK_SETTING.getKey(), "all").build());
-        assertThat(noClusterManagerBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_ALL));
+        assertThat(noClusterManagerBlockService.getNoClusterManagerBlock(), sameInstance(NO_CLUSTER_MANAGER_BLOCK_ALL));
 
         clusterSettings.applySettings(Settings.builder().put(NO_CLUSTER_MANAGER_BLOCK_SETTING.getKey(), "write").build());
-        assertThat(noClusterManagerBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_WRITES));
+        assertThat(noClusterManagerBlockService.getNoClusterManagerBlock(), sameInstance(NO_CLUSTER_MANAGER_BLOCK_WRITES));
 
         clusterSettings.applySettings(Settings.builder().put(NO_CLUSTER_MANAGER_BLOCK_SETTING.getKey(), "metadata_write").build());
-        assertThat(noClusterManagerBlockService.getNoMasterBlock(), sameInstance(NO_MASTER_BLOCK_METADATA_WRITES));
+        assertThat(noClusterManagerBlockService.getNoClusterManagerBlock(), sameInstance(NO_CLUSTER_MANAGER_BLOCK_METADATA_WRITES));
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/service/ClusterApplierServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/service/ClusterApplierServiceTests.java
@@ -319,7 +319,7 @@ public class ClusterApplierServiceTests extends OpenSearchTestCase {
         nodes = state.nodes();
         nodesBuilder = DiscoveryNodes.builder(nodes).clusterManagerNodeId(null);
         state = ClusterState.builder(state)
-            .blocks(ClusterBlocks.builder().addGlobalBlock(NoClusterManagerBlockService.NO_MASTER_BLOCK_WRITES))
+            .blocks(ClusterBlocks.builder().addGlobalBlock(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_WRITES))
             .nodes(nodesBuilder)
             .build();
         setState(timedClusterApplierService, state);

--- a/server/src/test/java/org/opensearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/service/MasterServiceTests.java
@@ -92,6 +92,7 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
 
 public class MasterServiceTests extends OpenSearchTestCase {
 
@@ -1096,6 +1097,18 @@ public class MasterServiceTests extends OpenSearchTestCase {
                 latch.await();
             }
         }
+    }
+
+    public void testDeprecatedMasterServiceUpdateTaskThreadName() {
+        Thread.currentThread().setName(MasterService.MASTER_UPDATE_THREAD_NAME);
+        assertThat(MasterService.assertClusterManagerUpdateThread(), is(Boolean.TRUE));
+        assertThrows(AssertionError.class, () -> MasterService.assertNotClusterManagerUpdateThread("test"));
+        Thread.currentThread().setName(MasterService.CLUSTER_MANAGER_UPDATE_THREAD_NAME);
+        assertThat(MasterService.assertClusterManagerUpdateThread(), is(Boolean.TRUE));
+        assertThrows(AssertionError.class, () -> MasterService.assertNotClusterManagerUpdateThread("test"));
+        Thread.currentThread().setName("test not cluster manager update thread");
+        assertThat(MasterService.assertNotClusterManagerUpdateThread("test"), is(Boolean.TRUE));
+        assertThrows(AssertionError.class, () -> MasterService.assertClusterManagerUpdateThread());
     }
 
     /**

--- a/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
+++ b/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
@@ -370,22 +370,26 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
         Supplier<MockIndicesService> indicesServiceSupplier
     ) {
         // randomly remove no_cluster_manager blocks
-        if (randomBoolean() && state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID)) {
+        if (randomBoolean() && state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID)) {
             state = ClusterState.builder(state)
-                .blocks(ClusterBlocks.builder().blocks(state.blocks()).removeGlobalBlock(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID))
+                .blocks(
+                    ClusterBlocks.builder()
+                        .blocks(state.blocks())
+                        .removeGlobalBlock(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID)
+                )
                 .build();
         }
 
         // randomly add no_cluster_manager blocks
-        if (rarely() && state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID) == false) {
+        if (rarely() && state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID) == false) {
             ClusterBlock block = randomBoolean()
-                ? NoClusterManagerBlockService.NO_MASTER_BLOCK_ALL
-                : NoClusterManagerBlockService.NO_MASTER_BLOCK_WRITES;
+                ? NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ALL
+                : NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_WRITES;
             state = ClusterState.builder(state).blocks(ClusterBlocks.builder().blocks(state.blocks()).addGlobalBlock(block)).build();
         }
 
         // if no_cluster_manager block is in place, make no other cluster state changes
-        if (state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_MASTER_BLOCK_ID)) {
+        if (state.blocks().hasGlobalBlockWithId(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID)) {
             return state;
         }
 

--- a/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -139,7 +139,7 @@ import static org.opensearch.cluster.coordination.FollowersChecker.FOLLOWER_CHEC
 import static org.opensearch.cluster.coordination.LeaderChecker.LEADER_CHECK_INTERVAL_SETTING;
 import static org.opensearch.cluster.coordination.LeaderChecker.LEADER_CHECK_RETRY_COUNT_SETTING;
 import static org.opensearch.cluster.coordination.LeaderChecker.LEADER_CHECK_TIMEOUT_SETTING;
-import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_MASTER_BLOCK_ID;
+import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID;
 import static org.opensearch.cluster.coordination.Reconfigurator.CLUSTER_AUTO_SHRINK_VOTING_CONFIGURATION;
 import static org.opensearch.discovery.PeerFinder.DISCOVERY_FIND_PEERS_INTERVAL_SETTING;
 import static org.opensearch.gateway.GatewayService.STATE_NOT_RECOVERED_BLOCK;
@@ -567,7 +567,7 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
             assertTrue(leaderId + " exists in its last-applied state", leader.getLastAppliedClusterState().getNodes().nodeExists(leaderId));
             assertThat(
                 leaderId + " has no NO_CLUSTER_MANAGER_BLOCK",
-                leader.getLastAppliedClusterState().blocks().hasGlobalBlockWithId(NO_MASTER_BLOCK_ID),
+                leader.getLastAppliedClusterState().blocks().hasGlobalBlockWithId(NO_CLUSTER_MANAGER_BLOCK_ID),
                 equalTo(false)
             );
             assertThat(
@@ -622,7 +622,7 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                     );
                     assertThat(
                         nodeId + " has no NO_CLUSTER_MANAGER_BLOCK",
-                        clusterNode.getLastAppliedClusterState().blocks().hasGlobalBlockWithId(NO_MASTER_BLOCK_ID),
+                        clusterNode.getLastAppliedClusterState().blocks().hasGlobalBlockWithId(NO_CLUSTER_MANAGER_BLOCK_ID),
                         equalTo(false)
                     );
                     assertThat(
@@ -639,7 +639,7 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                     );
                     assertThat(
                         nodeId + " has NO_CLUSTER_MANAGER_BLOCK",
-                        clusterNode.getLastAppliedClusterState().blocks().hasGlobalBlockWithId(NO_MASTER_BLOCK_ID),
+                        clusterNode.getLastAppliedClusterState().blocks().hasGlobalBlockWithId(NO_CLUSTER_MANAGER_BLOCK_ID),
                         equalTo(true)
                     );
                     assertFalse(

--- a/test/framework/src/main/java/org/opensearch/test/RandomObjects.java
+++ b/test/framework/src/main/java/org/opensearch/test/RandomObjects.java
@@ -331,7 +331,7 @@ public final class RandomObjects {
         int type = randomIntBetween(random, 0, 3);
         switch (type) {
             case 0:
-                actualException = new ClusterBlockException(singleton(NoClusterManagerBlockService.NO_MASTER_BLOCK_WRITES));
+                actualException = new ClusterBlockException(singleton(NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_WRITES));
                 expectedException = new OpenSearchException(
                     "OpenSearch exception [type=cluster_block_exception, "
                         + "reason=blocked by: [SERVICE_UNAVAILABLE/2/no cluster-manager];]"


### PR DESCRIPTION
### Description
To support inclusive language, the `master` terminology is going to be replaced by `cluster manager` in the code base.

- Deprecated public methods and variables in class `NoMasterBlockService` and `MasterService`, and created alternative methods or variables.
- A unit test is added to validate the change of thread name that identifies the thread running update task for MasterService.

List of public methods and variables that deprecated.
In class `NoMasterBlockService`:
```
int NO_MASTER_BLOCK_ID
ClusterBlock NO_MASTER_BLOCK_WRITES
ClusterBlock NO_MASTER_BLOCK_ALL
ClusterBlock NO_MASTER_BLOCK_METADATA_WRITES
ClusterBlock getNoMasterBlock()
```

In class `MasterService`:
```
String MASTER_UPDATE_THREAD_NAME
boolean assertMasterUpdateThread()
boolean assertNotMasterUpdateThread(String reason)
```
 
### Issues Resolved
A part of issue https://github.com/opensearch-project/OpenSearch/issues/3543
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
