### PR TITLE
Rename classes with name 'MasterService' to 'ClusterManagerService' in directory 'test/framework'

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/discovery/ClusterManagerDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/discovery/ClusterManagerDisruptionIT.java
@@ -43,7 +43,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.opensearch.test.disruption.BlockMasterServiceOnMaster;
+import org.opensearch.test.disruption.BlockClusterManagerServiceOnClusterManager;
 import org.opensearch.test.disruption.IntermittentLongGCDisruption;
 import org.opensearch.test.disruption.NetworkDisruption;
 import org.opensearch.test.disruption.NetworkDisruption.TwoPartitions;
@@ -316,7 +316,7 @@ public class ClusterManagerDisruptionIT extends AbstractDisruptionTestCase {
                 .setTransientSettings(Settings.builder().put("indices.mapping.dynamic_timeout", "1ms"))
         );
 
-        ServiceDisruptionScheme disruption = new BlockMasterServiceOnMaster(random());
+        ServiceDisruptionScheme disruption = new BlockClusterManagerServiceOnClusterManager(random());
         setDisruptionScheme(disruption);
 
         disruption.startDisrupting();

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -94,7 +94,7 @@ import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
 import org.opensearch.test.OpenSearchIntegTestCase.Scope;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.TestCustomMetadata;
-import org.opensearch.test.disruption.BusyMasterServiceDisruption;
+import org.opensearch.test.disruption.BusyClusterManagerServiceDisruption;
 import org.opensearch.test.disruption.ServiceDisruptionScheme;
 import org.opensearch.test.rest.FakeRestRequest;
 import org.opensearch.test.transport.MockTransportService;
@@ -1157,7 +1157,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
         final String dataNode = blockNodeWithIndex("test-repo", "test-idx");
         logger.info("-->  snapshot");
-        ServiceDisruptionScheme disruption = new BusyMasterServiceDisruption(random(), Priority.HIGH);
+        ServiceDisruptionScheme disruption = new BusyClusterManagerServiceDisruption(random(), Priority.HIGH);
         setDisruptionScheme(disruption);
         client(internalCluster().getClusterManagerName()).admin()
             .cluster()

--- a/server/src/test/java/org/opensearch/cluster/InternalClusterInfoServiceSchedulingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/InternalClusterInfoServiceSchedulingTests.java
@@ -48,7 +48,7 @@ import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterApplier;
 import org.opensearch.cluster.service.ClusterApplierService;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.cluster.service.FakeThreadPoolMasterService;
+import org.opensearch.cluster.service.FakeThreadPoolClusterManagerService;
 import org.opensearch.cluster.service.ClusterManagerService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
@@ -89,7 +89,7 @@ public class InternalClusterInfoServiceSchedulingTests extends OpenSearchTestCas
             }
         };
 
