### PR TITLE
[Feature/extensions] UserIdentity object for OpenSearch permissions and access

### DIFF
--- a/server/src/main/java/org/opensearch/identity/Identity.java
+++ b/server/src/main/java/org/opensearch/identity/Identity.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.identity;
+
+/**
+ * The distinguishing character or personality of an entity within OpenSearch.
+ */
+public interface Identity {
+
+    /** A durable, reusable identifier of this identity */
+ 
+    String getId();
+}

--- a/server/src/main/java/org/opensearch/identity/UserIdentity.java
+++ b/server/src/main/java/org/opensearch/identity/UserIdentity.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.identity;
+
+import java.util.List;
+
+/**
+ * An authenticated user in the system.
+ */
+public class UserIdentity implements Identity {
+
+    /** No identity information or identity information is unavaliable */
+    public static final AnonymousUser ANONYMOUS = new AnonymousUser();
+
+    /** A persistant identifier that is unqiue to the user */
+    private String id;
+
+    public UserIdentity(final String id) {
+        this.id = id;
+    }
+
+    /** A durable and reusable identifier of this user */
+    public String getId() {
+        return this.id;
+    }
+
+    /** No identity information or identity information is unavaliable */
+    public static final class AnonymousUser extends UserIdentity {
+        static final String ID = "Anonymous";
+        protected AnonymousUser() {
+            super(AnonymousUser.ID);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof AnonymousUser;
+        }
+
+        @Override
+        public int hashCode() {
+            return getId().hashCode();
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/identity/package-info.java
+++ b/server/src/main/java/org/opensearch/identity/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** OpenSearch Identity Classes. */
+package org.opensearch.identity;

--- a/server/src/test/java/org/opensearch/identity/UserIdentityTests.java
+++ b/server/src/test/java/org/opensearch/identity/UserIdentityTests.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.identity;
+
+import org.junit.Test;
+import org.opensearch.identity.UserIdentity.AnonymousUser;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+
+public class UserIdentityTests {
+
+    @Test
+    public void testGetIds() {
+        final String idOfSally = "Sally";
+        final UserIdentity sally = new UserIdentity(idOfSally);
+        
+        assertThat(sally.getId(), equalTo(idOfSally));
+    }
+
+    @Test
+    public void testUserVsAnonymous() {
+        final UserIdentity sally = new UserIdentity("Sally");
+
+        assertThat(sally, not(equalTo(UserIdentity.ANONYMOUS)));
+        assertThat(UserIdentity.ANONYMOUS, not(equalTo(sally)));
+    }
+
+    @Test
+    public void testEquality() {
+        final UserIdentity sally = new UserIdentity("Sally");
+        final UserIdentity bob = new UserIdentity("Bob");
+
+        assertThat(sally, not(equalTo(bob)));
+    }
+
+    @Test
+    public void testAnonymousGetId() {
+        assertThat(UserIdentity.ANONYMOUS.getId(), equalTo(AnonymousUser.ID));
+    }
+
+    @Test
+    public void testAnonymousEquality() {
+        final Identity blankIdentity = new Identity() {
+            @Override
+            public String getId() { return null; }
+        };
+    
+        final Identity otherIdentity = new Identity() {
+            @Override
+            public String getId() { return "other"; }
+        };
+    
+        assertThat(UserIdentity.ANONYMOUS, equalTo(UserIdentity.ANONYMOUS));
+        assertThat(UserIdentity.ANONYMOUS, not(equalTo(blankIdentity)));
+        assertThat(UserIdentity.ANONYMOUS, not(equalTo(otherIdentity)));
+    }
+}

--- a/server/src/test/java/org/opensearch/identity/UserIdentityTests.java
+++ b/server/src/test/java/org/opensearch/identity/UserIdentityTests.java
@@ -11,7 +11,6 @@
 
 package org.opensearch.identity;
 
-import org.junit.Test;
 import org.opensearch.identity.UserIdentity.AnonymousUser;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -20,7 +19,6 @@ import static org.hamcrest.core.IsNot.not;
 
 public class UserIdentityTests {
 
-    @Test
     public void testGetIds() {
         final String idOfSally = "Sally";
         final UserIdentity sally = new UserIdentity(idOfSally);
@@ -28,7 +26,6 @@ public class UserIdentityTests {
         assertThat(sally.getId(), equalTo(idOfSally));
     }
 
-    @Test
     public void testUserVsAnonymous() {
         final UserIdentity sally = new UserIdentity("Sally");
 
@@ -36,7 +33,6 @@ public class UserIdentityTests {
         assertThat(UserIdentity.ANONYMOUS, not(equalTo(sally)));
     }
 
-    @Test
     public void testEquality() {
         final UserIdentity sally = new UserIdentity("Sally");
         final UserIdentity bob = new UserIdentity("Bob");
@@ -44,12 +40,10 @@ public class UserIdentityTests {
         assertThat(sally, not(equalTo(bob)));
     }
 
-    @Test
     public void testAnonymousGetId() {
         assertThat(UserIdentity.ANONYMOUS.getId(), equalTo(AnonymousUser.ID));
     }
 
-    @Test
     public void testAnonymousEquality() {
         final Identity blankIdentity = new Identity() {
             @Override


### PR DESCRIPTION
### Description
Adding basic identity objects for OpenSearch, unifying all identity details within core.
 
### Issues Resolved
* Related https://github.com/opensearch-project/OpenSearch/issues/3846
* Related https://github.com/opensearch-project/opensearch-sdk/issues/37
* Design documentation https://github.com/opensearch-project/opensearch-sdk/blob/main/SECURITY.md#projects
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
