### PR TITLE
Update the head ref to changelog verifier (#4296)

### DIFF
--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: dangoslen/dependabot-changelog-helper@v1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- `opensearch-service.bat start` and `opensearch-service.bat manager` failing to run ([#4289](https://github.com/opensearch-project/OpenSearch/pull/4289))
+- PR reference to checkout code for changelog verifier ([#4296](https://github.com/opensearch-project/OpenSearch/pull/4296))
 
 ### Security
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,8 +126,6 @@ As a contributor, you must ensure that every pull request has the changes listed
 Adding in the change is two step process -
 1. Add your changes to the corresponding section within the CHANGELOG file with dummy pull request information, publish the PR
 
-  `Your change here ([#PR_NUMBER](PR_URL))`
-
 2. Update the entry for your change in [`CHANGELOG.md`](CHANGELOG.md) and make sure that you reference the pull request there.
 
 


### PR DESCRIPTION
* Update changelog contribution guide

Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>

* Fix reference to pull request

Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>

Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>
(cherry picked from commit 5dd79479a2ca84a633a7583eb37df07504cd8a90)

### Description
- Backports #4296 to 1.x

### Issues Resolved
- N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
