### PR TITLE
Use bash in systemd-entrypoint shebang

### DIFF
--- a/distribution/packages/src/common/systemd/systemd-entrypoint
+++ b/distribution/packages/src/common/systemd/systemd-entrypoint
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # This wrapper script allows SystemD to feed a file containing a passphrase into
 # the main OpenSearch startup script


### PR DESCRIPTION
### Description
Uses a shell environment where `-o pipefail` is available.

### Issues Resolved
Closes #4005
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).