### PR TITLE
Segment Replication - Fix NoSuchFileException errors caused when computing metadata snapshot on primary shards.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Restore using the class ClusterInfoRequest and ClusterInfoRequestBuilder from package 'org.opensearch.action.support.master.info' for subclasses ([#4324](https://github.com/opensearch-project/OpenSearch/pull/4324))
 - Fixed cancellation of segment replication events ([#4225](https://github.com/opensearch-project/OpenSearch/pull/4225))
 - [Segment Replication] Bump segment infos counter before commit during replica promotion ([#4365](https://github.com/opensearch-project/OpenSearch/pull/4365))
+- [Segment Replication] Fix NoSuchFileExceptions with segment replication when computing primary metadata snapshots ([#4366](https://github.com/opensearch-project/OpenSearch/pull/4366))
 
 ### Security
 

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -9,7 +9,6 @@
 package org.opensearch.indices.replication;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
-import org.apache.lucene.index.SegmentInfos;
 import org.junit.BeforeClass;
 import org.opensearch.action.admin.indices.segments.IndexShardSegments;
 import org.opensearch.action.admin.indices.segments.IndicesSegmentResponse;
@@ -458,10 +457,53 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
                 ClusterState state = client(internalCluster().getMasterName()).admin().cluster().prepareState().get().getState();
                 final DiscoveryNode replicaNode = state.nodes().resolveNode(replicaShardRouting.currentNodeId());
                 IndexShard indexShard = getIndexShard(replicaNode.getName());
-                final String lastCommitSegmentsFileName = SegmentInfos.getLastCommitSegmentsFileName(indexShard.store().directory());
                 // calls to readCommit will fail if a valid commit point and all its segments are not in the store.
-                SegmentInfos.readCommit(indexShard.store().directory(), lastCommitSegmentsFileName);
+                indexShard.store().readLastCommittedSegmentsInfo();
             }
+        }
+    }
+
+    public void testDropPrimaryDuringReplication() throws Exception {
+        final Settings settings = Settings.builder()
+            .put(indexSettings())
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 6)
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .build();
+        final String clusterManagerNode = internalCluster().startClusterManagerOnlyNode();
+        final String primaryNode = internalCluster().startDataOnlyNode(Settings.EMPTY);
+        createIndex(INDEX_NAME, settings);
+        internalCluster().startDataOnlyNodes(6);
+        ensureGreen(INDEX_NAME);
+
+        int initialDocCount = scaledRandomIntBetween(100, 200);
+        try (
+            BackgroundIndexer indexer = new BackgroundIndexer(
+                INDEX_NAME,
+                "_doc",
+                client(),
+                -1,
+                RandomizedTest.scaledRandomIntBetween(2, 5),
+                false,
+                random()
+            )
+        ) {
+            indexer.start(initialDocCount);
+            waitForDocs(initialDocCount, indexer);
+            refresh(INDEX_NAME);
+            // don't wait for replication to complete, stop the primary immediately.
+            internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNode));
+            ensureYellow(INDEX_NAME);
+
+            // start another replica.
+            internalCluster().startDataOnlyNode();
+            ensureGreen(INDEX_NAME);
+
+            // index another doc and refresh - without this the new replica won't catch up.
+            client().prepareIndex(INDEX_NAME).setId("1").setSource("foo", "bar").get();
+
+            flushAndRefresh(INDEX_NAME);
+            waitForReplicaUpdate();
+            assertSegmentStats(6);
         }
     }
 
@@ -483,10 +525,12 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
                 final List<ShardSegments> replicaShardSegments = segmentListMap.get(false);
                 // if we don't have any segments yet, proceed.
                 final ShardSegments primaryShardSegments = primaryShardSegmentsList.stream().findFirst().get();
+                logger.debug("Primary Segments: {}", primaryShardSegments.getSegments());
                 if (primaryShardSegments.getSegments().isEmpty() == false) {
                     final Map<String, Segment> latestPrimarySegments = getLatestSegments(primaryShardSegments);
                     final Long latestPrimaryGen = latestPrimarySegments.values().stream().findFirst().map(Segment::getGeneration).get();
                     for (ShardSegments shardSegments : replicaShardSegments) {
+                        logger.debug("Replica {} Segments: {}", shardSegments.getShardRouting(), shardSegments.getSegments());
                         final boolean isReplicaCaughtUpToPrimary = shardSegments.getSegments()
                             .stream()
                             .anyMatch(segment -> segment.getGeneration() == latestPrimaryGen);

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceService.java
@@ -133,12 +133,7 @@ public class SegmentReplicationSourceService extends AbstractLifecycleComponent 
             );
             final CopyState copyState = ongoingSegmentReplications.prepareForReplication(request, segmentSegmentFileChunkWriter);
             channel.sendResponse(
-                new CheckpointInfoResponse(
-                    copyState.getCheckpoint(),
-                    copyState.getMetadataSnapshot(),
-                    copyState.getInfosBytes(),
-                    copyState.getPendingDeleteFiles()
-                )
+                new CheckpointInfoResponse(copyState.getCheckpoint(), copyState.getMetadataMap(), copyState.getInfosBytes())
             );
             timer.stop();
             logger.trace(

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
@@ -23,6 +23,7 @@ import org.opensearch.action.ActionListener;
 import org.opensearch.action.StepListener;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.common.util.CancellableThreads;
 import org.opensearch.index.shard.IndexShard;
@@ -37,12 +38,9 @@ import org.opensearch.indices.replication.common.ReplicationTarget;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * Represents the target of a replication event.
@@ -174,9 +172,7 @@ public class SegmentReplicationTarget extends ReplicationTarget {
         throws IOException {
         cancellableThreads.checkForCancel();
         state.setStage(SegmentReplicationState.Stage.FILE_DIFF);
-        final Store.MetadataSnapshot snapshot = checkpointInfo.getSnapshot();
-        Store.MetadataSnapshot localMetadata = getMetadataSnapshot();
-        final Store.RecoveryDiff diff = snapshot.segmentReplicationDiff(localMetadata);
+        final Store.RecoveryDiff diff = Store.segmentReplicationDiff(checkpointInfo.getMetadataMap(), getMetadataMap());
         logger.trace("Replication diff {}", diff);
         /*
          * Segments are immutable. So if the replica has any segments with the same name that differ from the one in the incoming
@@ -191,24 +187,14 @@ public class SegmentReplicationTarget extends ReplicationTarget {
                 )
             );
         }
-        final List<StoreFileMetadata> filesToFetch = new ArrayList<StoreFileMetadata>(diff.missing);
 
-        Set<String> storeFiles = new HashSet<>(Arrays.asList(store.directory().listAll()));
-        final Set<StoreFileMetadata> pendingDeleteFiles = checkpointInfo.getPendingDeleteFiles()
-            .stream()
-            .filter(f -> storeFiles.contains(f.name()) == false)
-            .collect(Collectors.toSet());
-
-        filesToFetch.addAll(pendingDeleteFiles);
-        logger.trace("Files to fetch {}", filesToFetch);
-
-        for (StoreFileMetadata file : filesToFetch) {
+        for (StoreFileMetadata file : diff.missing) {
             state.getIndex().addFileDetail(file.name(), file.length(), false);
         }
         // always send a req even if not fetching files so the primary can clear the copyState for this shard.
         state.setStage(SegmentReplicationState.Stage.GET_FILES);
         cancellableThreads.checkForCancel();
-        source.getSegmentFiles(getId(), checkpointInfo.getCheckpoint(), filesToFetch, store, getFilesListener);
+        source.getSegmentFiles(getId(), checkpointInfo.getCheckpoint(), diff.missing, store, getFilesListener);
     }
 
     private void finalizeReplication(CheckpointInfoResponse checkpointInfoResponse, ActionListener<Void> listener) {
@@ -227,7 +213,7 @@ public class SegmentReplicationTarget extends ReplicationTarget {
                     responseCheckpoint.getSegmentsGen()
                 );
                 indexShard.finalizeReplication(infos, responseCheckpoint.getSeqNo());
-                store.cleanupAndPreserveLatestCommitPoint("finalize - clean with in memory infos", store.getMetadata(infos));
+                store.cleanupAndPreserveLatestCommitPoint("finalize - clean with in memory infos", infos);
             } catch (CorruptIndexException | IndexFormatTooNewException | IndexFormatTooOldException ex) {
                 // this is a fatal exception at this stage.
                 // this means we transferred files from the remote that have not be checksummed and they are
@@ -276,11 +262,13 @@ public class SegmentReplicationTarget extends ReplicationTarget {
         );
     }
 
-    Store.MetadataSnapshot getMetadataSnapshot() throws IOException {
+    Map<String, StoreFileMetadata> getMetadataMap() throws IOException {
         if (indexShard.getSegmentInfosSnapshot() == null) {
-            return Store.MetadataSnapshot.EMPTY;
+            return Collections.emptyMap();
         }
-        return store.getMetadata(indexShard.getSegmentInfosSnapshot().get());
+        try (final GatedCloseable<SegmentInfos> snapshot = indexShard.getSegmentInfosSnapshot()) {
+            return store.getSegmentMetadataMap(snapshot.get());
+        }
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/indices/replication/common/CopyState.java
+++ b/server/src/main/java/org/opensearch/indices/replication/common/CopyState.java
@@ -15,14 +15,12 @@ import org.apache.lucene.store.ByteBuffersIndexOutput;
 import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.util.concurrent.AbstractRefCounted;
 import org.opensearch.index.shard.IndexShard;
-import org.opensearch.index.store.Store;
 import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Map;
 
 /**
  * An Opensearch-specific version of Lucene's CopyState class that
@@ -37,8 +35,7 @@ public class CopyState extends AbstractRefCounted {
     private final ReplicationCheckpoint requestedReplicationCheckpoint;
     /** Actual ReplicationCheckpoint returned by the shard */
     private final ReplicationCheckpoint replicationCheckpoint;
-    private final Store.MetadataSnapshot metadataSnapshot;
-    private final HashSet<StoreFileMetadata> pendingDeleteFiles;
+    private final Map<String, StoreFileMetadata> metadataMap;
     private final byte[] infosBytes;
     private GatedCloseable<IndexCommit> commitRef;
     private final IndexShard shard;
@@ -49,7 +46,7 @@ public class CopyState extends AbstractRefCounted {
         this.shard = shard;
         this.segmentInfosRef = shard.getSegmentInfosSnapshot();
         SegmentInfos segmentInfos = this.segmentInfosRef.get();
-        this.metadataSnapshot = shard.store().getMetadata(segmentInfos);
+        this.metadataMap = shard.store().getSegmentMetadataMap(segmentInfos);
         this.replicationCheckpoint = new ReplicationCheckpoint(
             shard.shardId(),
             shard.getOperationPrimaryTerm(),
@@ -57,18 +54,7 @@ public class CopyState extends AbstractRefCounted {
             shard.getProcessedLocalCheckpoint(),
             segmentInfos.getVersion()
         );
-
-        // Send files that are merged away in the latest SegmentInfos but not in the latest on disk Segments_N.
-        // This ensures that the store on replicas is in sync with the store on primaries.
         this.commitRef = shard.acquireLastIndexCommit(false);
-        Store.MetadataSnapshot metadata = shard.store().getMetadata(this.commitRef.get());
-        final Store.RecoveryDiff diff = metadata.recoveryDiff(this.metadataSnapshot);
-        this.pendingDeleteFiles = new HashSet<>(diff.missing);
-        if (this.pendingDeleteFiles.isEmpty()) {
-            // If there are no additional files we can release the last commit immediately.
-            this.commitRef.close();
-            this.commitRef = null;
-        }
 
         ByteBuffersDataOutput buffer = new ByteBuffersDataOutput();
         // resource description and name are not used, but resource description cannot be null
@@ -95,16 +81,12 @@ public class CopyState extends AbstractRefCounted {
         return replicationCheckpoint;
     }
 
-    public Store.MetadataSnapshot getMetadataSnapshot() {
-        return metadataSnapshot;
+    public Map<String, StoreFileMetadata> getMetadataMap() {
+        return metadataMap;
     }
 
     public byte[] getInfosBytes() {
         return infosBytes;
-    }
-
-    public Set<StoreFileMetadata> getPendingDeleteFiles() {
-        return pendingDeleteFiles;
     }
 
     public IndexShard getShard() {

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
@@ -489,12 +489,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
         try {
             final CopyState copyState = new CopyState(ReplicationCheckpoint.empty(primary.shardId), primary);
             listener.onResponse(
-                new CheckpointInfoResponse(
-                    copyState.getCheckpoint(),
-                    copyState.getMetadataSnapshot(),
-                    copyState.getInfosBytes(),
-                    copyState.getPendingDeleteFiles()
-                )
+                new CheckpointInfoResponse(copyState.getCheckpoint(), copyState.getMetadataMap(), copyState.getInfosBytes())
             );
         } catch (IOException e) {
             logger.error("Unexpected error computing CopyState", e);

--- a/server/src/test/java/org/opensearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/opensearch/index/store/StoreTests.java
@@ -39,6 +39,7 @@ import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.IndexFormatTooNewException;
 import org.apache.lucene.index.IndexFormatTooOldException;
 import org.apache.lucene.index.IndexNotFoundException;
@@ -80,6 +81,7 @@ import org.opensearch.index.engine.Engine;
 import org.opensearch.index.seqno.ReplicationTracker;
 import org.opensearch.index.seqno.RetentionLease;
 import org.opensearch.index.shard.ShardId;
+import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.indices.store.TransportNodesListShardStoreMetadata;
 import org.opensearch.test.DummyShardLock;
 import org.opensearch.test.IndexSettingsModule;
@@ -93,6 +95,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -121,6 +124,12 @@ public class StoreTests extends OpenSearchTestCase {
         "index",
         Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, org.opensearch.Version.CURRENT).build()
     );
+
+    IndexSettings SEGMENT_REPLICATION_INDEX_SETTINGS = new IndexSettings(
+        INDEX_SETTINGS.getIndexMetadata(),
+        Settings.builder().put(INDEX_SETTINGS.getSettings()).put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT).build()
+    );
+
     private static final Version MIN_SUPPORTED_LUCENE_VERSION = org.opensearch.Version.CURRENT
         .minimumIndexCompatibilityVersion().luceneVersion;
 
@@ -1150,12 +1159,113 @@ public class StoreTests extends OpenSearchTestCase {
         store.close();
     }
 
-    public void testcleanupAndPreserveLatestCommitPoint() throws IOException {
+    public void testCleanupAndPreserveLatestCommitPoint() throws IOException {
         final ShardId shardId = new ShardId("index", "_na_", 1);
-        Store store = new Store(shardId, INDEX_SETTINGS, StoreTests.newDirectory(random()), new DummyShardLock(shardId));
+        Store store = new Store(
+            shardId,
+            SEGMENT_REPLICATION_INDEX_SETTINGS,
+            StoreTests.newDirectory(random()),
+            new DummyShardLock(shardId)
+        );
+        commitRandomDocs(store);
+
+        Store.MetadataSnapshot commitMetadata = store.getMetadata();
+
+        // index more docs but only IW.flush, this will create additional files we'll clean up.
+        final IndexWriter writer = indexRandomDocs(store);
+        writer.flush();
+        writer.close();
+
+        final List<String> additionalSegments = new ArrayList<>();
+        for (String file : store.directory().listAll()) {
+            if (commitMetadata.contains(file) == false) {
+                additionalSegments.add(file);
+            }
+        }
+        assertFalse(additionalSegments.isEmpty());
+
+        // clean up everything not in the latest commit point.
+        store.cleanupAndPreserveLatestCommitPoint("test", store.readLastCommittedSegmentsInfo());
+
+        // we want to ensure commitMetadata files are preserved after calling cleanup
+        for (String existingFile : store.directory().listAll()) {
+            assertTrue(commitMetadata.contains(existingFile));
+            assertFalse(additionalSegments.contains(existingFile));
+        }
+        deleteContent(store.directory());
+        IOUtils.close(store);
+    }
+
+    public void testGetSegmentMetadataMap() throws IOException {
+        final ShardId shardId = new ShardId("index", "_na_", 1);
+        Store store = new Store(
+            shardId,
+            SEGMENT_REPLICATION_INDEX_SETTINGS,
+            new NIOFSDirectory(createTempDir()),
+            new DummyShardLock(shardId)
+        );
+        store.createEmpty(Version.LATEST);
+        final Map<String, StoreFileMetadata> metadataSnapshot = store.getSegmentMetadataMap(store.readLastCommittedSegmentsInfo());
+        // no docs indexed only _N file exists.
+        assertTrue(metadataSnapshot.isEmpty());
+
+        // commit some docs to create a commit point.
+        commitRandomDocs(store);
+
+        final Map<String, StoreFileMetadata> snapshotAfterCommit = store.getSegmentMetadataMap(store.readLastCommittedSegmentsInfo());
+        assertFalse(snapshotAfterCommit.isEmpty());
+        assertFalse(snapshotAfterCommit.keySet().stream().anyMatch((name) -> name.startsWith(IndexFileNames.SEGMENTS)));
+        store.close();
+    }
+
+    public void testSegmentReplicationDiff() {
+        final String segmentName = "_0.si";
+        final StoreFileMetadata SEGMENT_FILE = new StoreFileMetadata(segmentName, 1L, "0", Version.LATEST);
+        // source has file target is missing.
+        Store.RecoveryDiff diff = Store.segmentReplicationDiff(Map.of(segmentName, SEGMENT_FILE), Collections.emptyMap());
+        assertEquals(List.of(SEGMENT_FILE), diff.missing);
+        assertTrue(diff.different.isEmpty());
+        assertTrue(diff.identical.isEmpty());
+
+        // target has file not on source.
+        diff = Store.segmentReplicationDiff(Collections.emptyMap(), Map.of(segmentName, SEGMENT_FILE));
+        assertTrue(diff.missing.isEmpty());
+        assertTrue(diff.different.isEmpty());
+        assertTrue(diff.identical.isEmpty());
+
+        // source and target have identical file.
+        diff = Store.segmentReplicationDiff(Map.of(segmentName, SEGMENT_FILE), Map.of(segmentName, SEGMENT_FILE));
+        assertTrue(diff.missing.isEmpty());
+        assertTrue(diff.different.isEmpty());
+        assertEquals(List.of(SEGMENT_FILE), diff.identical);
+
+        // source has diff copy of same file as target.
+        StoreFileMetadata SOURCE_DIFF_FILE = new StoreFileMetadata(segmentName, 1L, "abc", Version.LATEST);
+        diff = Store.segmentReplicationDiff(Map.of(segmentName, SOURCE_DIFF_FILE), Map.of(segmentName, SEGMENT_FILE));
+        assertTrue(diff.missing.isEmpty());
+        assertEquals(List.of(SOURCE_DIFF_FILE), diff.different);
+        assertTrue(diff.identical.isEmpty());
+
+        // ignore _N files if included in source map.
+        final String segmentsFile = IndexFileNames.SEGMENTS.concat("_2");
+        StoreFileMetadata SEGMENTS_FILE = new StoreFileMetadata(segmentsFile, 1L, "abc", Version.LATEST);
+        diff = Store.segmentReplicationDiff(Map.of(segmentsFile, SEGMENTS_FILE), Collections.emptyMap());
+        assertTrue(diff.missing.isEmpty());
+        assertTrue(diff.different.isEmpty());
+        assertTrue(diff.identical.isEmpty());
+    }
+
+    private void commitRandomDocs(Store store) throws IOException {
+        IndexWriter writer = indexRandomDocs(store);
+        writer.commit();
+        writer.close();
+    }
+
+    private IndexWriter indexRandomDocs(Store store) throws IOException {
         IndexWriterConfig indexWriterConfig = newIndexWriterConfig(random(), new MockAnalyzer(random())).setCodec(
             TestUtil.getDefaultCodec()
         );
+        indexWriterConfig.setCommitOnClose(false);
         indexWriterConfig.setIndexDeletionPolicy(NoDeletionPolicy.INSTANCE);
         IndexWriter writer = new IndexWriter(store.directory(), indexWriterConfig);
         int docs = 1 + random().nextInt(100);
@@ -1171,21 +1281,6 @@ public class StoreTests extends OpenSearchTestCase {
         );
         doc.add(new SortedDocValuesField("dv", new BytesRef(TestUtil.randomRealisticUnicodeString(random()))));
         writer.addDocument(doc);
-        writer.commit();
-        writer.close();
-
-        Store.MetadataSnapshot commitMetadata = store.getMetadata();
-
-        Store.MetadataSnapshot refreshMetadata = Store.MetadataSnapshot.EMPTY;
-
-        store.cleanupAndPreserveLatestCommitPoint("test", refreshMetadata);
-
-        // we want to ensure commitMetadata files are preserved after calling cleanup
-        for (String existingFile : store.directory().listAll()) {
-            assert (commitMetadata.contains(existingFile) == true);
-        }
-
-        deleteContent(store.directory());
-        IOUtils.close(store);
+        return writer;
     }
 }

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceHandlerTests.java
@@ -19,6 +19,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.CancellableThreads;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.IndexShardTestCase;
 import org.opensearch.index.store.StoreFileMetadata;
@@ -74,7 +75,7 @@ public class SegmentReplicationSourceHandlerTests extends IndexShardTestCase {
             1
         );
 
-        final List<StoreFileMetadata> expectedFiles = List.copyOf(copyState.getMetadataSnapshot().asMap().values());
+        final List<StoreFileMetadata> expectedFiles = List.copyOf(copyState.getMetadataMap().values());
 
         final GetSegmentFilesRequest getSegmentFilesRequest = new GetSegmentFilesRequest(
             1L,
@@ -135,6 +136,9 @@ public class SegmentReplicationSourceHandlerTests extends IndexShardTestCase {
     }
 
     public void testSendFileFails() throws IOException {
+        // index some docs on the primary so a segment is created.
+        indexDoc(primary, "1", "{\"foo\" : \"baz\"}", XContentType.JSON, "foobar");
+        primary.refresh("Test");
         chunkWriter = (fileMetadata, position, content, lastChunk, totalTranslogOps, listener) -> listener.onFailure(
             new OpenSearchException("Test")
         );
@@ -151,7 +155,7 @@ public class SegmentReplicationSourceHandlerTests extends IndexShardTestCase {
             1
         );
 
-        final List<StoreFileMetadata> expectedFiles = List.copyOf(copyState.getMetadataSnapshot().asMap().values());
+        final List<StoreFileMetadata> expectedFiles = List.copyOf(copyState.getMetadataMap().values());
 
         final GetSegmentFilesRequest getSegmentFilesRequest = new GetSegmentFilesRequest(
             1L,

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceServiceTests.java
@@ -121,9 +121,7 @@ public class SegmentReplicationSourceServiceTests extends OpenSearchTestCase {
             public void onResponse(CheckpointInfoResponse response) {
                 assertEquals(testCheckpoint, response.getCheckpoint());
                 assertNotNull(response.getInfosBytes());
-                // CopyStateTests sets up one pending delete file and one committed segments file
-                assertEquals(1, response.getPendingDeleteFiles().size());
-                assertEquals(1, response.getSnapshot().size());
+                assertEquals(1, response.getMetadataMap().size());
             }
 
             @Override

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
@@ -57,7 +57,7 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
             .put("node.name", SegmentReplicationTargetServiceTests.class.getSimpleName())
             .build();
         final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        primaryShard = newStartedShard(true);
+        primaryShard = newStartedShard(true, settings);
         replicaShard = newShard(false, settings, new NRTReplicationEngineFactory());
         recoverReplica(replicaShard, primaryShard, true);
         checkpoint = new ReplicationCheckpoint(replicaShard.shardId(), 0L, 0L, 0L, 0L);

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetTests.java
@@ -18,7 +18,6 @@ import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.IndexFormatTooNewException;
-import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.store.ByteBuffersIndexOutput;
 import org.apache.lucene.store.Directory;
@@ -51,7 +50,6 @@ import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.Random;
 import java.util.Arrays;
 
@@ -71,26 +69,13 @@ public class SegmentReplicationTargetTests extends IndexShardTestCase {
     private ReplicationCheckpoint repCheckpoint;
     private ByteBuffersDataOutput buffer;
 
-    private static final StoreFileMetadata SEGMENTS_FILE = new StoreFileMetadata(IndexFileNames.SEGMENTS, 1L, "0", Version.LATEST);
-    private static final StoreFileMetadata SEGMENTS_FILE_DIFF = new StoreFileMetadata(
-        IndexFileNames.SEGMENTS,
-        5L,
-        "different",
-        Version.LATEST
-    );
-    private static final StoreFileMetadata PENDING_DELETE_FILE = new StoreFileMetadata("pendingDelete.del", 1L, "1", Version.LATEST);
+    private static final String SEGMENT_NAME = "_0.si";
+    private static final StoreFileMetadata SEGMENT_FILE = new StoreFileMetadata(SEGMENT_NAME, 1L, "0", Version.LATEST);
+    private static final StoreFileMetadata SEGMENT_FILE_DIFF = new StoreFileMetadata(SEGMENT_NAME, 5L, "different", Version.LATEST);
 
-    private static final Store.MetadataSnapshot SI_SNAPSHOT = new Store.MetadataSnapshot(
-        Map.of(SEGMENTS_FILE.name(), SEGMENTS_FILE),
-        null,
-        0
-    );
+    private static final Map<String, StoreFileMetadata> SI_SNAPSHOT = Map.of(SEGMENT_FILE.name(), SEGMENT_FILE);
 
-    private static final Store.MetadataSnapshot SI_SNAPSHOT_DIFFERENT = new Store.MetadataSnapshot(
-        Map.of(SEGMENTS_FILE_DIFF.name(), SEGMENTS_FILE_DIFF),
-        null,
-        0
-    );
+    private static final Map<String, StoreFileMetadata> SI_SNAPSHOT_DIFFERENT = Map.of(SEGMENT_FILE_DIFF.name(), SEGMENT_FILE_DIFF);
 
     private static final IndexSettings INDEX_SETTINGS = IndexSettingsModule.newIndexSettings(
         "index",
@@ -135,7 +120,7 @@ public class SegmentReplicationTargetTests extends IndexShardTestCase {
                 ReplicationCheckpoint checkpoint,
                 ActionListener<CheckpointInfoResponse> listener
             ) {
-                listener.onResponse(new CheckpointInfoResponse(checkpoint, SI_SNAPSHOT, buffer.toArrayCopy(), Set.of(PENDING_DELETE_FILE)));
+                listener.onResponse(new CheckpointInfoResponse(checkpoint, SI_SNAPSHOT, buffer.toArrayCopy()));
             }
 
             @Override
@@ -146,9 +131,8 @@ public class SegmentReplicationTargetTests extends IndexShardTestCase {
                 Store store,
                 ActionListener<GetSegmentFilesResponse> listener
             ) {
-                assertEquals(filesToFetch.size(), 2);
-                assert (filesToFetch.contains(SEGMENTS_FILE));
-                assert (filesToFetch.contains(PENDING_DELETE_FILE));
+                assertEquals(1, filesToFetch.size());
+                assert (filesToFetch.contains(SEGMENT_FILE));
                 listener.onResponse(new GetSegmentFilesResponse(filesToFetch));
             }
         };
@@ -230,7 +214,7 @@ public class SegmentReplicationTargetTests extends IndexShardTestCase {
                 ReplicationCheckpoint checkpoint,
                 ActionListener<CheckpointInfoResponse> listener
             ) {
-                listener.onResponse(new CheckpointInfoResponse(checkpoint, SI_SNAPSHOT, buffer.toArrayCopy(), Set.of(PENDING_DELETE_FILE)));
+                listener.onResponse(new CheckpointInfoResponse(checkpoint, SI_SNAPSHOT, buffer.toArrayCopy()));
             }
 
             @Override
@@ -273,7 +257,7 @@ public class SegmentReplicationTargetTests extends IndexShardTestCase {
                 ReplicationCheckpoint checkpoint,
                 ActionListener<CheckpointInfoResponse> listener
             ) {
-                listener.onResponse(new CheckpointInfoResponse(checkpoint, SI_SNAPSHOT, buffer.toArrayCopy(), Set.of(PENDING_DELETE_FILE)));
+                listener.onResponse(new CheckpointInfoResponse(checkpoint, SI_SNAPSHOT, buffer.toArrayCopy()));
             }
 
             @Override
@@ -318,7 +302,7 @@ public class SegmentReplicationTargetTests extends IndexShardTestCase {
                 ReplicationCheckpoint checkpoint,
                 ActionListener<CheckpointInfoResponse> listener
             ) {
-                listener.onResponse(new CheckpointInfoResponse(checkpoint, SI_SNAPSHOT, buffer.toArrayCopy(), Set.of(PENDING_DELETE_FILE)));
+                listener.onResponse(new CheckpointInfoResponse(checkpoint, SI_SNAPSHOT, buffer.toArrayCopy()));
             }
 
             @Override
@@ -362,7 +346,7 @@ public class SegmentReplicationTargetTests extends IndexShardTestCase {
                 ReplicationCheckpoint checkpoint,
                 ActionListener<CheckpointInfoResponse> listener
             ) {
-                listener.onResponse(new CheckpointInfoResponse(checkpoint, SI_SNAPSHOT, buffer.toArrayCopy(), Set.of(PENDING_DELETE_FILE)));
+                listener.onResponse(new CheckpointInfoResponse(checkpoint, SI_SNAPSHOT, buffer.toArrayCopy()));
             }
 
             @Override
@@ -380,7 +364,7 @@ public class SegmentReplicationTargetTests extends IndexShardTestCase {
             SegmentReplicationTargetService.SegmentReplicationListener.class
         );
         segrepTarget = spy(new SegmentReplicationTarget(repCheckpoint, indexShard, segrepSource, segRepListener));
-        when(segrepTarget.getMetadataSnapshot()).thenReturn(SI_SNAPSHOT_DIFFERENT);
+        when(segrepTarget.getMetadataMap()).thenReturn(SI_SNAPSHOT_DIFFERENT);
         segrepTarget.startReplication(new ActionListener<Void>() {
             @Override
             public void onResponse(Void replicationResponse) {
@@ -413,9 +397,7 @@ public class SegmentReplicationTargetTests extends IndexShardTestCase {
                 ReplicationCheckpoint checkpoint,
                 ActionListener<CheckpointInfoResponse> listener
             ) {
-                listener.onResponse(
-                    new CheckpointInfoResponse(checkpoint, storeMetadataSnapshots.get(1), buffer.toArrayCopy(), Set.of(PENDING_DELETE_FILE))
-                );
+                listener.onResponse(new CheckpointInfoResponse(checkpoint, storeMetadataSnapshots.get(1).asMap(), buffer.toArrayCopy()));
             }
 
             @Override
@@ -434,7 +416,7 @@ public class SegmentReplicationTargetTests extends IndexShardTestCase {
         );
 
         segrepTarget = spy(new SegmentReplicationTarget(repCheckpoint, indexShard, segrepSource, segRepListener));
-        when(segrepTarget.getMetadataSnapshot()).thenReturn(storeMetadataSnapshots.get(0));
+        when(segrepTarget.getMetadataMap()).thenReturn(storeMetadataSnapshots.get(0).asMap());
         segrepTarget.startReplication(new ActionListener<Void>() {
             @Override
             public void onResponse(Void replicationResponse) {

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -133,6 +133,7 @@ import org.opensearch.transport.TransportService;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -1198,12 +1199,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                 try {
                     final CopyState copyState = new CopyState(ReplicationCheckpoint.empty(primaryShard.shardId), primaryShard);
                     listener.onResponse(
-                        new CheckpointInfoResponse(
-                            copyState.getCheckpoint(),
-                            copyState.getMetadataSnapshot(),
-                            copyState.getInfosBytes(),
-                            copyState.getPendingDeleteFiles()
-                        )
+                        new CheckpointInfoResponse(copyState.getCheckpoint(), copyState.getMetadataMap(), copyState.getInfosBytes())
                     );
                 } catch (IOException e) {
                     logger.error("Unexpected error computing CopyState", e);


### PR DESCRIPTION
Manual backport of https://github.com/opensearch-project/OpenSearch/pull/4366 to 2.x