### PR TITLE
Fix AbstractStringFieldDataTestCase tests to account for TotalHits lower bound

### DIFF
--- a/server/src/test/java/org/opensearch/index/fielddata/AbstractStringFieldDataTestCase.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/AbstractStringFieldDataTestCase.java
@@ -52,6 +52,7 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopFieldDocs;
+import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.join.QueryBitSetProducer;
 import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.search.join.ToParentBlockJoinQuery;
@@ -340,7 +341,12 @@ public abstract class AbstractStringFieldDataTestCase extends AbstractFieldDataI
             randomBoolean() ? numDocs : randomIntBetween(10, numDocs),
             new Sort(sortField)
         );
-        assertEquals(numDocs, topDocs.totalHits.value);
+        // As of Lucene 9.0.0, totalHits may be a lower bound
+        if (topDocs.totalHits.relation == TotalHits.Relation.EQUAL_TO) {
+            assertEquals(numDocs, topDocs.totalHits.value);            
+        } else {
+            assertTrue(numDocs >= topDocs.totalHits.value);                        
+        }
         BytesRef previousValue = first ? null : reverse ? UnicodeUtil.BIG_TERM : new BytesRef();
         for (int i = 0; i < topDocs.scoreDocs.length; ++i) {
             final String docValue = searcher.doc(topDocs.scoreDocs[i].doc).get("value");

--- a/server/src/test/java/org/opensearch/index/fielddata/AbstractStringFieldDataTestCase.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/AbstractStringFieldDataTestCase.java
@@ -343,9 +343,10 @@ public abstract class AbstractStringFieldDataTestCase extends AbstractFieldDataI
         );
         // As of Lucene 9.0.0, totalHits may be a lower bound
         if (topDocs.totalHits.relation == TotalHits.Relation.EQUAL_TO) {
-            assertEquals(numDocs, topDocs.totalHits.value);            
+            assertEquals(numDocs, topDocs.totalHits.value);
         } else {
-            assertTrue(numDocs >= topDocs.totalHits.value);                        
+            assertTrue(1000 <= topDocs.totalHits.value);
+            assertTrue(numDocs >= topDocs.totalHits.value);
         }
         BytesRef previousValue = first ? null : reverse ? UnicodeUtil.BIG_TERM : new BytesRef();
         for (int i = 0; i < topDocs.scoreDocs.length; ++i) {


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description
From Lucene's [`IndexSearcher`](https://lucene.apache.org/core/9_0_0/core/org/apache/lucene/search/IndexSearcher.html?is-external=true) javaDoc:
> NOTE: The [search(org.apache.lucene.search.Query, int)](https://lucene.apache.org/core/9_0_0/core/org/apache/lucene/search/IndexSearcher.html?is-external=true#search(org.apache.lucene.search.Query,int)) and [searchAfter(org.apache.lucene.search.ScoreDoc, org.apache.lucene.search.Query, int)](https://lucene.apache.org/core/9_0_0/core/org/apache/lucene/search/IndexSearcher.html?is-external=true#searchAfter(org.apache.lucene.search.ScoreDoc,org.apache.lucene.search.Query,int)) methods are configured to only count top hits accurately up to 1,000 and may return a [lower bound](https://lucene.apache.org/core/9_0_0/core/org/apache/lucene/search/TotalHits.Relation.html) of the hit count if the hit count is greater than or equal to 1,000. On queries that match lots of documents, counting the number of hits may take much longer than computing the top hits so this trade-off allows to get some minimal information about the hit count without slowing down search too much. 

The `AbstractStringFieldDataTestCase` assumed the `totalHits` value was exact.

This fixes the test to test for either exact accuracy or lower bound, as appropriate.
 
### Issues Resolved
Fixes #4238
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
