### PR TITLE
[Segment Replication] [Backport] Fix timeout issue by calculating time needed to process getSegmentFiles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Segment Replication] Update flaky testOnNewCheckpointFromNewPrimaryCancelOngoingReplication unit test ([#4414](https://github.com/opensearch-project/OpenSearch/pull/4414))
 - [Segment Replication] Extend FileChunkWriter to allow cancel on transport client ([#4386](https://github.com/opensearch-project/OpenSearch/pull/4386))
 - [Segment Replication] Fix NoSuchFileExceptions with segment replication when computing primary metadata snapshots ([#4366](https://github.com/opensearch-project/OpenSearch/pull/4366))
-- [Segment Replication] Fix timeout issue by calculating time needed to process getSegmentFiles ([#4432](https://github.com/opensearch-project/OpenSearch/pull/4432))
+- [Segment Replication] Fix timeout issue by calculating time needed to process getSegmentFiles ([#4434](https://github.com/opensearch-project/OpenSearch/pull/4434))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Segment Replication] Update flaky testOnNewCheckpointFromNewPrimaryCancelOngoingReplication unit test ([#4414](https://github.com/opensearch-project/OpenSearch/pull/4414))
 - [Segment Replication] Extend FileChunkWriter to allow cancel on transport client ([#4386](https://github.com/opensearch-project/OpenSearch/pull/4386))
 - [Segment Replication] Fix NoSuchFileExceptions with segment replication when computing primary metadata snapshots ([#4366](https://github.com/opensearch-project/OpenSearch/pull/4366))
+- [Segment Replication] Fix timeout issue by calculating time needed to process getSegmentFiles ([#4432](https://github.com/opensearch-project/OpenSearch/pull/4432))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/indices/replication/PrimaryShardReplicationSource.java
+++ b/server/src/main/java/org/opensearch/indices/replication/PrimaryShardReplicationSource.java
@@ -13,11 +13,13 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionListener;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.indices.recovery.RetryableTransportClient;
 import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
+import org.opensearch.transport.TransportRequestOptions;
 import org.opensearch.transport.TransportService;
 
 import java.util.List;
@@ -78,6 +80,17 @@ public class PrimaryShardReplicationSource implements SegmentReplicationSource {
     ) {
         final Writeable.Reader<GetSegmentFilesResponse> reader = GetSegmentFilesResponse::new;
         final ActionListener<GetSegmentFilesResponse> responseListener = ActionListener.map(listener, r -> r);
+        // Few of the below assumptions and calculations are added for experimental release of segment replication feature in 2.3
+        // version. These will be changed in next release.
+
+        // Storing the size of files to fetch in bytes.
+        final long sizeOfSegmentFiles = filesToFetch.stream().mapToLong(file -> file.length()).sum();
+
+        // Maximum size of files to fetch (segment files) in bytes, that can be processed in 1 minute for a m5.xlarge machine.
+        long baseSegmentFilesSize = 100000000;
+
+        // Formula for calculating time needed to process a replication event's files to fetch process
+        final long timeToGetSegmentFiles = 1 + (sizeOfSegmentFiles / baseSegmentFilesSize);
         final GetSegmentFilesRequest request = new GetSegmentFilesRequest(
             replicationId,
             targetAllocationId,
@@ -85,7 +98,10 @@ public class PrimaryShardReplicationSource implements SegmentReplicationSource {
             filesToFetch,
             checkpoint
         );
-        transportClient.executeRetryableAction(GET_SEGMENT_FILES, request, responseListener, reader);
+        final TransportRequestOptions options = TransportRequestOptions.builder()
+            .withTimeout(TimeValue.timeValueMinutes(timeToGetSegmentFiles))
+            .build();
+        transportClient.executeRetryableAction(GET_SEGMENT_FILES, request, options, responseListener, reader);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/indices/replication/PrimaryShardReplicationSource.java
+++ b/server/src/main/java/org/opensearch/indices/replication/PrimaryShardReplicationSource.java
@@ -81,7 +81,7 @@ public class PrimaryShardReplicationSource implements SegmentReplicationSource {
         final Writeable.Reader<GetSegmentFilesResponse> reader = GetSegmentFilesResponse::new;
         final ActionListener<GetSegmentFilesResponse> responseListener = ActionListener.map(listener, r -> r);
         // Few of the below assumptions and calculations are added for experimental release of segment replication feature in 2.3
-        // version. These will be changed in next release.
+        // version. These can change in upcoming releases.
 
         // Storing the size of files to fetch in bytes.
         final long sizeOfSegmentFiles = filesToFetch.stream().mapToLong(file -> file.length()).sum();


### PR DESCRIPTION
Signed-off-by: Rishikesh1159 <rishireddy1159@gmail.com>

### Description
This PR fixes timeout issue by calculating time needed to process getSegmentFiles.
This is Backport PR of #4426 

### Issues Resolved
#4392 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
