### PR TITLE
Fix invalid search location of JDK for arm64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,13 +72,14 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Segment Replication] Update flaky testOnNewCheckpointFromNewPrimaryCancelOngoingReplication unit test ([#4414](https://github.com/opensearch-project/OpenSearch/pull/4414))
 - Fixed the `_cat/shards/10_basic.yml` test cases fix.
 - [Segment Replication] Fix timeout issue by calculating time needed to process getSegmentFiles ([#4426](https://github.com/opensearch-project/OpenSearch/pull/4426))
-- [Bug]: gradle check failing with java heap OutOfMemoryError (([#4328](https://github.com/opensearch-project/OpenSearch/
+- [Bug]: gradle check failing with java heap OutOfMemoryError ([#4328](https://github.com/opensearch-project/OpenSearch/))
 - `opensearch.bat` fails to execute when install path includes spaces ([#4362](https://github.com/opensearch-project/OpenSearch/pull/4362))
 - Getting security exception due to access denied 'java.lang.RuntimePermission' 'accessDeclaredMembers' when trying to get snapshot with S3 IRSA ([#4469](https://github.com/opensearch-project/OpenSearch/pull/4469))
 - Fixed flaky test `ResourceAwareTasksTests.testTaskIdPersistsInThreadContext` ([#4484](https://github.com/opensearch-project/OpenSearch/pull/4484))
 - Fixed the ignore_malformed setting to also ignore objects ([#4494](https://github.com/opensearch-project/OpenSearch/pull/4494))
 - [Segment Replication] Ignore lock file when testing cleanupAndPreserveLatestCommitPoint ([#4544](https://github.com/opensearch-project/OpenSearch/pull/4544))
 - Updated jackson to 2.13.4 and snakeyml to 1.32 ([#4556](https://github.com/opensearch-project/OpenSearch/pull/4556))
+- [Bug]: Fixed invalid location of JDK dependency for arm64 architecture([#4613](https://github.com/opensearch-project/OpenSearch/pull/4613))
 
 ### Security
 - CVE-2022-25857 org.yaml:snakeyaml DOS vulnerability ([#4341](https://github.com/opensearch-project/OpenSearch/pull/4341))

--- a/buildSrc/src/main/java/org/opensearch/gradle/Jdk.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/Jdk.java
@@ -128,7 +128,7 @@ public class Jdk implements Buildable, Iterable<File> {
                 "unknown architecture [" + jdkArchitecture + "] for jdk [" + name + "], must be one of " + ALLOWED_ARCHITECTURES
             );
         }
-        this.architecture.set(architecture);
+        this.architecture.set(jdkArchitecture);
     }
 
     public String getBaseVersion() {


### PR DESCRIPTION
Related commit: 0e9f74e35f1255cb9ec45be3d8960aad195a9f6e

Signed-off-by: Heemin Kim <heemin@amazon.com>

### Description
JDK dependency location is invalid for arm64 architecture. This commit sets correct location for JDK dependency for arm64 architecture.

```
Execution failed for task ':test:logger-usage:test'.
> Error while evaluating property 'javaVersion' of task ':test:logger-usage:test'
   > Could not resolve all files for configuration ':jdk_provisioned_runtime'.
      > Failed to transform mac-17.0.4-arm64.tar.gz (adoptium_17:mac:17.0.4) to match attributes {artifactType=directory, jdk=true, org.gradle.status=integration}.
         > Could not find mac-17.0.4-arm64.tar.gz (adoptium_17:mac:17.0.4).
           Searched in the following locations:
               https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4+8/OpenJDK17U-jdk_arm64_mac_hotspot_17.0.4_8.tar.gz
```

### Issues Resolved
None

### Check List
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
