### PR TITLE
[Feature/extensions] Pass REST params and content to extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - Adding create component extension point support for AD ([#4517](https://github.com/opensearch-project/OpenSearch/pull/4517))
  - Add getSettings support for AD([#4519](https://github.com/opensearch-project/OpenSearch/pull/4519))
  - Fixed javadoc warning for build failure([#4581](https://github.com/opensearch-project/OpenSearch/pull/4581))
+ - Pass REST params to extensions ([#4633](https://github.com/opensearch-project/OpenSearch/pull/4633))
 
 ## [2.x]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - Adding create component extension point support for AD ([#4517](https://github.com/opensearch-project/OpenSearch/pull/4517))
  - Add getSettings support for AD([#4519](https://github.com/opensearch-project/OpenSearch/pull/4519))
  - Fixed javadoc warning for build failure([#4581](https://github.com/opensearch-project/OpenSearch/pull/4581))
- - Pass REST params to extensions ([#4633](https://github.com/opensearch-project/OpenSearch/pull/4633))
+ - Pass REST params and content to extensions ([#4633](https://github.com/opensearch-project/OpenSearch/pull/4633))
 
 ## [2.x]
 ### Added

--- a/server/src/main/java/org/opensearch/extensions/rest/ExtensionRestRequest.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/ExtensionRestRequest.java
@@ -16,8 +16,12 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.transport.TransportRequest;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Request to execute REST actions on extension node
@@ -31,6 +35,8 @@ public class ExtensionRestRequest extends TransportRequest {
     private Map<String, String> params;
     // The owner of this request object
     private PrincipalIdentifierToken principalIdentifierToken;
+    // Tracks consumed parameters
+    private final Set<String> consumedParams = new HashSet<>();
 
     /**
      * This object can be instantiated given method, uri, params and identifier
@@ -83,10 +89,43 @@ public class ExtensionRestRequest extends TransportRequest {
     }
 
     /**
+     * Gets the value of a parameter, consuming it in the process.
+     * @param key The parameter key
+     * @return The parameter value if it exists, or null.
+     */
+    public String param(String key) {
+        consumedParams.add(key);
+        return params.get(key);
+    }
+
+    /**
+     * Gets the value of a parameter, consuming it in the process.
+     * @param key The parameter key
+     * @param defaultValue A value to return if the parameter value doesn't exist.
+     * @return The parameter value if it exists, or the default value.
+     */
+    public String param(String key, String defaultValue) {
+        consumedParams.add(key);
+        return params.getOrDefault(key, defaultValue);
+    }
+
+    /**
+     * Gets the full map of params without consuming them.
+     * Rest Handlers should use {@link #param(String)} or {@link #param(String, String)} to get parameter values.
+     *
      * @return This REST request's params
      */
     public Map<String, String> params() {
         return params;
+    }
+
+    /**
+     * Returns parameters consumed by {@link #param(String)} or {@link #param(String, String)}.
+     *
+     * @return a list of consumed parameters.
+     */
+    public List<String> consumedParams() {
+        return new ArrayList<>(consumedParams);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/extensions/rest/ExtensionRestRequest.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/ExtensionRestRequest.java
@@ -22,33 +22,41 @@ import java.util.Objects;
 /**
  * Request to execute REST actions on extension node
  *
- * @opensearch.internal
+ * @opensearch.api
  */
-public class RestExecuteOnExtensionRequest extends TransportRequest {
+public class ExtensionRestRequest extends TransportRequest {
 
     private Method method;
     private String uri;
     private Map<String, String> params;
-    private PrincipalIdentifierToken requestIssuerIdentity;
+    // The owner of this request object
+    private PrincipalIdentifierToken principalIdentifierToken;
 
-    public RestExecuteOnExtensionRequest(
-        Method method,
-        String uri,
-        Map<String, String> params,
-        PrincipalIdentifierToken requesterIdentifier
-    ) {
+    /**
+     * This object can be instantiated given method, uri, params and identifier
+     * @param method of type {@link Method}
+     * @param uri url string
+     * @param params the REST params
+     * @param principalIdentifier the owner of this request
+     */
+    public ExtensionRestRequest(Method method, String uri, Map<String, String> params, PrincipalIdentifierToken principalIdentifier) {
         this.method = method;
         this.uri = uri;
         this.params = params;
-        this.requestIssuerIdentity = requesterIdentifier;
+        this.principalIdentifierToken = principalIdentifier;
     }
 
-    public RestExecuteOnExtensionRequest(StreamInput in) throws IOException {
+    /**
+     * Instantiate this request from input stream
+     * @param in Input stream
+     * @throws IOException on failure to read the stream
+     */
+    public ExtensionRestRequest(StreamInput in) throws IOException {
         super(in);
         method = in.readEnum(RestRequest.Method.class);
         uri = in.readString();
         params = in.readMap(StreamInput::readString, StreamInput::readString);
-        requestIssuerIdentity = in.readNamedWriteable(PrincipalIdentifierToken.class);
+        principalIdentifierToken = in.readNamedWriteable(PrincipalIdentifierToken.class);
     }
 
     @Override
@@ -57,35 +65,47 @@ public class RestExecuteOnExtensionRequest extends TransportRequest {
         out.writeEnum(method);
         out.writeString(uri);
         out.writeMap(params, StreamOutput::writeString, StreamOutput::writeString);
-        out.writeNamedWriteable(requestIssuerIdentity);
+        out.writeNamedWriteable(principalIdentifierToken);
     }
 
-    public Method getMethod() {
+    /**
+     * @return This REST request {@link Method} type
+     */
+    public Method method() {
         return method;
     }
 
-    public String getUri() {
+    /**
+     * @return This REST request's uri
+     */
+    public String uri() {
         return uri;
     }
 
-    public Map<String, String> getParams() {
+    /**
+     * @return This REST request's params
+     */
+    public Map<String, String> params() {
         return params;
     }
 
+    /**
+     * @return This REST request issuer's identity token
+     */
     public PrincipalIdentifierToken getRequestIssuerIdentity() {
-        return requestIssuerIdentity;
+        return principalIdentifierToken;
     }
 
     @Override
     public String toString() {
-        return "RestExecuteOnExtensionRequest{method="
+        return "ExtensionRestRequest{method="
             + method
             + ", uri="
             + uri
             + ", params="
             + params
             + ", requester="
-            + requestIssuerIdentity.getToken()
+            + principalIdentifierToken.getToken()
             + "}";
     }
 
@@ -93,15 +113,15 @@ public class RestExecuteOnExtensionRequest extends TransportRequest {
     public boolean equals(Object obj) {
         if (this == obj) return true;
         if (obj == null || getClass() != obj.getClass()) return false;
-        RestExecuteOnExtensionRequest that = (RestExecuteOnExtensionRequest) obj;
+        ExtensionRestRequest that = (ExtensionRestRequest) obj;
         return Objects.equals(method, that.method)
             && Objects.equals(uri, that.uri)
             && Objects.equals(params, that.params)
-            && Objects.equals(requestIssuerIdentity, that.requestIssuerIdentity);
+            && Objects.equals(principalIdentifierToken, that.principalIdentifierToken);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(method, uri, params, requestIssuerIdentity);
+        return Objects.hash(method, uri, params, principalIdentifierToken);
     }
 }

--- a/server/src/main/java/org/opensearch/extensions/rest/ExtensionRestRequest.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/ExtensionRestRequest.java
@@ -26,14 +26,15 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * Request to execute REST actions on extension node
+ * Request to execute REST actions on extension node.
+ * This contains necessary portions of a {@link RestRequest} object, but does not pass the full request for security concerns.
  *
  * @opensearch.api
  */
 public class ExtensionRestRequest extends TransportRequest {
 
     private Method method;
-    private String uri;
+    private String path;
     private Map<String, String> params;
     private XContentType xContentType = null;
     private BytesReference content;
@@ -48,7 +49,7 @@ public class ExtensionRestRequest extends TransportRequest {
      * This object can be instantiated given method, uri, params, content and identifier
      *
      * @param method of type {@link Method}
-     * @param uri url string
+     * @param path the REST path string (excluding the query)
      * @param params the REST params
      * @param xContentType the content type, or null for plain text or no content
      * @param content the REST request content
@@ -56,14 +57,14 @@ public class ExtensionRestRequest extends TransportRequest {
      */
     public ExtensionRestRequest(
         Method method,
-        String uri,
+        String path,
         Map<String, String> params,
         XContentType xContentType,
         BytesReference content,
         PrincipalIdentifierToken principalIdentifier
     ) {
         this.method = method;
-        this.uri = uri;
+        this.path = path;
         this.params = params;
         this.xContentType = xContentType;
         this.content = content;
@@ -79,7 +80,7 @@ public class ExtensionRestRequest extends TransportRequest {
     public ExtensionRestRequest(StreamInput in) throws IOException {
         super(in);
         method = in.readEnum(RestRequest.Method.class);
-        uri = in.readString();
+        path = in.readString();
         params = in.readMap(StreamInput::readString, StreamInput::readString);
         if (in.readBoolean()) {
             xContentType = in.readEnum(XContentType.class);
@@ -92,7 +93,7 @@ public class ExtensionRestRequest extends TransportRequest {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeEnum(method);
-        out.writeString(uri);
+        out.writeString(path);
         out.writeMap(params, StreamOutput::writeString, StreamOutput::writeString);
         out.writeBoolean(xContentType != null);
         if (xContentType != null) {
@@ -112,12 +113,12 @@ public class ExtensionRestRequest extends TransportRequest {
     }
 
     /**
-     * Gets the REST uri
+     * Gets the REST path
      *
-     * @return This REST request's uri
+     * @return This REST request's path
      */
-    public String uri() {
-        return uri;
+    public String path() {
+        return path;
     }
 
     /**
@@ -239,8 +240,8 @@ public class ExtensionRestRequest extends TransportRequest {
     public String toString() {
         return "ExtensionRestRequest{method="
             + method
-            + ", uri="
-            + uri
+            + ", path="
+            + path
             + ", params="
             + params
             + ", xContentType="
@@ -258,7 +259,7 @@ public class ExtensionRestRequest extends TransportRequest {
         if (obj == null || getClass() != obj.getClass()) return false;
         ExtensionRestRequest that = (ExtensionRestRequest) obj;
         return Objects.equals(method, that.method)
-            && Objects.equals(uri, that.uri)
+            && Objects.equals(path, that.path)
             && Objects.equals(params, that.params)
             && Objects.equals(xContentType, that.xContentType)
             && Objects.equals(content, that.content)
@@ -267,6 +268,6 @@ public class ExtensionRestRequest extends TransportRequest {
 
     @Override
     public int hashCode() {
-        return Objects.hash(method, uri, params, xContentType, content, principalIdentifierToken);
+        return Objects.hash(method, path, params, xContentType, content, principalIdentifierToken);
     }
 }

--- a/server/src/main/java/org/opensearch/extensions/rest/RestSendToExtensionAction.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/RestSendToExtensionAction.java
@@ -105,8 +105,10 @@ public class RestSendToExtensionAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        Method method = request.getHttpRequest().method();
-        String uri = request.getHttpRequest().uri();
+        Method method = request.method();
+        String uri = request.uri();
+        Map<String, String> params = request.params();
+
         if (uri.startsWith(uriPrefix)) {
             uri = uri.substring(uriPrefix.length());
         }
@@ -171,7 +173,7 @@ public class RestSendToExtensionAction extends BaseRestHandler {
                 ExtensionsOrchestrator.REQUEST_REST_EXECUTE_ON_EXTENSION_ACTION,
                 // HERE BE DRAGONS - DO NOT INCLUDE HEADERS
                 // SEE https://github.com/opensearch-project/OpenSearch/issues/4429
-                new RestExecuteOnExtensionRequest(method, uri, requestIssuerIdentity),
+                new RestExecuteOnExtensionRequest(method, uri, params, requestIssuerIdentity),
                 restExecuteOnExtensionResponseHandler
             );
             try {

--- a/server/src/main/java/org/opensearch/extensions/rest/RestSendToExtensionAction.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/RestSendToExtensionAction.java
@@ -173,7 +173,7 @@ public class RestSendToExtensionAction extends BaseRestHandler {
                 ExtensionsOrchestrator.REQUEST_REST_EXECUTE_ON_EXTENSION_ACTION,
                 // HERE BE DRAGONS - DO NOT INCLUDE HEADERS
                 // SEE https://github.com/opensearch-project/OpenSearch/issues/4429
-                new RestExecuteOnExtensionRequest(method, uri, params, requestIssuerIdentity),
+                new ExtensionRestRequest(method, uri, params, requestIssuerIdentity),
                 restExecuteOnExtensionResponseHandler
             );
             try {

--- a/server/src/test/java/org/opensearch/extensions/rest/ExtensionRestRequestTests.java
+++ b/server/src/test/java/org/opensearch/extensions/rest/ExtensionRestRequestTests.java
@@ -24,12 +24,14 @@ import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.List;
 import java.util.Map;
+import static java.util.Map.entry;
 
-public class RestExecuteOnExtensionTests extends OpenSearchTestCase {
+public class ExtensionRestRequestTests extends OpenSearchTestCase {
 
-    public void testRestExecuteOnExtensionRequest() throws Exception {
+    public void testExecuteRestRequest() throws Exception {
         Method expectedMethod = Method.GET;
         String expectedUri = "/test/uri";
+        Map<String, String> expectedParams = Map.ofEntries(entry("foo", "bar"), entry("baz", "qux"));
         String extensionUniqueId1 = "ext_1";
         Principal userPrincipal = () -> "user1";
         ExtensionTokenProcessor extensionTokenProcessor = new ExtensionTokenProcessor(extensionUniqueId1);
@@ -44,14 +46,11 @@ public class RestExecuteOnExtensionTests extends OpenSearchTestCase {
             )
         );
 
-        RestExecuteOnExtensionRequest request = new RestExecuteOnExtensionRequest(
-            expectedMethod,
-            expectedUri,
-            expectedRequestIssuerIdentity
-        );
+        ExtensionRestRequest request = new ExtensionRestRequest(expectedMethod, expectedUri, expectedParams, expectedRequestIssuerIdentity);
 
-        assertEquals(expectedMethod, request.getMethod());
-        assertEquals(expectedUri, request.getUri());
+        assertEquals(expectedMethod, request.method());
+        assertEquals(expectedUri, request.uri());
+        assertEquals(expectedParams, request.params());
         assertEquals(expectedRequestIssuerIdentity, request.getRequestIssuerIdentity());
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {
@@ -59,11 +58,12 @@ public class RestExecuteOnExtensionTests extends OpenSearchTestCase {
             out.flush();
             try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
                 try (NamedWriteableAwareStreamInput nameWritableAwareIn = new NamedWriteableAwareStreamInput(in, registry)) {
-                    request = new RestExecuteOnExtensionRequest(nameWritableAwareIn);
+                    request = new ExtensionRestRequest(nameWritableAwareIn);
                 }
 
-                assertEquals(expectedMethod, request.getMethod());
-                assertEquals(expectedUri, request.getUri());
+                assertEquals(expectedMethod, request.method());
+                assertEquals(expectedUri, request.uri());
+                assertEquals(expectedParams, request.params());
                 assertEquals(expectedRequestIssuerIdentity, request.getRequestIssuerIdentity());
             }
         }

--- a/server/src/test/java/org/opensearch/extensions/rest/ExtensionRestRequestTests.java
+++ b/server/src/test/java/org/opensearch/extensions/rest/ExtensionRestRequestTests.java
@@ -32,7 +32,7 @@ import static java.util.Map.entry;
 public class ExtensionRestRequestTests extends OpenSearchTestCase {
 
     private Method expectedMethod;
-    private String expectedUri;
+    private String expectedPath;
     Map<String, String> expectedParams;
     XContentType expectedContentType;
     BytesReference expectedContent;
@@ -45,7 +45,7 @@ public class ExtensionRestRequestTests extends OpenSearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
         expectedMethod = Method.GET;
-        expectedUri = "/test/uri";
+        expectedPath = "/test/uri";
         expectedParams = Map.ofEntries(entry("foo", "bar"), entry("baz", "42"));
         expectedContentType = XContentType.JSON;
         expectedContent = new BytesArray("content".getBytes(StandardCharsets.UTF_8));
@@ -67,7 +67,7 @@ public class ExtensionRestRequestTests extends OpenSearchTestCase {
     public void testExtensionRestRequest() throws Exception {
         ExtensionRestRequest request = new ExtensionRestRequest(
             expectedMethod,
-            expectedUri,
+            expectedPath,
             expectedParams,
             expectedContentType,
             expectedContent,
@@ -75,7 +75,7 @@ public class ExtensionRestRequestTests extends OpenSearchTestCase {
         );
 
         assertEquals(expectedMethod, request.method());
-        assertEquals(expectedUri, request.uri());
+        assertEquals(expectedPath, request.path());
 
         assertEquals(expectedParams, request.params());
         assertEquals(Collections.emptyList(), request.consumedParams());
@@ -103,7 +103,7 @@ public class ExtensionRestRequestTests extends OpenSearchTestCase {
                 try (NamedWriteableAwareStreamInput nameWritableAwareIn = new NamedWriteableAwareStreamInput(in, registry)) {
                     request = new ExtensionRestRequest(nameWritableAwareIn);
                     assertEquals(expectedMethod, request.method());
-                    assertEquals(expectedUri, request.uri());
+                    assertEquals(expectedPath, request.path());
                     assertEquals(expectedParams, request.params());
                     assertEquals(expectedContent, request.content());
                     assertEquals(expectedRequestIssuerIdentity, request.getRequestIssuerIdentity());
@@ -115,7 +115,7 @@ public class ExtensionRestRequestTests extends OpenSearchTestCase {
     public void testExtensionRestRequestWithNoContent() throws Exception {
         ExtensionRestRequest request = new ExtensionRestRequest(
             expectedMethod,
-            expectedUri,
+            expectedPath,
             expectedParams,
             null,
             new BytesArray(new byte[0]),
@@ -123,7 +123,7 @@ public class ExtensionRestRequestTests extends OpenSearchTestCase {
         );
 
         assertEquals(expectedMethod, request.method());
-        assertEquals(expectedUri, request.uri());
+        assertEquals(expectedPath, request.path());
         assertEquals(expectedParams, request.params());
         assertNull(request.getXContentType());
         assertEquals(0, request.content().length());
@@ -136,7 +136,7 @@ public class ExtensionRestRequestTests extends OpenSearchTestCase {
                 try (NamedWriteableAwareStreamInput nameWritableAwareIn = new NamedWriteableAwareStreamInput(in, registry)) {
                     request = new ExtensionRestRequest(nameWritableAwareIn);
                     assertEquals(expectedMethod, request.method());
-                    assertEquals(expectedUri, request.uri());
+                    assertEquals(expectedPath, request.path());
                     assertEquals(expectedParams, request.params());
                     assertNull(request.getXContentType());
                     assertEquals(0, request.content().length());
@@ -151,7 +151,7 @@ public class ExtensionRestRequestTests extends OpenSearchTestCase {
 
         ExtensionRestRequest request = new ExtensionRestRequest(
             expectedMethod,
-            expectedUri,
+            expectedPath,
             expectedParams,
             null,
             expectedText,
@@ -159,7 +159,7 @@ public class ExtensionRestRequestTests extends OpenSearchTestCase {
         );
 
         assertEquals(expectedMethod, request.method());
-        assertEquals(expectedUri, request.uri());
+        assertEquals(expectedPath, request.path());
         assertEquals(expectedParams, request.params());
         assertNull(request.getXContentType());
         assertEquals(expectedText, request.content());
@@ -172,7 +172,7 @@ public class ExtensionRestRequestTests extends OpenSearchTestCase {
                 try (NamedWriteableAwareStreamInput nameWritableAwareIn = new NamedWriteableAwareStreamInput(in, registry)) {
                     request = new ExtensionRestRequest(nameWritableAwareIn);
                     assertEquals(expectedMethod, request.method());
-                    assertEquals(expectedUri, request.uri());
+                    assertEquals(expectedPath, request.path());
                     assertEquals(expectedParams, request.params());
                     assertNull(request.getXContentType());
                     assertEquals(expectedText, request.content());


### PR DESCRIPTION
Companion PR on SDK: [#163](https://github.com/opensearch-project/opensearch-sdk-java/pull/163)

- This PR will break SDK build due to a class rename, merge these together.
- This PR will also break Extension API due to change in package location for ExtensionRestRequest. AD Extension will need to be updated

### Description

Passes the `params()` from the original `RestRequest` object to extensions.  Internally tracks the consumed params (similar to the `RestRequest` class) when they are consumed with the `param(key)` method (similar to existing plugin usage).

During the process, realized that the `RestExecuteOnExtensionRequest` class (here) completely duplicated the `ExtensionRestHandler` class (in the SDK), so removed the SDK duplicate and renamed the "Execute" class as `ExtensionRestHandler`.

Additionally added xContentType and content as well as getters for the params that will enable AD extension functionality, and handling the consumed content on the response.

### Issues Resolved
Fixes [#111](https://github.com/opensearch-project/opensearch-sdk-java/issues/111)

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
