### PR TITLE
[MUTE] search with uppercase regex in bwc testing

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/190_index_prefix_search.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/190_index_prefix_search.yml
@@ -84,6 +84,9 @@ setup:
 
 ---
 "search with uppercase regex":
+  - skip:
+        version: " - 2.99.99"
+        reason: uppercase regex not supported before 3.0.0
   - do:
       search:
         rest_total_hits_as_int: true


### PR DESCRIPTION
Mixed cluster testing is failing with the new [`search with uppercase regex`](https://github.com/opensearch-project/OpenSearch/blob/280b938b562fc2088a9afa8a8547f1adb96a84a5/rest-api-spec/src/main/resources/rest-api-spec/test/search/190_index_prefix_search.yml#L86) test from #3967. This PR prevents the test from running on pre-3.0 clusters until the feature is backported.
