### PR TITLE
[Feature/extensions] Only send one extension info when initializing

### DIFF
--- a/server/src/main/java/org/opensearch/discovery/InitializeExtensionsRequest.java
+++ b/server/src/main/java/org/opensearch/discovery/InitializeExtensionsRequest.java
@@ -15,7 +15,6 @@ import org.opensearch.extensions.DiscoveryExtension;
 import org.opensearch.transport.TransportRequest;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -25,40 +24,37 @@ import java.util.Objects;
  */
 public class InitializeExtensionsRequest extends TransportRequest {
     private final DiscoveryNode sourceNode;
-    /*
-     * TODO change DiscoveryNode to Extension information
-     */
-    private final List<DiscoveryExtension> extensions;
+    private final DiscoveryExtension extension;
 
-    public InitializeExtensionsRequest(DiscoveryNode sourceNode, List<DiscoveryExtension> extensions) {
+    public InitializeExtensionsRequest(DiscoveryNode sourceNode, DiscoveryExtension extension) {
         this.sourceNode = sourceNode;
-        this.extensions = extensions;
+        this.extension = extension;
     }
 
     public InitializeExtensionsRequest(StreamInput in) throws IOException {
         super(in);
         sourceNode = new DiscoveryNode(in);
-        extensions = in.readList(DiscoveryExtension::new);
+        extension = new DiscoveryExtension(in);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         sourceNode.writeTo(out);
-        out.writeList(extensions);
-    }
-
-    public List<DiscoveryExtension> getExtensions() {
-        return extensions;
+        extension.writeTo(out);
     }
 
     public DiscoveryNode getSourceNode() {
         return sourceNode;
     }
 
+    public DiscoveryExtension getExtension() {
+        return extension;
+    }
+
     @Override
     public String toString() {
-        return "InitializeExtensionsRequest{" + "sourceNode=" + sourceNode + ", extensions=" + extensions + '}';
+        return "InitializeExtensionsRequest{" + "sourceNode=" + sourceNode + ", extension=" + extension + '}';
     }
 
     @Override
@@ -66,11 +62,11 @@ public class InitializeExtensionsRequest extends TransportRequest {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         InitializeExtensionsRequest that = (InitializeExtensionsRequest) o;
-        return Objects.equals(sourceNode, that.sourceNode) && Objects.equals(extensions, that.extensions);
+        return Objects.equals(sourceNode, that.sourceNode) && Objects.equals(extension, that.extension);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(sourceNode, extensions);
+        return Objects.hash(sourceNode, extension);
     }
 }

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsOrchestratorTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsOrchestratorTests.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -211,6 +212,43 @@ public class ExtensionsOrchestratorTests extends OpenSearchTestCase {
                     "fakeClass2",
                     new ArrayList<String>(),
                     true
+                )
+            )
+        );
+        assertEquals(expectedExtensionsList, extensionsOrchestrator.extensionsList);
+    }
+
+    public void testNonUniqueExtensionsDiscovery() throws Exception {
+        Path extensionDir = createTempDir();
+
+        List<String> nonUniqueYmlLines = extensionsYmlLines.stream()
+            .map(s -> s.replace("uniqueid2", "uniqueid1"))
+            .collect(Collectors.toList());
+        Files.write(extensionDir.resolve("extensions.yml"), nonUniqueYmlLines, StandardCharsets.UTF_8);
+
+        ExtensionsOrchestrator extensionsOrchestrator = new ExtensionsOrchestrator(settings, extensionDir);
+
+        List<DiscoveryExtension> expectedExtensionsList = new ArrayList<DiscoveryExtension>();
+
+        expectedExtensionsList.add(
+            new DiscoveryExtension(
+                "firstExtension",
+                "uniqueid1",
+                "uniqueid1",
+                "myIndependentPluginHost1",
+                "127.0.0.0",
+                new TransportAddress(InetAddress.getByName("127.0.0.0"), 9300),
+                new HashMap<String, String>(),
+                Version.fromString("3.0.0"),
+                new PluginInfo(
+                    "firstExtension",
+                    "Fake description 1",
+                    "0.0.7",
+                    Version.fromString("3.0.0"),
+                    "14",
+                    "fakeClass1",
+                    new ArrayList<String>(),
+                    false
                 )
             )
         );


### PR DESCRIPTION
Companion PR: https://github.com/opensearch-project/opensearch-sdk-java/pull/103

### Description
Sends a single `DiscoveryExtension` object when initializing an extension, rather than the entire list.

### Issues Resolved
Fixes https://github.com/opensearch-project/opensearch-sdk-java/issues/93

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
