### PR TITLE
[Backport 2.x] ZIP publication groupId value is configurable (#4156) …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Change the version to remove deprecated code of adding node name into log pattern of log4j property file ([#4569](https://github.com/opensearch-project/OpenSearch/pull/4569))
 - Update to Apache Lucene 9.4.0 ([#4661](https://github.com/opensearch-project/OpenSearch/pull/4661))
 - Load the deprecated master role in a dedicated method instead of in setAdditionalRoles() ([#4582](https://github.com/opensearch-project/OpenSearch/pull/4582))
+- Plugin ZIP publication groupId value is configurable ([#4156](https://github.com/opensearch-project/OpenSearch/pull/4156))
+- Further simplification of the ZIP publication implementation ([#4360](https://github.com/opensearch-project/OpenSearch/pull/4360))
 
 ### Deprecated
 

--- a/buildSrc/src/main/java/org/opensearch/gradle/pluginzip/Publish.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/pluginzip/Publish.java
@@ -9,26 +9,54 @@ package org.opensearch.gradle.pluginzip;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
-import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
 
 import java.nio.file.Path;
 import org.gradle.api.Task;
+import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
 
 public class Publish implements Plugin<Project> {
-    public final static String EXTENSION_NAME = "zipmavensettings";
+    private final static String DEFAULT_GROUP_ID = "org.opensearch.plugin";
+
+    // public final static String PLUGIN_ZIP_PUBLISH_POM_TASK = "generatePomFileForPluginZipPublication";
     public final static String PUBLICATION_NAME = "pluginZip";
     public final static String STAGING_REPO = "zipStaging";
-    public final static String PLUGIN_ZIP_PUBLISH_POM_TASK = "generatePomFileForPluginZipPublication";
-    public final static String LOCALMAVEN = "publishToMavenLocal";
     public final static String LOCAL_STAGING_REPO_PATH = "/build/local-staging-repo";
-    public String zipDistributionLocation = "/build/distributions/";
+    // TODO: Does the path ^^ need to use platform dependant file separators ?
 
-    public static void configMaven(Project project) {
+    /**
+     * This method returns a "default" groupId value ("{@link #DEFAULT_GROUP_ID}").
+     * It is possible to have the `group` property unspecified in which case the default value is used instead.
+     * See <a href="https://github.com/opensearch-project/OpenSearch/pull/4156#issuecomment-1230397082">GitHub discussion</a>
+     * for details.
+     *
+     * @deprecated This method will be removed in OpenSearch 3.x and `group` property will be required
+     * @return The default groupId value
+     */
+    @Deprecated
+    public static String getDefaultGroupId(Project project) {
+        project.getLogger()
+            .warn(
+                String.format(
+                    "The 'project.group' property is empty, a default value '%s' will be used instead. "
+                        + "Please notice that in OpenSearch 3.x the 'project.group' property will be required.",
+                    DEFAULT_GROUP_ID
+                )
+            );
+        return DEFAULT_GROUP_ID;
+    }
+
+    private boolean isZipPublicationPresent(Project project) {
+        PublishingExtension pe = project.getExtensions().findByType(PublishingExtension.class);
+        if (pe == null) {
+            return false;
+        }
+        return pe.getPublications().findByName(PUBLICATION_NAME) != null;
+    }
+
+    private void addLocalMavenRepo(Project project) {
         final Path buildDirectory = project.getRootDir().toPath();
-        project.getPluginManager().apply(MavenPublishPlugin.class);
         project.getExtensions().configure(PublishingExtension.class, publishing -> {
             publishing.repositories(repositories -> {
                 repositories.maven(maven -> {
@@ -36,54 +64,43 @@ public class Publish implements Plugin<Project> {
                     maven.setUrl(buildDirectory.toString() + LOCAL_STAGING_REPO_PATH);
                 });
             });
+        });
+    }
+
+    private void addZipArtifact(Project project) {
+        project.getExtensions().configure(PublishingExtension.class, publishing -> {
             publishing.publications(publications -> {
-                final Publication publication = publications.findByName(PUBLICATION_NAME);
-                if (publication == null) {
-                    publications.create(PUBLICATION_NAME, MavenPublication.class, mavenZip -> {
-                        String zipGroup = "org.opensearch.plugin";
-                        String zipArtifact = project.getName();
-                        String zipVersion = getProperty("version", project);
-                        mavenZip.artifact(project.getTasks().named("bundlePlugin"));
-                        mavenZip.setGroupId(zipGroup);
-                        mavenZip.setArtifactId(zipArtifact);
-                        mavenZip.setVersion(zipVersion);
-                    });
-                } else {
-                    final MavenPublication mavenZip = (MavenPublication) publication;
-                    String zipGroup = "org.opensearch.plugin";
-                    String zipArtifact = project.getName();
-                    String zipVersion = getProperty("version", project);
+                MavenPublication mavenZip = (MavenPublication) publications.findByName(PUBLICATION_NAME);
+                if (mavenZip != null) {
                     mavenZip.artifact(project.getTasks().named("bundlePlugin"));
-                    mavenZip.setGroupId(zipGroup);
-                    mavenZip.setArtifactId(zipArtifact);
-                    mavenZip.setVersion(zipVersion);
+                    if (mavenZip.getGroupId().isEmpty()) {
+                        mavenZip.setGroupId(getDefaultGroupId(project));
+                    }
                 }
             });
         });
     }
 
-    static String getProperty(String name, Project project) {
-        if (project.hasProperty(name)) {
-            Object property = project.property(name);
-            if (property != null) {
-                return property.toString();
-            }
-        }
-        return null;
-    }
-
     @Override
     public void apply(Project project) {
+        project.getPluginManager().apply("nebula.maven-base-publish");
+        project.getPluginManager().apply(MavenPublishPlugin.class);
         project.afterEvaluate(evaluatedProject -> {
-            configMaven(project);
-            Task validatePluginZipPom = project.getTasks().findByName("validatePluginZipPom");
-            if (validatePluginZipPom != null) {
-                project.getTasks().getByName("validatePluginZipPom").dependsOn("generatePomFileForNebulaPublication");
-            }
-            Task publishPluginZipPublicationToZipStagingRepository = project.getTasks()
-                .findByName("publishPluginZipPublicationToZipStagingRepository");
-            if (publishPluginZipPublicationToZipStagingRepository != null) {
-                publishPluginZipPublicationToZipStagingRepository.dependsOn("generatePomFileForNebulaPublication");
+            if (isZipPublicationPresent(project)) {
+                addLocalMavenRepo(project);
+                addZipArtifact(project);
+                Task validatePluginZipPom = project.getTasks().findByName("validatePluginZipPom");
+                if (validatePluginZipPom != null) {
+                    validatePluginZipPom.dependsOn("generatePomFileForNebulaPublication");
+                }
+                Task publishPluginZipPublicationToZipStagingRepository = project.getTasks()
+                    .findByName("publishPluginZipPublicationToZipStagingRepository");
+                if (publishPluginZipPublicationToZipStagingRepository != null) {
+                    publishPluginZipPublicationToZipStagingRepository.dependsOn("generatePomFileForNebulaPublication");
+                }
+            } else {
+                project.getLogger()
+                    .warn(String.format("Plugin 'opensearch.pluginzip' is applied but no '%s' publication is defined.", PUBLICATION_NAME));
             }
         });
     }

--- a/buildSrc/src/test/java/org/opensearch/gradle/pluginzip/PublishTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/pluginzip/PublishTests.java
@@ -8,21 +8,25 @@
 
 package org.opensearch.gradle.pluginzip;
 
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
-import org.gradle.testfixtures.ProjectBuilder;
-import org.gradle.api.Project;
+import org.gradle.testkit.runner.UnexpectedBuildFailure;
 import org.opensearch.gradle.test.GradleUnitTestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.IOException;
-import org.gradle.api.publish.maven.tasks.PublishToMavenRepository;
 import java.io.File;
+import java.io.FileReader;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.Writer;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
@@ -30,14 +34,16 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
-import java.io.FileReader;
-import org.gradle.api.tasks.bundling.Zip;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
-import java.util.ArrayList;
 
 public class PublishTests extends GradleUnitTestCase {
     private TemporaryFolder projectDir;
+    private static final String TEMPLATE_RESOURCE_FOLDER = "pluginzip";
+    private final String PROJECT_NAME = "sample-plugin";
+    private final String ZIP_PUBLISH_TASK = "publishPluginZipPublicationToZipStagingRepository";
 
     @Before
     public void setUp() throws IOException {
@@ -50,161 +56,466 @@ public class PublishTests extends GradleUnitTestCase {
         projectDir.delete();
     }
 
+    /**
+     * This test is used to verify that adding the 'opensearch.pluginzip' to the project
+     * adds some other transitive plugins and tasks under the hood. This is basically
+     * a behavioral test of the {@link Publish#apply(Project)} method.
+     *
+     * This is equivalent of having a build.gradle script with just the following section:
+     * <pre>
+     *     plugins {
+     *       id 'opensearch.pluginzip'
+     *     }
+     * </pre>
+     */
     @Test
-    public void testZipPublish() throws IOException, XmlPullParserException {
-        String zipPublishTask = "publishPluginZipPublicationToZipStagingRepository";
-        prepareProjectForPublishTask(zipPublishTask);
-
-        // Generate the build.gradle file
-        String buildFileContent = "apply plugin: 'maven-publish' \n"
-            + "apply plugin: 'java' \n"
-            + "publishing {\n"
-            + "  repositories {\n"
-            + "       maven {\n"
-            + "          url = 'local-staging-repo/'\n"
-            + "          name = 'zipStaging'\n"
-            + "        }\n"
-            + "  }\n"
-            + "   publications {\n"
-            + "         pluginZip(MavenPublication) {\n"
-            + "             groupId = 'org.opensearch.plugin' \n"
-            + "             artifactId = 'sample-plugin' \n"
-            + "             version = '2.0.0.0' \n"
-            + "             artifact('sample-plugin.zip') \n"
-            + "         }\n"
-            + "   }\n"
-            + "}";
-        writeString(projectDir.newFile("build.gradle"), buildFileContent);
-        // Execute the task publishPluginZipPublicationToZipStagingRepository
-        List<String> allArguments = new ArrayList<String>();
-        allArguments.add("build");
-        allArguments.add(zipPublishTask);
-        GradleRunner runner = GradleRunner.create();
-        runner.forwardOutput();
-        runner.withPluginClasspath();
-        runner.withArguments(allArguments);
-        runner.withProjectDir(projectDir.getRoot());
-        BuildResult result = runner.build();
-        // Check if task publishMavenzipPublicationToZipstagingRepository has ran well
-        assertEquals(SUCCESS, result.task(":" + zipPublishTask).getOutcome());
-        // check if the zip has been published to local staging repo
-        assertTrue(
-            new File(projectDir.getRoot(), "local-staging-repo/org/opensearch/plugin/sample-plugin/2.0.0.0/sample-plugin-2.0.0.0.zip")
-                .exists()
-        );
-        assertEquals(SUCCESS, result.task(":" + "build").getOutcome());
-        // Parse the maven file and validate the groupID to org.opensearch.plugin
-        MavenXpp3Reader reader = new MavenXpp3Reader();
-        Model model = reader.read(
-            new FileReader(
-                new File(projectDir.getRoot(), "local-staging-repo/org/opensearch/plugin/sample-plugin/2.0.0.0/sample-plugin-2.0.0.0.pom")
-            )
-        );
-        assertEquals(model.getGroupId(), "org.opensearch.plugin");
-    }
-
-    @Test
-    public void testZipPublishWithPom() throws IOException, XmlPullParserException {
-        String zipPublishTask = "publishPluginZipPublicationToZipStagingRepository";
-        Project project = prepareProjectForPublishTask(zipPublishTask);
-
-        // Generate the build.gradle file
-        String buildFileContent = "apply plugin: 'maven-publish' \n"
-            + "apply plugin: 'java' \n"
-            + "publishing {\n"
-            + "  repositories {\n"
-            + "       maven {\n"
-            + "          url = 'local-staging-repo/'\n"
-            + "          name = 'zipStaging'\n"
-            + "        }\n"
-            + "  }\n"
-            + "   publications {\n"
-            + "         pluginZip(MavenPublication) {\n"
-            + "             groupId = 'org.opensearch.plugin' \n"
-            + "             artifactId = 'sample-plugin' \n"
-            + "             version = '2.0.0.0' \n"
-            + "             artifact('sample-plugin.zip') \n"
-            + "             pom {\n"
-            + "                name = 'sample-plugin'\n"
-            + "                description = 'sample-description'\n"
-            + "                licenses {\n"
-            + "                    license {\n"
-            + "                        name = \"The Apache License, Version 2.0\"\n"
-            + "                        url = \"http://www.apache.org/licenses/LICENSE-2.0.txt\"\n"
-            + "                    }\n"
-            + "                }\n"
-            + "                developers {\n"
-            + "                    developer {\n"
-            + "                        name = 'opensearch'\n"
-            + "                        url = 'https://github.com/opensearch-project/OpenSearch'\n"
-            + "                    }\n"
-            + "                }\n"
-            + "                url = 'https://github.com/opensearch-project/OpenSearch'\n"
-            + "                scm {\n"
-            + "                    url = 'https://github.com/opensearch-project/OpenSearch'\n"
-            + "                }\n"
-            + "            }"
-            + "         }\n"
-            + "   }\n"
-            + "}";
-        writeString(projectDir.newFile("build.gradle"), buildFileContent);
-        // Execute the task publishPluginZipPublicationToZipStagingRepository
-        List<String> allArguments = new ArrayList<String>();
-        allArguments.add("build");
-        allArguments.add(zipPublishTask);
-        GradleRunner runner = GradleRunner.create();
-        runner.forwardOutput();
-        runner.withPluginClasspath();
-        runner.withArguments(allArguments);
-        runner.withProjectDir(projectDir.getRoot());
-        BuildResult result = runner.build();
-        // Check if task publishMavenzipPublicationToZipstagingRepository has ran well
-        assertEquals(SUCCESS, result.task(":" + zipPublishTask).getOutcome());
-        // check if the zip has been published to local staging repo
-        assertTrue(
-            new File(projectDir.getRoot(), "local-staging-repo/org/opensearch/plugin/sample-plugin/2.0.0.0/sample-plugin-2.0.0.0.zip")
-                .exists()
-        );
-        assertEquals(SUCCESS, result.task(":" + "build").getOutcome());
-        // Parse the maven file and validate the groupID to org.opensearch.plugin
-        MavenXpp3Reader reader = new MavenXpp3Reader();
-        Model model = reader.read(
-            new FileReader(
-                new File(projectDir.getRoot(), "local-staging-repo/org/opensearch/plugin/sample-plugin/2.0.0.0/sample-plugin-2.0.0.0.pom")
-            )
-        );
-        assertEquals(model.getGroupId(), "org.opensearch.plugin");
-        assertEquals(model.getUrl(), "https://github.com/opensearch-project/OpenSearch");
-    }
-
-    protected Project prepareProjectForPublishTask(String zipPublishTask) throws IOException {
+    public void applyZipPublicationPluginNoConfig() {
+        // All we do here is creating an empty project and applying the Publish plugin.
         Project project = ProjectBuilder.builder().build();
+        project.getPluginManager().apply(Publish.class);
 
-        // Apply the opensearch.pluginzip plugin
-        project.getPluginManager().apply("opensearch.pluginzip");
-        // Check if the plugin has been applied to the project
-        assertTrue(project.getPluginManager().hasPlugin("opensearch.pluginzip"));
-        // Check if the project has the task from class PublishToMavenRepository after plugin apply
-        assertNotNull(project.getTasks().withType(PublishToMavenRepository.class));
-        // Create a mock bundlePlugin task
-        Zip task = project.getTasks().create("bundlePlugin", Zip.class);
-        Publish.configMaven(project);
-        // Check if the main task publishPluginZipPublicationToZipStagingRepository exists after plugin apply
-        assertTrue(project.getTasks().getNames().contains(zipPublishTask));
-        assertNotNull("Task to generate: ", project.getTasks().getByName(zipPublishTask));
-        // Run Gradle functional tests, but calling a build.gradle file, that resembles the plugin publish behavior
+        // WARNING: =====================================================================
+        // All the following tests will work only before the gradle project is evaluated.
+        // There are some methods that will cause the project to be evaluated, such as:
+        // project.getTasksByName()
+        // After the project is evaluated there are more tasks found in the project, like
+        // the [assemble, build, ...] and other standard tasks.
+        // This can potentially break in future gradle versions (?)
+        // ===============================================================================
 
-        // Create a sample plugin zip file
-        File sampleZip = new File(projectDir.getRoot(), "sample-plugin.zip");
-        Files.createFile(sampleZip.toPath());
-        writeString(projectDir.newFile("settings.gradle"), "");
+        assertEquals(
+            "The Publish plugin is applied which adds total of five tasks from Nebula and MavenPublishing plugins.",
+            5,
+            project.getTasks().size()
+        );
 
-        return project;
+        // Tasks applied from "nebula.maven-base-publish"
+        assertTrue(
+            project.getTasks()
+                .findByName("generateMetadataFileForNebulaPublication") instanceof org.gradle.api.publish.tasks.GenerateModuleMetadata
+        );
+        assertTrue(
+            project.getTasks()
+                .findByName("generatePomFileForNebulaPublication") instanceof org.gradle.api.publish.maven.tasks.GenerateMavenPom
+        );
+        assertTrue(
+            project.getTasks()
+                .findByName("publishNebulaPublicationToMavenLocal") instanceof org.gradle.api.publish.maven.tasks.PublishToMavenLocal
+        );
+
+        // Tasks applied from MavenPublishPlugin
+        assertTrue(project.getTasks().findByName("publishToMavenLocal") instanceof org.gradle.api.DefaultTask);
+        assertTrue(project.getTasks().findByName("publish") instanceof org.gradle.api.DefaultTask);
+
+        // And we miss the pluginzip publication task (because no publishing was defined for it)
+        assertNull(project.getTasks().findByName(ZIP_PUBLISH_TASK));
+
+        // We have the following publishing plugins
+        assertEquals(4, project.getPlugins().size());
+        // ... of the following types:
+        assertNotNull(
+            "Project is expected to have OpenSearch pluginzip Publish plugin",
+            project.getPlugins().findPlugin(org.opensearch.gradle.pluginzip.Publish.class)
+        );
+        assertNotNull(
+            "Project is expected to have MavenPublishPlugin (applied from OpenSearch pluginzip plugin)",
+            project.getPlugins().findPlugin(org.gradle.api.publish.maven.plugins.MavenPublishPlugin.class)
+        );
+        assertNotNull(
+            "Project is expected to have Publishing plugin (applied from MavenPublishPublish plugin)",
+            project.getPlugins().findPlugin(org.gradle.api.publish.plugins.PublishingPlugin.class)
+        );
+        assertNotNull(
+            "Project is expected to have nebula MavenBasePublishPlugin plugin (applied from OpenSearch pluginzip plugin)",
+            project.getPlugins().findPlugin(nebula.plugin.publishing.maven.MavenBasePublishPlugin.class)
+        );
+    }
+
+    /**
+     * Verify that if the zip publication is configured then relevant tasks are chained correctly.
+     * This test that the dependsOn() is applied correctly.
+     */
+    @Test
+    public void applyZipPublicationPluginWithConfig() throws IOException, URISyntaxException, InterruptedException {
+
+        /* -------------------------------
+        // The ideal approach would be to create a project (via ProjectBuilder) with publishzip plugin,
+        // have it evaluated (API call) and then check if there are tasks that the plugin uses to hookup into
+        // and how these tasks are chained. The problem is that there is a known gradle issue (#20301) that does
+        // not allow for it ATM. If, however, it is fixed in the future the following is the code that can
+        // be used...
+
+        Project project = ProjectBuilder.builder().build();
+        project.getPluginManager().apply(Publish.class);
+        // add publications via API
+
+        // evaluate the project
+        ((DefaultProject)project).evaluate();
+
+        // - Check that "validatePluginZipPom" and/or "publishPluginZipPublicationToZipStagingRepository"
+        //   tasks have dependencies on "generatePomFileForNebulaPublication".
+        // - Check that there is the staging repository added.
+
+        // However, due to known issue(1): https://github.com/gradle/gradle/issues/20301
+        // it is impossible to reach to individual tasks and work with them.
+        // (1): https://docs.gradle.org/7.4/release-notes.html#known-issues
+
+        // I.e.: The following code throws exception, basically any access to individual tasks fails.
+        project.getTasks().getByName("validatePluginZipPom");
+         ------------------------------- */
+
+        // Instead, we run the gradle project via GradleRunner (this way we get fully evaluated project)
+        // and using the minimal possible configuration (missingPOMEntity) we test that as soon as the zip publication
+        // configuration is specified then all the necessary tasks are hooked up and executed correctly.
+        // However, this does not test execution order of the tasks.
+        GradleRunner runner = prepareGradleRunnerFromTemplate("missingPOMEntity.gradle", ZIP_PUBLISH_TASK/*, "-m"*/);
+        BuildResult result = runner.build();
+
+        assertEquals(SUCCESS, result.task(":" + "bundlePlugin").getOutcome());
+        assertEquals(SUCCESS, result.task(":" + "generatePomFileForNebulaPublication").getOutcome());
+        assertEquals(SUCCESS, result.task(":" + "generatePomFileForPluginZipPublication").getOutcome());
+        assertEquals(SUCCESS, result.task(":" + ZIP_PUBLISH_TASK).getOutcome());
+    }
+
+    /**
+     * If the plugin is used but relevant publication is not defined then a message is printed.
+     */
+    @Test
+    public void missingPublications() throws IOException, URISyntaxException {
+        GradleRunner runner = prepareGradleRunnerFromTemplate("missingPublications.gradle", "build", "-m");
+        BuildResult result = runner.build();
+
+        assertTrue(result.getOutput().contains("Plugin 'opensearch.pluginzip' is applied but no 'pluginZip' publication is defined."));
+    }
+
+    /**
+     * In OpenSearch 3.x the `project.group` property will be mandatory.
+     * But in 2.x (2.4 and above) the `project.group` property can be empty in which case it falls back to default value.
+     */
+    @Test
+    public void missingGroupValue() throws IOException, URISyntaxException, XmlPullParserException {
+        GradleRunner runner = prepareGradleRunnerFromTemplate("missingGroupValue.gradle", "build", ZIP_PUBLISH_TASK);
+        BuildResult result = runner.build();
+
+        /** Check if build and {@value ZIP_PUBLISH_TASK} tasks have run well */
+        assertEquals(SUCCESS, result.task(":" + "build").getOutcome());
+        assertEquals(SUCCESS, result.task(":" + ZIP_PUBLISH_TASK).getOutcome());
+
+        // Parse the maven file and validate default values
+        MavenXpp3Reader reader = new MavenXpp3Reader();
+        Model model = reader.read(
+            new FileReader(
+                new File(
+                    projectDir.getRoot(),
+                    String.join(
+                        File.separator,
+                        "build",
+                        "local-staging-repo",
+                        "org",
+                        "opensearch",
+                        "plugin",
+                        PROJECT_NAME,
+                        "2.0.0.0",
+                        PROJECT_NAME + "-2.0.0.0.pom"
+                    )
+                )
+            )
+        );
+        assertEquals(model.getVersion(), "2.0.0.0");
+        assertEquals(model.getGroupId(), "org.opensearch.plugin");
+        assertEquals(model.getArtifactId(), PROJECT_NAME);
+    }
+
+    /**
+     * This would be the most common use case where user declares Maven publication entity with minimal info
+     * and the resulting POM file will use artifactId, groupId and version values based on the Gradle project object.
+     */
+    @Test
+    public void useDefaultValues() throws IOException, URISyntaxException, XmlPullParserException {
+        GradleRunner runner = prepareGradleRunnerFromTemplate("useDefaultValues.gradle", "build", ZIP_PUBLISH_TASK);
+        BuildResult result = runner.build();
+
+        /** Check if build and {@value ZIP_PUBLISH_TASK} tasks have run well */
+        assertEquals(SUCCESS, result.task(":" + "build").getOutcome());
+        assertEquals(SUCCESS, result.task(":" + ZIP_PUBLISH_TASK).getOutcome());
+
+        // check if both the zip and pom files have been published to local staging repo
+        assertTrue(
+            new File(
+                projectDir.getRoot(),
+                String.join(
+                    File.separator,
+                    "build",
+                    "local-staging-repo",
+                    "org",
+                    "custom",
+                    "group",
+                    PROJECT_NAME,
+                    "2.0.0.0",
+                    PROJECT_NAME + "-2.0.0.0.pom"
+                )
+            ).exists()
+        );
+        assertTrue(
+            new File(
+                projectDir.getRoot(),
+                String.join(
+                    File.separator,
+                    "build",
+                    "local-staging-repo",
+                    "org",
+                    "custom",
+                    "group",
+                    PROJECT_NAME,
+                    "2.0.0.0",
+                    PROJECT_NAME + "-2.0.0.0.zip"
+                )
+            ).exists()
+        );
+
+        // Parse the maven file and validate default values
+        MavenXpp3Reader reader = new MavenXpp3Reader();
+        Model model = reader.read(
+            new FileReader(
+                new File(
+                    projectDir.getRoot(),
+                    String.join(
+                        File.separator,
+                        "build",
+                        "local-staging-repo",
+                        "org",
+                        "custom",
+                        "group",
+                        PROJECT_NAME,
+                        "2.0.0.0",
+                        PROJECT_NAME + "-2.0.0.0.pom"
+                    )
+                )
+            )
+        );
+        assertEquals(model.getVersion(), "2.0.0.0");
+        assertEquals(model.getGroupId(), "org.custom.group");
+        assertEquals(model.getArtifactId(), PROJECT_NAME);
+        assertNull(model.getName());
+        assertNull(model.getDescription());
+
+        assertEquals(model.getUrl(), "https://github.com/doe/sample-plugin");
+    }
+
+    /**
+     * In this case the Publication entity is completely missing but still the POM file is generated using the default
+     * values including the groupId and version values obtained from the Gradle project object.
+     */
+    @Test
+    public void missingPOMEntity() throws IOException, URISyntaxException, XmlPullParserException {
+        GradleRunner runner = prepareGradleRunnerFromTemplate("missingPOMEntity.gradle", "build", ZIP_PUBLISH_TASK);
+        BuildResult result = runner.build();
+
+        /** Check if build and {@value ZIP_PUBLISH_TASK} tasks have run well */
+        assertEquals(SUCCESS, result.task(":" + "build").getOutcome());
+        assertEquals(SUCCESS, result.task(":" + ZIP_PUBLISH_TASK).getOutcome());
+
+        // Parse the maven file and validate it
+        MavenXpp3Reader reader = new MavenXpp3Reader();
+        Model model = reader.read(
+            new FileReader(
+                new File(
+                    projectDir.getRoot(),
+                    String.join(
+                        File.separator,
+                        "build",
+                        "local-staging-repo",
+                        "org",
+                        "custom",
+                        "group",
+                        PROJECT_NAME,
+                        "2.0.0.0",
+                        PROJECT_NAME + "-2.0.0.0.pom"
+                    )
+                )
+            )
+        );
+
+        assertEquals(model.getArtifactId(), PROJECT_NAME);
+        assertEquals(model.getGroupId(), "org.custom.group");
+        assertEquals(model.getVersion(), "2.0.0.0");
+        assertEquals(model.getPackaging(), "zip");
+
+        assertNull(model.getName());
+        assertNull(model.getDescription());
+
+        assertEquals(0, model.getDevelopers().size());
+        assertEquals(0, model.getContributors().size());
+        assertEquals(0, model.getLicenses().size());
+    }
+
+    /**
+     * In some cases we need the POM groupId value to be different from the Gradle "project.group" value hence we
+     * allow for groupId customization (it will override whatever the Gradle "project.group" value is).
+     */
+    @Test
+    public void customizedGroupValue() throws IOException, URISyntaxException, XmlPullParserException {
+        GradleRunner runner = prepareGradleRunnerFromTemplate("customizedGroupValue.gradle", "build", ZIP_PUBLISH_TASK);
+        BuildResult result = runner.build();
+
+        /** Check if build and {@value ZIP_PUBLISH_TASK} tasks have run well */
+        assertEquals(SUCCESS, result.task(":" + "build").getOutcome());
+        assertEquals(SUCCESS, result.task(":" + ZIP_PUBLISH_TASK).getOutcome());
+
+        // Parse the maven file and validate the groupID
+        MavenXpp3Reader reader = new MavenXpp3Reader();
+        Model model = reader.read(
+            new FileReader(
+                new File(
+                    projectDir.getRoot(),
+                    String.join(
+                        File.separator,
+                        "build",
+                        "local-staging-repo",
+                        "I",
+                        "am",
+                        "customized",
+                        PROJECT_NAME,
+                        "2.0.0.0",
+                        PROJECT_NAME + "-2.0.0.0.pom"
+                    )
+                )
+            )
+        );
+
+        assertEquals(model.getGroupId(), "I.am.customized");
+    }
+
+    /**
+     * If the customized groupId value is invalid (from the Maven POM perspective) then we need to be sure it is
+     * caught and reported properly.
+     */
+    @Test
+    public void customizedInvalidGroupValue() throws IOException, URISyntaxException {
+        GradleRunner runner = prepareGradleRunnerFromTemplate("customizedInvalidGroupValue.gradle", "build", ZIP_PUBLISH_TASK);
+        Exception e = assertThrows(UnexpectedBuildFailure.class, runner::build);
+        assertTrue(
+            e.getMessage().contains("Invalid publication 'pluginZip': groupId ( ) is not a valid Maven identifier ([A-Za-z0-9_\\-.]+).")
+        );
+    }
+
+    /**
+     * This test verifies that use of the pluginZip does not clash with other maven publication plugins.
+     * It covers the case when user calls the "publishToMavenLocal" task.
+     */
+    @Test
+    public void publishToMavenLocal() throws IOException, URISyntaxException, XmlPullParserException {
+        // By default, the "publishToMavenLocal" publishes artifacts to a local m2 repo, typically
+        // found in `~/.m2/repository`. But this is not practical for this unit test at all. We need to point
+        // the 'maven-publish' plugin to a custom m2 repo located in temporary directory associated with this
+        // test case instead.
+        //
+        // According to Gradle documentation this should be possible by proper configuration of the publishing
+        // task (https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:install).
+        // But for some reason this never worked as expected and artifacts created during this test case
+        // were always pushed into the default local m2 repository (ie: `~/.m2/repository`).
+        // The only workaround that seems to work is to pass "-Dmaven.repo.local" property via runner argument.
+        // (Kudos to: https://stackoverflow.com/questions/72265294/gradle-publishtomavenlocal-specify-custom-directory)
+        //
+        // The temporary directory that is used as the local m2 repository is created via in task "prepareLocalMVNRepo".
+        GradleRunner runner = prepareGradleRunnerFromTemplate(
+            "publishToMavenLocal.gradle",
+            String.join(File.separator, "-Dmaven.repo.local=" + projectDir.getRoot(), "build", "local-staging-repo"),
+            "build",
+            "prepareLocalMVNRepo",
+            "publishToMavenLocal"
+        );
+        BuildResult result = runner.build();
+
+        assertEquals(SUCCESS, result.task(":" + "build").getOutcome());
+        assertEquals(SUCCESS, result.task(":" + "publishToMavenLocal").getOutcome());
+
+        // Parse the maven file and validate it
+        MavenXpp3Reader reader = new MavenXpp3Reader();
+        Model model = reader.read(
+            new FileReader(
+                new File(
+                    projectDir.getRoot(),
+                    String.join(
+                        File.separator,
+                        "build",
+                        "local-staging-repo",
+                        "org",
+                        "custom",
+                        "group",
+                        PROJECT_NAME,
+                        "2.0.0.0",
+                        PROJECT_NAME + "-2.0.0.0.pom"
+                    )
+                )
+            )
+        );
+
+        // The "publishToMavenLocal" task will run ALL maven publications, hence we can expect the ZIP publication
+        // present as well: https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:tasks
+        assertEquals(model.getArtifactId(), PROJECT_NAME);
+        assertEquals(model.getGroupId(), "org.custom.group");
+        assertEquals(model.getVersion(), "2.0.0.0");
+        assertEquals(model.getPackaging(), "zip");
+
+        // We have two publications in the build.gradle file, both are "MavenPublication" based.
+        // Both the mavenJava and pluginZip publications publish to the same location (coordinates) and
+        // artifacts (the POM file) overwrite each other. However, we can verify that the Zip plugin is
+        // the last one and "wins" over the mavenJava.
+        assertEquals(model.getDescription(), "pluginZip publication");
+    }
+
+    /**
+     * A helper method for use cases
+     *
+     * @param templateName The name of the file (from "pluginzip" folder) to use as a build.gradle for the test
+     * @param gradleArguments Optional CLI parameters to pass into Gradle runner
+     */
+    private GradleRunner prepareGradleRunnerFromTemplate(String templateName, String... gradleArguments) throws IOException,
+        URISyntaxException {
+        useTemplateFile(projectDir.newFile("build.gradle"), templateName);
+        prepareGradleFilesAndSources();
+
+        GradleRunner runner = GradleRunner.create()
+            .forwardOutput()
+            .withPluginClasspath()
+            .withArguments(gradleArguments)
+            .withProjectDir(projectDir.getRoot());
+
+        return runner;
+    }
+
+    private void prepareGradleFilesAndSources() throws IOException {
+        // A dummy "source" file that is processed with bundlePlugin and put into a ZIP artifact file
+        File bundleFile = new File(projectDir.getRoot(), PROJECT_NAME + "-source.txt");
+        Files.createFile(bundleFile.toPath());
+        // Setting a project name via settings.gradle file
+        writeString(projectDir.newFile("settings.gradle"), "rootProject.name = '" + PROJECT_NAME + "'");
     }
 
     private void writeString(File file, String string) throws IOException {
         try (Writer writer = new FileWriter(file)) {
             writer.write(string);
+        }
+    }
+
+    /**
+     * Write the content of the "template" file into the target file.
+     * The template file must be located in the {@value TEMPLATE_RESOURCE_FOLDER} folder.
+     * @param targetFile A target file
+     * @param templateFile A name of the template file located under {@value TEMPLATE_RESOURCE_FOLDER} folder
+     */
+    private void useTemplateFile(File targetFile, String templateFile) throws IOException, URISyntaxException {
+
+        URL resource = getClass().getClassLoader().getResource(String.join(File.separator, TEMPLATE_RESOURCE_FOLDER, templateFile));
+        Path resPath = Paths.get(resource.toURI()).toAbsolutePath();
+        List<String> lines = Files.readAllLines(resPath, StandardCharsets.UTF_8);
+
+        try (Writer writer = new FileWriter(targetFile)) {
+            for (String line : lines) {
+                writer.write(line);
+                writer.write(System.lineSeparator());
+            }
         }
     }
 

--- a/buildSrc/src/test/resources/pluginzip/customizedGroupValue.gradle
+++ b/buildSrc/src/test/resources/pluginzip/customizedGroupValue.gradle
@@ -1,0 +1,44 @@
+plugins {
+  id 'java-gradle-plugin'
+  id 'opensearch.pluginzip'
+}
+
+group="org.custom.group"
+version='2.0.0.0'
+
+// A bundlePlugin task mockup
+tasks.register('bundlePlugin', Zip.class) {
+  archiveFileName = "sample-plugin-${version}.zip"
+  destinationDirectory = layout.buildDirectory.dir('distributions')
+  from layout.projectDirectory.file('sample-plugin-source.txt')
+}
+
+publishing {
+  publications {
+    pluginZip(MavenPublication) {
+      groupId = "I.am.customized"
+      pom {
+        name = "sample-plugin"
+        description = "pluginDescription"
+        licenses {
+          license {
+            name = "The Apache License, Version 2.0"
+            url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+        developers {
+          developer {
+            name = "John Doe"
+            url = "https://github.com/john-doe/"
+            organization = "Doe.inc"
+            organizationUrl = "https://doe.inc/"
+          }
+        }
+        url = "https://github.com/doe/sample-plugin"
+        scm {
+          url = "https://github.com/doe/sample-plugin"
+        }
+      }
+    }
+  }
+}

--- a/buildSrc/src/test/resources/pluginzip/customizedInvalidGroupValue.gradle
+++ b/buildSrc/src/test/resources/pluginzip/customizedInvalidGroupValue.gradle
@@ -1,0 +1,44 @@
+plugins {
+  id 'java-gradle-plugin'
+  id 'opensearch.pluginzip'
+}
+
+group="org.custom.group"
+version='2.0.0.0'
+
+// A bundlePlugin task mockup
+tasks.register('bundlePlugin', Zip.class) {
+  archiveFileName = "sample-plugin-${version}.zip"
+  destinationDirectory = layout.buildDirectory.dir('distributions')
+  from layout.projectDirectory.file('sample-plugin-source.txt')
+}
+
+publishing {
+  publications {
+    pluginZip(MavenPublication) {
+      groupId = " "  // <-- User provides invalid value
+      pom {
+        name = "sample-plugin"
+        description = "pluginDescription"
+        licenses {
+          license {
+            name = "The Apache License, Version 2.0"
+            url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+        developers {
+          developer {
+            name = "John Doe"
+            url = "https://github.com/john-doe/"
+            organization = "Doe.inc"
+            organizationUrl = "https://doe.inc/"
+          }
+        }
+        url = "https://github.com/doe/sample-plugin"
+        scm {
+          url = "https://github.com/doe/sample-plugin"
+        }
+      }
+    }
+  }
+}

--- a/buildSrc/src/test/resources/pluginzip/missingGroupValue.gradle
+++ b/buildSrc/src/test/resources/pluginzip/missingGroupValue.gradle
@@ -1,0 +1,21 @@
+plugins {
+  id 'java-gradle-plugin'
+  id 'opensearch.pluginzip'
+}
+
+//group="org.custom.group"
+version='2.0.0.0'
+
+// A bundlePlugin task mockup
+tasks.register('bundlePlugin', Zip.class) {
+  archiveFileName = "sample-plugin-${version}.zip"
+  destinationDirectory = layout.buildDirectory.dir('distributions')
+  from layout.projectDirectory.file('sample-plugin-source.txt')
+}
+
+publishing {
+  publications {
+    pluginZip(MavenPublication) {
+    }
+  }
+}

--- a/buildSrc/src/test/resources/pluginzip/missingPOMEntity.gradle
+++ b/buildSrc/src/test/resources/pluginzip/missingPOMEntity.gradle
@@ -1,0 +1,21 @@
+plugins {
+  id 'java-gradle-plugin'
+  id 'opensearch.pluginzip'
+}
+
+group="org.custom.group"
+version='2.0.0.0'
+
+// A bundlePlugin task mockup
+tasks.register('bundlePlugin', Zip.class) {
+  archiveFileName = "sample-plugin-${version}.zip"
+  destinationDirectory = layout.buildDirectory.dir('distributions')
+  from layout.projectDirectory.file('sample-plugin-source.txt')
+}
+
+publishing {
+  publications {
+    pluginZip(MavenPublication) {
+    }
+  }
+}

--- a/buildSrc/src/test/resources/pluginzip/missingPublications.gradle
+++ b/buildSrc/src/test/resources/pluginzip/missingPublications.gradle
@@ -1,0 +1,21 @@
+plugins {
+  id 'java-gradle-plugin'
+  id 'opensearch.pluginzip'
+}
+
+group="org.custom.group"
+version='2.0.0.0'
+
+// A bundlePlugin task mockup
+tasks.register('bundlePlugin', Zip.class) {
+  archiveFileName = "sample-plugin-${version}.zip"
+  destinationDirectory = layout.buildDirectory.dir('distributions')
+  from layout.projectDirectory.file('sample-plugin-source.txt')
+}
+
+//publishing {
+//  publications {
+//    pluginZip(MavenPublication) {
+//    }
+//  }
+//}

--- a/buildSrc/src/test/resources/pluginzip/publishToMavenLocal.gradle
+++ b/buildSrc/src/test/resources/pluginzip/publishToMavenLocal.gradle
@@ -1,0 +1,47 @@
+plugins {
+  // The java-gradle-plugin adds a new publication called 'pluginMaven' that causes some warnings because it
+  // clashes a bit with other publications defined in this file. If you are running at the --info level then you can
+  // expect some warning like the following:
+  // "Multiple publications with coordinates 'org.custom.group:sample-plugin:2.0.0.0' are published to repository 'mavenLocal'."
+  id 'java-gradle-plugin'
+  id 'opensearch.pluginzip'
+}
+
+group="org.custom.group"
+version='2.0.0.0'
+
+// A bundlePlugin task mockup
+tasks.register('bundlePlugin', Zip.class) {
+  archiveFileName = "sample-plugin-${version}.zip"
+  destinationDirectory = layout.buildDirectory.dir('distributions')
+  from layout.projectDirectory.file('sample-plugin-source.txt')
+}
+
+// A task to prepare directory for a temporary maven local repository
+tasks.register('prepareLocalMVNRepo') {
+  dependsOn ':bundlePlugin'
+  doFirst {
+    File localMVNRepo = new File (layout.buildDirectory.get().getAsFile().getPath(), 'local-staging-repo')
+    System.out.println('Creating temporary folder for mavenLocal repo: '+ localMVNRepo.toString())
+    System.out.println("Success: " + localMVNRepo.mkdir())
+  }
+}
+
+publishing {
+  publications {
+    // Plugin zip publication
+    pluginZip(MavenPublication) {
+      pom {
+        url = 'http://www.example.com/library'
+        description = 'pluginZip publication'
+      }
+    }
+    // Standard maven publication
+    mavenJava(MavenPublication) {
+      pom {
+        url = 'http://www.example.com/library'
+        description = 'mavenJava publication'
+      }
+    }
+  }
+}

--- a/buildSrc/src/test/resources/pluginzip/useDefaultValues.gradle
+++ b/buildSrc/src/test/resources/pluginzip/useDefaultValues.gradle
@@ -1,0 +1,43 @@
+plugins {
+  id 'java-gradle-plugin'
+  id 'opensearch.pluginzip'
+}
+
+group="org.custom.group"
+version='2.0.0.0'
+
+// A bundlePlugin task mockup
+tasks.register('bundlePlugin', Zip.class) {
+  archiveFileName = "sample-plugin-${version}.zip"
+  destinationDirectory = layout.buildDirectory.dir('distributions')
+  from layout.projectDirectory.file('sample-plugin-source.txt')
+}
+
+publishing {
+  publications {
+    pluginZip(MavenPublication) {
+      pom {
+//        name = "plugin name"
+//        description = "plugin description"
+        licenses {
+          license {
+            name = "The Apache License, Version 2.0"
+            url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+        developers {
+          developer {
+            name = "John Doe"
+            url = "https://github.com/john-doe/"
+            organization = "Doe.inc"
+            organizationUrl = "https://doe.inc/"
+          }
+        }
+        url = "https://github.com/doe/sample-plugin"
+        scm {
+          url = "https://github.com/doe/sample-plugin"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
…and Further simplification of the ZIP publication implementation (#4360)

### Description

* This is a backport of #4156 and #4360 to 2.x
* #4156 was cherry-picked from 7fe5830
  -  Resolving conflicts in CHANGELOG.md
* #4360 was cherry-picked from ab6849f
  -  Resolving conflicts in CHANGELOG.md

There is one noticeable difference, the `project.group` property can be empty in which case it will fall back to default value: `org.opensearch.plugin`. See <https://github.com/opensearch-project/OpenSearch/pull/4156#issuecomment-1230397082> for more details.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Lukáš Vlček <lukas.vlcek@aiven.io>
