### PR TITLE
Bug fixes for dependabot changelog verifier

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@
 - [ ] New functionality has been documented.
   - [ ] New functionality has javadoc added
 - [ ] Commits are signed per the DCO using --signoff
-- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../CONTRIBUTING.md#changelog))
+- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
 For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -7,37 +7,10 @@ jobs:
   # Enforces the update of a changelog file on every pull request
   verify-changelog:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
     steps:
-      - name: GitHub App token
-        id: github_app_token
-        if: ${{ github.actor == 'dependabot[bot]' }}
-        uses: tibdex/github-app-token@v1.5.0
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          installation_id: 22958780
-
       - uses: actions/checkout@v3
         with:
-          # token: ${{ steps.github_app_token.outputs.token }}
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}
-
-      - uses: dangoslen/dependabot-changelog-helper@v1
-        # if: ${{ github.actor == 'dependabot[bot]' }}
-        with:
-          version: 'Unreleased'
-
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        # if: ${{ github.actor == 'dependabot[bot]' }}
-        with:
-          commit_message: "Update changelog"
-          branch: ${{ github.head_ref }}
-          commit_user_name: dependabot[bot]
-          commit_user_email: support@github.com
-          commit_options: '--signoff'
 
       - uses: dangoslen/changelog-enforcer@v3

--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
+        if: ${{ github.actor == 'dependabot[bot]' }}
         uses: tibdex/github-app-token@v1.5.0
         with:
           app_id: ${{ secrets.APP_ID }}
@@ -25,10 +26,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: dangoslen/dependabot-changelog-helper@v1
+        if: ${{ github.actor == 'dependabot[bot]' }}
         with:
           version: 'Unreleased'
 
       - uses: stefanzweifel/git-auto-commit-action@v4
+        if: ${{ github.actor == 'dependabot[bot]' }}
         with:
           commit_message: "Update changelog"
           branch: ${{ github.head_ref }}

--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -7,10 +7,21 @@ jobs:
   # Enforces the update of a changelog file on every pull request
   verify-changelog:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.github_app_token.outputs.token }}
           ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: dangoslen/dependabot-changelog-helper@v1

--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -22,16 +22,17 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          token: ${{ steps.github_app_token.outputs.token }}
+          # token: ${{ steps.github_app_token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: dangoslen/dependabot-changelog-helper@v1
-        if: ${{ github.actor == 'dependabot[bot]' }}
+        # if: ${{ github.actor == 'dependabot[bot]' }}
         with:
           version: 'Unreleased'
 
       - uses: stefanzweifel/git-auto-commit-action@v4
-        if: ${{ github.actor == 'dependabot[bot]' }}
+        # if: ${{ github.actor == 'dependabot[bot]' }}
         with:
           commit_message: "Update changelog"
           branch: ${{ github.head_ref }}

--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -47,3 +47,17 @@ jobs:
           commit_user_name: dependabot[bot]
           commit_user_email: support@github.com
           commit_options: '--signoff'
+
+      - name: Update the changelog
+        uses: dangoslen/dependabot-changelog-helper@v1
+        with:
+          version: 'Unreleased'
+
+      - name: Commit the changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "Update changelog"
+          branch: ${{ github.head_ref }}
+          commit_user_name: dependabot[bot]
+          commit_user_email: support@github.com
+          commit_options: '--signoff'

--- a/.linelint.yml
+++ b/.linelint.yml
@@ -7,6 +7,7 @@ ignore:
   - .idea/
   - '*.sha1'
   - '*.txt'
+  - 'CHANGELOG.md'
   - '.github/CODEOWNERS'
   - 'buildSrc/src/testKit/opensearch.build/LICENSE'
   - 'buildSrc/src/testKit/opensearch.build/NOTICE'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added release notes for 2.2.1 ([#4344](https://github.com/opensearch-project/OpenSearch/pull/4344))
 - Label configuration for dependabot PRs ([#4348](https://github.com/opensearch-project/OpenSearch/pull/4348))
 - Support for HTTP/2 (server-side) ([#3847](https://github.com/opensearch-project/OpenSearch/pull/3847))
+### Dependencies
 
 ### Changed
 - Dependency updates (httpcore, mockito, slf4j, httpasyncclient, commons-codec) ([#4308](https://github.com/opensearch-project/OpenSearch/pull/4308))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add timeout on Mockito.verify to reduce flakyness in testReplicationOnDone test([#4314](https://github.com/opensearch-project/OpenSearch/pull/4314))
 - Commit workflow for dependabot changelog helper ([#4331](https://github.com/opensearch-project/OpenSearch/pull/4331))
 - Fixed cancellation of segment replication events ([#4225](https://github.com/opensearch-project/OpenSearch/pull/4225))
-- Bugs for dependabot changelog verifier workflow ([]()) 
+- Bugs for dependabot changelog verifier workflow ([#4364](https://github.com/opensearch-project/OpenSearch/pull/4364)) 
 
 ### Security
 - CVE-2022-25857 org.yaml:snakeyaml DOS vulnerability ([#4341](https://github.com/opensearch-project/OpenSearch/pull/4341))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added release notes for 2.2.1 ([#4344](https://github.com/opensearch-project/OpenSearch/pull/4344))
 - Label configuration for dependabot PRs ([#4348](https://github.com/opensearch-project/OpenSearch/pull/4348))
 - Support for HTTP/2 (server-side) ([#3847](https://github.com/opensearch-project/OpenSearch/pull/3847))
-### Dependencies
 
 ### Changed
 - Dependency updates (httpcore, mockito, slf4j, httpasyncclient, commons-codec) ([#4308](https://github.com/opensearch-project/OpenSearch/pull/4308))
@@ -29,6 +28,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add timeout on Mockito.verify to reduce flakyness in testReplicationOnDone test([#4314](https://github.com/opensearch-project/OpenSearch/pull/4314))
 - Commit workflow for dependabot changelog helper ([#4331](https://github.com/opensearch-project/OpenSearch/pull/4331))
 - Fixed cancellation of segment replication events ([#4225](https://github.com/opensearch-project/OpenSearch/pull/4225))
+- Bugs for dependabot changelog verifier workflow ([]()) 
 
 ### Security
 - CVE-2022-25857 org.yaml:snakeyaml DOS vulnerability ([#4341](https://github.com/opensearch-project/OpenSearch/pull/4341))


### PR DESCRIPTION
### Description
- Moves the depedenabot changelog plugin helper under the `dependabot_pr` workflow
- Fixes the link for changelog contributions under the pull_request_template

### Issues Resolved
- #1868 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
