### PR TITLE
Further simplification of the ZIP publication implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - PUT api for weighted shard routing ([#4272](https://github.com/opensearch-project/OpenSearch/pull/4272))
 - Unmute test RelocationIT.testRelocationWhileIndexingRandom ([#4580](https://github.com/opensearch-project/OpenSearch/pull/4580))
 - Add DecommissionService and helper to execute awareness attribute decommissioning ([#4084](https://github.com/opensearch-project/OpenSearch/pull/4084))
+- Further simplification of the ZIP publication implementation ([#4360](https://github.com/opensearch-project/OpenSearch/pull/4360))
 
 ### Deprecated
 

--- a/buildSrc/src/main/java/org/opensearch/gradle/pluginzip/Publish.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/pluginzip/Publish.java
@@ -9,30 +9,31 @@ package org.opensearch.gradle.pluginzip;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
-import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
 
 import java.nio.file.Path;
 import org.gradle.api.Task;
+import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
 
 public class Publish implements Plugin<Project> {
 
-    private static final Logger LOGGER = Logging.getLogger(Publish.class);
-
-    public final static String EXTENSION_NAME = "zipmavensettings";
+    // public final static String PLUGIN_ZIP_PUBLISH_POM_TASK = "generatePomFileForPluginZipPublication";
     public final static String PUBLICATION_NAME = "pluginZip";
     public final static String STAGING_REPO = "zipStaging";
-    public final static String PLUGIN_ZIP_PUBLISH_POM_TASK = "generatePomFileForPluginZipPublication";
-    public final static String LOCALMAVEN = "publishToMavenLocal";
     public final static String LOCAL_STAGING_REPO_PATH = "/build/local-staging-repo";
-    public String zipDistributionLocation = "/build/distributions/";
+    // TODO: Does the path ^^ need to use platform dependant file separators ?
 
-    public static void configMaven(Project project) {
+    private boolean isZipPublicationPresent(Project project) {
+        PublishingExtension pe = project.getExtensions().findByType(PublishingExtension.class);
+        if (pe == null) {
+            return false;
+        }
+        return pe.getPublications().findByName(PUBLICATION_NAME) != null;
+    }
+
+    private void addLocalMavenRepo(Project project) {
         final Path buildDirectory = project.getRootDir().toPath();
-        project.getPluginManager().apply(MavenPublishPlugin.class);
         project.getExtensions().configure(PublishingExtension.class, publishing -> {
             publishing.repositories(repositories -> {
                 repositories.maven(maven -> {
@@ -40,52 +41,40 @@ public class Publish implements Plugin<Project> {
                     maven.setUrl(buildDirectory.toString() + LOCAL_STAGING_REPO_PATH);
                 });
             });
+        });
+    }
+
+    private void addZipArtifact(Project project) {
+        project.getExtensions().configure(PublishingExtension.class, publishing -> {
             publishing.publications(publications -> {
                 MavenPublication mavenZip = (MavenPublication) publications.findByName(PUBLICATION_NAME);
-
-                if (mavenZip == null) {
-                    mavenZip = publications.create(PUBLICATION_NAME, MavenPublication.class);
+                if (mavenZip != null) {
+                    mavenZip.artifact(project.getTasks().named("bundlePlugin"));
                 }
-
-                String groupId = mavenZip.getGroupId();
-                if (groupId == null) {
-                    // The groupId is not customized thus we get the value from "project.group".
-                    // See https://docs.gradle.org/current/userguide/publishing_maven.html#sec:identity_values_in_the_generated_pom
-                    groupId = getProperty("group", project);
-                }
-
-                String artifactId = project.getName();
-                String pluginVersion = getProperty("version", project);
-                mavenZip.artifact(project.getTasks().named("bundlePlugin"));
-                mavenZip.setGroupId(groupId);
-                mavenZip.setArtifactId(artifactId);
-                mavenZip.setVersion(pluginVersion);
             });
         });
     }
 
-    static String getProperty(String name, Project project) {
-        if (project.hasProperty(name)) {
-            Object property = project.property(name);
-            if (property != null) {
-                return property.toString();
-            }
-        }
-        return null;
-    }
-
     @Override
     public void apply(Project project) {
+        project.getPluginManager().apply("nebula.maven-base-publish");
+        project.getPluginManager().apply(MavenPublishPlugin.class);
         project.afterEvaluate(evaluatedProject -> {
-            configMaven(project);
-            Task validatePluginZipPom = project.getTasks().findByName("validatePluginZipPom");
-            if (validatePluginZipPom != null) {
-                project.getTasks().getByName("validatePluginZipPom").dependsOn("generatePomFileForNebulaPublication");
-            }
-            Task publishPluginZipPublicationToZipStagingRepository = project.getTasks()
-                .findByName("publishPluginZipPublicationToZipStagingRepository");
-            if (publishPluginZipPublicationToZipStagingRepository != null) {
-                publishPluginZipPublicationToZipStagingRepository.dependsOn("generatePomFileForNebulaPublication");
+            if (isZipPublicationPresent(project)) {
+                addLocalMavenRepo(project);
+                addZipArtifact(project);
+                Task validatePluginZipPom = project.getTasks().findByName("validatePluginZipPom");
+                if (validatePluginZipPom != null) {
+                    validatePluginZipPom.dependsOn("generatePomFileForNebulaPublication");
+                }
+                Task publishPluginZipPublicationToZipStagingRepository = project.getTasks()
+                    .findByName("publishPluginZipPublicationToZipStagingRepository");
+                if (publishPluginZipPublicationToZipStagingRepository != null) {
+                    publishPluginZipPublicationToZipStagingRepository.dependsOn("generatePomFileForNebulaPublication");
+                }
+            } else {
+                project.getLogger()
+                    .warn(String.format("Plugin 'opensearch.pluginzip' is applied but no '%s' publication is defined.", PUBLICATION_NAME));
             }
         });
     }

--- a/buildSrc/src/test/java/org/opensearch/gradle/pluginzip/PublishTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/pluginzip/PublishTests.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.gradle.pluginzip;
 
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.UnexpectedBuildFailure;
@@ -54,20 +56,152 @@ public class PublishTests extends GradleUnitTestCase {
         projectDir.delete();
     }
 
+    /**
+     * This test is used to verify that adding the 'opensearch.pluginzip' to the project
+     * adds some other transitive plugins and tasks under the hood. This is basically
+     * a behavioral test of the {@link Publish#apply(Project)} method.
+     *
+     * This is equivalent of having a build.gradle script with just the following section:
+     * <pre>
+     *     plugins {
+     *       id 'opensearch.pluginzip'
+     *     }
+     * </pre>
+     */
+    @Test
+    public void applyZipPublicationPluginNoConfig() {
+        // All we do here is creating an empty project and applying the Publish plugin.
+        Project project = ProjectBuilder.builder().build();
+        project.getPluginManager().apply(Publish.class);
+
+        // WARNING: =====================================================================
+        // All the following tests will work only before the gradle project is evaluated.
+        // There are some methods that will cause the project to be evaluated, such as:
+        // project.getTasksByName()
+        // After the project is evaluated there are more tasks found in the project, like
+        // the [assemble, build, ...] and other standard tasks.
+        // This can potentially break in future gradle versions (?)
+        // ===============================================================================
+
+        assertEquals(
+            "The Publish plugin is applied which adds total of five tasks from Nebula and MavenPublishing plugins.",
+            5,
+            project.getTasks().size()
+        );
+
+        // Tasks applied from "nebula.maven-base-publish"
+        assertTrue(
+            project.getTasks()
+                .findByName("generateMetadataFileForNebulaPublication") instanceof org.gradle.api.publish.tasks.GenerateModuleMetadata
+        );
+        assertTrue(
+            project.getTasks()
+                .findByName("generatePomFileForNebulaPublication") instanceof org.gradle.api.publish.maven.tasks.GenerateMavenPom
+        );
+        assertTrue(
+            project.getTasks()
+                .findByName("publishNebulaPublicationToMavenLocal") instanceof org.gradle.api.publish.maven.tasks.PublishToMavenLocal
+        );
+
+        // Tasks applied from MavenPublishPlugin
+        assertTrue(project.getTasks().findByName("publishToMavenLocal") instanceof org.gradle.api.DefaultTask);
+        assertTrue(project.getTasks().findByName("publish") instanceof org.gradle.api.DefaultTask);
+
+        // And we miss the pluginzip publication task (because no publishing was defined for it)
+        assertNull(project.getTasks().findByName(ZIP_PUBLISH_TASK));
+
+        // We have the following publishing plugins
+        assertEquals(4, project.getPlugins().size());
+        // ... of the following types:
+        assertNotNull(
+            "Project is expected to have OpenSearch pluginzip Publish plugin",
+            project.getPlugins().findPlugin(org.opensearch.gradle.pluginzip.Publish.class)
+        );
+        assertNotNull(
+            "Project is expected to have MavenPublishPlugin (applied from OpenSearch pluginzip plugin)",
+            project.getPlugins().findPlugin(org.gradle.api.publish.maven.plugins.MavenPublishPlugin.class)
+        );
+        assertNotNull(
+            "Project is expected to have Publishing plugin (applied from MavenPublishPublish plugin)",
+            project.getPlugins().findPlugin(org.gradle.api.publish.plugins.PublishingPlugin.class)
+        );
+        assertNotNull(
+            "Project is expected to have nebula MavenBasePublishPlugin plugin (applied from OpenSearch pluginzip plugin)",
+            project.getPlugins().findPlugin(nebula.plugin.publishing.maven.MavenBasePublishPlugin.class)
+        );
+    }
+
+    /**
+     * Verify that if the zip publication is configured then relevant tasks are chained correctly.
+     * This test that the dependsOn() is applied correctly.
+     */
+    @Test
+    public void applyZipPublicationPluginWithConfig() throws IOException, URISyntaxException, InterruptedException {
+
+        /* -------------------------------
+        // The ideal approach would be to create a project (via ProjectBuilder) with publishzip plugin,
+        // have it evaluated (API call) and then check if there are tasks that the plugin uses to hookup into
+        // and how these tasks are chained. The problem is that there is a known gradle issue (#20301) that does
+        // not allow for it ATM. If, however, it is fixed in the future the following is the code that can
+        // be used...
+
+        Project project = ProjectBuilder.builder().build();
+        project.getPluginManager().apply(Publish.class);
+        // add publications via API
+
+        // evaluate the project
+        ((DefaultProject)project).evaluate();
+
+        // - Check that "validatePluginZipPom" and/or "publishPluginZipPublicationToZipStagingRepository"
+        //   tasks have dependencies on "generatePomFileForNebulaPublication".
+        // - Check that there is the staging repository added.
+
+        // However, due to known issue(1): https://github.com/gradle/gradle/issues/20301
+        // it is impossible to reach to individual tasks and work with them.
+        // (1): https://docs.gradle.org/7.4/release-notes.html#known-issues
+
+        // I.e.: The following code throws exception, basically any access to individual tasks fails.
+        project.getTasks().getByName("validatePluginZipPom");
+         ------------------------------- */
+
+        // Instead, we run the gradle project via GradleRunner (this way we get fully evaluated project)
+        // and using the minimal possible configuration (missingPOMEntity) we test that as soon as the zip publication
+        // configuration is specified then all the necessary tasks are hooked up and executed correctly.
+        // However, this does not test execution order of the tasks.
+        GradleRunner runner = prepareGradleRunnerFromTemplate("missingPOMEntity.gradle", ZIP_PUBLISH_TASK/*, "-m"*/);
+        BuildResult result = runner.build();
+
+        assertEquals(SUCCESS, result.task(":" + "bundlePlugin").getOutcome());
+        assertEquals(SUCCESS, result.task(":" + "generatePomFileForNebulaPublication").getOutcome());
+        assertEquals(SUCCESS, result.task(":" + "generatePomFileForPluginZipPublication").getOutcome());
+        assertEquals(SUCCESS, result.task(":" + ZIP_PUBLISH_TASK).getOutcome());
+    }
+
+    /**
+     * If the plugin is used but relevant publication is not defined then a message is printed.
+     */
+    @Test
+    public void missingPublications() throws IOException, URISyntaxException {
+        GradleRunner runner = prepareGradleRunnerFromTemplate("missingPublications.gradle", "build", "-m");
+        BuildResult result = runner.build();
+
+        assertTrue(result.getOutput().contains("Plugin 'opensearch.pluginzip' is applied but no 'pluginZip' publication is defined."));
+    }
+
     @Test
     public void missingGroupValue() throws IOException, URISyntaxException, XmlPullParserException {
-        GradleRunner runner = prepareGradleRunnerFromTemplate("missingGroupValue.gradle");
+        GradleRunner runner = prepareGradleRunnerFromTemplate("missingGroupValue.gradle", "build", ZIP_PUBLISH_TASK);
         Exception e = assertThrows(UnexpectedBuildFailure.class, runner::build);
         assertTrue(e.getMessage().contains("Invalid publication 'pluginZip': groupId cannot be empty."));
     }
 
     /**
-     * This would be the most common use case where user declares Maven publication entity with basic info
-     * and the resulting POM file will use groupId and version values from the Gradle project object.
+     * This would be the most common use case where user declares Maven publication entity with minimal info
+     * and the resulting POM file will use artifactId, groupId and version values based on the Gradle project object.
      */
     @Test
-    public void groupAndVersionValue() throws IOException, URISyntaxException, XmlPullParserException {
-        GradleRunner runner = prepareGradleRunnerFromTemplate("groupAndVersionValue.gradle");
+    public void useDefaultValues() throws IOException, URISyntaxException, XmlPullParserException {
+        GradleRunner runner = prepareGradleRunnerFromTemplate("useDefaultValues.gradle", "build", ZIP_PUBLISH_TASK);
         BuildResult result = runner.build();
 
         /** Check if build and {@value ZIP_PUBLISH_TASK} tasks have run well */
@@ -108,7 +242,7 @@ public class PublishTests extends GradleUnitTestCase {
             ).exists()
         );
 
-        // Parse the maven file and validate the groupID
+        // Parse the maven file and validate default values
         MavenXpp3Reader reader = new MavenXpp3Reader();
         Model model = reader.read(
             new FileReader(
@@ -130,6 +264,10 @@ public class PublishTests extends GradleUnitTestCase {
         );
         assertEquals(model.getVersion(), "2.0.0.0");
         assertEquals(model.getGroupId(), "org.custom.group");
+        assertEquals(model.getArtifactId(), PROJECT_NAME);
+        assertNull(model.getName());
+        assertNull(model.getDescription());
+
         assertEquals(model.getUrl(), "https://github.com/doe/sample-plugin");
     }
 
@@ -139,7 +277,7 @@ public class PublishTests extends GradleUnitTestCase {
      */
     @Test
     public void missingPOMEntity() throws IOException, URISyntaxException, XmlPullParserException {
-        GradleRunner runner = prepareGradleRunnerFromTemplate("missingPOMEntity.gradle");
+        GradleRunner runner = prepareGradleRunnerFromTemplate("missingPOMEntity.gradle", "build", ZIP_PUBLISH_TASK);
         BuildResult result = runner.build();
 
         /** Check if build and {@value ZIP_PUBLISH_TASK} tasks have run well */
@@ -186,7 +324,7 @@ public class PublishTests extends GradleUnitTestCase {
      */
     @Test
     public void customizedGroupValue() throws IOException, URISyntaxException, XmlPullParserException {
-        GradleRunner runner = prepareGradleRunnerFromTemplate("customizedGroupValue.gradle");
+        GradleRunner runner = prepareGradleRunnerFromTemplate("customizedGroupValue.gradle", "build", ZIP_PUBLISH_TASK);
         BuildResult result = runner.build();
 
         /** Check if build and {@value ZIP_PUBLISH_TASK} tasks have run well */
@@ -223,21 +361,94 @@ public class PublishTests extends GradleUnitTestCase {
      */
     @Test
     public void customizedInvalidGroupValue() throws IOException, URISyntaxException {
-        GradleRunner runner = prepareGradleRunnerFromTemplate("customizedInvalidGroupValue.gradle");
+        GradleRunner runner = prepareGradleRunnerFromTemplate("customizedInvalidGroupValue.gradle", "build", ZIP_PUBLISH_TASK);
         Exception e = assertThrows(UnexpectedBuildFailure.class, runner::build);
         assertTrue(
             e.getMessage().contains("Invalid publication 'pluginZip': groupId ( ) is not a valid Maven identifier ([A-Za-z0-9_\\-.]+).")
         );
     }
 
-    private GradleRunner prepareGradleRunnerFromTemplate(String templateName) throws IOException, URISyntaxException {
+    /**
+     * This test verifies that use of the pluginZip does not clash with other maven publication plugins.
+     * It covers the case when user calls the "publishToMavenLocal" task.
+     */
+    @Test
+    public void publishToMavenLocal() throws IOException, URISyntaxException, XmlPullParserException {
+        // By default, the "publishToMavenLocal" publishes artifacts to a local m2 repo, typically
+        // found in `~/.m2/repository`. But this is not practical for this unit test at all. We need to point
+        // the 'maven-publish' plugin to a custom m2 repo located in temporary directory associated with this
+        // test case instead.
+        //
+        // According to Gradle documentation this should be possible by proper configuration of the publishing
+        // task (https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:install).
+        // But for some reason this never worked as expected and artifacts created during this test case
+        // were always pushed into the default local m2 repository (ie: `~/.m2/repository`).
+        // The only workaround that seems to work is to pass "-Dmaven.repo.local" property via runner argument.
+        // (Kudos to: https://stackoverflow.com/questions/72265294/gradle-publishtomavenlocal-specify-custom-directory)
+        //
+        // The temporary directory that is used as the local m2 repository is created via in task "prepareLocalMVNRepo".
+        GradleRunner runner = prepareGradleRunnerFromTemplate(
+            "publishToMavenLocal.gradle",
+            String.join(File.separator, "-Dmaven.repo.local=" + projectDir.getRoot(), "build", "local-staging-repo"),
+            "build",
+            "prepareLocalMVNRepo",
+            "publishToMavenLocal"
+        );
+        BuildResult result = runner.build();
+
+        assertEquals(SUCCESS, result.task(":" + "build").getOutcome());
+        assertEquals(SUCCESS, result.task(":" + "publishToMavenLocal").getOutcome());
+
+        // Parse the maven file and validate it
+        MavenXpp3Reader reader = new MavenXpp3Reader();
+        Model model = reader.read(
+            new FileReader(
+                new File(
+                    projectDir.getRoot(),
+                    String.join(
+                        File.separator,
+                        "build",
+                        "local-staging-repo",
+                        "org",
+                        "custom",
+                        "group",
+                        PROJECT_NAME,
+                        "2.0.0.0",
+                        PROJECT_NAME + "-2.0.0.0.pom"
+                    )
+                )
+            )
+        );
+
+        // The "publishToMavenLocal" task will run ALL maven publications, hence we can expect the ZIP publication
+        // present as well: https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:tasks
+        assertEquals(model.getArtifactId(), PROJECT_NAME);
+        assertEquals(model.getGroupId(), "org.custom.group");
+        assertEquals(model.getVersion(), "2.0.0.0");
+        assertEquals(model.getPackaging(), "zip");
+
+        // We have two publications in the build.gradle file, both are "MavenPublication" based.
+        // Both the mavenJava and pluginZip publications publish to the same location (coordinates) and
+        // artifacts (the POM file) overwrite each other. However, we can verify that the Zip plugin is
+        // the last one and "wins" over the mavenJava.
+        assertEquals(model.getDescription(), "pluginZip publication");
+    }
+
+    /**
+     * A helper method for use cases
+     *
+     * @param templateName The name of the file (from "pluginzip" folder) to use as a build.gradle for the test
+     * @param gradleArguments Optional CLI parameters to pass into Gradle runner
+     */
+    private GradleRunner prepareGradleRunnerFromTemplate(String templateName, String... gradleArguments) throws IOException,
+        URISyntaxException {
         useTemplateFile(projectDir.newFile("build.gradle"), templateName);
         prepareGradleFilesAndSources();
 
         GradleRunner runner = GradleRunner.create()
             .forwardOutput()
             .withPluginClasspath()
-            .withArguments("build", ZIP_PUBLISH_TASK)
+            .withArguments(gradleArguments)
             .withProjectDir(projectDir.getRoot());
 
         return runner;
@@ -246,7 +457,7 @@ public class PublishTests extends GradleUnitTestCase {
     private void prepareGradleFilesAndSources() throws IOException {
         // A dummy "source" file that is processed with bundlePlugin and put into a ZIP artifact file
         File bundleFile = new File(projectDir.getRoot(), PROJECT_NAME + "-source.txt");
-        Path zipFile = Files.createFile(bundleFile.toPath());
+        Files.createFile(bundleFile.toPath());
         // Setting a project name via settings.gradle file
         writeString(projectDir.newFile("settings.gradle"), "rootProject.name = '" + PROJECT_NAME + "'");
     }

--- a/buildSrc/src/test/resources/pluginzip/customizedGroupValue.gradle
+++ b/buildSrc/src/test/resources/pluginzip/customizedGroupValue.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'java-gradle-plugin'
-  id 'nebula.maven-base-publish'
   id 'opensearch.pluginzip'
 }
 

--- a/buildSrc/src/test/resources/pluginzip/customizedInvalidGroupValue.gradle
+++ b/buildSrc/src/test/resources/pluginzip/customizedInvalidGroupValue.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'java-gradle-plugin'
-  id 'nebula.maven-base-publish'
   id 'opensearch.pluginzip'
 }
 

--- a/buildSrc/src/test/resources/pluginzip/missingGroupValue.gradle
+++ b/buildSrc/src/test/resources/pluginzip/missingGroupValue.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'java-gradle-plugin'
-  id 'nebula.maven-base-publish'
   id 'opensearch.pluginzip'
 }
 

--- a/buildSrc/src/test/resources/pluginzip/missingPublications.gradle
+++ b/buildSrc/src/test/resources/pluginzip/missingPublications.gradle
@@ -13,9 +13,9 @@ tasks.register('bundlePlugin', Zip.class) {
   from layout.projectDirectory.file('sample-plugin-source.txt')
 }
 
-publishing {
-  publications {
-    pluginZip(MavenPublication) {
-    }
-  }
-}
+//publishing {
+//  publications {
+//    pluginZip(MavenPublication) {
+//    }
+//  }
+//}

--- a/buildSrc/src/test/resources/pluginzip/publishToMavenLocal.gradle
+++ b/buildSrc/src/test/resources/pluginzip/publishToMavenLocal.gradle
@@ -1,0 +1,47 @@
+plugins {
+  // The java-gradle-plugin adds a new publication called 'pluginMaven' that causes some warnings because it
+  // clashes a bit with other publications defined in this file. If you are running at the --info level then you can
+  // expect some warning like the following:
+  // "Multiple publications with coordinates 'org.custom.group:sample-plugin:2.0.0.0' are published to repository 'mavenLocal'."
+  id 'java-gradle-plugin'
+  id 'opensearch.pluginzip'
+}
+
+group="org.custom.group"
+version='2.0.0.0'
+
+// A bundlePlugin task mockup
+tasks.register('bundlePlugin', Zip.class) {
+  archiveFileName = "sample-plugin-${version}.zip"
+  destinationDirectory = layout.buildDirectory.dir('distributions')
+  from layout.projectDirectory.file('sample-plugin-source.txt')
+}
+
+// A task to prepare directory for a temporary maven local repository
+tasks.register('prepareLocalMVNRepo') {
+  dependsOn ':bundlePlugin'
+  doFirst {
+    File localMVNRepo = new File (layout.buildDirectory.get().getAsFile().getPath(), 'local-staging-repo')
+    System.out.println('Creating temporary folder for mavenLocal repo: '+ localMVNRepo.toString())
+    System.out.println("Success: " + localMVNRepo.mkdir())
+  }
+}
+
+publishing {
+  publications {
+    // Plugin zip publication
+    pluginZip(MavenPublication) {
+      pom {
+        url = 'http://www.example.com/library'
+        description = 'pluginZip publication'
+      }
+    }
+    // Standard maven publication
+    mavenJava(MavenPublication) {
+      pom {
+        url = 'http://www.example.com/library'
+        description = 'mavenJava publication'
+      }
+    }
+  }
+}

--- a/buildSrc/src/test/resources/pluginzip/useDefaultValues.gradle
+++ b/buildSrc/src/test/resources/pluginzip/useDefaultValues.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'java-gradle-plugin'
-  id 'nebula.maven-base-publish'
   id 'opensearch.pluginzip'
 }
 
@@ -18,8 +17,8 @@ publishing {
   publications {
     pluginZip(MavenPublication) {
       pom {
-        name = "sample-plugin"
-        description = "pluginDescription"
+//        name = "plugin name"
+//        description = "plugin description"
         licenses {
           license {
             name = "The Apache License, Version 2.0"


### PR DESCRIPTION
### Description

A follow-up of PR https://github.com/opensearch-project/OpenSearch/pull/4156 that brings in further simplification of the ZIP publication implementation and new tests.

It is possible to remove some of the initialization code because the work is already handled by other library under the hood (most likely by NebulaPublishPlugin).

For instance the condition to test the `groupId` presence: `if (groupId == null)` was pointless. It was never `true`. If the `project.group` is not defined the publication task fails with an exception, if there is a custom `groupId` value setup in publication config then it overrides the `project.group` as well. Tests are provided to cover these use cases.

As for the new tests they cover the following cases:

- verify that the task "publishToMavenLocal" gets expected results. The inspiration for this comes from https://github.com/opensearch-project/opensearch-plugin-template-java/pull/35

- verify that applying only the 'opensearch.pluginzip' is enough, because both the NebulaPublish and MavenPublishPlugin plugins are added explicitly and tasks are chained correctly

- verify that if the plugin is applied but no publication is defined then a message is printed for the user

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Lukáš Vlček <lukas.vlcek@aiven.io>