### PR TITLE
Validating fuzziness value in query

### DIFF
--- a/server/src/main/java/org/opensearch/common/unit/Fuzziness.java
+++ b/server/src/main/java/org/opensearch/common/unit/Fuzziness.java
@@ -70,7 +70,7 @@ public final class Fuzziness implements ToXContentFragment, Writeable {
         if (fuzziness != 0 && fuzziness != 1 && fuzziness != 2) {
             throw new IllegalArgumentException("Valid edit distances are [0, 1, 2] but was [" + fuzziness + "]");
         }
-        this.fuzziness = Integer.toString(fuzziness);   
+        this.fuzziness = Integer.toString(fuzziness);
     }
 
     private Fuzziness(String fuzziness) {
@@ -243,6 +243,9 @@ public final class Fuzziness implements ToXContentFragment, Writeable {
         }
         if(fuzziness.startsWith("AUTO:")) {
             String[] fuzzinessLimit = fuzziness.substring("AUTO:".length()).split(",");
+            if(fuzzinessLimit.length!=2) {
+                return false;
+            }
             return isValidFuzzinessLimit(fuzzinessLimit[0]) && isValidFuzzinessLimit(fuzzinessLimit[1]);
         }
         return isValidFuzzinessLimit(fuzziness);


### PR DESCRIPTION
Signed-off-by: Subramanian S <subbu.dvk0@gmail.com>

### Description
Validated fuzziness values are only positive integers, AUTO or AUTO:int,int

### Issues Resolved
[Issue 4223](https://github.com/opensearch-project/OpenSearch/issues/4223)

### Check List
Tested positive integers, AUTO, AUTO:int,int cases, working as expected.
Other illegal values throw error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
