### PR TITLE
Adding support for labels on version bump PRs, skip label support for…

### DIFF
--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -14,3 +14,5 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: dangoslen/changelog-enforcer@v3
+        with:
+          skipLabels: "autocut"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - '*.*.*'
 
-jobs:  
+jobs:
   build:
     runs-on: ubuntu-latest
     steps:
@@ -61,6 +61,8 @@ jobs:
           commit-message: Incremented version to ${{ env.NEXT_VERSION }}
           signoff: true
           delete-branch: true
+          labels: |
+            autocut
           title: '[AUTO] Incremented version to ${{ env.NEXT_VERSION }}.'
           body: |
             I've noticed that a new tag ${{ env.TAG }} was pushed, and incremented the version from ${{ env.CURRENT_VERSION }} to ${{ env.NEXT_VERSION }}.
@@ -86,6 +88,8 @@ jobs:
           commit-message: Added bwc version ${{ env.NEXT_VERSION }}
           signoff: true
           delete-branch: true
+          labels: |
+            autocut
           title: '[AUTO] [${{ env.BASE_X }}] Added bwc version ${{ env.NEXT_VERSION }}.'
           body: |
             I've noticed that a new tag ${{ env.TAG }} was pushed, and added a bwc version ${{ env.NEXT_VERSION }}.
@@ -111,6 +115,8 @@ jobs:
           commit-message: Added bwc version ${{ env.NEXT_VERSION }}
           signoff: true
           delete-branch: true
+          labels: |
+            autocut
           title: '[AUTO] [main] Added bwc version ${{ env.NEXT_VERSION }}.'
           body: |
             I've noticed that a new tag ${{ env.TAG }} was pushed, and added a bwc version ${{ env.NEXT_VERSION }}.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Label configuration for dependabot PRs ([#4348](https://github.com/opensearch-project/OpenSearch/pull/4348))
 - Support for HTTP/2 (server-side) ([#3847](https://github.com/opensearch-project/OpenSearch/pull/3847))
 - BWC version 2.2.2 ([#4383](https://github.com/opensearch-project/OpenSearch/pull/4383))
-- Support for labels on version bump PRs, skip label support for changelog verifier ([]())
+- Support for labels on version bump PRs, skip label support for changelog verifier ([#4391](https://github.com/opensearch-project/OpenSearch/pull/4391))
 
 ### Dependencies
 - Bumps `com.diffplug.spotless` from 6.9.1 to 6.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Label configuration for dependabot PRs ([#4348](https://github.com/opensearch-project/OpenSearch/pull/4348))
 - Support for HTTP/2 (server-side) ([#3847](https://github.com/opensearch-project/OpenSearch/pull/3847))
 - BWC version 2.2.2 ([#4383](https://github.com/opensearch-project/OpenSearch/pull/4383))
+- Support for labels on version bump PRs, skip label support for changelog verifier ([]())
 
 ### Dependencies
 - Bumps `com.diffplug.spotless` from 6.9.1 to 6.10.0


### PR DESCRIPTION
… changelog verifier

Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>

### Description
- Adds support for labels on version bump PRs
- Adds support for skip label support for changelog verifier

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
