### PR TITLE
[Remove] Legacy Version support from Snapshot/Restore Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Remove LegacyESVersion.V_7_2_ and V_7_3_ Constants ([#4702](https://github.com/opensearch-project/OpenSearch/pull/4702))
 - Always auto release the flood stage block ([#4703](https://github.com/opensearch-project/OpenSearch/pull/4703))
 - Remove LegacyESVersion.V_7_4_ and V_7_5_ Constants ([#4704](https://github.com/opensearch-project/OpenSearch/pull/4704))
+- Remove Legacy Version support from Snapshot/Restore Service ([#4728](https://github.com/opensearch-project/OpenSearch/pull/4728))
+
 ### Fixed
 - `opensearch-service.bat start` and `opensearch-service.bat manager` failing to run ([#4289](https://github.com/opensearch-project/OpenSearch/pull/4289))
 - PR reference to checkout code for changelog verifier ([#4296](https://github.com/opensearch-project/OpenSearch/pull/4296))

--- a/plugins/repository-s3/src/internalClusterTest/java/org/opensearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/plugins/repository-s3/src/internalClusterTest/java/org/opensearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -36,8 +36,6 @@ import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import fixture.s3.S3HttpHandler;
-import org.opensearch.action.ActionRunnable;
-import org.opensearch.action.support.PlainActionFuture;
 
 import org.opensearch.cluster.metadata.RepositoryMetadata;
 import org.opensearch.cluster.service.ClusterService;
@@ -45,29 +43,21 @@ import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.blobstore.BlobContainer;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.blobstore.BlobStore;
-import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.regex.Regex;
 import org.opensearch.common.settings.MockSecureSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.ByteSizeUnit;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
-import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.plugins.Plugin;
-import org.opensearch.repositories.RepositoriesService;
-import org.opensearch.repositories.RepositoryData;
 import org.opensearch.repositories.blobstore.BlobStoreRepository;
 import org.opensearch.repositories.blobstore.OpenSearchMockAPIBasedRepositoryIntegTestCase;
-import org.opensearch.snapshots.SnapshotId;
-import org.opensearch.snapshots.SnapshotsService;
 import org.opensearch.snapshots.mockstore.BlobStoreWrapper;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -75,16 +65,12 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.startsWith;
 
 @SuppressForbidden(reason = "this test uses a HttpServer to emulate an S3 endpoint")
 // Need to set up a new cluster for each test because cluster settings use randomized authentication settings
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST)
 public class S3BlobStoreRepositoryTests extends OpenSearchMockAPIBasedRepositoryIntegTestCase {
-
-    private static final TimeValue TEST_COOLDOWN_PERIOD = TimeValue.timeValueSeconds(10L);
 
     private String region;
     private String signerOverride;
@@ -156,56 +142,6 @@ public class S3BlobStoreRepositoryTests extends OpenSearchMockAPIBasedRepository
             builder.put(S3ClientSettings.REGION.getConcreteSettingForNamespace("test").getKey(), region);
         }
         return builder.build();
-    }
-
-    public void testEnforcedCooldownPeriod() throws IOException {
-        final String repoName = createRepository(
-            randomName(),
-            Settings.builder().put(repositorySettings()).put(S3Repository.COOLDOWN_PERIOD.getKey(), TEST_COOLDOWN_PERIOD).build()
-        );
-
-        final SnapshotId fakeOldSnapshot = client().admin()
-            .cluster()
-            .prepareCreateSnapshot(repoName, "snapshot-old")
-            .setWaitForCompletion(true)
-            .setIndices()
-            .get()
-            .getSnapshotInfo()
-            .snapshotId();
-        final RepositoriesService repositoriesService = internalCluster().getCurrentClusterManagerNodeInstance(RepositoriesService.class);
-        final BlobStoreRepository repository = (BlobStoreRepository) repositoriesService.repository(repoName);
-        final RepositoryData repositoryData = getRepositoryData(repository);
-        final RepositoryData modifiedRepositoryData = repositoryData.withVersions(
-            Collections.singletonMap(fakeOldSnapshot, SnapshotsService.SHARD_GEN_IN_REPO_DATA_VERSION.minimumCompatibilityVersion())
-        );
-        final BytesReference serialized = BytesReference.bytes(
-            modifiedRepositoryData.snapshotsToXContent(XContentFactory.jsonBuilder(), SnapshotsService.OLD_SNAPSHOT_FORMAT)
-        );
-        PlainActionFuture.get(f -> repository.threadPool().generic().execute(ActionRunnable.run(f, () -> {
-            try (InputStream stream = serialized.streamInput()) {
-                repository.blobStore()
-                    .blobContainer(repository.basePath())
-                    .writeBlobAtomic(
-                        BlobStoreRepository.INDEX_FILE_PREFIX + modifiedRepositoryData.getGenId(),
-                        stream,
-                        serialized.length(),
-                        true
-                    );
-            }
-        })));
-
-        final String newSnapshotName = "snapshot-new";
-        final long beforeThrottledSnapshot = repository.threadPool().relativeTimeInNanos();
-        client().admin().cluster().prepareCreateSnapshot(repoName, newSnapshotName).setWaitForCompletion(true).setIndices().get();
-        assertThat(repository.threadPool().relativeTimeInNanos() - beforeThrottledSnapshot, greaterThan(TEST_COOLDOWN_PERIOD.getNanos()));
-
-        final long beforeThrottledDelete = repository.threadPool().relativeTimeInNanos();
-        client().admin().cluster().prepareDeleteSnapshot(repoName, newSnapshotName).get();
-        assertThat(repository.threadPool().relativeTimeInNanos() - beforeThrottledDelete, greaterThan(TEST_COOLDOWN_PERIOD.getNanos()));
-
-        final long beforeFastDelete = repository.threadPool().relativeTimeInNanos();
-        client().admin().cluster().prepareDeleteSnapshot(repoName, fakeOldSnapshot.getName()).get();
-        assertThat(repository.threadPool().relativeTimeInNanos() - beforeFastDelete, lessThan(TEST_COOLDOWN_PERIOD.getNanos()));
     }
 
     /**

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Repository.java
@@ -35,10 +35,8 @@ package org.opensearch.repositories.s3;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
-import org.opensearch.action.ActionRunnable;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.metadata.RepositoryMetadata;
@@ -52,7 +50,6 @@ import org.opensearch.common.settings.SecureString;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.unit.ByteSizeUnit;
 import org.opensearch.common.unit.ByteSizeValue;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.monitor.jvm.JvmInfo;
@@ -62,13 +59,10 @@ import org.opensearch.repositories.ShardGenerations;
 import org.opensearch.repositories.blobstore.MeteredBlobStoreRepository;
 import org.opensearch.snapshots.SnapshotId;
 import org.opensearch.snapshots.SnapshotInfo;
-import org.opensearch.snapshots.SnapshotsService;
 import org.opensearch.threadpool.Scheduler;
-import org.opensearch.threadpool.ThreadPool;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
@@ -183,24 +177,6 @@ class S3Repository extends MeteredBlobStoreRepository {
     static final Setting<String> CLIENT_NAME = new Setting<>("client", "default", Function.identity());
 
     /**
-     * Artificial delay to introduce after a snapshot finalization or delete has finished so long as the repository is still using the
-     * backwards compatible snapshot format from before
-     * {@link org.opensearch.snapshots.SnapshotsService#SHARD_GEN_IN_REPO_DATA_VERSION} ({@link LegacyESVersion#V_7_6_0}).
-     * This delay is necessary so that the eventually consistent nature of AWS S3 does not randomly result in repository corruption when
-     * doing repository operations in rapid succession on a repository in the old metadata format.
-     * This setting should not be adjusted in production when working with an AWS S3 backed repository. Doing so risks the repository
-     * becoming silently corrupted. To get rid of this waiting period, either create a new S3 repository or remove all snapshots older than
-     * {@link LegacyESVersion#V_7_6_0} from the repository which will trigger an upgrade of the repository metadata to the new
-     * format and disable the cooldown period.
-     */
-    static final Setting<TimeValue> COOLDOWN_PERIOD = Setting.timeSetting(
-        "cooldown_period",
-        new TimeValue(3, TimeUnit.MINUTES),
-        new TimeValue(0, TimeUnit.MILLISECONDS),
-        Setting.Property.Dynamic
-    );
-
-    /**
      * Specifies the path within bucket to repository data. Defaults to root directory.
      */
     static final Setting<String> BASE_PATH_SETTING = Setting.simpleString("base_path");
@@ -222,12 +198,6 @@ class S3Repository extends MeteredBlobStoreRepository {
     private final String cannedACL;
 
     private final RepositoryMetadata repositoryMetadata;
-
-    /**
-     * Time period to delay repository operations by after finalizing or deleting a snapshot.
-     * See {@link #COOLDOWN_PERIOD} for details.
-     */
-    private final TimeValue coolDown;
 
     /**
      * Constructs an s3 backed repository
@@ -296,8 +266,6 @@ class S3Repository extends MeteredBlobStoreRepository {
             );
         }
 
-        coolDown = COOLDOWN_PERIOD.get(metadata.settings());
-
         logger.debug(
             "using bucket [{}], chunk_size [{}], server_side_encryption [{}], buffer_size [{}], cannedACL [{}], storageClass [{}]",
             bucket,
@@ -334,9 +302,6 @@ class S3Repository extends MeteredBlobStoreRepository {
         Function<ClusterState, ClusterState> stateTransformer,
         ActionListener<RepositoryData> listener
     ) {
-        if (SnapshotsService.useShardGenerations(repositoryMetaVersion) == false) {
-            listener = delayedListener(listener);
-        }
         super.finalizeSnapshot(
             shardGenerations,
             repositoryStateId,
@@ -355,57 +320,7 @@ class S3Repository extends MeteredBlobStoreRepository {
         Version repositoryMetaVersion,
         ActionListener<RepositoryData> listener
     ) {
-        if (SnapshotsService.useShardGenerations(repositoryMetaVersion) == false) {
-            listener = delayedListener(listener);
-        }
         super.deleteSnapshots(snapshotIds, repositoryStateId, repositoryMetaVersion, listener);
-    }
-
-    /**
-     * Wraps given listener such that it is executed with a delay of {@link #coolDown} on the snapshot thread-pool after being invoked.
-     * See {@link #COOLDOWN_PERIOD} for details.
-     */
-    private <T> ActionListener<T> delayedListener(ActionListener<T> listener) {
-        final ActionListener<T> wrappedListener = ActionListener.runBefore(listener, () -> {
-            final Scheduler.Cancellable cancellable = finalizationFuture.getAndSet(null);
-            assert cancellable != null;
-        });
-        return new ActionListener<T>() {
-            @Override
-            public void onResponse(T response) {
-                logCooldownInfo();
-                final Scheduler.Cancellable existing = finalizationFuture.getAndSet(
-                    threadPool.schedule(
-                        ActionRunnable.wrap(wrappedListener, l -> l.onResponse(response)),
-                        coolDown,
-                        ThreadPool.Names.SNAPSHOT
-                    )
-                );
-                assert existing == null : "Already have an ongoing finalization " + finalizationFuture;
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                logCooldownInfo();
-                final Scheduler.Cancellable existing = finalizationFuture.getAndSet(
-                    threadPool.schedule(ActionRunnable.wrap(wrappedListener, l -> l.onFailure(e)), coolDown, ThreadPool.Names.SNAPSHOT)
-                );
-                assert existing == null : "Already have an ongoing finalization " + finalizationFuture;
-            }
-        };
-    }
-
-    private void logCooldownInfo() {
-        logger.info(
-            "Sleeping for [{}] after modifying repository [{}] because it contains snapshots older than version [{}]"
-                + " and therefore is using a backwards compatible metadata format that requires this cooldown period to avoid "
-                + "repository corruption. To get rid of this message and move to the new repository metadata format, either remove "
-                + "all snapshots older than version [{}] from the repository or create a new repository at an empty location.",
-            coolDown,
-            metadata.name(),
-            SnapshotsService.SHARD_GEN_IN_REPO_DATA_VERSION,
-            SnapshotsService.SHARD_GEN_IN_REPO_DATA_VERSION
-        );
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/ConcurrentSnapshotsIT.java
@@ -56,7 +56,6 @@ import org.opensearch.discovery.AbstractDisruptionTestCase;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoryData;
 import org.opensearch.repositories.RepositoryException;
-import org.opensearch.repositories.ShardGenerations;
 import org.opensearch.repositories.blobstore.BlobStoreRepository;
 import org.opensearch.snapshots.mockstore.MockRepository;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -1295,43 +1294,6 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         for (ActionFuture<CreateSnapshotResponse> snapshotFuture : snapshotFutures) {
             assertSuccessful(snapshotFuture);
         }
-    }
-
-    public void testConcurrentSnapshotWorksWithOldVersionRepo() throws Exception {
-        internalCluster().startClusterManagerOnlyNode();
-        final String dataNode = internalCluster().startDataOnlyNode();
-        final String repoName = "test-repo";
-        final Path repoPath = randomRepoPath();
-        createRepository(
-            repoName,
-            "mock",
-            Settings.builder().put(BlobStoreRepository.CACHE_REPOSITORY_DATA.getKey(), false).put("location", repoPath)
-        );
-        initWithSnapshotVersion(repoName, repoPath, SnapshotsService.OLD_SNAPSHOT_FORMAT);
-
-        createIndexWithContent("index-slow");
-
-        final ActionFuture<CreateSnapshotResponse> createSlowFuture = startFullSnapshotBlockedOnDataNode(
-            "slow-snapshot",
-            repoName,
-            dataNode
-        );
-
-        final String dataNode2 = internalCluster().startDataOnlyNode();
-        ensureStableCluster(3);
-        final String indexFast = "index-fast";
-        createIndexWithContent(indexFast, dataNode2, dataNode);
-
-        final ActionFuture<CreateSnapshotResponse> createFastSnapshot = startFullSnapshot(repoName, "fast-snapshot");
-
-        assertThat(createSlowFuture.isDone(), is(false));
-        unblockNode(repoName, dataNode);
-
-        assertSuccessful(createFastSnapshot);
-        assertSuccessful(createSlowFuture);
-
-        final RepositoryData repositoryData = getRepositoryData(repoName);
-        assertThat(repositoryData.shardGenerations(), is(ShardGenerations.EMPTY));
     }
 
     public void testQueuedDeleteAfterFinalizationFailure() throws Exception {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/delete/DeleteSnapshotRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/delete/DeleteSnapshotRequest.java
@@ -36,7 +36,6 @@ import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
-import org.opensearch.snapshots.SnapshotsService;
 
 import java.io.IOException;
 
@@ -84,27 +83,14 @@ public class DeleteSnapshotRequest extends ClusterManagerNodeRequest<DeleteSnaps
     public DeleteSnapshotRequest(StreamInput in) throws IOException {
         super(in);
         repository = in.readString();
-        if (in.getVersion().onOrAfter(SnapshotsService.MULTI_DELETE_VERSION)) {
-            snapshots = in.readStringArray();
-        } else {
-            snapshots = new String[] { in.readString() };
-        }
+        snapshots = in.readStringArray();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeString(repository);
-        if (out.getVersion().onOrAfter(SnapshotsService.MULTI_DELETE_VERSION)) {
-            out.writeStringArray(snapshots);
-        } else {
-            if (snapshots.length != 1) {
-                throw new IllegalArgumentException(
-                    "Can't write snapshot delete with more than one snapshot to version [" + out.getVersion() + "]"
-                );
-            }
-            out.writeString(snapshots[0]);
-        }
+        out.writeStringArray(snapshots);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/SnapshotDeletionsInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/SnapshotDeletionsInProgress.java
@@ -34,7 +34,6 @@ package org.opensearch.cluster;
 
 import org.opensearch.Version;
 import org.opensearch.cluster.ClusterState.Custom;
-import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -42,9 +41,7 @@ import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.repositories.RepositoryOperation;
-import org.opensearch.snapshots.Snapshot;
 import org.opensearch.snapshots.SnapshotId;
-import org.opensearch.snapshots.SnapshotsService;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -245,23 +242,12 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
         }
 
         public Entry(StreamInput in) throws IOException {
-            if (in.getVersion().onOrAfter(SnapshotsService.MULTI_DELETE_VERSION)) {
-                this.repoName = in.readString();
-                this.snapshots = in.readList(SnapshotId::new);
-            } else {
-                final Snapshot snapshot = new Snapshot(in);
-                this.snapshots = Collections.singletonList(snapshot.getSnapshotId());
-                this.repoName = snapshot.getRepository();
-            }
+            this.repoName = in.readString();
+            this.snapshots = in.readList(SnapshotId::new);
             this.startTime = in.readVLong();
             this.repositoryStateId = in.readLong();
-            if (in.getVersion().onOrAfter(SnapshotsService.FULL_CONCURRENCY_VERSION)) {
-                this.state = State.readFrom(in);
-                this.uuid = in.readString();
-            } else {
-                this.state = State.STARTED;
-                this.uuid = IndexMetadata.INDEX_UUID_NA_VALUE;
-            }
+            this.state = State.readFrom(in);
+            this.uuid = in.readString();
         }
 
         public Entry started() {
@@ -343,22 +329,12 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if (out.getVersion().onOrAfter(SnapshotsService.MULTI_DELETE_VERSION)) {
-                out.writeString(repoName);
-                out.writeCollection(snapshots);
-            } else {
-                assert snapshots.size() == 1 : "Only single deletion allowed in mixed version cluster containing ["
-                    + out.getVersion()
-                    + "] but saw "
-                    + snapshots;
-                new Snapshot(repoName, snapshots.get(0)).writeTo(out);
-            }
+            out.writeString(repoName);
+            out.writeCollection(snapshots);
             out.writeVLong(startTime);
             out.writeLong(repositoryStateId);
-            if (out.getVersion().onOrAfter(SnapshotsService.FULL_CONCURRENCY_VERSION)) {
-                state.writeTo(out);
-                out.writeString(uuid);
-            }
+            state.writeTo(out);
+            out.writeString(uuid);
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/SnapshotsInProgress.java
@@ -35,7 +35,6 @@ package org.opensearch.cluster;
 import com.carrotsearch.hppc.ObjectContainer;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.cluster.ClusterState.Custom;
 import org.opensearch.common.Nullable;
@@ -54,7 +53,6 @@ import org.opensearch.repositories.RepositoryShardId;
 import org.opensearch.snapshots.InFlightShardSnapshotStates;
 import org.opensearch.snapshots.Snapshot;
 import org.opensearch.snapshots.SnapshotId;
-import org.opensearch.snapshots.SnapshotsService;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -66,8 +64,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.opensearch.snapshots.SnapshotInfo.DATA_STREAMS_IN_SNAPSHOT;
-
 /**
  * Meta data about snapshots that are currently executing
  *
@@ -76,8 +72,6 @@ import static org.opensearch.snapshots.SnapshotInfo.DATA_STREAMS_IN_SNAPSHOT;
 public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implements Custom {
 
     public static final SnapshotsInProgress EMPTY = new SnapshotsInProgress(Collections.emptyList());
-
-    private static final Version VERSION_IN_SNAPSHOT_VERSION = LegacyESVersion.V_7_7_0;
 
     public static final String TYPE = "snapshots";
 
@@ -296,28 +290,10 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             repositoryStateId = in.readLong();
             failure = in.readOptionalString();
             userMetadata = in.readMap();
-            if (in.getVersion().onOrAfter(VERSION_IN_SNAPSHOT_VERSION)) {
-                version = Version.readVersion(in);
-            } else if (in.getVersion().onOrAfter(SnapshotsService.SHARD_GEN_IN_REPO_DATA_VERSION)) {
-                // If an older cluster-manager informs us that shard generations are supported
-                // we use the minimum shard generation compatible version.
-                // If shard generations are not supported yet we use a placeholder for a version that does not use shard generations.
-                version = in.readBoolean() ? SnapshotsService.SHARD_GEN_IN_REPO_DATA_VERSION : SnapshotsService.OLD_SNAPSHOT_FORMAT;
-            } else {
-                version = SnapshotsService.OLD_SNAPSHOT_FORMAT;
-            }
-            if (in.getVersion().onOrAfter(DATA_STREAMS_IN_SNAPSHOT)) {
-                dataStreams = in.readStringList();
-            } else {
-                dataStreams = Collections.emptyList();
-            }
-            if (in.getVersion().onOrAfter(SnapshotsService.CLONE_SNAPSHOT_VERSION)) {
-                source = in.readOptionalWriteable(SnapshotId::new);
-                clones = in.readImmutableMap(RepositoryShardId::new, ShardSnapshotStatus::readFrom);
-            } else {
-                source = null;
-                clones = ImmutableOpenMap.of();
-            }
+            version = Version.readVersion(in);
+            dataStreams = in.readStringList();
+            source = in.readOptionalWriteable(SnapshotId::new);
+            clones = in.readImmutableMap(RepositoryShardId::new, ShardSnapshotStatus::readFrom);
         }
 
         private static boolean assertShardsConsistent(
@@ -732,18 +708,10 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             out.writeLong(repositoryStateId);
             out.writeOptionalString(failure);
             out.writeMap(userMetadata);
-            if (out.getVersion().onOrAfter(VERSION_IN_SNAPSHOT_VERSION)) {
-                Version.writeVersion(version, out);
-            } else if (out.getVersion().onOrAfter(SnapshotsService.SHARD_GEN_IN_REPO_DATA_VERSION)) {
-                out.writeBoolean(SnapshotsService.useShardGenerations(version));
-            }
-            if (out.getVersion().onOrAfter(DATA_STREAMS_IN_SNAPSHOT)) {
-                out.writeStringCollection(dataStreams);
-            }
-            if (out.getVersion().onOrAfter(SnapshotsService.CLONE_SNAPSHOT_VERSION)) {
-                out.writeOptionalWriteable(source);
-                out.writeMap(clones);
-            }
+            Version.writeVersion(version, out);
+            out.writeStringCollection(dataStreams);
+            out.writeOptionalWriteable(source);
+            out.writeMap(clones);
         }
 
         @Override
@@ -840,12 +808,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         public static ShardSnapshotStatus readFrom(StreamInput in) throws IOException {
             String nodeId = in.readOptionalString();
             final ShardState state = ShardState.fromValue(in.readByte());
-            final String generation;
-            if (SnapshotsService.useShardGenerations(in.getVersion())) {
-                generation = in.readOptionalString();
-            } else {
-                generation = null;
-            }
+            final String generation = in.readOptionalString();
             final String reason = in.readOptionalString();
             if (state == ShardState.QUEUED) {
                 return UNASSIGNED_QUEUED;
@@ -884,9 +847,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         public void writeTo(StreamOutput out) throws IOException {
             out.writeOptionalString(nodeId);
             out.writeByte(state.value);
-            if (SnapshotsService.useShardGenerations(out.getVersion())) {
-                out.writeOptionalString(generation);
-            }
+            out.writeOptionalString(generation);
             out.writeOptionalString(reason);
         }
 

--- a/server/src/main/java/org/opensearch/repositories/IndexMetaDataGenerations.java
+++ b/server/src/main/java/org/opensearch/repositories/IndexMetaDataGenerations.java
@@ -92,10 +92,7 @@ public final class IndexMetaDataGenerations {
     }
 
     /**
-     * Get the blob id by {@link SnapshotId} and {@link IndexId} and fall back to the value of {@link SnapshotId#getUUID()} if none is
-     * known to enable backwards compatibility with versions older than
-     * {@link org.opensearch.snapshots.SnapshotsService#SHARD_GEN_IN_REPO_DATA_VERSION} which used the snapshot uuid as index metadata
-     * blob uuid.
+     * Get the blob id by {@link SnapshotId} and {@link IndexId}.
      *
      * @param snapshotId Snapshot Id
      * @param indexId    Index Id
@@ -103,11 +100,7 @@ public final class IndexMetaDataGenerations {
      */
     public String indexMetaBlobId(SnapshotId snapshotId, IndexId indexId) {
         final String identifier = lookup.getOrDefault(snapshotId, Collections.emptyMap()).get(indexId);
-        if (identifier == null) {
-            return snapshotId.getUUID();
-        } else {
-            return identifiers.get(identifier);
-        }
+        return identifiers.get(identifier);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoryData.java
@@ -540,6 +540,7 @@ public final class RepositoryData {
     private static final String UUID = "uuid";
     private static final String STATE = "state";
     private static final String VERSION = "version";
+    private static final String MIN_VERSION = "min_version";
 
     /**
      * Writes the snapshots metadata and the related indices metadata to x-content.
@@ -625,6 +626,11 @@ public final class RepositoryData {
                 case INDEX_METADATA_IDENTIFIERS:
                     XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                     indexMetaIdentifiers = parser.mapStrings();
+                    break;
+                case MIN_VERSION:
+                    // ignore min_version
+                    // todo: remove in next version
+                    parser.nextToken();
                     break;
                 default:
                     XContentParserUtils.throwUnknownField(field, parser.getTokenLocation());

--- a/server/src/main/java/org/opensearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoryData.java
@@ -42,7 +42,6 @@ import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParserUtils;
 import org.opensearch.snapshots.SnapshotId;
 import org.opensearch.snapshots.SnapshotState;
-import org.opensearch.snapshots.SnapshotsService;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -238,7 +237,6 @@ public final class RepositoryData {
     /**
      * Returns the {@link Version} for the given snapshot or {@code null} if unknown.
      */
-    @Nullable
     public Version getVersion(SnapshotId snapshotId) {
         return snapshotVersions.get(snapshotId.getUUID());
     }
@@ -542,7 +540,6 @@ public final class RepositoryData {
     private static final String UUID = "uuid";
     private static final String STATE = "state";
     private static final String VERSION = "version";
-    private static final String MIN_VERSION = "min_version";
 
     /**
      * Writes the snapshots metadata and the related indices metadata to x-content.
@@ -551,8 +548,6 @@ public final class RepositoryData {
         builder.startObject();
         // write the snapshots list
         builder.startArray(SNAPSHOTS);
-        final boolean shouldWriteIndexGens = SnapshotsService.useIndexGenerations(repoMetaVersion);
-        final boolean shouldWriteShardGens = SnapshotsService.useShardGenerations(repoMetaVersion);
         for (final SnapshotId snapshot : getSnapshotIds()) {
             builder.startObject();
             builder.field(NAME, snapshot.getName());
@@ -562,14 +557,12 @@ public final class RepositoryData {
             if (state != null) {
                 builder.field(STATE, state.value());
             }
-            if (shouldWriteIndexGens) {
-                builder.startObject(INDEX_METADATA_LOOKUP);
-                for (Map.Entry<IndexId, String> entry : indexMetaDataGenerations.lookup.getOrDefault(snapshot, Collections.emptyMap())
-                    .entrySet()) {
-                    builder.field(entry.getKey().getId(), entry.getValue());
-                }
-                builder.endObject();
+            builder.startObject(INDEX_METADATA_LOOKUP);
+            for (Map.Entry<IndexId, String> entry : indexMetaDataGenerations.lookup.getOrDefault(snapshot, Collections.emptyMap())
+                .entrySet()) {
+                builder.field(entry.getKey().getId(), entry.getValue());
             }
+            builder.endObject();
             final Version version = snapshotVersions.get(snapshotUUID);
             if (version != null) {
                 builder.field(VERSION, version.toString());
@@ -589,23 +582,15 @@ public final class RepositoryData {
                 builder.value(snapshotId.getUUID());
             }
             builder.endArray();
-            if (shouldWriteShardGens) {
-                builder.startArray(SHARD_GENERATIONS);
-                for (String gen : shardGenerations.getGens(indexId)) {
-                    builder.value(gen);
-                }
-                builder.endArray();
+            builder.startArray(SHARD_GENERATIONS);
+            for (String gen : shardGenerations.getGens(indexId)) {
+                builder.value(gen);
             }
+            builder.endArray();
             builder.endObject();
         }
         builder.endObject();
-        if (shouldWriteIndexGens) {
-            builder.field(MIN_VERSION, SnapshotsService.INDEX_GEN_IN_REPO_DATA_VERSION.toString());
-            builder.field(INDEX_METADATA_IDENTIFIERS, indexMetaDataGenerations.identifiers);
-        } else if (shouldWriteShardGens) {
-            // Add min version field to make it impossible for older OpenSearch versions to deserialize this object
-            builder.field(MIN_VERSION, SnapshotsService.SHARD_GEN_IN_REPO_DATA_VERSION.toString());
-        }
+        builder.field(INDEX_METADATA_IDENTIFIERS, indexMetaDataGenerations.identifiers);
         builder.endObject();
         return builder;
     }
@@ -616,12 +601,8 @@ public final class RepositoryData {
 
     /**
      * Reads an instance of {@link RepositoryData} from x-content, loading the snapshots and indices metadata.
-     *
-     * @param fixBrokenShardGens set to {@code true} to filter out broken shard generations read from the {@code parser} via
-     *                           {@link ShardGenerations#fixShardGeneration}. Used to disable fixing broken generations when reading
-     *                           from cached bytes that we trust to not contain broken generations.
      */
-    public static RepositoryData snapshotsFromXContent(XContentParser parser, long genId, boolean fixBrokenShardGens) throws IOException {
+    public static RepositoryData snapshotsFromXContent(XContentParser parser, long genId) throws IOException {
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
 
         final Map<String, SnapshotId> snapshots = new HashMap<>();
@@ -639,16 +620,11 @@ public final class RepositoryData {
                     parseSnapshots(parser, snapshots, snapshotStates, snapshotVersions, indexMetaLookup);
                     break;
                 case INDICES:
-                    parseIndices(parser, fixBrokenShardGens, snapshots, indexSnapshots, indexLookup, shardGenerations);
+                    parseIndices(parser, snapshots, indexSnapshots, indexLookup, shardGenerations);
                     break;
                 case INDEX_METADATA_IDENTIFIERS:
                     XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                     indexMetaIdentifiers = parser.mapStrings();
-                    break;
-                case MIN_VERSION:
-                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.VALUE_STRING, parser.nextToken(), parser);
-                    final Version version = Version.fromString(parser.text());
-                    assert SnapshotsService.useShardGenerations(version);
                     break;
                 default:
                     XContentParserUtils.throwUnknownField(field, parser.getTokenLocation());
@@ -763,7 +739,6 @@ public final class RepositoryData {
      * {@code shardGenerations}.
      *
      * @param parser              x-content parser
-     * @param fixBrokenShardGens  whether or not to fix broken shard generation (see {@link #snapshotsFromXContent} for details)
      * @param snapshots           map of snapshot uuid to {@link SnapshotId} that was populated by {@link #parseSnapshots}
      * @param indexSnapshots      map of {@link IndexId} to list of {@link SnapshotId} that contain the given index
      * @param indexLookup         map of index uuid (as returned by {@link IndexId#getId}) to {@link IndexId}
@@ -771,7 +746,6 @@ public final class RepositoryData {
      */
     private static void parseIndices(
         XContentParser parser,
-        boolean fixBrokenShardGens,
         Map<String, SnapshotId> snapshots,
         Map<IndexId, List<SnapshotId>> indexSnapshots,
         Map<String, IndexId> indexLookup,
@@ -835,9 +809,6 @@ public final class RepositoryData {
             indexLookup.put(indexId.getId(), indexId);
             for (int i = 0; i < gens.size(); i++) {
                 String parsedGen = gens.get(i);
-                if (fixBrokenShardGens) {
-                    parsedGen = ShardGenerations.fixShardGeneration(parsedGen);
-                }
                 if (parsedGen != null) {
                     shardGenerations.put(indexId, i, parsedGen);
                 }

--- a/server/src/main/java/org/opensearch/repositories/ShardGenerations.java
+++ b/server/src/main/java/org/opensearch/repositories/ShardGenerations.java
@@ -33,7 +33,6 @@
 package org.opensearch.repositories;
 
 import org.opensearch.common.Nullable;
-import org.opensearch.index.snapshots.IndexShardSnapshotStatus;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -44,7 +43,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -72,24 +70,6 @@ public final class ShardGenerations {
 
     private ShardGenerations(Map<IndexId, List<String>> shardGenerations) {
         this.shardGenerations = shardGenerations;
-    }
-
-    private static final Pattern IS_NUMBER = Pattern.compile("^\\d+$");
-
-    /**
-     * Filters out unreliable numeric shard generations read from {@link RepositoryData} or {@link IndexShardSnapshotStatus}, returning
-     * {@code null} in their place.
-     * @see <a href="https://github.com/elastic/elasticsearch/issues/57798">Issue #57988</a>
-     *
-     * @param shardGeneration shard generation to fix
-     * @return given shard generation or {@code null} if it was filtered out or {@code null} was passed
-     */
-    @Nullable
-    public static String fixShardGeneration(@Nullable String shardGeneration) {
-        if (shardGeneration == null) {
-            return null;
-        }
-        return IS_NUMBER.matcher(shardGeneration).matches() ? null : shardGeneration;
     }
 
     /**
@@ -145,8 +125,7 @@ public final class ShardGenerations {
      * <ul>
      *     <li>{@link #DELETED_SHARD_GEN} a deleted shard that isn't referenced by any snapshot in the repository any longer</li>
      *     <li>{@link #NEW_SHARD_GEN} a new shard that we know doesn't hold any valid data yet in the repository</li>
-     *     <li>{@code null} unknown state. The shard either does not exist at all or it was created by a node older than
-     *     {@link org.opensearch.snapshots.SnapshotsService#SHARD_GEN_IN_REPO_DATA_VERSION}. If a caller expects a shard to exist in the
+     *     <li>{@code null} unknown state. The shard does not exist at all. If a caller expects a shard to exist in the
      *     repository but sees a {@code null} return, it should try to recover the generation by falling back to listing the contents
      *     of the respective shard directory.</li>
      * </ul>

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.snapshots;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.ShardOperationFailedException;
 import org.opensearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
@@ -68,8 +67,6 @@ import java.util.stream.Collectors;
  * @opensearch.internal
  */
 public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent, Writeable {
-
-    public static final Version DATA_STREAMS_IN_SNAPSHOT = LegacyESVersion.V_7_9_0;
 
     public static final String CONTEXT_MODE_PARAM = "context_mode";
     public static final String CONTEXT_MODE_SNAPSHOT = "SNAPSHOT";
@@ -401,11 +398,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         version = in.readBoolean() ? Version.readVersion(in) : null;
         includeGlobalState = in.readOptionalBoolean();
         userMetadata = in.readMap();
-        if (in.getVersion().onOrAfter(DATA_STREAMS_IN_SNAPSHOT)) {
-            dataStreams = in.readStringList();
-        } else {
-            dataStreams = Collections.emptyList();
-        }
+        dataStreams = in.readStringList();
     }
 
     /**
@@ -836,9 +829,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         }
         out.writeOptionalBoolean(includeGlobalState);
         out.writeMap(userMetadata);
-        if (out.getVersion().onOrAfter(DATA_STREAMS_IN_SNAPSHOT)) {
-            out.writeStringCollection(dataStreams);
-        }
+        out.writeStringCollection(dataStreams);
     }
 
     private static SnapshotState snapshotState(final String reason, final List<SnapshotShardFailure> shardFailures) {

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotShardsService.java
@@ -67,7 +67,6 @@ import org.opensearch.indices.IndicesService;
 import org.opensearch.repositories.IndexId;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
-import org.opensearch.repositories.ShardGenerations;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportRequestDeduplicator;
@@ -276,11 +275,6 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                 final IndexShardSnapshotStatus snapshotStatus = shardEntry.getValue();
                 final IndexId indexId = indicesMap.get(shardId.getIndexName());
                 assert indexId != null;
-                assert SnapshotsService.useShardGenerations(entry.version())
-                    || ShardGenerations.fixShardGeneration(snapshotStatus.generation()) == null
-                    : "Found non-null, non-numeric shard generation ["
-                        + snapshotStatus.generation()
-                        + "] for snapshot with old-format compatibility";
                 snapshot(shardId, snapshot, indexId, entry.userMetadata(), snapshotStatus, entry.version(), new ActionListener<String>() {
                     @Override
                     public void onResponse(String newGeneration) {

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -38,7 +38,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.ExceptionsHelper;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionRunnable;
@@ -141,18 +140,6 @@ import static org.opensearch.cluster.SnapshotsInProgress.completed;
  */
 public class SnapshotsService extends AbstractLifecycleComponent implements ClusterStateApplier {
 
-    public static final Version FULL_CONCURRENCY_VERSION = LegacyESVersion.V_7_9_0;
-
-    public static final Version CLONE_SNAPSHOT_VERSION = LegacyESVersion.V_7_10_0;
-
-    public static final Version SHARD_GEN_IN_REPO_DATA_VERSION = LegacyESVersion.V_7_6_0;
-
-    public static final Version INDEX_GEN_IN_REPO_DATA_VERSION = LegacyESVersion.V_7_9_0;
-
-    public static final Version OLD_SNAPSHOT_FORMAT = LegacyESVersion.fromId(7050099);
-
-    public static final Version MULTI_DELETE_VERSION = LegacyESVersion.V_7_8_0;
-
     private static final Logger logger = LogManager.getLogger(SnapshotsService.class);
 
     public static final String UPDATE_SNAPSHOT_STATUS_ACTION_NAME = "internal:cluster/snapshot/update_snapshot_status";
@@ -167,9 +154,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
     private final Map<Snapshot, List<ActionListener<Tuple<RepositoryData, SnapshotInfo>>>> snapshotCompletionListeners =
         new ConcurrentHashMap<>();
-
-    // Set of snapshots that are currently being initialized by this node
-    private final Set<Snapshot> initializingSnapshots = Collections.synchronizedSet(new HashSet<>());
 
     /**
      * Listeners for snapshot deletion keyed by delete uuid as returned from {@link SnapshotDeletionsInProgress.Entry#uuid()}
@@ -285,18 +269,10 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 final List<SnapshotsInProgress.Entry> runningSnapshots = snapshots.entries();
                 ensureSnapshotNameNotRunning(runningSnapshots, repositoryName, snapshotName);
                 validate(repositoryName, snapshotName, currentState);
-                final boolean concurrentOperationsAllowed = currentState.nodes().getMinNodeVersion().onOrAfter(FULL_CONCURRENCY_VERSION);
                 final SnapshotDeletionsInProgress deletionsInProgress = currentState.custom(
                     SnapshotDeletionsInProgress.TYPE,
                     SnapshotDeletionsInProgress.EMPTY
                 );
-                if (deletionsInProgress.hasDeletionsInProgress() && concurrentOperationsAllowed == false) {
-                    throw new ConcurrentSnapshotExecutionException(
-                        repositoryName,
-                        snapshotName,
-                        "cannot snapshot while a snapshot deletion is in-progress in [" + deletionsInProgress + "]"
-                    );
-                }
                 final RepositoryCleanupInProgress repositoryCleanupInProgress = currentState.custom(
                     RepositoryCleanupInProgress.TYPE,
                     RepositoryCleanupInProgress.EMPTY
@@ -307,13 +283,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         snapshotName,
                         "cannot snapshot while a repository cleanup is in-progress in [" + repositoryCleanupInProgress + "]"
                     );
-                }
-                // Fail if there are any concurrently running snapshots. The only exception to this being a snapshot in INIT state from a
-                // previous cluster-manager that we can simply ignore and remove from the cluster state because we would clean it up from
-                // the
-                // cluster state anyway in #applyClusterState.
-                if (concurrentOperationsAllowed == false && runningSnapshots.stream().anyMatch(entry -> entry.state() != State.INIT)) {
-                    throw new ConcurrentSnapshotExecutionException(repositoryName, snapshotName, " a snapshot is already running");
                 }
                 ensureNoCleanupInProgress(currentState, repositoryName, snapshotName);
                 ensureBelowConcurrencyLimit(repositoryName, snapshotName, snapshots, deletionsInProgress);
@@ -339,7 +308,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     currentState.metadata(),
                     currentState.routingTable(),
                     indexIds,
-                    useShardGenerations(version),
                     repositoryData,
                     repositoryName
                 );
@@ -1817,16 +1785,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
             @Override
             public ClusterState execute(ClusterState currentState) throws Exception {
-                final Version minNodeVersion = currentState.nodes().getMinNodeVersion();
-                if (snapshotNames.length > 1 && minNodeVersion.before(MULTI_DELETE_VERSION)) {
-                    throw new IllegalArgumentException(
-                        "Deleting multiple snapshots in a single request is only supported in version [ "
-                            + MULTI_DELETE_VERSION
-                            + "] but cluster contained node of version ["
-                            + currentState.nodes().getMinNodeVersion()
-                            + "]"
-                    );
-                }
                 final SnapshotsInProgress snapshots = currentState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
                 final List<SnapshotsInProgress.Entry> snapshotEntries = findInProgressSnapshots(snapshots, snapshotNames, repoName);
                 final List<SnapshotId> snapshotIds = matchingSnapshotIds(
@@ -1835,76 +1793,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     snapshotNames,
                     repoName
                 );
-                if (snapshotEntries.isEmpty() || minNodeVersion.onOrAfter(SnapshotsService.FULL_CONCURRENCY_VERSION)) {
-                    deleteFromRepoTask = createDeleteStateUpdate(snapshotIds, repoName, repositoryData, Priority.NORMAL, listener);
-                    return deleteFromRepoTask.execute(currentState);
-                }
-                assert snapshotEntries.size() == 1 : "Expected just a single running snapshot but saw " + snapshotEntries;
-                final SnapshotsInProgress.Entry snapshotEntry = snapshotEntries.get(0);
-                runningSnapshot = snapshotEntry.snapshot();
-                final ImmutableOpenMap<ShardId, ShardSnapshotStatus> shards;
-
-                final State state = snapshotEntry.state();
-                final String failure;
-
-                outstandingDeletes = new ArrayList<>(snapshotIds);
-                if (state != State.INIT) {
-                    // INIT state snapshots won't ever be physically written to the repository but all other states will end up in the repo
-                    outstandingDeletes.add(runningSnapshot.getSnapshotId());
-                }
-                if (state == State.INIT) {
-                    // snapshot is still initializing, mark it as aborted
-                    shards = snapshotEntry.shards();
-                    assert shards.isEmpty();
-                    failure = "Snapshot was aborted during initialization";
-                    abortedDuringInit = true;
-                } else if (state == State.STARTED) {
-                    // snapshot is started - mark every non completed shard as aborted
-                    final SnapshotsInProgress.Entry abortedEntry = snapshotEntry.abort();
-                    shards = abortedEntry.shards();
-                    failure = abortedEntry.failure();
-                } else {
-                    boolean hasUncompletedShards = false;
-                    // Cleanup in case a node gone missing and snapshot wasn't updated for some reason
-                    for (ObjectCursor<ShardSnapshotStatus> shardStatus : snapshotEntry.shards().values()) {
-                        // Check if we still have shard running on existing nodes
-                        if (shardStatus.value.state().completed() == false
-                            && shardStatus.value.nodeId() != null
-                            && currentState.nodes().get(shardStatus.value.nodeId()) != null) {
-                            hasUncompletedShards = true;
-                            break;
-                        }
-                    }
-                    if (hasUncompletedShards) {
-                        // snapshot is being finalized - wait for shards to complete finalization process
-                        logger.debug("trying to delete completed snapshot - should wait for shards to finalize on all nodes");
-                        return currentState;
-                    } else {
-                        // no shards to wait for but a node is gone - this is the only case
-                        // where we force to finish the snapshot
-                        logger.debug("trying to delete completed snapshot with no finalizing shards - can delete immediately");
-                        shards = snapshotEntry.shards();
-                    }
-                    failure = snapshotEntry.failure();
-                }
-                return ClusterState.builder(currentState)
-                    .putCustom(
-                        SnapshotsInProgress.TYPE,
-                        SnapshotsInProgress.of(
-                            snapshots.entries()
-                                .stream()
-                                // remove init state snapshot we found from a previous cluster-manager if there was one
-                                .filter(existing -> abortedDuringInit == false || existing.equals(snapshotEntry) == false)
-                                .map(existing -> {
-                                    if (existing.equals(snapshotEntry)) {
-                                        return snapshotEntry.fail(shards, State.ABORTED, failure);
-                                    }
-                                    return existing;
-                                })
-                                .collect(Collectors.toList())
-                        )
-                    )
-                    .build();
+                deleteFromRepoTask = createDeleteStateUpdate(snapshotIds, repoName, repositoryData, Priority.NORMAL, listener);
+                return deleteFromRepoTask.execute(currentState);
             }
 
             @Override
@@ -2053,14 +1943,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     SnapshotDeletionsInProgress.EMPTY
                 );
                 final Version minNodeVersion = currentState.nodes().getMinNodeVersion();
-                if (minNodeVersion.before(FULL_CONCURRENCY_VERSION)) {
-                    if (deletionsInProgress.hasDeletionsInProgress()) {
-                        throw new ConcurrentSnapshotExecutionException(
-                            new Snapshot(repoName, snapshotIds.get(0)),
-                            "cannot delete - another snapshot is currently being deleted in [" + deletionsInProgress + "]"
-                        );
-                    }
-                }
                 final RepositoryCleanupInProgress repositoryCleanupInProgress = currentState.custom(
                     RepositoryCleanupInProgress.TYPE,
                     RepositoryCleanupInProgress.EMPTY
@@ -2100,44 +1982,32 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 }
                 // Snapshot ids that will have to be physically deleted from the repository
                 final Set<SnapshotId> snapshotIdsRequiringCleanup = new HashSet<>(snapshotIds);
-                final SnapshotsInProgress updatedSnapshots;
-                if (minNodeVersion.onOrAfter(FULL_CONCURRENCY_VERSION)) {
-                    updatedSnapshots = SnapshotsInProgress.of(snapshots.entries().stream().map(existing -> {
-                        if (existing.state() == State.STARTED
-                            && snapshotIdsRequiringCleanup.contains(existing.snapshot().getSnapshotId())) {
-                            // snapshot is started - mark every non completed shard as aborted
-                            final SnapshotsInProgress.Entry abortedEntry = existing.abort();
-                            if (abortedEntry == null) {
-                                // No work has been done for this snapshot yet so we remove it from the cluster state directly
-                                final Snapshot existingNotYetStartedSnapshot = existing.snapshot();
-                                // Adding the snapshot to #endingSnapshots since we still have to resolve its listeners to not trip
-                                // any leaked listener assertions
-                                if (endingSnapshots.add(existingNotYetStartedSnapshot)) {
-                                    completedNoCleanup.add(existingNotYetStartedSnapshot);
-                                }
-                                snapshotIdsRequiringCleanup.remove(existingNotYetStartedSnapshot.getSnapshotId());
-                            } else if (abortedEntry.state().completed()) {
-                                completedWithCleanup.add(abortedEntry);
+                final SnapshotsInProgress updatedSnapshots = SnapshotsInProgress.of(snapshots.entries().stream().map(existing -> {
+                    if (existing.state() == State.STARTED && snapshotIdsRequiringCleanup.contains(existing.snapshot().getSnapshotId())) {
+                        // snapshot is started - mark every non completed shard as aborted
+                        final SnapshotsInProgress.Entry abortedEntry = existing.abort();
+                        if (abortedEntry == null) {
+                            // No work has been done for this snapshot yet so we remove it from the cluster state directly
+                            final Snapshot existingNotYetStartedSnapshot = existing.snapshot();
+                            // Adding the snapshot to #endingSnapshots since we still have to resolve its listeners to not trip
+                            // any leaked listener assertions
+                            if (endingSnapshots.add(existingNotYetStartedSnapshot)) {
+                                completedNoCleanup.add(existingNotYetStartedSnapshot);
                             }
-                            return abortedEntry;
+                            snapshotIdsRequiringCleanup.remove(existingNotYetStartedSnapshot.getSnapshotId());
+                        } else if (abortedEntry.state().completed()) {
+                            completedWithCleanup.add(abortedEntry);
                         }
-                        return existing;
-                    }).filter(Objects::nonNull).collect(Collectors.toList()));
-                    if (snapshotIdsRequiringCleanup.isEmpty()) {
-                        // We only saw snapshots that could be removed from the cluster state right away, no need to update the deletions
-                        return updateWithSnapshots(currentState, updatedSnapshots, null);
+                        return abortedEntry;
                     }
-                } else {
-                    if (snapshots.entries().isEmpty() == false) {
-                        // However other snapshots are running - cannot continue
-                        throw new ConcurrentSnapshotExecutionException(
-                            repoName,
-                            snapshotIds.toString(),
-                            "another snapshot is currently running cannot delete"
-                        );
-                    }
-                    updatedSnapshots = snapshots;
+                    return existing;
+                }).filter(Objects::nonNull).collect(Collectors.toList()));
+
+                if (snapshotIdsRequiringCleanup.isEmpty()) {
+                    // We only saw snapshots that could be removed from the cluster state right away, no need to update the deletions
+                    return updateWithSnapshots(currentState, updatedSnapshots, null);
                 }
+
                 // add the snapshot deletion to the cluster state
                 final SnapshotDeletionsInProgress.Entry replacedEntry = deletionsInProgress.getEntries()
                     .stream()
@@ -2266,39 +2136,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             .filter(excluded == null ? sn -> true : sn -> excluded.contains(sn) == false)
             .collect(Collectors.toList())) {
             final Version known = repositoryData.getVersion(snapshotId);
-            // If we don't have the version cached in the repository data yet we load it from the snapshot info blobs
-            if (known == null) {
-                assert repositoryData.shardGenerations().totalShards() == 0 : "Saw shard generations ["
-                    + repositoryData.shardGenerations()
-                    + "] but did not have versions tracked for snapshot ["
-                    + snapshotId
-                    + "]";
-                return OLD_SNAPSHOT_FORMAT;
-            } else {
-                minCompatVersion = minCompatVersion.before(known) ? minCompatVersion : known;
-            }
+            minCompatVersion = minCompatVersion.before(known) ? minCompatVersion : known;
         }
         return minCompatVersion;
-    }
-
-    /**
-     * Checks whether the metadata version supports writing {@link ShardGenerations} to the repository.
-     *
-     * @param repositoryMetaVersion version to check
-     * @return true if version supports {@link ShardGenerations}
-     */
-    public static boolean useShardGenerations(Version repositoryMetaVersion) {
-        return repositoryMetaVersion.onOrAfter(SHARD_GEN_IN_REPO_DATA_VERSION);
-    }
-
-    /**
-     * Checks whether the metadata version supports writing {@link ShardGenerations} to the repository.
-     *
-     * @param repositoryMetaVersion version to check
-     * @return true if version supports {@link ShardGenerations}
-     */
-    public static boolean useIndexGenerations(Version repositoryMetaVersion) {
-        return repositoryMetaVersion.onOrAfter(INDEX_GEN_IN_REPO_DATA_VERSION);
     }
 
     /** Deletes snapshot from repository
@@ -2578,7 +2418,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                                     currentState.metadata(),
                                     currentState.routingTable(),
                                     entry.indices(),
-                                    entry.version().onOrAfter(SHARD_GEN_IN_REPO_DATA_VERSION),
                                     repositoryData,
                                     repoName
                                 );
@@ -2677,7 +2516,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
      * indices that should be included in the snapshot.
      *
      * @param indices             Indices to snapshot
-     * @param useShardGenerations whether to write {@link ShardGenerations} during the snapshot
      * @return list of shard to be included into current snapshot
      */
     private static ImmutableOpenMap<ShardId, SnapshotsInProgress.ShardSnapshotStatus> shards(
@@ -2686,7 +2524,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         Metadata metadata,
         RoutingTable routingTable,
         List<IndexId> indices,
-        boolean useShardGenerations,
         RepositoryData repositoryData,
         String repoName
     ) {
@@ -2712,18 +2549,15 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 for (int i = 0; i < indexMetadata.getNumberOfShards(); i++) {
                     final ShardId shardId = indexRoutingTable.shard(i).shardId();
                     final String shardRepoGeneration;
-                    if (useShardGenerations) {
-                        final String inFlightGeneration = inFlightShardStates.generationForShard(index, shardId.id(), shardGenerations);
-                        if (inFlightGeneration == null && isNewIndex) {
-                            assert shardGenerations.getShardGen(index, shardId.getId()) == null : "Found shard generation for new index ["
-                                + index
-                                + "]";
-                            shardRepoGeneration = ShardGenerations.NEW_SHARD_GEN;
-                        } else {
-                            shardRepoGeneration = inFlightGeneration;
-                        }
+
+                    final String inFlightGeneration = inFlightShardStates.generationForShard(index, shardId.id(), shardGenerations);
+                    if (inFlightGeneration == null && isNewIndex) {
+                        assert shardGenerations.getShardGen(index, shardId.getId()) == null : "Found shard generation for new index ["
+                            + index
+                            + "]";
+                        shardRepoGeneration = ShardGenerations.NEW_SHARD_GEN;
                     } else {
-                        shardRepoGeneration = null;
+                        shardRepoGeneration = inFlightGeneration;
                     }
                     final ShardSnapshotStatus shardSnapshotStatus;
                     if (indexRoutingTable == null) {

--- a/server/src/test/java/org/opensearch/repositories/RepositoryDataTests.java
+++ b/server/src/test/java/org/opensearch/repositories/RepositoryDataTests.java
@@ -95,7 +95,7 @@ public class RepositoryDataTests extends OpenSearchTestCase {
         repositoryData.snapshotsToXContent(builder, Version.CURRENT);
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
             long gen = (long) randomIntBetween(0, 500);
-            RepositoryData fromXContent = RepositoryData.snapshotsFromXContent(parser, gen, randomBoolean());
+            RepositoryData fromXContent = RepositoryData.snapshotsFromXContent(parser, gen);
             assertEquals(repositoryData, fromXContent);
             assertEquals(gen, fromXContent.getGenId());
         }
@@ -234,7 +234,7 @@ public class RepositoryDataTests extends OpenSearchTestCase {
         repositoryData.snapshotsToXContent(builder, Version.CURRENT);
         RepositoryData parsedRepositoryData;
         try (XContentParser xParser = createParser(builder)) {
-            parsedRepositoryData = RepositoryData.snapshotsFromXContent(xParser, repositoryData.getGenId(), randomBoolean());
+            parsedRepositoryData = RepositoryData.snapshotsFromXContent(xParser, repositoryData.getGenId());
         }
         assertEquals(repositoryData, parsedRepositoryData);
 
@@ -281,7 +281,7 @@ public class RepositoryDataTests extends OpenSearchTestCase {
         try (XContentParser xParser = createParser(corruptedBuilder)) {
             OpenSearchParseException e = expectThrows(
                 OpenSearchParseException.class,
-                () -> RepositoryData.snapshotsFromXContent(xParser, corruptedRepositoryData.getGenId(), randomBoolean())
+                () -> RepositoryData.snapshotsFromXContent(xParser, corruptedRepositoryData.getGenId())
             );
             assertThat(
                 e.getMessage(),
@@ -327,7 +327,7 @@ public class RepositoryDataTests extends OpenSearchTestCase {
         try (XContentParser xParser = createParser(builder)) {
             OpenSearchParseException e = expectThrows(
                 OpenSearchParseException.class,
-                () -> RepositoryData.snapshotsFromXContent(xParser, randomNonNegativeLong(), randomBoolean())
+                () -> RepositoryData.snapshotsFromXContent(xParser, randomNonNegativeLong())
             );
             assertThat(
                 e.getMessage(),

--- a/test/framework/src/main/java/org/opensearch/repositories/blobstore/BlobStoreTestUtil.java
+++ b/test/framework/src/main/java/org/opensearch/repositories/blobstore/BlobStoreTestUtil.java
@@ -136,7 +136,7 @@ public final class BlobStoreTestUtil {
                     XContentParser parser = XContentType.JSON.xContent()
                         .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, blob)
                 ) {
-                    repositoryData = RepositoryData.snapshotsFromXContent(parser, latestGen, false);
+                    repositoryData = RepositoryData.snapshotsFromXContent(parser, latestGen);
                 }
                 assertIndexUUIDs(repository, repositoryData);
                 assertSnapshotUUIDs(repository, repositoryData);

--- a/test/framework/src/main/java/org/opensearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -419,8 +419,7 @@ public abstract class AbstractSnapshotIntegTestCase extends OpenSearchIntegTestC
                 DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
                 Strings.toString(jsonBuilder).replace(Version.CURRENT.toString(), version.toString())
             ),
-            repositoryData.getGenId(),
-            randomBoolean()
+            repositoryData.getGenId()
         );
         Files.write(
             repoPath.resolve(BlobStoreRepository.INDEX_FILE_PREFIX + repositoryData.getGenId()),
@@ -512,7 +511,7 @@ public abstract class AbstractSnapshotIntegTestCase extends OpenSearchIntegTestC
             Collections.emptyList(),
             SnapshotState.FAILED,
             "failed on purpose",
-            SnapshotsService.OLD_SNAPSHOT_FORMAT,
+            Version.V_2_0_0,
             0L,
             0L,
             0,
@@ -527,7 +526,7 @@ public abstract class AbstractSnapshotIntegTestCase extends OpenSearchIntegTestC
                 getRepositoryData(repoName).getGenId(),
                 state.metadata(),
                 snapshotInfo,
-                SnapshotsService.OLD_SNAPSHOT_FORMAT,
+                Version.V_2_0_0,
                 Function.identity(),
                 f
             )


### PR DESCRIPTION
Removes all stale snapshot / restore code for legacy versions prior to OpenSearch 2.0. This includes 
handling null ShardGenerations, partial concurrency, null index generations, etc. which are no longer 
supported in snapshot versions after legacy 7.5.

relates #2747
depends on #4729