### PR TITLE
Support shard promotion with Segment Replication.

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -19,7 +19,9 @@ import org.opensearch.action.support.WriteRequest;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.routing.IndexShardRoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.Index;
@@ -30,6 +32,7 @@ import org.opensearch.index.shard.IndexShard;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.test.BackgroundIndexer;
+import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.io.IOException;
@@ -71,6 +74,87 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
     @Override
     protected boolean addMockInternalEngine() {
         return false;
+    }
+
+    public void testPrimaryStopped_ReplicaPromoted() throws Exception {
+        final String nodeA = internalCluster().startNode();
+        final String nodeB = internalCluster().startNode();
+        createIndex(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        client().prepareIndex(INDEX_NAME).setId("1").setSource("foo", "bar").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        refresh(INDEX_NAME);
+
+        waitForReplicaUpdate();
+        assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 1);
+        assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 1);
+
+        final DiscoveryNode primaryDiscoveryNode = getNodeContainingPrimaryShard();
+        final String primaryNodeName = primaryDiscoveryNode.getName();
+        final String replicaNodeName = nodeA.equals(primaryNodeName) ? nodeB : nodeA;
+
+        // index another doc but don't refresh, we will ensure this is searchable once replica is promoted.
+        client().prepareIndex(INDEX_NAME).setId("2").setSource("bar", "baz").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+
+        // stop the primary node - we only have one shard on here.
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNodeName));
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+
+        final ShardRouting replicaShardRouting = getShardRoutingForNodeName(replicaNodeName);
+        assertNotNull(replicaShardRouting);
+        assertTrue(replicaShardRouting + " should be promoted as a primary", replicaShardRouting.primary());
+        assertHitCount(client(replicaNodeName).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 2);
+
+        // assert we can index into the new primary.
+        client().prepareIndex(INDEX_NAME).setId("3").setSource("bar", "baz").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        assertHitCount(client(replicaNodeName).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 3);
+
+        // start another node, index another doc and replicate.
+        String nodeC = internalCluster().startNode();
+        ensureGreen(INDEX_NAME);
+        client().prepareIndex(INDEX_NAME).setId("4").setSource("baz", "baz").get();
+        refresh(INDEX_NAME);
+        waitForReplicaUpdate();
+        assertHitCount(client(nodeC).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 4);
+        assertHitCount(client(replicaNodeName).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 4);
+        assertSegmentStats(REPLICA_COUNT);
+    }
+
+    private DiscoveryNode getNodeContainingPrimaryShard() {
+        final ClusterState state = client(internalCluster().getClusterManagerName()).admin().cluster().prepareState().get().getState();
+        final ShardRouting primaryShard = state.routingTable().index(INDEX_NAME).shard(0).primaryShard();
+        return state.nodes().resolveNode(primaryShard.currentNodeId());
+    }
+
+    public void testRestartPrimary() throws Exception {
+        final String nodeA = internalCluster().startNode();
+        final String nodeB = internalCluster().startNode();
+        createIndex(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        final DiscoveryNode primaryDiscoveryNode = getNodeContainingPrimaryShard();
+        final String primaryNodeName = primaryDiscoveryNode.getName();
+        final String replicaNodeName = nodeA.equals(primaryNodeName) ? nodeB : nodeA;
+
+        final int initialDocCount = 1;
+
+        client().prepareIndex(INDEX_NAME).setId("1").setSource("foo", "bar").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        refresh(INDEX_NAME);
+
+        waitForReplicaUpdate();
+        assertDocCounts(initialDocCount, replicaNodeName, primaryNodeName);
+
+        internalCluster().restartNode(primaryNodeName);
+        ensureGreen(INDEX_NAME);
+
+        final DiscoveryNode newPrimaryNode = getNodeContainingPrimaryShard();
+        assertEquals(newPrimaryNode.getName(), replicaNodeName);
+
+        flushAndRefresh(INDEX_NAME);
+        waitForReplicaUpdate();
+
+        assertDocCounts(initialDocCount, replicaNodeName, primaryNodeName);
+        assertSegmentStats(REPLICA_COUNT);
     }
 
     public void testReplicationAfterPrimaryRefreshAndFlush() throws Exception {
@@ -418,5 +502,26 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
 
     private Map<Boolean, List<ShardSegments>> segmentsByShardType(ShardSegments[] replicationGroupSegments) {
         return Arrays.stream(replicationGroupSegments).collect(Collectors.groupingBy(s -> s.getShardRouting().primary()));
+    }
+
+    @Nullable
+    private ShardRouting getShardRoutingForNodeName(String nodeName) {
+        final ClusterState state = client(internalCluster().getClusterManagerName()).admin().cluster().prepareState().get().getState();
+        for (IndexShardRoutingTable shardRoutingTable : state.routingTable().index(INDEX_NAME)) {
+            for (ShardRouting shardRouting : shardRoutingTable.activeShards()) {
+                final String nodeId = shardRouting.currentNodeId();
+                final DiscoveryNode discoveryNode = state.nodes().resolveNode(nodeId);
+                if (discoveryNode.getName().equals(nodeName)) {
+                    return shardRouting;
+                }
+            }
+        }
+        return null;
+    }
+
+    private void assertDocCounts(int expectedDocCount, String... nodeNames) {
+        for (String node : nodeNames) {
+            assertHitCount(client(node).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedDocCount);
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -550,7 +550,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 circuitBreakerService,
                 // TODO Replace with remote translog factory in the follow up PR
                 this.indexSettings.isRemoteTranslogStoreEnabled() ? null : new InternalTranslogFactory(),
-                this.indexSettings.isSegRepEnabled() && routing.primary() ? checkpointPublisher : null,
+                this.indexSettings.isSegRepEnabled() ? checkpointPublisher : null,
                 remoteStore
             );
             eventListener.indexShardStateChanged(indexShard, null, indexShard.state(), "shard created");

--- a/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
@@ -133,8 +133,9 @@ public class NRTReplicationEngine extends Engine {
      * Persist the latest live SegmentInfos.
      *
      * This method creates a commit point from the latest SegmentInfos. It is intended to be used when this shard is about to be promoted as the new primary.
-     * If this method is invoked while the engine is currently updating segments on its reader, it will wait for that update to complete so the updated segments are used.
-     * It does not wait for segment copy to complete, that
+     *
+     * TODO: If this method is invoked while the engine is currently updating segments on its reader, wait for that update to complete so the updated segments are used.
+     *
      *
      * @throws IOException - When there is an IO error committing the SegmentInfos.
      */

--- a/server/src/main/java/org/opensearch/index/shard/CheckpointRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/CheckpointRefreshListener.java
@@ -40,7 +40,8 @@ public class CheckpointRefreshListener implements ReferenceManager.RefreshListen
 
     @Override
     public void afterRefresh(boolean didRefresh) throws IOException {
-        if (didRefresh && shard.getReplicationTracker().isPrimaryMode()) {
+        if (didRefresh && shard.state() != IndexShardState.CLOSED &&
+            shard.getReplicationTracker().isPrimaryMode()) {
             publisher.publish(shard);
         }
     }

--- a/server/src/main/java/org/opensearch/index/shard/CheckpointRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/CheckpointRefreshListener.java
@@ -40,8 +40,7 @@ public class CheckpointRefreshListener implements ReferenceManager.RefreshListen
 
     @Override
     public void afterRefresh(boolean didRefresh) throws IOException {
-        if (didRefresh && shard.state() != IndexShardState.CLOSED &&
-            shard.getReplicationTracker().isPrimaryMode()) {
+        if (didRefresh && shard.state() != IndexShardState.CLOSED && shard.getReplicationTracker().isPrimaryMode()) {
             publisher.publish(shard);
         }
     }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -3230,7 +3230,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             Directory remoteDirectory = ((FilterDirectory) ((FilterDirectory) remoteStore.directory()).getDelegate()).getDelegate();
             internalRefreshListener.add(new RemoteStoreRefreshListener(store.directory(), remoteDirectory));
         }
-        if (this.checkpointPublisher != null && indexSettings.isSegRepEnabled()) {
+        if (this.checkpointPublisher != null && indexSettings.isSegRepEnabled() && shardRouting.primary()) {
             internalRefreshListener.add(new CheckpointRefreshListener(this, this.checkpointPublisher));
         }
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -242,6 +242,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     private final GlobalCheckpointListeners globalCheckpointListeners;
     private final PendingReplicationActions pendingReplicationActions;
     private final ReplicationTracker replicationTracker;
+    private final SegmentReplicationCheckpointPublisher checkpointPublisher;
 
     protected volatile ShardRouting shardRouting;
     protected volatile IndexShardState state;
@@ -306,8 +307,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     private final AtomicReference<Translog.Location> pendingRefreshLocation = new AtomicReference<>();
     private final RefreshPendingLocationListener refreshPendingLocationListener;
     private volatile boolean useRetentionLeasesInPeerRecovery;
-    private final ReferenceManager.RefreshListener checkpointRefreshListener;
-
     private final Store remoteStore;
     private final TranslogFactory translogFactory;
 
@@ -417,11 +416,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         persistMetadata(path, indexSettings, shardRouting, null, logger);
         this.useRetentionLeasesInPeerRecovery = replicationTracker.hasAllPeerRecoveryRetentionLeases();
         this.refreshPendingLocationListener = new RefreshPendingLocationListener();
-        if (checkpointPublisher != null) {
-            this.checkpointRefreshListener = new CheckpointRefreshListener(this, checkpointPublisher);
-        } else {
-            this.checkpointRefreshListener = null;
-        }
+        this.checkpointPublisher = checkpointPublisher;
         this.remoteStore = remoteStore;
         this.translogFactory = translogFactory;
     }
@@ -627,6 +622,10 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                             + newRouting;
                         assert getOperationPrimaryTerm() == newPrimaryTerm;
                         try {
+                            if (indexSettings.isSegRepEnabled()) {
+                                // this Shard's engine was read only, we need to update its engine before restoring local history from xlog.
+                                promoteNRTReplicaToPrimary();
+                            }
                             replicationTracker.activatePrimaryMode(getLocalCheckpoint());
                             ensurePeerRecoveryRetentionLeasesExist();
                             /*
@@ -3231,8 +3230,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             Directory remoteDirectory = ((FilterDirectory) ((FilterDirectory) remoteStore.directory()).getDelegate()).getDelegate();
             internalRefreshListener.add(new RemoteStoreRefreshListener(store.directory(), remoteDirectory));
         }
-        if (this.checkpointRefreshListener != null) {
-            internalRefreshListener.add(checkpointRefreshListener);
+        if (this.checkpointPublisher != null && indexSettings.isSegRepEnabled()) {
+            internalRefreshListener.add(new CheckpointRefreshListener(this, this.checkpointPublisher));
         }
 
         return this.engineConfigFactory.newEngineConfig(
@@ -4122,5 +4121,27 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      */
     public GatedCloseable<SegmentInfos> getSegmentInfosSnapshot() {
         return getEngine().getSegmentInfosSnapshot();
+    }
+
+    /**
+     * With segment replication enabled - prepare the shard's engine to be promoted as the new primary.
+     *
+     * If this shard is currently using a replication engine, this method:
+     * 1. Invokes {@link NRTReplicationEngine#commitSegmentInfos()} to ensure the engine can be reopened as writeable from the latest refresh point.
+     * InternalEngine opens its IndexWriter from an on-disk commit point, but this replica may have recently synced from a primary's refresh point, meaning it has documents searchable in its in-memory SegmentInfos
+     * that are not part of a commit point.  This ensures that those documents are made part of a commit and do not need to be reindexed after promotion.
+     * 2. Invokes resetEngineToGlobalCheckpoint - This call performs the engine swap, opening up as a writeable engine and replays any operations in the xlog. The operations indexed from xlog here will be
+     * any ack'd writes that were not copied to this replica before promotion.
+     */
+    private void promoteNRTReplicaToPrimary() {
+        assert shardRouting.primary() && indexSettings.isSegRepEnabled();
+        getReplicationEngine().ifPresentOrElse(engine -> {
+            try {
+                engine.commitSegmentInfos();
+                resetEngineToGlobalCheckpoint();
+            } catch (IOException e) {
+                throw new OpenSearchException("Unable to change engine type, failing", e);
+            }
+        }, () -> { throw new OpenSearchException("Expected replica engine to be of type NRTReplicationEngine"); });
     }
 }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -624,6 +624,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                         try {
                             if (indexSettings.isSegRepEnabled()) {
                                 // this Shard's engine was read only, we need to update its engine before restoring local history from xlog.
+                                assert newRouting.primary() && currentRouting.primary() == false;
                                 promoteNRTReplicaToPrimary();
                             }
                             replicationTracker.activatePrimaryMode(getLocalCheckpoint());
@@ -4140,8 +4141,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 engine.commitSegmentInfos();
                 resetEngineToGlobalCheckpoint();
             } catch (IOException e) {
-                throw new OpenSearchException("Unable to change engine type, failing", e);
+                throw new EngineException(shardId, "Unable to update  replica to writeable engine, failing shard", e);
             }
-        }, () -> { throw new OpenSearchException("Expected replica engine to be of type NRTReplicationEngine"); });
+        }, () -> { throw new EngineException(shardId, "Expected replica engine to be of type NRTReplicationEngine"); });
     }
 }

