### PR TITLE
[Segment Replication] Convert user input of index setting replication type to upper case while parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix NoSuchFileExceptions with segment replication when computing primary metadata snapshots ([#4366](https://github.com/opensearch-project/OpenSearch/pull/4366))
 - [Segment Replication] Update flaky testOnNewCheckpointFromNewPrimaryCancelOngoingReplication unit test ([#4414](https://github.com/opensearch-project/OpenSearch/pull/4414))
 - Fixed the `_cat/shards/10_basic.yml` test cases fix.
+- [Segment Replication] Convert user input of index setting replication type to upper case while parsing.
 
 ### Security
 - CVE-2022-25857 org.yaml:snakeyaml DOS vulnerability ([#4341](https://github.com/opensearch-project/OpenSearch/pull/4341))

--- a/server/src/main/java/org/opensearch/indices/replication/common/ReplicationType.java
+++ b/server/src/main/java/org/opensearch/indices/replication/common/ReplicationType.java
@@ -21,7 +21,7 @@ public enum ReplicationType {
 
     public static ReplicationType parseString(String replicationType) {
         try {
-            return ReplicationType.valueOf(replicationType);
+            return ReplicationType.valueOf(replicationType.toUpperCase());
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Could not parse ReplicationStrategy for [" + replicationType + "]");
         } catch (NullPointerException npe) {


### PR DESCRIPTION

Signed-off-by: Rishikesh1159 <rishireddy1159@gmail.com>

### Description
This PR makes user pass index setting replication type to be any case not just upper case.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
