### PR TITLE
[Remote Store] Change remote_store setting validation message to make it more clear

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -302,12 +302,12 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 final Object replicationType = settings.get(INDEX_REPLICATION_TYPE_SETTING);
                 if (replicationType != ReplicationType.SEGMENT && value == true) {
                     throw new IllegalArgumentException(
-                        "Settings "
+                        "To enable "
                             + INDEX_REMOTE_STORE_ENABLED_SETTING.getKey()
-                            + " cannot be enabled when "
+                            + ", "
                             + INDEX_REPLICATION_TYPE_SETTING.getKey()
-                            + " is set to "
-                            + settings.get(INDEX_REPLICATION_TYPE_SETTING)
+                            + " should be set to "
+                            + ReplicationType.SEGMENT
                     );
                 }
             }

--- a/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
@@ -865,10 +865,7 @@ public class IndexSettingsTests extends OpenSearchTestCase {
             IllegalArgumentException.class,
             () -> IndexMetadata.INDEX_REMOTE_STORE_ENABLED_SETTING.get(indexSettings)
         );
-        assertEquals(
-            "To enable index.remote_store.enabled, index.replication.type should be set to SEGMENT",
-            iae.getMessage()
-        );
+        assertEquals("To enable index.remote_store.enabled, index.replication.type should be set to SEGMENT", iae.getMessage());
     }
 
     public void testEnablingRemoteStoreFailsWhenReplicationTypeIsDefault() {
@@ -877,9 +874,6 @@ public class IndexSettingsTests extends OpenSearchTestCase {
             IllegalArgumentException.class,
             () -> IndexMetadata.INDEX_REMOTE_STORE_ENABLED_SETTING.get(indexSettings)
         );
-        assertEquals(
-            "To enable index.remote_store.enabled, index.replication.type should be set to SEGMENT",
-            iae.getMessage()
-        );
+        assertEquals("To enable index.remote_store.enabled, index.replication.type should be set to SEGMENT", iae.getMessage());
     }
 }

--- a/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
@@ -866,7 +866,7 @@ public class IndexSettingsTests extends OpenSearchTestCase {
             () -> IndexMetadata.INDEX_REMOTE_STORE_ENABLED_SETTING.get(indexSettings)
         );
         assertEquals(
-            "Settings index.remote_store.enabled cannot be enabled when index.replication.type is set to DOCUMENT",
+            "To enable index.remote_store.enabled, index.replication.type should be set to SEGMENT",
             iae.getMessage()
         );
     }
@@ -878,7 +878,7 @@ public class IndexSettingsTests extends OpenSearchTestCase {
             () -> IndexMetadata.INDEX_REMOTE_STORE_ENABLED_SETTING.get(indexSettings)
         );
         assertEquals(
-            "Settings index.remote_store.enabled cannot be enabled when index.replication.type is set to DOCUMENT",
+            "To enable index.remote_store.enabled, index.replication.type should be set to SEGMENT",
             iae.getMessage()
         );
     }


### PR DESCRIPTION
Signed-off-by: Sachin Kale <kalsac@amazon.com>

### Description
- Currently, if we try to enable `index.remote_store.enabled` without setting replication type to SEGMENT, we get following error:
```
{
  "error" : {
    "root_cause" : [
      {
        "type" : "illegal_argument_exception",
        "reason" : "Settings index.remote_store.enabled cannot be enabled when index.replication.type is set to DOCUMENT"
      }
    ],
    "type" : "illegal_argument_exception",
    "reason" : "Settings index.remote_store.enabled cannot be enabled when index.replication.type is set to DOCUMENT"
  },
  "status" : 400
}
```
- But this does not make the dependency of segment replication clear. With this change, we are changing the error message to:
```
{
  "error" : {
    "root_cause" : [
      {
        "type" : "illegal_argument_exception",
        "reason" : "To enable index.remote_store.enabled, index.replication.type should be set to SEGMENT"
      }
    ],
    "type" : "illegal_argument_exception",
    "reason" : "To enable index.remote_store.enabled, index.replication.type should be set to SEGMENT"
  },
  "status" : 400
}
```

### Issues Resolved
- https://github.com/opensearch-project/OpenSearch/issues/4201
 
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
