### PR TITLE
[Feature/extensions] Warn future developers not to pass headers to extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Support for labels on version bump PRs, skip label support for changelog verifier ([#4391](https://github.com/opensearch-project/OpenSearch/pull/4391))
 - Update previous release bwc version to 2.4.0 ([#4455](https://github.com/opensearch-project/OpenSearch/pull/4455))
 - 2.3.0 release notes ([#4457](https://github.com/opensearch-project/OpenSearch/pull/4457))
+- Warn future developers not to pass headers to extensions ([#4430](https://github.com/opensearch-project/OpenSearch/pull/4430))
 
 ### Dependencies
 - Bumps `org.gradle.test-retry` from 1.4.0 to 1.4.1

--- a/server/src/main/java/org/opensearch/extensions/rest/RestSendToExtensionAction.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/RestSendToExtensionAction.java
@@ -143,7 +143,7 @@ public class RestSendToExtensionAction extends BaseRestHandler {
             transportService.sendRequest(
                 discoveryExtension,
                 ExtensionsOrchestrator.REQUEST_REST_EXECUTE_ON_EXTENSION_ACTION,
-                // HERE BE DRAGONS - DO NOT INCLUDE HEADERS 
+                // HERE BE DRAGONS - DO NOT INCLUDE HEADERS
                 // SEE https://github.com/opensearch-project/OpenSearch/issues/4429
                 new RestExecuteOnExtensionRequest(method, uri),
                 restExecuteOnExtensionResponseHandler

--- a/server/src/main/java/org/opensearch/extensions/rest/RestSendToExtensionAction.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/RestSendToExtensionAction.java
@@ -143,7 +143,7 @@ public class RestSendToExtensionAction extends BaseRestHandler {
             transportService.sendRequest(
                 discoveryExtension,
                 ExtensionsOrchestrator.REQUEST_REST_EXECUTE_ON_EXTENSION_ACTION,
-                // DO NOT INCLUDE HEADERS
+                // HERE BE DRAGONS - DO NOT INCLUDE HEADERS 
                 // SEE https://github.com/opensearch-project/OpenSearch/issues/4429
                 new RestExecuteOnExtensionRequest(method, uri),
                 restExecuteOnExtensionResponseHandler

--- a/server/src/main/java/org/opensearch/extensions/rest/RestSendToExtensionAction.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/RestSendToExtensionAction.java
@@ -143,6 +143,8 @@ public class RestSendToExtensionAction extends BaseRestHandler {
             transportService.sendRequest(
                 discoveryExtension,
                 ExtensionsOrchestrator.REQUEST_REST_EXECUTE_ON_EXTENSION_ACTION,
+                // DO NOT INCLUDE HEADERS
+                // SEE https://github.com/opensearch-project/OpenSearch/issues/4429
                 new RestExecuteOnExtensionRequest(method, uri),
                 restExecuteOnExtensionResponseHandler
             );


### PR DESCRIPTION
### Description
Warn future developers not to pass headers to extensions

### Issues Resolved
* Related https://github.com/opensearch-project/OpenSearch/issues/4429

### Check List
- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [X] Commits are signed per the DCO using --signoff
- [ ] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~ Note; I did not include any change log changes because I don't see a change log in this branch

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
