### PR TITLE
[Backport] [1.x] [Bug]: gradle check failing with java heap OutOfMemoryError (#4150)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@
 org.gradle.warning.mode=none
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Xss2m
-options.forkOptions.memoryMaximumSize=2g
+options.forkOptions.memoryMaximumSize=3g
 
 # Disable duplicate project id detection
 # See https://docs.gradle.org/current/userguide/upgrading_version_6.html#duplicate_project_names_may_cause_publication_to_fail


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Backport 0f2ed704577d6a8a2fa95ee7c110dd7a2b91a141 from #4150
 
### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/3973
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
