### PR TITLE
[2.x] Change the version to remove deprecated code of adding node name into log pattern of log4j property file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Use RemoteSegmentStoreDirectory instead of RemoteDirectory ([#4240](https://github.com/opensearch-project/OpenSearch/pull/4240))
 - Add index specific setting for remote repository ([#4253](https://github.com/opensearch-project/OpenSearch/pull/4253))
 - [Segment Replication] Update replicas to commit SegmentInfos instead of relying on SIS files from primary shards. ([#4402](https://github.com/opensearch-project/OpenSearch/pull/4402))
+- Change the version to remove deprecated code of adding node name into log pattern of log4j property file ([#4569](https://github.com/opensearch-project/OpenSearch/pull/4569))
 
 ### Deprecated
 

--- a/qa/evil-tests/src/test/java/org/opensearch/common/logging/EvilLoggerTests.java
+++ b/qa/evil-tests/src/test/java/org/opensearch/common/logging/EvilLoggerTests.java
@@ -299,7 +299,7 @@ public class EvilLoggerTests extends OpenSearchTestCase {
         // the first message is a warning for unsupported configuration files
         assertLogLine(events.get(0), Level.WARN, location, "\\[" + nodeName + "\\] Some logging configurations have "
                 + "%marker but don't have %node_name. We will automatically add %node_name to the pattern to ease the "
-                + "migration for users who customize log4j2.properties but will stop this behavior in 7.0. You should "
+                + "migration for users who customize log4j2.properties but will stop this behavior in 3.0. You should "
                 + "manually replace `%node_name` with `\\[%node_name\\]%marker ` in these locations:");
         if (Constants.WINDOWS) {
             assertThat(events.get(1), endsWith("no_node_name\\log4j2.properties"));

--- a/server/src/main/java/org/opensearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/opensearch/common/logging/LogConfigurator.java
@@ -258,7 +258,7 @@ public class LogConfigurator {
                 .warn(
                     "Some logging configurations have %marker but don't have %node_name. "
                         + "We will automatically add %node_name to the pattern to ease the migration for users who customize "
-                        + "log4j2.properties but will stop this behavior in 7.0. You should manually replace `%node_name` with "
+                        + "log4j2.properties but will stop this behavior in 3.0. You should manually replace `%node_name` with "
                         + "`[%node_name]%marker ` in these locations:\n  {}",
                     deprecatedLocationsString
                 );


### PR DESCRIPTION
### Description
A following PR of https://github.com/opensearch-project/OpenSearch/pull/4568, please see detailed description there.

The part of code is introduced by https://github.com/elastic/elasticsearch/commit/22459576d757833d9dfbca59cb44b09fc8bd77b1.
The main purpose of the commit is to make the node name available to all loggers all the time, aims make the way of getting logger unified and simple.

There is temporary code added to help users migrate to the new usage of getting node name in log, by scanning the specific pattern setting in log4j.properties files and add the node name into the pattern. A warning message is also added to notify the removal of the temporary code.

- Change the version number to `3.0` from `7.0` that shown in the warning message.

### Issues Resolved
Related to https://github.com/opensearch-project/OpenSearch/issues/4274

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
