### PR TITLE
[Feature/extensions] Revert "[Feature/extensions] Added HostAddress and Port in initial extension request"

### DIFF
--- a/server/src/main/java/org/opensearch/discovery/InitializeExtensionsRequest.java
+++ b/server/src/main/java/org/opensearch/discovery/InitializeExtensionsRequest.java
@@ -29,20 +29,16 @@ public class InitializeExtensionsRequest extends TransportRequest {
      * TODO change DiscoveryNode to Extension information
      */
     private final List<DiscoveryExtension> extensions;
-    public static final int OS_DEFAULT_PORT = 9200;
-    private int port;
 
     public InitializeExtensionsRequest(DiscoveryNode sourceNode, List<DiscoveryExtension> extensions) {
         this.sourceNode = sourceNode;
         this.extensions = extensions;
-        this.port = OS_DEFAULT_PORT;
     }
 
     public InitializeExtensionsRequest(StreamInput in) throws IOException {
         super(in);
         sourceNode = new DiscoveryNode(in);
         extensions = in.readList(DiscoveryExtension::new);
-        port = in.readInt();
     }
 
     @Override
@@ -50,7 +46,6 @@ public class InitializeExtensionsRequest extends TransportRequest {
         super.writeTo(out);
         sourceNode.writeTo(out);
         out.writeList(extensions);
-        out.writeInt(port);
     }
 
     public List<DiscoveryExtension> getExtensions() {
@@ -61,17 +56,9 @@ public class InitializeExtensionsRequest extends TransportRequest {
         return sourceNode;
     }
 
-    public int getPort() {
-        return port;
-    }
-
-    public void setPort(int port) {
-        this.port = port;
-    }
-
     @Override
     public String toString() {
-        return "InitializeExtensionsRequest{" + "sourceNode=" + sourceNode + ", extensions=" + extensions + ", port=" + port + '}';
+        return "InitializeExtensionsRequest{" + "sourceNode=" + sourceNode + ", extensions=" + extensions + '}';
     }
 
     @Override
@@ -79,13 +66,11 @@ public class InitializeExtensionsRequest extends TransportRequest {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         InitializeExtensionsRequest that = (InitializeExtensionsRequest) o;
-        return Objects.equals(sourceNode, that.sourceNode)
-            && Objects.equals(extensions, that.extensions)
-            && Objects.equals(port, that.port);
+        return Objects.equals(sourceNode, that.sourceNode) && Objects.equals(extensions, that.extensions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(sourceNode, extensions, port);
+        return Objects.hash(sourceNode, extensions);
     }
 }


### PR DESCRIPTION
Reverts opensearch-project/OpenSearch#4197

When originally reviewing this, I neglected to look at it in the context of https://github.com/opensearch-project/opensearch-sdk-java/pull/67

I did make some initial review requests commenting on the configurability of the fixed port (9200) when making room for a setter, but in fact if a user has customized their port in the config, this will break the SDK code in [SDK PR 67](https://github.com/opensearch-project/opensearch-sdk-java/pull/67) by using the incorrect (default) port.  To fix this, if we were to keep this change, we would additionally need to use that setter in the `ExtensionsOrchestrator` to get the current OpenSearch configured port and add it.

However, per [this comment](https://github.com/opensearch-project/opensearch-sdk-java/pull/67#discussion_r951801106) on [SDK PR 67](https://github.com/opensearch-project/opensearch-sdk-java/pull/67), we don't need this added at all.  The `DiscoveryNode sourceNode` parameter already being passed includes the host address and (possibly customized) port, so adding the port separately is redundant.