### PR TITLE
[Backport 1.x] Bug fixes for dependabot changelog verifier (#4364)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@
 - [ ] New functionality has been documented.
   - [ ] New functionality has javadoc added
 - [ ] Commits are signed per the DCO using --signoff
-- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../CONTRIBUTING.md#changelog))
+- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
 For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -13,10 +13,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - uses: dangoslen/dependabot-changelog-helper@v1
-
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: "Update changelog"
-
       - uses: dangoslen/changelog-enforcer@v3

--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -1,0 +1,63 @@
+name: Dependabot PR actions
+on: pull_request
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ steps.github_app_token.outputs.token }}
+
+      - name: Update Gradle SHAs
+        run: |
+          ./gradlew updateSHAs
+
+      - name: Commit the changes
+        uses: stefanzweifel/git-auto-commit-action@v4.7.2
+        with:
+          commit_message: Updating SHAs
+          branch: ${{ github.head_ref }}
+          commit_user_name: dependabot[bot]
+          commit_user_email: support@github.com
+          commit_options: '--signoff'
+
+      - name: Run spotless
+        run: |
+          ./gradlew spotlessApply
+
+      - name: Commit the changes
+        uses: stefanzweifel/git-auto-commit-action@v4.7.2
+        with:
+          commit_message: Spotless formatting
+          branch: ${{ github.head_ref }}
+          commit_user_name: dependabot[bot]
+          commit_user_email: support@github.com
+          commit_options: '--signoff'
+
+      - name: Update the changelog
+        uses: dangoslen/dependabot-changelog-helper@v1
+        with:
+          version: 'Unreleased'
+
+      - name: Commit the changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "Update changelog"
+          branch: ${{ github.head_ref }}
+          commit_user_name: dependabot[bot]
+          commit_user_email: support@github.com
+          commit_options: '--signoff'

