### PR TITLE
[Deprecate] RepositoryData.MIN_VERSION for removal in next major release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 
 ### Removed
+- Remove RepositoryData.MIN_VERSION support for next major release ([4729](https://github.com/opensearch-project/OpenSearch/pull/4729))
 
 ### Fixed
 - PR reference to checkout code for changelog verifier ([#4296](https://github.com/opensearch-project/OpenSearch/pull/4296))


### PR DESCRIPTION
This `min_version` field in the RepositoryData metadata is only used for ancient snapshot generations 
and needs to be removed in the next major version. This commit sets up the removal for backwards 
compatibility support.

