### PR TITLE
Fixing Gradle warnings associated with publishPluginZipPublicationToXxx tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix flaky DecommissionControllerTests.testTimesOut ([4683](https://github.com/opensearch-project/OpenSearch/pull/4683))
 - Fix new race condition in DecommissionControllerTests ([4688](https://github.com/opensearch-project/OpenSearch/pull/4688))
 - Fix SearchStats (de)serialization (caused by https://github.com/opensearch-project/OpenSearch/pull/4616) ([#4697](https://github.com/opensearch-project/OpenSearch/pull/4697))
+- Fixing Gradle warnings associated with publishPluginZipPublicationToXxx tasks ([#4696](https://github.com/opensearch-project/OpenSearch/pull/4696))
 
 ### Security
 

--- a/buildSrc/src/main/java/org/opensearch/gradle/PublishPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/PublishPlugin.java
@@ -92,7 +92,7 @@ public class PublishPlugin implements Plugin<Project> {
                 return String.format(
                     "%s/distributions/%s-%s.pom",
                     project.getBuildDir(),
-                    getArchivesBaseName(project),
+                    pomTask.getName().toLowerCase().contains("zip") ? project.getName() : getArchivesBaseName(project),
                     project.getVersion()
                 );
             }
@@ -130,7 +130,6 @@ public class PublishPlugin implements Plugin<Project> {
             publication.getPom().withXml(PublishPlugin::addScmInfo);
 
             if (!publication.getName().toLowerCase().contains("zip")) {
-
                 // have to defer this until archivesBaseName is set
                 project.afterEvaluate(p -> publication.setArtifactId(getArchivesBaseName(project)));
 
@@ -139,6 +138,8 @@ public class PublishPlugin implements Plugin<Project> {
                     publication.artifact(project.getTasks().getByName("sourcesJar"));
                     publication.artifact(project.getTasks().getByName("javadocJar"));
                 }
+            } else {
+                project.afterEvaluate(p -> publication.setArtifactId(project.getName()));
             }
 
             generatePomTask.configure(

--- a/buildSrc/src/main/java/org/opensearch/gradle/pluginzip/Publish.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/pluginzip/Publish.java
@@ -13,12 +13,14 @@ import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
 
 import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.gradle.api.Task;
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
 
 public class Publish implements Plugin<Project> {
 
-    // public final static String PLUGIN_ZIP_PUBLISH_POM_TASK = "generatePomFileForPluginZipPublication";
     public final static String PUBLICATION_NAME = "pluginZip";
     public final static String STAGING_REPO = "zipStaging";
     public final static String LOCAL_STAGING_REPO_PATH = "/build/local-staging-repo";
@@ -67,10 +69,15 @@ public class Publish implements Plugin<Project> {
                 if (validatePluginZipPom != null) {
                     validatePluginZipPom.dependsOn("generatePomFileForNebulaPublication");
                 }
-                Task publishPluginZipPublicationToZipStagingRepository = project.getTasks()
-                    .findByName("publishPluginZipPublicationToZipStagingRepository");
-                if (publishPluginZipPublicationToZipStagingRepository != null) {
-                    publishPluginZipPublicationToZipStagingRepository.dependsOn("generatePomFileForNebulaPublication");
+
+                // There are number of tasks prefixed by 'publishPluginZipPublication', f.e.:
+                // publishPluginZipPublicationToZipStagingRepository, publishPluginZipPublicationToMavenLocal
+                final Set<Task> publishPluginZipPublicationToTasks = project.getTasks()
+                    .stream()
+                    .filter(t -> t.getName().startsWith("publishPluginZipPublicationTo"))
+                    .collect(Collectors.toSet());
+                if (!publishPluginZipPublicationToTasks.isEmpty()) {
+                    publishPluginZipPublicationToTasks.forEach(t -> t.dependsOn("generatePomFileForNebulaPublication"));
                 }
             } else {
                 project.getLogger()


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Fixing 

```
> Task :publishPluginZipPublicationToMavenLocal
Execution optimizations have been disabled for task ':publishPluginZipPublicationToMavenLocal' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/home/opensearch-plugin-template-java/build/distributions/rename-unspecified.pom'. Reason: Task ':publishPluginZipPublicationToMavenLocal' uses this output of task ':generatePomFileForNebulaPublication' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

```

And

```
> Task :generatePomFileForPluginZipPublication
Execution optimizations have been disabled for task ':generatePomFileForPluginZipPublication' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/home/opensearch-plugin-template-java/build/distributions/rename-unspecified.pom'. Reason: Task ':publishNebulaPublicationToMavenLocal' uses this output of task ':generatePomFileForPluginZipPublication' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.

```

### Issues Resolved
Related to https://github.com/opensearch-project/opensearch-plugin-template-java/pull/35

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
