### PR TITLE
Revert "[Backport 2.2] Handles the status code for `.` properties"

### DIFF
--- a/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
@@ -380,10 +380,6 @@ public class ObjectMapper extends Mapper implements Cloneable {
                         throw new MapperParsingException("No handler for type [" + type + "] declared on field [" + fieldName + "]");
                     }
                     String[] fieldNameParts = fieldName.split("\\.");
-                    // field name is just ".", which is invalid
-                    if (fieldNameParts.length < 1) {
-                        throw new MapperParsingException("Invalid field name " + fieldName);
-                    }
                     String realFieldName = fieldNameParts[fieldNameParts.length - 1];
                     Mapper.Builder<?> fieldBuilder = typeParser.parse(realFieldName, propNode, parserContext);
                     for (int i = fieldNameParts.length - 2; i >= 0; --i) {

--- a/server/src/test/java/org/opensearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ObjectMapperTests.java
@@ -178,26 +178,6 @@ public class ObjectMapperTests extends OpenSearchSingleNodeTestCase {
         }
     }
 
-    public void testDotAsFieldName() throws Exception {
-        String mapping = Strings.toString(
-            XContentFactory.jsonBuilder()
-                .startObject()
-                .startObject("properties")
-                .startObject(".")
-                .field("type", "text")
-                .endObject()
-                .endObject()
-                .endObject()
-        );
-
-        try {
-            createIndex("test").mapperService().documentMapperParser().parse("tweet", new CompressedXContent(mapping));
-            fail("Expected MapperParsingException");
-        } catch (MapperParsingException e) {
-            assertThat(e.getMessage(), containsString("Invalid field name"));
-        }
-    }
-
     public void testFieldPropertiesArray() throws Exception {
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()


### PR DESCRIPTION
Reverts opensearch-project/OpenSearch#4251