### PR TITLE
[Segment Replication] Refactor Store.recoveryDiff method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Use RemoteSegmentStoreDirectory instead of RemoteDirectory ([#4240](https://github.com/opensearch-project/OpenSearch/pull/4240))
 - Plugin ZIP publication groupId value is configurable ([#4156](https://github.com/opensearch-project/OpenSearch/pull/4156))
 - Update to Netty 4.1.80.Final ([#4359](https://github.com/opensearch-project/OpenSearch/pull/4359))
+- [Segment Replication] Refactor Store.recoveryDiff method ([#4221](https://github.com/opensearch-project/OpenSearch/pull/4221))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/index/store/Store.java
+++ b/server/src/main/java/org/opensearch/index/store/Store.java
@@ -1147,7 +1147,8 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         /**
          * Returns a diff between the two snapshots that can be used for recovery. The given snapshot is treated as the
          * recovery target and this snapshot as the source. This method is also used for segment replication where
-         * missing files should not be considered as inconsistent.
+         * per-segment missing files are not considered inconsistent due to replication lag between primary and
+         * replica in file copy operation.
          * The returned diff will hold a list
          * of files that are:
          * <ul>
@@ -1179,6 +1180,12 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
          * </ul>
          * <p>
          * NOTE: this diff will not contain the {@code segments.gen} file. This file is omitted on recovery.
+         *
+         * @param recoveryTargetSnapshot recovery target snapshot to diff against
+         * @param ignoreMissingFiles when false treats missing files as exception state. It ignores remaining identical files
+         *                           in per-segment group and add them to different field in returned object, when true treats
+         *                           missing files as norm and returns different field where files are actually different
+         *
          */
         public RecoveryDiff recoveryDiff(MetadataSnapshot recoveryTargetSnapshot, boolean ignoreMissingFiles) {
             final List<StoreFileMetadata> identical = new ArrayList<>();

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
@@ -176,7 +176,7 @@ public class SegmentReplicationTarget extends ReplicationTarget {
         state.setStage(SegmentReplicationState.Stage.FILE_DIFF);
         final Store.MetadataSnapshot snapshot = checkpointInfo.getSnapshot();
         Store.MetadataSnapshot localMetadata = getMetadataSnapshot();
-        final Store.RecoveryDiff diff = snapshot.segmentReplicationDiff(localMetadata);
+        final Store.RecoveryDiff diff = snapshot.recoveryDiff(localMetadata, false);
         logger.trace("Replication diff {}", diff);
         /*
          * Segments are immutable. So if the replica has any segments with the same name that differ from the one in the incoming


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
This is a cleanup change, coming from https://github.com/opensearch-project/OpenSearch/pull/4185/files#r944055590. This PR refactors Store.recoveryDiff to make it usable for segment replication and removes previously added methods. 
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/3787

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
