### PR TITLE
Fix/2659 deprecation messages updated

### DIFF
--- a/modules/ingest-user-agent/src/main/java/org/opensearch/ingest/useragent/UserAgentProcessor.java
+++ b/modules/ingest-user-agent/src/main/java/org/opensearch/ingest/useragent/UserAgentProcessor.java
@@ -352,7 +352,7 @@ public class UserAgentProcessor extends AbstractProcessor {
                 deprecationLogger.deprecate(
                     "ecs_false_non_common_schema",
                     "setting [ecs] to false for non-common schema "
-                        + "format is deprecated and will be removed in 8.0, set to true or remove to use the non-deprecated format"
+                        + "format is deprecated and will be removed in 3.0, set to true or remove to use the non-deprecated format"
                 );
             }
 

--- a/modules/ingest-user-agent/src/yamlRestTest/resources/rest-api-spec/test/ingest-useragent/20_useragent_processor.yml
+++ b/modules/ingest-user-agent/src/yamlRestTest/resources/rest-api-spec/test/ingest-useragent/20_useragent_processor.yml
@@ -87,7 +87,7 @@
 
   - do:
       allowed_warnings:
-        - "setting [ecs] to false for non-common schema format is deprecated and will be removed in 8.0, set to true or remove to use the non-deprecated format"
+        - "setting [ecs] to false for non-common schema format is deprecated and will be removed in 3.0, set to true or remove to use the non-deprecated format"
         - "the [os_major] property is deprecated for the user-agent processor"
       ingest.put_pipeline:
         id: "my_pipeline"

--- a/plugins/mapper-annotated-text/src/internalClusterTest/java/org/opensearch/index/mapper/annotatedtext/AnnotatedTextFieldMapperTests.java
+++ b/plugins/mapper-annotated-text/src/internalClusterTest/java/org/opensearch/index/mapper/annotatedtext/AnnotatedTextFieldMapperTests.java
@@ -99,7 +99,7 @@ public class AnnotatedTextFieldMapperTests extends MapperTestCase {
 
     @Override
     protected void assertParseMaximalWarnings() {
-        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 3.0");
     }
 
     @Override

--- a/qa/mixed-cluster/src/test/java/org/opensearch/backwards/IndexingIT.java
+++ b/qa/mixed-cluster/src/test/java/org/opensearch/backwards/IndexingIT.java
@@ -323,7 +323,7 @@ public class IndexingIT extends OpenSearchRestTestCase {
                 ResponseException responseException = expectThrows(ResponseException.class, () -> oldNodeClient.performRequest(request));
                 assertThat(responseException.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.CONFLICT.getStatus()));
                 assertThat(responseException.getResponse().getWarnings(),
-                    contains("Synced flush is deprecated and will be removed in 8.0. Use flush at _/flush or /{index}/_flush instead."));
+                    contains("Synced flush is deprecated and will be removed in 3.0. Use flush at _/flush or /{index}/_flush instead."));
                 Map<String, Object> result = ObjectPath.createFromResponse(responseException.getResponse()).evaluate("_shards");
                 assertThat(result.get("total"), equalTo(totalShards));
                 assertThat(result.get("successful"), equalTo(0));

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/30_copy_settings.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/30_copy_settings.yml
@@ -46,7 +46,7 @@
             index.number_of_replicas: 0
             index.merge.scheduler.max_thread_count: 2
       allowed_warnings:
-        - "parameter [copy_settings] is deprecated and will be removed in 8.0.0"
+        - "parameter [copy_settings] is deprecated and will be removed in 3.0.0"
         - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
@@ -48,7 +48,7 @@
             index.number_of_shards: 2
             index.merge.scheduler.max_thread_count: 2
       allowed_warnings:
-        - "parameter [copy_settings] is deprecated and will be removed in 8.0.0"
+        - "parameter [copy_settings] is deprecated and will be removed in 3.0.0"
         - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
 
   - do:

--- a/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
@@ -705,7 +705,7 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
                 if (Objects.equals("boost", propName)) {
                     deprecationLogger.deprecate(
                         "boost_" + name,
-                        "Parameter [boost] on field [{}] is deprecated and will be removed in 8.0",
+                        "Parameter [boost] on field [{}] is deprecated and will be removed in 3.0",
                         name
                     );
                 }

