### PR TITLE
[Backport] [2.x] Update merge on refresh and merge on commit defaults in Opensearch (Lucene 9.3) (#3561)

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -193,6 +193,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING,
                 IndexSettings.INDEX_MERGE_ON_FLUSH_ENABLED,
                 IndexSettings.INDEX_MERGE_ON_FLUSH_MAX_FULL_FLUSH_MERGE_WAIT_TIME,
+                IndexSettings.INDEX_MERGE_ON_FLUSH_POLICY,
 
                 // validate that built-in similarities don't get redefined
                 Setting.groupSetting("index.similarity.", (s) -> {

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -32,11 +32,12 @@
 package org.opensearch.index;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.util.Strings;
 import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.sandbox.index.MergeOnFlushMergePolicy;
 import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.Strings;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Setting;
@@ -53,9 +54,11 @@ import org.opensearch.node.Node;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import static org.opensearch.index.mapper.MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING;
 import static org.opensearch.index.mapper.MapperService.INDEX_MAPPING_FIELD_NAME_LENGTH_LIMIT_SETTING;
@@ -73,6 +76,9 @@ import static org.opensearch.index.mapper.MapperService.INDEX_MAPPING_TOTAL_FIEL
  * @opensearch.internal
  */
 public final class IndexSettings {
+    private static final String MERGE_ON_FLUSH_DEFAULT_POLICY = "default";
+    private static final String MERGE_ON_FLUSH_MERGE_POLICY = "merge-on-flush";
+
     public static final Setting<List<String>> DEFAULT_FIELD_SETTING = Setting.listSetting(
         "index.query.default_field",
         Collections.singletonList("*"),
@@ -515,14 +521,21 @@ public final class IndexSettings {
     public static final Setting<TimeValue> INDEX_MERGE_ON_FLUSH_MAX_FULL_FLUSH_MERGE_WAIT_TIME = Setting.timeSetting(
         "index.merge_on_flush.max_full_flush_merge_wait_time",
         new TimeValue(10, TimeUnit.SECONDS),
-        new TimeValue(0, TimeUnit.MILLISECONDS),
+        new TimeValue(1, TimeUnit.MILLISECONDS),
         Property.Dynamic,
         Property.IndexScope
     );
 
     public static final Setting<Boolean> INDEX_MERGE_ON_FLUSH_ENABLED = Setting.boolSetting(
         "index.merge_on_flush.enabled",
-        false,
+        true, /* https://issues.apache.org/jira/browse/LUCENE-10078 */
+        Property.IndexScope,
+        Property.Dynamic
+    );
+
+    public static final Setting<String> INDEX_MERGE_ON_FLUSH_POLICY = Setting.simpleString(
+        "index.merge_on_flush.policy",
+        MERGE_ON_FLUSH_DEFAULT_POLICY,
         Property.IndexScope,
         Property.Dynamic
     );
@@ -617,6 +630,10 @@ public final class IndexSettings {
      * Is merge of flush enabled or not
      */
     private volatile boolean mergeOnFlushEnabled;
+    /**
+     * Specialized merge-on-flush policy if provided
+     */
+    private volatile UnaryOperator<MergePolicy> mergeOnFlushPolicy;
 
     /**
      * Returns the default search fields for this index.
@@ -733,6 +750,7 @@ public final class IndexSettings {
         mappingFieldNameLengthLimit = scopedSettings.get(INDEX_MAPPING_FIELD_NAME_LENGTH_LIMIT_SETTING);
         maxFullFlushMergeWaitTime = scopedSettings.get(INDEX_MERGE_ON_FLUSH_MAX_FULL_FLUSH_MERGE_WAIT_TIME);
         mergeOnFlushEnabled = scopedSettings.get(INDEX_MERGE_ON_FLUSH_ENABLED);
+        setMergeOnFlushPolicy(scopedSettings.get(INDEX_MERGE_ON_FLUSH_POLICY));
 
         scopedSettings.addSettingsUpdateConsumer(MergePolicyConfig.INDEX_COMPOUND_FORMAT_SETTING, mergePolicyConfig::setNoCFSRatio);
         scopedSettings.addSettingsUpdateConsumer(
@@ -804,6 +822,7 @@ public final class IndexSettings {
         scopedSettings.addSettingsUpdateConsumer(INDEX_MAPPING_FIELD_NAME_LENGTH_LIMIT_SETTING, this::setMappingFieldNameLengthLimit);
         scopedSettings.addSettingsUpdateConsumer(INDEX_MERGE_ON_FLUSH_MAX_FULL_FLUSH_MERGE_WAIT_TIME, this::setMaxFullFlushMergeWaitTime);
         scopedSettings.addSettingsUpdateConsumer(INDEX_MERGE_ON_FLUSH_ENABLED, this::setMergeOnFlushEnabled);
+        scopedSettings.addSettingsUpdateConsumer(INDEX_MERGE_ON_FLUSH_POLICY, this::setMergeOnFlushPolicy);
     }
 
     private void setSearchIdleAfter(TimeValue searchIdleAfter) {
@@ -874,7 +893,7 @@ public final class IndexSettings {
      * Returns <code>true</code> if the index has a custom data path
      */
     public boolean hasCustomDataPath() {
-        return Strings.isNotEmpty(customDataPath());
+        return !Strings.isEmpty(customDataPath());
     }
 
     /**
@@ -1389,5 +1408,28 @@ public final class IndexSettings {
 
     public boolean isMergeOnFlushEnabled() {
         return mergeOnFlushEnabled;
+    }
+
+    private void setMergeOnFlushPolicy(String policy) {
+        if (Strings.isEmpty(policy) || MERGE_ON_FLUSH_DEFAULT_POLICY.equalsIgnoreCase(policy)) {
+            mergeOnFlushPolicy = null;
+        } else if (MERGE_ON_FLUSH_MERGE_POLICY.equalsIgnoreCase(policy)) {
+            this.mergeOnFlushPolicy = MergeOnFlushMergePolicy::new;
+        } else {
+            throw new IllegalArgumentException(
+                "The "
+                    + IndexSettings.INDEX_MERGE_ON_FLUSH_POLICY.getKey()
+                    + " has unsupported policy specified: "
+                    + policy
+                    + ". Please use one of: "
+                    + MERGE_ON_FLUSH_DEFAULT_POLICY
+                    + ", "
+                    + MERGE_ON_FLUSH_MERGE_POLICY
+            );
+        }
+    }
+
+    public Optional<UnaryOperator<MergePolicy>> getMergeOnFlushPolicy() {
+        return Optional.ofNullable(mergeOnFlushPolicy);
     }
 }

--- a/server/src/test/java/org/opensearch/common/lucene/LuceneTests.java
+++ b/server/src/test/java/org/opensearch/common/lucene/LuceneTests.java
@@ -590,10 +590,8 @@ public class LuceneTests extends OpenSearchTestCase {
     public void testWrapLiveDocsNotExposeAbortedDocuments() throws Exception {
         Directory dir = newDirectory();
         IndexWriterConfig config = newIndexWriterConfig().setSoftDeletesField(Lucene.SOFT_DELETES_FIELD)
-            .setMergePolicy(new SoftDeletesRetentionMergePolicy(Lucene.SOFT_DELETES_FIELD, MatchAllDocsQuery::new, newMergePolicy()));
-        // override 500ms default introduced in
-        // https://issues.apache.org/jira/browse/LUCENE-10078
-        config.setMaxFullFlushMergeWaitMillis(0);
+            .setMergePolicy(new SoftDeletesRetentionMergePolicy(Lucene.SOFT_DELETES_FIELD, MatchAllDocsQuery::new, newMergePolicy()))
+            .setMaxFullFlushMergeWaitMillis(0);
         IndexWriter writer = new IndexWriter(dir, config);
         int numDocs = between(1, 10);
         List<String> liveDocs = new ArrayList<>();

--- a/server/src/test/java/org/opensearch/index/shard/ShardGetServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/ShardGetServiceTests.java
@@ -56,7 +56,6 @@ public class ShardGetServiceTests extends IndexShardTestCase {
             .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-
             .build();
         IndexMetadata metadata = IndexMetadata.builder("test")
             .putMapping("{ \"properties\": { \"foo\":  { \"type\": \"text\"}}}")


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Manual backport of https://github.com/opensearch-project/OpenSearch/pull/3561 to `2.x` (automatic one failed).
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/3553
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
