### PR TITLE
[Feature/extensions] Adding extensibility support for extension point getNamedXContents

### DIFF
--- a/server/src/main/java/org/opensearch/common/xcontent/NamedXContentRegistryParseRequest.java
+++ b/server/src/main/java/org/opensearch/common/xcontent/NamedXContentRegistryParseRequest.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.xcontent;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportRequest;
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Extensibility support for Named XContent Registry: request to extensions to parse context
+ *
+ * @opensearch.internal
+ */
+public class NamedXContentRegistryParseRequest extends TransportRequest {
+
+    private final Class categoryClass;
+    private final String context;
+
+    /**
+     * @param categoryClass Class category for this parse request
+     * @param context String to transport to the extension
+     */
+    public NamedXContentRegistryParseRequest(Class categoryClass, String context) {
+        this.categoryClass = categoryClass;
+        this.context = context;
+    }
+
+    /**
+     * @param in StreamInput from which class fields are read from
+     * @throws IllegalArgumentException if the fully qualified class name is invalid and the class object cannot be generated at runtime
+     */
+    public NamedXContentRegistryParseRequest(StreamInput in) throws IOException {
+        super(in);
+        try {
+            this.categoryClass = Class.forName(in.readString());
+            this.context = in.readOptionalString();
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException("Category class definition not found", e);
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(categoryClass.getName());
+        out.writeOptionalString(context);
+    }
+
+    @Override
+    public String toString() {
+        return "NamedXContentRegistryParseRequest{" + "categoryClass=" + categoryClass.getName() + ", context=" + context + " }";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        NamedXContentRegistryParseRequest that = (NamedXContentRegistryParseRequest) o;
+        return Objects.equals(categoryClass, that.categoryClass) && Objects.equals(context, that.context);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(categoryClass, context);
+    }
+
+    /**
+     * Returns the class instance of the category class sent over by the SDK
+     */
+    public Class getCategoryClass() {
+        return this.categoryClass;
+    }
+
+    /**
+     * Returns the string context of this request
+     */
+    public String getContext() {
+        return this.context;
+    }
+}

--- a/server/src/main/java/org/opensearch/common/xcontent/NamedXContentRegistryResponse.java
+++ b/server/src/main/java/org/opensearch/common/xcontent/NamedXContentRegistryResponse.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.xcontent;
+
+import org.opensearch.common.ParseField;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportResponse;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Extensibility support for Named XContent Registry : response from extensions for named xcontent registry entries
+ *
+ * @opensearch.internal
+ */
+
+public class NamedXContentRegistryResponse extends TransportResponse {
+
+    private final Map<ParseField, Class> registry;
+
+    /**
+     * @param registry Map of ParseFields and their associated category class
+     */
+    public NamedXContentRegistryResponse(Map<ParseField, Class> registry) {
+        this.registry = new HashMap<>(registry);
+    }
+
+    /**
+     * @param in StreamInput from which map entries of writeable names and their associated category classes are read from
+     * @throws IllegalArgumentException if the fully qualified class name is invalid and the class object cannot be generated at runtime
+     */
+    public NamedXContentRegistryResponse(StreamInput in) throws IOException {
+        super(in);
+
+        Map<ParseField, Class> registry = new HashMap<>();
+        int registryEntryCount = in.readVInt();
+        for (int i = 0; i < registryEntryCount; i++) {
+            try {
+                String name = in.readString();
+                String[] deprecatedNames = in.readStringArray();
+                ParseField parseField = new ParseField(name, deprecatedNames);
+                Class categoryClass = Class.forName(in.readString());
+                registry.put(parseField, categoryClass);
+            } catch (ClassNotFoundException e) {
+                throw new IllegalArgumentException("Category class definition not found", e);
+            }
+        }
+        this.registry = registry;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+
+        out.writeVInt(this.registry.size());
+        for (Map.Entry<ParseField, Class> entry : registry.entrySet()) {
+
+            ParseField parseField = entry.getKey();
+            Class categoryClass = entry.getValue();
+
+            // First write out ParseField metadata then category class
+            out.writeString(parseField.getPreferredName());
+            out.writeStringArray(parseField.getDeprecatedNames());
+            out.writeString(categoryClass.getName());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "NamedXContentRegistryResponse{" + "registry=" + registry.toString() + "}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        NamedXContentRegistryResponse that = (NamedXContentRegistryResponse) o;
+        return Objects.equals(registry, that.registry);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(registry);
+    }
+
+    /**
+     * Returns a map of ParseFields and their associated category class
+     */
+    public Map<ParseField, Class> getRegistry() {
+        return Collections.unmodifiableMap(this.registry);
+    }
+
+}

--- a/server/src/main/java/org/opensearch/extensions/ExtensionNamedXContentRegistry.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionNamedXContentRegistry.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.extensions;
+
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.ParseField;
+import org.opensearch.extensions.ExtensionsOrchestrator.OpenSearchRequestType;
+import org.opensearch.transport.TransportService;
+
+/**
+ * API for Named Xcontents for extensions
+ *
+ * @opensearch.internal
+ */
+public class ExtensionNamedXContentRegistry {
+
+    private static final Logger logger = LogManager.getLogger(ExtensionNamedXContentRegistry.class);
+
+    private Map<DiscoveryNode, Map<Class, Map<String, Map<ParseField, ExtensionReader>>>> extensionNamedXContentRegistry;
+    private List<DiscoveryExtension> extensionsInitializedList;
+    private TransportService transportService;
+
+    /**
+     * Initializes a new ExtensionXContentRegistry
+     *
+     * @param extensionsInitializedList List of DiscoveryExtensions to send requests to
+     * @param transportService Service that facilitates transport requests
+     */
+    public ExtensionNamedXContentRegistry(List<DiscoveryExtension> extensionsInitializedList, TransportService transportService) {
+        this.extensionsInitializedList = extensionsInitializedList;
+        this.extensionNamedXContentRegistry = new HashMap<>();
+        this.transportService = transportService;
+
+        getNamedXContents();
+    }
+
+    /**
+     * Iterates through all discovered extensions, sends transport requests for named xcontent and consolidates all entires into a central named xcontent registry for extensions.
+     */
+    public void getNamedXContents() {
+
+        // Retrieve named xcontent registry entries from each extension
+        for (DiscoveryNode extensionNode : extensionsInitializedList) {
+            try {
+                Map<DiscoveryNode, Map<Class, Map<String, Map<ParseField, ExtensionReader>>>> extensionRegistry = getNamedXContents(
+                    extensionNode
+                );
+                if (extensionRegistry.isEmpty() == false) {
+                    this.extensionNamedXContentRegistry.putAll(extensionRegistry);
+                }
+            } catch (UnknownHostException e) {
+                logger.error(e.toString());
+            }
+        }
+    }
+
+    /**
+     * Sends a transport request for named xcontent to an extension, identified by the given DiscoveryNode, and processes the response into registry entries
+     *
+     * @param extensionNode DiscoveryNode identifying the extension
+     * @throws UnknownHostException if connection to the extension node failed
+     * @return A map of category classes and their associated ParseFields and readers for this discovery node
+     */
+    private Map<DiscoveryNode, Map<Class, Map<String, Map<ParseField, ExtensionReader>>>> getNamedXContents(DiscoveryNode extensionNode)
+        throws UnknownHostException {
+        NamedXContentRegistryResponseHandler namedXContentRegistryResponseHandler = new NamedXContentRegistryResponseHandler(
+            extensionNode,
+            transportService,
+            ExtensionsOrchestrator.REQUEST_OPENSEARCH_NAMED_XCONTENT_REGISTRY
+        );
+        try {
+            logger.info("Sending extension request type: " + ExtensionsOrchestrator.REQUEST_OPENSEARCH_NAMED_XCONTENT_REGISTRY);
+            transportService.sendRequest(
+                extensionNode,
+                ExtensionsOrchestrator.REQUEST_OPENSEARCH_NAMED_XCONTENT_REGISTRY,
+                new OpenSearchRequest(OpenSearchRequestType.REQUEST_OPENSEARCH_NAMED_XCONTENT_REGISTRY),
+                namedXContentRegistryResponseHandler
+            );
+        } catch (Exception e) {
+            logger.error(e.toString());
+        }
+
+        return namedXContentRegistryResponseHandler.getExtensionRegistry();
+    }
+
+}

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsOrchestrator.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsOrchestrator.java
@@ -73,6 +73,8 @@ public class ExtensionsOrchestrator implements ReportingService<PluginsAndModule
     public static final String REQUEST_EXTENSION_CLUSTER_SETTINGS = "internal:discovery/clustersettings";
     public static final String REQUEST_OPENSEARCH_NAMED_WRITEABLE_REGISTRY = "internal:discovery/namedwriteableregistry";
     public static final String REQUEST_OPENSEARCH_PARSE_NAMED_WRITEABLE = "internal:discovery/parsenamedwriteable";
+    public static final String REQUEST_OPENSEARCH_NAMED_XCONTENT_REGISTRY = "internal:discovery/namedxcontentregistry";
+    public static final String REQUEST_OPENSEARCH_PARSE_NAMED_XCONTENT = "internal:discovery/parsenamedxcontent";
 
     private static final Logger logger = LogManager.getLogger(ExtensionsOrchestrator.class);
 
@@ -96,7 +98,8 @@ public class ExtensionsOrchestrator implements ReportingService<PluginsAndModule
      * @opensearch.internal
      */
     public static enum OpenSearchRequestType {
-        REQUEST_OPENSEARCH_NAMED_WRITEABLE_REGISTRY
+        REQUEST_OPENSEARCH_NAMED_WRITEABLE_REGISTRY,
+        REQUEST_OPENSEARCH_NAMED_XCONTENT_REGISTRY
     }
 
     private final Path extensionsPath;
@@ -105,6 +108,7 @@ public class ExtensionsOrchestrator implements ReportingService<PluginsAndModule
     TransportService transportService;
     ClusterService clusterService;
     ExtensionNamedWriteableRegistry namedWriteableRegistry;
+    ExtensionNamedXContentRegistry namedXContentRegistry;
 
     public ExtensionsOrchestrator(Settings settings, Path extensionsPath) throws IOException {
         logger.info("ExtensionsOrchestrator initialized");
@@ -113,6 +117,7 @@ public class ExtensionsOrchestrator implements ReportingService<PluginsAndModule
         this.extensionsList = new ArrayList<DiscoveryExtension>();
         this.extensionsInitializedList = new ArrayList<DiscoveryExtension>();
         this.clusterService = null;
+        this.namedWriteableRegistry = null;
         this.namedWriteableRegistry = null;
 
         /*
@@ -133,6 +138,10 @@ public class ExtensionsOrchestrator implements ReportingService<PluginsAndModule
 
     public void setNamedWriteableRegistry() {
         this.namedWriteableRegistry = new ExtensionNamedWriteableRegistry(extensionsInitializedList, transportService);
+    }
+
+    public void setNamedXContentRegistry() {
+        this.namedXContentRegistry = new ExtensionNamedXContentRegistry(extensionsInitializedList, transportService);
     }
 
     private void registerRequestHandler() {

--- a/server/src/main/java/org/opensearch/extensions/NamedXContentRegistryParseResponseHandler.java
+++ b/server/src/main/java/org/opensearch/extensions/NamedXContentRegistryParseResponseHandler.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.extensions;
+
+import java.io.IOException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportException;
+import org.opensearch.transport.TransportResponseHandler;
+
+/**
+ * Response handler for NamedXContentRegistryParse Requests
+ *
+ * @opensearch.internal
+ */
+public class NamedXContentRegistryParseResponseHandler implements TransportResponseHandler<ExtensionBooleanResponse> {
+    private static final Logger logger = LogManager.getLogger(NamedXContentRegistryParseResponseHandler.class);
+
+    @Override
+    public ExtensionBooleanResponse read(StreamInput in) throws IOException {
+        return new ExtensionBooleanResponse(in);
+    }
+
+    @Override
+    public void handleResponse(ExtensionBooleanResponse response) {
+        logger.info("response {}", response.getStatus());
+    }
+
+    @Override
+    public void handleException(TransportException exp) {
+        logger.error(new ParameterizedMessage("NamedXContentRegistryParseRequest failed"), exp);
+    }
+
+    @Override
+    public String executor() {
+        return ThreadPool.Names.GENERIC;
+    }
+}

--- a/server/src/main/java/org/opensearch/extensions/NamedXContentRegistryResponseHandler.java
+++ b/server/src/main/java/org/opensearch/extensions/NamedXContentRegistryResponseHandler.java
@@ -1,0 +1,163 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.extensions;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.ParseField;
+import org.opensearch.common.xcontent.NamedXContentRegistryParseRequest;
+import org.opensearch.common.xcontent.NamedXContentRegistryResponse;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportException;
+import org.opensearch.transport.TransportResponseHandler;
+import org.opensearch.transport.TransportService;
+
+/**
+ * Response handler for NamedXContentRegistry Requests
+ *
+ * @opensearch.internal
+ */
+public class NamedXContentRegistryResponseHandler implements TransportResponseHandler<NamedXContentRegistryResponse> {
+    private static final Logger logger = LogManager.getLogger(NamedXContentRegistryResponseHandler.class);
+
+    private final Map<DiscoveryNode, Map<Class, Map<String, Map<ParseField, ExtensionReader>>>> extensionRegistry;
+    private final DiscoveryNode extensionNode;
+    private final TransportService transportService;
+    private final String requestType;
+
+    /**
+    * Instantiates a new NamedXContentRegistry response handler
+    *
+    * @param extensionNode Discovery Node identifying the extension associated with the category class and ParseField
+    * @param transportService The transport service communicating with the SDK
+    * @param requestType The type of request that OpenSearch will send to the SDK
+    */
+    public NamedXContentRegistryResponseHandler(DiscoveryNode extensionNode, TransportService transportService, String requestType) {
+        this.extensionRegistry = new HashMap<>();
+        this.extensionNode = extensionNode;
+        this.transportService = transportService;
+        this.requestType = requestType;
+    }
+
+    /**
+     * Transports a StreamInput, converted into a byte array, and associated category class to the given extension, identified by its discovery node
+     *
+     * @param extensionNode Discovery Node identifying the extension associated with the category class and name
+     * @param categoryClass Class that the XContent object extends
+     * @param context String that the parser will be applied to
+     * @throws UnknownHostException if connection to the extension node failed
+     */
+    public void parseNamedXContent(DiscoveryNode extensionNode, Class categoryClass, String context) throws UnknownHostException {
+        NamedXContentRegistryParseResponseHandler namedXContentRegistryParseResponseHandler =
+            new NamedXContentRegistryParseResponseHandler();
+        try {
+            logger.info("Sending extension request type: " + requestType);
+            transportService.sendRequest(
+                extensionNode,
+                requestType,
+                new NamedXContentRegistryParseRequest(categoryClass, context),
+                namedXContentRegistryParseResponseHandler
+            );
+        } catch (Exception e) {
+            logger.error(e.toString());
+        }
+    }
+
+    /**
+     * @return A map of the given DiscoveryNode and its inner names xcontent registry map
+     */
+
+    public Map<DiscoveryNode, Map<Class, Map<String, Map<ParseField, ExtensionReader>>>> getExtensionRegistry() {
+        return Collections.unmodifiableMap(this.extensionRegistry);
+    }
+
+    @Override
+    public NamedXContentRegistryResponse read(StreamInput in) throws IOException {
+        return new NamedXContentRegistryResponse(in);
+    }
+
+    @Override
+    public void handleResponse(NamedXContentRegistryResponse response) {
+
+        logger.info("response {}", response);
+        logger.info("EXTENSION [" + extensionNode.getName() + "] returned " + response.getRegistry().size() + " entries");
+
+        if (response.getRegistry().isEmpty() == false) {
+
+            // Initialize inner category map
+            Map<Class, Map<String, Map<ParseField, ExtensionReader>>> categoryMap = new HashMap<>();
+
+            // ParseField name map associated with this current category
+            Map<String, Map<ParseField, ExtensionReader>> nameMap = null;
+            Class currentCategory = null;
+
+            // Extract response entries and populate the registry
+            for (Map.Entry<ParseField, Class> entry : response.getRegistry().entrySet()) {
+
+                ParseField parseField = entry.getKey();
+                Class categoryClass = entry.getValue();
+
+                if (currentCategory != categoryClass) {
+                    // After first pass, parsefield names and current category are set
+                    if (currentCategory != null) {
+                        categoryMap.put(currentCategory, nameMap);
+                    }
+                    nameMap = new HashMap<>();
+                    currentCategory = categoryClass;
+                }
+
+                Map<ParseField, ExtensionReader> readerMap = null;
+                String currentName = null;
+
+                // Iterate through all parsefield names (including deprecated names)
+                for (String name : parseField.getAllNamesIncludedDeprecated()) {
+
+                    if (currentName != name) {
+                        if (currentName != null) {
+                            // After first pass, ParseFields are set with their corresponding parseField name
+                            nameMap.put(currentName, readerMap);
+                        }
+                        readerMap = new HashMap<>();
+                        currentName = name;
+                    }
+                    ExtensionReader callback = (en, cc, context) -> parseNamedXContent(en, cc, (String) context);
+                    readerMap.put(parseField, callback);
+                }
+
+                // Handle last name and reader map
+                nameMap.put(currentName, readerMap);
+            }
+
+            // Handle last category class and name map
+            categoryMap.put(currentCategory, nameMap);
+
+            // Attach extension node to category map
+            extensionRegistry.put(extensionNode, categoryMap);
+        }
+
+    }
+
+    @Override
+    public void handleException(TransportException exp) {
+        logger.error(new ParameterizedMessage("OpenSearchRequest failed"), exp);
+    }
+
+    @Override
+    public String executor() {
+        return ThreadPool.Names.GENERIC;
+    }
+}

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -1166,6 +1166,7 @@ public class Node implements Closeable {
         transportService.acceptIncomingRequests();
         extensionsOrchestrator.extensionsInitialize();
         extensionsOrchestrator.setNamedWriteableRegistry();
+        extensionsOrchestrator.setNamedXContentRegistry();
         discovery.startInitialJoin();
         final TimeValue initialStateTimeout = DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.get(settings());
         configureNodeAndClusterIdStateListener(clusterService);

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsOrchestratorTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsOrchestratorTests.java
@@ -451,7 +451,7 @@ public class ExtensionsOrchestratorTests extends OpenSearchTestCase {
             Exception.class,
             () -> extensionsOrchestrator.namedWriteableRegistry.getExtensionReader(Example.class, Example.NAME)
         );
-        assertEquals(e.getMessage(), "Unknown NamedWriteable [" + Example.class.getName() + "][" + Example.NAME + "]");
+        assertEquals("Unknown NamedWriteable [" + Example.class.getName() + "][" + Example.NAME + "]", e.getMessage());
         verify(extensionsOrchestrator.namedWriteableRegistry, times(1)).getExtensionReader(any(), any());
     }
 
@@ -584,6 +584,10 @@ public class ExtensionsOrchestratorTests extends OpenSearchTestCase {
         Exception e = expectThrows(
             Exception.class,
             () -> extensionsOrchestrator.namedXContentRegistry.getExtensionReader(categoryClass, parseField, parseField.getPreferredName())
+        );
+        assertEquals(
+            "Unknown NamedXContent [" + categoryClass.getName() + "][" + parseField.toString() + "][" + parseField.getPreferredName() + "]",
+            e.getMessage()
         );
         verify(extensionsOrchestrator.namedXContentRegistry, times(1)).getExtensionReader(any(), any(), any());
     }

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsOrchestratorTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsOrchestratorTests.java
@@ -602,7 +602,7 @@ public class ExtensionsOrchestratorTests extends OpenSearchTestCase {
         String requestType = ExtensionsOrchestrator.REQUEST_OPENSEARCH_PARSE_NAMED_XCONTENT;
         DiscoveryNode extensionNode = extensionsOrchestrator.extensionsList.get(0);
         Class categoryClass = Object.class;
-        String context = "test context";
+        String context = "test";
 
         try (
             MockLogAppender mockLogAppender = MockLogAppender.createForLoggers(


### PR DESCRIPTION
### Description
Adds support for registering named xcontent entries from extensions and transporting parse requests to extensions to generate XContent Parsers
 
### Issues Resolved
https://github.com/opensearch-project/opensearch/issues/3379
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
