### PR TITLE
[Backport] [1.3] OpenJDK Update (July 2022 Patch releases)

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/Jdk.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/Jdk.java
@@ -56,7 +56,7 @@ public class Jdk implements Buildable, Iterable<File> {
     private static final Pattern VERSION_PATTERN = Pattern.compile(
         "(\\d+)(\\.\\d+\\.\\d+(?:.\\d+)?)?\\+(\\d+(?:\\.\\d+)?)(@([a-f0-9]{32}))?"
     );
-    private static final Pattern LEGACY_VERSION_PATTERN = Pattern.compile("(\\d)(u\\d+)\\+(b\\d+?)(@([a-f0-9]{32}))?");
+    private static final Pattern LEGACY_VERSION_PATTERN = Pattern.compile("(\\d)(u\\d+)(?:\\+|\\-)(b\\d+?)(@([a-f0-9]{32}))?");
 
     private final String name;
     private final Configuration configuration;

--- a/buildSrc/src/main/java/org/opensearch/gradle/JdkDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/JdkDownloadPlugin.java
@@ -110,22 +110,38 @@ public class JdkDownloadPlugin implements Plugin<Project> {
 
         if (jdk.getVendor().equals(VENDOR_ADOPTIUM)) {
             repoUrl = "https://github.com/adoptium/temurin" + jdk.getMajor() + "-binaries/releases/download/";
-            // JDK updates are suffixed with 'U' (fe OpenJDK17U), whereas GA releases are not (fe OpenJDK17).
-            // To distinguish between those, the GA releases have only major version component (fe 17+32),
-            // the updates always have minor/patch components (fe 17.0.1+12), checking for the presence of
-            // version separator '.' should be enough.
-            artifactPattern = "jdk-"
-                + jdk.getBaseVersion()
-                + "+"
-                + jdk.getBuild()
-                + "/OpenJDK"
-                + jdk.getMajor()
-                + (jdk.getBaseVersion().contains(".") ? "U" : "")
-                + "-jdk_[classifier]_[module]_hotspot_"
-                + jdk.getBaseVersion()
-                + "_"
-                + jdk.getBuild()
-                + ".[ext]";
+
+            if (jdk.getMajor().equals("8")) {
+                // JDK-8 updates are always suffixed with 'U' (fe OpenJDK8U).
+                artifactPattern = "jdk"
+                    + jdk.getBaseVersion()
+                    + "-"
+                    + jdk.getBuild()
+                    + "/OpenJDK"
+                    + jdk.getMajor()
+                    + "U"
+                    + "-jdk_[classifier]_[module]_hotspot_"
+                    + jdk.getBaseVersion()
+                    + jdk.getBuild()
+                    + ".[ext]";
+            } else {
+                // JDK updates are suffixed with 'U' (fe OpenJDK17U), whereas GA releases are not (fe OpenJDK17).
+                // To distinguish between those, the GA releases have only major version component (fe 17+32),
+                // the updates always have minor/patch components (fe 17.0.1+12), checking for the presence of
+                // version separator '.' should be enough.
+                artifactPattern = "jdk-"
+                    + jdk.getBaseVersion()
+                    + "+"
+                    + jdk.getBuild()
+                    + "/OpenJDK"
+                    + jdk.getMajor()
+                    + (jdk.getBaseVersion().contains(".") ? "U" : "")
+                    + "-jdk_[classifier]_[module]_hotspot_"
+                    + jdk.getBaseVersion()
+                    + "_"
+                    + jdk.getBuild()
+                    + ".[ext]";
+            }
         } else if (jdk.getVendor().equals(VENDOR_ADOPTOPENJDK)) {
             repoUrl = "https://api.adoptopenjdk.net/v3/binary/version/";
             if (jdk.getMajor().equals("8")) {

--- a/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java
@@ -75,9 +75,9 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public class DistroTestPlugin implements Plugin<Project> {
-    private static final String SYSTEM_JDK_VERSION = "8u242+b08";
-    private static final String SYSTEM_JDK_VENDOR = "adoptopenjdk";
-    private static final String GRADLE_JDK_VERSION = "11.0.15+10";
+    private static final String SYSTEM_JDK_VERSION = "8u342-b07";
+    private static final String SYSTEM_JDK_VENDOR = "adoptium";
+    private static final String GRADLE_JDK_VERSION = "11.0.16+8";
     private static final String GRADLE_JDK_VENDOR = "adoptium";
 
     // all distributions used by distro tests. this is temporary until tests are per distribution

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -2,7 +2,7 @@ opensearch        = 1.3.5
 lucene            = 8.10.1
 
 bundled_jdk_vendor = adoptium
-bundled_jdk = 11.0.15+10
+bundled_jdk = 11.0.16+8
 
 
 


### PR DESCRIPTION
### Description
Backporting https://github.com/opensearch-project/OpenSearch/pull/3323 and https://github.com/opensearch-project/OpenSearch/pull/4091 to 1.3
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/4011
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
