### PR TITLE
Compatibility issue with /_mget: RHLC 2.x connected to OpenSearch Cluster 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix recovery path for searchable snapshots ([4813](https://github.com/opensearch-project/OpenSearch/pull/4813))
 - Fix bug in AwarenessAttributeDecommissionIT([4822](https://github.com/opensearch-project/OpenSearch/pull/4822))
 - Fix 'org.apache.hc.core5.http.ParseException: Invalid protocol version' under JDK 16+ ([#4827](https://github.com/opensearch-project/OpenSearch/pull/4827))
+- Compatibility issue with /_mget: RHLC 2.x connected to OpenSearch Cluster 1.x ([#4812](https://github.com/opensearch-project/OpenSearch/pull/4812))
 
 ### Security
 - CVE-2022-25857 org.yaml:snakeyaml DOS vulnerability ([#4341](https://github.com/opensearch-project/OpenSearch/pull/4341))

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -38,6 +38,10 @@ apply plugin: 'opensearch.standalone-test'
 apply from : "$rootDir/gradle/bwc-test.gradle"
 apply plugin: 'opensearch.rest-resources'
 
+dependencies {
+  testImplementation project(":client:rest-high-level")
+}
+
 restResources {
   restTests {
     includeCore '*'

--- a/qa/mixed-cluster/src/test/java/org/opensearch/backwards/SearchingIT.java
+++ b/qa/mixed-cluster/src/test/java/org/opensearch/backwards/SearchingIT.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.backwards;
+
+import org.apache.hc.core5.http.HttpHost;
+import org.opensearch.LegacyESVersion;
+import org.opensearch.Version;
+import org.opensearch.action.get.MultiGetRequest;
+import org.opensearch.action.get.MultiGetResponse;
+import org.opensearch.backwards.IndexingIT.Nodes;
+import org.opensearch.client.Request;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.Strings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.common.xcontent.support.XContentMapValues;
+import org.opensearch.index.seqno.SeqNoStats;
+import org.opensearch.rest.RestStatus;
+import org.opensearch.test.rest.OpenSearchRestTestCase;
+import org.opensearch.test.rest.yaml.ObjectPath;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class SearchingIT extends OpenSearchRestTestCase {
+    public void testMultiGet() throws Exception {
+        final Set<HttpHost> nodes = buildNodes();
+
+        final MultiGetRequest multiGetRequest = new MultiGetRequest();
+        multiGetRequest.add("index", "id1");
+
+        try (RestHighLevelClient client = new RestHighLevelClient(RestClient.builder(nodes.toArray(HttpHost[]::new)))) {
+            MultiGetResponse response = client.mget(multiGetRequest, RequestOptions.DEFAULT);
+            assertEquals(1, response.getResponses().length);
+    
+            assertTrue(response.getResponses()[0].isFailed());
+            assertNotNull(response.getResponses()[0].getFailure());
+            assertEquals(response.getResponses()[0].getFailure().getId(), "id1");
+            assertEquals(response.getResponses()[0].getFailure().getIndex(), "index");
+            assertThat(response.getResponses()[0].getFailure().getMessage(), containsString("no such index [index]"));
+       }
+    }
+
+    private Set<HttpHost> buildNodes() throws IOException, URISyntaxException {
+        Response response = client().performRequest(new Request("GET", "_nodes"));
+        ObjectPath objectPath = ObjectPath.createFromResponse(response);
+        Map<String, Object> nodesAsMap = objectPath.evaluate("nodes");
+        final Set<HttpHost> nodes = new HashSet<>();
+        for (String id : nodesAsMap.keySet()) {
+            nodes.add(HttpHost.create((String) objectPath.evaluate("nodes." + id + ".http.publish_address")));
+        }
+
+        return nodes;
+    }
+}

--- a/server/src/main/java/org/opensearch/action/get/MultiGetResponse.java
+++ b/server/src/main/java/org/opensearch/action/get/MultiGetResponse.java
@@ -63,6 +63,10 @@ public class MultiGetResponse extends ActionResponse implements Iterable<MultiGe
     private static final ParseField ID = new ParseField("_id");
     private static final ParseField ERROR = new ParseField("error");
     private static final ParseField DOCS = new ParseField("docs");
+    // In mixed clusters, the 1.x cluster could still return the '_type' in the response payload, it has to
+    // be handled gracefully
+    @Deprecated(forRemoval = true)
+    private static final ParseField TYPE = new ParseField("_type");
 
     /**
      * Represents a failure.
@@ -212,6 +216,7 @@ public class MultiGetResponse extends ActionResponse implements Iterable<MultiGe
                     currentFieldName = parser.currentName();
                     if (INDEX.match(currentFieldName, parser.getDeprecationHandler()) == false
                         && ID.match(currentFieldName, parser.getDeprecationHandler()) == false
+                        && TYPE.match(currentFieldName, parser.getDeprecationHandler()) == false
                         && ERROR.match(currentFieldName, parser.getDeprecationHandler()) == false) {
                         getResult = GetResult.fromXContentEmbedded(parser, index, id);
                     }


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
There is a compatibility issue with `/_mget` API: RHLC 2.x connected to OpenSearch Cluster 1.x, which basically renders the API unusable in certain cases, ending up with `NullPointerException`.

```
Exception in thread "main" java.io.IOException: Unable to parse response body for Response{requestLine=POST /_mget HTTP/1.1, host=http://localhost:9200, response=HTTP/1.1 200 OK}
	at org.opensearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:1777)
	at org.opensearch.client.RestHighLevelClient.performRequest(RestHighLevelClient.java:1724)
	at org.opensearch.client.RestHighLevelClient.performRequestAndParseEntity(RestHighLevelClient.java:1692)
	at org.opensearch.client.RestHighLevelClient.mget(RestHighLevelClient.java:751)
	at io.aven.opensearch.client_runners.RestClientMultigetRunner.main(RestClientMultigetRunner.java:29)
Caused by: java.lang.NullPointerException
	at org.opensearch.index.get.GetResult.fromXContentEmbedded(GetResult.java:411)
	at org.opensearch.action.get.MultiGetResponse.parseItem(MultiGetResponse.java:216)
	at org.opensearch.action.get.MultiGetResponse.fromXContent(MultiGetResponse.java:189)
	at org.opensearch.client.RestHighLevelClient.parseEntity(RestHighLevelClient.java:2075)
	at org.opensearch.client.RestHighLevelClient.lambda$performRequestAndParseEntity$8(RestHighLevelClient.java:1692)
	at org.opensearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:1775)
	... 4 more
```

### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/4749

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
