### PR TITLE
[Feature/extensions] Get Extension API during initialization

### DIFF
--- a/server/src/main/java/org/opensearch/discovery/PluginResponse.java
+++ b/server/src/main/java/org/opensearch/discovery/PluginResponse.java
@@ -37,6 +37,8 @@ import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.transport.TransportResponse;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -46,31 +48,38 @@ import java.util.Objects;
  */
 public class PluginResponse extends TransportResponse {
     private String name;
+    private List<String> api;
 
-    public PluginResponse(String name) {
+    public PluginResponse(String name, List<String> api) {
         this.name = name;
+        this.api = new ArrayList<>(api);
     }
 
     public PluginResponse(StreamInput in) throws IOException {
         name = in.readString();
+        api = in.readStringList();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
+        out.writeStringCollection(api);
     }
 
     /**
      * @return the node that is currently leading, according to the responding node.
      */
-
     public String getName() {
         return this.name;
     }
 
+    public List<String> getApi() {
+        return new ArrayList<>(api);
+    }
+
     @Override
     public String toString() {
-        return "PluginResponse{" + "name" + name + "}";
+        return "PluginResponse {" + "name=" + name + ", api=" + api + "}";
     }
 
     @Override
@@ -78,11 +87,12 @@ public class PluginResponse extends TransportResponse {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         PluginResponse that = (PluginResponse) o;
-        return Objects.equals(name, that.name);
+        return Objects.equals(name, that.name) && Objects.equals(api, that.api);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name);
+        return Objects.hash(api, name);
     }
+
 }

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsOrchestrator.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsOrchestrator.java
@@ -8,17 +8,8 @@
 
 package org.opensearch.extensions;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -52,8 +43,17 @@ import org.opensearch.transport.TransportResponse;
 import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The main class for Plugin Extensibility
@@ -220,6 +220,8 @@ public class ExtensionsOrchestrator implements ReportingService<PluginsAndModule
                 for (DiscoveryExtension extension : extensionsList) {
                     if (extension.getName().equals(response.getName())) {
                         extensionsInitializedList.add(extension);
+                        // Temporary for debug
+                        logger.info("Received API from " + response.getName() + ": " + response.getApi());
                         break;
                     }
                 }


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

(This is a draft PR submitted for review/feedback of initial approach. Please wait until all sub-issues are complete before merging.)

Companion PR: https://github.com/opensearch-project/opensearch-sdk/pull/71

Extensions will report their APIs to the ExtensionsOrchestrator during initialization. These APIs will be registered and mapped so that when Users submit API requests they can be forwarded to the appropriate extensions.
 
### Issues Resolved
Meta issue https://github.com/opensearch-project/opensearch-sdk/issues/64
 - [X] https://github.com/opensearch-project/opensearch-sdk/issues/68
 - [ ] https://github.com/opensearch-project/opensearch-sdk/issues/69
 - [ ] https://github.com/opensearch-project/opensearch-sdk/issues/70
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
