### PR TITLE
Added regex check to prevent certain special characers from being placed in index properties fields

### DIFF
--- a/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
@@ -55,6 +55,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Field mapper for object field types
@@ -349,6 +351,11 @@ public class ObjectMapper extends Mapper implements Cloneable {
             while (iterator.hasNext()) {
                 Map.Entry<String, Object> entry = iterator.next();
                 String fieldName = entry.getKey();
+                Pattern p = Pattern.compile("[^a-zA-Z0-9_.@$-]");
+                Matcher m = p.matcher(fieldName);
+                if (m.find()) {
+                    throw new MapperParsingException("Properties cannot contain special characters: " + fieldName);
+                }
                 // Should accept empty arrays, as a work around for when the
                 // user can't provide an empty Map. (PHP for example)
                 boolean isEmptyList = entry.getValue() instanceof List && ((List<?>) entry.getValue()).isEmpty();

--- a/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
@@ -351,7 +351,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
             while (iterator.hasNext()) {
                 Map.Entry<String, Object> entry = iterator.next();
                 String fieldName = entry.getKey();
-                Pattern p = Pattern.compile("[^a-zA-Z0-9_.@$-]");
+                Pattern p = Pattern.compile("[^a-zA-Z0-9_.@ $-]");
                 Matcher m = p.matcher(fieldName);
                 if (m.find()) {
                     throw new MapperParsingException("Properties cannot contain special characters: " + fieldName);

--- a/server/src/test/java/org/opensearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ObjectMapperTests.java
@@ -462,7 +462,7 @@ public class ObjectMapperTests extends OpenSearchSingleNodeTestCase {
             XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("properties")
-                .startObject("Test<Field>Name?*#\\")
+                .startObject("Test<Field>Name? *#\\")
                 .field("type", "text")
                 .endObject()
                 .endObject()

--- a/server/src/test/java/org/opensearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ObjectMapperTests.java
@@ -462,7 +462,7 @@ public class ObjectMapperTests extends OpenSearchSingleNodeTestCase {
             XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("properties")
-                .startObject("<script>alert(\"Potential Cross-Site Scripting\");</script>")
+                .startObject("<>\\")
                 .field("type", "text")
                 .endObject()
                 .endObject()

--- a/server/src/test/java/org/opensearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ObjectMapperTests.java
@@ -462,7 +462,7 @@ public class ObjectMapperTests extends OpenSearchSingleNodeTestCase {
             XContentFactory.jsonBuilder()
                 .startObject()
                 .startObject("properties")
-                .startObject("<>\\")
+                .startObject("Test<Field>Name?*#\\")
                 .field("type", "text")
                 .endObject()
                 .endObject()


### PR DESCRIPTION
Signed-off-by: Ryan Bogan <rbogan@amazon.com>

### Description
Previously, the API would allow indices with special characters to be added.  Now, a MapperParsingException will be thrown when certain special characters are part of the properties field.

```
{
  "error" : {
    "root_cause" : [
      {
        "type" : "mapper_parsing_exception",
        "reason" : "Properties cannot contain special characters: Test<Field>Name?*#\\"
      }
    ],
    "type" : "mapper_parsing_exception",
    "reason" : "Properties cannot contain special characters: Test<Field>Name?*#\\"
  },
  "status" : 400
}
```
 
### Check List
- [X ] New functionality includes testing.
  - [X ] All tests pass
- [X ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
