### PR TITLE
Remove deprecated code to add node name into log pattern of log4j property file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 
 ### Removed
+- Remove deprecated code to add node name into log pattern of log4j property file ([#4568](https://github.com/opensearch-project/OpenSearch/pull/4568))
 
 ### Fixed
 - `opensearch-service.bat start` and `opensearch-service.bat manager` failing to run ([#4289](https://github.com/opensearch-project/OpenSearch/pull/4289))

--- a/qa/evil-tests/src/test/java/org/opensearch/common/logging/EvilLoggerTests.java
+++ b/qa/evil-tests/src/test/java/org/opensearch/common/logging/EvilLoggerTests.java
@@ -285,29 +285,6 @@ public class EvilLoggerTests extends OpenSearchTestCase {
         assertThat(System.getProperty("opensearch.logs.node_name"), equalTo(Node.NODE_NAME_SETTING.get(settings)));
     }
 
-    public void testNoNodeNameInPatternWarning() throws IOException, UserException {
-        String nodeName = randomAlphaOfLength(16);
-        LogConfigurator.setNodeName(nodeName);
-        setupLogging("no_node_name");
-        final String path =
-            System.getProperty("opensearch.logs.base_path") +
-                System.getProperty("file.separator") +
-                System.getProperty("opensearch.logs.cluster_name") + ".log";
-        final List<String> events = Files.readAllLines(PathUtils.get(path));
-        assertThat(events.size(), equalTo(2));
-        final String location = "org.opensearch.common.logging.LogConfigurator";
-        // the first message is a warning for unsupported configuration files
-        assertLogLine(events.get(0), Level.WARN, location, "\\[" + nodeName + "\\] Some logging configurations have "
-                + "%marker but don't have %node_name. We will automatically add %node_name to the pattern to ease the "
-                + "migration for users who customize log4j2.properties but will stop this behavior in 7.0. You should "
-                + "manually replace `%node_name` with `\\[%node_name\\]%marker ` in these locations:");
-        if (Constants.WINDOWS) {
-            assertThat(events.get(1), endsWith("no_node_name\\log4j2.properties"));
-        } else {
-            assertThat(events.get(1), endsWith("no_node_name/log4j2.properties"));
-        }
-    }
-
     private void setupLogging(final String config) throws IOException, UserException {
         setupLogging(config, Settings.EMPTY);
     }

--- a/server/src/main/java/org/opensearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/opensearch/common/logging/LogConfigurator.java
@@ -36,8 +36,6 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.AbstractConfiguration;
-import org.apache.logging.log4j.core.config.ConfigurationException;
-import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
@@ -45,7 +43,6 @@ import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.logging.log4j.core.config.composite.CompositeConfiguration;
 import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
 import org.apache.logging.log4j.core.config.properties.PropertiesConfiguration;
-import org.apache.logging.log4j.core.config.properties.PropertiesConfigurationBuilder;
 import org.apache.logging.log4j.core.config.properties.PropertiesConfigurationFactory;
 import org.apache.logging.log4j.status.StatusConsoleListener;
 import org.apache.logging.log4j.status.StatusData;
@@ -60,7 +57,6 @@ import org.opensearch.env.Environment;
 import org.opensearch.node.Node;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitOption;
@@ -75,7 +71,6 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.StreamSupport;
@@ -189,50 +184,7 @@ public class LogConfigurator {
 
         final Set<String> locationsWithDeprecatedPatterns = Collections.synchronizedSet(new HashSet<>());
         final List<AbstractConfiguration> configurations = new ArrayList<>();
-        /*
-         * Subclass the properties configurator to hack the new pattern in
-         * place so users don't have to change log4j2.properties in
-         * a minor release. In 7.0 we'll remove this and force users to
-         * change log4j2.properties. If they don't customize log4j2.properties
-         * then they won't have to do anything anyway.
-         *
-         * Everything in this subclass that isn't marked as a hack is copied
-         * from log4j2's source.
-         */
-        final PropertiesConfigurationFactory factory = new PropertiesConfigurationFactory() {
-            @Override
-            public PropertiesConfiguration getConfiguration(final LoggerContext loggerContext, final ConfigurationSource source) {
-                final Properties properties = new Properties();
-                try (InputStream configStream = source.getInputStream()) {
-                    properties.load(configStream);
-                } catch (final IOException ioe) {
-                    throw new ConfigurationException("Unable to load " + source.toString(), ioe);
-                }
-                // Hack the new pattern into place
-                for (String name : properties.stringPropertyNames()) {
-                    if (false == name.endsWith(".pattern")) continue;
-                    // Null is weird here but we can't do anything with it so ignore it
-                    String value = properties.getProperty(name);
-                    if (value == null) continue;
-                    // Tests don't need to be changed
-                    if (value.contains("%test_thread_info")) continue;
-                    /*
-                     * Patterns without a marker are sufficiently customized
-                     * that we don't have an opinion about them.
-                     */
-                    if (false == value.contains("%marker")) continue;
-                    if (false == value.contains("%node_name")) {
-                        locationsWithDeprecatedPatterns.add(source.getLocation());
-                        properties.setProperty(name, value.replace("%marker", "[%node_name]%marker "));
-                    }
-                }
-                // end hack
-                return new PropertiesConfigurationBuilder().setConfigurationSource(source)
-                    .setRootProperties(properties)
-                    .setLoggerContext(loggerContext)
-                    .build();
-            }
-        };
+        final PropertiesConfigurationFactory factory = new PropertiesConfigurationFactory();
         final Set<FileVisitOption> options = EnumSet.of(FileVisitOption.FOLLOW_LINKS);
         Files.walkFileTree(configsPath, options, Integer.MAX_VALUE, new SimpleFileVisitor<Path>() {
             @Override
@@ -251,18 +203,6 @@ public class LogConfigurator {
         context.start(new CompositeConfiguration(configurations));
 
         configureLoggerLevels(settings);
-
-        final String deprecatedLocationsString = String.join("\n  ", locationsWithDeprecatedPatterns);
-        if (deprecatedLocationsString.length() > 0) {
-            LogManager.getLogger(LogConfigurator.class)
-                .warn(
-                    "Some logging configurations have %marker but don't have %node_name. "
-                        + "We will automatically add %node_name to the pattern to ease the migration for users who customize "
-                        + "log4j2.properties but will stop this behavior in 7.0. You should manually replace `%node_name` with "
-                        + "`[%node_name]%marker ` in these locations:\n  {}",
-                    deprecatedLocationsString
-                );
-        }
 
         // Redirect stdout/stderr to log4j. While we ensure Elasticsearch code does not write to those streams,
         // third party libraries may do that


### PR DESCRIPTION
### Description
The part of code is introduced by https://github.com/elastic/elasticsearch/commit/22459576d757833d9dfbca59cb44b09fc8bd77b1.
The main purpose of the commit is to make the node name available to all loggers all the time, aims make the way of getting logger unified and simple.

The code that removed in this PR used for helping users migrate to the new usage of getting node name in log, by scanning the specific pattern setting in log4j.properties files and add the node name into the pattern.

I think the part of code can be removed safely in next major version, because:
1 there is already a warning message shown to the user:
https://github.com/opensearch-project/OpenSearch/blob/2c27dfddbdabbf064317bd315a5464ba5f41c1da/server/src/main/java/org/opensearch/common/logging/LogConfigurator.java#L257-L262
(This link contains a actual example of the warning message: https://forum.search-guard.com/t/no-known-master-node/1460)
2 it has been declared as a breaking change in document: https://www.elastic.co/guide/en/elasticsearch/reference/6.5/breaking-changes-6.5.html#breaking_65_logging_changes or https://github.com/elastic/elasticsearch/blob/v6.5.0/docs/reference/migration/migrate_6_5.asciidoc#logging-changes
> To make the node name appear consistently in Elasticsearch’s logs and to clean up much of the internal logging code we’ve removed the node name from the "marker" in the logging configuration. If you do not customize your logging configuration file then there is nothing for you to do. If you do customize your logging configuration properties then you should replace %marker with `[%node_name]%marker `, including the trailing space. If you do not do so Elasticsearch will log a warning on startup and log with the new pattern. It will not change the logging configuration files though. You should make this change before 7.0 because in 7.0 Elasticsearch will no longer automatically add the node name to the logging configuration if it isn’t already present.

In addition, I created a following PR https://github.com/opensearch-project/OpenSearch/pull/4569 to change the version number to `3.0` from `7.0` that shown in the warning message.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/4274

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
