### PR TITLE
Add missing Javadoc tag descriptions in unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add BWC version 2.3.1 ([#4513](https://github.com/opensearch-project/OpenSearch/pull/4513))
 - [Segment Replication] Add snapshot and restore tests for segment replication feature ([#3993](https://github.com/opensearch-project/OpenSearch/pull/3993))
 - Added missing javadocs for `:example-plugins` modules ([#4540](https://github.com/opensearch-project/OpenSearch/pull/4540))
+- Add missing Javadoc tag descriptions in unit tests ([#dummy](https://github.com/opensearch-project/OpenSearch/pull/dummy))
 ### Dependencies
 - Bumps `log4j-core` from 2.18.0 to 2.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add BWC version 2.3.1 ([#4513](https://github.com/opensearch-project/OpenSearch/pull/4513))
 - [Segment Replication] Add snapshot and restore tests for segment replication feature ([#3993](https://github.com/opensearch-project/OpenSearch/pull/3993))
 - Added missing javadocs for `:example-plugins` modules ([#4540](https://github.com/opensearch-project/OpenSearch/pull/4540))
-- Add missing Javadoc tag descriptions in unit tests ([#dummy](https://github.com/opensearch-project/OpenSearch/pull/dummy))
+- Add missing Javadoc tag descriptions in unit tests ([#4629](https://github.com/opensearch-project/OpenSearch/pull/4629))
 ### Dependencies
 - Bumps `log4j-core` from 2.18.0 to 2.19.0
 

--- a/modules/geo/src/test/java/org/opensearch/geo/search/aggregations/metrics/GeoBoundsGeoShapeAggregatorTests.java
+++ b/modules/geo/src/test/java/org/opensearch/geo/search/aggregations/metrics/GeoBoundsGeoShapeAggregatorTests.java
@@ -68,7 +68,7 @@ public class GeoBoundsGeoShapeAggregatorTests extends AggregatorTestCase {
     /**
      * Testing Empty aggregator results.
      *
-     * @throws Exception
+     * @throws Exception if an error occurs accessing the index
      */
     public void testEmpty() throws Exception {
         try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
@@ -93,7 +93,7 @@ public class GeoBoundsGeoShapeAggregatorTests extends AggregatorTestCase {
     /**
      * Testing GeoBoundAggregator for random shapes which are indexed.
      *
-     * @throws Exception
+     * @throws Exception if an error occurs accessing the index
      */
     public void testRandom() throws Exception {
         final int numDocs = randomIntBetween(50, 100);

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetTests.java
@@ -381,7 +381,7 @@ public class SegmentReplicationTargetTests extends IndexShardTestCase {
 
     /**
      * This tests ensures that new files generated on primary (due to delete operation) are not considered missing on replica
-     * @throws IOException
+     * @throws IOException if an indexing operation fails or segment replication fails
      */
     public void test_MissingFiles_NotCausingFailure() throws IOException {
         int docCount = 1 + random().nextInt(10);
@@ -435,9 +435,9 @@ public class SegmentReplicationTargetTests extends IndexShardTestCase {
     /**
      * Generates a list of Store.MetadataSnapshot with two elements where second snapshot has extra files due to delete
      * operation. A list of snapshots is returned so that identical files have same checksum.
-     * @param docCount
-     * @return
-     * @throws IOException
+     * @param docCount the number of documents to index in the first snapshot
+     * @return a list of Store.MetadataSnapshot with two elements where second snapshot has extra files due to delete
+     * @throws IOException if one of the indexing operations fails
      */
     private List<Store.MetadataSnapshot> generateStoreMetadataSnapshot(int docCount) throws IOException {
         List<Document> docList = new ArrayList<>();


### PR DESCRIPTION
Using JDK14 (downloaded from https://jdk.java.net/archive/), I tried running ./gradlew check, and received errors like:

server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetTests.java:440: warning: no description for @throws

The build then failed with "warnings found and -Werror specified".

I tried again with JDK17 and the build passed.

According to DEVELOPER_GUIDE.md, we should be able to build with JDK14, I added the missing Javadoc tag descriptions.

Signed-off-by: Michael Froh <froh@amazon.com>

### Description
Fixes unit test compilation with JDK14.

### Issues Resolved
None

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