-        final ClusterManagerService clusterManagerService = new FakeThreadPoolMasterService(
+        final ClusterManagerService clusterManagerService = new FakeThreadPoolClusterManagerService(
             "test",
             "clusterManagerService",
             threadPool,

--- a/server/src/test/java/org/opensearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/NodeJoinTests.java
@@ -43,7 +43,7 @@ import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.node.DiscoveryNodes;
-import org.opensearch.cluster.service.FakeThreadPoolMasterService;
+import org.opensearch.cluster.service.FakeThreadPoolClusterManagerService;
 import org.opensearch.cluster.service.ClusterManagerService;
 import org.opensearch.cluster.service.MasterServiceTests;
 import org.opensearch.common.Randomness;
@@ -144,7 +144,7 @@ public class NodeJoinTests extends OpenSearchTestCase {
             random()
         );
         final ThreadPool fakeThreadPool = deterministicTaskQueue.getThreadPool();
-        FakeThreadPoolMasterService fakeClusterManagerService = new FakeThreadPoolMasterService(
+        FakeThreadPoolClusterManagerService fakeClusterManagerService = new FakeThreadPoolClusterManagerService(
             "test_node",
             "test",
             fakeThreadPool,

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -146,7 +146,7 @@ import org.opensearch.cluster.routing.allocation.command.AllocateEmptyPrimaryAll
 import org.opensearch.cluster.service.ClusterApplierService;
 import org.opensearch.cluster.service.ClusterManagerService;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.cluster.service.FakeThreadPoolMasterService;
+import org.opensearch.cluster.service.FakeThreadPoolClusterManagerService;
 import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
@@ -1666,7 +1666,7 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                 this.node = node;
                 final Environment environment = createEnvironment(node.getName());
                 threadPool = deterministicTaskQueue.getThreadPool(runnable -> CoordinatorTests.onNodeLog(node, runnable));
-                clusterManagerService = new FakeThreadPoolMasterService(
+                clusterManagerService = new FakeThreadPoolClusterManagerService(
                     node.getName(),
                     "test",
                     threadPool,

--- a/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -54,7 +54,7 @@ import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.routing.allocation.AllocationService;
 import org.opensearch.cluster.service.ClusterApplierService;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.cluster.service.FakeThreadPoolMasterService;
+import org.opensearch.cluster.service.FakeThreadPoolClusterManagerService;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.Randomness;
 import org.opensearch.common.UUIDs;
@@ -1026,7 +1026,7 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
             private final DiscoveryNode localNode;
             final MockPersistedState persistedState;
             final Settings nodeSettings;
-            private AckedFakeThreadPoolMasterService clusterManagerService;
+            private AckedFakeThreadPoolClusterManagerService clusterManagerService;
             private DisruptableClusterApplierService clusterApplierService;
             private ClusterService clusterService;
             TransportService transportService;
@@ -1106,7 +1106,7 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                     null,
                     emptySet()
                 );
-                clusterManagerService = new AckedFakeThreadPoolMasterService(
+                clusterManagerService = new AckedFakeThreadPoolClusterManagerService(
                     localNode.getId(),
                     "test",
                     threadPool,
@@ -1513,11 +1513,11 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
         }
     }
 
-    static class AckedFakeThreadPoolMasterService extends FakeThreadPoolMasterService {
+    static class AckedFakeThreadPoolClusterManagerService extends FakeThreadPoolClusterManagerService {
 
         AckCollector nextAckCollector = new AckCollector();
 
-        AckedFakeThreadPoolMasterService(
+        AckedFakeThreadPoolClusterManagerService(
             String nodeName,
             String serviceName,
             ThreadPool threadPool,

--- a/test/framework/src/main/java/org/opensearch/cluster/service/FakeThreadPoolClusterManagerService.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/service/FakeThreadPoolClusterManagerService.java
@@ -55,8 +55,8 @@ import java.util.function.Consumer;
 import static org.apache.lucene.tests.util.LuceneTestCase.random;
 import static org.opensearch.test.OpenSearchTestCase.randomInt;
 
-public class FakeThreadPoolMasterService extends ClusterManagerService {
-    private static final Logger logger = LogManager.getLogger(FakeThreadPoolMasterService.class);
+public class FakeThreadPoolClusterManagerService extends ClusterManagerService {
+    private static final Logger logger = LogManager.getLogger(FakeThreadPoolClusterManagerService.class);
 
     private final String name;
     private final List<Runnable> pendingTasks = new ArrayList<>();
@@ -65,7 +65,7 @@ public class FakeThreadPoolMasterService extends ClusterManagerService {
     private boolean taskInProgress = false;
     private boolean waitForPublish = false;
 
-    public FakeThreadPoolMasterService(
+    public FakeThreadPoolClusterManagerService(
         String nodeName,
         String serviceName,
         ThreadPool threadPool,
@@ -137,7 +137,7 @@ public class FakeThreadPoolMasterService extends ClusterManagerService {
                     if (waitForPublish == false) {
                         taskInProgress = false;
                     }
-                    FakeThreadPoolMasterService.this.scheduleNextTaskIfNecessary();
+                    FakeThreadPoolClusterManagerService.this.scheduleNextTaskIfNecessary();
                 }
             });
         }

--- a/test/framework/src/main/java/org/opensearch/test/disruption/BlockClusterManagerServiceOnClusterManager.java
+++ b/test/framework/src/main/java/org/opensearch/test/disruption/BlockClusterManagerServiceOnClusterManager.java
@@ -43,11 +43,11 @@ import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class BlockMasterServiceOnMaster extends SingleNodeDisruption {
+public class BlockClusterManagerServiceOnClusterManager extends SingleNodeDisruption {
 
     AtomicReference<CountDownLatch> disruptionLatch = new AtomicReference<>();
 
-    public BlockMasterServiceOnMaster(Random random) {
+    public BlockClusterManagerServiceOnClusterManager(Random random) {
         super(random);
     }
 

--- a/test/framework/src/main/java/org/opensearch/test/disruption/BusyClusterManagerServiceDisruption.java
+++ b/test/framework/src/main/java/org/opensearch/test/disruption/BusyClusterManagerServiceDisruption.java
@@ -41,11 +41,11 @@ import org.opensearch.test.InternalTestCluster;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class BusyMasterServiceDisruption extends SingleNodeDisruption {
+public class BusyClusterManagerServiceDisruption extends SingleNodeDisruption {
     private final AtomicBoolean active = new AtomicBoolean();
     private final Priority priority;
 
-    public BusyMasterServiceDisruption(Random random, Priority priority) {
+    public BusyClusterManagerServiceDisruption(Random random, Priority priority) {
         super(random);
         this.priority = priority;
     }

--- a/test/framework/src/test/java/org/opensearch/cluster/service/FakeThreadPoolClusterManagerServiceTests.java
+++ b/test/framework/src/test/java/org/opensearch/cluster/service/FakeThreadPoolClusterManagerServiceTests.java
@@ -61,7 +61,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class FakeThreadPoolMasterServiceTests extends OpenSearchTestCase {
+public class FakeThreadPoolClusterManagerServiceTests extends OpenSearchTestCase {
 
     public void testFakeClusterManagerService() {
         List<Runnable> runnableTasks = new ArrayList<>();
@@ -84,7 +84,7 @@ public class FakeThreadPoolMasterServiceTests extends OpenSearchTestCase {
         doAnswer(invocationOnMock -> runnableTasks.add((Runnable) invocationOnMock.getArguments()[0])).when(executorService).execute(any());
         when(mockThreadPool.generic()).thenReturn(executorService);
 
-        FakeThreadPoolMasterService clusterManagerService = new FakeThreadPoolMasterService(
+        FakeThreadPoolClusterManagerService clusterManagerService = new FakeThreadPoolClusterManagerService(
             "test_node",
             "test",
             mockThreadPool,


### PR DESCRIPTION
### Description
To support inclusive language, the master terminology is going to be replaced by cluster manager in the code base.

After the class `MasterService` has been deprecated and class `ClusterManagerService` has been created in https://github.com/opensearch-project/OpenSearch/pull/4022 / commit https://github.com/opensearch-project/OpenSearch/commit/740f75d2051f27cffbbbfe2b601a85db9b30328c, the classes in `test/framework` directory with name 'MasterService' can be deprecated and renamed.

- Rename the following classes in `test/framework` directory:
```
FakeThreadPoolMasterService -> FakeThreadPoolClusterManagerService
BlockMasterServiceOnMaster -> BlockClusterManagerServiceOnClusterManager
BusyMasterServiceDisruption -> BusyClusterManagerServiceDisruption
```

In the following PR, I will add back the above 3 classes with the old name and deprecate them, to keep the backwards compatibility.
 
### Issues Resolved
A part of issue https://github.com/opensearch-project/OpenSearch/issues/3543
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