--- a/.linelint.yml
+++ b/.linelint.yml
@@ -1,0 +1,49 @@
+# 'true' will fix files
+autofix: true
+
+ignore:
+  - .git/
+  - .gradle/
+  - .idea/
+  - '*.sha1'
+  - '*.txt'
+  - 'CHANGELOG.md'
+  - '.github/CODEOWNERS'
+  - 'buildSrc/src/testKit/opensearch.build/LICENSE'
+  - 'buildSrc/src/testKit/opensearch.build/NOTICE'
+  - 'server/licenses/apache-log4j-extras-DEPENDENCIES'
+  # Empty files
+  - 'buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/build.gradle'
+  - 'buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/archives/oss-darwin-tar/build.gradle'
+  - 'buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/bwc/bugfix/build.gradle'
+  - 'buildSrc/src/integTest/resources/org/opensearch/gradle/internal/fake_git/remote/distribution/bwc/minor/build.gradle'
+  - 'buildSrc/src/main/resources/buildSrc.marker'
+  - 'buildSrc/src/testKit/opensearch-build-resources/settings.gradle'
+  - 'buildSrc/src/testKit/opensearch.build/settings.gradle'
+  - 'buildSrc/src/testKit/reaper/settings.gradle'
+  - 'buildSrc/src/testKit/symbolic-link-preserving-tar/settings.gradle'
+  - 'buildSrc/src/testKit/testingConventions/empty_test_task/.gitignore'
+  - 'client/rest-high-level/src/main/resources/META-INF/services/org.opensearch.plugins.spi.NamedXContentProvider'
+  - 'distribution/bwc/bugfix/build.gradle'
+  - 'distribution/bwc/maintenance/build.gradle'
+  - 'distribution/bwc/minor/build.gradle'
+  - 'distribution/bwc/staged/build.gradle'
+  - 'libs/ssl-config/src/test/resources/certs/pem-utils/empty.pem'
+  - 'qa/evil-tests/src/test/resources/org/opensearch/common/logging/does_not_exist/nothing_to_see_here'
+  - 'qa/os/centos-6/build.gradle'
+  - 'qa/os/debian-8/build.gradle'
+  - 'qa/os/oel-6/build.gradle'
+  - 'qa/os/oel-7/build.gradle'
+  - 'qa/os/sles-12/build.gradle'
+  # Test requires no new line for these files
+  - 'server/src/test/resources/org/opensearch/action/bulk/simple-bulk11.json'
+  - 'server/src/test/resources/org/opensearch/action/search/simple-msearch5.json'
+
+rules:
+  # checks if file ends in a newline character
+  end-of-file:
+    # set to true to enable this rule
+    enable: true
+
+    # if true also checks if file ends in a single newline character
+    single-new-line: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 - Github workflow for changelog verification ([#4085](https://github.com/opensearch-project/OpenSearch/pull/4085))
+- Added @dreamer-89 as an Opensearch maintainer ([#4342](https://github.com/opensearch-project/OpenSearch/pull/4342))
+- Added release notes for 1.3.5 ([#4343](https://github.com/opensearch-project/OpenSearch/pull/4343))
+- Added release notes for 2.2.1 ([#4344](https://github.com/opensearch-project/OpenSearch/pull/4344))
+- Label configuration for dependabot PRs ([#4348](https://github.com/opensearch-project/OpenSearch/pull/4348))
+- Support for HTTP/2 (server-side) ([#3847](https://github.com/opensearch-project/OpenSearch/pull/3847))
+
+### Changed
+- Dependency updates (httpcore, mockito, slf4j, httpasyncclient, commons-codec) ([#4308](https://github.com/opensearch-project/OpenSearch/pull/4308))
+- Use RemoteSegmentStoreDirectory instead of RemoteDirectory ([#4240](https://github.com/opensearch-project/OpenSearch/pull/4240))
+- Plugin ZIP publication groupId value is configurable ([#4156](https://github.com/opensearch-project/OpenSearch/pull/4156))
+
+### Deprecated
+
+### Removed
+
+### Fixed
+- `opensearch-service.bat start` and `opensearch-service.bat manager` failing to run ([#4289](https://github.com/opensearch-project/OpenSearch/pull/4289))
+- PR reference to checkout code for changelog verifier ([#4296](https://github.com/opensearch-project/OpenSearch/pull/4296))
+- `opensearch.bat` and `opensearch-service.bat install` failing to run, missing logs directory ([#4305](https://github.com/opensearch-project/OpenSearch/pull/4305))
+- Restore using the class ClusterInfoRequest and ClusterInfoRequestBuilder from package 'org.opensearch.action.support.master.info' for subclasses ([#4307](https://github.com/opensearch-project/OpenSearch/pull/4307))
+- Do not fail replica shard due to primary closure ([#4133](https://github.com/opensearch-project/OpenSearch/pull/4133))
+- Add timeout on Mockito.verify to reduce flakyness in testReplicationOnDone test([#4314](https://github.com/opensearch-project/OpenSearch/pull/4314))
+- Commit workflow for dependabot changelog helper ([#4331](https://github.com/opensearch-project/OpenSearch/pull/4331))
+- Fixed cancellation of segment replication events ([#4225](https://github.com/opensearch-project/OpenSearch/pull/4225))
+- Bugs for dependabot changelog verifier workflow ([#4364](https://github.com/opensearch-project/OpenSearch/pull/4364))
+
+### Security
+- CVE-2022-25857 org.yaml:snakeyaml DOS vulnerability ([#4341](https://github.com/opensearch-project/OpenSearch/pull/4341))
+
+## [2.x]
+### Added
+- Github workflow for changelog verification ([#4085](https://github.com/opensearch-project/OpenSearch/pull/4085))
+- Label configuration for dependabot PRs ([#4348](https://github.com/opensearch-project/OpenSearch/pull/4348))
 
 ### Changed
 


### PR DESCRIPTION
* Fix token usage for changelog helper

Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>

* Add conditional check for dependabot steps

Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>

* Add dependency section

Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>

* Bug fixes for dependabot changelog verifier

Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>

* Update the changelog

Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>

Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>
(cherry picked from commit 4a6e937b3ba120f38fa991c9c481a01daec18e94)

### Description
- Backports #4364 to 1.x

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
