### PR TITLE
Getting security exception due to access denied 'java.lang.RuntimePermission' 'accessDeclaredMembers' when trying to get snapshot with S3 IRSA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Segment Replication] Fix timeout issue by calculating time needed to process getSegmentFiles ([#4426](https://github.com/opensearch-project/OpenSearch/pull/4426))
 - [Bug]: gradle check failing with java heap OutOfMemoryError (([#4328](https://github.com/opensearch-project/OpenSearch/
 - `opensearch.bat` fails to execute when install path includes spaces ([#4362](https://github.com/opensearch-project/OpenSearch/pull/4362))
+- Getting security exception due to access denied 'java.lang.RuntimePermission' 'accessDeclaredMembers' when trying to get snapshot with S3 IRSA ([#4469](https://github.com/opensearch-project/OpenSearch/pull/4469))
 
 ### Security
 - CVE-2022-25857 org.yaml:snakeyaml DOS vulnerability ([#4341](https://github.com/opensearch-project/OpenSearch/pull/4341))

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Service.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Service.java
@@ -305,21 +305,28 @@ class S3Service implements Closeable {
             }
 
             if (irsaCredentials.getIdentityTokenFile() == null) {
-                return new PrivilegedSTSAssumeRoleSessionCredentialsProvider<>(
-                    securityTokenService,
+                final STSAssumeRoleSessionCredentialsProvider.Builder stsCredentialsProviderBuilder =
                     new STSAssumeRoleSessionCredentialsProvider.Builder(irsaCredentials.getRoleArn(), irsaCredentials.getRoleSessionName())
-                        .withStsClient(securityTokenService)
-                        .build()
+                        .withStsClient(securityTokenService);
+
+                final STSAssumeRoleSessionCredentialsProvider stsCredentialsProvider = SocketAccess.doPrivileged(
+                    stsCredentialsProviderBuilder::build
                 );
+
+                return new PrivilegedSTSAssumeRoleSessionCredentialsProvider<>(securityTokenService, stsCredentialsProvider);
             } else {
-                return new PrivilegedSTSAssumeRoleSessionCredentialsProvider<>(
-                    securityTokenService,
+                final STSAssumeRoleWithWebIdentitySessionCredentialsProvider.Builder stsCredentialsProviderBuilder =
                     new STSAssumeRoleWithWebIdentitySessionCredentialsProvider.Builder(
                         irsaCredentials.getRoleArn(),
                         irsaCredentials.getRoleSessionName(),
                         irsaCredentials.getIdentityTokenFile()
-                    ).withStsClient(securityTokenService).build()
+                    ).withStsClient(securityTokenService);
+
+                final STSAssumeRoleWithWebIdentitySessionCredentialsProvider stsCredentialsProvider = SocketAccess.doPrivileged(
+                    stsCredentialsProviderBuilder::build
                 );
+
+                return new PrivilegedSTSAssumeRoleSessionCredentialsProvider<>(securityTokenService, stsCredentialsProvider);
             }
         } else if (basicCredentials != null) {
             logger.debug("Using basic key/secret credentials");


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Configuring to use IRSA via repository-s3 plugin for S3 access with identity file may end up with `SecurityException` due to access denied "java.lang.RuntimePermission" "accessDeclaredMembers" when trying to get snapshots.

### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/4269

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
