### PR TITLE
[Segment Replication] Fix OngoingSegmentReplications to key by allocation ID instead of DiscoveryNode.

### DIFF
--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
@@ -55,6 +55,7 @@ class SegmentReplicationSourceHandler {
     private final Logger logger;
     private final AtomicBoolean isReplicating = new AtomicBoolean();
     private final DiscoveryNode targetNode;
+    private final String allocationId;
 
     /**
      * Constructor.
@@ -71,6 +72,7 @@ class SegmentReplicationSourceHandler {
         FileChunkWriter writer,
         ThreadPool threadPool,
         CopyState copyState,
+        String allocationId,
         int fileChunkSizeInBytes,
         int maxConcurrentFileChunks
     ) {
@@ -91,6 +93,7 @@ class SegmentReplicationSourceHandler {
             fileChunkSizeInBytes,
             maxConcurrentFileChunks
         );
+        this.allocationId = allocationId;
         this.copyState = copyState;
     }
 
@@ -180,5 +183,9 @@ class SegmentReplicationSourceHandler {
 
     public DiscoveryNode getTargetNode() {
         return targetNode;
+    }
+
+    public String getAllocationId() {
+        return allocationId;
     }
 }

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
@@ -54,6 +54,7 @@ class SegmentReplicationSourceHandler {
     private final List<Closeable> resources = new CopyOnWriteArrayList<>();
     private final Logger logger;
     private final AtomicBoolean isReplicating = new AtomicBoolean();
+    private final DiscoveryNode targetNode;
 
     /**
      * Constructor.
@@ -73,6 +74,7 @@ class SegmentReplicationSourceHandler {
         int fileChunkSizeInBytes,
         int maxConcurrentFileChunks
     ) {
+        this.targetNode = targetNode;
         this.shard = copyState.getShard();
         this.logger = Loggers.getLogger(
             SegmentReplicationSourceHandler.class,
@@ -118,7 +120,7 @@ class SegmentReplicationSourceHandler {
                     logger.debug(
                         "delaying replication of {} as it is not listed as assigned to target node {}",
                         shard.shardId(),
-                        request.getTargetNode()
+                        targetNode
                     );
                     throw new DelayRecoveryException("source node does not have the shard listed in its state as allocated on the node");
                 }
@@ -174,5 +176,9 @@ class SegmentReplicationSourceHandler {
 
     public boolean isReplicating() {
         return isReplicating.get();
+    }
+
+    public DiscoveryNode getTargetNode() {
+        return targetNode;
     }
 }

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceHandlerTests.java
@@ -63,6 +63,7 @@ public class SegmentReplicationSourceHandlerTests extends IndexShardTestCase {
             chunkWriter,
             threadPool,
             copyState,
+            primary.routingEntry().allocationId().getId(),
             5000,
             1
         );
@@ -100,6 +101,7 @@ public class SegmentReplicationSourceHandlerTests extends IndexShardTestCase {
             chunkWriter,
             threadPool,
             copyState,
+            primary.routingEntry().allocationId().getId(),
             5000,
             1
         );
@@ -138,6 +140,7 @@ public class SegmentReplicationSourceHandlerTests extends IndexShardTestCase {
             chunkWriter,
             threadPool,
             copyState,
+            primary.routingEntry().allocationId().getId(),
             5000,
             1
         );
@@ -175,6 +178,7 @@ public class SegmentReplicationSourceHandlerTests extends IndexShardTestCase {
             chunkWriter,
             threadPool,
             copyState,
+            primary.routingEntry().allocationId().getId(),
             5000,
             1
         );


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
This change fixes segrep to work with multiple shards per node by keying ongoing replications on
allocation ID.  This also updates cancel methods to ensure state is properly cleared on shard cancel.

### Issues Resolved
#4129.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
