### PR TITLE
[2.x] Restore using the class ClusterInfoRequest and ClusterInfoRequestBuilder from package 'org.opensearch.action.support.master.info' for subclasses (#4307)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - `opensearch-service.bat start` and `opensearch-service.bat manager` failing to run ([#4289](https://github.com/opensearch-project/OpenSearch/pull/4289))
 - PR reference to checkout code for changelog verifier ([#4296](https://github.com/opensearch-project/OpenSearch/pull/4296))
+- Restore using the class ClusterInfoRequest and ClusterInfoRequestBuilder from package 'org.opensearch.action.support.master.info' for subclasses ([#4307](https://github.com/opensearch-project/OpenSearch/pull/4307))
 - Do not fail replica shard due to primary closure ([#4133](https://github.com/opensearch-project/OpenSearch/pull/4133))
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - PR reference to checkout code for changelog verifier ([#4296](https://github.com/opensearch-project/OpenSearch/pull/4296))
+- Restore using the class ClusterInfoRequest and ClusterInfoRequestBuilder from package 'org.opensearch.action.support.master.info' for subclasses ([#4324](https://github.com/opensearch-project/OpenSearch/pull/4324))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/get/GetIndexRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/get/GetIndexRequest.java
@@ -33,7 +33,7 @@
 package org.opensearch.action.admin.indices.get;
 
 import org.opensearch.action.ActionRequestValidationException;
-import org.opensearch.action.support.clustermanager.info.ClusterInfoRequest;
+import org.opensearch.action.support.master.info.ClusterInfoRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.util.ArrayUtils;

--- a/server/src/main/java/org/opensearch/action/admin/indices/get/GetIndexRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/get/GetIndexRequestBuilder.java
@@ -32,7 +32,7 @@
 
 package org.opensearch.action.admin.indices.get;
 
-import org.opensearch.action.support.clustermanager.info.ClusterInfoRequestBuilder;
+import org.opensearch.action.support.master.info.ClusterInfoRequestBuilder;
 import org.opensearch.client.OpenSearchClient;
 
 /**

--- a/server/src/main/java/org/opensearch/action/admin/indices/mapping/get/GetMappingsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/mapping/get/GetMappingsRequest.java
@@ -33,7 +33,7 @@
 package org.opensearch.action.admin.indices.mapping.get;
 
 import org.opensearch.action.ActionRequestValidationException;
-import org.opensearch.action.support.clustermanager.info.ClusterInfoRequest;
+import org.opensearch.action.support.master.info.ClusterInfoRequest;
 import org.opensearch.common.io.stream.StreamInput;
 
 import java.io.IOException;

--- a/server/src/main/java/org/opensearch/action/admin/indices/mapping/get/GetMappingsRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/mapping/get/GetMappingsRequestBuilder.java
@@ -32,7 +32,7 @@
 
 package org.opensearch.action.admin.indices.mapping.get;
 
-import org.opensearch.action.support.clustermanager.info.ClusterInfoRequestBuilder;
+import org.opensearch.action.support.master.info.ClusterInfoRequestBuilder;
 import org.opensearch.client.OpenSearchClient;
 
 /**

--- a/server/src/test/java/org/opensearch/action/admin/indices/get/GetIndexRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/get/GetIndexRequestTests.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.indices.get;
+
+import org.opensearch.action.support.master.info.ClusterInfoRequest;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.hamcrest.Matchers.is;
+
+public class GetIndexRequestTests extends OpenSearchTestCase {
+    public void testGetIndexRequestExtendsClusterInfoRequestOfDeprecatedClassPath() {
+        GetIndexRequest getIndexRequest = new GetIndexRequest().indices("test");
+        assertThat(getIndexRequest instanceof ClusterInfoRequest, is(true));
+    }
+}


### PR DESCRIPTION
### Description
Backport PR https://github.com/opensearch-project/OpenSearch/pull/4307 / commit https://github.com/opensearch-project/OpenSearch/commit/65f966ed71ff9bc0a53490ee801943869c0f536d into `2.x` branch

- Restore the inheritance relationship of the class `GetIndexRequest` and `GetMappingsRequest`, to extend `org.opensearch.action.support.master.info.ClusterInfoRequest`. The 2 classes are the only subclasses of `ClusterInfoRequest` in other packages.
- Add a unit test to validate the return type for the method `GetIndexRequest#indices(java.lang.String[])` is an instance of `org.opensearch.action.support.master.info.ClusterInfoRequest`. 

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/4203

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
