### PR TITLE
Publish transport-netty4 module to Central Repository

### DIFF
--- a/modules/transport-netty4/build.gradle
+++ b/modules/transport-netty4/build.gradle
@@ -38,6 +38,9 @@ apply plugin: 'opensearch.yaml-rest-test'
 apply plugin: 'opensearch.java-rest-test'
 apply plugin: 'opensearch.internal-cluster-test'
 
+// The transport-netty4 plugin is published to maven
+apply plugin: 'opensearch.publish'
+
 /*
  TODOs:
    * fix permissions such that only netty4 can open sockets etc?


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description
The extension framework [opensearch-sdk](https://github.com/opensearch-project/opensearch-sdk) requires the [transport-netty4](https://github.com/opensearch-project/OpenSearch/tree/main/modules/transport-netty4) module as a dependency.
 
### Issues Resolved
Fixes #3118

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
