### PR TITLE
[Feature/extensions] Add contentParser method to ExtensionRestRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - Pass REST params and content to extensions ([#4633](https://github.com/opensearch-project/OpenSearch/pull/4633))
  - Return consumed params and content from extensions ([#4705](https://github.com/opensearch-project/OpenSearch/pull/4705))
  - Modified EnvironmentSettingsRequest to pass entire Settings object ([#4731](https://github.com/opensearch-project/OpenSearch/pull/4731))
+ - Added contentParser method to ExtensionRestRequest ([#4760](https://github.com/opensearch-project/OpenSearch/pull/4760))
 
 ## [2.x]
 

--- a/server/src/main/java/org/opensearch/extensions/rest/ExtensionRestRequest.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/ExtensionRestRequest.java
@@ -8,9 +8,13 @@
 
 package org.opensearch.extensions.rest;
 
+import org.opensearch.OpenSearchParseException;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.identity.PrincipalIdentifierToken;
 import org.opensearch.rest.RestRequest;
@@ -227,6 +231,21 @@ public class ExtensionRestRequest extends TransportRequest {
      */
     public boolean isContentConsumed() {
         return contentConsumed;
+    }
+
+    /**
+     * Gets a parser for the contents of this request if there is content and an xContentType.
+     *
+     * @param xContentRegistry The extension's xContentRegistry
+     * @return A parser for the given content and content type.
+     * @throws OpenSearchParseException on missing body or xContentType.
+     * @throws IOException on a failure creating the parser.
+     */
+    public final XContentParser contentParser(NamedXContentRegistry xContentRegistry) throws IOException {
+        if (!hasContent() || getXContentType() == null) {
+            throw new OpenSearchParseException("There is no request body or the ContentType is invalid.");
+        }
+        return getXContentType().xContent().createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, content.streamInput());
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

Companion PR: https://github.com/opensearch-project/opensearch-sdk-java/pull/192

This PR does not change the API and can be merged at any time before the companion PR even if it is still in review.

### Description
Adds a `contentParser()` method to the `ExtensionRestRequest` class to enable extensions to parse REST requests with bodies containing JSON, SMILE, YAML, or CBOR.

### Issues Resolved
OpenSearch part of [SDK #178](https://github.com/opensearch-project/opensearch-sdk-java/issues/178)

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
