### PR TITLE
Deprecate and Rename abstract methods from 'Master' terminology to 'ClusterManager'.

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/repositories/RepositoryBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/repositories/RepositoryBlocksIT.java
@@ -97,7 +97,7 @@ public class RepositoryBlocksIT extends OpenSearchIntegTestCase {
                 .prepareVerifyRepository("test-repo-blocks")
                 .execute()
                 .actionGet();
-            assertThat(response.getNodes().size(), equalTo(cluster().numDataAndMasterNodes()));
+            assertThat(response.getNodes().size(), equalTo(cluster().numDataAndClusterManagerNodes()));
         } finally {
             setClusterReadOnly(false);
         }

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/snapshots/SnapshotBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/snapshots/SnapshotBlocksIT.java
@@ -92,7 +92,7 @@ public class SnapshotBlocksIT extends OpenSearchIntegTestCase {
 
         logger.info("--> verify the repository");
         VerifyRepositoryResponse verifyResponse = client().admin().cluster().prepareVerifyRepository(REPOSITORY_NAME).get();
-        assertThat(verifyResponse.getNodes().size(), equalTo(cluster().numDataAndMasterNodes()));
+        assertThat(verifyResponse.getNodes().size(), equalTo(cluster().numDataAndClusterManagerNodes()));
 
         logger.info("--> create a snapshot");
         CreateSnapshotResponse snapshotResponse = client().admin()

--- a/server/src/internalClusterTest/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryCleanupIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryCleanupIT.java
@@ -54,7 +54,7 @@ public class BlobStoreRepositoryCleanupIT extends AbstractSnapshotIntegTestCase 
     public void testClusterManagerFailoverDuringCleanup() throws Exception {
         startBlockedCleanup("test-repo");
 
-        final int nodeCount = internalCluster().numDataAndMasterNodes();
+        final int nodeCount = internalCluster().numDataAndClusterManagerNodes();
         logger.info("-->  stopping cluster-manager node");
         internalCluster().stopCurrentClusterManagerNode();
 

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/RepositoriesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/RepositoriesIT.java
@@ -74,7 +74,7 @@ public class RepositoriesIT extends AbstractSnapshotIntegTestCase {
         logger.info("--> verify the repository");
         int numberOfFiles = FileSystemUtils.files(location).length;
         VerifyRepositoryResponse verifyRepositoryResponse = client.admin().cluster().prepareVerifyRepository("test-repo-1").get();
-        assertThat(verifyRepositoryResponse.getNodes().size(), equalTo(cluster().numDataAndMasterNodes()));
+        assertThat(verifyRepositoryResponse.getNodes().size(), equalTo(cluster().numDataAndClusterManagerNodes()));
 
         logger.info("--> verify that we didn't leave any files as a result of verification");
         assertThat(FileSystemUtils.files(location).length, equalTo(numberOfFiles));

--- a/server/src/main/java/org/opensearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
@@ -125,7 +125,7 @@ public class TransportClusterAllocationExplainAction extends TransportClusterMan
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final ClusterAllocationExplainRequest request,
         final ClusterState state,
         final ActionListener<ClusterAllocationExplainResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsAction.java
@@ -126,7 +126,7 @@ public class TransportAddVotingConfigExclusionsAction extends TransportClusterMa
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         AddVotingConfigExclusionsRequest request,
         ClusterState state,
         ActionListener<AddVotingConfigExclusionsResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsAction.java
@@ -101,7 +101,7 @@ public class TransportClearVotingConfigExclusionsAction extends TransportCluster
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         ClearVotingConfigExclusionsRequest request,
         ClusterState initialState,
         ActionListener<ClearVotingConfigExclusionsResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -118,14 +118,17 @@ public class TransportClusterHealthAction extends TransportClusterManagerNodeRea
     }
 
     @Override
-    protected final void masterOperation(ClusterHealthRequest request, ClusterState state, ActionListener<ClusterHealthResponse> listener)
-        throws Exception {
+    protected final void clusterManagerOperation(
+        ClusterHealthRequest request,
+        ClusterState state,
+        ActionListener<ClusterHealthResponse> listener
+    ) throws Exception {
         logger.warn("attempt to execute a cluster health operation without a task");
         throw new UnsupportedOperationException("task parameter is required for this operation");
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final Task task,
         final ClusterHealthRequest request,
         final ClusterState unusedState,

--- a/server/src/main/java/org/opensearch/action/admin/cluster/repositories/cleanup/TransportCleanupRepositoryAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/repositories/cleanup/TransportCleanupRepositoryAction.java
@@ -174,7 +174,7 @@ public final class TransportCleanupRepositoryAction extends TransportClusterMana
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         CleanupRepositoryRequest request,
         ClusterState state,
         ActionListener<CleanupRepositoryResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/cluster/repositories/delete/TransportDeleteRepositoryAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/repositories/delete/TransportDeleteRepositoryAction.java
@@ -95,7 +95,7 @@ public class TransportDeleteRepositoryAction extends TransportClusterManagerNode
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final DeleteRepositoryRequest request,
         ClusterState state,
         final ActionListener<AcknowledgedResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/cluster/repositories/get/TransportGetRepositoriesAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/repositories/get/TransportGetRepositoriesAction.java
@@ -99,7 +99,7 @@ public class TransportGetRepositoriesAction extends TransportClusterManagerNodeR
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final GetRepositoriesRequest request,
         ClusterState state,
         final ActionListener<GetRepositoriesResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/cluster/repositories/put/TransportPutRepositoryAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/repositories/put/TransportPutRepositoryAction.java
@@ -95,7 +95,7 @@ public class TransportPutRepositoryAction extends TransportClusterManagerNodeAct
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final PutRepositoryRequest request,
         ClusterState state,
         final ActionListener<AcknowledgedResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/cluster/repositories/verify/TransportVerifyRepositoryAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/repositories/verify/TransportVerifyRepositoryAction.java
@@ -95,7 +95,7 @@ public class TransportVerifyRepositoryAction extends TransportClusterManagerNode
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final VerifyRepositoryRequest request,
         ClusterState state,
         final ActionListener<VerifyRepositoryResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/reroute/TransportClusterRerouteAction.java
@@ -119,7 +119,7 @@ public class TransportClusterRerouteAction extends TransportClusterManagerNodeAc
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final ClusterRerouteRequest request,
         final ClusterState state,
         final ActionListener<ClusterRerouteResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -124,7 +124,7 @@ public class TransportClusterUpdateSettingsAction extends TransportClusterManage
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final ClusterUpdateSettingsRequest request,
         final ClusterState state,
         final ActionListener<ClusterUpdateSettingsResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
@@ -108,7 +108,7 @@ public class TransportClusterSearchShardsAction extends TransportClusterManagerN
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final ClusterSearchShardsRequest request,
         final ClusterState state,
         final ActionListener<ClusterSearchShardsResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/clone/TransportCloneSnapshotAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/clone/TransportCloneSnapshotAction.java
@@ -90,7 +90,11 @@ public final class TransportCloneSnapshotAction extends TransportClusterManagerN
     }
 
     @Override
-    protected void masterOperation(CloneSnapshotRequest request, ClusterState state, ActionListener<AcknowledgedResponse> listener) {
+    protected void clusterManagerOperation(
+        CloneSnapshotRequest request,
+        ClusterState state,
+        ActionListener<AcknowledgedResponse> listener
+    ) {
         snapshotsService.cloneSnapshot(request, ActionListener.map(listener, v -> new AcknowledgedResponse(true)));
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
@@ -98,7 +98,7 @@ public class TransportCreateSnapshotAction extends TransportClusterManagerNodeAc
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final CreateSnapshotRequest request,
         ClusterState state,
         final ActionListener<CreateSnapshotResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/delete/TransportDeleteSnapshotAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/delete/TransportDeleteSnapshotAction.java
@@ -95,7 +95,7 @@ public class TransportDeleteSnapshotAction extends TransportClusterManagerNodeAc
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final DeleteSnapshotRequest request,
         ClusterState state,
         final ActionListener<AcknowledgedResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -122,7 +122,7 @@ public class TransportGetSnapshotsAction extends TransportClusterManagerNodeActi
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final GetSnapshotsRequest request,
         final ClusterState state,
         final ActionListener<GetSnapshotsResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
@@ -102,7 +102,7 @@ public class TransportRestoreSnapshotAction extends TransportClusterManagerNodeA
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final RestoreSnapshotRequest request,
         final ClusterState state,
         final ActionListener<RestoreSnapshotResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
@@ -136,7 +136,7 @@ public class TransportSnapshotsStatusAction extends TransportClusterManagerNodeA
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final SnapshotsStatusRequest request,
         final ClusterState state,
         final ActionListener<SnapshotsStatusResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -115,7 +115,7 @@ public class TransportClusterStateAction extends TransportClusterManagerNodeRead
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final ClusterStateRequest request,
         final ClusterState state,
         final ActionListener<ClusterStateResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/cluster/storedscripts/TransportDeleteStoredScriptAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/storedscripts/TransportDeleteStoredScriptAction.java
@@ -90,8 +90,11 @@ public class TransportDeleteStoredScriptAction extends TransportClusterManagerNo
     }
 
     @Override
-    protected void masterOperation(DeleteStoredScriptRequest request, ClusterState state, ActionListener<AcknowledgedResponse> listener)
-        throws Exception {
+    protected void clusterManagerOperation(
+        DeleteStoredScriptRequest request,
+        ClusterState state,
+        ActionListener<AcknowledgedResponse> listener
+    ) throws Exception {
         scriptService.deleteStoredScript(clusterService, request, listener);
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/storedscripts/TransportGetStoredScriptAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/storedscripts/TransportGetStoredScriptAction.java
@@ -89,8 +89,11 @@ public class TransportGetStoredScriptAction extends TransportClusterManagerNodeR
     }
 
     @Override
-    protected void masterOperation(GetStoredScriptRequest request, ClusterState state, ActionListener<GetStoredScriptResponse> listener)
-        throws Exception {
+    protected void clusterManagerOperation(
+        GetStoredScriptRequest request,
+        ClusterState state,
+        ActionListener<GetStoredScriptResponse> listener
+    ) throws Exception {
         listener.onResponse(new GetStoredScriptResponse(request.id(), scriptService.getStoredScript(state, request)));
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/storedscripts/TransportPutStoredScriptAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/storedscripts/TransportPutStoredScriptAction.java
@@ -90,8 +90,11 @@ public class TransportPutStoredScriptAction extends TransportClusterManagerNodeA
     }
 
     @Override
-    protected void masterOperation(PutStoredScriptRequest request, ClusterState state, ActionListener<AcknowledgedResponse> listener)
-        throws Exception {
+    protected void clusterManagerOperation(
+        PutStoredScriptRequest request,
+        ClusterState state,
+        ActionListener<AcknowledgedResponse> listener
+    ) throws Exception {
         scriptService.putStoredScript(clusterService, request, listener);
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/tasks/TransportPendingClusterTasksAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/tasks/TransportPendingClusterTasksAction.java
@@ -100,7 +100,7 @@ public class TransportPendingClusterTasksAction extends TransportClusterManagerN
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         PendingClusterTasksRequest request,
         ClusterState state,
         ActionListener<PendingClusterTasksResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -126,7 +126,7 @@ public class TransportIndicesAliasesAction extends TransportClusterManagerNodeAc
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final IndicesAliasesRequest request,
         final ClusterState state,
         final ActionListener<AcknowledgedResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
@@ -112,7 +112,7 @@ public class TransportGetAliasesAction extends TransportClusterManagerNodeReadAc
     }
 
     @Override
-    protected void masterOperation(GetAliasesRequest request, ClusterState state, ActionListener<GetAliasesResponse> listener) {
+    protected void clusterManagerOperation(GetAliasesRequest request, ClusterState state, ActionListener<GetAliasesResponse> listener) {
         String[] concreteIndices;
         // Switch to a context which will drop any deprecation warnings, because there may be indices resolved here which are not
         // returned in the final response. We'll add warnings back later if necessary in checkSystemIndexAccess.

--- a/server/src/main/java/org/opensearch/action/admin/indices/close/TransportCloseIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/close/TransportCloseIndexAction.java
@@ -140,7 +140,7 @@ public class TransportCloseIndexAction extends TransportClusterManagerNodeAction
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final CloseIndexRequest request,
         final ClusterState state,
         final ActionListener<CloseIndexResponse> listener
@@ -149,7 +149,7 @@ public class TransportCloseIndexAction extends TransportClusterManagerNodeAction
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final Task task,
         final CloseIndexRequest request,
         final ClusterState state,

--- a/server/src/main/java/org/opensearch/action/admin/indices/create/AutoCreateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/create/AutoCreateAction.java
@@ -112,7 +112,11 @@ public final class AutoCreateAction extends ActionType<CreateIndexResponse> {
         }
 
         @Override
-        protected void masterOperation(CreateIndexRequest request, ClusterState state, ActionListener<CreateIndexResponse> finalListener) {
+        protected void clusterManagerOperation(
+            CreateIndexRequest request,
+            ClusterState state,
+            ActionListener<CreateIndexResponse> finalListener
+        ) {
             AtomicReference<String> indexNameRef = new AtomicReference<>();
             ActionListener<ClusterStateUpdateResponse> listener = ActionListener.wrap(response -> {
                 String indexName = indexNameRef.get();

--- a/server/src/main/java/org/opensearch/action/admin/indices/create/TransportCreateIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/create/TransportCreateIndexAction.java
@@ -95,7 +95,7 @@ public class TransportCreateIndexAction extends TransportClusterManagerNodeActio
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final CreateIndexRequest request,
         final ClusterState state,
         final ActionListener<CreateIndexResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/dangling/delete/TransportDeleteDanglingIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/dangling/delete/TransportDeleteDanglingIndexAction.java
@@ -115,7 +115,7 @@ public class TransportDeleteDanglingIndexAction extends TransportClusterManagerN
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         DeleteDanglingIndexRequest deleteRequest,
         ClusterState state,
         ActionListener<AcknowledgedResponse> deleteListener

--- a/server/src/main/java/org/opensearch/action/admin/indices/datastream/CreateDataStreamAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/datastream/CreateDataStreamAction.java
@@ -162,7 +162,7 @@ public class CreateDataStreamAction extends ActionType<AcknowledgedResponse> {
         }
 
         @Override
-        protected void masterOperation(Request request, ClusterState state, ActionListener<AcknowledgedResponse> listener)
+        protected void clusterManagerOperation(Request request, ClusterState state, ActionListener<AcknowledgedResponse> listener)
             throws Exception {
             CreateDataStreamClusterStateUpdateRequest updateRequest = new CreateDataStreamClusterStateUpdateRequest(
                 request.name,

--- a/server/src/main/java/org/opensearch/action/admin/indices/datastream/DeleteDataStreamAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/datastream/DeleteDataStreamAction.java
@@ -192,7 +192,7 @@ public class DeleteDataStreamAction extends ActionType<AcknowledgedResponse> {
         }
 
         @Override
-        protected void masterOperation(Request request, ClusterState state, ActionListener<AcknowledgedResponse> listener)
+        protected void clusterManagerOperation(Request request, ClusterState state, ActionListener<AcknowledgedResponse> listener)
             throws Exception {
             clusterService.submitStateUpdateTask(
                 "remove-data-stream [" + Strings.arrayToCommaDelimitedString(request.names) + "]",

--- a/server/src/main/java/org/opensearch/action/admin/indices/datastream/GetDataStreamAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/datastream/GetDataStreamAction.java
@@ -313,7 +313,7 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
         }
 
         @Override
-        protected void masterOperation(Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
+        protected void clusterManagerOperation(Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
             List<DataStream> dataStreams = getDataStreams(state, indexNameExpressionResolver, request);
             List<Response.DataStreamInfo> dataStreamInfos = new ArrayList<>(dataStreams.size());
             for (DataStream dataStream : dataStreams) {

--- a/server/src/main/java/org/opensearch/action/admin/indices/delete/TransportDeleteIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/delete/TransportDeleteIndexAction.java
@@ -115,7 +115,7 @@ public class TransportDeleteIndexAction extends TransportClusterManagerNodeActio
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final DeleteIndexRequest request,
         final ClusterState state,
         final ActionListener<AcknowledgedResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/exists/indices/TransportIndicesExistsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/exists/indices/TransportIndicesExistsAction.java
@@ -103,7 +103,7 @@ public class TransportIndicesExistsAction extends TransportClusterManagerNodeRea
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final IndicesExistsRequest request,
         final ClusterState state,
         final ActionListener<IndicesExistsResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/get/TransportGetIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/get/TransportGetIndexAction.java
@@ -98,7 +98,7 @@ public class TransportGetIndexAction extends TransportClusterInfoAction<GetIndex
     }
 
     @Override
-    protected void doMasterOperation(
+    protected void doClusterManagerOperation(
         final GetIndexRequest request,
         String[] concreteIndices,
         final ClusterState state,

--- a/server/src/main/java/org/opensearch/action/admin/indices/mapping/get/TransportGetMappingsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/mapping/get/TransportGetMappingsAction.java
@@ -88,7 +88,7 @@ public class TransportGetMappingsAction extends TransportClusterInfoAction<GetMa
     }
 
     @Override
-    protected void doMasterOperation(
+    protected void doClusterManagerOperation(
         final GetMappingsRequest request,
         String[] concreteIndices,
         final ClusterState state,

--- a/server/src/main/java/org/opensearch/action/admin/indices/mapping/put/TransportAutoPutMappingAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/mapping/put/TransportAutoPutMappingAction.java
@@ -107,7 +107,7 @@ public class TransportAutoPutMappingAction extends TransportClusterManagerNodeAc
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final PutMappingRequest request,
         final ClusterState state,
         final ActionListener<AcknowledgedResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
@@ -119,7 +119,7 @@ public class TransportPutMappingAction extends TransportClusterManagerNodeAction
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final PutMappingRequest request,
         final ClusterState state,
         final ActionListener<AcknowledgedResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/open/TransportOpenIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/open/TransportOpenIndexAction.java
@@ -114,7 +114,7 @@ public class TransportOpenIndexAction extends TransportClusterManagerNodeAction<
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final OpenIndexRequest request,
         final ClusterState state,
         final ActionListener<OpenIndexResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/readonly/TransportAddIndexBlockAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/readonly/TransportAddIndexBlockAction.java
@@ -123,13 +123,13 @@ public class TransportAddIndexBlockAction extends TransportClusterManagerNodeAct
     }
 
     @Override
-    protected void masterOperation(AddIndexBlockRequest request, ClusterState state, ActionListener<AddIndexBlockResponse> listener)
+    protected void clusterManagerOperation(AddIndexBlockRequest request, ClusterState state, ActionListener<AddIndexBlockResponse> listener)
         throws Exception {
         throw new UnsupportedOperationException("The task parameter is required");
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final Task task,
         final AddIndexBlockRequest request,
         final ClusterState state,

--- a/server/src/main/java/org/opensearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -130,13 +130,13 @@ public class TransportRolloverAction extends TransportClusterManagerNodeAction<R
     }
 
     @Override
-    protected void masterOperation(RolloverRequest request, ClusterState state, ActionListener<RolloverResponse> listener)
+    protected void clusterManagerOperation(RolloverRequest request, ClusterState state, ActionListener<RolloverResponse> listener)
         throws Exception {
         throw new UnsupportedOperationException("The task parameter is required");
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         Task task,
         final RolloverRequest rolloverRequest,
         final ClusterState state,

--- a/server/src/main/java/org/opensearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
@@ -110,7 +110,7 @@ public class TransportGetSettingsAction extends TransportClusterManagerNodeReadA
     }
 
     @Override
-    protected void masterOperation(GetSettingsRequest request, ClusterState state, ActionListener<GetSettingsResponse> listener) {
+    protected void clusterManagerOperation(GetSettingsRequest request, ClusterState state, ActionListener<GetSettingsResponse> listener) {
         Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
         ImmutableOpenMap.Builder<String, Settings> indexToSettingsBuilder = ImmutableOpenMap.builder();
         ImmutableOpenMap.Builder<String, Settings> indexToDefaultSettingsBuilder = ImmutableOpenMap.builder();

--- a/server/src/main/java/org/opensearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
@@ -116,7 +116,7 @@ public class TransportUpdateSettingsAction extends TransportClusterManagerNodeAc
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final UpdateSettingsRequest request,
         final ClusterState state,
         final ActionListener<AcknowledgedResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
@@ -121,7 +121,7 @@ public class TransportIndicesShardStoresAction extends TransportClusterManagerNo
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         IndicesShardStoresRequest request,
         ClusterState state,
         ActionListener<IndicesShardStoresResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/shrink/TransportResizeAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/shrink/TransportResizeAction.java
@@ -127,7 +127,7 @@ public class TransportResizeAction extends TransportClusterManagerNodeAction<Res
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final ResizeRequest resizeRequest,
         final ClusterState state,
         final ActionListener<ResizeResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/delete/TransportDeleteComponentTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/delete/TransportDeleteComponentTemplateAction.java
@@ -102,7 +102,7 @@ public class TransportDeleteComponentTemplateAction extends TransportClusterMana
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final DeleteComponentTemplateAction.Request request,
         final ClusterState state,
         final ActionListener<AcknowledgedResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/delete/TransportDeleteComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/delete/TransportDeleteComposableIndexTemplateAction.java
@@ -102,7 +102,7 @@ public class TransportDeleteComposableIndexTemplateAction extends TransportClust
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final DeleteComposableIndexTemplateAction.Request request,
         final ClusterState state,
         final ActionListener<AcknowledgedResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/delete/TransportDeleteIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/delete/TransportDeleteIndexTemplateAction.java
@@ -102,7 +102,7 @@ public class TransportDeleteIndexTemplateAction extends TransportClusterManagerN
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final DeleteIndexTemplateRequest request,
         final ClusterState state,
         final ActionListener<AcknowledgedResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/get/TransportGetComponentTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/get/TransportGetComponentTemplateAction.java
@@ -96,7 +96,7 @@ public class TransportGetComponentTemplateAction extends TransportClusterManager
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         GetComponentTemplateAction.Request request,
         ClusterState state,
         ActionListener<GetComponentTemplateAction.Response> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/get/TransportGetComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/get/TransportGetComposableIndexTemplateAction.java
@@ -96,7 +96,7 @@ public class TransportGetComposableIndexTemplateAction extends TransportClusterM
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         GetComposableIndexTemplateAction.Request request,
         ClusterState state,
         ActionListener<GetComposableIndexTemplateAction.Response> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
@@ -96,7 +96,7 @@ public class TransportGetIndexTemplatesAction extends TransportClusterManagerNod
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         GetIndexTemplatesRequest request,
         ClusterState state,
         ActionListener<GetIndexTemplatesResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -127,7 +127,7 @@ public class TransportSimulateIndexTemplateAction extends TransportClusterManage
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         SimulateIndexTemplateRequest request,
         ClusterState state,
         ActionListener<SimulateIndexTemplateResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/post/TransportSimulateTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/post/TransportSimulateTemplateAction.java
@@ -113,7 +113,7 @@ public class TransportSimulateTemplateAction extends TransportClusterManagerNode
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         SimulateTemplateAction.Request request,
         ClusterState state,
         ActionListener<SimulateIndexTemplateResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/put/TransportPutComponentTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/put/TransportPutComponentTemplateAction.java
@@ -106,7 +106,7 @@ public class TransportPutComponentTemplateAction extends TransportClusterManager
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final PutComponentTemplateAction.Request request,
         final ClusterState state,
         final ActionListener<AcknowledgedResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/put/TransportPutComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/put/TransportPutComposableIndexTemplateAction.java
@@ -99,7 +99,7 @@ public class TransportPutComposableIndexTemplateAction extends TransportClusterM
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final PutComposableIndexTemplateAction.Request request,
         final ClusterState state,
         final ActionListener<AcknowledgedResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
@@ -106,7 +106,7 @@ public class TransportPutIndexTemplateAction extends TransportClusterManagerNode
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final PutIndexTemplateRequest request,
         final ClusterState state,
         final ActionListener<AcknowledgedResponse> listener

--- a/server/src/main/java/org/opensearch/action/admin/indices/upgrade/post/TransportUpgradeSettingsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/upgrade/post/TransportUpgradeSettingsAction.java
@@ -102,7 +102,7 @@ public class TransportUpgradeSettingsAction extends TransportClusterManagerNodeA
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         final UpgradeSettingsRequest request,
         final ClusterState state,
         final ActionListener<AcknowledgedResponse> listener

--- a/server/src/main/java/org/opensearch/action/ingest/DeletePipelineTransportAction.java
+++ b/server/src/main/java/org/opensearch/action/ingest/DeletePipelineTransportAction.java
@@ -88,7 +88,7 @@ public class DeletePipelineTransportAction extends TransportClusterManagerNodeAc
     }
 
     @Override
-    protected void masterOperation(DeletePipelineRequest request, ClusterState state, ActionListener<AcknowledgedResponse> listener)
+    protected void clusterManagerOperation(DeletePipelineRequest request, ClusterState state, ActionListener<AcknowledgedResponse> listener)
         throws Exception {
         ingestService.delete(request, listener);
     }

--- a/server/src/main/java/org/opensearch/action/ingest/GetPipelineTransportAction.java
+++ b/server/src/main/java/org/opensearch/action/ingest/GetPipelineTransportAction.java
@@ -85,7 +85,7 @@ public class GetPipelineTransportAction extends TransportClusterManagerNodeReadA
     }
 
     @Override
-    protected void masterOperation(GetPipelineRequest request, ClusterState state, ActionListener<GetPipelineResponse> listener)
+    protected void clusterManagerOperation(GetPipelineRequest request, ClusterState state, ActionListener<GetPipelineResponse> listener)
         throws Exception {
         listener.onResponse(new GetPipelineResponse(IngestService.getPipelines(state, request.getIds())));
     }

--- a/server/src/main/java/org/opensearch/action/ingest/PutPipelineTransportAction.java
+++ b/server/src/main/java/org/opensearch/action/ingest/PutPipelineTransportAction.java
@@ -103,7 +103,7 @@ public class PutPipelineTransportAction extends TransportClusterManagerNodeActio
     }
 
     @Override
-    protected void masterOperation(PutPipelineRequest request, ClusterState state, ActionListener<AcknowledgedResponse> listener)
+    protected void clusterManagerOperation(PutPipelineRequest request, ClusterState state, ActionListener<AcknowledgedResponse> listener)
         throws Exception {
         NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
         nodesInfoRequest.clear().addMetric(NodesInfoRequest.Metric.INGEST.metricName());

--- a/server/src/main/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeAction.java
@@ -117,13 +117,24 @@ public abstract class TransportClusterManagerNodeAction<Request extends ClusterM
 
     protected abstract Response read(StreamInput in) throws IOException;
 
-    protected abstract void masterOperation(Request request, ClusterState state, ActionListener<Response> listener) throws Exception;
+    /**
+     * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #clusterManagerOperation(ClusterManagerNodeRequest, ClusterState, ActionListener)}
+     */
+    @Deprecated
+    protected void masterOperation(Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
+        throw new UnsupportedOperationException("Must be overridden");
+    }
+
+    protected void clusterManagerOperation(Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
+        masterOperation(request, state, listener);
+    }
 
     /**
      * Override this operation if access to the task parameter is needed
      */
-    protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
-        masterOperation(request, state, listener);
+    protected void clusterManagerOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener)
+        throws Exception {
+        clusterManagerOperation(request, state, listener);
     }
 
     protected boolean localExecute(Request request) {
@@ -201,7 +212,7 @@ public abstract class TransportClusterManagerNodeAction<Request extends ClusterM
                             }
                         });
                         threadPool.executor(executor)
-                            .execute(ActionRunnable.wrap(delegate, l -> masterOperation(task, request, clusterState, l)));
+                            .execute(ActionRunnable.wrap(delegate, l -> clusterManagerOperation(task, request, clusterState, l)));
                     }
                 } else {
                     if (nodes.getClusterManagerNode() == null) {
@@ -304,4 +315,5 @@ public abstract class TransportClusterManagerNodeAction<Request extends ClusterM
     protected String getMasterActionName(DiscoveryNode node) {
         return getClusterManagerActionName(node);
     }
+
 }

--- a/server/src/main/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeAction.java
@@ -118,7 +118,7 @@ public abstract class TransportClusterManagerNodeAction<Request extends ClusterM
     protected abstract Response read(StreamInput in) throws IOException;
 
     /**
-     * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #clusterManagerOperation(ClusterManagerNodeRequest, ClusterState, ActionListener)}
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #clusterManagerOperation(ClusterManagerNodeRequest, ClusterState, ActionListener)}
      */
     @Deprecated
     protected void masterOperation(Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
@@ -127,6 +127,11 @@ public abstract class TransportClusterManagerNodeAction<Request extends ClusterM
 
     protected void clusterManagerOperation(Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
         masterOperation(request, state, listener);
+    }
+
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #clusterManagerOperation(Task, ClusterManagerNodeRequest, ClusterState, ActionListener)} */
+    protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
+        clusterManagerOperation(task, request, state, listener);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeAction.java
@@ -130,6 +130,7 @@ public abstract class TransportClusterManagerNodeAction<Request extends ClusterM
     }
 
     /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #clusterManagerOperation(Task, ClusterManagerNodeRequest, ClusterState, ActionListener)} */
+    @Deprecated
     protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
         clusterManagerOperation(task, request, state, listener);
     }

--- a/server/src/main/java/org/opensearch/action/support/clustermanager/info/TransportClusterInfoAction.java
+++ b/server/src/main/java/org/opensearch/action/support/clustermanager/info/TransportClusterInfoAction.java
@@ -77,15 +77,26 @@ public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequ
     }
 
     @Override
-    protected final void masterOperation(final Request request, final ClusterState state, final ActionListener<Response> listener) {
+    protected final void clusterManagerOperation(final Request request, final ClusterState state, final ActionListener<Response> listener) {
         String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(state, request);
-        doMasterOperation(request, concreteIndices, state, listener);
+        doClusterManagerOperation(request, concreteIndices, state, listener);
     }
 
-    protected abstract void doMasterOperation(
+    protected void doClusterManagerOperation(
         Request request,
         String[] concreteIndices,
         ClusterState state,
         ActionListener<Response> listener
-    );
+    ) {
+        doMasterOperation(request, concreteIndices, state, listener);
+    }
+
+    /**
+     * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #doClusterManagerOperation(ClusterInfoRequest, String[], ClusterState, ActionListener)}
+     */
+    @Deprecated
+    protected void doMasterOperation(Request request, String[] concreteIndices, ClusterState state, ActionListener<Response> listener) {
+        throw new UnsupportedOperationException("Must be overridden");
+    }
+
 }

--- a/server/src/main/java/org/opensearch/action/support/clustermanager/info/TransportClusterInfoAction.java
+++ b/server/src/main/java/org/opensearch/action/support/clustermanager/info/TransportClusterInfoAction.java
@@ -76,6 +76,12 @@ public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequ
             .indicesBlockedException(ClusterBlockLevel.METADATA_READ, indexNameExpressionResolver.concreteIndexNames(state, request));
     }
 
+    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #clusterManagerOperation(ClusterInfoRequest, ClusterState, ActionListener)} */
+    @Deprecated
+    protected final void masterOperation(final Request request, final ClusterState state, final ActionListener<Response> listener) {
+        clusterManagerOperation(request, state, listener);
+    }
+
     @Override
     protected final void clusterManagerOperation(final Request request, final ClusterState state, final ActionListener<Response> listener) {
         String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(state, request);
@@ -92,7 +98,7 @@ public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequ
     }
 
     /**
-     * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #doClusterManagerOperation(ClusterInfoRequest, String[], ClusterState, ActionListener)}
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #doClusterManagerOperation(ClusterInfoRequest, String[], ClusterState, ActionListener)}
      */
     @Deprecated
     protected void doMasterOperation(Request request, String[] concreteIndices, ClusterState state, ActionListener<Response> listener) {

--- a/server/src/main/java/org/opensearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/master/TransportMasterNodeAction.java
@@ -32,11 +32,9 @@
 
 package org.opensearch.action.support.master;
 
-import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
-import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.io.stream.Writeable;
@@ -86,8 +84,5 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
             indexNameExpressionResolver
         );
     }
-
-    @Deprecated
-    protected abstract void masterOperation(Request request, ClusterState state, ActionListener<Response> listener) throws Exception;
 
 }

--- a/server/src/main/java/org/opensearch/action/support/master/info/TransportClusterInfoAction.java
+++ b/server/src/main/java/org/opensearch/action/support/master/info/TransportClusterInfoAction.java
@@ -31,10 +31,8 @@
 
 package org.opensearch.action.support.master.info;
 
-import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.action.support.ActionFilters;
-import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.io.stream.Writeable;
@@ -61,11 +59,4 @@ public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequ
         super(actionName, transportService, clusterService, threadPool, actionFilters, request, indexNameExpressionResolver);
     }
 
-    @Deprecated
-    protected abstract void doMasterOperation(
-        Request request,
-        String[] concreteIndices,
-        ClusterState state,
-        ActionListener<Response> listener
-    );
 }

--- a/server/src/main/java/org/opensearch/persistent/CompletionPersistentTaskAction.java
+++ b/server/src/main/java/org/opensearch/persistent/CompletionPersistentTaskAction.java
@@ -193,7 +193,7 @@ public class CompletionPersistentTaskAction extends ActionType<PersistentTaskRes
         }
 
         @Override
-        protected final void masterOperation(
+        protected final void clusterManagerOperation(
             final Request request,
             ClusterState state,
             final ActionListener<PersistentTaskResponse> listener

--- a/server/src/main/java/org/opensearch/persistent/RemovePersistentTaskAction.java
+++ b/server/src/main/java/org/opensearch/persistent/RemovePersistentTaskAction.java
@@ -181,7 +181,7 @@ public class RemovePersistentTaskAction extends ActionType<PersistentTaskRespons
         }
 
         @Override
-        protected final void masterOperation(
+        protected final void clusterManagerOperation(
             final Request request,
             ClusterState state,
             final ActionListener<PersistentTaskResponse> listener

--- a/server/src/main/java/org/opensearch/persistent/StartPersistentTaskAction.java
+++ b/server/src/main/java/org/opensearch/persistent/StartPersistentTaskAction.java
@@ -254,7 +254,7 @@ public class StartPersistentTaskAction extends ActionType<PersistentTaskResponse
         }
 
         @Override
-        protected final void masterOperation(
+        protected final void clusterManagerOperation(
             final Request request,
             ClusterState state,
             final ActionListener<PersistentTaskResponse> listener

--- a/server/src/main/java/org/opensearch/persistent/UpdatePersistentTaskStatusAction.java
+++ b/server/src/main/java/org/opensearch/persistent/UpdatePersistentTaskStatusAction.java
@@ -213,7 +213,7 @@ public class UpdatePersistentTaskStatusAction extends ActionType<PersistentTaskR
         }
 
         @Override
-        protected final void masterOperation(
+        protected final void clusterManagerOperation(
             final Request request,
             final ClusterState state,
             final ActionListener<PersistentTaskResponse> listener

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -3654,7 +3654,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         }
 
         @Override
-        protected void masterOperation(
+        protected void clusterManagerOperation(
             UpdateIndexShardSnapshotStatusRequest request,
             ClusterState state,
             ActionListener<UpdateIndexShardSnapshotStatusResponse> listener

--- a/server/src/test/java/org/opensearch/action/admin/indices/get/GetIndexActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/get/GetIndexActionTests.java
@@ -145,14 +145,14 @@ public class GetIndexActionTests extends OpenSearchSingleNodeTestCase {
         }
 
         @Override
-        protected void doMasterOperation(
+        protected void doClusterManagerOperation(
             GetIndexRequest request,
             String[] concreteIndices,
             ClusterState state,
             ActionListener<GetIndexResponse> listener
         ) {
             ClusterState stateWithIndex = ClusterStateCreationUtils.state(indexName, 1, 1);
-            super.doMasterOperation(request, concreteIndices, stateWithIndex, listener);
+            super.doClusterManagerOperation(request, concreteIndices, stateWithIndex, listener);
         }
     }
 

--- a/server/src/test/java/org/opensearch/action/admin/indices/rollover/TransportRolloverActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/rollover/TransportRolloverActionTests.java
@@ -298,7 +298,7 @@ public class TransportRolloverActionTests extends OpenSearchTestCase {
         RolloverRequest rolloverRequest = new RolloverRequest("logs-alias", "logs-index-000003");
         rolloverRequest.addMaxIndexDocsCondition(500L);
         rolloverRequest.dryRun(true);
-        transportRolloverAction.masterOperation(mock(Task.class), rolloverRequest, stateBefore, future);
+        transportRolloverAction.clusterManagerOperation(mock(Task.class), rolloverRequest, stateBefore, future);
 
         RolloverResponse response = future.actionGet();
         assertThat(response.getOldIndex(), equalTo("logs-index-000002"));
@@ -314,7 +314,7 @@ public class TransportRolloverActionTests extends OpenSearchTestCase {
         rolloverRequest = new RolloverRequest("logs-alias", "logs-index-000003");
         rolloverRequest.addMaxIndexDocsCondition(300L);
         rolloverRequest.dryRun(true);
-        transportRolloverAction.masterOperation(mock(Task.class), rolloverRequest, stateBefore, future);
+        transportRolloverAction.clusterManagerOperation(mock(Task.class), rolloverRequest, stateBefore, future);
 
         response = future.actionGet();
         assertThat(response.getOldIndex(), equalTo("logs-index-000002"));

--- a/server/src/test/java/org/opensearch/action/admin/indices/settings/get/GetSettingsActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/settings/get/GetSettingsActionTests.java
@@ -84,9 +84,13 @@ public class GetSettingsActionTests extends OpenSearchTestCase {
         }
 
         @Override
-        protected void masterOperation(GetSettingsRequest request, ClusterState state, ActionListener<GetSettingsResponse> listener) {
+        protected void clusterManagerOperation(
+            GetSettingsRequest request,
+            ClusterState state,
+            ActionListener<GetSettingsResponse> listener
+        ) {
             ClusterState stateWithIndex = ClusterStateCreationUtils.state(indexName, 1, 1);
-            super.masterOperation(request, stateWithIndex, listener);
+            super.clusterManagerOperation(request, stateWithIndex, listener);
         }
     }
 

--- a/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeActionTests.java
@@ -229,7 +229,7 @@ public class TransportClusterManagerNodeActionTests extends OpenSearchTestCase {
         }
 
         @Override
-        protected void masterOperation(Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
+        protected void clusterManagerOperation(Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
             listener.onResponse(new Response()); // default implementation, overridden in specific tests
         }
 
@@ -252,7 +252,7 @@ public class TransportClusterManagerNodeActionTests extends OpenSearchTestCase {
 
         new Action("internal:testAction", transportService, clusterService, threadPool) {
             @Override
-            protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener) {
+            protected void clusterManagerOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener) {
                 if (clusterManagerOperationFailure) {
                     listener.onFailure(exception);
                 } else {
@@ -511,7 +511,8 @@ public class TransportClusterManagerNodeActionTests extends OpenSearchTestCase {
 
         new Action("internal:testAction", transportService, clusterService, threadPool) {
             @Override
-            protected void masterOperation(Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
+            protected void clusterManagerOperation(Request request, ClusterState state, ActionListener<Response> listener)
+                throws Exception {
                 // The other node has become cluster-manager, simulate failures of this node while publishing cluster state through
                 // ZenDiscovery
                 setState(clusterService, ClusterStateCreationUtils.state(localNode, remoteNode, allNodes));

--- a/server/src/test/java/org/opensearch/action/support/clustermanager/TransportMasterNodeActionUtils.java
+++ b/server/src/test/java/org/opensearch/action/support/clustermanager/TransportMasterNodeActionUtils.java
@@ -39,7 +39,7 @@ import org.opensearch.cluster.ClusterState;
 public class TransportMasterNodeActionUtils {
 
     /**
-     * Allows to directly call {@link TransportClusterManagerNodeAction#masterOperation(ClusterManagerNodeRequest, ClusterState, ActionListener)} which is
+     * Allows to directly call {@link TransportClusterManagerNodeAction#clusterManagerOperation(ClusterManagerNodeRequest, ClusterState, ActionListener)} which is
      * a protected method.
      */
     public static <Request extends ClusterManagerNodeRequest<Request>, Response extends ActionResponse> void runClusterManagerOperation(
@@ -49,6 +49,6 @@ public class TransportMasterNodeActionUtils {
         ActionListener<Response> actionListener
     ) throws Exception {
         assert clusterManagerNodeAction.checkBlock(request, clusterState) == null;
-        clusterManagerNodeAction.masterOperation(request, clusterState, actionListener);
+        clusterManagerNodeAction.clusterManagerOperation(request, clusterState, actionListener);
     }
 }

--- a/server/src/test/java/org/opensearch/indices/settings/InternalOrPrivateSettingsPlugin.java
+++ b/server/src/test/java/org/opensearch/indices/settings/InternalOrPrivateSettingsPlugin.java
@@ -173,7 +173,7 @@ public class InternalOrPrivateSettingsPlugin extends Plugin implements ActionPlu
         }
 
         @Override
-        protected void masterOperation(
+        protected void clusterManagerOperation(
             final UpdateInternalOrPrivateAction.Request request,
             final ClusterState state,
             final ActionListener<UpdateInternalOrPrivateAction.Response> listener

--- a/test/framework/src/main/java/org/opensearch/test/ExternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/ExternalTestCluster.java
@@ -190,7 +190,7 @@ public final class ExternalTestCluster extends TestCluster {
     }
 
     @Override
-    public int numDataAndMasterNodes() {
+    public int numDataAndClusterManagerNodes() {
         return numClusterManagerAndDataNodes;
     }
 

--- a/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
@@ -2348,7 +2348,7 @@ public final class InternalTestCluster extends TestCluster {
     }
 
     @Override
-    public int numDataAndMasterNodes() {
+    public int numDataAndClusterManagerNodes() {
         return filterNodes(nodes, DATA_NODE_PREDICATE.or(CLUSTER_MANAGER_NODE_PREDICATE)).size();
     }
 

--- a/test/framework/src/main/java/org/opensearch/test/TestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/TestCluster.java
@@ -127,7 +127,18 @@ public abstract class TestCluster implements Closeable {
     /**
      * Returns the number of data and cluster-manager eligible nodes in the cluster.
      */
-    public abstract int numDataAndMasterNodes();
+    public int numDataAndClusterManagerNodes() {
+        return numDataAndMasterNodes();
+    }
+
+    /**
+     * Returns the number of data and cluster-manager eligible nodes in the cluster.
+     * @deprecated As of 2.1, because supporting inclusive language, replaced by {@link #numDataAndClusterManagerNodes()}
+     */
+    @Deprecated
+    public int numDataAndMasterNodes() {
+        throw new UnsupportedOperationException("Must be overridden");
+    }
 
     /**
      * Returns the http addresses of the nodes within the cluster.


### PR DESCRIPTION
Signed-off-by: Rishikesh1159 <rishireddy1159@gmail.com>

### Description
This PR deprecates and renames the following abstract methods:

```
In class TransportMasterNodeAction -
abstract void masterOperation(Request request, ClusterState state, ActionListener listener)

In class TransportClusterInfoAction -
abstract void doMasterOperation(Request request, String[] concreteIndices, ClusterState state, ActionListener listener)

In test/framework directory:
public abstract int numDataAndMasterNodes();
```
 
### Issues Resolved
Part of #3542, #3544


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
