### PR TITLE
Removing dead code in RecoveryTarget.

### DIFF
--- a/server/src/main/java/org/opensearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoveryTarget.java
@@ -201,8 +201,6 @@ public class RecoveryTarget extends ReplicationTarget implements RecoveryTargetH
     @Override
     protected void onDone() {
         assert multiFileWriter.tempFileNames.isEmpty() : "not all temporary files are renamed";
-        // this might still throw an exception ie. if the shard is CLOSED due to some other event.
-        // it's safer to decrement the reference in a try finally here.
         indexShard.postRecovery("peer recovery done");
     }
 

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoveryTarget.java
@@ -177,51 +177,6 @@ public class RecoveryTarget extends ReplicationTarget implements RecoveryTargetH
         return false;
     }
 
-    /**
-     * cancel the recovery. calling this method will clean temporary files and release the store
-     * unless this object is in use (in which case it will be cleaned once all ongoing users call
-     * {@link #decRef()}
-     * <p>
-     * if {@link #cancellableThreads()} was used, the threads will be interrupted.
-     */
-    public void cancel(String reason) {
-        if (finished.compareAndSet(false, true)) {
-            try {
-                logger.debug("recovery canceled (reason: [{}])", reason);
-                cancellableThreads.cancel(reason);
-            } finally {
-                // release the initial reference. recovery files will be cleaned as soon as ref count goes to zero, potentially now
-                decRef();
-            }
-        }
-    }
-
-    /**
-     * fail the recovery and call listener
-     *
-     * @param e                exception that encapsulating the failure
-     * @param sendShardFailure indicates whether to notify the cluster-manager of the shard failure
-     */
-    public void fail(RecoveryFailedException e, boolean sendShardFailure) {
-        super.fail(e, sendShardFailure);
-    }
-
-    /** mark the current recovery as done */
-    public void markAsDone() {
-        if (finished.compareAndSet(false, true)) {
-            assert multiFileWriter.tempFileNames.isEmpty() : "not all temporary files are renamed";
-            try {
-                // this might still throw an exception ie. if the shard is CLOSED due to some other event.
-                // it's safer to decrement the reference in a try finally here.
-                indexShard.postRecovery("peer recovery done");
-            } finally {
-                // release the initial reference. recovery files will be cleaned as soon as ref count goes to zero, potentially now
-                decRef();
-            }
-            listener.onDone(state());
-        }
-    }
-
     @Override
     protected void closeInternal() {
         try {

--- a/server/src/main/java/org/opensearch/indices/replication/common/ReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/common/ReplicationTarget.java
@@ -155,7 +155,7 @@ public abstract class ReplicationTarget extends AbstractRefCounted {
     public void cancel(String reason) {
         if (finished.compareAndSet(false, true)) {
             try {
-                logger.debug("replication cancelled (reason: [{}])", reason);
+                logger.debug("replication/recovery cancelled (reason: [{}])", reason);
                 onCancel(reason);
             } finally {
                 // release the initial reference. replication files will be cleaned as soon as ref count goes to zero, potentially now


### PR DESCRIPTION
This code in RecoveryTarget is not invoked, all of these methods are implemented by the parent ReplicationTarget with the same behavior.

Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
