### PR TITLE
Bugfix/496 rollover alias with filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Segment Replication] Ignore lock file when testing cleanupAndPreserveLatestCommitPoint ([#4544](https://github.com/opensearch-project/OpenSearch/pull/4544))
 - Updated jackson to 2.13.4 and snakeyml to 1.32 ([#4556](https://github.com/opensearch-project/OpenSearch/pull/4556))
 - [Bug]: Fixed invalid location of JDK dependency for arm64 architecture([#4613](https://github.com/opensearch-project/OpenSearch/pull/4613))
+- [Bug]: Alias filter lost after rollover ([#4499](https://github.com/opensearch-project/OpenSearch/pull/4499))
 
 ### Security
 - CVE-2022-25857 org.yaml:snakeyaml DOS vulnerability ([#4341](https://github.com/opensearch-project/OpenSearch/pull/4341))

--- a/server/src/main/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -188,7 +188,7 @@ public class MetadataRolloverService {
         ClusterState newState = createIndexService.applyCreateIndexRequest(currentState, createIndexClusterStateRequest, silent);
         newState = indexAliasesService.applyAliasActions(
             newState,
-            rolloverAliasToNewIndex(sourceIndexName, rolloverIndexName, explicitWriteIndex, aliasMetadata.isHidden(), aliasName)
+            rolloverAliasToNewIndex(sourceIndexName, rolloverIndexName, explicitWriteIndex, aliasMetadata, aliasName)
         );
 
         RolloverInfo rolloverInfo = new RolloverInfo(aliasName, metConditions, threadPool.absoluteTimeInMillis());
@@ -309,20 +309,20 @@ public class MetadataRolloverService {
         String oldIndex,
         String newIndex,
         boolean explicitWriteIndex,
-        @Nullable Boolean isHidden,
+        AliasMetadata aliasMetada,
         String alias
     ) {
         if (explicitWriteIndex) {
             return Collections.unmodifiableList(
                 Arrays.asList(
-                    new AliasAction.Add(newIndex, alias, null, null, null, true, isHidden),
-                    new AliasAction.Add(oldIndex, alias, null, null, null, false, isHidden)
+                    new AliasAction.Add(newIndex, alias, aliasMetada.getFilterAsString(), aliasMetada.getIndexRouting(), aliasMetada.getSearchRouting(), true, aliasMetada.isHidden()),
+                    new AliasAction.Add(oldIndex, alias, aliasMetada.getFilterAsString(), aliasMetada.getIndexRouting(), aliasMetada.getSearchRouting(), false, aliasMetada.isHidden())
                 )
             );
         } else {
             return Collections.unmodifiableList(
                 Arrays.asList(
-                    new AliasAction.Add(newIndex, alias, null, null, null, null, isHidden),
+                    new AliasAction.Add(newIndex, alias, aliasMetada.getFilterAsString(), aliasMetada.getIndexRouting(), aliasMetada.getSearchRouting(), null, aliasMetada.isHidden()),
                     new AliasAction.Remove(oldIndex, alias, null)
                 )
             );
@@ -385,8 +385,8 @@ public class MetadataRolloverService {
                     + indexAbstraction.getType().getDisplayName()
                     + "] but one of ["
                     + Strings.collectionToCommaDelimitedString(
-                        VALID_ROLLOVER_TARGETS.stream().map(IndexAbstraction.Type::getDisplayName).collect(Collectors.toList())
-                    )
+                    VALID_ROLLOVER_TARGETS.stream().map(IndexAbstraction.Type::getDisplayName).collect(Collectors.toList())
+                )
                     + "] was expected"
             );
         }

--- a/server/src/main/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -309,20 +309,46 @@ public class MetadataRolloverService {
         String oldIndex,
         String newIndex,
         boolean explicitWriteIndex,
-        AliasMetadata aliasMetada,
+        AliasMetadata aliasMetadata,
         String alias
     ) {
+        String filterAsString = aliasMetadata.getFilter() != null ? aliasMetadata.getFilter().string() : null;
+
         if (explicitWriteIndex) {
             return Collections.unmodifiableList(
                 Arrays.asList(
-                    new AliasAction.Add(newIndex, alias, aliasMetada.getFilterAsString(), aliasMetada.getIndexRouting(), aliasMetada.getSearchRouting(), true, aliasMetada.isHidden()),
-                    new AliasAction.Add(oldIndex, alias, aliasMetada.getFilterAsString(), aliasMetada.getIndexRouting(), aliasMetada.getSearchRouting(), false, aliasMetada.isHidden())
+                    new AliasAction.Add(
+                        newIndex,
+                        alias,
+                        filterAsString,
+                        aliasMetadata.getIndexRouting(),
+                        aliasMetadata.getSearchRouting(),
+                        true,
+                        aliasMetadata.isHidden()
+                    ),
+                    new AliasAction.Add(
+                        oldIndex,
+                        alias,
+                        filterAsString,
+                        aliasMetadata.getIndexRouting(),
+                        aliasMetadata.getSearchRouting(),
+                        false,
+                        aliasMetadata.isHidden()
+                    )
                 )
             );
         } else {
             return Collections.unmodifiableList(
                 Arrays.asList(
-                    new AliasAction.Add(newIndex, alias, aliasMetada.getFilterAsString(), aliasMetada.getIndexRouting(), aliasMetada.getSearchRouting(), null, aliasMetada.isHidden()),
+                    new AliasAction.Add(
+                        newIndex,
+                        alias,
+                        filterAsString,
+                        aliasMetadata.getIndexRouting(),
+                        aliasMetadata.getSearchRouting(),
+                        null,
+                        aliasMetadata.isHidden()
+                    ),
                     new AliasAction.Remove(oldIndex, alias, null)
                 )
             );
@@ -385,8 +411,8 @@ public class MetadataRolloverService {
                     + indexAbstraction.getType().getDisplayName()
                     + "] but one of ["
                     + Strings.collectionToCommaDelimitedString(
-                    VALID_ROLLOVER_TARGETS.stream().map(IndexAbstraction.Type::getDisplayName).collect(Collectors.toList())
-                )
+                        VALID_ROLLOVER_TARGETS.stream().map(IndexAbstraction.Type::getDisplayName).collect(Collectors.toList())
+                    )
                     + "] was expected"
             );
         }

--- a/server/src/main/java/org/opensearch/cluster/metadata/AliasAction.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AliasAction.java
@@ -138,11 +138,17 @@ public abstract class AliasAction {
             return alias;
         }
 
-        public String getFilter(){ return filter; }
+        public String getFilter() {
+            return filter;
+        }
 
-        public String getSearchRouting() { return searchRouting; }
+        public String getSearchRouting() {
+            return searchRouting;
+        }
 
-        public String getIndexRouting() { return indexRouting; }
+        public String getIndexRouting() {
+            return indexRouting;
+        }
 
         public Boolean writeIndex() {
             return writeIndex;

--- a/server/src/main/java/org/opensearch/cluster/metadata/AliasAction.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AliasAction.java
@@ -138,6 +138,12 @@ public abstract class AliasAction {
             return alias;
         }
 
+        public String getFilter(){ return filter; }
+
+        public String getSearchRouting() { return searchRouting; }
+
+        public String getIndexRouting() { return indexRouting; }
+
         public Boolean writeIndex() {
             return writeIndex;
         }

--- a/server/src/main/java/org/opensearch/cluster/metadata/AliasMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AliasMetadata.java
@@ -129,13 +129,6 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
         return filter();
     }
 
-    public String getFilterAsString() {
-        if(filter == null){
-            return null;
-        }
-        return filter.string();
-    }
-
     public boolean filteringRequired() {
         return filter != null;
     }

--- a/server/src/main/java/org/opensearch/cluster/metadata/AliasMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AliasMetadata.java
@@ -129,6 +129,13 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
         return filter();
     }
 
+    public String getFilterAsString() {
+        if(filter == null){
+            return null;
+        }
+        return filter.string();
+    }
+
     public boolean filteringRequired() {
         return filter != null;
     }

--- a/server/src/test/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
@@ -43,6 +43,7 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.DataStreamTestHelper;
 import org.opensearch.cluster.metadata.AliasAction;
 import org.opensearch.cluster.metadata.AliasMetadata;
+import org.opensearch.cluster.metadata.AliasMetadata.Builder;
 import org.opensearch.cluster.metadata.AliasValidator;
 import org.opensearch.cluster.metadata.ComponentTemplate;
 import org.opensearch.cluster.metadata.ComposableIndexTemplate;
@@ -100,6 +101,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
+import static org.hamcrest.Matchers.in;
 import static org.opensearch.cluster.DataStreamTestHelper.generateMapping;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -126,7 +128,7 @@ public class MetadataRolloverServiceTests extends OpenSearchTestCase {
         String sourceIndex = randomAlphaOfLength(10);
         String targetIndex = randomAlphaOfLength(10);
 
-        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(sourceIndex, targetIndex, false, null, sourceAlias);
+        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(sourceIndex, targetIndex, false, createDefaultAliasMetadata(sourceAlias, null), sourceAlias);
         assertThat(actions, hasSize(2));
         boolean foundAdd = false;
         boolean foundRemove = false;
@@ -149,7 +151,7 @@ public class MetadataRolloverServiceTests extends OpenSearchTestCase {
         String sourceAlias = randomAlphaOfLength(10);
         String sourceIndex = randomAlphaOfLength(10);
         String targetIndex = randomAlphaOfLength(10);
-        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(sourceIndex, targetIndex, true, null, sourceAlias);
+        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(sourceIndex, targetIndex, true, createDefaultAliasMetadata(sourceAlias, null), sourceAlias);
 
         assertThat(actions, hasSize(2));
         boolean foundAddWrite = false;
@@ -172,11 +174,47 @@ public class MetadataRolloverServiceTests extends OpenSearchTestCase {
         assertTrue(foundRemoveWrite);
     }
 
+    public void testRolloverAliasActionsWithFilterAndExplicitWriteIndex() {
+        String sourceAlias = randomAlphaOfLength(10);
+        String sourceIndex = randomAlphaOfLength(10);
+        String targetIndex = randomAlphaOfLength(10);
+        Map filter = Collections.singletonMap(randomAlphaOfLength(2), randomAlphaOfLength(2));
+        String indexRouting = randomAlphaOfLength(10);
+        String sourceRouting = randomAlphaOfLength(10);
+        AliasMetadata aliasMetadata = createAliasMetadata(sourceAlias, filter, indexRouting, sourceRouting, true);
+
+        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(sourceIndex, targetIndex, true, aliasMetadata, sourceAlias);
+
+        assertThat(actions, hasSize(2));
+        boolean foundAddWrite = false;
+        boolean foundRemoveWrite = false;
+        for (AliasAction action : actions) {
+            AliasAction.Add addAction = (AliasAction.Add) action;
+            if (action.getIndex().equals(targetIndex)) {
+                assertEquals(sourceAlias, addAction.getAlias());
+                assertEquals(aliasMetadata.getFilterAsString(), addAction.getFilter());
+                assertEquals(indexRouting, addAction.getIndexRouting());
+                assertEquals(sourceRouting, addAction.getSearchRouting());
+
+                assertTrue(addAction.writeIndex());
+                foundAddWrite = true;
+            } else if (action.getIndex().equals(sourceIndex)) {
+                assertEquals(sourceAlias, addAction.getAlias());
+                assertFalse(addAction.writeIndex());
+                foundRemoveWrite = true;
+            } else {
+                throw new AssertionError("Unknown index [" + action.getIndex() + "]");
+            }
+        }
+        assertTrue(foundAddWrite);
+        assertTrue(foundRemoveWrite);
+    }
+
     public void testRolloverAliasActionsWithHiddenAliasAndExplicitWriteIndex() {
         String sourceAlias = randomAlphaOfLength(10);
         String sourceIndex = randomAlphaOfLength(10);
         String targetIndex = randomAlphaOfLength(10);
-        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(sourceIndex, targetIndex, true, true, sourceAlias);
+        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(sourceIndex, targetIndex, true, createDefaultAliasMetadata(sourceAlias,true), sourceAlias);
 
         assertThat(actions, hasSize(2));
         boolean foundAddWrite = false;
@@ -202,11 +240,49 @@ public class MetadataRolloverServiceTests extends OpenSearchTestCase {
         assertTrue(foundRemoveWrite);
     }
 
+    public void testRolloverAliasActionsWithFilterAndHiddenAliasAndImplicitWriteIndex() {
+        String sourceAlias = randomAlphaOfLength(10);
+        String sourceIndex = randomAlphaOfLength(10);
+        String targetIndex = randomAlphaOfLength(10);
+        Map filter = Collections.singletonMap(randomAlphaOfLength(2), randomAlphaOfLength(2));
+        String indexRouting = randomAlphaOfLength(10);
+        String sourceRouting = randomAlphaOfLength(10);
+        AliasMetadata aliasMetadata = createAliasMetadata(sourceAlias, filter, indexRouting, sourceRouting, true);
+
+        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(sourceIndex, targetIndex, false,  aliasMetadata, sourceAlias);
+
+        assertThat(actions, hasSize(2));
+        boolean foundAddWrite = false;
+        boolean foundRemoveWrite = false;
+        for (AliasAction action : actions) {
+            if (action.getIndex().equals(targetIndex)) {
+                assertThat(action, instanceOf(AliasAction.Add.class));
+                AliasAction.Add addAction = (AliasAction.Add) action;
+                assertEquals(sourceAlias, addAction.getAlias());
+                assertThat(addAction.writeIndex(), nullValue());
+                assertTrue(addAction.isHidden());
+                assertEquals(aliasMetadata.getFilterAsString(), addAction.getFilter());
+                assertEquals(indexRouting, addAction.getIndexRouting());
+                assertEquals(sourceRouting, addAction.getSearchRouting());
+                foundAddWrite = true;
+            } else if (action.getIndex().equals(sourceIndex)) {
+                assertThat(action, instanceOf(AliasAction.Remove.class));
+                AliasAction.Remove removeAction = (AliasAction.Remove) action;
+                assertEquals(sourceAlias, removeAction.getAlias());
+                foundRemoveWrite = true;
+            } else {
+                throw new AssertionError("Unknown index [" + action.getIndex() + "]");
+            }
+        }
+        assertTrue(foundAddWrite);
+        assertTrue(foundRemoveWrite);
+    }
+
     public void testRolloverAliasActionsWithHiddenAliasAndImplicitWriteIndex() {
         String sourceAlias = randomAlphaOfLength(10);
         String sourceIndex = randomAlphaOfLength(10);
         String targetIndex = randomAlphaOfLength(10);
-        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(sourceIndex, targetIndex, false, true, sourceAlias);
+        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(sourceIndex, targetIndex, false,  createDefaultAliasMetadata(sourceAlias,true), sourceAlias);
 
         assertThat(actions, hasSize(2));
         boolean foundAddWrite = false;
@@ -1008,6 +1084,20 @@ public class MetadataRolloverServiceTests extends OpenSearchTestCase {
         return IndexMetadata.builder(indexName)
             .creationDate(System.currentTimeMillis() - TimeValue.timeValueHours(3).getMillis())
             .settings(settings)
+            .build();
+    }
+
+    private static AliasMetadata createDefaultAliasMetadata(String alias, Boolean isHidden) {
+        return AliasMetadata.builder(alias).isHidden(isHidden).build();
+    }
+
+    private static AliasMetadata createAliasMetadata(String alias, Map filter, String indexRouting, String searchRouting, Boolean isHidden) {
+        return AliasMetadata
+            .builder(alias)
+            .isHidden(isHidden)
+            .filter(filter)
+            .indexRouting(indexRouting)
+            .searchRouting(searchRouting)
             .build();
     }
 }

--- a/server/src/test/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverServiceTests.java
@@ -43,7 +43,6 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.DataStreamTestHelper;
 import org.opensearch.cluster.metadata.AliasAction;
 import org.opensearch.cluster.metadata.AliasMetadata;
-import org.opensearch.cluster.metadata.AliasMetadata.Builder;
 import org.opensearch.cluster.metadata.AliasValidator;
 import org.opensearch.cluster.metadata.ComponentTemplate;
 import org.opensearch.cluster.metadata.ComposableIndexTemplate;
@@ -101,7 +100,6 @@ import java.util.Locale;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
-import static org.hamcrest.Matchers.in;
 import static org.opensearch.cluster.DataStreamTestHelper.generateMapping;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -128,7 +126,13 @@ public class MetadataRolloverServiceTests extends OpenSearchTestCase {
         String sourceIndex = randomAlphaOfLength(10);
         String targetIndex = randomAlphaOfLength(10);
 
-        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(sourceIndex, targetIndex, false, createDefaultAliasMetadata(sourceAlias, null), sourceAlias);
+        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(
+            sourceIndex,
+            targetIndex,
+            false,
+            createDefaultAliasMetadata(sourceAlias, null),
+            sourceAlias
+        );
         assertThat(actions, hasSize(2));
         boolean foundAdd = false;
         boolean foundRemove = false;
@@ -151,7 +155,13 @@ public class MetadataRolloverServiceTests extends OpenSearchTestCase {
         String sourceAlias = randomAlphaOfLength(10);
         String sourceIndex = randomAlphaOfLength(10);
         String targetIndex = randomAlphaOfLength(10);
-        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(sourceIndex, targetIndex, true, createDefaultAliasMetadata(sourceAlias, null), sourceAlias);
+        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(
+            sourceIndex,
+            targetIndex,
+            true,
+            createDefaultAliasMetadata(sourceAlias, null),
+            sourceAlias
+        );
 
         assertThat(actions, hasSize(2));
         boolean foundAddWrite = false;
@@ -178,12 +188,23 @@ public class MetadataRolloverServiceTests extends OpenSearchTestCase {
         String sourceAlias = randomAlphaOfLength(10);
         String sourceIndex = randomAlphaOfLength(10);
         String targetIndex = randomAlphaOfLength(10);
-        Map filter = Collections.singletonMap(randomAlphaOfLength(2), randomAlphaOfLength(2));
         String indexRouting = randomAlphaOfLength(10);
         String sourceRouting = randomAlphaOfLength(10);
-        AliasMetadata aliasMetadata = createAliasMetadata(sourceAlias, filter, indexRouting, sourceRouting, true);
+        AliasMetadata aliasMetadata = createAliasMetadata(
+            sourceAlias,
+            Collections.singletonMap(randomAlphaOfLength(2), randomAlphaOfLength(2)),
+            indexRouting,
+            sourceRouting,
+            true
+        );
 
-        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(sourceIndex, targetIndex, true, aliasMetadata, sourceAlias);
+        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(
+            sourceIndex,
+            targetIndex,
+            true,
+            aliasMetadata,
+            sourceAlias
+        );
 
         assertThat(actions, hasSize(2));
         boolean foundAddWrite = false;
@@ -192,7 +213,7 @@ public class MetadataRolloverServiceTests extends OpenSearchTestCase {
             AliasAction.Add addAction = (AliasAction.Add) action;
             if (action.getIndex().equals(targetIndex)) {
                 assertEquals(sourceAlias, addAction.getAlias());
-                assertEquals(aliasMetadata.getFilterAsString(), addAction.getFilter());
+                assertEquals(aliasMetadata.filter().string(), addAction.getFilter());
                 assertEquals(indexRouting, addAction.getIndexRouting());
                 assertEquals(sourceRouting, addAction.getSearchRouting());
 
@@ -214,7 +235,13 @@ public class MetadataRolloverServiceTests extends OpenSearchTestCase {
         String sourceAlias = randomAlphaOfLength(10);
         String sourceIndex = randomAlphaOfLength(10);
         String targetIndex = randomAlphaOfLength(10);
-        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(sourceIndex, targetIndex, true, createDefaultAliasMetadata(sourceAlias,true), sourceAlias);
+        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(
+            sourceIndex,
+            targetIndex,
+            true,
+            createDefaultAliasMetadata(sourceAlias, true),
+            sourceAlias
+        );
 
         assertThat(actions, hasSize(2));
         boolean foundAddWrite = false;
@@ -244,12 +271,23 @@ public class MetadataRolloverServiceTests extends OpenSearchTestCase {
         String sourceAlias = randomAlphaOfLength(10);
         String sourceIndex = randomAlphaOfLength(10);
         String targetIndex = randomAlphaOfLength(10);
-        Map filter = Collections.singletonMap(randomAlphaOfLength(2), randomAlphaOfLength(2));
         String indexRouting = randomAlphaOfLength(10);
         String sourceRouting = randomAlphaOfLength(10);
-        AliasMetadata aliasMetadata = createAliasMetadata(sourceAlias, filter, indexRouting, sourceRouting, true);
+        AliasMetadata aliasMetadata = createAliasMetadata(
+            sourceAlias,
+            Collections.singletonMap(randomAlphaOfLength(2), randomAlphaOfLength(2)),
+            indexRouting,
+            sourceRouting,
+            true
+        );
 
-        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(sourceIndex, targetIndex, false,  aliasMetadata, sourceAlias);
+        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(
+            sourceIndex,
+            targetIndex,
+            false,
+            aliasMetadata,
+            sourceAlias
+        );
 
         assertThat(actions, hasSize(2));
         boolean foundAddWrite = false;
@@ -261,7 +299,7 @@ public class MetadataRolloverServiceTests extends OpenSearchTestCase {
                 assertEquals(sourceAlias, addAction.getAlias());
                 assertThat(addAction.writeIndex(), nullValue());
                 assertTrue(addAction.isHidden());
-                assertEquals(aliasMetadata.getFilterAsString(), addAction.getFilter());
+                assertEquals(aliasMetadata.filter().string(), addAction.getFilter());
                 assertEquals(indexRouting, addAction.getIndexRouting());
                 assertEquals(sourceRouting, addAction.getSearchRouting());
                 foundAddWrite = true;
@@ -282,7 +320,13 @@ public class MetadataRolloverServiceTests extends OpenSearchTestCase {
         String sourceAlias = randomAlphaOfLength(10);
         String sourceIndex = randomAlphaOfLength(10);
         String targetIndex = randomAlphaOfLength(10);
-        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(sourceIndex, targetIndex, false,  createDefaultAliasMetadata(sourceAlias,true), sourceAlias);
+        List<AliasAction> actions = MetadataRolloverService.rolloverAliasToNewIndex(
+            sourceIndex,
+            targetIndex,
+            false,
+            createDefaultAliasMetadata(sourceAlias, true),
+            sourceAlias
+        );
 
         assertThat(actions, hasSize(2));
         boolean foundAddWrite = false;
@@ -1091,9 +1135,14 @@ public class MetadataRolloverServiceTests extends OpenSearchTestCase {
         return AliasMetadata.builder(alias).isHidden(isHidden).build();
     }
 
-    private static AliasMetadata createAliasMetadata(String alias, Map filter, String indexRouting, String searchRouting, Boolean isHidden) {
-        return AliasMetadata
-            .builder(alias)
+    private static AliasMetadata createAliasMetadata(
+        String alias,
+        Map filter,
+        String indexRouting,
+        String searchRouting,
+        Boolean isHidden
+    ) {
+        return AliasMetadata.builder(alias)
             .isHidden(isHidden)
             .filter(filter)
             .indexRouting(indexRouting)


### PR DESCRIPTION
### Description
Once the rollover happens on alias, filter, search and index routing both on source and target indicies were missing.
This pull request should fix the previously mentioned behaviors by remembering the alias filter, search and index routing settings. 

### Issues Resolved
https://github.com/opensearch-project/index-management/issues/496

### Check List

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
