### PR TITLE
Replace master terminology in documentation

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -460,7 +460,7 @@ Work to make sure that OpenSearch can scale in a distributed manner.
 
 Includes:
 
-- Nodes (Master, Data, Compute, Ingest, Discovery, etc.)
+- Nodes (Cluster Manager, Data, Compute, Ingest, Discovery, etc.)
 - Replication & Merge Policies (Document, Segment level)
 - Snapshot/Restore (repositories; S3, Azure, GCP, NFS)
 - Translog (e.g., OpenSearch, Kafka, Kinesis)

--- a/TESTING.md
+++ b/TESTING.md
@@ -395,7 +395,7 @@ The branch needs to be available on the remote that the BWC makes of the reposit
 
 Example:
 
-Say you need to make a change to `master` and have a BWC layer in `5.x`. You will need to: . Create a branch called `index_req_change` off your remote `${remote}`. This will contain your change. . Create a branch called `index_req_bwc_5.x` off `5.x`. This will contain your bwc layer. . Push both branches to your remote repository. . Run the tests with `./gradlew check -Dbwc.remote=${remote} -Dbwc.refspec.5.x=index_req_bwc_5.x`.
+Say you need to make a change to `main` and have a BWC layer in `5.x`. You will need to: . Create a branch called `index_req_change` off your remote `${remote}`. This will contain your change. . Create a branch called `index_req_bwc_5.x` off `5.x`. This will contain your bwc layer. . Push both branches to your remote repository. . Run the tests with `./gradlew check -Dbwc.remote=${remote} -Dbwc.refspec.5.x=index_req_bwc_5.x`.
 
 ### Skip fetching latest
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/README.md
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/README.md
@@ -115,7 +115,7 @@ Indicates the runner can parse `node_selector` under the `do` operator and use i
 
 Allows you to use a stashed value in any key of an object during a `match` assertion
 
-    - set: {nodes.$master.http.publish_address: host}
+    - set: {nodes.$cluster_manager.http.publish_address: host}
     - match:
         $body:
           {
@@ -319,13 +319,13 @@ Stashed values can be used in property names, eg:
     - do:
         cluster.state: {}
 
-    - set: { master_node: master }
+    - set: { cluster_manager_node: cluster_manager }
 
     - do:
         nodes.info:
             metric: [ transport ]
 
-    - is_true: nodes.$master.transport.profiles
+    - is_true: nodes.$cluster_manager.transport.profiles
 
 Note that not only expected values can be retrieved from the stashed values (as in the example above), but the same goes for actual values:
 


### PR DESCRIPTION
### Description
Replace non-inclusive word "master" in `*.md` documentation file.
 
### Issues Resolved
Close #2694
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
