### PR TITLE
Added timing data and more granular stages to SegmentReplicationState

### DIFF
--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationState.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationState.java
@@ -8,9 +8,13 @@
 
 package org.opensearch.indices.replication;
 
+import org.opensearch.common.collect.Tuple;
 import org.opensearch.indices.replication.common.ReplicationLuceneIndex;
 import org.opensearch.indices.replication.common.ReplicationState;
 import org.opensearch.indices.replication.common.ReplicationTimer;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * ReplicationState implementation to track Segment Replication events.
@@ -26,10 +30,12 @@ public class SegmentReplicationState implements ReplicationState {
      */
     public enum Stage {
         DONE((byte) 0),
-
         INIT((byte) 1),
-
-        REPLICATING((byte) 2);
+        REPLICATING((byte) 2),
+        GET_CHECKPOINT_INFO((byte) 3),
+        FILE_DIFF((byte) 4),
+        GET_FILES((byte) 5),
+        FINALIZE_REPLICATION((byte) 6);
 
         private static final Stage[] STAGES = new Stage[Stage.values().length];
 
@@ -60,13 +66,20 @@ public class SegmentReplicationState implements ReplicationState {
 
     private Stage stage;
     private final ReplicationLuceneIndex index;
-    private final ReplicationTimer timer;
+    private final ReplicationTimer overallTimer;
+    private final ReplicationTimer stepTimer;
+    private final List<Tuple<String, Long>> timingData;
+    private long replicationId;
 
     public SegmentReplicationState(ReplicationLuceneIndex index) {
         stage = Stage.INIT;
         this.index = index;
-        timer = new ReplicationTimer();
-        timer.start();
+        // Timing data will have as many entries as stages, plus one
+        // additional entry for the overall timer
+        timingData = new ArrayList<>(Stage.values().length + 1);
+        overallTimer = new ReplicationTimer();
+        stepTimer = new ReplicationTimer();
+        stepTimer.start();
     }
 
     @Override
@@ -74,9 +87,21 @@ public class SegmentReplicationState implements ReplicationState {
         return index;
     }
 
+    public long getReplicationId() {
+        return replicationId;
+    }
+
+    public void setReplicationId(long replicationId) {
+        this.replicationId = replicationId;
+    }
+
     @Override
     public ReplicationTimer getTimer() {
-        return timer;
+        return overallTimer;
+    }
+
+    public List<Tuple<String, Long>> getTimingData() {
+        return timingData;
     }
 
     public Stage getStage() {
@@ -90,6 +115,12 @@ public class SegmentReplicationState implements ReplicationState {
                 "can't move replication to stage [" + next + "]. current stage: [" + stage + "] (expected [" + expected + "])"
             );
         }
+        // save the timing data for the current step
+        stepTimer.stop();
+        timingData.add(new Tuple<>(stage.name(), stepTimer.time()));
+        // restart the step timer
+        stepTimer.reset();
+        stepTimer.start();
         stage = next;
     }
 
@@ -97,16 +128,29 @@ public class SegmentReplicationState implements ReplicationState {
         switch (stage) {
             case INIT:
                 this.stage = Stage.INIT;
-                getIndex().reset();
                 break;
             case REPLICATING:
                 validateAndSetStage(Stage.INIT, stage);
-                getIndex().start();
+                // only start the overall timer once we've started replication
+                overallTimer.start();
+                break;
+            case GET_CHECKPOINT_INFO:
+                validateAndSetStage(Stage.REPLICATING, stage);
+                break;
+            case FILE_DIFF:
+                validateAndSetStage(Stage.GET_CHECKPOINT_INFO, stage);
+                break;
+            case GET_FILES:
+                validateAndSetStage(Stage.FILE_DIFF, stage);
+                break;
+            case FINALIZE_REPLICATION:
+                validateAndSetStage(Stage.GET_FILES, stage);
                 break;
             case DONE:
-                validateAndSetStage(Stage.REPLICATING, stage);
-                getIndex().stop();
-                getTimer().stop();
+                validateAndSetStage(Stage.FINALIZE_REPLICATION, stage);
+                // add the overall timing data
+                overallTimer.stop();
+                timingData.add(new Tuple<>("OVERALL", overallTimer.time()));
                 break;
             default:
                 throw new IllegalArgumentException("unknown SegmentReplicationState.Stage [" + stage + "]");

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationState.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationState.java
@@ -67,7 +67,7 @@ public class SegmentReplicationState implements ReplicationState {
     private Stage stage;
     private final ReplicationLuceneIndex index;
     private final ReplicationTimer overallTimer;
-    private final ReplicationTimer stepTimer;
+    private final ReplicationTimer stageTimer;
     private final List<Tuple<String, Long>> timingData;
     private long replicationId;
 
@@ -78,8 +78,15 @@ public class SegmentReplicationState implements ReplicationState {
         // additional entry for the overall timer
         timingData = new ArrayList<>(Stage.values().length + 1);
         overallTimer = new ReplicationTimer();
-        stepTimer = new ReplicationTimer();
-        stepTimer.start();
+        stageTimer = new ReplicationTimer();
+        stageTimer.start();
+        // set an invalid value by default
+        this.replicationId = -1L;
+    }
+
+    public SegmentReplicationState(ReplicationLuceneIndex index, long replicationId) {
+        this(index);
+        this.replicationId = replicationId;
     }
 
     @Override
@@ -89,10 +96,6 @@ public class SegmentReplicationState implements ReplicationState {
 
     public long getReplicationId() {
         return replicationId;
-    }
-
-    public void setReplicationId(long replicationId) {
-        this.replicationId = replicationId;
     }
 
     @Override
@@ -116,11 +119,11 @@ public class SegmentReplicationState implements ReplicationState {
             );
         }
         // save the timing data for the current step
-        stepTimer.stop();
-        timingData.add(new Tuple<>(stage.name(), stepTimer.time()));
+        stageTimer.stop();
+        timingData.add(new Tuple<>(stage.name(), stageTimer.time()));
         // restart the step timer
-        stepTimer.reset();
-        stepTimer.start();
+        stageTimer.reset();
+        stageTimer.start();
         stage = next;
     }
 

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
@@ -65,6 +65,7 @@ public class SegmentReplicationTarget extends ReplicationTarget {
         this.checkpoint = checkpoint;
         this.source = source;
         this.state = new SegmentReplicationState(stateIndex);
+        this.state.setReplicationId(getId());
         this.multiFileWriter = new MultiFileWriter(indexShard.store(), stateIndex, getPrefix(), logger, this::ensureRefCount);
     }
 
@@ -139,7 +140,9 @@ public class SegmentReplicationTarget extends ReplicationTarget {
         final StepListener<GetSegmentFilesResponse> getFilesListener = new StepListener<>();
         final StepListener<Void> finalizeListener = new StepListener<>();
 
+        logger.trace("[shardId {}] Replica starting replication [id {}]", shardId().getId(), getId());
         // Get list of files to copy from this checkpoint.
+        state.setStage(SegmentReplicationState.Stage.GET_CHECKPOINT_INFO);
         source.getCheckpointMetadata(getId(), checkpoint, checkpointInfoListener);
 
         checkpointInfoListener.whenComplete(checkpointInfo -> getFiles(checkpointInfo, getFilesListener), listener::onFailure);
@@ -152,14 +155,16 @@ public class SegmentReplicationTarget extends ReplicationTarget {
 
     private void getFiles(CheckpointInfoResponse checkpointInfo, StepListener<GetSegmentFilesResponse> getFilesListener)
         throws IOException {
+        state.setStage(SegmentReplicationState.Stage.FILE_DIFF);
         final Store.MetadataSnapshot snapshot = checkpointInfo.getSnapshot();
         Store.MetadataSnapshot localMetadata = getMetadataSnapshot();
         final Store.RecoveryDiff diff = snapshot.segmentReplicationDiff(localMetadata);
-        logger.debug("Replication diff {}", diff);
-        // Segments are immutable. So if the replica has any segments with the same name that differ from the one in the incoming snapshot
-        // from
-        // source that means the local copy of the segment has been corrupted/changed in some way and we throw an IllegalStateException to
-        // fail the shard
+        logger.trace("Replication diff {}", diff);
+        /*
+         * Segments are immutable. So if the replica has any segments with the same name that differ from the one in the incoming
+         * snapshot from source that means the local copy of the segment has been corrupted/changed in some way and we throw an
+         * IllegalStateException to fail the shard
+         */
         if (diff.different.isEmpty() == false) {
             getFilesListener.onFailure(
                 new IllegalStateException(
@@ -177,15 +182,18 @@ public class SegmentReplicationTarget extends ReplicationTarget {
             .collect(Collectors.toSet());
 
         filesToFetch.addAll(pendingDeleteFiles);
+        logger.trace("Files to fetch {}", filesToFetch);
 
         for (StoreFileMetadata file : filesToFetch) {
             state.getIndex().addFileDetail(file.name(), file.length(), false);
         }
         // always send a req even if not fetching files so the primary can clear the copyState for this shard.
+        state.setStage(SegmentReplicationState.Stage.GET_FILES);
         source.getSegmentFiles(getId(), checkpointInfo.getCheckpoint(), filesToFetch, store, getFilesListener);
     }
 
     private void finalizeReplication(CheckpointInfoResponse checkpointInfoResponse, ActionListener<Void> listener) {
+        state.setStage(SegmentReplicationState.Stage.FINALIZE_REPLICATION);
         ActionListener.completeWith(listener, () -> {
             multiFileWriter.renameAllTempFiles();
             final Store store = store();

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
@@ -64,8 +64,7 @@ public class SegmentReplicationTarget extends ReplicationTarget {
         super("replication_target", indexShard, new ReplicationLuceneIndex(), listener);
         this.checkpoint = checkpoint;
         this.source = source;
-        this.state = new SegmentReplicationState(stateIndex);
-        this.state.setReplicationId(getId());
+        this.state = new SegmentReplicationState(stateIndex, getId());
         this.multiFileWriter = new MultiFileWriter(indexShard.store(), stateIndex, getPrefix(), logger, this::ensureRefCount);
     }
 

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
@@ -100,8 +100,8 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
         );
         final SegmentReplicationTarget spy = Mockito.spy(target);
         doAnswer(invocation -> {
-            // setting stage to REPLICATING so transition in markAsDone succeeds on listener completion
-            target.state().setStage(SegmentReplicationState.Stage.REPLICATING);
+            // set up stage correctly so the transition in markAsDone succeeds on listener completion
+            moveTargetToFinalStage(target);
             final ActionListener<Void> listener = invocation.getArgument(0);
             listener.onResponse(null);
             return null;
@@ -123,7 +123,7 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
 
                 @Override
                 public void onReplicationFailure(SegmentReplicationState state, OpenSearchException e, boolean sendShardFailure) {
-                    assertEquals(SegmentReplicationState.Stage.REPLICATING, state.getStage());
+                    assertEquals(SegmentReplicationState.Stage.INIT, state.getStage());
                     assertEquals(expectedError, e.getCause());
                     assertTrue(sendShardFailure);
                 }
@@ -131,8 +131,6 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
         );
         final SegmentReplicationTarget spy = Mockito.spy(target);
         doAnswer(invocation -> {
-            // setting stage to REPLICATING so transition in markAsDone succeeds on listener completion
-            target.state().setStage(SegmentReplicationState.Stage.REPLICATING);
             final ActionListener<Void> listener = invocation.getArgument(0);
             listener.onFailure(expectedError);
             return null;
@@ -270,5 +268,18 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
         sut.startReplication(spy);
         sut.beforeIndexShardClosed(indexShard.shardId(), indexShard, Settings.EMPTY);
         verify(spy, times(1)).cancel(any());
+    }
+
+    /**
+     * Move the {@link SegmentReplicationTarget} object through its {@link SegmentReplicationState.Stage} values in order
+     * until the final, non-terminal stage.
+     */
+    private void moveTargetToFinalStage(SegmentReplicationTarget target) {
+        SegmentReplicationState.Stage[] stageValues = SegmentReplicationState.Stage.values();
+        assertEquals(target.state().getStage(), SegmentReplicationState.Stage.INIT);
+        // Skip the first two stages (DONE and INIT) and iterate until the last value
+        for (int i = 2; i < stageValues.length; i++) {
+            target.state().setStage(stageValues[i]);
+        }
     }
 }


### PR DESCRIPTION
### Description
This change introduces instrumentation logging that measures the latency of the various stages of segment replication as seen by each replica. Logs have also been added to the source node for checkpoint publishing and checkpoint metadata responses. All logging is currently at the TRACE level.

Signed-off-by: Kartik Ganesh <gkart@amazon.com>
 
### Issues Resolved
Part of #2583 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