--- a/server/src/main/java/org/opensearch/index/store/Store.java
+++ b/server/src/main/java/org/opensearch/index/store/Store.java
@@ -121,6 +121,7 @@ import java.util.zip.Checksum;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
+import static org.opensearch.index.seqno.SequenceNumbers.LOCAL_CHECKPOINT_KEY;
 
 /**
  * A Store provides plain access to files written by an opensearch index shard. Each shard
@@ -797,6 +798,46 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
 
     public void beforeClose() {
         shardLock.setDetails("closing shard");
+    }
+
+    /**
+     * This method should only be used with Segment Replication.
+     * Perform a commit from a live {@link SegmentInfos}.  Replica engines with segrep do not have an IndexWriter and Lucene does not currently
+     * have the ability to create a writer directly from a SegmentInfos object.  To promote the replica as a primary and avoid reindexing, we must first commit
+     * on the replica so that it can be opened with a writeable engine. Further, InternalEngine currently invokes `trimUnsafeCommits` which reverts the engine to a previous safeCommit where the max seqNo is less than or equal
+     * to the current global checkpoint. It is likely that the replica has a maxSeqNo that is higher than the global cp and a new commit will be wiped.
+     *
+     * To get around these limitations, this method first creates an IndexCommit directly from SegmentInfos, it then
+     * uses an appending IW to create an IndexCommit from the commit created on SegmentInfos.
+     * This ensures that 1. All files in the new commit are fsynced and 2. Deletes older commit points so the only commit to start from is our new commit.
+     *
+     * @param latestSegmentInfos {@link SegmentInfos} The latest active infos
+     * @param maxSeqNo The engine's current maxSeqNo
+     * @param processedCheckpoint The engine's current processed checkpoint.
+     * @throws IOException when there is an IO error committing.
+     */
+    public void commitSegmentInfos(SegmentInfos latestSegmentInfos, long maxSeqNo, long processedCheckpoint) throws IOException {
+        assert indexSettings.isSegRepEnabled();
+        metadataLock.writeLock().lock();
+        try {
+            final Map<String, String> userData = new HashMap<>(latestSegmentInfos.getUserData());
+            userData.put(LOCAL_CHECKPOINT_KEY, String.valueOf(processedCheckpoint));
+            userData.put(SequenceNumbers.MAX_SEQ_NO, Long.toString(maxSeqNo));
+            latestSegmentInfos.setUserData(userData, true);
+            latestSegmentInfos.commit(directory());
+
+            // similar to TrimUnsafeCommits, create a commit with an appending IW, this will delete old commits and ensure all files
+            // associated with the SegmentInfos.commit are fsynced.
+            final List<IndexCommit> existingCommits = DirectoryReader.listCommits(directory);
+            assert existingCommits.isEmpty() == false : "No commits found";
+            final IndexCommit lastIndexCommit = existingCommits.get(existingCommits.size() - 1);
+            try (IndexWriter writer = newAppendingIndexWriter(directory, lastIndexCommit)) {
+                writer.setLiveCommitData(lastIndexCommit.getUserData().entrySet());
+                writer.commit();
+            }
+        } finally {
+            metadataLock.writeLock().unlock();
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/store/Store.java
+++ b/server/src/main/java/org/opensearch/index/store/Store.java
@@ -829,8 +829,9 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
             // similar to TrimUnsafeCommits, create a commit with an appending IW, this will delete old commits and ensure all files
             // associated with the SegmentInfos.commit are fsynced.
             final List<IndexCommit> existingCommits = DirectoryReader.listCommits(directory);
-            assert existingCommits.isEmpty() == false : "No commits found";
+            assert existingCommits.isEmpty() == false : "Expected at least one commit but none found";
             final IndexCommit lastIndexCommit = existingCommits.get(existingCommits.size() - 1);
+            assert latestSegmentInfos.getSegmentsFileName().equals(lastIndexCommit.getSegmentsFileName());
             try (IndexWriter writer = newAppendingIndexWriter(directory, lastIndexCommit)) {
                 writer.setLiveCommitData(lastIndexCommit.getUserData().entrySet());
                 writer.commit();

--- a/server/src/test/java/org/opensearch/index/engine/NRTReplicationEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/NRTReplicationEngineTests.java
@@ -12,18 +12,25 @@ import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.SegmentInfos;
 import org.hamcrest.MatcherAssert;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.common.lucene.search.Queries;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.ParsedDocument;
+import org.opensearch.index.seqno.LocalCheckpointTracker;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.translog.TestTranslog;
 import org.opensearch.index.translog.Translog;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.test.IndexSettingsModule;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -31,6 +38,8 @@ import java.util.stream.Collectors;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.opensearch.index.seqno.SequenceNumbers.NO_OPS_PERFORMED;
+import static org.opensearch.index.seqno.SequenceNumbers.LOCAL_CHECKPOINT_KEY;
+import static org.opensearch.index.seqno.SequenceNumbers.MAX_SEQ_NO;
 
 public class NRTReplicationEngineTests extends EngineTestCase {
 
@@ -207,6 +216,49 @@ public class NRTReplicationEngineTests extends EngineTestCase {
                 assertThat(snapshot.totalOperations(), equalTo(0));
                 assertNull(snapshot.next());
             }
+        }
+    }
+
+    public void testCommitSegmentInfos() throws Exception {
+        // This test asserts that NRTReplication#commitSegmentInfos creates a new commit point with the latest checkpoints
+        // stored in user data.
+        final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+        final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(
+            "index",
+            Settings.builder().put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT).build()
+        );
+        try (
+            final Store nrtEngineStore = createStore(indexSettings, newDirectory());
+            final NRTReplicationEngine nrtEngine = buildNrtReplicaEngine(globalCheckpoint, nrtEngineStore)
+        ) {
+            List<Engine.Operation> operations = generateHistoryOnReplica(between(1, 500), randomBoolean(), randomBoolean(), randomBoolean())
+                .stream()
+                .filter(op -> op.operationType().equals(Engine.Operation.TYPE.INDEX))
+                .collect(Collectors.toList());
+            for (Engine.Operation op : operations) {
+                applyOperation(nrtEngine, op);
+            }
+
+            final SegmentInfos previousInfos = nrtEngine.getLatestSegmentInfos();
+            LocalCheckpointTracker localCheckpointTracker = nrtEngine.getLocalCheckpointTracker();
+            final long maxSeqNo = localCheckpointTracker.getMaxSeqNo();
+            final long processedCheckpoint = localCheckpointTracker.getProcessedCheckpoint();
+            nrtEngine.commitSegmentInfos();
+
+            // ensure getLatestSegmentInfos returns an updated infos ref with correct userdata.
+            final SegmentInfos latestSegmentInfos = nrtEngine.getLatestSegmentInfos();
+            assertEquals(previousInfos.getGeneration(), latestSegmentInfos.getLastGeneration());
+            Map<String, String> userData = latestSegmentInfos.getUserData();
+            assertEquals(processedCheckpoint, localCheckpointTracker.getProcessedCheckpoint());
+            assertEquals(maxSeqNo, Long.parseLong(userData.get(MAX_SEQ_NO)));
+            assertEquals(processedCheckpoint, Long.parseLong(userData.get(LOCAL_CHECKPOINT_KEY)));
+
+            // read infos from store and assert userdata
+            final String lastCommitSegmentsFileName = SegmentInfos.getLastCommitSegmentsFileName(nrtEngineStore.directory());
+            final SegmentInfos committedInfos = SegmentInfos.readCommit(nrtEngineStore.directory(), lastCommitSegmentsFileName);
+            userData = committedInfos.getUserData();
+            assertEquals(processedCheckpoint, Long.parseLong(userData.get(LOCAL_CHECKPOINT_KEY)));
+            assertEquals(maxSeqNo, Long.parseLong(userData.get(MAX_SEQ_NO)));
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
This change adds basic failover support with segment replication.  Once selected, a replica will commit its SegmentInfos and reopen a writeable engine.  The replica will also remove all other commits so that this commit is selected when the writeable engine is opened.  It is possible that this commit is not considered 'safe' by the primary, meaning its max seqNo is higher than the global cp.  While an edge case, we never want replicas to reindex with segment replication enabled, so if the global cp has not been updated yet we do not want to revert to a safe commit. This change also updates how SegmentReplicationCheckpointPublisher is wired up within IndexShard so that once promoted the new primary can publish checkpoints.

This PR does not handle edge cases of promotion while there are ongoing replication events, that will be covered in a separate issue.
 
### Issues Resolved
closes #3989
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
