### PR TITLE
Always auto release the flood stage block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Remove deprecated code to add node name into log pattern of log4j property file ([#4568](https://github.com/opensearch-project/OpenSearch/pull/4568))
 - Unused object and import within TransportClusterAllocationExplainAction ([#4639](https://github.com/opensearch-project/OpenSearch/pull/4639))
 - Remove LegacyESVersion.V_7_0_* and V_7_1_* Constants ([#2768](https://https://github.com/opensearch-project/OpenSearch/pull/2768))
+- Always auto release the flood stage block ([#4703](https://github.com/opensearch-project/OpenSearch/pull/4703))
 
 ### Fixed
 

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -37,7 +37,6 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.client.Client;
@@ -54,7 +53,6 @@ import org.opensearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.opensearch.common.Priority;
 import org.opensearch.common.Strings;
 import org.opensearch.common.collect.ImmutableOpenMap;
-import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.set.Sets;
@@ -88,7 +86,6 @@ public class DiskThresholdMonitor {
     private final RerouteService rerouteService;
     private final AtomicLong lastRunTimeMillis = new AtomicLong(Long.MIN_VALUE);
     private final AtomicBoolean checkInProgress = new AtomicBoolean();
-    private final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(logger.getName());
 
     /**
      * The IDs of the nodes that were over the low threshold in the last check (and maybe over another threshold too). Tracked so that we
@@ -121,14 +118,6 @@ public class DiskThresholdMonitor {
         this.rerouteService = rerouteService;
         this.diskThresholdSettings = new DiskThresholdSettings(settings, clusterSettings);
         this.client = client;
-        if (diskThresholdSettings.isAutoReleaseIndexEnabled() == false) {
-            deprecationLogger.deprecate(
-                DiskThresholdSettings.AUTO_RELEASE_INDEX_ENABLED_KEY.replace(".", "_"),
-                "[{}] will be removed in version {}",
-                DiskThresholdSettings.AUTO_RELEASE_INDEX_ENABLED_KEY,
-                LegacyESVersion.V_7_4_0.major + 1
-            );
-        }
     }
 
     private void checkFinished() {
@@ -371,23 +360,7 @@ public class DiskThresholdMonitor {
             .collect(Collectors.toSet());
 
         if (indicesToAutoRelease.isEmpty() == false) {
-            if (diskThresholdSettings.isAutoReleaseIndexEnabled()) {
-                logger.info("releasing read-only-allow-delete block on indices: [{}]", indicesToAutoRelease);
-                updateIndicesReadOnly(indicesToAutoRelease, listener, false);
-            } else {
-                deprecationLogger.deprecate(
-                    DiskThresholdSettings.AUTO_RELEASE_INDEX_ENABLED_KEY.replace(".", "_"),
-                    "[{}] will be removed in version {}",
-                    DiskThresholdSettings.AUTO_RELEASE_INDEX_ENABLED_KEY,
-                    LegacyESVersion.V_7_4_0.major + 1
-                );
-                logger.debug(
-                    "[{}] disabled, not releasing read-only-allow-delete block on indices: [{}]",
-                    DiskThresholdSettings.AUTO_RELEASE_INDEX_ENABLED_KEY,
-                    indicesToAutoRelease
-                );
-                listener.onResponse(null);
-            }
+            updateIndicesReadOnly(indicesToAutoRelease, listener, false);
         } else {
             logger.trace("no auto-release required");
             listener.onResponse(null);
@@ -421,11 +394,9 @@ public class DiskThresholdMonitor {
     ) {
         for (RoutingNode routingNode : routingNodes) {
             if (usages.containsKey(routingNode.nodeId()) == false) {
-                if (routingNode != null) {
-                    for (ShardRouting routing : routingNode) {
-                        String indexName = routing.index().getName();
-                        indicesToMarkIneligibleForAutoRelease.add(indexName);
-                    }
+                for (ShardRouting routing : routingNode) {
+                    String indexName = routing.index().getName();
+                    indicesToMarkIneligibleForAutoRelease.add(indexName);
                 }
             }
         }

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
@@ -33,6 +33,7 @@
 package org.opensearch.cluster.routing.allocation;
 
 import org.opensearch.OpenSearchParseException;
+import org.opensearch.Version;
 import org.opensearch.common.Strings;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
@@ -108,19 +109,14 @@ public class DiskThresholdSettings {
     private volatile TimeValue rerouteInterval;
     private volatile Double freeDiskThresholdFloodStage;
     private volatile ByteSizeValue freeBytesThresholdFloodStage;
-    private static final boolean autoReleaseIndexEnabled;
-    public static final String AUTO_RELEASE_INDEX_ENABLED_KEY = "opensearch.disk.auto_release_flood_stage_block";
 
     static {
+        assert Version.CURRENT.major == Version.V_2_0_0.major + 1; // this check is unnecessary in v4
+        final String AUTO_RELEASE_INDEX_ENABLED_KEY = "opensearch.disk.auto_release_flood_stage_block";
+
         final String property = System.getProperty(AUTO_RELEASE_INDEX_ENABLED_KEY);
-        if (property == null) {
-            autoReleaseIndexEnabled = true;
-        } else if (Boolean.FALSE.toString().equals(property)) {
-            autoReleaseIndexEnabled = false;
-        } else {
-            throw new IllegalArgumentException(
-                AUTO_RELEASE_INDEX_ENABLED_KEY + " may only be unset or set to [false] but was [" + property + "]"
-            );
+        if (property != null) {
+            throw new IllegalArgumentException("system property [" + AUTO_RELEASE_INDEX_ENABLED_KEY + "] may not be set");
         }
     }
 
@@ -369,10 +365,6 @@ public class DiskThresholdSettings {
 
     public ByteSizeValue getFreeBytesThresholdFloodStage() {
         return freeBytesThresholdFloodStage;
-    }
-
-    public boolean isAutoReleaseIndexEnabled() {
-        return autoReleaseIndexEnabled;
     }
 
     public boolean includeRelocations() {

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
@@ -116,7 +116,9 @@ public class DiskThresholdSettings {
 
         final String property = System.getProperty(AUTO_RELEASE_INDEX_ENABLED_KEY);
         if (property != null) {
-            throw new IllegalArgumentException("system property [" + AUTO_RELEASE_INDEX_ENABLED_KEY + "] may not be set");
+            throw new IllegalArgumentException(
+                "system property [" + AUTO_RELEASE_INDEX_ENABLED_KEY + "] has been removed in 3.0.0 and is not supported anymore"
+            );
         }
     }
 

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettingsTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettingsTests.java
@@ -60,7 +60,6 @@ public class DiskThresholdSettingsTests extends OpenSearchTestCase {
         assertTrue(diskThresholdSettings.includeRelocations());
         assertEquals(zeroBytes, diskThresholdSettings.getFreeBytesThresholdFloodStage());
         assertEquals(5.0D, diskThresholdSettings.getFreeDiskThresholdFloodStage(), 0.0D);
-        assertTrue(diskThresholdSettings.isAutoReleaseIndexEnabled());
     }
 
     public void testUpdate() {


### PR DESCRIPTION
Removes support for using a system property to disable the automatic release 
of the write block applied when a node exceeds the flood-stage watermark.