### PR TITLE
[Segment Replication] Wait for documents to replicate to replica shards

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -293,6 +293,7 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
 
             refresh(INDEX_NAME);
             waitForReplicaUpdate();
+            Thread.sleep(1000);
 
             assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount - 1);
             assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount - 1);


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
This test adds thread sleep in testDeleteOperations test to account for generic replica lag. Please check https://github.com/opensearch-project/OpenSearch/issues/4216 for more details.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/4216

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
