### PR TITLE
[Remote Store] Change behaviour in replica recovery for remote translog enabled indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add index specific setting for remote repository ([#4253](https://github.com/opensearch-project/OpenSearch/pull/4253))
 - [Segment Replication] Update replicas to commit SegmentInfos instead of relying on SIS files from primary shards. ([#4402](https://github.com/opensearch-project/OpenSearch/pull/4402))
 - [CCR] Add getHistoryOperationsFromTranslog method to fetch the history snapshot from translogs ([#3948](https://github.com/opensearch-project/OpenSearch/pull/3948))
+- [Remote Store] Change behaviour in replica recovery for remote translog enabled indices ([#4318](https://github.com/opensearch-project/OpenSearch/pull/4318))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -3310,11 +3310,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return (remoteStore != null && shardRouting.primary());
     }
 
-    public boolean isRemoteTxlogEnabledOnPrimary() {
-        return indexSettings != null
-            && indexSettings.isSegRepEnabled()
-            && indexSettings.isRemoteStoreEnabled()
-            && indexSettings.isRemoteTranslogStoreEnabled();
+    public boolean isRemoteTranslogEnabledOnPrimary() {
+        return indexSettings() != null && indexSettings().isRemoteTranslogStoreEnabled();
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -3310,6 +3310,13 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return (remoteStore != null && shardRouting.primary());
     }
 
+    public boolean isRemoteTxlogEnabledOnPrimary() {
+        return indexSettings != null
+            && indexSettings.isSegRepEnabled()
+            && indexSettings.isRemoteStoreEnabled()
+            && indexSettings.isRemoteTranslogStoreEnabled();
+    }
+
     /**
      * Acquire a primary operation permit whenever the shard is ready for indexing. If a permit is directly available, the provided
      * ActionListener will be called on the calling thread. During relocation hand-off, permit acquisition can be delayed. The provided

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1703,7 +1703,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * @return a sequence number that an operation-based peer recovery can start with.
      * This is the first operation after the local checkpoint of the safe commit if exists.
      */
-    public long recoverLocallyUpToGlobalCheckpoint() {
+    private long recoverLocallyUpToGlobalCheckpoint() {
         assert Thread.holdsLock(mutex) == false : "recover locally under mutex";
         if (state != IndexShardState.RECOVERING) {
             throw new IndexShardNotRecoveringException(shardId, state);
@@ -1805,7 +1805,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      *
      * @return the starting sequence number from which the recovery should start.
      */
-    public long recoverLocallyUptoLastCommit() {
+    private long recoverLocallyUptoLastCommit() {
         long seqNo;
         assert Thread.holdsLock(mutex) == false : "recover locally under mutex";
         if (state != IndexShardState.RECOVERING) {

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1792,6 +1792,41 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
     }
 
+    /**
+     * The method figures out the sequence number basis the last commit.
+     *
+     * @return the starting sequence number from which the recovery should start.
+     */
+    public long fetchStartSeqNoFromLastCommit() {
+        long seqNo;
+        assert Thread.holdsLock(mutex) == false : "recover locally under mutex";
+        if (state != IndexShardState.RECOVERING) {
+            throw new IndexShardNotRecoveringException(shardId, state);
+        }
+        recoveryState.validateCurrentStage(RecoveryState.Stage.INDEX);
+        assert routingEntry().recoverySource().getType() == RecoverySource.Type.PEER : "not a peer recovery [" + routingEntry() + "]";
+
+        try {
+            seqNo = Long.parseLong(store.readLastCommittedSegmentsInfo().getUserData().get(SequenceNumbers.MAX_SEQ_NO));
+        } catch (org.apache.lucene.index.IndexNotFoundException e) {
+            logger.trace("skip local recovery as no index commit found");
+            return UNASSIGNED_SEQ_NO;
+        } catch (Exception e) {
+            logger.debug("skip local recovery as failed to find the safe commit", e);
+            return UNASSIGNED_SEQ_NO;
+        }
+
+        try {
+            maybeCheckIndex();
+            recoveryState.setStage(RecoveryState.Stage.TRANSLOG);
+            recoveryState.getTranslog().totalLocal(0);
+        } catch (Exception e) {
+            logger.debug("check index failed during fetch seqNo", e);
+            return UNASSIGNED_SEQ_NO;
+        }
+        return seqNo;
+    }
+
     public void trimOperationOfPreviousPrimaryTerms(long aboveSeqNo) {
         getEngine().translogManager().trimOperationsFromTranslog(getOperationPrimaryTerm(), aboveSeqNo);
     }

--- a/server/src/main/java/org/opensearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/PeerRecoveryTargetService.java
@@ -239,7 +239,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                     logger.trace("{} preparing shard for peer recovery", recoveryTarget.shardId());
                     indexShard.prepareForIndexRecovery();
                     boolean isRecoveringReplicaWithRemoteTxLogEnabledIndex = recoveryTarget.state().getPrimary() == false
-                        && indexShard.isRemoteTxlogEnabledOnPrimary();
+                        && indexShard.isRemoteTranslogEnabledOnPrimary();
                     final long startingSeqNo = isRecoveringReplicaWithRemoteTxLogEnabledIndex
                         ? indexShard.fetchStartSeqNoFromLastCommit()
                         : indexShard.recoverLocallyUpToGlobalCheckpoint();

--- a/server/src/main/java/org/opensearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/PeerRecoveryTargetService.java
@@ -42,7 +42,6 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchTimeoutException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionRunnable;
-import org.opensearch.action.support.replication.TransportWriteAction;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterStateObserver;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -240,7 +239,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                     logger.trace("{} preparing shard for peer recovery", recoveryTarget.shardId());
                     indexShard.prepareForIndexRecovery();
                     boolean isRecoveringReplicaWithRemoteTxLogEnabledIndex = recoveryTarget.state().getPrimary() == false
-                        && TransportWriteAction.IS_REMOTE_TXLOG_ENABLED.apply(indexShard);
+                        && indexShard.isRemoteTxlogEnabledOnPrimary();
                     final long startingSeqNo = isRecoveringReplicaWithRemoteTxLogEnabledIndex
                         ? indexShard.fetchStartSeqNoFromLastCommit()
                         : indexShard.recoverLocallyUpToGlobalCheckpoint();

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
@@ -317,7 +317,7 @@ public class RecoverySourceHandler {
             assert startingSeqNo >= 0 : "startingSeqNo must be non negative. got: " + startingSeqNo;
 
             boolean isRecoveringReplicaWithRemoteTxLogEnabledIndex = request.isPrimaryRelocation() == false
-                && shard.isRemoteTxlogEnabledOnPrimary();
+                && shard.isRemoteTranslogEnabledOnPrimary();
 
             if (isRecoveringReplicaWithRemoteTxLogEnabledIndex) {
                 sendFileStep.whenComplete(r -> {

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
@@ -47,6 +47,7 @@ import org.opensearch.action.StepListener;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.support.ThreadedActionListener;
 import org.opensearch.action.support.replication.ReplicationResponse;
+import org.opensearch.action.support.replication.TransportWriteAction;
 import org.opensearch.cluster.routing.IndexShardRoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.common.CheckedRunnable;
@@ -316,60 +317,85 @@ public class RecoverySourceHandler {
             }
             assert startingSeqNo >= 0 : "startingSeqNo must be non negative. got: " + startingSeqNo;
 
-            sendFileStep.whenComplete(r -> {
-                assert Transports.assertNotTransportThread(RecoverySourceHandler.this + "[prepareTargetForTranslog]");
-                // For a sequence based recovery, the target can keep its local translog
-                prepareTargetForTranslog(countNumberOfHistoryOperations(startingSeqNo), prepareEngineStep);
-            }, onFailure);
+            boolean isRecoveringReplicaWithRemoteTxLogEnabledIndex = request.isPrimaryRelocation() == false
+                && TransportWriteAction.IS_REMOTE_TXLOG_ENABLED.apply(shard);
 
-            prepareEngineStep.whenComplete(prepareEngineTime -> {
-                assert Transports.assertNotTransportThread(RecoverySourceHandler.this + "[phase2]");
-                /*
-                 * add shard to replication group (shard will receive replication requests from this point on) now that engine is open.
-                 * This means that any document indexed into the primary after this will be replicated to this replica as well
-                 * make sure to do this before sampling the max sequence number in the next step, to ensure that we send
-                 * all documents up to maxSeqNo in phase2.
-                 */
-                RunUnderPrimaryPermit.run(
-                    () -> shard.initiateTracking(request.targetAllocationId()),
-                    shardId + " initiating tracking of " + request.targetAllocationId(),
-                    shard,
-                    cancellableThreads,
-                    logger
-                );
+            if (isRecoveringReplicaWithRemoteTxLogEnabledIndex) {
+                sendFileStep.whenComplete(r -> {
+                    assert Transports.assertNotTransportThread(RecoverySourceHandler.this + "[prepareTargetForTranslog]");
+                    // For a sequence based recovery, the target can keep its local translog
+                    prepareTargetForTranslog(0, prepareEngineStep);
+                }, onFailure);
 
-                final long endingSeqNo = shard.seqNoStats().getMaxSeqNo();
-                if (logger.isTraceEnabled()) {
-                    logger.trace("snapshot translog for recovery; current size is [{}]", countNumberOfHistoryOperations(startingSeqNo));
-                }
-                final Translog.Snapshot phase2Snapshot = shard.newChangesSnapshot(
-                    PEER_RECOVERY_NAME,
-                    startingSeqNo,
-                    Long.MAX_VALUE,
-                    false,
-                    true
-                );
-                resources.add(phase2Snapshot);
-                retentionLock.close();
+                prepareEngineStep.whenComplete(prepareEngineTime -> {
+                    assert Transports.assertNotTransportThread(RecoverySourceHandler.this + "[phase2]");
+                    RunUnderPrimaryPermit.run(
+                        () -> shard.initiateTracking(request.targetAllocationId()),
+                        shardId + " initiating tracking of " + request.targetAllocationId(),
+                        shard,
+                        cancellableThreads,
+                        logger
+                    );
+                    final long endingSeqNo = shard.seqNoStats().getMaxSeqNo();
+                    retentionLock.close();
+                    sendSnapshotStep.onResponse(new SendSnapshotResult(endingSeqNo, 0, TimeValue.ZERO));
+                }, onFailure);
+            } else {
+                sendFileStep.whenComplete(r -> {
+                    assert Transports.assertNotTransportThread(RecoverySourceHandler.this + "[prepareTargetForTranslog]");
+                    // For a sequence based recovery, the target can keep its local translog
+                    prepareTargetForTranslog(countNumberOfHistoryOperations(startingSeqNo), prepareEngineStep);
+                }, onFailure);
 
-                // we have to capture the max_seen_auto_id_timestamp and the max_seq_no_of_updates to make sure that these values
-                // are at least as high as the corresponding values on the primary when any of these operations were executed on it.
-                final long maxSeenAutoIdTimestamp = shard.getMaxSeenAutoIdTimestamp();
-                final long maxSeqNoOfUpdatesOrDeletes = shard.getMaxSeqNoOfUpdatesOrDeletes();
-                final RetentionLeases retentionLeases = shard.getRetentionLeases();
-                final long mappingVersionOnPrimary = shard.indexSettings().getIndexMetadata().getMappingVersion();
-                phase2(
-                    startingSeqNo,
-                    endingSeqNo,
-                    phase2Snapshot,
-                    maxSeenAutoIdTimestamp,
-                    maxSeqNoOfUpdatesOrDeletes,
-                    retentionLeases,
-                    mappingVersionOnPrimary,
-                    sendSnapshotStep
-                );
+                prepareEngineStep.whenComplete(prepareEngineTime -> {
+                    assert Transports.assertNotTransportThread(RecoverySourceHandler.this + "[phase2]");
+                    /*
+                     * add shard to replication group (shard will receive replication requests from this point on) now that engine is open.
+                     * This means that any document indexed into the primary after this will be replicated to this replica as well
+                     * make sure to do this before sampling the max sequence number in the next step, to ensure that we send
+                     * all documents up to maxSeqNo in phase2.
+                     */
+                    RunUnderPrimaryPermit.run(
+                        () -> shard.initiateTracking(request.targetAllocationId()),
+                        shardId + " initiating tracking of " + request.targetAllocationId(),
+                        shard,
+                        cancellableThreads,
+                        logger
+                    );
 
-            }, onFailure);
+                    final long endingSeqNo = shard.seqNoStats().getMaxSeqNo();
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("snapshot translog for recovery; current size is [{}]", countNumberOfHistoryOperations(startingSeqNo));
+                    }
+                    final Translog.Snapshot phase2Snapshot = shard.newChangesSnapshot(
+                        PEER_RECOVERY_NAME,
+                        startingSeqNo,
+                        Long.MAX_VALUE,
+                        false,
+                        true
+                    );
+                    resources.add(phase2Snapshot);
+                    retentionLock.close();
+
+                    // we have to capture the max_seen_auto_id_timestamp and the max_seq_no_of_updates to make sure that these values
+                    // are at least as high as the corresponding values on the primary when any of these operations were executed on it.
+                    final long maxSeenAutoIdTimestamp = shard.getMaxSeenAutoIdTimestamp();
+                    final long maxSeqNoOfUpdatesOrDeletes = shard.getMaxSeqNoOfUpdatesOrDeletes();
+                    final RetentionLeases retentionLeases = shard.getRetentionLeases();
+                    final long mappingVersionOnPrimary = shard.indexSettings().getIndexMetadata().getMappingVersion();
+                    phase2(
+                        startingSeqNo,
+                        endingSeqNo,
+                        phase2Snapshot,
+                        maxSeenAutoIdTimestamp,
+                        maxSeqNoOfUpdatesOrDeletes,
+                        retentionLeases,
+                        mappingVersionOnPrimary,
+                        sendSnapshotStep
+                    );
+
+                }, onFailure);
+            }
 
             // Recovery target can trim all operations >= startingSeqNo as we have sent all these operations in the phase 2
             final long trimAboveSeqNo = startingSeqNo - 1;

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
@@ -47,7 +47,6 @@ import org.opensearch.action.StepListener;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.support.ThreadedActionListener;
 import org.opensearch.action.support.replication.ReplicationResponse;
-import org.opensearch.action.support.replication.TransportWriteAction;
 import org.opensearch.cluster.routing.IndexShardRoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.common.CheckedRunnable;
@@ -318,7 +317,7 @@ public class RecoverySourceHandler {
             assert startingSeqNo >= 0 : "startingSeqNo must be non negative. got: " + startingSeqNo;
 
             boolean isRecoveringReplicaWithRemoteTxLogEnabledIndex = request.isPrimaryRelocation() == false
-                && TransportWriteAction.IS_REMOTE_TXLOG_ENABLED.apply(shard);
+                && shard.isRemoteTxlogEnabledOnPrimary();
 
             if (isRecoveringReplicaWithRemoteTxLogEnabledIndex) {
                 sendFileStep.whenComplete(r -> {

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
@@ -317,7 +317,7 @@ public class RecoverySourceHandler {
             assert startingSeqNo >= 0 : "startingSeqNo must be non negative. got: " + startingSeqNo;
 
             boolean isRecoveringReplicaWithRemoteTxLogEnabledIndex = request.isPrimaryRelocation() == false
-                && shard.isRemoteTranslogEnabledOnPrimary();
+                && shard.isRemoteTranslogEnabled();
 
             if (isRecoveringReplicaWithRemoteTxLogEnabledIndex) {
                 sendFileStep.whenComplete(r -> {

--- a/server/src/test/java/org/opensearch/index/shard/ReplicaRecoveryWithRemoteTranslogOnPrimaryTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/ReplicaRecoveryWithRemoteTranslogOnPrimaryTests.java
@@ -10,9 +10,14 @@ package org.opensearch.index.shard;
 
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.index.engine.DocIdSeqNoAndSource;
+import org.opensearch.index.engine.NRTReplicationEngine;
 import org.opensearch.index.engine.NRTReplicationEngineFactory;
 import org.opensearch.index.replication.OpenSearchIndexLevelReplicationTestCase;
+import org.opensearch.index.translog.WriteOnlyTranslogManager;
 import org.opensearch.indices.replication.common.ReplicationType;
+
+import java.util.List;
 
 public class ReplicaRecoveryWithRemoteTranslogOnPrimaryTests extends OpenSearchIndexLevelReplicationTestCase {
 
@@ -52,6 +57,37 @@ public class ReplicaRecoveryWithRemoteTranslogOnPrimaryTests extends OpenSearchI
             assertDocCount(replica2, numDocs);
 
             // Step 6 - Segment replication, check all shards have same number of docs
+            replicateSegments(primary, shards.getReplicas());
+            shards.assertAllEqual(numDocs + moreDocs);
+        }
+    }
+
+    public void testNoTranslogHistoryTransferred() throws Exception {
+        try (ReplicationGroup shards = createGroup(0, settings, new NRTReplicationEngineFactory())) {
+
+            // Step1 - Start primary, index docs, flush, index more docs, check translog in primary as expected
+            shards.startPrimary();
+            final IndexShard primary = shards.getPrimary();
+            int numDocs = shards.indexDocs(randomIntBetween(10, 100));
+            shards.flush();
+            List<DocIdSeqNoAndSource> docIdAndSeqNosAfterFlush = getDocIdAndSeqNos(primary);
+            int moreDocs = shards.indexDocs(randomIntBetween(20, 100));
+            assertEquals(moreDocs, getTranslog(primary).totalOperations());
+
+            // Step 2 - Start replica, recovery happens, check docs recovered till last flush
+            final IndexShard replica = shards.addReplica();
+            shards.startAll();
+            assertEquals(docIdAndSeqNosAfterFlush, getDocIdAndSeqNos(replica));
+            assertDocCount(replica, numDocs);
+            assertEquals(NRTReplicationEngine.class, replica.getEngine().getClass());
+
+            // Step 3 - Check replica's translog has no operations
+            assertEquals(WriteOnlyTranslogManager.class, replica.getEngine().translogManager().getClass());
+            WriteOnlyTranslogManager replicaTranslogManager = (WriteOnlyTranslogManager) replica.getEngine().translogManager();
+            assertEquals(0, replicaTranslogManager.getTranslog().totalOperations());
+
+            // Adding this for close to succeed
+            shards.flush();
             replicateSegments(primary, shards.getReplicas());
             shards.assertAllEqual(numDocs + moreDocs);
         }

--- a/server/src/test/java/org/opensearch/index/shard/ReplicaRecoveryWithRemoteTranslogOnPrimaryTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/ReplicaRecoveryWithRemoteTranslogOnPrimaryTests.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.shard;
+
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.engine.NRTReplicationEngineFactory;
+import org.opensearch.index.replication.OpenSearchIndexLevelReplicationTestCase;
+import org.opensearch.indices.replication.common.ReplicationType;
+
+public class ReplicaRecoveryWithRemoteTranslogOnPrimaryTests extends OpenSearchIndexLevelReplicationTestCase {
+
+    private static final Settings settings = Settings.builder()
+        .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+        .put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, "true")
+        .put(IndexMetadata.SETTING_REMOTE_TRANSLOG_STORE_ENABLED, "true")
+        .build();
+
+    public void testReplicaShardRecoveryUptoLastFlushedCommit() throws Exception {
+        try (ReplicationGroup shards = createGroup(0, settings, new NRTReplicationEngineFactory())) {
+
+            // Step1 - Start primary, index docs and flush
+            shards.startPrimary();
+            final IndexShard primary = shards.getPrimary();
+            int numDocs = shards.indexDocs(randomIntBetween(10, 100));
+            shards.flush();
+
+            // Step 2 - Start replica for recovery to happen, check both has same number of docs
+            final IndexShard replica1 = shards.addReplica();
+            shards.startAll();
+            assertEquals(getDocIdAndSeqNos(primary), getDocIdAndSeqNos(replica1));
+
+            // Step 3 - Index more docs, run segment replication, check both have same number of docs
+            int moreDocs = shards.indexDocs(randomIntBetween(10, 100));
+            primary.refresh("test");
+            replicateSegments(primary, shards.getReplicas());
+            assertEquals(getDocIdAndSeqNos(primary), getDocIdAndSeqNos(replica1));
+
+            // Step 4 - Check both shard has expected number of doc count
+            assertDocCount(primary, numDocs + moreDocs);
+            assertDocCount(replica1, numDocs + moreDocs);
+
+            // Step 5 - Start new replica, recovery happens, and check that new replica has docs upto last flush
+            final IndexShard replica2 = shards.addReplica();
+            shards.startAll();
+            assertDocCount(replica2, numDocs);
+
+            // Step 6 - Segment replication, check all shards have same number of docs
+            replicateSegments(primary, shards.getReplicas());
+            shards.assertAllEqual(numDocs + moreDocs);
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -211,7 +211,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         IndexShard shard = newShard(false);
         shard.markAsRecovering("for testing", new RecoveryState(shard.routingEntry(), localNode, localNode));
         shard.prepareForIndexRecovery();
-        assertThat(shard.recoverLocallyUpToGlobalCheckpoint(), equalTo(UNASSIGNED_SEQ_NO));
+        assertThat(shard.recoverLocallyAndFetchStartSeqNo(true), equalTo(UNASSIGNED_SEQ_NO));
         assertThat(shard.recoveryState().getTranslog().totalLocal(), equalTo(RecoveryState.Translog.UNKNOWN));
         assertThat(shard.recoveryState().getTranslog().recoveredOperations(), equalTo(0));
         assertThat(shard.getLastKnownGlobalCheckpoint(), equalTo(UNASSIGNED_SEQ_NO));
@@ -239,7 +239,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         );
         replica.markAsRecovering("for testing", new RecoveryState(replica.routingEntry(), localNode, localNode));
         replica.prepareForIndexRecovery();
-        assertThat(replica.recoverLocallyUpToGlobalCheckpoint(), equalTo(globalCheckpoint + 1));
+        assertThat(replica.recoverLocallyAndFetchStartSeqNo(true), equalTo(globalCheckpoint + 1));
         assertThat(replica.recoveryState().getTranslog().totalLocal(), equalTo(expectedTotalLocal));
         assertThat(replica.recoveryState().getTranslog().recoveredOperations(), equalTo(expectedTotalLocal));
         assertThat(replica.getLastKnownGlobalCheckpoint(), equalTo(UNASSIGNED_SEQ_NO));
@@ -254,7 +254,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         replica = reinitShard(shard, ShardRoutingHelper.initWithSameId(shard.routingEntry(), RecoverySource.PeerRecoverySource.INSTANCE));
         replica.markAsRecovering("for testing", new RecoveryState(replica.routingEntry(), localNode, localNode));
         replica.prepareForIndexRecovery();
-        assertThat(replica.recoverLocallyUpToGlobalCheckpoint(), equalTo(UNASSIGNED_SEQ_NO));
+        assertThat(replica.recoverLocallyAndFetchStartSeqNo(true), equalTo(UNASSIGNED_SEQ_NO));
         assertThat(replica.recoveryState().getTranslog().totalLocal(), equalTo(RecoveryState.Translog.UNKNOWN));
         assertThat(replica.recoveryState().getTranslog().recoveredOperations(), equalTo(0));
         assertThat(replica.getLastKnownGlobalCheckpoint(), equalTo(UNASSIGNED_SEQ_NO));
@@ -276,10 +276,10 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         replica.markAsRecovering("for testing", new RecoveryState(replica.routingEntry(), localNode, localNode));
         replica.prepareForIndexRecovery();
         if (safeCommit.isPresent()) {
-            assertThat(replica.recoverLocallyUpToGlobalCheckpoint(), equalTo(safeCommit.get().localCheckpoint + 1));
+            assertThat(replica.recoverLocallyAndFetchStartSeqNo(true), equalTo(safeCommit.get().localCheckpoint + 1));
             assertThat(replica.recoveryState().getTranslog().totalLocal(), equalTo(0));
         } else {
-            assertThat(replica.recoverLocallyUpToGlobalCheckpoint(), equalTo(UNASSIGNED_SEQ_NO));
+            assertThat(replica.recoverLocallyAndFetchStartSeqNo(true), equalTo(UNASSIGNED_SEQ_NO));
             assertThat(replica.recoveryState().getTranslog().totalLocal(), equalTo(RecoveryState.Translog.UNKNOWN));
         }
         assertThat(replica.recoveryState().getStage(), equalTo(RecoveryState.Stage.TRANSLOG));
@@ -322,7 +322,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         );
         replica.markAsRecovering("for testing", new RecoveryState(replica.routingEntry(), localNode, localNode));
         replica.prepareForIndexRecovery();
-        assertThat(replica.recoverLocallyUpToGlobalCheckpoint(), equalTo(safeCommit.get().localCheckpoint + 1));
+        assertThat(replica.recoverLocallyAndFetchStartSeqNo(true), equalTo(safeCommit.get().localCheckpoint + 1));
         assertThat(replica.recoveryState().getTranslog().totalLocal(), equalTo(0));
         assertThat(replica.recoveryState().getTranslog().recoveredOperations(), equalTo(0));
         assertThat(replica.getLastKnownGlobalCheckpoint(), equalTo(UNASSIGNED_SEQ_NO));
@@ -349,7 +349,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         shard = reinitShard(shard, ShardRoutingHelper.initWithSameId(shard.routingEntry(), RecoverySource.PeerRecoverySource.INSTANCE));
         shard.markAsRecovering("peer recovery", new RecoveryState(shard.routingEntry(), pNode, rNode));
         shard.prepareForIndexRecovery();
-        long startingSeqNo = shard.recoverLocallyUpToGlobalCheckpoint();
+        long startingSeqNo = shard.recoverLocallyAndFetchStartSeqNo(true);
         shard.store().markStoreCorrupted(new IOException("simulated"));
         RecoveryTarget recoveryTarget = new RecoveryTarget(shard, null, null);
         StartRecoveryRequest request = PeerRecoveryTargetService.getStartRecoveryRequest(logger, rNode, recoveryTarget, startingSeqNo);

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -134,7 +134,6 @@ import org.opensearch.transport.TransportService;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -854,11 +853,8 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
         replica.prepareForIndexRecovery();
         final RecoveryTarget recoveryTarget = targetSupplier.apply(replica, pNode);
         IndexShard indexShard = recoveryTarget.indexShard();
-        boolean isRecoveringReplicaWithRemoteTxLogEnabledIndex = recoveryTarget.state().getPrimary() == false
-            && indexShard.isRemoteTranslogEnabledOnPrimary();
-        final long startingSeqNo = isRecoveringReplicaWithRemoteTxLogEnabledIndex
-            ? indexShard.fetchStartSeqNoFromLastCommit()
-            : indexShard.recoverLocallyUpToGlobalCheckpoint();
+        boolean remoteTranslogEnabled = recoveryTarget.state().getPrimary() == false && indexShard.isRemoteTranslogEnabled();
+        final long startingSeqNo = indexShard.recoverLocallyAndFetchStartSeqNo(remoteTranslogEnabled == false);
         final StartRecoveryRequest request = PeerRecoveryTargetService.getStartRecoveryRequest(
             logger,
             rNode,

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -854,7 +854,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
         final RecoveryTarget recoveryTarget = targetSupplier.apply(replica, pNode);
         IndexShard indexShard = recoveryTarget.indexShard();
         boolean remoteTranslogEnabled = recoveryTarget.state().getPrimary() == false && indexShard.isRemoteTranslogEnabled();
-        final long startingSeqNo = indexShard.recoverLocallyAndFetchStartSeqNo(remoteTranslogEnabled == false);
+        final long startingSeqNo = indexShard.recoverLocallyAndFetchStartSeqNo(!remoteTranslogEnabled);
         final StartRecoveryRequest request = PeerRecoveryTargetService.getStartRecoveryRequest(
             logger,
             rNode,


### PR DESCRIPTION
### Description
With remote translog, nrt segment replication and no-op replication, the need for translog on replicas become obsolete. Recovery consists of multiple steps - where replaying lucene operation (after acquiring PRRL post the last safe commit) is one of the steps. Since with segment replication, we don't really index the data, and with remote translog, the need to keep the operations in translog goes away, we can skip recovering the lucene operations.

### PeerRecoveryTargetService.java changes
Initiate Recovery (Existing) -
![image](https://user-images.githubusercontent.com/9309003/190414571-77c13b84-77e3-4817-b42b-facbb1fe786f.png)

**[PR Scope]** Initiate Recovery for remote translog enabled indices -
![image](https://user-images.githubusercontent.com/9309003/190414721-2e22dfa8-75fd-49f0-932b-9cc8b2403bc0.png)

### RecoverySourceHandler.java changes
Recovery process (Existing) -
![image](https://user-images.githubusercontent.com/9309003/190417196-c922a678-ea5a-4a51-9008-fbf150403b9b.png)

**[PR Scope]** Recovery process for remote translog enabled indices -
![image](https://user-images.githubusercontent.com/9309003/190417601-634a8d85-4fec-4159-9dc6-1cf4d2a3e765.png)



Couple of open items -
- PRRL might be not required for replica recovery. This needs to looked further into. This will be fixed in #4502.

### Issues Resolved
#4527

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
