### PR TITLE
[Segment Replication] Add check to cancel ongoing replication with old primary on onNewCheckpoint on replica

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed cancellation of segment replication events ([#4225](https://github.com/opensearch-project/OpenSearch/pull/4225))
 - Bugs for dependabot changelog verifier workflow ([#4364](https://github.com/opensearch-project/OpenSearch/pull/4364))
 - Fix flaky random test `NRTReplicationEngineTests.testUpdateSegments` ([#4352](https://github.com/opensearch-project/OpenSearch/pull/4352))
+- [Segment Replication] Add check to cancel ongoing replication with old primary on onNewCheckpoint on replica ([#4363](https://github.com/opensearch-project/OpenSearch/pull/4363))
 
 ### Security
 - CVE-2022-25857 org.yaml:snakeyaml DOS vulnerability ([#4341](https://github.com/opensearch-project/OpenSearch/pull/4341))

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
@@ -56,6 +56,10 @@ public class SegmentReplicationTarget extends ReplicationTarget {
     private final SegmentReplicationState state;
     protected final MultiFileWriter multiFileWriter;
 
+    public ReplicationCheckpoint getCheckpoint() {
+        return this.checkpoint;
+    }
+
     public SegmentReplicationTarget(
         ReplicationCheckpoint checkpoint,
         IndexShard indexShard,

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
@@ -162,7 +162,7 @@ public class SegmentReplicationTargetService implements IndexEventListener {
                     "Cancelling ongoing replication from old primary with primary term {}",
                     target.getCheckpoint().getPrimaryTerm()
                 );
-                onGoingReplications.cancelForShard(replicaShard.shardId(), "Cancelling stuck target after new primary");
+                onGoingReplications.cancel(target.getId(), "Cancelling stuck target after new primary");
             } else {
                 logger.trace(
                     () -> new ParameterizedMessage(

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
@@ -158,11 +158,11 @@ public class SegmentReplicationTargetService implements IndexEventListener {
         if (ongoingReplicationTarget.isPresent()) {
             final SegmentReplicationTarget target = ongoingReplicationTarget.get();
             if (target.getCheckpoint().getPrimaryTerm() < receivedCheckpoint.getPrimaryTerm()) {
-                logger.info(
+                logger.trace(
                     "Cancelling ongoing replication from old primary with primary term {}",
                     target.getCheckpoint().getPrimaryTerm()
                 );
-                target.cancel("Cancelling stuck target after new primary");
+                onGoingReplications.cancelForShard(replicaShard.shardId(), "Cancelling stuck target after new primary");
             } else {
                 logger.trace(
                     () -> new ParameterizedMessage(

--- a/server/src/main/java/org/opensearch/indices/replication/common/ReplicationCollection.java
+++ b/server/src/main/java/org/opensearch/indices/replication/common/ReplicationCollection.java
@@ -50,6 +50,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Stream;
 
 /**
  * This class holds a collection of all on going replication events on the current node (i.e., the node is the target node
@@ -243,7 +244,9 @@ public class ReplicationCollection<T extends ReplicationTarget> {
      * @return Optional ReplicationTarget for input shardId
      */
     public Optional<T> getOngoingReplicationTarget(ShardId shardId) {
-        return onGoingTargetEvents.values().stream().filter(t -> t.indexShard.shardId().equals(shardId)).findFirst();
+        final Stream<T> replicationTargets = onGoingTargetEvents.values().stream().filter(t -> t.indexShard.shardId().equals(shardId));
+        assert replicationTargets.count() == 1 : "More than one on-going replication targets";
+        return replicationTargets.findAny();
     }
 
     /**

--- a/server/src/main/java/org/opensearch/indices/replication/common/ReplicationCollection.java
+++ b/server/src/main/java/org/opensearch/indices/replication/common/ReplicationCollection.java
@@ -48,9 +48,8 @@ import org.opensearch.threadpool.ThreadPool;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Stream;
+import java.util.stream.Collectors;
 
 /**
  * This class holds a collection of all on going replication events on the current node (i.e., the node is the target node
@@ -241,12 +240,15 @@ public class ReplicationCollection<T extends ReplicationTarget> {
      * Get target for shard
      *
      * @param shardId      shardId
-     * @return Optional ReplicationTarget for input shardId
+     * @return ReplicationTarget for input shardId
      */
-    public Optional<T> getOngoingReplicationTarget(ShardId shardId) {
-        final Stream<T> replicationTargets = onGoingTargetEvents.values().stream().filter(t -> t.indexShard.shardId().equals(shardId));
-        assert replicationTargets.count() == 1 : "More than one on-going replication targets";
-        return replicationTargets.findAny();
+    public T getOngoingReplicationTarget(ShardId shardId) {
+        final List<T> replicationTargetList = onGoingTargetEvents.values()
+            .stream()
+            .filter(t -> t.indexShard.shardId().equals(shardId))
+            .collect(Collectors.toList());
+        assert replicationTargetList.size() <= 1 : "More than one on-going replication targets";
+        return replicationTargetList.size() > 0 ? replicationTargetList.get(0) : null;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/indices/replication/common/ReplicationCollection.java
+++ b/server/src/main/java/org/opensearch/indices/replication/common/ReplicationCollection.java
@@ -48,6 +48,7 @@ import org.opensearch.threadpool.ThreadPool;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentMap;
 
 /**
@@ -236,13 +237,13 @@ public class ReplicationCollection<T extends ReplicationTarget> {
     }
 
     /**
-     * check if a shard is currently replicating
+     * Get target for shard
      *
-     * @param shardId      shardId for which to check if replicating
-     * @return true if shard is currently replicating
+     * @param shardId      shardId
+     * @return Optional ReplicationTarget for input shardId
      */
-    public boolean isShardReplicating(ShardId shardId) {
-        return onGoingTargetEvents.values().stream().anyMatch(t -> t.indexShard.shardId().equals(shardId));
+    public Optional<T> getOngoingReplicationTarget(ShardId shardId) {
+        return onGoingTargetEvents.values().stream().filter(t -> t.indexShard.shardId().equals(shardId)).findFirst();
     }
 
     /**

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
@@ -231,7 +231,7 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
         // wait for the new checkpoint to arrive, before the listener completes.
         latch.await(5, TimeUnit.SECONDS);
         doNothing().when(targetSpy).startReplication(any());
-        verify(targetSpy, times(1)).cancel(any());
+        verify(targetSpy, times(1)).cancel("Cancelling stuck target after new primary");
         verify(serviceSpy, times(1)).startReplication(eq(newPrimaryCheckpoint), eq(replicaShard), any());
         closeShards(replicaShard);
     }

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
@@ -49,6 +49,8 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
     private ReplicationCheckpoint initialCheckpoint;
     private ReplicationCheckpoint aheadCheckpoint;
 
+    private ReplicationCheckpoint newPrimaryCheckpoint;
+
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -70,6 +72,14 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
         aheadCheckpoint = new ReplicationCheckpoint(
             initialCheckpoint.getShardId(),
             initialCheckpoint.getPrimaryTerm(),
+            initialCheckpoint.getSegmentsGen(),
+            initialCheckpoint.getSeqNo(),
+            initialCheckpoint.getSegmentInfosVersion() + 1
+        );
+
+        newPrimaryCheckpoint = new ReplicationCheckpoint(
+            initialCheckpoint.getShardId(),
+            initialCheckpoint.getPrimaryTerm() + 1,
             initialCheckpoint.getSegmentsGen(),
             initialCheckpoint.getSeqNo(),
             initialCheckpoint.getSegmentInfosVersion() + 1
@@ -160,7 +170,7 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
         // Create a spy of Target Service so that we can verify invocation of startReplication call with specific checkpoint on it.
         SegmentReplicationTargetService serviceSpy = spy(sut);
         final SegmentReplicationTarget target = new SegmentReplicationTarget(
-            checkpoint,
+            initialCheckpoint,
             replicaShard,
             replicationSource,
             mock(SegmentReplicationTargetService.SegmentReplicationListener.class)
@@ -185,7 +195,45 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
 
         // wait for the new checkpoint to arrive, before the listener completes.
         latch.await(30, TimeUnit.SECONDS);
+        verify(targetSpy, times(0)).cancel(any());
         verify(serviceSpy, times(0)).startReplication(eq(aheadCheckpoint), eq(replicaShard), any());
+    }
+
+    public void testOnNewCheckpointFromNewPrimaryCancelOngoingReplication() throws IOException, InterruptedException {
+        // Create a spy of Target Service so that we can verify invocation of startReplication call with specific checkpoint on it.
+        SegmentReplicationTargetService serviceSpy = spy(sut);
+        // Create a Mockito spy of target to stub response of few method calls.
+        final SegmentReplicationTarget targetSpy = spy(
+            new SegmentReplicationTarget(
+                initialCheckpoint,
+                replicaShard,
+                replicationSource,
+                mock(SegmentReplicationTargetService.SegmentReplicationListener.class)
+            )
+        );
+
+        CountDownLatch latch = new CountDownLatch(1);
+        // Mocking response when startReplication is called on targetSpy we send a new checkpoint to serviceSpy and later reduce countdown
+        // of latch.
+        doAnswer(invocation -> {
+            final ActionListener<Void> listener = invocation.getArgument(0);
+            // a new checkpoint arrives before we've completed.
+            serviceSpy.onNewCheckpoint(newPrimaryCheckpoint, replicaShard);
+            listener.onResponse(null);
+            latch.countDown();
+            return null;
+        }).when(targetSpy).startReplication(any());
+        doNothing().when(targetSpy).onDone();
+
+        // start replication. This adds the target to on-ongoing replication collection
+        serviceSpy.startReplication(targetSpy);
+
+        // wait for the new checkpoint to arrive, before the listener completes.
+        latch.await(5, TimeUnit.SECONDS);
+        doNothing().when(targetSpy).startReplication(any());
+        verify(targetSpy, times(1)).cancel(any());
+        verify(serviceSpy, times(1)).startReplication(eq(newPrimaryCheckpoint), eq(replicaShard), any());
+        closeShards(replicaShard);
     }
 
     public void testNewCheckpointBehindCurrentCheckpoint() {

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
@@ -76,7 +76,6 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
             initialCheckpoint.getSeqNo(),
             initialCheckpoint.getSegmentInfosVersion() + 1
         );
-
         newPrimaryCheckpoint = new ReplicationCheckpoint(
             initialCheckpoint.getShardId(),
             initialCheckpoint.getPrimaryTerm() + 1,


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
During failover, when a new primary is chosen, replica should close on-going replication with previous primary. Continuing to copy files from two different primaries can be catastrophic and lead to multiple failures e.g. shard failure. Though logically two primary can't co-exist but due to some random bug, an older primary node can continue to hold onto replica for file transfer. This change is also needed:
1. To clean local store and cleanup temporary files already copied. 
2. Interrupt the existing threads involved in replication. 

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/4205

### Related
https://github.com/opensearch-project/OpenSearch/pull/4225

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
