### PR TITLE
Deprecate class FakeThreadPoolMasterService, BlockMasterServiceOnMaster and BusyMasterServiceDisruption, in 'test/framework' directory

### DIFF
--- a/test/framework/src/main/java/org/opensearch/cluster/service/FakeThreadPoolMasterService.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/service/FakeThreadPoolMasterService.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.service;
+
+import org.opensearch.threadpool.ThreadPool;
+
+import java.util.function.Consumer;
+
+/**
+ * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link FakeThreadPoolClusterManagerService}
+ */
+@Deprecated
+public class FakeThreadPoolMasterService extends FakeThreadPoolClusterManagerService {
+    public FakeThreadPoolMasterService(
+        String nodeName,
+        String serviceName,
+        ThreadPool threadPool,
+        Consumer<Runnable> onTaskAvailableToRun
+    ) {
+        super(nodeName, serviceName, threadPool, onTaskAvailableToRun);
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/test/disruption/BlockMasterServiceOnMaster.java
+++ b/test/framework/src/main/java/org/opensearch/test/disruption/BlockMasterServiceOnMaster.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.test.disruption;
+
+import java.util.Random;
+
+/**
+ * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link BlockClusterManagerServiceOnClusterManager}
+ */
+@Deprecated
+public class BlockMasterServiceOnMaster extends BlockClusterManagerServiceOnClusterManager {
+    public BlockMasterServiceOnMaster(Random random) {
+        super(random);
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/test/disruption/BusyMasterServiceDisruption.java
+++ b/test/framework/src/main/java/org/opensearch/test/disruption/BusyMasterServiceDisruption.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.test.disruption;
+
+import org.opensearch.common.Priority;
+
+import java.util.Random;
+
+/**
+ * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link BusyClusterManagerServiceDisruption}
+ */
+@Deprecated
+public class BusyMasterServiceDisruption extends BusyClusterManagerServiceDisruption {
+    public BusyMasterServiceDisruption(Random random, Priority priority) {
+        super(random, priority);
+    }
+}


### PR DESCRIPTION
### Description
To support inclusive language, the master terminology is going to be replaced by cluster manager in the code base.

In a previous PR https://github.com/opensearch-project/OpenSearch/pull/4051, 3 classes in `test/framework` directory that contains `master` in the name were renamed:
```
FakeThreadPoolMasterService -> FakeThreadPoolClusterManagerService
BlockMasterServiceOnMaster -> BlockClusterManagerServiceOnClusterManager
BusyMasterServiceDisruption -> BusyClusterManagerServiceDisruption
```

This is a following PR to add back the classes with the old name to keep the backwards compatibility. The classes with the old name will be subclass of the classes with new name, so that maintaining one implementation can support the usage for two classes.
 
### Issues Resolved
A part of issue https://github.com/opensearch-project/OpenSearch/issues/3543
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