--- a/server/src/main/java/org/opensearch/index/mapper/TypeParsers.java
+++ b/server/src/main/java/org/opensearch/index/mapper/TypeParsers.java
@@ -155,7 +155,7 @@ public class TypeParsers {
                 builder.boost(nodeFloatValue(propNode));
                 deprecationLogger.deprecate(
                     "boost_" + name,
-                    "Parameter [boost] on field [{}] is deprecated and will be removed in 8.0",
+                    "Parameter [boost] on field [{}] is deprecated and will be removed in 3.0",
                     name
                 );
                 iterator.remove();

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestResizeHandler.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestResizeHandler.java
@@ -90,7 +90,7 @@ public abstract class RestResizeHandler extends BaseRestHandler {
             }
             deprecationLogger.deprecate(
                 "resize_deprecated_parameter",
-                "parameter [copy_settings] is deprecated and will be removed in 8.0.0"
+                "parameter [copy_settings] is deprecated and will be removed in 3.0.0"
             );
         }
         resizeRequest.setCopySettings(copySettings);

--- a/server/src/test/java/org/opensearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/BooleanFieldMapperTests.java
@@ -62,7 +62,7 @@ public class BooleanFieldMapperTests extends MapperTestCase {
 
     @Override
     protected void assertParseMaximalWarnings() {
-        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 3.0");
     }
 
     protected void registerParameters(ParameterChecker checker) throws IOException {

--- a/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
@@ -83,7 +83,7 @@ public class DateFieldMapperTests extends MapperTestCase {
 
     @Override
     protected void assertParseMaximalWarnings() {
-        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 3.0");
     }
 
     public void testDefaults() throws Exception {

--- a/server/src/test/java/org/opensearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/KeywordFieldMapperTests.java
@@ -173,7 +173,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
 
     @Override
     protected void assertParseMaximalWarnings() {
-        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 3.0");
     }
 
     protected void registerParameters(ParameterChecker checker) throws IOException {
@@ -309,7 +309,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
     public void testBoost() throws IOException {
         MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword").field("boost", 2f)));
         assertThat(mapperService.fieldType("field").boost(), equalTo(2f));
-        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 3.0");
     }
 
     public void testEnableNorms() throws IOException {

--- a/server/src/test/java/org/opensearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/RangeFieldMapperTests.java
@@ -97,7 +97,7 @@ public class RangeFieldMapperTests extends AbstractNumericFieldMapperTestCase {
 
     @Override
     protected void assertParseMaximalWarnings() {
-        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 3.0");
     }
 
     protected void registerParameters(ParameterChecker checker) throws IOException {

--- a/server/src/test/java/org/opensearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/TextFieldMapperTests.java
@@ -103,7 +103,7 @@ public class TextFieldMapperTests extends MapperTestCase {
 
     @Override
     protected void assertParseMaximalWarnings() {
-        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 8.0");
+        assertWarnings("Parameter [boost] on field [field] is deprecated and will be removed in 3.0");
     }
 
     public final void testExistsQueryIndexDisabled() throws IOException {

--- a/test/framework/src/main/java/org/opensearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/mapper/MapperTestCase.java
@@ -274,7 +274,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         }));
         String type = typeName();
         String[] warnings = new String[] {
-            "Parameter [boost] on field [field] is deprecated and will be removed in 8.0",
+            "Parameter [boost] on field [field] is deprecated and will be removed in 3.0",
             "Parameter [boost] has no effect on type [" + type + "] and will be removed in future" };
         allowedWarnings(warnings);
     }

--- a/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
@@ -1244,7 +1244,7 @@ public abstract class OpenSearchRestTestCase extends OpenSearchTestCase {
         final Builder options = RequestOptions.DEFAULT.toBuilder();
         // 8.0 kept in warning message for legacy purposes TODO: changge to 3.0
         final List<String> warningMessage = Arrays.asList(
-            "Synced flush is deprecated and will be removed in 8.0. Use flush at _/flush or /{index}/_flush instead."
+            "Synced flush is deprecated and will be removed in 3.0. Use flush at _/flush or /{index}/_flush instead."
         );
         final List<String> expectedWarnings = Arrays.asList(
             "Synced flush was removed and a normal flush was performed instead. This transition will be removed in a future version."


### PR DESCRIPTION
### Description
Some deprecation messages refer to Elasticsearch version 8.0. Now they do not refer to Elasticsearch.

### Issues Resolved
Issue #2659 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
