### PR TITLE
Use the project.group value for Zip POM groupId value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Dependency updates (httpcore, mockito, slf4j, httpasyncclient, commons-codec) ([#4308](https://github.com/opensearch-project/OpenSearch/pull/4308))
 - Use RemoteSegmentStoreDirectory instead of RemoteDirectory ([#4240](https://github.com/opensearch-project/OpenSearch/pull/4240))
+- Plugin ZIP publication groupId value is configurable ([#4156](https://github.com/opensearch-project/OpenSearch/pull/4156))
 
 ### Deprecated
 

--- a/buildSrc/src/test/resources/pluginzip/customizedGroupValue.gradle
+++ b/buildSrc/src/test/resources/pluginzip/customizedGroupValue.gradle
@@ -1,0 +1,45 @@
+plugins {
+  id 'java-gradle-plugin'
+  id 'nebula.maven-base-publish'
+  id 'opensearch.pluginzip'
+}
+
+group="org.custom.group"
+version='2.0.0.0'
+
+// A bundlePlugin task mockup
+tasks.register('bundlePlugin', Zip.class) {
+  archiveFileName = "sample-plugin-${version}.zip"
+  destinationDirectory = layout.buildDirectory.dir('distributions')
+  from layout.projectDirectory.file('sample-plugin-source.txt')
+}
+
+publishing {
+  publications {
+    pluginZip(MavenPublication) {
+      groupId = "I.am.customized"
+      pom {
+        name = "sample-plugin"
+        description = "pluginDescription"
+        licenses {
+          license {
+            name = "The Apache License, Version 2.0"
+            url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+        developers {
+          developer {
+            name = "John Doe"
+            url = "https://github.com/john-doe/"
+            organization = "Doe.inc"
+            organizationUrl = "https://doe.inc/"
+          }
+        }
+        url = "https://github.com/doe/sample-plugin"
+        scm {
+          url = "https://github.com/doe/sample-plugin"
+        }
+      }
+    }
+  }
+}

--- a/buildSrc/src/test/resources/pluginzip/customizedInvalidGroupValue.gradle
+++ b/buildSrc/src/test/resources/pluginzip/customizedInvalidGroupValue.gradle
@@ -1,0 +1,45 @@
+plugins {
+  id 'java-gradle-plugin'
+  id 'nebula.maven-base-publish'
+  id 'opensearch.pluginzip'
+}
+
+group="org.custom.group"
+version='2.0.0.0'
+
+// A bundlePlugin task mockup
+tasks.register('bundlePlugin', Zip.class) {
+  archiveFileName = "sample-plugin-${version}.zip"
+  destinationDirectory = layout.buildDirectory.dir('distributions')
+  from layout.projectDirectory.file('sample-plugin-source.txt')
+}
+
+publishing {
+  publications {
+    pluginZip(MavenPublication) {
+      groupId = " "  // <-- User provides invalid value
+      pom {
+        name = "sample-plugin"
+        description = "pluginDescription"
+        licenses {
+          license {
+            name = "The Apache License, Version 2.0"
+            url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+        developers {
+          developer {
+            name = "John Doe"
+            url = "https://github.com/john-doe/"
+            organization = "Doe.inc"
+            organizationUrl = "https://doe.inc/"
+          }
+        }
+        url = "https://github.com/doe/sample-plugin"
+        scm {
+          url = "https://github.com/doe/sample-plugin"
+        }
+      }
+    }
+  }
+}

--- a/buildSrc/src/test/resources/pluginzip/groupAndVersionValue.gradle
+++ b/buildSrc/src/test/resources/pluginzip/groupAndVersionValue.gradle
@@ -1,0 +1,44 @@
+plugins {
+  id 'java-gradle-plugin'
+  id 'nebula.maven-base-publish'
+  id 'opensearch.pluginzip'
+}
+
+group="org.custom.group"
+version='2.0.0.0'
+
+// A bundlePlugin task mockup
+tasks.register('bundlePlugin', Zip.class) {
+  archiveFileName = "sample-plugin-${version}.zip"
+  destinationDirectory = layout.buildDirectory.dir('distributions')
+  from layout.projectDirectory.file('sample-plugin-source.txt')
+}
+
+publishing {
+  publications {
+    pluginZip(MavenPublication) {
+      pom {
+        name = "sample-plugin"
+        description = "pluginDescription"
+        licenses {
+          license {
+            name = "The Apache License, Version 2.0"
+            url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+        developers {
+          developer {
+            name = "John Doe"
+            url = "https://github.com/john-doe/"
+            organization = "Doe.inc"
+            organizationUrl = "https://doe.inc/"
+          }
+        }
+        url = "https://github.com/doe/sample-plugin"
+        scm {
+          url = "https://github.com/doe/sample-plugin"
+        }
+      }
+    }
+  }
+}

--- a/buildSrc/src/test/resources/pluginzip/missingGroupValue.gradle
+++ b/buildSrc/src/test/resources/pluginzip/missingGroupValue.gradle
@@ -1,0 +1,22 @@
+plugins {
+  id 'java-gradle-plugin'
+  id 'nebula.maven-base-publish'
+  id 'opensearch.pluginzip'
+}
+
+//group="org.custom.group"
+version='2.0.0.0'
+
+// A bundlePlugin task mockup
+tasks.register('bundlePlugin', Zip.class) {
+  archiveFileName = "sample-plugin-${version}.zip"
+  destinationDirectory = layout.buildDirectory.dir('distributions')
+  from layout.projectDirectory.file('sample-plugin-source.txt')
+}
+
+publishing {
+  publications {
+    pluginZip(MavenPublication) {
+    }
+  }
+}

--- a/buildSrc/src/test/resources/pluginzip/missingPOMEntity.gradle
+++ b/buildSrc/src/test/resources/pluginzip/missingPOMEntity.gradle
@@ -1,0 +1,22 @@
+plugins {
+  id 'java-gradle-plugin'
+  id 'nebula.maven-base-publish'
+  id 'opensearch.pluginzip'
+}
+
+group="org.custom.group"
+version='2.0.0.0'
+
+// A bundlePlugin task mockup
+tasks.register('bundlePlugin', Zip.class) {
+  archiveFileName = "sample-plugin-${version}.zip"
+  destinationDirectory = layout.buildDirectory.dir('distributions')
+  from layout.projectDirectory.file('sample-plugin-source.txt')
+}
+
+publishing {
+  publications {
+    pluginZip(MavenPublication) {
+    }
+  }
+}


### PR DESCRIPTION
### Description

When publishing Zip POM the groupId value was hard-coded to `org.opensearch.plugin` value which works fine for existing core plugins but is not convenient for other plugins (such as community plugins maintained in independent repositories).

This PR introduces a main change in where the value for the groupId is taken from. Instead of using a hard-coded value it is taken from the `project.group` value.

This PR also brings a major rework of tests in PublishTests class. Individual testing scenarios are driven by "real" gradle building scripts (utilizing `java-gradle-plugin` gradle plugin).
 
### Issues Resolved

Closes #3692
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Lukáš Vlček <lukas.vlcek@aiven.io>