### PR TITLE
issue #49 Rename and possibly move static method for determining local ephemeral address

### DIFF
--- a/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
@@ -2136,7 +2136,7 @@ public abstract class AbstractSimpleTransportTestCase extends OpenSearchTestCase
             // means that once we received an ACK from the client we just drop the packet on the floor (which is what we want) and we run
             // into a connection timeout quickly. Yet other implementations can for instance can terminate the connection within the 3 way
             // handshake which I haven't tested yet.
-            socket.bind(getLocalEphemeral(), 1);
+            socket.bind(createLocalEphemeralAddress(), 1);
             socket.setReuseAddress(true);
             DiscoveryNode first = new DiscoveryNode(
                 "TEST",
@@ -2278,7 +2278,7 @@ public abstract class AbstractSimpleTransportTestCase extends OpenSearchTestCase
 
     public void testTcpHandshakeTimeout() throws IOException {
         try (ServerSocket socket = new ServerSocket()) {
-            socket.bind(getLocalEphemeral(), 1);
+            socket.bind(createLocalEphemeralAddress(), 1);
             socket.setReuseAddress(true);
             DiscoveryNode dummy = new DiscoveryNode(
                 "TEST",
@@ -2307,7 +2307,7 @@ public abstract class AbstractSimpleTransportTestCase extends OpenSearchTestCase
 
     public void testTcpHandshakeConnectionReset() throws IOException, InterruptedException {
         try (ServerSocket socket = new ServerSocket()) {
-            socket.bind(getLocalEphemeral(), 1);
+            socket.bind(createLocalEphemeralAddress(), 1);
             socket.setReuseAddress(true);
             DiscoveryNode dummy = new DiscoveryNode(
                 "TEST",
@@ -3126,7 +3126,7 @@ public abstract class AbstractSimpleTransportTestCase extends OpenSearchTestCase
     }
 
     @SuppressForbidden(reason = "need local ephemeral port")
-    protected InetSocketAddress getLocalEphemeral() throws UnknownHostException {
+    private InetSocketAddress createLocalEphemeralAddress() throws UnknownHostException {
         return new InetSocketAddress(InetAddress.getLocalHost(), 0);
     }
 


### PR DESCRIPTION
Signed-off-by: mloufra <mloufra@amazon.com>

### Description
The ActionListener class has a protected static method getLocalEphemeral().

Subclasses can't access static method so protected access is inappropriate. Consider making private if only this class will use it. Consider refactoring to another class if it's going to be used by other classes
As it's not a field accessor, get*() is not the best name. Consider createLocalEphemeralAddress().
Equivalent PR on OpenSearch :https://github.com/opensearch-project/opensearch-sdk/pull/85
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-sdk/issues/49
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
