### PR TITLE
[Javadoc] add missing javadocs for :distribution:tools modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Support for labels on version bump PRs, skip label support for changelog verifier ([#4391](https://github.com/opensearch-project/OpenSearch/pull/4391))
 - Update previous release bwc version to 2.4.0 ([#4455](https://github.com/opensearch-project/OpenSearch/pull/4455))
 - 2.3.0 release notes ([#4457](https://github.com/opensearch-project/OpenSearch/pull/4457))
+- Added missing javadocs for `:distribution:tools` modules ([#4483](https://github.com/opensearch-project/OpenSearch/pull/4483))
 
 ### Dependencies
 - Bumps `org.gradle.test-retry` from 1.4.0 to 1.4.1

--- a/distribution/tools/java-version-checker/src/main/java/org/opensearch/tools/java_version_checker/SuppressForbidden.java
+++ b/distribution/tools/java-version-checker/src/main/java/org/opensearch/tools/java_version_checker/SuppressForbidden.java
@@ -43,5 +43,10 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.CLASS)
 @Target({ ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
 public @interface SuppressForbidden {
+    /**
+     * The argument to this annotation, specifying the reason a forbidden API is being used.
+     *
+     * @return The reason the error is being suppressed.
+     */
     String reason();
 }

--- a/distribution/tools/java-version-checker/src/main/java/org/opensearch/tools/java_version_checker/package-info.java
+++ b/distribution/tools/java-version-checker/src/main/java/org/opensearch/tools/java_version_checker/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Tools to validate minimum version of the runtime Java.
+ */
+package org.opensearch.tools.java_version_checker;

--- a/distribution/tools/keystore-cli/src/main/java/org/opensearch/common/settings/KeyStoreCli.java
+++ b/distribution/tools/keystore-cli/src/main/java/org/opensearch/common/settings/KeyStoreCli.java
@@ -36,7 +36,7 @@ import org.opensearch.cli.LoggingAwareMultiCommand;
 import org.opensearch.cli.Terminal;
 
 /**
- * A cli tool for managing secrets in the opensearch keystore.
+ * A CLI tool for managing secrets in the OpenSearch keystore.
  */
 public class KeyStoreCli extends LoggingAwareMultiCommand {
 
@@ -52,6 +52,12 @@ public class KeyStoreCli extends LoggingAwareMultiCommand {
         subcommands.put("has-passwd", new HasPasswordKeyStoreCommand());
     }
 
+    /**
+     * Main entry point for the OpenSearch Keystore CLI tool.
+     *
+     * @param args  CLI commands for managing secrets.
+     * @throws Exception if an exception was encountered executing the command.
+     */
     public static void main(String[] args) throws Exception {
         exit(new KeyStoreCli().main(args, Terminal.DEFAULT));
     }

--- a/distribution/tools/keystore-cli/src/main/java/org/opensearch/common/settings/package-info.java
+++ b/distribution/tools/keystore-cli/src/main/java/org/opensearch/common/settings/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Classes implementing a CLI tool for managing secrets in the OpenSearch keystore.
+ */
+package org.opensearch.common.settings;

--- a/distribution/tools/launchers/build.gradle
+++ b/distribution/tools/launchers/build.gradle
@@ -54,6 +54,5 @@ testingConventions {
 }
 
 javadoc.enabled = false
-missingJavadoc.enabled = false
 loggerUsageCheck.enabled = false
 jarHell.enabled = false

--- a/distribution/tools/launchers/src/main/java/org/opensearch/tools/launchers/package-info.java
+++ b/distribution/tools/launchers/src/main/java/org/opensearch/tools/launchers/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Classes implementing utility methods for launching JVMs.
+ */
+package org.opensearch.tools.launchers;

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/PluginCli.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/PluginCli.java
@@ -42,7 +42,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 /**
- * A cli tool for adding, removing and listing plugins for opensearch.
+ * A CLI tool for adding, removing and listing plugins for OpenSearch.
  */
 public class PluginCli extends LoggingAwareMultiCommand {
 
@@ -56,6 +56,12 @@ public class PluginCli extends LoggingAwareMultiCommand {
         commands = Collections.unmodifiableCollection(subcommands.values());
     }
 
+    /**
+     * Main entry point for the OpenSearch Plugin CLI tool.
+     *
+     * @param args  CLI commands for managing plugins.
+     * @throws Exception if an exception was encountered executing the command.
+     */
     public static void main(String[] args) throws Exception {
         exit(new PluginCli().main(args, Terminal.DEFAULT));
     }

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/PluginHelper.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/PluginHelper.java
@@ -19,6 +19,8 @@ import java.util.stream.Collectors;
  */
 public class PluginHelper {
 
+    private PluginHelper() {}
+
     /**
      * Verify if a plugin exists with any folder name.
      * @param pluginPath   the path for the plugins directory.

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/package-info.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Classes implementing a CLI tool for managing plugins in OpenSearch.
+ */
+package org.opensearch.plugins;

--- a/gradle/missing-javadoc.gradle
+++ b/gradle/missing-javadoc.gradle
@@ -96,7 +96,6 @@ configure([
   project(":client:rest-high-level"),
   project(":client:test"),
   project(":distribution:tools:launchers"),
-  project(":distribution:tools:plugin-cli"),
   project(":doc-tools"),
   project(":example-plugins:custom-settings"),
   project(":example-plugins:custom-significance-heuristic"),

--- a/gradle/missing-javadoc.gradle
+++ b/gradle/missing-javadoc.gradle
@@ -95,7 +95,6 @@ configure([
   project(":client:client-benchmark-noop-api-plugin"),
   project(":client:rest-high-level"),
   project(":client:test"),
-  project(":distribution:tools:java-version-checker"),
   project(":distribution:tools:keystore-cli"),
   project(":distribution:tools:launchers"),
   project(":distribution:tools:plugin-cli"),

--- a/gradle/missing-javadoc.gradle
+++ b/gradle/missing-javadoc.gradle
@@ -95,7 +95,6 @@ configure([
   project(":client:client-benchmark-noop-api-plugin"),
   project(":client:rest-high-level"),
   project(":client:test"),
-  project(":distribution:tools:keystore-cli"),
   project(":distribution:tools:launchers"),
   project(":distribution:tools:plugin-cli"),
   project(":doc-tools"),

--- a/gradle/missing-javadoc.gradle
+++ b/gradle/missing-javadoc.gradle
@@ -95,7 +95,6 @@ configure([
   project(":client:client-benchmark-noop-api-plugin"),
   project(":client:rest-high-level"),
   project(":client:test"),
-  project(":distribution:tools:launchers"),
   project(":doc-tools"),
   project(":example-plugins:custom-settings"),
   project(":example-plugins:custom-significance-heuristic"),


### PR DESCRIPTION
### Description
Adds javadocs and removes exclusions for  `:distribution:tools:java-version-checker`, `:distribution:tools:keystore-cli`, `:distribution:tools:launchers`, and `:distribution:tools:plugin-cli`.

### Issues Resolved
Relates to #221

### Check List
~- [ ] New functionality includes testing.~
  ~- [ ] All tests pass~
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
