### PR TITLE
Updating release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -12,11 +12,18 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
       - name: Get tag
         id: tag
         uses: dawidd6/action-get-tag@v1
       - uses: actions/checkout@v2
       - uses: ncipollo/release-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.github_app_token.outputs.token }}
           bodyFile: release-notes/opensearch.release-notes-${{steps.tag.outputs.tag}}.md

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,7 +3,7 @@ name: Releases
 on:
   push:
     tags:
-      - '*.*.*'
+      - '*'
 
 jobs:
 


### PR DESCRIPTION
### Description
Release workflow automates releasing github tags. 
Looks like the workflow was never run because tags regex didnt match. 
Since we only push tags when there is a release, automating it to release when a tag is pushed.
 
Follow up of: https://github.com/opensearch-project/OpenSearch/pull/3813
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
