### PR TITLE
Platform dependent github action workflows for gradle check

### DIFF
--- a/.github/workflows/gradle-check-linux.yml
+++ b/.github/workflows/gradle-check-linux.yml
@@ -1,4 +1,4 @@
-name: Gradle Check (Jenkins)
+name: Gradle Check Linux (Jenkins)
 on:
   push:
     branches-ignore:
@@ -30,6 +30,7 @@ jobs:
             echo "pr_to_clone_url=$(jq --raw-output .pull_request.base.repo.clone_url $GITHUB_EVENT_PATH)" >> $GITHUB_ENV
             echo "pr_title=$(jq --raw-output .pull_request.title $GITHUB_EVENT_PATH)" >> $GITHUB_ENV
             echo "pr_number=$(jq --raw-output .pull_request.number $GITHUB_EVENT_PATH)" >> $GITHUB_ENV
+            echo "platform=linux" >> $GITHUB_ENV
 
       - name: Setup environment variables (Push)
         if: github.event_name == 'push'
@@ -42,6 +43,7 @@ jobs:
             echo "pr_to_clone_url=$repo_url" >> $GITHUB_ENV
             echo "pr_title=Push trigger $branch_name $ref_id $repo_url" >> $GITHUB_ENV
             echo "pr_number=Null" >> $GITHUB_ENV
+            echo "platform=linux" >> $GITHUB_ENV
 
       - name: Checkout opensearch-build repo
         uses: actions/checkout@v2

--- a/.github/workflows/gradle-check-windows.yml
+++ b/.github/workflows/gradle-check-windows.yml
@@ -1,0 +1,54 @@
+name: Gradle Check Windows (Jenkins)
+on:
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  gradle-check:
+    runs-on: windows-latest
+    timeout-minutes: 160
+    steps:
+      - name: Checkout OpenSearch repo
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Setup environment variables (Cron Schedule)
+        if: github.event_name == 'schedule'
+        run: |
+          repo_url="https://github.com/opensearch-project/OpenSearch"
+          ref_id=$(git rev-parse HEAD)
+          branch_name=$(git rev-parse --abbrev-ref HEAD)
+          echo "pr_from_sha=$ref_id" >> $GITHUB_ENV
+          echo "pr_from_clone_url=$repo_url" >> $GITHUB_ENV
+          echo "pr_to_clone_url=$repo_url" >> $GITHUB_ENV
+          echo "pr_title=Cron trigger $branch_name $ref_id $repo_url" >> $GITHUB_ENV
+          echo "pr_number=Null" >> $GITHUB_ENV
+          echo "platform=windows" >> $GITHUB_ENV
+
+      - name: Checkout opensearch-build repo
+        uses: actions/checkout@v2
+        with:
+          repository: opensearch-project/opensearch-build
+          ref: main
+          path: opensearch-build
+
+      - name: Trigger jenkins workflow to run gradle check
+        run: |
+          set -e
+          set -o pipefail
+          bash opensearch-build/scripts/gradle/gradle-check.sh ${{ secrets.JENKINS_GRADLE_CHECK_GENERIC_WEBHOOK_TOKEN }} | tee -a gradle-check.log
+
+      - name: Setup Result Status
+        if: always()
+        run: |
+          WORKFLOW_URL=`cat gradle-check.log | grep 'WORKFLOW_URL' | awk '{print $2}'`
+          RESULT=`cat gradle-check.log | grep 'Result:' | awk '{print $2}'`
+          echo "workflow_url=$WORKFLOW_URL" >> $GITHUB_ENV
+          echo "result=$RESULT" >> $GITHUB_ENV
+
+      - name: Upload Coverage Report
+        if: success()
+        uses: codecov/codecov-action@v2
+        with:
+          files: ./codeCoverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Recommissioning of zone. REST layer support. ([#4624](https://github.com/opensearch-project/OpenSearch/pull/4604))
 - Added in-flight cancellation of SearchShardTask based on resource consumption ([#4565](https://github.com/opensearch-project/OpenSearch/pull/4565))
 - Apply reproducible builds configuration for OpenSearch plugins through gradle plugin ([#4746](https://github.com/opensearch-project/OpenSearch/pull/4746))
+- Platform dependent github action workflows for gradle check ([#4824](https://github.com/opensearch-project/OpenSearch/pull/4824))
 
 ### Dependencies
 - Bumps `log4j-core` from 2.18.0 to 2.19.0


### PR DESCRIPTION
Signed-off-by: Poojita Raj <poojiraj@amazon.com>

### Description
As part of creating windows CI, we create a new github action workflow to run gradle check on windows. 

### Issues Resolved
Resolves #4815 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
