### PR TITLE
[Backport 2.x] Implement segment replication event cancellation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - PR reference to checkout code for changelog verifier ([#4296](https://github.com/opensearch-project/OpenSearch/pull/4296))
 - Restore using the class ClusterInfoRequest and ClusterInfoRequestBuilder from package 'org.opensearch.action.support.master.info' for subclasses ([#4324](https://github.com/opensearch-project/OpenSearch/pull/4324))
+- Fixed cancellation of segment replication events ([#4225](https://github.com/opensearch-project/OpenSearch/pull/4225))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/opensearch/indices/cluster/IndicesClusterStateService.java
@@ -81,6 +81,7 @@ import org.opensearch.indices.recovery.PeerRecoverySourceService;
 import org.opensearch.indices.recovery.PeerRecoveryTargetService;
 import org.opensearch.indices.recovery.RecoveryListener;
 import org.opensearch.indices.recovery.RecoveryState;
+import org.opensearch.indices.replication.SegmentReplicationSourceService;
 import org.opensearch.indices.replication.SegmentReplicationTargetService;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.indices.replication.common.ReplicationState;
@@ -152,6 +153,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         final ThreadPool threadPool,
         final PeerRecoveryTargetService recoveryTargetService,
         final SegmentReplicationTargetService segmentReplicationTargetService,
+        final SegmentReplicationSourceService segmentReplicationSourceService,
         final ShardStateAction shardStateAction,
         final NodeMappingRefreshAction nodeMappingRefreshAction,
         final RepositoriesService repositoriesService,
@@ -170,6 +172,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             threadPool,
             checkpointPublisher,
             segmentReplicationTargetService,
+            segmentReplicationSourceService,
             recoveryTargetService,
             shardStateAction,
             nodeMappingRefreshAction,
@@ -191,6 +194,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         final ThreadPool threadPool,
         final SegmentReplicationCheckpointPublisher checkpointPublisher,
         final SegmentReplicationTargetService segmentReplicationTargetService,
+        final SegmentReplicationSourceService segmentReplicationSourceService,
         final PeerRecoveryTargetService recoveryTargetService,
         final ShardStateAction shardStateAction,
         final NodeMappingRefreshAction nodeMappingRefreshAction,
@@ -211,6 +215,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         // if segrep feature flag is not enabled, don't wire the target serivce as an IndexEventListener.
         if (FeatureFlags.isEnabled(FeatureFlags.REPLICATION_TYPE)) {
             indexEventListeners.add(segmentReplicationTargetService);
+            indexEventListeners.add(segmentReplicationSourceService);
         }
         this.builtInIndexListener = Collections.unmodifiableList(indexEventListeners);
         this.indicesService = indicesService;

--- a/server/src/main/java/org/opensearch/indices/replication/PrimaryShardReplicationSource.java
+++ b/server/src/main/java/org/opensearch/indices/replication/PrimaryShardReplicationSource.java
@@ -87,4 +87,10 @@ public class PrimaryShardReplicationSource implements SegmentReplicationSource {
         );
         transportClient.executeRetryableAction(GET_SEGMENT_FILES, request, responseListener, reader);
     }
+
+    @Override
+    public void cancel() {
+        transportClient.cancel();
+    }
+
 }

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSource.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSource.java
@@ -9,6 +9,7 @@
 package org.opensearch.indices.replication;
 
 import org.opensearch.action.ActionListener;
+import org.opensearch.common.util.CancellableThreads.ExecutionCancelledException;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
@@ -47,4 +48,9 @@ public interface SegmentReplicationSource {
         Store store,
         ActionListener<GetSegmentFilesResponse> listener
     );
+
+    /**
+     * Cancel any ongoing requests, should resolve any ongoing listeners with onFailure with a {@link ExecutionCancelledException}.
+     */
+    default void cancel() {}
 }

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
@@ -17,6 +17,7 @@ import org.apache.lucene.store.BufferedChecksumIndexInput;
 import org.apache.lucene.store.ByteBuffersDataInput;
 import org.apache.lucene.store.ByteBuffersIndexInput;
 import org.apache.lucene.store.ChecksumIndexInput;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.StepListener;
@@ -103,7 +104,15 @@ public class SegmentReplicationTarget extends ReplicationTarget {
 
     @Override
     public void notifyListener(OpenSearchException e, boolean sendShardFailure) {
-        listener.onFailure(state(), e, sendShardFailure);
+        // Cancellations still are passed to our SegmentReplicationListner as failures, if we have failed because of cancellation
+        // update the stage.
+        final Throwable cancelledException = ExceptionsHelper.unwrap(e, CancellableThreads.ExecutionCancelledException.class);
+        if (cancelledException != null) {
+            state.setStage(SegmentReplicationState.Stage.CANCELLED);
+            listener.onFailure(state(), (CancellableThreads.ExecutionCancelledException) cancelledException, sendShardFailure);
+        } else {
+            listener.onFailure(state(), e, sendShardFailure);
+        }
     }
 
     @Override
@@ -134,6 +143,14 @@ public class SegmentReplicationTarget extends ReplicationTarget {
      * @param listener {@link ActionListener} listener.
      */
     public void startReplication(ActionListener<Void> listener) {
+        cancellableThreads.setOnCancel((reason, beforeCancelEx) -> {
+            // This method only executes when cancellation is triggered by this node and caught by a call to checkForCancel,
+            // SegmentReplicationSource does not share CancellableThreads.
+            final CancellableThreads.ExecutionCancelledException executionCancelledException =
+                new CancellableThreads.ExecutionCancelledException("replication was canceled reason [" + reason + "]");
+            notifyListener(executionCancelledException, false);
+            throw executionCancelledException;
+        });
         state.setStage(SegmentReplicationState.Stage.REPLICATING);
         final StepListener<CheckpointInfoResponse> checkpointInfoListener = new StepListener<>();
         final StepListener<GetSegmentFilesResponse> getFilesListener = new StepListener<>();
@@ -141,6 +158,7 @@ public class SegmentReplicationTarget extends ReplicationTarget {
 
         logger.trace("[shardId {}] Replica starting replication [id {}]", shardId().getId(), getId());
         // Get list of files to copy from this checkpoint.
+        cancellableThreads.checkForCancel();
         state.setStage(SegmentReplicationState.Stage.GET_CHECKPOINT_INFO);
         source.getCheckpointMetadata(getId(), checkpoint, checkpointInfoListener);
 
@@ -154,6 +172,7 @@ public class SegmentReplicationTarget extends ReplicationTarget {
 
     private void getFiles(CheckpointInfoResponse checkpointInfo, StepListener<GetSegmentFilesResponse> getFilesListener)
         throws IOException {
+        cancellableThreads.checkForCancel();
         state.setStage(SegmentReplicationState.Stage.FILE_DIFF);
         final Store.MetadataSnapshot snapshot = checkpointInfo.getSnapshot();
         Store.MetadataSnapshot localMetadata = getMetadataSnapshot();
@@ -188,12 +207,14 @@ public class SegmentReplicationTarget extends ReplicationTarget {
         }
         // always send a req even if not fetching files so the primary can clear the copyState for this shard.
         state.setStage(SegmentReplicationState.Stage.GET_FILES);
+        cancellableThreads.checkForCancel();
         source.getSegmentFiles(getId(), checkpointInfo.getCheckpoint(), filesToFetch, store, getFilesListener);
     }
 
     private void finalizeReplication(CheckpointInfoResponse checkpointInfoResponse, ActionListener<Void> listener) {
-        state.setStage(SegmentReplicationState.Stage.FINALIZE_REPLICATION);
         ActionListener.completeWith(listener, () -> {
+            cancellableThreads.checkForCancel();
+            state.setStage(SegmentReplicationState.Stage.FINALIZE_REPLICATION);
             multiFileWriter.renameAllTempFiles();
             final Store store = store();
             store.incRef();
@@ -260,5 +281,11 @@ public class SegmentReplicationTarget extends ReplicationTarget {
             return Store.MetadataSnapshot.EMPTY;
         }
         return store.getMetadata(indexShard.getSegmentInfosSnapshot().get());
+    }
+
+    @Override
+    protected void onCancel(String reason) {
+        cancellableThreads.cancel(reason);
+        source.cancel();
     }
 }

--- a/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
+++ b/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
@@ -66,6 +66,7 @@ import org.opensearch.index.seqno.RetentionLeaseSyncer;
 import org.opensearch.index.shard.PrimaryReplicaSyncer;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.indices.recovery.PeerRecoveryTargetService;
+import org.opensearch.indices.replication.SegmentReplicationSourceService;
 import org.opensearch.indices.replication.SegmentReplicationTargetService;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.repositories.RepositoriesService;
@@ -572,6 +573,7 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
             threadPool,
             SegmentReplicationCheckpointPublisher.EMPTY,
             SegmentReplicationTargetService.NO_OP,
+            SegmentReplicationSourceService.NO_OP,
             recoveryTargetService,
             shardStateAction,
             null,

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceHandlerTests.java
@@ -18,6 +18,7 @@ import org.opensearch.action.ActionListener;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.CancellableThreads;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.IndexShardTestCase;
 import org.opensearch.index.store.StoreFileMetadata;
@@ -28,6 +29,8 @@ import org.opensearch.indices.replication.common.CopyState;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Mockito.mock;
 
@@ -196,5 +199,48 @@ public class SegmentReplicationSourceHandlerTests extends IndexShardTestCase {
 
         handler.sendFiles(getSegmentFilesRequest, mock(ActionListener.class));
         Assert.assertThrows(OpenSearchException.class, () -> { handler.sendFiles(getSegmentFilesRequest, mock(ActionListener.class)); });
+    }
+
+    public void testCancelReplication() throws IOException, InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        chunkWriter = mock(FileChunkWriter.class);
+
+        final ReplicationCheckpoint latestReplicationCheckpoint = primary.getLatestReplicationCheckpoint();
+        final CopyState copyState = new CopyState(latestReplicationCheckpoint, primary);
+        SegmentReplicationSourceHandler handler = new SegmentReplicationSourceHandler(
+            localNode,
+            chunkWriter,
+            threadPool,
+            copyState,
+            primary.routingEntry().allocationId().getId(),
+            5000,
+            1
+        );
+
+        final GetSegmentFilesRequest getSegmentFilesRequest = new GetSegmentFilesRequest(
+            1L,
+            replica.routingEntry().allocationId().getId(),
+            replicaDiscoveryNode,
+            Collections.emptyList(),
+            latestReplicationCheckpoint
+        );
+
+        // cancel before xfer starts. Cancels during copy will be tested in SegmentFileTransferHandlerTests, that uses the same
+        // cancellableThreads.
+        handler.cancel("test");
+        handler.sendFiles(getSegmentFilesRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(GetSegmentFilesResponse getSegmentFilesResponse) {
+                Assert.fail("Expected failure.");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                assertEquals(CancellableThreads.ExecutionCancelledException.class, e.getClass());
+                latch.countDown();
+            }
+        });
+        latch.await(2, TimeUnit.SECONDS);
+        assertEquals("listener should have resolved with failure", 0, latch.getCount());
     }
 }

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
@@ -9,38 +9,39 @@
 package org.opensearch.indices.replication;
 
 import org.junit.Assert;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.index.engine.NRTReplicationEngineFactory;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.IndexShardTestCase;
-import org.opensearch.indices.recovery.RecoverySettings;
+import org.opensearch.index.store.Store;
+import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
-import org.opensearch.indices.replication.common.ReplicationLuceneIndex;
-import org.opensearch.transport.TransportService;
+import org.opensearch.indices.replication.common.ReplicationType;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.eq;
 
 public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
 
-    private IndexShard indexShard;
+    private IndexShard replicaShard;
+    private IndexShard primaryShard;
     private ReplicationCheckpoint checkpoint;
     private SegmentReplicationSource replicationSource;
     private SegmentReplicationTargetService sut;
@@ -52,20 +53,20 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
     public void setUp() throws Exception {
         super.setUp();
         final Settings settings = Settings.builder()
-            .put(IndexMetadata.SETTING_REPLICATION_TYPE, "SEGMENT")
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
             .put("node.name", SegmentReplicationTargetServiceTests.class.getSimpleName())
             .build();
         final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        final RecoverySettings recoverySettings = new RecoverySettings(settings, clusterSettings);
-        final TransportService transportService = mock(TransportService.class);
-        indexShard = newStartedShard(false, settings);
-        checkpoint = new ReplicationCheckpoint(indexShard.shardId(), 0L, 0L, 0L, 0L);
+        primaryShard = newStartedShard(true);
+        replicaShard = newShard(false, settings, new NRTReplicationEngineFactory());
+        recoverReplica(replicaShard, primaryShard, true);
+        checkpoint = new ReplicationCheckpoint(replicaShard.shardId(), 0L, 0L, 0L, 0L);
         SegmentReplicationSourceFactory replicationSourceFactory = mock(SegmentReplicationSourceFactory.class);
         replicationSource = mock(SegmentReplicationSource.class);
-        when(replicationSourceFactory.get(indexShard)).thenReturn(replicationSource);
+        when(replicationSourceFactory.get(replicaShard)).thenReturn(replicationSource);
 
-        sut = new SegmentReplicationTargetService(threadPool, recoverySettings, transportService, replicationSourceFactory);
-        initialCheckpoint = indexShard.getLatestReplicationCheckpoint();
+        sut = prepareForReplication(primaryShard);
+        initialCheckpoint = replicaShard.getLatestReplicationCheckpoint();
         aheadCheckpoint = new ReplicationCheckpoint(
             initialCheckpoint.getShardId(),
             initialCheckpoint.getPrimaryTerm(),
@@ -77,44 +78,58 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
 
     @Override
     public void tearDown() throws Exception {
-        closeShards(indexShard);
+        closeShards(primaryShard, replicaShard);
         super.tearDown();
     }
 
-    public void testTargetReturnsSuccess_listenerCompletes() {
-        final SegmentReplicationTarget target = new SegmentReplicationTarget(
-            checkpoint,
-            indexShard,
-            replicationSource,
-            new SegmentReplicationTargetService.SegmentReplicationListener() {
-                @Override
-                public void onReplicationDone(SegmentReplicationState state) {
-                    assertEquals(SegmentReplicationState.Stage.DONE, state.getStage());
-                }
-
-                @Override
-                public void onReplicationFailure(SegmentReplicationState state, OpenSearchException e, boolean sendShardFailure) {
-                    Assert.fail();
-                }
+    public void testsSuccessfulReplication_listenerCompletes() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        sut.startReplication(checkpoint, replicaShard, new SegmentReplicationTargetService.SegmentReplicationListener() {
+            @Override
+            public void onReplicationDone(SegmentReplicationState state) {
+                assertEquals(SegmentReplicationState.Stage.DONE, state.getStage());
+                latch.countDown();
             }
-        );
-        final SegmentReplicationTarget spy = Mockito.spy(target);
-        doAnswer(invocation -> {
-            // set up stage correctly so the transition in markAsDone succeeds on listener completion
-            moveTargetToFinalStage(target);
-            final ActionListener<Void> listener = invocation.getArgument(0);
-            listener.onResponse(null);
-            return null;
-        }).when(spy).startReplication(any());
-        sut.startReplication(spy);
+
+            @Override
+            public void onReplicationFailure(SegmentReplicationState state, OpenSearchException e, boolean sendShardFailure) {
+                logger.error("Unexpected error", e);
+                Assert.fail("Test should succeed");
+            }
+        });
+        latch.await(2, TimeUnit.SECONDS);
+        assertEquals(0, latch.getCount());
     }
 
-    public void testTargetThrowsException() {
+    public void testReplicationFails() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
         final OpenSearchException expectedError = new OpenSearchException("Fail");
+        SegmentReplicationSource source = new SegmentReplicationSource() {
+
+            @Override
+            public void getCheckpointMetadata(
+                long replicationId,
+                ReplicationCheckpoint checkpoint,
+                ActionListener<CheckpointInfoResponse> listener
+            ) {
+                listener.onFailure(expectedError);
+            }
+
+            @Override
+            public void getSegmentFiles(
+                long replicationId,
+                ReplicationCheckpoint checkpoint,
+                List<StoreFileMetadata> filesToFetch,
+                Store store,
+                ActionListener<GetSegmentFilesResponse> listener
+            ) {
+                Assert.fail("Should not be called");
+            }
+        };
         final SegmentReplicationTarget target = new SegmentReplicationTarget(
             checkpoint,
-            indexShard,
-            replicationSource,
+            replicaShard,
+            source,
             new SegmentReplicationTargetService.SegmentReplicationListener() {
                 @Override
                 public void onReplicationDone(SegmentReplicationState state) {
@@ -123,24 +138,21 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
 
                 @Override
                 public void onReplicationFailure(SegmentReplicationState state, OpenSearchException e, boolean sendShardFailure) {
-                    assertEquals(SegmentReplicationState.Stage.INIT, state.getStage());
+                    // failures leave state object in last entered stage.
+                    assertEquals(SegmentReplicationState.Stage.GET_CHECKPOINT_INFO, state.getStage());
                     assertEquals(expectedError, e.getCause());
-                    assertTrue(sendShardFailure);
+                    latch.countDown();
                 }
             }
         );
-        final SegmentReplicationTarget spy = Mockito.spy(target);
-        doAnswer(invocation -> {
-            final ActionListener<Void> listener = invocation.getArgument(0);
-            listener.onFailure(expectedError);
-            return null;
-        }).when(spy).startReplication(any());
-        sut.startReplication(spy);
+        sut.startReplication(target);
+        latch.await(2, TimeUnit.SECONDS);
+        assertEquals(0, latch.getCount());
     }
 
     public void testAlreadyOnNewCheckpoint() {
         SegmentReplicationTargetService spy = spy(sut);
-        spy.onNewCheckpoint(indexShard.getLatestReplicationCheckpoint(), indexShard);
+        spy.onNewCheckpoint(replicaShard.getLatestReplicationCheckpoint(), replicaShard);
         verify(spy, times(0)).startReplication(any(), any(), any());
     }
 
@@ -149,7 +161,7 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
         SegmentReplicationTargetService serviceSpy = spy(sut);
         final SegmentReplicationTarget target = new SegmentReplicationTarget(
             checkpoint,
-            indexShard,
+            replicaShard,
             replicationSource,
             mock(SegmentReplicationTargetService.SegmentReplicationListener.class)
         );
@@ -161,7 +173,7 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
         doAnswer(invocation -> {
             final ActionListener<Void> listener = invocation.getArgument(0);
             // a new checkpoint arrives before we've completed.
-            serviceSpy.onNewCheckpoint(aheadCheckpoint, indexShard);
+            serviceSpy.onNewCheckpoint(aheadCheckpoint, replicaShard);
             listener.onResponse(null);
             latch.countDown();
             return null;
@@ -173,12 +185,12 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
 
         // wait for the new checkpoint to arrive, before the listener completes.
         latch.await(30, TimeUnit.SECONDS);
-        verify(serviceSpy, times(0)).startReplication(eq(aheadCheckpoint), eq(indexShard), any());
+        verify(serviceSpy, times(0)).startReplication(eq(aheadCheckpoint), eq(replicaShard), any());
     }
 
     public void testNewCheckpointBehindCurrentCheckpoint() {
         SegmentReplicationTargetService spy = spy(sut);
-        spy.onNewCheckpoint(checkpoint, indexShard);
+        spy.onNewCheckpoint(checkpoint, replicaShard);
         verify(spy, times(0)).startReplication(any(), any(), any());
     }
 
@@ -190,22 +202,6 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
         closeShards(shard);
     }
 
-    public void testNewCheckpoint_validationPassesAndReplicationFails() throws IOException {
-        allowShardFailures();
-        SegmentReplicationTargetService spy = spy(sut);
-        IndexShard spyShard = spy(indexShard);
-        ArgumentCaptor<SegmentReplicationTargetService.SegmentReplicationListener> captor = ArgumentCaptor.forClass(
-            SegmentReplicationTargetService.SegmentReplicationListener.class
-        );
-        doNothing().when(spy).startReplication(any(), any(), any());
-        spy.onNewCheckpoint(aheadCheckpoint, spyShard);
-        verify(spy, times(1)).startReplication(any(), any(), captor.capture());
-        SegmentReplicationTargetService.SegmentReplicationListener listener = captor.getValue();
-        listener.onFailure(new SegmentReplicationState(new ReplicationLuceneIndex()), new OpenSearchException("testing"), true);
-        verify(spyShard).failShard(any(), any());
-        closeShard(indexShard, false);
-    }
-
     /**
      * here we are starting a new shard in PrimaryMode and testing that we don't process a checkpoint on shard when it is in PrimaryMode.
      */
@@ -215,71 +211,10 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
         // Starting a new shard in PrimaryMode.
         IndexShard primaryShard = newStartedShard(true);
         IndexShard spyShard = spy(primaryShard);
-        doNothing().when(spy).startReplication(any(), any(), any());
         spy.onNewCheckpoint(aheadCheckpoint, spyShard);
 
         // Verify that checkpoint is not processed as shard is in PrimaryMode.
         verify(spy, times(0)).startReplication(any(), any(), any());
         closeShards(primaryShard);
-    }
-
-    public void testReplicationOnDone() throws IOException {
-        SegmentReplicationTargetService spy = spy(sut);
-        IndexShard spyShard = spy(indexShard);
-        ReplicationCheckpoint cp = indexShard.getLatestReplicationCheckpoint();
-        ReplicationCheckpoint newCheckpoint = new ReplicationCheckpoint(
-            cp.getShardId(),
-            cp.getPrimaryTerm(),
-            cp.getSegmentsGen(),
-            cp.getSeqNo(),
-            cp.getSegmentInfosVersion() + 1
-        );
-        ReplicationCheckpoint anotherNewCheckpoint = new ReplicationCheckpoint(
-            cp.getShardId(),
-            cp.getPrimaryTerm(),
-            cp.getSegmentsGen(),
-            cp.getSeqNo(),
-            cp.getSegmentInfosVersion() + 2
-        );
-        ArgumentCaptor<SegmentReplicationTargetService.SegmentReplicationListener> captor = ArgumentCaptor.forClass(
-            SegmentReplicationTargetService.SegmentReplicationListener.class
-        );
-        doNothing().when(spy).startReplication(any(), any(), any());
-        spy.onNewCheckpoint(newCheckpoint, spyShard);
-        spy.onNewCheckpoint(anotherNewCheckpoint, spyShard);
-        verify(spy, times(1)).startReplication(eq(newCheckpoint), any(), captor.capture());
-        verify(spy, times(1)).onNewCheckpoint(eq(anotherNewCheckpoint), any());
-        SegmentReplicationTargetService.SegmentReplicationListener listener = captor.getValue();
-        listener.onDone(new SegmentReplicationState(new ReplicationLuceneIndex()));
-        doNothing().when(spy).onNewCheckpoint(any(), any());
-        verify(spy, timeout(0).times(2)).onNewCheckpoint(eq(anotherNewCheckpoint), any());
-        closeShard(indexShard, false);
-
-    }
-
-    public void testBeforeIndexShardClosed_CancelsOngoingReplications() {
-        final SegmentReplicationTarget target = new SegmentReplicationTarget(
-            checkpoint,
-            indexShard,
-            replicationSource,
-            mock(SegmentReplicationTargetService.SegmentReplicationListener.class)
-        );
-        final SegmentReplicationTarget spy = Mockito.spy(target);
-        sut.startReplication(spy);
-        sut.beforeIndexShardClosed(indexShard.shardId(), indexShard, Settings.EMPTY);
-        verify(spy, times(1)).cancel(any());
-    }
-
-    /**
-     * Move the {@link SegmentReplicationTarget} object through its {@link SegmentReplicationState.Stage} values in order
-     * until the final, non-terminal stage.
-     */
-    private void moveTargetToFinalStage(SegmentReplicationTarget target) {
-        SegmentReplicationState.Stage[] stageValues = SegmentReplicationState.Stage.values();
-        assertEquals(target.state().getStage(), SegmentReplicationState.Stage.INIT);
-        // Skip the first two stages (DONE and INIT) and iterate until the last value
-        for (int i = 2; i < stageValues.length; i++) {
-            target.state().setStage(stageValues[i]);
-        }
     }
 }

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -185,6 +185,7 @@ import org.opensearch.indices.recovery.PeerRecoverySourceService;
 import org.opensearch.indices.recovery.PeerRecoveryTargetService;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.indices.replication.SegmentReplicationSourceFactory;
+import org.opensearch.indices.replication.SegmentReplicationSourceService;
 import org.opensearch.indices.replication.SegmentReplicationTargetService;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.ingest.IngestService;
@@ -1857,6 +1858,7 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                         transportService,
                         new SegmentReplicationSourceFactory(transportService, recoverySettings, clusterService)
                     ),
+                    SegmentReplicationSourceService.NO_OP,
                     shardStateAction,
                     new NodeMappingRefreshAction(transportService, metadataMappingService),
                     repositoriesService,


### PR DESCRIPTION
Manual backport of https://github.com/opensearch-project/OpenSearch/pull/4225 to 2.x.