### PR TITLE
Handles the status code for `.` properties

### DIFF
--- a/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
@@ -380,6 +380,9 @@ public class ObjectMapper extends Mapper implements Cloneable {
                         throw new MapperParsingException("No handler for type [" + type + "] declared on field [" + fieldName + "]");
                     }
                     String[] fieldNameParts = fieldName.split("\\.");
+                    if (fieldNameParts.length < 1) {
+                        throw new MapperParsingException("Index -1 out of bounds for length 0");
+                    } 
                     String realFieldName = fieldNameParts[fieldNameParts.length - 1];
                     Mapper.Builder<?> fieldBuilder = typeParser.parse(realFieldName, propNode, parserContext);
                     for (int i = fieldNameParts.length - 2; i >= 0; --i) {

--- a/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
@@ -380,8 +380,9 @@ public class ObjectMapper extends Mapper implements Cloneable {
                         throw new MapperParsingException("No handler for type [" + type + "] declared on field [" + fieldName + "]");
                     }
                     String[] fieldNameParts = fieldName.split("\\.");
+                    // field name is just ".", which is invalid
                     if (fieldNameParts.length < 1) {
-                        throw new MapperParsingException("Index -1 out of bounds for length 0");
+                        throw new MapperParsingException("Invalid field name " + fieldName);
                     }
                     String realFieldName = fieldNameParts[fieldNameParts.length - 1];
                     Mapper.Builder<?> fieldBuilder = typeParser.parse(realFieldName, propNode, parserContext);

--- a/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
@@ -382,7 +382,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
                     String[] fieldNameParts = fieldName.split("\\.");
                     if (fieldNameParts.length < 1) {
                         throw new MapperParsingException("Index -1 out of bounds for length 0");
-                    } 
+                    }
                     String realFieldName = fieldNameParts[fieldNameParts.length - 1];
                     Mapper.Builder<?> fieldBuilder = typeParser.parse(realFieldName, propNode, parserContext);
                     for (int i = fieldNameParts.length - 2; i >= 0; --i) {

--- a/server/src/test/java/org/opensearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ObjectMapperTests.java
@@ -178,19 +178,13 @@ public class ObjectMapperTests extends OpenSearchSingleNodeTestCase {
         }
     }
 
-    public void testDottedFields() throws Exception {
+    public void testDotAsFieldName() throws Exception {
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("properties")
                 .startObject(".")
                 .field("type", "text")
-                .field("dimension", 4)
-                .startObject("method")
-                .field("name", "hnsw")
-                .field("space", "l2")
-                .field("engine", "lucene")
-                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -200,7 +194,7 @@ public class ObjectMapperTests extends OpenSearchSingleNodeTestCase {
             createIndex("test").mapperService().documentMapperParser().parse("tweet", new CompressedXContent(mapping));
             fail("Expected MapperParsingException");
         } catch (MapperParsingException e) {
-            assertThat(e.getMessage(), containsString("out of bounds for length"));
+            assertThat(e.getMessage(), containsString("Invalid field name"));
         }
     }
 

--- a/server/src/test/java/org/opensearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ObjectMapperTests.java
@@ -179,21 +179,21 @@ public class ObjectMapperTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testDottedFields() throws Exception {
-            String mapping = Strings.toString(
+        String mapping = Strings.toString(
             XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("properties")
-            .startObject(".")
-            .field("type", "text")
-            .field("dimension", 4)
-            .startObject("method")
-            .field("name", "hnsw")
-            .field("space", "l2")
-            .field("engine", "lucene")
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject()
+                .startObject()
+                .startObject("properties")
+                .startObject(".")
+                .field("type", "text")
+                .field("dimension", 4)
+                .startObject("method")
+                .field("name", "hnsw")
+                .field("space", "l2")
+                .field("engine", "lucene")
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
         );
 
         try {

--- a/server/src/test/java/org/opensearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ObjectMapperTests.java
@@ -178,6 +178,32 @@ public class ObjectMapperTests extends OpenSearchSingleNodeTestCase {
         }
     }
 
+    public void testDottedFields() throws Exception {
+            String mapping = Strings.toString(
+            XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(".")
+            .field("type", "text")
+            .field("dimension", 4)
+            .startObject("method")
+            .field("name", "hnsw")
+            .field("space", "l2")
+            .field("engine", "lucene")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+        );
+
+        try {
+            createIndex("test").mapperService().documentMapperParser().parse("tweet", new CompressedXContent(mapping));
+            fail("Expected MapperParsingException");
+        } catch (MapperParsingException e) {
+            assertThat(e.getMessage(), containsString("out of bounds for length"));
+        }
+    }
+
     public void testFieldPropertiesArray() throws Exception {
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()


### PR DESCRIPTION
### Description
This change returns a 400 status code when a mapping with "." properties is created
Previously
```
{
  "error": {
    "root_cause": [
      {
        "type": "array_index_out_of_bounds_exception",
        "reason": "Index -1 out of bounds for length 0"
      }
    ],
    "type": "array_index_out_of_bounds_exception",
    "reason": "Index -1 out of bounds for length 0"
  },
  "status": 500
}
 ```
Now:
```
{
  "error" : {
    "root_cause" : [
      {
        "type" : "mapper_parsing_exception",
        "reason" : "Index -1 out of bounds for length 0"
      }
    ],
    "type" : "mapper_parsing_exception",
    "reason" : "Index -1 out of bounds for length 0"
  },
  "status" : 400
}
```
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
