### PR TITLE
Deprecate and rename abstract methods in interfaces that contain 'master' in name

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/LocalNodeClusterManagerListener.java
+++ b/server/src/main/java/org/opensearch/cluster/LocalNodeClusterManagerListener.java
@@ -42,21 +42,21 @@ public interface LocalNodeClusterManagerListener extends ClusterStateListener {
     /**
      * Called when local node is elected to be the cluster-manager
      */
-    void onMaster();
+    void onClusterManager();
 
     /**
      * Called when the local node used to be the cluster-manager, a new cluster-manager was elected and it's no longer the local node.
      */
-    void offMaster();
+    void offClusterManager();
 
     @Override
     default void clusterChanged(ClusterChangedEvent event) {
         final boolean wasClusterManager = event.previousState().nodes().isLocalNodeElectedClusterManager();
         final boolean isClusterManager = event.localNodeClusterManager();
         if (wasClusterManager == false && isClusterManager) {
-            onMaster();
+            onClusterManager();
         } else if (wasClusterManager && isClusterManager == false) {
-            offMaster();
+            offClusterManager();
         }
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/LocalNodeMasterListener.java
+++ b/server/src/main/java/org/opensearch/cluster/LocalNodeMasterListener.java
@@ -41,4 +41,33 @@ package org.opensearch.cluster;
 @Deprecated
 public interface LocalNodeMasterListener extends LocalNodeClusterManagerListener {
 
+    /**
+     * Called when local node is elected to be the cluster-manager.
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #onClusterManager()}
+     */
+    @Deprecated
+    void onMaster();
+
+    /**
+     * Called when the local node used to be the cluster-manager, a new cluster-manager was elected and it's no longer the local node.
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #offClusterManager()}
+     */
+    @Deprecated
+    void offMaster();
+
+    /**
+     * Called when local node is elected to be the cluster-manager.
+     */
+    @Override
+    default void onClusterManager() {
+        onMaster();
+    }
+
+    /**
+     * Called when the local node used to be the cluster-manager, a new cluster-manager was elected and it's no longer the local node.
+     */
+    @Override
+    default void offClusterManager() {
+        offMaster();
+    }
 }

--- a/server/src/main/java/org/opensearch/cluster/ack/AckedRequest.java
+++ b/server/src/main/java/org/opensearch/cluster/ack/AckedRequest.java
@@ -48,6 +48,18 @@ public interface AckedRequest {
 
     /**
      * Returns the timeout for the request to be completed on the cluster-manager node
+     * @deprecated As of 2.2, because supporting inclusive language, replaced by {@link #clusterManagerNodeTimeout()}
      */
-    TimeValue masterNodeTimeout();
+    @Deprecated
+    default TimeValue masterNodeTimeout() {
+        throw new UnsupportedOperationException("Must be overridden");
+    }
+
+    /**
+     * Returns the timeout for the request to be completed on the cluster-manager node
+     */
+    // TODO: Remove default implementation after removing the deprecated masterNodeTimeout()
+    default TimeValue clusterManagerNodeTimeout() {
+        return masterNodeTimeout();
+    }
 }

--- a/server/src/test/java/org/opensearch/cluster/service/ClusterApplierServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/service/ClusterApplierServiceTests.java
@@ -299,12 +299,12 @@ public class ClusterApplierServiceTests extends OpenSearchTestCase {
         AtomicBoolean isClusterManager = new AtomicBoolean();
         timedClusterApplierService.addLocalNodeClusterManagerListener(new LocalNodeClusterManagerListener() {
             @Override
-            public void onMaster() {
+            public void onClusterManager() {
                 isClusterManager.set(true);
             }
 
             @Override
-            public void offMaster() {
+            public void offClusterManager() {
                 isClusterManager.set(false);
             }
         });


### PR DESCRIPTION
Signed-off-by: Xue Zhou <xuezhou@amazon.com>

### Description
Deprecate and rename abstract methods in interface
```
void onMaster()
void offMaster()
TimeValue masterNodeTimeout()
```
 
### Issues Resolved
#3544 
#3543 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
