### PR TITLE
Segment Replication - Remove unnecessary call to markAllocationIdAsIn…

### DIFF
--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceHandler.java
@@ -147,14 +147,6 @@ class SegmentReplicationSourceHandler {
             transfer.start();
 
             sendFileStep.whenComplete(r -> {
-                final String targetAllocationId = request.getTargetAllocationId();
-                RunUnderPrimaryPermit.run(
-                    () -> shard.markAllocationIdAsInSync(targetAllocationId, request.getCheckpoint().getSeqNo()),
-                    shard.shardId() + " marking " + targetAllocationId + " as in sync",
-                    shard,
-                    cancellableThreads,
-                    logger
-                );
                 try {
                     future.onResponse(new GetSegmentFilesResponse(List.of(storeFileMetadata)));
                 } finally {


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Segment Replication - Remove unnecessary call to markAllocationIdAsInSync.
    
This PR Removes an unnecessary call to markAllocationIdAsInSync on the primary shard when replication events complete.
Recovery will manage this, segment replication does not need to mark the id in sync.  After replication events we update replicas with segments, advancing its processed checkpoint.  Persisted checkpoints, which drive the local checkpoint calculation on each shard, will be unchanged during these events.  Only xlog syncs advance the local checkpoint.
    

### Issues Resolved
related https://github.com/opensearch-project/OpenSearch/issues/2873
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
