### PR TITLE
[Refactor] Base Action class javadocs to OpenSearch.API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update to Apache Lucene 9.4.0 ([#4661](https://github.com/opensearch-project/OpenSearch/pull/4661))
 - Controlling discovery for decommissioned nodes ([#4590](https://github.com/opensearch-project/OpenSearch/pull/4590))
 - Backport Apache Lucene version change for 2.4.0 ([#4677](https://github.com/opensearch-project/OpenSearch/pull/4677))
+- Refactor Base Action class javadocs to OpenSearch.API ([#4732](https://github.com/opensearch-project/OpenSearch/pull/4732))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/action/ActionFuture.java
+++ b/server/src/main/java/org/opensearch/action/ActionFuture.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * An extension to {@link Future} allowing for simplified "get" operations.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
 public interface ActionFuture<T> extends Future<T> {
 

--- a/server/src/main/java/org/opensearch/action/ActionListener.java
+++ b/server/src/main/java/org/opensearch/action/ActionListener.java
@@ -46,7 +46,7 @@ import java.util.function.Consumer;
 /**
  * A listener for action responses or failures.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
 public interface ActionListener<Response> {
     /**

--- a/server/src/main/java/org/opensearch/action/ActionListenerResponseHandler.java
+++ b/server/src/main/java/org/opensearch/action/ActionListenerResponseHandler.java
@@ -46,7 +46,7 @@ import java.util.Objects;
  * A simple base class for action response listeners, defaulting to using the SAME executor (as its
  * very common on response handlers).
  *
- * @opensearch.internal
+ * @opensearch.api
  */
 public class ActionListenerResponseHandler<Response extends TransportResponse> implements TransportResponseHandler<Response> {
 

--- a/server/src/main/java/org/opensearch/action/ActionRequest.java
+++ b/server/src/main/java/org/opensearch/action/ActionRequest.java
@@ -39,9 +39,9 @@ import org.opensearch.transport.TransportRequest;
 import java.io.IOException;
 
 /**
- * Base action request
+ * Base action request implemented by plugins.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
 public abstract class ActionRequest extends TransportRequest {
 

--- a/server/src/main/java/org/opensearch/action/ActionRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/ActionRequestBuilder.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 /**
  * Base Action Request Builder
  *
- * @opensearch.internal
+ * @opensearch.api
  */
 public abstract class ActionRequestBuilder<Request extends ActionRequest, Response extends ActionResponse> {
 

--- a/server/src/main/java/org/opensearch/action/ActionRequestValidationException.java
+++ b/server/src/main/java/org/opensearch/action/ActionRequestValidationException.java
@@ -35,8 +35,8 @@ package org.opensearch.action;
 import org.opensearch.common.ValidationException;
 
 /**
- * Base exception for an action request validation
+ * Base exception for an action request validation extendable by plugins
  *
- * @opensearch.internal
+ * @opensearch.api
  */
 public class ActionRequestValidationException extends ValidationException {}

--- a/server/src/main/java/org/opensearch/action/ActionResponse.java
+++ b/server/src/main/java/org/opensearch/action/ActionResponse.java
@@ -38,9 +38,9 @@ import org.opensearch.transport.TransportResponse;
 import java.io.IOException;
 
 /**
- * Base class for responses to action requests.
+ * Base class for responses to action requests implemented by plugins.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
 public abstract class ActionResponse extends TransportResponse {
 

--- a/server/src/main/java/org/opensearch/action/ActionRunnable.java
+++ b/server/src/main/java/org/opensearch/action/ActionRunnable.java
@@ -41,7 +41,7 @@ import org.opensearch.common.util.concurrent.AbstractRunnable;
  * Base class for {@link Runnable}s that need to call {@link ActionListener#onFailure(Exception)} in case an uncaught
  * exception or error is thrown while the actual action is run.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
 public abstract class ActionRunnable<Response> extends AbstractRunnable {
 

--- a/server/src/main/java/org/opensearch/action/ActionType.java
+++ b/server/src/main/java/org/opensearch/action/ActionType.java
@@ -39,7 +39,7 @@ import org.opensearch.transport.TransportRequestOptions;
 /**
  * A generic action. Should strive to make it a singleton.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
 public class ActionType<Response extends ActionResponse> {
 


### PR DESCRIPTION
Refactors base action classes implemented by external plugins through `ActionPlugin` from `@opensearch.internal` to `@opensearch.api` to signal extensibility to third-party developers. This should help clear confusion on which classes should be extensible through ActionPlugin.