### PR TITLE
[Remote Store] Add support to add nested settings for remote store

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -283,12 +283,12 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         Property.Final
     );
 
-    public static final String SETTING_REMOTE_STORE = "index.remote_store.enabled";
+    public static final String SETTING_REMOTE_STORE_ENABLED = "index.remote_store.enabled";
     /**
      * Used to specify if the index data should be persisted in the remote store.
      */
-    public static final Setting<Boolean> INDEX_REMOTE_STORE_SETTING = Setting.boolSetting(
-        SETTING_REMOTE_STORE,
+    public static final Setting<Boolean> INDEX_REMOTE_STORE_ENABLED_SETTING = Setting.boolSetting(
+        SETTING_REMOTE_STORE_ENABLED,
         false,
         Property.IndexScope,
         Property.Final

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -283,7 +283,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         Property.Final
     );
 
-    public static final String SETTING_REMOTE_STORE = "index.remote_store";
+    public static final String SETTING_REMOTE_STORE = "index.remote_store.enabled";
     /**
      * Used to specify if the index data should be persisted in the remote store.
      */

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -222,7 +222,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         FeatureFlags.REPLICATION_TYPE,
         IndexMetadata.INDEX_REPLICATION_TYPE_SETTING,
         FeatureFlags.REMOTE_STORE,
-        IndexMetadata.INDEX_REMOTE_STORE_SETTING
+        IndexMetadata.INDEX_REMOTE_STORE_ENABLED_SETTING
     );
 
     public static final IndexScopedSettings DEFAULT_SCOPED_SETTINGS = new IndexScopedSettings(Settings.EMPTY, BUILT_IN_INDEX_SETTINGS);

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -718,7 +718,7 @@ public final class IndexSettings {
         this.indexMetadata = indexMetadata;
         numberOfShards = settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, null);
         replicationType = ReplicationType.parseString(settings.get(IndexMetadata.SETTING_REPLICATION_TYPE));
-        isRemoteStoreEnabled = settings.getAsBoolean(IndexMetadata.SETTING_REMOTE_STORE, false);
+        isRemoteStoreEnabled = settings.getAsBoolean(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, false);
 
         this.searchThrottled = INDEX_SEARCH_THROTTLED.get(settings);
         this.queryStringLenient = QUERY_STRING_LENIENT_SETTING.get(settings);

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -116,7 +116,7 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_RE
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_VERSION_UPGRADED;
-import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_STORE;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_STORE_ENABLED;
 import static org.opensearch.common.util.set.Sets.newHashSet;
 import static org.opensearch.snapshots.SnapshotUtils.filterIndices;
 
@@ -227,7 +227,7 @@ public class RestoreService implements ClusterStateApplier {
                         logger.warn("Remote store restore is not supported for non-existent index. Skipping: {}", index);
                         continue;
                     }
-                    if (currentIndexMetadata.getSettings().getAsBoolean(SETTING_REMOTE_STORE, false)) {
+                    if (currentIndexMetadata.getSettings().getAsBoolean(SETTING_REMOTE_STORE_ENABLED, false)) {
                         if (currentIndexMetadata.getState() != IndexMetadata.State.CLOSE) {
                             throw new IllegalStateException(
                                 "cannot restore index ["

--- a/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
@@ -770,7 +770,7 @@ public class IndexSettingsTests extends OpenSearchTestCase {
             "index",
             Settings.builder()
                 .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
-                .put(IndexMetadata.SETTING_REMOTE_STORE, true)
+                .put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true)
                 .build()
         );
         IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
@@ -784,12 +784,12 @@ public class IndexSettingsTests extends OpenSearchTestCase {
         IllegalArgumentException error = expectThrows(
             IllegalArgumentException.class,
             () -> settings.updateSettings(
-                Settings.builder().put("index.remote_store", randomBoolean()).build(),
+                Settings.builder().put("index.remote_store.enabled", randomBoolean()).build(),
                 Settings.builder(),
                 Settings.builder(),
                 "index"
             )
         );
-        assertEquals(error.getMessage(), "final index setting [index.remote_store], not updateable");
+        assertEquals(error.getMessage(), "final index setting [index.remote_store.enabled], not updateable");
     }
 }

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -2660,7 +2660,7 @@ public class IndexShardTests extends IndexShardTestCase {
     public void testRestoreShardFromRemoteStore() throws IOException {
         IndexShard target = newStartedShard(
             true,
-            Settings.builder().put(IndexMetadata.SETTING_REMOTE_STORE, true).build(),
+            Settings.builder().put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true).build(),
             new InternalEngineFactory()
         );
 


### PR DESCRIPTION
Signed-off-by: Sachin Kale <kalsac@amazon.com>

### Description
Current setting index.remote_store removes the flexibility of adding few sub-settings related to remote store for the same index. In the future, we can have requirements like supporting only remote trans-log, separate remote store for given index. With this change, we introduce `index.remote_store.enabled`, which will allow inclusion of all the remote_store settings under `index.remote_store`.
 
### Issues Resolved
- https://github.com/opensearch-project/OpenSearch/issues/4059
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
