### PR TITLE
[Segment Replication] Ignore lock file when testing cleanupAndPreserveLatestCommitPoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Getting security exception due to access denied 'java.lang.RuntimePermission' 'accessDeclaredMembers' when trying to get snapshot with S3 IRSA ([#4469](https://github.com/opensearch-project/OpenSearch/pull/4469))
 - Fixed flaky test `ResourceAwareTasksTests.testTaskIdPersistsInThreadContext` ([#4484](https://github.com/opensearch-project/OpenSearch/pull/4484))
 - Fixed the ignore_malformed setting to also ignore objects ([#4494](https://github.com/opensearch-project/OpenSearch/pull/4494))
+- [Segment Replication] Ignore lock file when testing cleanupAndPreserveLatestCommitPoint ([#4544](https://github.com/opensearch-project/OpenSearch/pull/4544))
 - Updated jackson to 2.13.4 and snakeyml to 1.32 ([#4556](https://github.com/opensearch-project/OpenSearch/pull/4556))
 
 ### Security

--- a/server/src/test/java/org/opensearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/opensearch/index/store/StoreTests.java
@@ -1189,8 +1189,10 @@ public class StoreTests extends OpenSearchTestCase {
 
         // we want to ensure commitMetadata files are preserved after calling cleanup
         for (String existingFile : store.directory().listAll()) {
-            assertTrue(commitMetadata.contains(existingFile));
-            assertFalse(additionalSegments.contains(existingFile));
+            if (!IndexWriter.WRITE_LOCK_NAME.equals(existingFile)) {
+                assertTrue(commitMetadata.contains(existingFile));
+                assertFalse(additionalSegments.contains(existingFile));
+            }
         }
         deleteContent(store.directory());
         IOUtils.close(store);


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description
In `StoreTests.testCleanupAndPreserveLatestCommitPoint()` a lock file is used during the test.  Since it is not one of the committed files, it does not appear in the commit metadata snapshot, but as it is in use during the cleanup operation, it is also not cleaned up.

This PR updates the test to ignore the presence of the lock file.

### Issues Resolved
Fixes #4538

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
~- [ ] New functionality has been documented.~
  ~- [ ] New functionality has javadoc added~
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
