### PR TITLE
Segment Replication - Add additional unit tests for update & delete ops.

### DIFF
--- a/test/framework/src/main/java/org/opensearch/index/replication/OpenSearchIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/replication/OpenSearchIndexLevelReplicationTestCase.java
@@ -144,7 +144,8 @@ public abstract class OpenSearchIndexLevelReplicationTestCase extends IndexShard
         return createGroup(replicas, settings, indexMapping, engineFactory);
     }
 
-    protected ReplicationGroup createGroup(int replicas, Settings settings, String mappings, EngineFactory engineFactory) throws IOException {
+    protected ReplicationGroup createGroup(int replicas, Settings settings, String mappings, EngineFactory engineFactory)
+        throws IOException {
         IndexMetadata metadata = buildIndexMetadata(replicas, settings, mappings);
         return new ReplicationGroup(metadata) {
             @Override

--- a/test/framework/src/main/java/org/opensearch/index/replication/OpenSearchIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/replication/OpenSearchIndexLevelReplicationTestCase.java
@@ -141,7 +141,11 @@ public abstract class OpenSearchIndexLevelReplicationTestCase extends IndexShard
     }
 
     protected ReplicationGroup createGroup(int replicas, Settings settings, EngineFactory engineFactory) throws IOException {
-        IndexMetadata metadata = buildIndexMetadata(replicas, settings, indexMapping);
+        return createGroup(replicas, settings, indexMapping, engineFactory);
+    }
+
+    protected ReplicationGroup createGroup(int replicas, Settings settings, String mappings, EngineFactory engineFactory) throws IOException {
+        IndexMetadata metadata = buildIndexMetadata(replicas, settings, mappings);
         return new ReplicationGroup(metadata) {
             @Override
             protected EngineFactory getEngineFactory(ShardRouting routing) {


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
This adds index shard level tests for update & delete ops while using segrep.
 
### Issues Resolved
related #4216 
 
### Check List
- [ x] New functionality includes testing.
  - [ x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
