### PR TITLE
It is possible to disable NodeAndClusterIdConverter plugin.

### DIFF
--- a/server/src/main/java/org/opensearch/common/logging/NodeAndClusterIdConverter.java
+++ b/server/src/main/java/org/opensearch/common/logging/NodeAndClusterIdConverter.java
@@ -50,6 +50,7 @@ import java.util.Locale;
 @Plugin(category = PatternConverter.CATEGORY, name = "NodeAndClusterIdConverter")
 @ConverterKeys({ "node_and_cluster_id" })
 public final class NodeAndClusterIdConverter extends LogEventPatternConverter {
+    static final String ENABLED_SYSTEM_PROPERTY = "org.opensearch.common.logging.NodeAndClusterIdConverter.enabled";
     private static final SetOnce<String> nodeAndClusterId = new SetOnce<>();
 
     /**
@@ -71,7 +72,9 @@ public final class NodeAndClusterIdConverter extends LogEventPatternConverter {
      * @param clusterUUID a clusterId received from cluster state update
      */
     public static void setNodeIdAndClusterId(String nodeId, String clusterUUID) {
-        nodeAndClusterId.set(formatIds(clusterUUID, nodeId));
+        if (isEnabled()) {
+            nodeAndClusterId.set(formatIds(clusterUUID, nodeId));
+        }
     }
 
     /**
@@ -89,5 +92,10 @@ public final class NodeAndClusterIdConverter extends LogEventPatternConverter {
 
     private static String formatIds(String clusterUUID, String nodeId) {
         return String.format(Locale.ROOT, "\"cluster.uuid\": \"%s\", \"node.id\": \"%s\"", clusterUUID, nodeId);
+    }
+
+    private static boolean isEnabled() {
+        String enabled = System.getProperty(ENABLED_SYSTEM_PROPERTY, "true");
+        return Boolean.valueOf(enabled);
     }
 }

--- a/server/src/test/java/org/opensearch/common/logging/NodeAndClusterIdConverterTest.java
+++ b/server/src/test/java/org/opensearch/common/logging/NodeAndClusterIdConverterTest.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.logging;
+
+import org.apache.lucene.util.SetOnce;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class NodeAndClusterIdConverterTest {
+
+    public static final String NODE_ID = "node-id";
+    public static final String CLUSTER_UUID = "cluster-uuid";
+
+    @After
+    @Before
+    public void cleanSystemProperties() {
+        System.clearProperty(NodeAndClusterIdConverter.ENABLED_SYSTEM_PROPERTY);
+    }
+
+    @Test(expected = SetOnce.AlreadySetException.class)
+    public void testTryToSetClusterAndNodeIdByDefault() {
+        NodeAndClusterIdConverter.setNodeIdAndClusterId(NODE_ID, CLUSTER_UUID);
+        NodeAndClusterIdConverter.setNodeIdAndClusterId(NODE_ID, CLUSTER_UUID);
+    }
+
+    @Test(expected = SetOnce.AlreadySetException.class)
+    public void testTryToSetClusterAndNodeIdWhenPluginIsEnabled() {
+        System.setProperty(NodeAndClusterIdConverter.ENABLED_SYSTEM_PROPERTY, "true");
+
+        NodeAndClusterIdConverter.setNodeIdAndClusterId(NODE_ID, CLUSTER_UUID);
+        NodeAndClusterIdConverter.setNodeIdAndClusterId(NODE_ID, CLUSTER_UUID);
+    }
+
+    @Test
+    public void testNotSetClusterIdWhenPluginIsDisabled() {
+        System.setProperty(NodeAndClusterIdConverter.ENABLED_SYSTEM_PROPERTY, "false");
+
+        NodeAndClusterIdConverter.setNodeIdAndClusterId(NODE_ID, CLUSTER_UUID);
+
+        // second invocation should not throw an exception
+        NodeAndClusterIdConverter.setNodeIdAndClusterId(NODE_ID, CLUSTER_UUID);
+    }
+
+}


### PR DESCRIPTION
### Description
New system property `org.opensearch.common.logging.NodeAndClusterIdConverter.enabled` added to disable custom Log4j2 plugin NodeAndClusterIdConverter. 

Probably this change needs to be merged to another or additional branch.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
