### PR TITLE
[Segment Replication] [Bug] Wrap IndexInput inside try with resources to prevent file handle leaks

### DIFF
--- a/server/src/main/java/org/opensearch/indices/replication/SegmentFileTransferHandler.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentFileTransferHandler.java
@@ -104,13 +104,14 @@ public final class SegmentFileTransferHandler {
             protected void onNewResource(StoreFileMetadata md) throws IOException {
                 offset = 0;
                 IOUtils.close(currentInput, () -> currentInput = null);
-                final IndexInput indexInput = store.directory().openInput(md.name(), IOContext.READONCE);
-                currentInput = new InputStreamIndexInput(indexInput, md.length()) {
-                    @Override
-                    public void close() throws IOException {
-                        IOUtils.close(indexInput, super::close); // InputStreamIndexInput's close is a noop
-                    }
-                };
+                try (final IndexInput indexInput = store.directory().openInput(md.name(), IOContext.READONCE)) {
+                    currentInput = new InputStreamIndexInput(indexInput, md.length()) {
+                        @Override
+                        public void close() throws IOException {
+                            IOUtils.close(indexInput, super::close); // InputStreamIndexInput's close is a noop
+                        }
+                    };
+                }
             }
 
             private byte[] acquireBuffer() {


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Wrap IndexInput inside try-with-resources to fix runtime exception due to file handle leaks
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/4205


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
