### PR TITLE
Added in-flight cancellation of SearchShardTask based on resource consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add BWC version 2.3.1 ([#4513](https://github.com/opensearch-project/OpenSearch/pull/4513))
 - [Segment Replication] Add snapshot and restore tests for segment replication feature ([#3993](https://github.com/opensearch-project/OpenSearch/pull/3993))
 - Added missing javadocs for `:example-plugins` modules ([#4540](https://github.com/opensearch-project/OpenSearch/pull/4540))
+- Added in-flight cancellation of SearchShardTask based on resource consumption ([#4565](https://github.com/opensearch-project/OpenSearch/pull/4565))
+
 ### Dependencies
 - Bumps `log4j-core` from 2.18.0 to 2.19.0
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -237,7 +237,8 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         ADAPTIVE_SELECTION("adaptive_selection"),
         SCRIPT_CACHE("script_cache"),
         INDEXING_PRESSURE("indexing_pressure"),
-        SHARD_INDEXING_PRESSURE("shard_indexing_pressure");
+        SHARD_INDEXING_PRESSURE("shard_indexing_pressure"),
+        SEARCH_BACKPRESSURE("search_backpressure");
 
         private String metricName;
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -118,7 +118,8 @@ public class TransportNodesStatsAction extends TransportNodesAction<
             NodesStatsRequest.Metric.ADAPTIVE_SELECTION.containedIn(metrics),
             NodesStatsRequest.Metric.SCRIPT_CACHE.containedIn(metrics),
             NodesStatsRequest.Metric.INDEXING_PRESSURE.containedIn(metrics),
-            NodesStatsRequest.Metric.SHARD_INDEXING_PRESSURE.containedIn(metrics)
+            NodesStatsRequest.Metric.SHARD_INDEXING_PRESSURE.containedIn(metrics),
+            NodesStatsRequest.Metric.SEARCH_BACKPRESSURE.containedIn(metrics)
         );
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -162,6 +162,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<
             false,
             false,
             false,
+            false,
             false
         );
         List<ShardStats> shardsStats = new ArrayList<>();

--- a/server/src/main/java/org/opensearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterModule.java
@@ -95,7 +95,6 @@ import org.opensearch.plugins.ClusterPlugin;
 import org.opensearch.script.ScriptMetadata;
 import org.opensearch.snapshots.SnapshotsInfoService;
 import org.opensearch.tasks.Task;
-import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.tasks.TaskResultsService;
 
 import java.util.ArrayList;
@@ -406,7 +405,6 @@ public class ClusterModule extends AbstractModule {
         bind(NodeMappingRefreshAction.class).asEagerSingleton();
         bind(MappingUpdatedAction.class).asEagerSingleton();
         bind(TaskResultsService.class).asEagerSingleton();
-        bind(TaskResourceTrackingService.class).asEagerSingleton();
         bind(AllocationDeciders.class).toInstance(allocationDeciders);
         bind(ShardsAllocator.class).toInstance(shardsAllocator);
     }

--- a/server/src/main/java/org/opensearch/common/Streak.java
+++ b/server/src/main/java/org/opensearch/common/Streak.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Streak is a data structure that keeps track of the number of consecutive successful events.
+ */
+public class Streak {
+    private final AtomicInteger consecutiveSuccessfulEvents = new AtomicInteger();
+
+    public int record(boolean isSuccessful) {
+        if (isSuccessful) {
+            return consecutiveSuccessfulEvents.incrementAndGet();
+        } else {
+            consecutiveSuccessfulEvents.set(0);
+            return 0;
+        }
+    }
+
+    public int length() {
+        return consecutiveSuccessfulEvents.get();
+    }
+}

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -41,6 +41,7 @@ import org.opensearch.index.IndexingPressure;
 import org.opensearch.index.ShardIndexingPressureMemoryManager;
 import org.opensearch.index.ShardIndexingPressureSettings;
 import org.opensearch.index.ShardIndexingPressureStore;
+import org.opensearch.search.backpressure.SearchBackpressureSettings;
 import org.opensearch.tasks.TaskManager;
 import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.watcher.ResourceWatcherService;
@@ -580,7 +581,17 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 ShardIndexingPressureMemoryManager.MAX_OUTSTANDING_REQUESTS,
                 IndexingPressure.MAX_INDEXING_BYTES,
                 TaskResourceTrackingService.TASK_RESOURCE_TRACKING_ENABLED,
-                TaskManager.TASK_RESOURCE_CONSUMERS_ENABLED
+                TaskManager.TASK_RESOURCE_CONSUMERS_ENABLED,
+                SearchBackpressureSettings.SETTING_ENABLED,
+                SearchBackpressureSettings.SETTING_ENFORCED,
+                SearchBackpressureSettings.SETTING_NODE_DURESS_NUM_CONSECUTIVE_BREACHES,
+                SearchBackpressureSettings.SETTING_NODE_DURESS_CPU_THRESHOLD,
+                SearchBackpressureSettings.SETTING_NODE_DURESS_HEAP_THRESHOLD,
+                SearchBackpressureSettings.SETTING_SEARCH_HEAP_THRESHOLD,
+                SearchBackpressureSettings.SETTING_SEARCH_TASK_HEAP_THRESHOLD,
+                SearchBackpressureSettings.SETTING_SEARCH_TASK_HEAP_VARIANCE_THRESHOLD,
+                SearchBackpressureSettings.SETTING_SEARCH_TASK_CPU_TIME_THRESHOLD,
+                SearchBackpressureSettings.SETTING_SEARCH_TASK_ELAPSED_TIME_THRESHOLD
             )
         )
     );

--- a/server/src/main/java/org/opensearch/common/util/MovingAverage.java
+++ b/server/src/main/java/org/opensearch/common/util/MovingAverage.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.util;
+
+/**
+ * MovingAverage is used to calculate the moving average of last 'n' observations.
+ */
+public class MovingAverage {
+    private final int windowSize;
+    private final long[] observations;
+
+    private long count = 0;
+    private long sum = 0;
+    private double average = 0;
+
+    public MovingAverage(int windowSize) {
+        if (windowSize <= 0) {
+            throw new IllegalArgumentException("window size must be greater than zero");
+        }
+
+        this.windowSize = windowSize;
+        this.observations = new long[windowSize];
+    }
+
+    /**
+     * Records a new observation and evicts the n-th last observation.
+     */
+    public synchronized double record(long value) {
+        long delta = value - observations[(int) (count % observations.length)];
+        observations[(int) (count % observations.length)] = value;
+
+        count++;
+        sum += delta;
+        average = (double) sum / Math.min(count, observations.length);
+        return average;
+    }
+
+    public double getAverage() {
+        return average;
+    }
+
+    public long getCount() {
+        return count;
+    }
+
+    public boolean isReady() {
+        return count >= windowSize;
+    }
+}

--- a/server/src/main/java/org/opensearch/common/util/TokenBucket.java
+++ b/server/src/main/java/org/opensearch/common/util/TokenBucket.java
@@ -1,0 +1,95 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.util;
+
+import java.util.function.LongSupplier;
+
+/**
+ * TokenBucket is used to limit the number of operations at a constant rate while allowing for short bursts.
+ */
+public class TokenBucket {
+    /**
+     * Defines a monotonically increasing counter.
+     *
+     * Usage examples:
+     * 1. clock = System::nanoTime can be used to perform rate-limiting per unit time
+     * 2. clock = AtomicLong::get can be used to perform rate-limiting per unit number of operations
+     */
+    private final LongSupplier clock;
+
+    /**
+     * Defines the number of tokens added to the bucket per clock cycle.
+     */
+    private final double rate;
+
+    /**
+     * Defines the capacity and the maximum number of operations that can be performed per clock cycle before
+     * the bucket runs out of tokens.
+     */
+    private final double burst;
+
+    private double tokens;
+
+    private long lastRefilledAt;
+
+    public TokenBucket(LongSupplier clock, double rate, double burst) {
+        this(clock, rate, burst, burst);
+    }
+
+    public TokenBucket(LongSupplier clock, double rate, double burst, double initialTokens) {
+        if (rate <= 0.0) {
+            throw new IllegalArgumentException("rate must be greater than zero");
+        }
+
+        if (burst <= 0.0) {
+            throw new IllegalArgumentException("burst must be greater than zero");
+        }
+
+        this.clock = clock;
+        this.rate = rate;
+        this.burst = burst;
+        this.tokens = initialTokens;
+        this.lastRefilledAt = clock.getAsLong();
+    }
+
+    /**
+     * Refills the token bucket.
+     */
+    private void refill() {
+        long now = clock.getAsLong();
+        double incr = (now - lastRefilledAt) * rate;
+        tokens = Math.min(tokens + incr, burst);
+        lastRefilledAt = now;
+    }
+
+    /**
+     * If there are enough tokens in the bucket, it requests/deducts 'n' tokens and returns true.
+     * Otherwise, returns false and leaves the bucket untouched.
+     */
+    public boolean request(double n) {
+        if (n <= 0) {
+            throw new IllegalArgumentException("requested tokens must be greater than zero");
+        }
+
+        synchronized (this) {
+            refill();
+
+            if (tokens >= n) {
+                tokens -= n;
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    public boolean request() {
+        return request(1.0);
+    }
+}

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -42,6 +42,8 @@ import org.opensearch.index.IndexingPressureService;
 import org.opensearch.indices.replication.SegmentReplicationSourceFactory;
 import org.opensearch.indices.replication.SegmentReplicationTargetService;
 import org.opensearch.indices.replication.SegmentReplicationSourceService;
+import org.opensearch.search.backpressure.SearchBackpressureManager;
+import org.opensearch.search.backpressure.SearchBackpressureSettings;
 import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.threadpool.RunnableTaskExecutionListener;
 import org.opensearch.index.store.RemoteSegmentStoreDirectoryFactory;
@@ -780,6 +782,23 @@ public class Node implements Closeable {
             // development. Then we can deprecate Getter and Setter for IndexingPressureService in ClusterService (#478).
             clusterService.setIndexingPressureService(indexingPressureService);
 
+            final TaskResourceTrackingService taskResourceTrackingService = new TaskResourceTrackingService(
+                settings,
+                clusterService.getClusterSettings(),
+                threadPool
+            );
+
+            final SearchBackpressureSettings searchBackpressureSettings = new SearchBackpressureSettings(
+                settings,
+                clusterService.getClusterSettings()
+            );
+
+            final SearchBackpressureManager searchBackpressureManager = new SearchBackpressureManager(
+                searchBackpressureSettings,
+                taskResourceTrackingService,
+                threadPool
+            );
+
             final RecoverySettings recoverySettings = new RecoverySettings(settings, settingsModule.getClusterSettings());
             RepositoriesModule repositoriesModule = new RepositoriesModule(
                 this.environment,
@@ -867,7 +886,8 @@ public class Node implements Closeable {
                 responseCollectorService,
                 searchTransportService,
                 indexingPressureService,
-                searchModule.getValuesSourceRegistry().getUsageService()
+                searchModule.getValuesSourceRegistry().getUsageService(),
+                searchBackpressureManager
             );
 
             final SearchService searchService = newSearchService(
@@ -925,6 +945,8 @@ public class Node implements Closeable {
                 b.bind(AnalysisRegistry.class).toInstance(analysisModule.getAnalysisRegistry());
                 b.bind(IngestService.class).toInstance(ingestService);
                 b.bind(IndexingPressureService.class).toInstance(indexingPressureService);
+                b.bind(TaskResourceTrackingService.class).toInstance(taskResourceTrackingService);
+                b.bind(SearchBackpressureManager.class).toInstance(searchBackpressureManager);
                 b.bind(UsageService.class).toInstance(usageService);
                 b.bind(AggregationUsageService.class).toInstance(searchModule.getValuesSourceRegistry().getUsageService());
                 b.bind(NamedWriteableRegistry.class).toInstance(namedWriteableRegistry);

--- a/server/src/main/java/org/opensearch/node/NodeService.java
+++ b/server/src/main/java/org/opensearch/node/NodeService.java
@@ -53,6 +53,7 @@ import org.opensearch.monitor.MonitorService;
 import org.opensearch.plugins.PluginsService;
 import org.opensearch.script.ScriptService;
 import org.opensearch.search.aggregations.support.AggregationUsageService;
+import org.opensearch.search.backpressure.SearchBackpressureManager;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
@@ -81,6 +82,7 @@ public class NodeService implements Closeable {
     private final SearchTransportService searchTransportService;
     private final IndexingPressureService indexingPressureService;
     private final AggregationUsageService aggregationUsageService;
+    private final SearchBackpressureManager searchBackpressureManager;
 
     private final Discovery discovery;
 
@@ -101,7 +103,8 @@ public class NodeService implements Closeable {
         ResponseCollectorService responseCollectorService,
         SearchTransportService searchTransportService,
         IndexingPressureService indexingPressureService,
-        AggregationUsageService aggregationUsageService
+        AggregationUsageService aggregationUsageService,
+        SearchBackpressureManager searchBackpressureManager
     ) {
         this.settings = settings;
         this.threadPool = threadPool;
@@ -119,6 +122,7 @@ public class NodeService implements Closeable {
         this.searchTransportService = searchTransportService;
         this.indexingPressureService = indexingPressureService;
         this.aggregationUsageService = aggregationUsageService;
+        this.searchBackpressureManager = searchBackpressureManager;
         clusterService.addStateApplier(ingestService);
     }
 
@@ -169,7 +173,8 @@ public class NodeService implements Closeable {
         boolean adaptiveSelection,
         boolean scriptCache,
         boolean indexingPressure,
-        boolean shardIndexingPressure
+        boolean shardIndexingPressure,
+        boolean searchBackpressure
     ) {
         // for indices stats we want to include previous allocated shards stats as well (it will
         // only be applied to the sensible ones to use, like refresh/merge/flush/indexing stats)
@@ -191,7 +196,8 @@ public class NodeService implements Closeable {
             adaptiveSelection ? responseCollectorService.getAdaptiveStats(searchTransportService.getPendingSearchRequests()) : null,
             scriptCache ? scriptService.cacheStats() : null,
             indexingPressure ? this.indexingPressureService.nodeStats() : null,
-            shardIndexingPressure ? this.indexingPressureService.shardStats(indices) : null
+            shardIndexingPressure ? this.indexingPressureService.shardStats(indices) : null,
+            searchBackpressure ? this.searchBackpressureManager.nodeStats() : null
         );
     }
 

--- a/server/src/main/java/org/opensearch/search/backpressure/SearchBackpressureManager.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/SearchBackpressureManager.java
@@ -1,0 +1,283 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure;
+
+import com.sun.management.OperatingSystemMXBean;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.common.Streak;
+import org.opensearch.common.SuppressForbidden;
+import org.opensearch.common.util.TokenBucket;
+import org.opensearch.monitor.jvm.JvmStats;
+import org.opensearch.search.backpressure.stats.CancellationStats;
+import org.opensearch.search.backpressure.stats.CancelledTaskStats;
+import org.opensearch.search.backpressure.stats.SearchBackpressureStats;
+import org.opensearch.search.backpressure.trackers.CpuUsageTracker;
+import org.opensearch.search.backpressure.trackers.ElapsedTimeTracker;
+import org.opensearch.search.backpressure.trackers.HeapUsageTracker;
+import org.opensearch.search.backpressure.trackers.ResourceUsageTracker;
+import org.opensearch.tasks.CancellableTask;
+import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskResourceTrackingService;
+import org.opensearch.tasks.TaskResourceTrackingService.TaskCompletionListener;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.lang.management.ManagementFactory;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.DoubleSupplier;
+import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
+
+/**
+ * SearchBackpressureManager is responsible for monitoring and cancelling in-flight search tasks if they are
+ * breaching resource usage limits when the node is in duress.
+ */
+@SuppressForbidden(reason = "OperatingSystemMXBean#getProcessCpuLoad")
+public class SearchBackpressureManager implements Runnable, TaskCompletionListener {
+    private static final Logger logger = LogManager.getLogger(SearchBackpressureManager.class);
+    private static final OperatingSystemMXBean osMXBean = (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
+
+    private final SearchBackpressureSettings settings;
+    private final TaskResourceTrackingService taskResourceTrackingService;
+    private final List<ResourceUsageTracker> trackers;
+
+    private final Streak cpuBreachesStreak = new Streak();
+    private final Streak heapBreachesStreak = new Streak();
+
+    private final AtomicLong completionCount = new AtomicLong();
+    private final AtomicLong cancellationCount = new AtomicLong();
+    private final AtomicLong limitReachedCount = new AtomicLong();
+    private final AtomicReference<CancelledTaskStats> lastCancelledTaskUsage = new AtomicReference<>();
+
+    private final TokenBucket taskCancellationRateLimiter;
+    private final TokenBucket taskCancellationRatioLimiter;
+
+    private final LongSupplier timeNanosSupplier;
+    private final DoubleSupplier cpuUsageSupplier;
+    private final DoubleSupplier heapUsageSupplier;
+
+    public SearchBackpressureManager(
+        SearchBackpressureSettings settings,
+        TaskResourceTrackingService taskResourceTrackingService,
+        ThreadPool threadPool
+    ) {
+        this(
+            settings,
+            taskResourceTrackingService,
+            threadPool,
+            System::nanoTime,
+            osMXBean::getProcessCpuLoad,
+            () -> JvmStats.jvmStats().getMem().getHeapUsedPercent() / 100.0,
+            List.of(
+                new CpuUsageTracker(() -> TimeUnit.MILLISECONDS.toNanos(settings.getSearchTaskCpuTimeThreshold())),
+                new HeapUsageTracker(settings::getSearchTaskHeapThresholdBytes, settings::getSearchTaskHeapVarianceThreshold),
+                new ElapsedTimeTracker(System::nanoTime, () -> TimeUnit.MILLISECONDS.toNanos(settings.getSearchTaskElapsedTimeThreshold()))
+            )
+        );
+    }
+
+    public SearchBackpressureManager(
+        SearchBackpressureSettings settings,
+        TaskResourceTrackingService taskResourceTrackingService,
+        ThreadPool threadPool,
+        LongSupplier timeNanosSupplier,
+        DoubleSupplier cpuUsageSupplier,
+        DoubleSupplier heapUsageSupplier,
+        List<ResourceUsageTracker> trackers
+    ) {
+        this.settings = settings;
+        this.taskResourceTrackingService = taskResourceTrackingService;
+        this.taskResourceTrackingService.addTaskCompletionListener(this);
+        this.trackers = trackers;
+        this.taskCancellationRateLimiter = new TokenBucket(
+            timeNanosSupplier,
+            getSettings().getCancellationRateNanos(),
+            getSettings().getCancellationBurst()
+        );
+        this.taskCancellationRatioLimiter = new TokenBucket(
+            completionCount::get,
+            getSettings().getCancellationRatio(),
+            getSettings().getCancellationBurst()
+        );
+        this.timeNanosSupplier = timeNanosSupplier;
+        this.cpuUsageSupplier = cpuUsageSupplier;
+        this.heapUsageSupplier = heapUsageSupplier;
+
+        threadPool.scheduleWithFixedDelay(this, getSettings().getInterval(), ThreadPool.Names.SAME);
+    }
+
+    @Override
+    public void run() {
+        if (getSettings().isEnabled() == false) {
+            return;
+        }
+
+        if (isNodeInDuress() == false) {
+            return;
+        }
+
+        // We are only targeting in-flight cancellation of SearchShardTask for now.
+        List<CancellableTask> searchShardTasks = getSearchShardTasks();
+
+        // Force-refresh usage stats of these tasks before making a cancellation decision.
+        taskResourceTrackingService.refreshResourceStats(searchShardTasks.toArray(new Task[0]));
+
+        // Skip cancellation if the increase in heap usage is not due to search requests.
+        long runningTasksHeapUsage = searchShardTasks.stream().mapToLong(task -> task.getTotalResourceStats().getMemoryInBytes()).sum();
+        if (runningTasksHeapUsage < getSettings().getSearchHeapThresholdBytes()) {
+            return;
+        }
+
+        for (TaskCancellation taskCancellation : getTaskCancellations(searchShardTasks)) {
+            logger.debug(
+                "cancelling task [{}] due to high resource consumption [{}]",
+                taskCancellation.getTask().getId(),
+                taskCancellation.getReasonString()
+            );
+
+            if (getSettings().isEnforced() == false) {
+                continue;
+            }
+
+            // Independently remove tokens from both token buckets.
+            boolean rateLimitReached = taskCancellationRateLimiter.request() == false;
+            boolean ratioLimitReached = taskCancellationRatioLimiter.request() == false;
+
+            // Stop cancelling tasks if there are no tokens in either of the two token buckets.
+            if (rateLimitReached && ratioLimitReached) {
+                limitReachedCount.incrementAndGet();
+                break;
+            }
+
+            CancelledTaskStats stats = taskCancellation.cancel();
+            lastCancelledTaskUsage.set(stats);
+            cancellationCount.incrementAndGet();
+        }
+    }
+
+    /**
+     * Returns true if the node is breaching CPU or memory limits consecutively for the past 'n' observations.
+     */
+    boolean isNodeInDuress() {
+        boolean isCpuBreached = cpuUsageSupplier.getAsDouble() >= getSettings().getNodeDuressCpuThreshold();
+        boolean isHeapBreached = heapUsageSupplier.getAsDouble() >= getSettings().getNodeDuressHeapThreshold();
+
+        int numConsecutiveBreaches = getSettings().getNodeDuressNumConsecutiveBreaches();
+        boolean isCpuConsecutivelyBreached = cpuBreachesStreak.record(isCpuBreached) >= numConsecutiveBreaches;
+        boolean isHeapConsecutivelyBreached = heapBreachesStreak.record(isHeapBreached) >= numConsecutiveBreaches;
+
+        return isCpuConsecutivelyBreached || isHeapConsecutivelyBreached;
+    }
+
+    /**
+     * Filters and returns the list of currently running SearchShardTasks.
+     */
+    List<CancellableTask> getSearchShardTasks() {
+        return taskResourceTrackingService.getResourceAwareTasks()
+            .values()
+            .stream()
+            .filter(task -> task instanceof SearchShardTask)
+            .map(task -> (CancellableTask) task)
+            .collect(Collectors.toUnmodifiableList());
+    }
+
+    /**
+     * Returns a TaskCancellation wrapper containing the list of reasons (possibly zero), along with an overall
+     * cancellation score for the given task. Cancelling a task with a higher score has better chance of recovering the
+     * node from duress.
+     */
+    TaskCancellation getTaskCancellation(CancellableTask task) {
+        List<TaskCancellation.Reason> reasons = trackers.stream()
+            .map(tracker -> tracker.cancellationReason(task))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(Collectors.toUnmodifiableList());
+
+        return new TaskCancellation(task, reasons, timeNanosSupplier);
+    }
+
+    /**
+     * Returns a list of TaskCancellations sorted by descending order of their cancellation scores.
+     */
+    List<TaskCancellation> getTaskCancellations(List<CancellableTask> tasks) {
+        return tasks.stream()
+            .map(this::getTaskCancellation)
+            .filter(TaskCancellation::isEligibleForCancellation)
+            .sorted(Comparator.reverseOrder())
+            .collect(Collectors.toUnmodifiableList());
+    }
+
+    @Override
+    public void onTaskCompleted(Task task) {
+        if (task instanceof SearchShardTask == false) {
+            return;
+        }
+
+        SearchShardTask searchShardTask = (SearchShardTask) task;
+        if (searchShardTask.isCancelled() == false) {
+            completionCount.incrementAndGet();
+        }
+
+        // TODO: Should we update tracker stats with cancelled tasks? Or should we let the tracker decide what to do?
+        for (ResourceUsageTracker tracker : trackers) {
+            tracker.update(searchShardTask);
+        }
+    }
+
+    public SearchBackpressureSettings getSettings() {
+        return settings;
+    }
+
+    public long getCompletionCount() {
+        return completionCount.get();
+    }
+
+    public long getCancellationCount() {
+        return cancellationCount.get();
+    }
+
+    public long getLimitReachedCount() {
+        return limitReachedCount.get();
+    }
+
+    public CancelledTaskStats getLastCancelledTaskUsage() {
+        return lastCancelledTaskUsage.get();
+    }
+
+    /**
+     * Returns the search backpressure stats as seen in the "_node/stats/search_backpressure" API.
+     */
+    public SearchBackpressureStats nodeStats() {
+        List<Task> searchShardTasks = taskResourceTrackingService.getResourceAwareTasks()
+            .values()
+            .stream()
+            .filter(task -> task instanceof SearchShardTask)
+            .collect(Collectors.toUnmodifiableList());
+
+        Map<String, ResourceUsageTracker.Stats> currentStats = trackers.stream()
+            .collect(Collectors.toMap(ResourceUsageTracker::name, tracker -> tracker.currentStats(searchShardTasks)));
+
+        Map<String, Long> cancellationsBreakup = trackers.stream()
+            .collect(Collectors.toMap(ResourceUsageTracker::name, ResourceUsageTracker::getCancellations));
+
+        return new SearchBackpressureStats(
+            currentStats,
+            new CancellationStats(cancellationCount.get(), cancellationsBreakup, limitReachedCount.get(), lastCancelledTaskUsage.get()),
+            getSettings().isEnabled(),
+            getSettings().isEnforced()
+        );
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/SearchBackpressureSettings.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/SearchBackpressureSettings.java
@@ -1,0 +1,369 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure;
+
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.monitor.jvm.JvmStats;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Settings related to search backpressure and cancellation of in-flight requests.
+ */
+public class SearchBackpressureSettings {
+    private static final long heapSizeBytes = JvmStats.jvmStats().getMem().getHeapMax().getBytes();
+
+    /**
+     * Default values for each setting.
+     */
+    public interface Defaults {
+        long INTERVAL = 1000;
+
+        double CANCELLATION_RATIO = 0.1;
+        double CANCELLATION_RATE = 0.003;
+        double CANCELLATION_BURST = 10.0;
+
+        boolean ENABLED = true;
+        boolean ENFORCED = true;
+
+        int NODE_DURESS_NUM_CONSECUTIVE_BREACHES = 3;
+        double NODE_DURESS_CPU_THRESHOLD = 0.9;
+        double NODE_DURESS_HEAP_THRESHOLD = 0.7;
+
+        double SEARCH_HEAP_THRESHOLD = 0.05;
+        double SEARCH_TASK_HEAP_THRESHOLD = 0.005;
+        double SEARCH_TASK_HEAP_VARIANCE_THRESHOLD = 2.0;
+
+        long SEARCH_TASK_CPU_TIME_THRESHOLD = 15;
+        long SEARCH_TASK_ELAPSED_TIME_THRESHOLD = 30000;
+    }
+
+    // Static settings
+
+    /**
+     * Defines the interval (in millis) at which the SearchBackpressureManager monitors and cancels tasks.
+     */
+    private final TimeValue interval;
+    public static final Setting<Long> SETTING_INTERVAL = Setting.longSetting(
+        "search_backpressure.interval",
+        Defaults.INTERVAL,
+        1,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the percentage of tasks to cancel relative to the number of successful task completions.
+     * In other words, it is the number of tokens added to the bucket on each successful task completion.
+     */
+    private final double cancellationRatio;
+    public static final Setting<Double> SETTING_CANCELLATION_RATIO = Setting.doubleSetting(
+        "search_backpressure.cancellation_ratio",
+        Defaults.CANCELLATION_RATIO,
+        0.0,
+        1.0,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the number of tasks to cancel per unit time (in millis).
+     * In other words, it is the number of tokens added to the bucket each millisecond.
+     */
+    private final double cancellationRate;
+    public static final Setting<Double> SETTING_CANCELLATION_RATE = Setting.doubleSetting(
+        "search_backpressure.cancellation_rate",
+        Defaults.CANCELLATION_RATE,
+        0.0,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the maximum number of tasks that can be cancelled before being rate-limited.
+     */
+    private final double cancellationBurst;
+    public static final Setting<Double> SETTING_CANCELLATION_BURST = Setting.doubleSetting(
+        "search_backpressure.cancellation_burst",
+        Defaults.CANCELLATION_BURST,
+        1.0,
+        Setting.Property.NodeScope
+    );
+
+    // Dynamic settings
+
+    /**
+     * Defines whether search backpressure is enabled or not.
+     */
+    private volatile boolean enabled;
+    public static final Setting<Boolean> SETTING_ENABLED = Setting.boolSetting(
+        "search_backpressure.enabled",
+        Defaults.ENABLED,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines whether in-flight cancellation of tasks is enabled or not.
+     */
+    private volatile boolean enforced;
+    public static final Setting<Boolean> SETTING_ENFORCED = Setting.boolSetting(
+        "search_backpressure.enforced",
+        Defaults.ENFORCED,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the number of consecutive limit breaches after the node is marked "in duress".
+     */
+    private volatile int nodeDuressNumConsecutiveBreaches;
+    public static final Setting<Integer> SETTING_NODE_DURESS_NUM_CONSECUTIVE_BREACHES = Setting.intSetting(
+        "search_backpressure.node_duress.num_consecutive_breaches",
+        Defaults.NODE_DURESS_NUM_CONSECUTIVE_BREACHES,
+        1,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the CPU usage threshold (in percentage) for a node to be considered "in duress".
+     */
+    private volatile double nodeDuressCpuThreshold;
+    public static final Setting<Double> SETTING_NODE_DURESS_CPU_THRESHOLD = Setting.doubleSetting(
+        "search_backpressure.node_duress.cpu_threshold",
+        Defaults.NODE_DURESS_CPU_THRESHOLD,
+        0.0,
+        1.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the heap usage threshold (in percentage) for a node to be considered "in duress".
+     */
+    private volatile double nodeDuressHeapThreshold;
+    public static final Setting<Double> SETTING_NODE_DURESS_HEAP_THRESHOLD = Setting.doubleSetting(
+        "search_backpressure.node_duress.heap_threshold",
+        Defaults.NODE_DURESS_HEAP_THRESHOLD,
+        0.0,
+        1.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the heap usage threshold (in percentage) for the sum of heap usages across all search tasks
+     * before in-flight cancellation is applied.
+     */
+    private volatile double searchHeapThreshold;
+    public static final Setting<Double> SETTING_SEARCH_HEAP_THRESHOLD = Setting.doubleSetting(
+        "search_backpressure.search_heap_threshold",
+        Defaults.SEARCH_HEAP_THRESHOLD,
+        0.0,
+        1.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the heap usage threshold (in percentage) for an individual task before it is considered for cancellation.
+     */
+    private volatile double searchTaskHeapThreshold;
+    public static final Setting<Double> SETTING_SEARCH_TASK_HEAP_THRESHOLD = Setting.doubleSetting(
+        "search_backpressure.search_task_heap_threshold",
+        Defaults.SEARCH_TASK_HEAP_THRESHOLD,
+        0.0,
+        1.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the heap usage variance for an individual task before it is considered for cancellation.
+     * A task is considered for cancellation when taskHeapUsage is greater than or equal to heapUsageMovingAverage * variance.
+     */
+    private volatile double searchTaskHeapVarianceThreshold;
+    public static final Setting<Double> SETTING_SEARCH_TASK_HEAP_VARIANCE_THRESHOLD = Setting.doubleSetting(
+        "search_backpressure.search_task_heap_variance",
+        Defaults.SEARCH_TASK_HEAP_VARIANCE_THRESHOLD,
+        0.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the CPU usage threshold (in millis) for an individual task before it is considered for cancellation.
+     */
+    private volatile long searchTaskCpuTimeThreshold;
+    public static final Setting<Long> SETTING_SEARCH_TASK_CPU_TIME_THRESHOLD = Setting.longSetting(
+        "search_backpressure.search_task_cpu_time_threshold",
+        Defaults.SEARCH_TASK_CPU_TIME_THRESHOLD,
+        0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the elapsed time threshold (in millis) for an individual task before it is considered for cancellation.
+     */
+    private volatile long searchTaskElapsedTimeThreshold;
+    public static final Setting<Long> SETTING_SEARCH_TASK_ELAPSED_TIME_THRESHOLD = Setting.longSetting(
+        "search_backpressure.search_task_elapsed_time_threshold",
+        Defaults.SEARCH_TASK_ELAPSED_TIME_THRESHOLD,
+        0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    public SearchBackpressureSettings(Settings settings, ClusterSettings clusterSettings) {
+        interval = new TimeValue(SETTING_INTERVAL.get(settings));
+        cancellationRatio = SETTING_CANCELLATION_RATIO.get(settings);
+        cancellationRate = SETTING_CANCELLATION_RATE.get(settings);
+        cancellationBurst = SETTING_CANCELLATION_BURST.get(settings);
+
+        enabled = SETTING_ENABLED.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_ENABLED, this::setEnabled);
+
+        enforced = SETTING_ENFORCED.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_ENFORCED, this::setEnforced);
+
+        nodeDuressNumConsecutiveBreaches = SETTING_NODE_DURESS_NUM_CONSECUTIVE_BREACHES.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_NODE_DURESS_NUM_CONSECUTIVE_BREACHES, this::setNodeDuressNumConsecutiveBreaches);
+
+        nodeDuressCpuThreshold = SETTING_NODE_DURESS_CPU_THRESHOLD.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_NODE_DURESS_CPU_THRESHOLD, this::setNodeDuressCpuThreshold);
+
+        nodeDuressHeapThreshold = SETTING_NODE_DURESS_HEAP_THRESHOLD.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_NODE_DURESS_HEAP_THRESHOLD, this::setNodeDuressHeapThreshold);
+
+        searchHeapThreshold = SETTING_SEARCH_HEAP_THRESHOLD.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_SEARCH_HEAP_THRESHOLD, this::setSearchHeapThreshold);
+
+        searchTaskHeapThreshold = SETTING_SEARCH_TASK_HEAP_THRESHOLD.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_SEARCH_TASK_HEAP_THRESHOLD, this::setSearchTaskHeapThreshold);
+
+        searchTaskHeapVarianceThreshold = SETTING_SEARCH_TASK_HEAP_VARIANCE_THRESHOLD.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_SEARCH_TASK_HEAP_VARIANCE_THRESHOLD, this::setSearchTaskHeapVarianceThreshold);
+
+        searchTaskCpuTimeThreshold = SETTING_SEARCH_TASK_CPU_TIME_THRESHOLD.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_SEARCH_TASK_CPU_TIME_THRESHOLD, this::setSearchTaskCpuTimeThreshold);
+
+        searchTaskElapsedTimeThreshold = SETTING_SEARCH_TASK_ELAPSED_TIME_THRESHOLD.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_SEARCH_TASK_ELAPSED_TIME_THRESHOLD, this::setSearchTaskElapsedTimeThreshold);
+    }
+
+    public TimeValue getInterval() {
+        return interval;
+    }
+
+    public double getCancellationRatio() {
+        return cancellationRatio;
+    }
+
+    public double getCancellationRate() {
+        return cancellationRate;
+    }
+
+    public double getCancellationRateNanos() {
+        return getCancellationRate() / TimeUnit.MILLISECONDS.toNanos(1); // rate per nanoseconds
+    }
+
+    public double getCancellationBurst() {
+        return cancellationBurst;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isEnforced() {
+        return enforced;
+    }
+
+    public void setEnforced(boolean enforced) {
+        this.enforced = enforced;
+    }
+
+    public int getNodeDuressNumConsecutiveBreaches() {
+        return nodeDuressNumConsecutiveBreaches;
+    }
+
+    public void setNodeDuressNumConsecutiveBreaches(int nodeDuressNumConsecutiveBreaches) {
+        this.nodeDuressNumConsecutiveBreaches = nodeDuressNumConsecutiveBreaches;
+    }
+
+    public double getNodeDuressCpuThreshold() {
+        return nodeDuressCpuThreshold;
+    }
+
+    public void setNodeDuressCpuThreshold(double nodeDuressCpuThreshold) {
+        this.nodeDuressCpuThreshold = nodeDuressCpuThreshold;
+    }
+
+    public double getNodeDuressHeapThreshold() {
+        return nodeDuressHeapThreshold;
+    }
+
+    public void setNodeDuressHeapThreshold(double nodeDuressHeapThreshold) {
+        this.nodeDuressHeapThreshold = nodeDuressHeapThreshold;
+    }
+
+    public double getSearchHeapThreshold() {
+        return searchHeapThreshold;
+    }
+
+    public long getSearchHeapThresholdBytes() {
+        return (long) (heapSizeBytes * getSearchHeapThreshold());
+    }
+
+    public void setSearchHeapThreshold(double searchHeapThreshold) {
+        this.searchHeapThreshold = searchHeapThreshold;
+    }
+
+    public double getSearchTaskHeapThreshold() {
+        return searchTaskHeapThreshold;
+    }
+
+    public long getSearchTaskHeapThresholdBytes() {
+        return (long) (heapSizeBytes * getSearchTaskHeapThreshold());
+    }
+
+    public void setSearchTaskHeapThreshold(double searchTaskHeapThreshold) {
+        this.searchTaskHeapThreshold = searchTaskHeapThreshold;
+    }
+
+    public double getSearchTaskHeapVarianceThreshold() {
+        return searchTaskHeapVarianceThreshold;
+    }
+
+    public void setSearchTaskHeapVarianceThreshold(double searchTaskHeapVarianceThreshold) {
+        this.searchTaskHeapVarianceThreshold = searchTaskHeapVarianceThreshold;
+    }
+
+    public long getSearchTaskCpuTimeThreshold() {
+        return searchTaskCpuTimeThreshold;
+    }
+
+    public void setSearchTaskCpuTimeThreshold(long searchTaskCpuTimeThreshold) {
+        this.searchTaskCpuTimeThreshold = searchTaskCpuTimeThreshold;
+    }
+
+    public long getSearchTaskElapsedTimeThreshold() {
+        return searchTaskElapsedTimeThreshold;
+    }
+
+    public void setSearchTaskElapsedTimeThreshold(long searchTaskElapsedTimeThreshold) {
+        this.searchTaskElapsedTimeThreshold = searchTaskElapsedTimeThreshold;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/TaskCancellation.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/TaskCancellation.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure;
+
+import org.opensearch.search.backpressure.stats.CancelledTaskStats;
+import org.opensearch.search.backpressure.trackers.ResourceUsageTracker;
+import org.opensearch.tasks.CancellableTask;
+
+import java.util.List;
+import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
+
+/**
+ * TaskCancellation is a wrapper for a task and its cancellation reasons.
+ */
+public class TaskCancellation implements Comparable<TaskCancellation> {
+    private final CancellableTask task;
+    private final List<Reason> reasons;
+    private final LongSupplier timeNanosSupplier;
+
+    public TaskCancellation(CancellableTask task, List<Reason> reasons, LongSupplier timeNanosSupplier) {
+        this.task = task;
+        this.reasons = reasons;
+        this.timeNanosSupplier = timeNanosSupplier;
+    }
+
+    public CancellableTask getTask() {
+        return task;
+    }
+
+    public List<Reason> getReasons() {
+        return reasons;
+    }
+
+    public String getReasonString() {
+        return reasons.stream().map(Reason::getMessage).collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Cancels the task and increments the cancellation counters for all breaching resource usage trackers.
+     */
+    public CancelledTaskStats cancel() {
+        task.cancel("resource consumption exceeded [" + getReasonString() + "]");
+        reasons.forEach(reason -> reason.getTracker().incrementCancellations());
+
+        return new CancelledTaskStats(
+            task.getTotalResourceStats().getCpuTimeInNanos(),
+            task.getTotalResourceStats().getMemoryInBytes(),
+            timeNanosSupplier.getAsLong() - task.getStartTimeNanos()
+        );
+    }
+
+    /**
+     * Returns the sum of all cancellation scores.
+     *
+     * A zero score indicates no thresholds were breached, i.e., the task should not be cancelled.
+     * A task with higher score suggests greater possibility of recovering the node when that task is cancelled.
+     */
+    public int totalCancellationScore() {
+        return reasons.stream().mapToInt(Reason::getCancellationScore).sum();
+    }
+
+    /**
+     * A task is eligible for cancellation if it has one or more cancellation reasons, and is not already cancelled.
+     */
+    public boolean isEligibleForCancellation() {
+        return (task.isCancelled() == false) && (reasons.size() > 0);
+    }
+
+    @Override
+    public int compareTo(TaskCancellation other) {
+        return Integer.compare(totalCancellationScore(), other.totalCancellationScore());
+    }
+
+    /**
+     * Represents the cancellation reason for a task.
+     */
+    public static class Reason {
+        private final ResourceUsageTracker tracker;
+        private final String message;
+        private final int cancellationScore;
+
+        public Reason(ResourceUsageTracker tracker, String message, int cancellationScore) {
+            this.tracker = tracker;
+            this.message = message;
+            this.cancellationScore = cancellationScore;
+        }
+
+        public ResourceUsageTracker getTracker() {
+            return tracker;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public int getCancellationScore() {
+            return cancellationScore;
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/package-info.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * This package contains classes responsible for search backpressure.
+ */
+package org.opensearch.search.backpressure;

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/CancellationStats.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/CancellationStats.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.stats;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.xcontent.ToXContentObject;
+import org.opensearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Stats related to the number of task cancellations.
+ */
+public class CancellationStats implements ToXContentObject, Writeable {
+    private final long count;
+    private final Map<String, Long> countBreakup;
+    private final long limitReachedCount;
+    private final CancelledTaskStats lastCancelledTaskStats;
+
+    public CancellationStats(
+        long count,
+        Map<String, Long> countBreakup,
+        long limitReachedCount,
+        CancelledTaskStats lastCancelledTaskStats
+    ) {
+        this.count = count;
+        this.countBreakup = countBreakup;
+        this.limitReachedCount = limitReachedCount;
+        this.lastCancelledTaskStats = lastCancelledTaskStats;
+    }
+
+    public CancellationStats(StreamInput in) throws IOException {
+        this(
+            in.readVLong(),
+            in.readMap(StreamInput::readString, StreamInput::readVLong),
+            in.readVLong(),
+            in.readOptionalWriteable(CancelledTaskStats::new)
+        );
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.startObject()
+            .field("cancellation_count", count)
+            .field("cancellation_breakup", countBreakup)
+            .field("cancellation_limit_reached_count", limitReachedCount)
+            .field("last_cancelled_task", lastCancelledTaskStats)
+            .endObject();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(count);
+        out.writeMap(countBreakup, StreamOutput::writeString, StreamOutput::writeVLong);
+        out.writeVLong(limitReachedCount);
+        out.writeOptionalWriteable(lastCancelledTaskStats);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CancellationStats that = (CancellationStats) o;
+        return count == that.count
+            && limitReachedCount == that.limitReachedCount
+            && countBreakup.equals(that.countBreakup)
+            && Objects.equals(lastCancelledTaskStats, that.lastCancelledTaskStats);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(count, countBreakup, limitReachedCount, lastCancelledTaskStats);
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/CancelledTaskStats.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/CancelledTaskStats.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.stats;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.unit.ByteSizeValue;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.xcontent.ToXContentObject;
+import org.opensearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Stats related to a single cancelled task.
+ */
+public class CancelledTaskStats implements ToXContentObject, Writeable {
+    private final long cpuUsageNanos;
+    private final long heapUsageBytes;
+    private final long elapsedTimeNanos;
+
+    public CancelledTaskStats(StreamInput in) throws IOException {
+        this(in.readVLong(), in.readVLong(), in.readVLong());
+    }
+
+    public CancelledTaskStats(long cpuUsageNanos, long heapUsageBytes, long elapsedTimeNanos) {
+        this.cpuUsageNanos = cpuUsageNanos;
+        this.heapUsageBytes = heapUsageBytes;
+        this.elapsedTimeNanos = elapsedTimeNanos;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.startObject()
+            .humanReadableField("cpu_usage_nanos", "cpu_usage", new TimeValue(cpuUsageNanos, TimeUnit.NANOSECONDS))
+            .humanReadableField("heap_usage_bytes", "heap_usage", new ByteSizeValue(heapUsageBytes))
+            .humanReadableField("elapsed_time_nanos", "elapsed_time", new TimeValue(elapsedTimeNanos, TimeUnit.NANOSECONDS))
+            .endObject();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(cpuUsageNanos);
+        out.writeVLong(heapUsageBytes);
+        out.writeVLong(elapsedTimeNanos);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CancelledTaskStats that = (CancelledTaskStats) o;
+        return cpuUsageNanos == that.cpuUsageNanos && heapUsageBytes == that.heapUsageBytes && elapsedTimeNanos == that.elapsedTimeNanos;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cpuUsageNanos, heapUsageBytes, elapsedTimeNanos);
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/SearchBackpressureStats.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/SearchBackpressureStats.java
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.stats;
+
+import org.opensearch.common.collect.MapBuilder;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.xcontent.ToXContentFragment;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.search.backpressure.trackers.CpuUsageTracker;
+import org.opensearch.search.backpressure.trackers.ElapsedTimeTracker;
+import org.opensearch.search.backpressure.trackers.HeapUsageTracker;
+import org.opensearch.search.backpressure.trackers.ResourceUsageTracker;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Stats related to search backpressure.
+ */
+public class SearchBackpressureStats implements ToXContentFragment, Writeable {
+    private final Map<String, ResourceUsageTracker.Stats> searchShardTaskCurrentStats;
+    private final CancellationStats searchShardTaskCancellationStats;
+    private final boolean enabled;
+    private final boolean enforced;
+
+    public SearchBackpressureStats(
+        Map<String, ResourceUsageTracker.Stats> searchShardTaskCurrentStats,
+        CancellationStats searchShardTaskCancellationStats,
+        boolean enabled,
+        boolean enforced
+    ) {
+        this.searchShardTaskCurrentStats = searchShardTaskCurrentStats;
+        this.searchShardTaskCancellationStats = searchShardTaskCancellationStats;
+        this.enabled = enabled;
+        this.enforced = enforced;
+    }
+
+    public SearchBackpressureStats(StreamInput in) throws IOException {
+        this(readStats(in), new CancellationStats(in), in.readBoolean(), in.readBoolean());
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.startObject("search_backpressure")
+            .startObject("current_stats")
+            .field("search_shard_task", searchShardTaskCurrentStats)
+            .endObject()
+            .startObject("cancellation_stats")
+            .field("search_shard_task", searchShardTaskCancellationStats)
+            .endObject()
+            .field("enabled", enabled)
+            .field("enforced", enforced)
+            .endObject();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeMap(searchShardTaskCurrentStats, StreamOutput::writeString, (o, stats) -> stats.writeTo(o));
+        searchShardTaskCancellationStats.writeTo(out);
+        out.writeBoolean(enabled);
+        out.writeBoolean(enforced);
+    }
+
+    private static Map<String, ResourceUsageTracker.Stats> readStats(StreamInput in) throws IOException {
+        int size = in.readVInt();
+        if (size == 0) {
+            return Collections.emptyMap();
+        }
+
+        MapBuilder<String, ResourceUsageTracker.Stats> builder = new MapBuilder<>();
+        for (int i = 0; i < size; i++) {
+            String key = in.readString();
+            switch (key) {
+                case CpuUsageTracker.NAME:
+                    builder.put(key, new CpuUsageTracker.Stats(in));
+                    break;
+                case HeapUsageTracker.NAME:
+                    builder.put(key, new HeapUsageTracker.Stats(in));
+                    break;
+                case ElapsedTimeTracker.NAME:
+                    builder.put(key, new ElapsedTimeTracker.Stats(in));
+                    break;
+                default:
+                    throw new IllegalArgumentException("invalid stats type = " + key);
+            }
+        }
+
+        return builder.immutableMap();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SearchBackpressureStats that = (SearchBackpressureStats) o;
+        return enabled == that.enabled
+            && enforced == that.enforced
+            && searchShardTaskCurrentStats.equals(that.searchShardTaskCurrentStats)
+            && searchShardTaskCancellationStats.equals(that.searchShardTaskCancellationStats);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(searchShardTaskCurrentStats, searchShardTaskCancellationStats, enabled, enforced);
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/package-info.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * This package contains classes responsible for search backpressure stats as seen in the "_node/stats/search_backpressure" API.
+ */
+package org.opensearch.search.backpressure.stats;

--- a/server/src/main/java/org/opensearch/search/backpressure/trackers/CpuUsageTracker.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/trackers/CpuUsageTracker.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.trackers;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.search.backpressure.TaskCancellation;
+import org.opensearch.tasks.Task;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.LongSupplier;
+
+/**
+ * CpuUsageTracker evaluates if the task has consumed too many CPU cycles than allowed.
+ */
+public class CpuUsageTracker extends ResourceUsageTracker {
+    public static final String NAME = "cpu_usage_tracker";
+
+    private final LongSupplier cpuTimeNanosThresholdSupplier;
+
+    public CpuUsageTracker(LongSupplier cpuTimeNanosThresholdSupplier) {
+        this.cpuTimeNanosThresholdSupplier = cpuTimeNanosThresholdSupplier;
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void update(Task task) {
+        // nothing to do
+    }
+
+    @Override
+    public Optional<TaskCancellation.Reason> cancellationReason(Task task) {
+        if (task.getTotalResourceStats().getCpuTimeInNanos() < cpuTimeNanosThresholdSupplier.getAsLong()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new TaskCancellation.Reason(this, "cpu usage exceeded", 1));
+    }
+
+    @Override
+    public Stats currentStats(List<Task> activeTasks) {
+        long currentMax = activeTasks.stream().mapToLong(t -> t.getTotalResourceStats().getCpuTimeInNanos()).max().orElse(0);
+        long currentAvg = (long) activeTasks.stream().mapToLong(t -> t.getTotalResourceStats().getCpuTimeInNanos()).average().orElse(0);
+        return new Stats(currentMax, currentAvg);
+    }
+
+    /**
+     * Stats for CpuUsageTracker as seen in "_node/stats/search_backpressure" API.
+     */
+    public static class Stats implements ResourceUsageTracker.Stats {
+        private final long currentMax;
+        private final long currentAvg;
+
+        public Stats(long currentMax, long currentAvg) {
+            this.currentMax = currentMax;
+            this.currentAvg = currentAvg;
+        }
+
+        public Stats(StreamInput in) throws IOException {
+            this(in.readVLong(), in.readVLong());
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder.startObject()
+                .humanReadableField("current_max_nanos", "current_max", new TimeValue(currentMax))
+                .humanReadableField("current_avg_nanos", "current_avg", new TimeValue(currentAvg))
+                .endObject();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVLong(currentMax);
+            out.writeVLong(currentAvg);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Stats stats = (Stats) o;
+            return currentMax == stats.currentMax && currentAvg == stats.currentAvg;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(currentMax, currentAvg);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/trackers/ElapsedTimeTracker.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/trackers/ElapsedTimeTracker.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.trackers;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.search.backpressure.TaskCancellation;
+import org.opensearch.tasks.Task;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.LongSupplier;
+
+/**
+ * ElapsedTimeTracker evaluates if the task has been running for more time than allowed.
+ */
+public class ElapsedTimeTracker extends ResourceUsageTracker {
+    public static final String NAME = "elapsed_time_tracker";
+
+    private final LongSupplier timeNanosSupplier;
+    private final LongSupplier elapsedTimeNanosThresholdSupplier;
+
+    public ElapsedTimeTracker(LongSupplier timeNanosSupplier, LongSupplier elapsedTimeNanosThresholdSupplier) {
+        this.timeNanosSupplier = timeNanosSupplier;
+        this.elapsedTimeNanosThresholdSupplier = elapsedTimeNanosThresholdSupplier;
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void update(Task task) {
+        // nothing to do
+    }
+
+    @Override
+    public Optional<TaskCancellation.Reason> cancellationReason(Task task) {
+        if (timeNanosSupplier.getAsLong() - task.getStartTimeNanos() < elapsedTimeNanosThresholdSupplier.getAsLong()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new TaskCancellation.Reason(this, "elapsed time exceeded", 1));
+    }
+
+    @Override
+    public ResourceUsageTracker.Stats currentStats(List<Task> activeTasks) {
+        long now = timeNanosSupplier.getAsLong();
+        long currentMax = activeTasks.stream().mapToLong(t -> now - t.getStartTimeNanos()).max().orElse(0);
+        long currentAvg = (long) activeTasks.stream().mapToLong(t -> now - t.getStartTimeNanos()).average().orElse(0);
+        return new Stats(currentMax, currentAvg);
+    }
+
+    /**
+     * Stats for ElapsedTimeTracker as seen in "_node/stats/search_backpressure" API.
+     */
+    public static class Stats implements ResourceUsageTracker.Stats {
+        private final long currentMax;
+        private final long currentAvg;
+
+        public Stats(long currentMax, long currentAvg) {
+            this.currentMax = currentMax;
+            this.currentAvg = currentAvg;
+        }
+
+        public Stats(StreamInput in) throws IOException {
+            this(in.readVLong(), in.readVLong());
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder.startObject()
+                .humanReadableField("current_max_nanos", "current_max", new TimeValue(currentMax))
+                .humanReadableField("current_avg_nanos", "current_avg", new TimeValue(currentAvg))
+                .endObject();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVLong(currentMax);
+            out.writeVLong(currentAvg);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Stats stats = (Stats) o;
+            return currentMax == stats.currentMax && currentAvg == stats.currentAvg;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(currentMax, currentAvg);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/trackers/HeapUsageTracker.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/trackers/HeapUsageTracker.java
@@ -1,0 +1,124 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.trackers;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.unit.ByteSizeValue;
+import org.opensearch.common.util.MovingAverage;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.search.backpressure.TaskCancellation;
+import org.opensearch.tasks.Task;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.DoubleSupplier;
+import java.util.function.LongSupplier;
+
+/**
+ * HeapUsageTracker evaluates if the task has consumed too much heap than allowed.
+ * It also compares the task's heap usage against a historical moving average of previously completed tasks.
+ */
+public class HeapUsageTracker extends ResourceUsageTracker {
+    public static final String NAME = "heap_usage_tracker";
+
+    private final LongSupplier searchTaskHeapThresholdBytesSupplier;
+    private final DoubleSupplier searchTaskHeapVarianceThresholdSupplier;
+    private final MovingAverage movingAverage = new MovingAverage(100);
+
+    public HeapUsageTracker(LongSupplier searchTaskHeapThresholdBytesSupplier, DoubleSupplier searchTaskHeapVarianceThresholdSupplier) {
+        this.searchTaskHeapThresholdBytesSupplier = searchTaskHeapThresholdBytesSupplier;
+        this.searchTaskHeapVarianceThresholdSupplier = searchTaskHeapVarianceThresholdSupplier;
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void update(Task task) {
+        movingAverage.record(task.getTotalResourceStats().getMemoryInBytes());
+    }
+
+    @Override
+    public Optional<TaskCancellation.Reason> cancellationReason(Task task) {
+        // There haven't been enough measurements.
+        if (movingAverage.isReady() == false) {
+            return Optional.empty();
+        }
+
+        double taskHeapUsage = task.getTotalResourceStats().getMemoryInBytes();
+        double averageHeapUsage = movingAverage.getAverage();
+        double allowedHeapUsage = averageHeapUsage * searchTaskHeapVarianceThresholdSupplier.getAsDouble();
+
+        if (taskHeapUsage < searchTaskHeapThresholdBytesSupplier.getAsLong() || taskHeapUsage < allowedHeapUsage) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new TaskCancellation.Reason(this, "heap usage exceeded", (int) (taskHeapUsage / averageHeapUsage)));
+    }
+
+    @Override
+    public ResourceUsageTracker.Stats currentStats(List<Task> activeTasks) {
+        long currentMax = activeTasks.stream().mapToLong(t -> t.getTotalResourceStats().getMemoryInBytes()).max().orElse(0);
+        long currentAvg = (long) activeTasks.stream().mapToLong(t -> t.getTotalResourceStats().getMemoryInBytes()).average().orElse(0);
+        return new Stats(currentMax, currentAvg, (long) movingAverage.getAverage());
+    }
+
+    /**
+     * Stats for HeapUsageTracker as seen in "_node/stats/search_backpressure" API.
+     */
+    public static class Stats implements ResourceUsageTracker.Stats {
+        private final long currentMax;
+        private final long currentAvg;
+        private final long rollingAvg;
+
+        public Stats(long currentMax, long currentAvg, long rollingAvg) {
+            this.currentMax = currentMax;
+            this.currentAvg = currentAvg;
+            this.rollingAvg = rollingAvg;
+        }
+
+        public Stats(StreamInput in) throws IOException {
+            this(in.readVLong(), in.readVLong(), in.readVLong());
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder.startObject()
+                .humanReadableField("current_max_bytes", "current_max", new ByteSizeValue(currentMax))
+                .humanReadableField("current_avg_bytes", "current_avg", new ByteSizeValue(currentAvg))
+                .humanReadableField("rolling_avg_bytes", "rolling_avg", new ByteSizeValue(rollingAvg))
+                .endObject();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVLong(currentMax);
+            out.writeVLong(currentAvg);
+            out.writeVLong(rollingAvg);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Stats stats = (Stats) o;
+            return currentMax == stats.currentMax && currentAvg == stats.currentAvg && rollingAvg == stats.rollingAvg;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(currentMax, currentAvg, rollingAvg);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/trackers/ResourceUsageTracker.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/trackers/ResourceUsageTracker.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.trackers;
+
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.xcontent.ToXContentObject;
+import org.opensearch.search.backpressure.TaskCancellation;
+import org.opensearch.tasks.Task;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * ResourceUsageTracker is used to track completions and cancellations of search related tasks.
+ */
+public abstract class ResourceUsageTracker {
+    /**
+     * Counts the number of cancellations made due to this tracker.
+     */
+    private final AtomicLong cancellations = new AtomicLong();
+
+    public long incrementCancellations() {
+        return cancellations.incrementAndGet();
+    }
+
+    public long getCancellations() {
+        return cancellations.get();
+    }
+
+    /**
+     * Returns a unique name for this tracker.
+     */
+    public abstract String name();
+
+    /**
+     * Notifies the tracker to update its state when a task execution completes.
+     */
+    public abstract void update(Task task);
+
+    /**
+     * Returns the cancellation reason for the given task, if it's eligible for cancellation.
+     */
+    public abstract Optional<TaskCancellation.Reason> cancellationReason(Task task);
+
+    /**
+     * Returns the current state of the tracker as seen in the "_node/stats/search_backpressure" API.
+     */
+    public abstract Stats currentStats(List<Task> activeTasks);
+
+    /**
+     * Interface for the tracker's state as seen in the "_node/stats/search_backpressure" API.
+     */
+    public interface Stats extends ToXContentObject, Writeable {}
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/trackers/package-info.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/trackers/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * This package contains various ResourceUsageTracker implementations which are used to track the completions
+ * and cancellations of search related tasks.
+ */
+package org.opensearch.search.backpressure.trackers;

--- a/server/src/main/java/org/opensearch/tasks/CancellableTask.java
+++ b/server/src/main/java/org/opensearch/tasks/CancellableTask.java
@@ -71,7 +71,7 @@ public abstract class CancellableTask extends Task {
     /**
      * This method is called by the task manager when this task is cancelled.
      */
-    final void cancel(String reason) {
+    public void cancel(String reason) {
         assert reason != null;
         if (cancelled.compareAndSet(false, true)) {
             this.reason = reason;

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -709,6 +709,7 @@ public class NodeStatsTests extends OpenSearchTestCase {
             adaptiveSelectionStats,
             scriptCacheStats,
             null,
+            null,
             null
         );
     }

--- a/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
+++ b/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
@@ -185,6 +185,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -205,6 +206,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -216,6 +218,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 new FsInfo(0, null, node3FSInfo),
+                null,
                 null,
                 null,
                 null,
@@ -276,6 +279,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -296,6 +300,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -307,6 +312,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 new FsInfo(0, null, node3FSInfo),
+                null,
                 null,
                 null,
                 null,

--- a/server/src/test/java/org/opensearch/common/StreakTests.java
+++ b/server/src/test/java/org/opensearch/common/StreakTests.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class StreakTests extends OpenSearchTestCase {
+
+    public void testStreak() {
+        Streak streak = new Streak();
+
+        // Streak starts with zero.
+        assertEquals(0, streak.length());
+
+        // Streak increases on consecutive successful events.
+        streak.record(true);
+        assertEquals(1, streak.length());
+        streak.record(true);
+        assertEquals(2, streak.length());
+        streak.record(true);
+        assertEquals(3, streak.length());
+
+        // Streak resets to zero after an unsuccessful event.
+        streak.record(false);
+        assertEquals(0, streak.length());
+    }
+}

--- a/server/src/test/java/org/opensearch/common/util/MovingAverageTests.java
+++ b/server/src/test/java/org/opensearch/common/util/MovingAverageTests.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.util;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class MovingAverageTests extends OpenSearchTestCase {
+
+    public void testMovingAverage() {
+        MovingAverage ma = new MovingAverage(5);
+
+        // No observations
+        assertEquals(0.0, ma.getAverage(), 0.0);
+        assertEquals(0, ma.getCount());
+
+        // Not enough observations
+        ma.record(1);
+        ma.record(2);
+        ma.record(3);
+        assertEquals(2.0, ma.getAverage(), 0.0);
+        assertEquals(3, ma.getCount());
+        assertFalse(ma.isReady());
+
+        // Enough observations
+        ma.record(4);
+        ma.record(5);
+        ma.record(6);
+        assertEquals(4, ma.getAverage(), 0.0);
+        assertEquals(6, ma.getCount());
+        assertTrue(ma.isReady());
+    }
+
+    public void testMovingAverageWithZeroSize() {
+        try {
+            new MovingAverage(0);
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("window size must be greater than zero"));
+            return;
+        }
+
+        fail("exception should have been thrown");
+    }
+}

--- a/server/src/test/java/org/opensearch/common/util/TokenBucketTests.java
+++ b/server/src/test/java/org/opensearch/common/util/TokenBucketTests.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.util;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+
+public class TokenBucketTests extends OpenSearchTestCase {
+
+    public void testTokenBucket() {
+        AtomicLong mockTimeNanos = new AtomicLong();
+        LongSupplier mockTimeNanosSupplier = mockTimeNanos::get;
+
+        // Token bucket that refills at 2 tokens/second and allows short bursts up to 3 operations.
+        TokenBucket tokenBucket = new TokenBucket(mockTimeNanosSupplier, 2.0 / TimeUnit.SECONDS.toNanos(1), 3);
+
+        // Three operations succeed, fourth fails.
+        assertTrue(tokenBucket.request());
+        assertTrue(tokenBucket.request());
+        assertTrue(tokenBucket.request());
+        assertFalse(tokenBucket.request());
+
+        // Clock moves ahead by one second. Two operations succeed, third fails.
+        mockTimeNanos.addAndGet(TimeUnit.SECONDS.toNanos(1));
+        assertTrue(tokenBucket.request());
+        assertTrue(tokenBucket.request());
+        assertFalse(tokenBucket.request());
+
+        // Clock moves ahead by half a second. One operation succeeds, second fails.
+        mockTimeNanos.addAndGet(TimeUnit.MILLISECONDS.toNanos(500));
+        assertTrue(tokenBucket.request());
+        assertFalse(tokenBucket.request());
+
+        // Clock moves ahead by many seconds, but the token bucket should be capped at the 'burst' capacity.
+        mockTimeNanos.addAndGet(TimeUnit.SECONDS.toNanos(10));
+        assertTrue(tokenBucket.request());
+        assertTrue(tokenBucket.request());
+        assertTrue(tokenBucket.request());
+        assertFalse(tokenBucket.request());
+
+        // Ability to request fractional tokens.
+        mockTimeNanos.addAndGet(TimeUnit.MILLISECONDS.toNanos(250));
+        assertFalse(tokenBucket.request(1.0));
+        assertTrue(tokenBucket.request(0.5));
+    }
+
+    public void testTokenBucketWithInvalidRate() {
+        try {
+            new TokenBucket(System::nanoTime, -1, 2);
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("rate must be greater than zero"));
+            return;
+        }
+
+        fail("exception should have been thrown");
+    }
+
+    public void testTokenBucketWithInvalidBurst() {
+        try {
+            new TokenBucket(System::nanoTime, 1, 0);
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("burst must be greater than zero"));
+            return;
+        }
+
+        fail("exception should have been thrown");
+    }
+}

--- a/server/src/test/java/org/opensearch/search/backpressure/SearchBackpressureManagerTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/SearchBackpressureManagerTests.java
@@ -1,0 +1,305 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure;
+
+import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.search.backpressure.stats.CancellationStats;
+import org.opensearch.search.backpressure.stats.CancelledTaskStats;
+import org.opensearch.search.backpressure.stats.SearchBackpressureStats;
+import org.opensearch.search.backpressure.trackers.CpuUsageTracker;
+import org.opensearch.search.backpressure.trackers.ElapsedTimeTracker;
+import org.opensearch.search.backpressure.trackers.ResourceUsageTracker;
+import org.opensearch.tasks.CancellableTask;
+import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskResourceTrackingService;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.DoubleSupplier;
+import java.util.function.LongSupplier;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.search.backpressure.SearchBackpressureTestHelpers.createMockTaskWithResourceStats;
+
+public class SearchBackpressureManagerTests extends OpenSearchTestCase {
+
+    public void testIsNodeInDuress() {
+        TaskResourceTrackingService mockTaskResourceTrackingService = mock(TaskResourceTrackingService.class);
+        ThreadPool mockThreadPool = mock(ThreadPool.class);
+
+        AtomicReference<Double> cpuUsage = new AtomicReference<>();
+        AtomicReference<Double> heapUsage = new AtomicReference<>();
+        DoubleSupplier cpuUsageSupplier = cpuUsage::get;
+        DoubleSupplier heapUsageSupplier = heapUsage::get;
+
+        SearchBackpressureSettings settings = new SearchBackpressureSettings(
+            Settings.EMPTY,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+
+        SearchBackpressureManager manager = new SearchBackpressureManager(
+            settings,
+            mockTaskResourceTrackingService,
+            mockThreadPool,
+            System::nanoTime,
+            cpuUsageSupplier,
+            heapUsageSupplier,
+            Collections.emptyList()
+        );
+
+        // Node not in duress.
+        cpuUsage.set(0.0);
+        heapUsage.set(0.0);
+        assertFalse(manager.isNodeInDuress());
+
+        // Node in duress; but not for many consecutive data points.
+        cpuUsage.set(1.0);
+        heapUsage.set(1.0);
+        assertFalse(manager.isNodeInDuress());
+
+        // Node in duress for consecutive data points.
+        assertFalse(manager.isNodeInDuress());
+        assertTrue(manager.isNodeInDuress());
+
+        // Node not in duress anymore.
+        cpuUsage.set(0.0);
+        heapUsage.set(0.0);
+        assertFalse(manager.isNodeInDuress());
+    }
+
+    public void testGetTaskCancellations() {
+        TaskResourceTrackingService mockTaskResourceTrackingService = mock(TaskResourceTrackingService.class);
+        ThreadPool mockThreadPool = mock(ThreadPool.class);
+        LongSupplier mockTimeNanosSupplier = () -> TimeUnit.SECONDS.toNanos(1234);
+        long cpuTimeThreshold = 100;
+        long elapsedTimeThreshold = 500;
+
+        doReturn(
+            Map.of(
+                1L,
+                createMockTaskWithResourceStats(SearchShardTask.class, cpuTimeThreshold + 1, 0, mockTimeNanosSupplier.getAsLong()),
+                2L,
+                createMockTaskWithResourceStats(
+                    SearchShardTask.class,
+                    cpuTimeThreshold + 1,
+                    0,
+                    mockTimeNanosSupplier.getAsLong() - elapsedTimeThreshold
+                ),
+                3L,
+                createMockTaskWithResourceStats(SearchShardTask.class, 0, 0, mockTimeNanosSupplier.getAsLong()),
+                4L,
+                createMockTaskWithResourceStats(CancellableTask.class, 100, 200)  // generic task; not eligible for search backpressure
+            )
+        ).when(mockTaskResourceTrackingService).getResourceAwareTasks();
+
+        SearchBackpressureSettings settings = new SearchBackpressureSettings(
+            Settings.EMPTY,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+
+        SearchBackpressureManager manager = new SearchBackpressureManager(
+            settings,
+            mockTaskResourceTrackingService,
+            mockThreadPool,
+            mockTimeNanosSupplier,
+            () -> 0,
+            () -> 0,
+            List.of(new CpuUsageTracker(() -> cpuTimeThreshold), new ElapsedTimeTracker(mockTimeNanosSupplier, () -> elapsedTimeThreshold))
+        );
+
+        // There are three search shard tasks.
+        List<CancellableTask> searchShardTasks = manager.getSearchShardTasks();
+        assertEquals(3, searchShardTasks.size());
+
+        // But only two of them are breaching thresholds.
+        List<TaskCancellation> taskCancellations = manager.getTaskCancellations(searchShardTasks);
+        assertEquals(2, taskCancellations.size());
+
+        // Task cancellations are sorted in reverse order of the score.
+        assertEquals(2, taskCancellations.get(0).getReasons().size());
+        assertEquals(1, taskCancellations.get(1).getReasons().size());
+        assertEquals(2, taskCancellations.get(0).totalCancellationScore());
+        assertEquals(1, taskCancellations.get(1).totalCancellationScore());
+    }
+
+    public void testTrackerStateUpdateOnTaskCompletion() {
+        TaskResourceTrackingService mockTaskResourceTrackingService = mock(TaskResourceTrackingService.class);
+        ThreadPool mockThreadPool = mock(ThreadPool.class);
+        LongSupplier mockTimeNanosSupplier = () -> TimeUnit.SECONDS.toNanos(1234);
+        ResourceUsageTracker mockTracker = mock(ResourceUsageTracker.class);
+
+        SearchBackpressureSettings settings = new SearchBackpressureSettings(
+            Settings.EMPTY,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+
+        SearchBackpressureManager manager = new SearchBackpressureManager(
+            settings,
+            mockTaskResourceTrackingService,
+            mockThreadPool,
+            mockTimeNanosSupplier,
+            () -> 0.5,
+            () -> 0.5,
+            List.of(mockTracker)
+        );
+
+        // Record task completions to update the tracker state. Tasks other than SearchShardTask are ignored.
+        manager.onTaskCompleted(createMockTaskWithResourceStats(CancellableTask.class, 100, 200));
+        for (int i = 0; i < 100; i++) {
+            manager.onTaskCompleted(createMockTaskWithResourceStats(SearchShardTask.class, 100, 200));
+        }
+        assertEquals(100, manager.getCompletionCount());
+        verify(mockTracker, times(100)).update(any());
+    }
+
+    public void testInFlightCancellation() {
+        TaskResourceTrackingService mockTaskResourceTrackingService = mock(TaskResourceTrackingService.class);
+        ThreadPool mockThreadPool = mock(ThreadPool.class);
+        AtomicLong mockTime = new AtomicLong(0);
+        LongSupplier mockTimeNanosSupplier = mockTime::get;
+
+        class MockStats implements ResourceUsageTracker.Stats {
+            @Override
+            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+                return builder.startObject().endObject();
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {}
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                return o != null && getClass() == o.getClass();
+            }
+
+            @Override
+            public int hashCode() {
+                return 0;
+            }
+        }
+
+        ResourceUsageTracker mockTracker = new ResourceUsageTracker() {
+            @Override
+            public String name() {
+                return "mock_tracker";
+            }
+
+            @Override
+            public void update(Task task) {}
+
+            @Override
+            public Optional<TaskCancellation.Reason> cancellationReason(Task task) {
+                if (task.getTotalResourceStats().getCpuTimeInNanos() < 300) {
+                    return Optional.empty();
+                }
+
+                return Optional.of(new TaskCancellation.Reason(this, "limits exceeded", 5));
+            }
+
+            @Override
+            public Stats currentStats(List<Task> activeTasks) {
+                return new MockStats();
+            }
+        };
+
+        SearchBackpressureSettings settings = spy(
+            new SearchBackpressureSettings(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS))
+        );
+
+        // Mocking 'settings' with predictable rate limiting thresholds.
+        when(settings.getCancellationRatio()).thenReturn(0.1);
+        when(settings.getCancellationRate()).thenReturn(0.003);
+        when(settings.getCancellationBurst()).thenReturn(10.0);
+
+        SearchBackpressureManager manager = new SearchBackpressureManager(
+            settings,
+            mockTaskResourceTrackingService,
+            mockThreadPool,
+            mockTimeNanosSupplier,
+            () -> 1.0,  // node in duress
+            () -> 0.0,
+            List.of(mockTracker)
+        );
+
+        manager.run();
+        manager.run();  // allowing node to be marked 'in duress' from the next iteration
+        assertNull(manager.getLastCancelledTaskUsage());
+
+        // Mocking 'settings' with predictable searchHeapThresholdBytes so that cancellation logic doesn't get skipped.
+        long taskHeapUsageBytes = 500;
+        when(settings.getSearchHeapThresholdBytes()).thenReturn(taskHeapUsageBytes);
+
+        // Create a mix of low and high resource usage tasks (60 low + 15 high resource usage tasks).
+        Map<Long, Task> activeTasks = new HashMap<>();
+        for (long i = 0; i < 75; i++) {
+            if (i % 5 == 0) {
+                activeTasks.put(i, createMockTaskWithResourceStats(SearchShardTask.class, 500, taskHeapUsageBytes));
+            } else {
+                activeTasks.put(i, createMockTaskWithResourceStats(SearchShardTask.class, 100, taskHeapUsageBytes));
+            }
+        }
+        doReturn(activeTasks).when(mockTaskResourceTrackingService).getResourceAwareTasks();
+
+        // There are 15 tasks eligible for cancellation but only 10 will be cancelled (burst limit).
+        manager.run();
+        assertEquals(10, manager.getCancellationCount());
+        assertEquals(1, manager.getLimitReachedCount());
+        assertNotNull(manager.getLastCancelledTaskUsage());
+
+        // If the clock or completed task count haven't made sufficient progress, we'll continue to be rate-limited.
+        manager.run();
+        assertEquals(10, manager.getCancellationCount());
+        assertEquals(2, manager.getLimitReachedCount());
+
+        // Simulate task completion to replenish some tokens.
+        // This will add 2 tokens (task count delta * cancellationRatio) to 'rateLimitPerTaskCompletion'.
+        for (int i = 0; i < 20; i++) {
+            manager.onTaskCompleted(createMockTaskWithResourceStats(SearchShardTask.class, 100, taskHeapUsageBytes));
+        }
+        manager.run();
+        assertEquals(12, manager.getCancellationCount());
+        assertEquals(3, manager.getLimitReachedCount());
+
+        // Fast-forward the clock by one second to replenish some tokens.
+        // This will add 3 tokens (time delta * rate) to 'rateLimitPerTime'.
+        mockTime.addAndGet(TimeUnit.SECONDS.toNanos(1));
+        manager.run();
+        assertEquals(15, manager.getCancellationCount());
+        assertEquals(3, manager.getLimitReachedCount());  // no more tasks to cancel; limit not reached
+
+        // Verify search backpressure stats.
+        SearchBackpressureStats expectedStats = new SearchBackpressureStats(
+            Map.of("mock_tracker", new MockStats()),
+            new CancellationStats(15, Map.of("mock_tracker", 15L), 3, new CancelledTaskStats(500, taskHeapUsageBytes, 1000000000)),
+            true,
+            true
+        );
+        assertEquals(expectedStats, manager.nodeStats());
+    }
+}

--- a/server/src/test/java/org/opensearch/search/backpressure/TaskCancellationTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/TaskCancellationTests.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure;
+
+import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.search.backpressure.trackers.CpuUsageTracker;
+import org.opensearch.search.backpressure.trackers.ElapsedTimeTracker;
+import org.opensearch.search.backpressure.trackers.HeapUsageTracker;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class TaskCancellationTests extends OpenSearchTestCase {
+
+    public void testTaskCancellation() {
+        SearchShardTask mockTask = new SearchShardTask(123L, "", "", "", null, Collections.emptyMap());
+        CpuUsageTracker mockCpuUsageTracker = new CpuUsageTracker(() -> 0);
+        HeapUsageTracker mockHeapUsageTracker = new HeapUsageTracker(() -> 0, () -> 0.0);
+        ElapsedTimeTracker mockElapsedTimeTracker = new ElapsedTimeTracker(() -> 0, () -> 0);
+
+        List<TaskCancellation.Reason> reasons = new ArrayList<>();
+        TaskCancellation taskCancellation = new TaskCancellation(mockTask, reasons, System::nanoTime);
+
+        // Task does not have any reason to be cancelled.
+        assertEquals(0, taskCancellation.totalCancellationScore());
+        assertFalse(taskCancellation.isEligibleForCancellation());
+
+        // Task has one or more reasons to be cancelled.
+        reasons.add(new TaskCancellation.Reason(mockCpuUsageTracker, "cpu usage exceeded", 10));
+        reasons.add(new TaskCancellation.Reason(mockHeapUsageTracker, "heap usage exceeded", 20));
+        assertEquals(30, taskCancellation.totalCancellationScore());
+        assertTrue(taskCancellation.isEligibleForCancellation());
+
+        // Cancel the task and validate the cancellation reason and cancellation counters.
+        taskCancellation.cancel();
+        assertTrue(mockTask.getReasonCancelled().contains("[cpu usage exceeded, heap usage exceeded]"));
+        assertEquals(1, mockCpuUsageTracker.getCancellations());
+        assertEquals(1, mockHeapUsageTracker.getCancellations());
+        assertEquals(0, mockElapsedTimeTracker.getCancellations());
+    }
+}

--- a/server/src/test/java/org/opensearch/search/backpressure/stats/CancellationStatsTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/stats/CancellationStatsTests.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.stats;
+
+import org.opensearch.common.collect.MapBuilder;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.test.AbstractWireSerializingTestCase;
+
+import java.io.IOException;
+
+public class CancellationStatsTests extends AbstractWireSerializingTestCase<CancellationStats> {
+    @Override
+    protected Writeable.Reader<CancellationStats> instanceReader() {
+        return CancellationStats::new;
+    }
+
+    @Override
+    protected CancellationStats createTestInstance() {
+        return randomInstance();
+    }
+
+    public void testLastCancelledTaskStatsIsNull() throws IOException {
+        CancellationStats expected = new CancellationStats(
+            randomNonNegativeLong(),
+            new MapBuilder<String, Long>().put("foo", randomNonNegativeLong()).put("bar", randomNonNegativeLong()).immutableMap(),
+            randomNonNegativeLong(),
+            null
+        );
+
+        CancellationStats actual = copyInstance(expected);
+        assertEquals(expected, actual);
+    }
+
+    public static CancellationStats randomInstance() {
+        return new CancellationStats(
+            randomNonNegativeLong(),
+            new MapBuilder<String, Long>().put("foo", randomNonNegativeLong()).put("bar", randomNonNegativeLong()).immutableMap(),
+            randomNonNegativeLong(),
+            CancelledTaskStatsTests.randomInstance()
+        );
+    }
+}

--- a/server/src/test/java/org/opensearch/search/backpressure/stats/CancelledTaskStatsTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/stats/CancelledTaskStatsTests.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.stats;
+
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.test.AbstractWireSerializingTestCase;
+
+public class CancelledTaskStatsTests extends AbstractWireSerializingTestCase<CancelledTaskStats> {
+    @Override
+    protected Writeable.Reader<CancelledTaskStats> instanceReader() {
+        return CancelledTaskStats::new;
+    }
+
+    @Override
+    protected CancelledTaskStats createTestInstance() {
+        return randomInstance();
+    }
+
+    public static CancelledTaskStats randomInstance() {
+        return new CancelledTaskStats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong());
+    }
+}

--- a/server/src/test/java/org/opensearch/search/backpressure/stats/SearchBackpressureStatsTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/stats/SearchBackpressureStatsTests.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.stats;
+
+import org.opensearch.common.collect.MapBuilder;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.search.backpressure.trackers.CpuUsageTracker;
+import org.opensearch.search.backpressure.trackers.ElapsedTimeTracker;
+import org.opensearch.search.backpressure.trackers.HeapUsageTracker;
+import org.opensearch.search.backpressure.trackers.ResourceUsageTracker;
+import org.opensearch.test.AbstractWireSerializingTestCase;
+
+public class SearchBackpressureStatsTests extends AbstractWireSerializingTestCase<SearchBackpressureStats> {
+    @Override
+    protected Writeable.Reader<SearchBackpressureStats> instanceReader() {
+        return SearchBackpressureStats::new;
+    }
+
+    @Override
+    protected SearchBackpressureStats createTestInstance() {
+        return new SearchBackpressureStats(
+            new MapBuilder<String, ResourceUsageTracker.Stats>().put(
+                CpuUsageTracker.NAME,
+                new CpuUsageTracker.Stats(randomNonNegativeLong(), randomNonNegativeLong())
+            )
+                .put(
+                    HeapUsageTracker.NAME,
+                    new HeapUsageTracker.Stats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong())
+                )
+                .put(ElapsedTimeTracker.NAME, new ElapsedTimeTracker.Stats(randomNonNegativeLong(), randomNonNegativeLong()))
+                .immutableMap(),
+            CancellationStatsTests.randomInstance(),
+            randomBoolean(),
+            randomBoolean()
+        );
+    }
+}

--- a/server/src/test/java/org/opensearch/search/backpressure/trackers/CpuUsageTrackerTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/trackers/CpuUsageTrackerTests.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.trackers;
+
+import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.search.backpressure.TaskCancellation;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Optional;
+
+import static org.opensearch.search.backpressure.SearchBackpressureTestHelpers.createMockTaskWithResourceStats;
+
+public class CpuUsageTrackerTests extends OpenSearchTestCase {
+
+    public void testEligibleForCancellation() {
+        Task task = createMockTaskWithResourceStats(SearchShardTask.class, 200, 200);
+        CpuUsageTracker tracker = new CpuUsageTracker(() -> 100);
+
+        Optional<TaskCancellation.Reason> reason = tracker.cancellationReason(task);
+        assertTrue(reason.isPresent());
+        assertSame(tracker, reason.get().getTracker());
+        assertEquals(1, reason.get().getCancellationScore());
+        assertEquals("cpu usage exceeded", reason.get().getMessage());
+    }
+
+    public void testNotEligibleForCancellation() {
+        Task task = createMockTaskWithResourceStats(SearchShardTask.class, 50, 200);
+        CpuUsageTracker tracker = new CpuUsageTracker(() -> 100);
+
+        Optional<TaskCancellation.Reason> reason = tracker.cancellationReason(task);
+        assertFalse(reason.isPresent());
+    }
+}

--- a/server/src/test/java/org/opensearch/search/backpressure/trackers/ElapsedTimeTrackerTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/trackers/ElapsedTimeTrackerTests.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.trackers;
+
+import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.search.backpressure.TaskCancellation;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Optional;
+
+import static org.opensearch.search.backpressure.SearchBackpressureTestHelpers.createMockTaskWithResourceStats;
+
+public class ElapsedTimeTrackerTests extends OpenSearchTestCase {
+
+    public void testEligibleForCancellation() {
+        Task task = createMockTaskWithResourceStats(SearchShardTask.class, 1, 1, 100);
+        ElapsedTimeTracker tracker = new ElapsedTimeTracker(() -> 200, () -> 50);
+
+        Optional<TaskCancellation.Reason> reason = tracker.cancellationReason(task);
+        assertTrue(reason.isPresent());
+        assertSame(tracker, reason.get().getTracker());
+        assertEquals(1, reason.get().getCancellationScore());
+        assertEquals("elapsed time exceeded", reason.get().getMessage());
+    }
+
+    public void testNotEligibleForCancellation() {
+        Task task = createMockTaskWithResourceStats(SearchShardTask.class, 1, 1, 100);
+        ElapsedTimeTracker tracker = new ElapsedTimeTracker(() -> 200, () -> 200);
+
+        Optional<TaskCancellation.Reason> reason = tracker.cancellationReason(task);
+        assertFalse(reason.isPresent());
+    }
+}

--- a/server/src/test/java/org/opensearch/search/backpressure/trackers/HeapUsageTrackerTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/trackers/HeapUsageTrackerTests.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.trackers;
+
+import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.search.backpressure.TaskCancellation;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Optional;
+
+import static org.opensearch.search.backpressure.SearchBackpressureTestHelpers.createMockTaskWithResourceStats;
+
+public class HeapUsageTrackerTests extends OpenSearchTestCase {
+
+    public void testEligibleForCancellation() {
+        HeapUsageTracker tracker = new HeapUsageTracker(() -> 100L, () -> 2.0);
+        Task task = createMockTaskWithResourceStats(SearchShardTask.class, 1, 50);
+
+        // Record enough observations to make the moving average 'ready'.
+        for (int i = 0; i < 100; i++) {
+            tracker.update(task);
+        }
+
+        // Task that has heap usage >= searchTaskHeapThresholdBytes and (moving average * variance).
+        task = createMockTaskWithResourceStats(SearchShardTask.class, 1, 200);
+        Optional<TaskCancellation.Reason> reason = tracker.cancellationReason(task);
+        assertTrue(reason.isPresent());
+        assertSame(tracker, reason.get().getTracker());
+        assertEquals(4, reason.get().getCancellationScore());
+        assertEquals("heap usage exceeded", reason.get().getMessage());
+    }
+
+    public void testNotEligibleForCancellation() {
+        Task task;
+        Optional<TaskCancellation.Reason> reason;
+        HeapUsageTracker tracker = new HeapUsageTracker(() -> 100L, () -> 2.0);
+
+        // Task with heap usage < searchTaskHeapThresholdBytes.
+        task = createMockTaskWithResourceStats(SearchShardTask.class, 1, 99);
+
+        // Not enough observations.
+        reason = tracker.cancellationReason(task);
+        assertFalse(reason.isPresent());
+
+        // Record enough observations to make the moving average 'ready'.
+        for (int i = 0; i < 100; i++) {
+            tracker.update(task);
+        }
+
+        // Task with heap usage < searchTaskHeapThresholdBytes should not be cancelled.
+        reason = tracker.cancellationReason(task);
+        assertFalse(reason.isPresent());
+
+        // Task with heap usage between [searchTaskHeapThresholdBytes, moving average * variance) should not be cancelled.
+        double allowedHeapUsage = 99.0 * 2.0;
+        task = createMockTaskWithResourceStats(SearchShardTask.class, 1, randomLongBetween(99, (long) allowedHeapUsage - 1));
+        reason = tracker.cancellationReason(task);
+        assertFalse(reason.isPresent());
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/cluster/MockInternalClusterInfoService.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/MockInternalClusterInfoService.java
@@ -114,7 +114,8 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
                 nodeStats.getAdaptiveSelectionStats(),
                 nodeStats.getScriptCacheStats(),
                 nodeStats.getIndexingPressureStats(),
-                nodeStats.getShardIndexingPressureStats()
+                nodeStats.getShardIndexingPressureStats(),
+                nodeStats.getSearchBackpressureStats()
             );
         }).collect(Collectors.toList());
     }

--- a/test/framework/src/main/java/org/opensearch/search/backpressure/SearchBackpressureTestHelpers.java
+++ b/test/framework/src/main/java/org/opensearch/search/backpressure/SearchBackpressureTestHelpers.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure;
+
+import org.opensearch.tasks.CancellableTask;
+import org.opensearch.tasks.TaskResourceUsage;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SearchBackpressureTestHelpers extends OpenSearchTestCase {
+
+    public static <T extends CancellableTask> T createMockTaskWithResourceStats(Class<T> type, long cpuUsage, long heapUsage) {
+        return createMockTaskWithResourceStats(type, cpuUsage, heapUsage, 0);
+    }
+
+    public static <T extends CancellableTask> T createMockTaskWithResourceStats(
+        Class<T> type,
+        long cpuUsage,
+        long heapUsage,
+        long startTimeNanos
+    ) {
+        T task = mock(type);
+        when(task.getTotalResourceStats()).thenReturn(new TaskResourceUsage(cpuUsage, heapUsage));
+        when(task.getStartTimeNanos()).thenReturn(startTimeNanos);
+
+        AtomicBoolean isCancelled = new AtomicBoolean(false);
+        doAnswer(invocation -> {
+            isCancelled.set(true);
+            return null;
+        }).when(task).cancel(anyString());
+        doAnswer(invocation -> isCancelled.get()).when(task).isCancelled();
+
+        return task;
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
@@ -2586,6 +2586,7 @@ public final class InternalTestCluster extends TestCluster {
                     false,
                     false,
                     false,
+                    false,
                     false
                 );
                 assertThat(


### PR DESCRIPTION
### Description
This feature aims to identify and cancel resource intensive SearchShardTasks if they have breached certain thresholds. This will help in terminating problematic queries which can put nodes in duress and degrade the cluster performance.

### Issues Resolved
#1181 

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Ketan Verma <ketan9495@gmail.com>