### PR TITLE
[Bug] [Segment Replication] Fix isAheadOf logic for ReplicationCheckpoint comparison

### DIFF
--- a/server/src/main/java/org/opensearch/indices/replication/checkpoint/ReplicationCheckpoint.java
+++ b/server/src/main/java/org/opensearch/indices/replication/checkpoint/ReplicationCheckpoint.java
@@ -125,10 +125,13 @@ public class ReplicationCheckpoint implements Writeable {
     }
 
     /**
-     * Checks if other is aheadof current replication point by comparing segmentInfosVersion. Returns true for null
+     * Checks if current replication checkpoint is AheadOf `other` replication checkpoint point by first comparing
+     * primaryTerm followed by segmentInfosVersion. Returns true when `other` is null.
      */
     public boolean isAheadOf(@Nullable ReplicationCheckpoint other) {
-        return other == null || segmentInfosVersion > other.getSegmentInfosVersion() || primaryTerm > other.getPrimaryTerm();
+        return other == null
+            || primaryTerm > other.getPrimaryTerm()
+            || (primaryTerm == other.getPrimaryTerm() && segmentInfosVersion > other.getSegmentInfosVersion());
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Coming from https://github.com/opensearch-project/OpenSearch/issues/3988 which relies on ReplicationCheckpoint ordering for correctly identifying the furthest ahead replica. The existing `ReplicationCheckpoint#isAheadOf` is not correct as it uses `||` b/w `segmentInfosVersion` (1st) & PrimaryTerm(2nd) terms; instead of relying on 2nd term (PrimaryTerm field) `ONLY WHEN` first field (`segmentInfosVersion`) is equal.

This PR also fixes, the comparison order i.e. PrimaryTerm first followed by segmentInfosVersion; this is to prioritize active primary over stale. 

### Issues Related
https://github.com/opensearch-project/OpenSearch/issues/3988

### Related
https://github.com/opensearch-project/OpenSearch/pull/4041

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
