### PR TITLE
[Remote Store] Add validator that forces segment replication type before enabling remote store

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -292,6 +292,32 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     public static final Setting<Boolean> INDEX_REMOTE_STORE_ENABLED_SETTING = Setting.boolSetting(
         SETTING_REMOTE_STORE_ENABLED,
         false,
+        new Setting.Validator<>() {
+
+            @Override
+            public void validate(final Boolean value) {}
+
+            @Override
+            public void validate(final Boolean value, final Map<Setting<?>, Object> settings) {
+                final Object replicationType = settings.get(INDEX_REPLICATION_TYPE_SETTING);
+                if (replicationType != ReplicationType.SEGMENT && value == true) {
+                    throw new IllegalArgumentException(
+                        "Settings "
+                            + INDEX_REMOTE_STORE_ENABLED_SETTING.getKey()
+                            + " cannot be enabled when "
+                            + INDEX_REPLICATION_TYPE_SETTING.getKey()
+                            + " is set to "
+                            + settings.get(INDEX_REPLICATION_TYPE_SETTING)
+                    );
+                }
+            }
+
+            @Override
+            public Iterator<Setting<?>> settings() {
+                final List<Setting<?>> settings = Collections.singletonList(INDEX_REPLICATION_TYPE_SETTING);
+                return settings.iterator();
+            }
+        },
         Property.IndexScope,
         Property.Final
     );

--- a/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
@@ -42,6 +42,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.index.translog.Translog;
+import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.VersionUtils;
 
@@ -851,6 +852,35 @@ public class IndexSettingsTests extends OpenSearchTestCase {
         );
         assertEquals(
             "Settings index.remote_store.translog.enabled cannot be enabled when index.remote_store.enabled is set to false",
+            iae.getMessage()
+        );
+    }
+
+    public void testEnablingRemoteStoreFailsWhenReplicationTypeIsDocument() {
+        Settings indexSettings = Settings.builder()
+            .put("index.replication.type", ReplicationType.DOCUMENT)
+            .put("index.remote_store.enabled", true)
+            .build();
+        IllegalArgumentException iae = expectThrows(
+            IllegalArgumentException.class,
+            () -> IndexMetadata.INDEX_REMOTE_STORE_ENABLED_SETTING.get(indexSettings)
+        );
+        assertEquals(
+            "Settings index.remote_store.enabled cannot be enabled when index.replication.type is set to DOCUMENT",
+            iae.getMessage()
+        );
+    }
+
+    public void testEnablingRemoteStoreFailsWhenReplicationTypeIsDefault() {
+        Settings indexSettings = Settings.builder()
+            .put("index.remote_store.enabled", true)
+            .build();
+        IllegalArgumentException iae = expectThrows(
+            IllegalArgumentException.class,
+            () -> IndexMetadata.INDEX_REMOTE_STORE_ENABLED_SETTING.get(indexSettings)
+        );
+        assertEquals(
+            "Settings index.remote_store.enabled cannot be enabled when index.replication.type is set to DOCUMENT",
             iae.getMessage()
         );
     }

--- a/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
@@ -872,9 +872,7 @@ public class IndexSettingsTests extends OpenSearchTestCase {
     }
 
     public void testEnablingRemoteStoreFailsWhenReplicationTypeIsDefault() {
-        Settings indexSettings = Settings.builder()
-            .put("index.remote_store.enabled", true)
-            .build();
+        Settings indexSettings = Settings.builder().put("index.remote_store.enabled", true).build();
         IllegalArgumentException iae = expectThrows(
             IllegalArgumentException.class,
             () -> IndexMetadata.INDEX_REMOTE_STORE_ENABLED_SETTING.get(indexSettings)


### PR DESCRIPTION
Signed-off-by: Sachin Kale <kalsac@amazon.com>

### Description
Allow `remote_store.enabled=true` index setting only when replication type is set to segment replication (`replicaiton.type=SEGMENT`).
 
### Issues Resolved
- https://github.com/opensearch-project/OpenSearch/issues/3147
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
