### PR TITLE
Add IndexShard#getLatestReplicationCheckpoint behind segrep enable feature flag

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1396,10 +1396,13 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     /**
-     * Returns the lastest Replication Checkpoint that shard received. Shards will return an EMPTY checkpoint before
-     * the engine is opened.
+     * Returns the latest ReplicationCheckpoint that shard received.
+     * @return EMPTY checkpoint before the engine is opened and null for non-segrep enabled indices
      */
     public ReplicationCheckpoint getLatestReplicationCheckpoint() {
+        if (indexSettings.isSegRepEnabled() == false) {
+            return null;
+        }
         if (getEngineOrNull() == null) {
             return ReplicationCheckpoint.empty(shardId);
         }

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -139,7 +139,6 @@ import org.opensearch.indices.breaker.NoneCircuitBreakerService;
 import org.opensearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.opensearch.indices.recovery.RecoveryState;
 import org.opensearch.indices.recovery.RecoveryTarget;
-import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.indices.replication.common.ReplicationLuceneIndex;
 import org.opensearch.indices.replication.common.ReplicationType;
@@ -3499,27 +3498,6 @@ public class IndexShardTests extends IndexShardTestCase {
         assertTrue(stop.compareAndSet(false, true));
         thread.join();
         closeShards(newShard);
-    }
-
-    /**
-     *  Test that latestReplicationCheckpoint returns null only for docrep enabled indices
-     */
-    public void testReplicationCheckpointNullForDocRep() throws IOException {
-        Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_REPLICATION_TYPE, "DOCUMENT").put(Settings.EMPTY).build();
-        final IndexShard indexShard = newStartedShard(false, indexSettings);
-        assertNull(indexShard.getLatestReplicationCheckpoint());
-        closeShards(indexShard);
-    }
-
-    /**
-     *  Test that latestReplicationCheckpoint returns ReplicationCheckpoint for segrep enabled indices
-     */
-    public void testReplicationCheckpointNotNullForSegReb() throws IOException {
-        Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_REPLICATION_TYPE, "SEGMENT").put(Settings.EMPTY).build();
-        final IndexShard indexShard = newStartedShard(indexSettings);
-        final ReplicationCheckpoint replicationCheckpoint = indexShard.getLatestReplicationCheckpoint();
-        assertNotNull(replicationCheckpoint);
-        closeShards(indexShard);
     }
 
     /**

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -139,6 +139,7 @@ import org.opensearch.indices.breaker.NoneCircuitBreakerService;
 import org.opensearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.opensearch.indices.recovery.RecoveryState;
 import org.opensearch.indices.recovery.RecoveryTarget;
+import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.indices.replication.common.ReplicationLuceneIndex;
 import org.opensearch.indices.replication.common.ReplicationType;
@@ -3498,6 +3499,27 @@ public class IndexShardTests extends IndexShardTestCase {
         assertTrue(stop.compareAndSet(false, true));
         thread.join();
         closeShards(newShard);
+    }
+
+    /**
+     *  Test that latestReplicationCheckpoint returns null only for docrep enabled indices
+     */
+    public void testReplicationCheckpointNullForDocRep() throws IOException {
+        Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_REPLICATION_TYPE, "DOCUMENT").put(Settings.EMPTY).build();
+        final IndexShard indexShard = newStartedShard(false, indexSettings);
+        assertNull(indexShard.getLatestReplicationCheckpoint());
+        closeShards(indexShard);
+    }
+
+    /**
+     *  Test that latestReplicationCheckpoint returns ReplicationCheckpoint for segrep enabled indices
+     */
+    public void testReplicationCheckpointNotNullForSegReb() throws IOException {
+        Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_REPLICATION_TYPE, "SEGMENT").put(Settings.EMPTY).build();
+        final IndexShard indexShard = newStartedShard(indexSettings);
+        final ReplicationCheckpoint replicationCheckpoint = indexShard.getLatestReplicationCheckpoint();
+        assertNotNull(replicationCheckpoint);
+        closeShards(indexShard);
     }
 
     /**

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceHandlerTests.java
@@ -15,7 +15,9 @@ import org.mockito.Mockito;
 import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.IndexShardTestCase;
 import org.opensearch.index.store.StoreFileMetadata;
@@ -41,7 +43,8 @@ public class SegmentReplicationSourceHandlerTests extends IndexShardTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        primary = newStartedShard(true);
+        final Settings settings = Settings.builder().put(IndexMetadata.SETTING_REPLICATION_TYPE, "SEGMENT").put(Settings.EMPTY).build();
+        primary = newStartedShard(true, settings);
         replica = newShard(primary.shardId(), false);
         recoverReplica(replica, primary, true);
         replicaDiscoveryNode = replica.recoveryState().getTargetNode();

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
@@ -13,6 +13,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionListener;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.shard.IndexShard;
@@ -50,7 +51,10 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        final Settings settings = Settings.builder().put("node.name", SegmentReplicationTargetServiceTests.class.getSimpleName()).build();
+        final Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, "SEGMENT")
+            .put("node.name", SegmentReplicationTargetServiceTests.class.getSimpleName())
+            .build();
         final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         final RecoverySettings recoverySettings = new RecoverySettings(settings, clusterSettings);
         final TransportService transportService = mock(TransportService.class);


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Came from discussion in https://github.com/opensearch-project/OpenSearch/pull/4041#discussion_r939084536, this PR adds `getLatestReplicationCheckpoint` behind feature flag. 
 
### Issues Related
#2212 #3988 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
