### PR TITLE
[Feature/extensions] Fixed javadoc warning for build failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - Handle named wildcards (REST path parameters) ([#4415](https://github.com/opensearch-project/OpenSearch/pull/4415))
  - Adding ActionListener onFailure to ExtensionsOrchestrator ([#61](https://github.com/opensearch-project/opensearch-sdk/issues/61))
  - Add getSettings support for AD([#4519](https://github.com/opensearch-project/OpenSearch/pull/4519))
+ - Fixed javadoc warning for build failure([#4581](https://github.com/opensearch-project/OpenSearch/pull/4581))
 
 ## [2.x]
 ### Added

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsOrchestrator.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsOrchestrator.java
@@ -150,7 +150,7 @@ public class ExtensionsOrchestrator implements ReportingService<PluginsAndModule
      * Lists/maps of extensions have already been initialized but not yet populated.
      *
      * @param restController  The RestController on which to register Rest Actions.
-     * @param settingsModule
+     * @param settingsModule The module that binds the provided settings to interface
      * @param transportService  The Node's transport service.
      * @param clusterService  The Node's cluster service.
      */


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Fixed javadoc warning for build failure

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
