### PR TITLE
Fix the bug that masterOperation(with task param) is bypassed

### DIFF
--- a/server/src/main/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeAction.java
@@ -129,7 +129,10 @@ public abstract class TransportClusterManagerNodeAction<Request extends ClusterM
         masterOperation(request, state, listener);
     }
 
-    /** @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #clusterManagerOperation(Task, ClusterManagerNodeRequest, ClusterState, ActionListener)} */
+    /**
+     * Override this operation if access to the task parameter is needed
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #clusterManagerOperation(Task, ClusterManagerNodeRequest, ClusterState, ActionListener)}
+     */
     @Deprecated
     protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
         clusterManagerOperation(task, request, state, listener);
@@ -218,7 +221,7 @@ public abstract class TransportClusterManagerNodeAction<Request extends ClusterM
                             }
                         });
                         threadPool.executor(executor)
-                            .execute(ActionRunnable.wrap(delegate, l -> clusterManagerOperation(task, request, clusterState, l)));
+                            .execute(ActionRunnable.wrap(delegate, l -> masterOperation(task, request, clusterState, l)));
                     }
                 } else {
                     if (nodes.getClusterManagerNode() == null) {

--- a/server/src/main/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeAction.java
@@ -125,6 +125,7 @@ public abstract class TransportClusterManagerNodeAction<Request extends ClusterM
         throw new UnsupportedOperationException("Must be overridden");
     }
 
+    // TODO: Add abstract keyword after removing the deprecated masterOperation()
     protected void clusterManagerOperation(Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
         masterOperation(request, state, listener);
     }

--- a/server/src/main/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/clustermanager/TransportClusterManagerNodeAction.java
@@ -136,15 +136,16 @@ public abstract class TransportClusterManagerNodeAction<Request extends ClusterM
      */
     @Deprecated
     protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
-        clusterManagerOperation(task, request, state, listener);
+        clusterManagerOperation(request, state, listener);
     }
 
     /**
      * Override this operation if access to the task parameter is needed
      */
+    // TODO: Change the implementation to call 'clusterManagerOperation(request...)' after removing the deprecated masterOperation()
     protected void clusterManagerOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener)
         throws Exception {
-        clusterManagerOperation(request, state, listener);
+        masterOperation(task, request, state, listener);
     }
 
     protected boolean localExecute(Request request) {
@@ -222,7 +223,7 @@ public abstract class TransportClusterManagerNodeAction<Request extends ClusterM
                             }
                         });
                         threadPool.executor(executor)
-                            .execute(ActionRunnable.wrap(delegate, l -> masterOperation(task, request, clusterState, l)));
+                            .execute(ActionRunnable.wrap(delegate, l -> clusterManagerOperation(task, request, clusterState, l)));
                     }
                 } else {
                     if (nodes.getClusterManagerNode() == null) {

--- a/server/src/main/java/org/opensearch/action/support/clustermanager/info/TransportClusterInfoAction.java
+++ b/server/src/main/java/org/opensearch/action/support/clustermanager/info/TransportClusterInfoAction.java
@@ -88,6 +88,7 @@ public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequ
         doClusterManagerOperation(request, concreteIndices, state, listener);
     }
 
+    // TODO: Add abstract keyword after removing the deprecated doMasterOperation()
     protected void doClusterManagerOperation(
         Request request,
         String[] concreteIndices,

--- a/test/framework/src/main/java/org/opensearch/test/TestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/TestCluster.java
@@ -127,6 +127,7 @@ public abstract class TestCluster implements Closeable {
     /**
      * Returns the number of data and cluster-manager eligible nodes in the cluster.
      */
+    // TODO: Add abstract keyword after removing the deprecated numDataAndMasterNodes()
     public int numDataAndClusterManagerNodes() {
         return numDataAndMasterNodes();
     }


### PR DESCRIPTION
### Description
The method `protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener)` was not properly deprecated by the commit https://github.com/opensearch-project/OpenSearch/commit/2a1b239c2af8d7f333a404c66467a50dc0a52c80 / PR https://github.com/opensearch-project/OpenSearch/pull/403.

There is a problem that it doesn't make any difference to whether overriding the method `void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener)` or not.
The reason is the only usage for the method changed to call another method `clusterManagerOperation(task, request, clusterState, l)`, which is the default implementation for the method `masterOperation(with task param)`. There is no other usage for the method `masterOperation()` so it's bypassed.

In the PR:
~I restored the usage of the method `masterOperation(with task param)`~ 
- Change delegation model for method `clusterManagerOperation(with task param)` to call `masterOperation(with task param)`, according to the comment below https://github.com/opensearch-project/OpenSearch/pull/4103#discussion_r936946699
- Add a test to validate the backwards compatibility, which copied and modified from an existing test.
 
### Issues Resolved
Resolve https://github.com/opensearch-project/OpenSearch/issues/4062
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
