### PR TITLE
[Segment Replication] Update getSegmentInfosSnapshot() logic to return SegmentInfos with highest generation number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - PR reference to checkout code for changelog verifier ([#4296](https://github.com/opensearch-project/OpenSearch/pull/4296))
 - Restore using the class ClusterInfoRequest and ClusterInfoRequestBuilder from package 'org.opensearch.action.support.master.info' for subclasses ([#4307](https://github.com/opensearch-project/OpenSearch/pull/4307))
 - Do not fail replica shard due to primary closure ([#4133](https://github.com/opensearch-project/OpenSearch/pull/4133))
+- [Segment Replication] Update getSegmentInfosSnapshot() logic to return SegmentInfos with the highest generation number
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -2143,7 +2143,6 @@ public class InternalEngine extends Engine {
         try {
             final long lastCommitGeneration = store.getLastCommitGeneration();
             final long generation = inMemorySegInfos.getGeneration();
-            logger.info("Latest gen {} - {}", generation, lastCommitGeneration);
             if (generation < lastCommitGeneration) {
                 // the latest in memory infos is behind disk, read the latest SegmentInfos from disk and return that.
                 final SegmentInfos latestCommit = store.readLastCommittedSegmentsInfo();

--- a/server/src/main/java/org/opensearch/index/store/Store.java
+++ b/server/src/main/java/org/opensearch/index/store/Store.java
@@ -335,6 +335,13 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
     }
 
     /**
+     * Returns generation number (_N in segment_N) from last commit on disk.
+     */
+    public long getLastCommitGeneration() throws IOException {
+        return SegmentInfos.getLastCommitGeneration(directory());
+    }
+
+    /**
      * Renames all the given files from the key of the map to the
      * value of the map. All successfully renamed files are removed from the map in-place.
      */

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -7546,29 +7546,6 @@ public class InternalEngineTests extends EngineTestCase {
         engine.close();
     }
 
-    // This test performs indexing ops and verifies engine.getSegmentInfosSnapshot() returns SegmentInfos having highest
-    // generation
-    public void testGetSegmentInfosSnapshotWithIndexing() throws IOException {
-        final int numDocs = randomIntBetween(10, 100);
-        for (int docId = 0; docId < numDocs; docId++) {
-            index(engine, docId);
-            if (randomBoolean()) {
-                engine.refresh("test");
-            }
-        }
-        engine.flush(true, true);
-
-        // Fetch SegmentInfos from memory & disk
-        final SegmentInfos inMemorySegInfos = engine.getLatestSegmentInfos();
-        final long generation = inMemorySegInfos.getGeneration();
-        final long lastCommitGeneration = SegmentInfos.getLastCommitGeneration(store.directory());
-
-        // Verify largest (generation file) of two is returned in engine.getSegmentInfosSnapshot
-        SegmentInfos segmentInfos = engine.getSegmentInfosSnapshot().get();
-        assertEquals(segmentInfos.getGeneration(), lastCommitGeneration > generation ? lastCommitGeneration : generation);
-        assertEquals(segmentInfos, lastCommitGeneration > generation ? SegmentInfos.readLatestCommit(store.directory()) : inMemorySegInfos);
-    }
-
     // This method simulates behaviour of on-disk SegmentInfos having higher segment generation number compared to
     // actual in-memory SegmentInfos and verified that engine.getSegmentInfosSnapshot returns on-disk SegmentInfos
     public void testGetSegmentInfosWithHighestGenOnDisk() throws IOException {
@@ -7584,17 +7561,17 @@ public class InternalEngineTests extends EngineTestCase {
         }
         engine.flush(true, true);
 
-        SegmentInfos sisInMemory = engine.getLatestSegmentInfos();
-        long memoryGen = sisInMemory.getGeneration();
-        SegmentInfos sisDisk = new SegmentInfos(org.apache.lucene.util.Version.LATEST.major);
-        sisDisk.setNextWriteGeneration(memoryGen + 1);
+        SegmentInfos sisDisk = store.readLastCommittedSegmentsInfo();
+        // Increment generation number of on-disk SegmentInfos
+        sisDisk.setNextWriteGeneration(sisDisk.getGeneration() + 1);
 
         when(store.getLastCommitGeneration()).thenReturn(sisDisk.getGeneration());
         when(store.readLastCommittedSegmentsInfo()).thenReturn(sisDisk);
 
-        SegmentInfos segmentInfos = engine.getSegmentInfosSnapshot().get();
-        assertEquals(segmentInfos, sisDisk);
-        assertEquals(segmentInfos.getGeneration(), sisDisk.getGeneration());
+        GatedCloseable<SegmentInfos> segmentInfosSnapshot = engine.getSegmentInfosSnapshot();
+        assertEquals(segmentInfosSnapshot.get(), sisDisk);
+        assertEquals(segmentInfosSnapshot.get().getGeneration(), sisDisk.getGeneration());
+        segmentInfosSnapshot.close();
         store.close();
         engine.close();
     }
@@ -7615,16 +7592,14 @@ public class InternalEngineTests extends EngineTestCase {
         engine.flush(true, true);
 
         SegmentInfos sisInMemory = engine.getLatestSegmentInfos();
-        long memoryGen = sisInMemory.getGeneration();
-        SegmentInfos sisDisk = new SegmentInfos(org.apache.lucene.util.Version.LATEST.major);
-        sisDisk.setNextWriteGeneration(memoryGen - 1);
+        SegmentInfos sisDisk = store.readLastCommittedSegmentsInfo();
 
         when(store.getLastCommitGeneration()).thenReturn(sisDisk.getGeneration());
-        when(store.readLastCommittedSegmentsInfo()).thenReturn(sisDisk);
 
-        SegmentInfos segmentInfos = engine.getSegmentInfosSnapshot().get();
-        assertEquals(segmentInfos, sisInMemory);
-        assertEquals(segmentInfos.getGeneration(), sisInMemory.getGeneration());
+        GatedCloseable<SegmentInfos> segmentInfosSnapshot = engine.getSegmentInfosSnapshot();
+        assertEquals(segmentInfosSnapshot.get(), sisInMemory);
+        assertEquals(segmentInfosSnapshot.get().getGeneration(), sisInMemory.getGeneration());
+        segmentInfosSnapshot.close();
         store.close();
         engine.close();
     }

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -7576,8 +7576,8 @@ public class InternalEngineTests extends EngineTestCase {
         engine.close();
     }
 
-    // This method simulates behaviour of on-disk SegmentInfos having lower segment generation number compared to
-    // actual in-memory SegmentInfos and verified that engine.getSegmentInfosSnapshot returns in-memory SegmentInfos
+    // This method verifies that when on-disk segment generation is not higher compared to memory copy, then
+    // engine.getSegmentInfosSnapsho returns in-memory SegmentInfos
     public void testGetSegmentInfosWithHighestGenInMemory() throws IOException {
         IOUtils.close(store, engine);
         Store store = spy(createStore());
@@ -7592,9 +7592,6 @@ public class InternalEngineTests extends EngineTestCase {
         engine.flush(true, true);
 
         SegmentInfos sisInMemory = engine.getLatestSegmentInfos();
-        SegmentInfos sisDisk = store.readLastCommittedSegmentsInfo();
-
-        when(store.getLastCommitGeneration()).thenReturn(sisDisk.getGeneration());
 
         GatedCloseable<SegmentInfos> segmentInfosSnapshot = engine.getSegmentInfosSnapshot();
         assertEquals(segmentInfosSnapshot.get(), sisInMemory);


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
The PR updates the logic getSegmentInfosSnapshot() to return SegmentInfos copy (In memory Vs On-disk) with highest generation number. The logic is copied from https://github.com/opensearch-project/OpenSearch/issues/4178#issuecomment-1221049072 with minor tweaks and unit tests.

### Issues Resolved
#4178 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
