### PR TITLE
[Remove] LegacyESVersion.V_7_6_* and V_7_7_* constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Remove unused private methods ([#4926](https://github.com/opensearch-project/OpenSearch/pull/4926))
 - Revert PR 4656 to unblock Windows CI ([#4949](https://github.com/opensearch-project/OpenSearch/pull/4949))
 - Remove LegacyESVersion.V_7_8_ and V_7_9_ Constants ([#4855](https://github.com/opensearch-project/OpenSearch/pull/4855))
+- Remove LegacyESVersion.V_7_6_ and V_7_7_ Constants ([#4837](https://github.com/opensearch-project/OpenSearch/pull/4837))
 
 ### Fixed
 - `opensearch-service.bat start` and `opensearch-service.bat manager` failing to run ([#4289](https://github.com/opensearch-project/OpenSearch/pull/4289))

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/CommonAnalysisModulePlugin.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/CommonAnalysisModulePlugin.java
@@ -124,7 +124,7 @@ import org.apache.lucene.analysis.tr.ApostropheFilter;
 import org.apache.lucene.analysis.tr.TurkishAnalyzer;
 import org.apache.lucene.analysis.util.ElisionFilter;
 import org.apache.lucene.util.SetOnce;
-import org.opensearch.LegacyESVersion;
+import org.opensearch.Version;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
@@ -347,7 +347,12 @@ public class CommonAnalysisModulePlugin extends Plugin implements AnalysisPlugin
         tokenizers.put("simple_pattern_split", SimplePatternSplitTokenizerFactory::new);
         tokenizers.put("thai", ThaiTokenizerFactory::new);
         tokenizers.put("nGram", (IndexSettings indexSettings, Environment environment, String name, Settings settings) -> {
-            if (indexSettings.getIndexVersionCreated().onOrAfter(LegacyESVersion.V_7_6_0)) {
+            if (indexSettings.getIndexVersionCreated().onOrAfter(Version.V_3_0_0)) {
+                throw new IllegalArgumentException(
+                    "The [nGram] tokenizer name was deprecated pre 1.0. "
+                        + "Please use the tokenizer name to [ngram] for indices created in versions 3.0 or higher instead."
+                );
+            } else {
                 deprecationLogger.deprecate(
                     "nGram_tokenizer_deprecation",
                     "The [nGram] tokenizer name is deprecated and will be removed in a future version. "
@@ -358,7 +363,12 @@ public class CommonAnalysisModulePlugin extends Plugin implements AnalysisPlugin
         });
         tokenizers.put("ngram", NGramTokenizerFactory::new);
         tokenizers.put("edgeNGram", (IndexSettings indexSettings, Environment environment, String name, Settings settings) -> {
-            if (indexSettings.getIndexVersionCreated().onOrAfter(LegacyESVersion.V_7_6_0)) {
+            if (indexSettings.getIndexVersionCreated().onOrAfter(Version.V_3_0_0)) {
+                throw new IllegalArgumentException(
+                    "The [edgeNGram] tokenizer name was deprecated pre 1.0. "
+                        + "Please use the tokenizer name to [edge_ngram] for indices created in versions 3.0 or higher instead."
+                );
+            } else {
                 deprecationLogger.deprecate(
                     "edgeNGram_tokenizer_deprecation",
                     "The [edgeNGram] tokenizer name is deprecated and will be removed in a future version. "
@@ -606,7 +616,12 @@ public class CommonAnalysisModulePlugin extends Plugin implements AnalysisPlugin
 
         // Temporary shim for aliases. TODO deprecate after they are moved
         tokenizers.add(PreConfiguredTokenizer.openSearchVersion("nGram", (version) -> {
-            if (version.onOrAfter(LegacyESVersion.V_7_6_0)) {
+            if (version.onOrAfter(Version.V_3_0_0)) {
+                throw new IllegalArgumentException(
+                    "The [nGram] tokenizer name was deprecated pre 1.0. "
+                        + "Please use the tokenizer name to [ngram] for indices created in versions 3.0 or higher instead."
+                );
+            } else {
                 deprecationLogger.deprecate(
                     "nGram_tokenizer_deprecation",
                     "The [nGram] tokenizer name is deprecated and will be removed in a future version. "
@@ -616,7 +631,12 @@ public class CommonAnalysisModulePlugin extends Plugin implements AnalysisPlugin
             return new NGramTokenizer();
         }));
         tokenizers.add(PreConfiguredTokenizer.openSearchVersion("edgeNGram", (version) -> {
-            if (version.onOrAfter(LegacyESVersion.V_7_6_0)) {
+            if (version.onOrAfter(Version.V_3_0_0)) {
+                throw new IllegalArgumentException(
+                    "The [edgeNGram] tokenizer name was deprecated pre 1.0. "
+                        + "Please use the tokenizer name to [edge_ngram] for indices created in versions 3.0 or higher instead."
+                );
+            } else {
                 deprecationLogger.deprecate(
                     "edgeNGram_tokenizer_deprecation",
                     "The [edgeNGram] tokenizer name is deprecated and will be removed in a future version. "

--- a/modules/geo/src/main/java/org/opensearch/geo/search/aggregations/bucket/composite/GeoTileGridValuesSourceBuilder.java
+++ b/modules/geo/src/main/java/org/opensearch/geo/search/aggregations/bucket/composite/GeoTileGridValuesSourceBuilder.java
@@ -33,7 +33,6 @@
 package org.opensearch.geo.search.aggregations.bucket.composite;
 
 import org.apache.lucene.index.IndexReader;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.geo.GeoBoundingBox;
 import org.opensearch.common.geo.GeoPoint;
@@ -175,9 +174,7 @@ public class GeoTileGridValuesSourceBuilder extends CompositeValuesSourceBuilder
     public GeoTileGridValuesSourceBuilder(StreamInput in) throws IOException {
         super(in);
         this.precision = in.readInt();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-            this.geoBoundingBox = new GeoBoundingBox(in);
-        }
+        this.geoBoundingBox = new GeoBoundingBox(in);
     }
 
     public GeoTileGridValuesSourceBuilder precision(int precision) {
@@ -198,9 +195,7 @@ public class GeoTileGridValuesSourceBuilder extends CompositeValuesSourceBuilder
     @Override
     protected void innerWriteTo(StreamOutput out) throws IOException {
         out.writeInt(precision);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-            geoBoundingBox.writeTo(out);
-        }
+        geoBoundingBox.writeTo(out);
     }
 
     @Override

--- a/modules/geo/src/main/java/org/opensearch/geo/search/aggregations/bucket/geogrid/GeoGridAggregationBuilder.java
+++ b/modules/geo/src/main/java/org/opensearch/geo/search/aggregations/bucket/geogrid/GeoGridAggregationBuilder.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.geo.search.aggregations.bucket.geogrid;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchException;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.geo.GeoBoundingBox;
@@ -125,9 +124,7 @@ public abstract class GeoGridAggregationBuilder extends ValuesSourceAggregationB
         precision = in.readVInt();
         requiredSize = in.readVInt();
         shardSize = in.readVInt();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-            geoBoundingBox = new GeoBoundingBox(in);
-        }
+        geoBoundingBox = new GeoBoundingBox(in);
     }
 
     @Override
@@ -140,9 +137,7 @@ public abstract class GeoGridAggregationBuilder extends ValuesSourceAggregationB
         out.writeVInt(precision);
         out.writeVInt(requiredSize);
         out.writeVInt(shardSize);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-            geoBoundingBox.writeTo(out);
-        }
+        geoBoundingBox.writeTo(out);
     }
 
     /**

--- a/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/RankEvalRequest.java
+++ b/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/RankEvalRequest.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.index.rankeval;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.IndicesRequest;
@@ -69,9 +68,7 @@ public class RankEvalRequest extends ActionRequest implements IndicesRequest.Rep
         rankingEvaluationSpec = new RankEvalSpec(in);
         indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-            searchType = SearchType.fromId(in.readByte());
-        }
+        searchType = SearchType.fromId(in.readByte());
     }
 
     RankEvalRequest() {}
@@ -150,9 +147,7 @@ public class RankEvalRequest extends ActionRequest implements IndicesRequest.Rep
         rankingEvaluationSpec.writeTo(out);
         out.writeStringArray(indices);
         indicesOptions.writeIndicesOptions(out);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-            out.writeByte(searchType.id());
-        }
+        out.writeByte(searchType.id());
     }
 
     @Override

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/RecoveryIT.java
@@ -720,12 +720,8 @@ public class RecoveryIT extends AbstractRollingTestCase {
 
         final int numberOfReplicas = Integer.parseInt(
             getIndexSettingsAsMap(indexName).get(IndexMetadata.SETTING_NUMBER_OF_REPLICAS).toString());
-        if (minimumNodeVersion.onOrAfter(LegacyESVersion.V_7_6_0)) {
-            assertEquals(nodes.size() - 2, numberOfReplicas);
-            ensureGreen(indexName);
-        } else {
-            assertEquals(nodes.size() - 1, numberOfReplicas);
-        }
+        assertEquals(nodes.size() - 2, numberOfReplicas);
+        ensureGreen(indexName);
     }
 
     public void testSoftDeletesDisabledWarning() throws Exception {

--- a/server/src/main/java/org/opensearch/LegacyESVersion.java
+++ b/server/src/main/java/org/opensearch/LegacyESVersion.java
@@ -48,11 +48,6 @@ import java.lang.reflect.Field;
  */
 public class LegacyESVersion extends Version {
 
-    public static final LegacyESVersion V_7_6_0 = new LegacyESVersion(7060099, org.apache.lucene.util.Version.LUCENE_8_4_0);
-    public static final LegacyESVersion V_7_6_1 = new LegacyESVersion(7060199, org.apache.lucene.util.Version.LUCENE_8_4_0);
-    public static final LegacyESVersion V_7_6_2 = new LegacyESVersion(7060299, org.apache.lucene.util.Version.LUCENE_8_4_0);
-    public static final LegacyESVersion V_7_7_0 = new LegacyESVersion(7070099, org.apache.lucene.util.Version.LUCENE_8_5_1);
-    public static final LegacyESVersion V_7_7_1 = new LegacyESVersion(7070199, org.apache.lucene.util.Version.LUCENE_8_5_1);
     public static final LegacyESVersion V_7_10_0 = new LegacyESVersion(7100099, org.apache.lucene.util.Version.LUCENE_8_7_0);
     public static final LegacyESVersion V_7_10_1 = new LegacyESVersion(7100199, org.apache.lucene.util.Version.LUCENE_8_7_0);
     public static final LegacyESVersion V_7_10_2 = new LegacyESVersion(7100299, org.apache.lucene.util.Version.LUCENE_8_7_0);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.cluster.node.info;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.support.nodes.BaseNodesRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -63,22 +62,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
     public NodesInfoRequest(StreamInput in) throws IOException {
         super(in);
         requestedMetrics.clear();
-        if (in.getVersion().before(LegacyESVersion.V_7_7_0)) {
-            // prior to version 8.x, a NodesInfoRequest was serialized as a list
-            // of booleans in a fixed order
-            optionallyAddMetric(in.readBoolean(), Metric.SETTINGS.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.OS.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.PROCESS.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.JVM.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.THREAD_POOL.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.TRANSPORT.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.HTTP.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.PLUGINS.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.INGEST.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.INDICES.metricName());
-        } else {
-            requestedMetrics.addAll(Arrays.asList(in.readStringArray()));
-        }
+        requestedMetrics.addAll(Arrays.asList(in.readStringArray()));
     }
 
     /**
@@ -165,22 +149,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().before(LegacyESVersion.V_7_7_0)) {
-            // prior to version 8.x, a NodesInfoRequest was serialized as a list
-            // of booleans in a fixed order
-            out.writeBoolean(Metric.SETTINGS.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.OS.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.PROCESS.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.JVM.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.THREAD_POOL.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.TRANSPORT.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.HTTP.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.PLUGINS.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.INGEST.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.INDICES.containedIn(requestedMetrics));
-        } else {
-            out.writeStringArray(requestedMetrics.toArray(new String[0]));
-        }
+        out.writeStringArray(requestedMetrics.toArray(new String[0]));
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsRequest.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.cluster.node.reload;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.support.nodes.BaseNodesRequest;
 import org.opensearch.common.io.stream.StreamInput;
 
@@ -68,18 +67,16 @@ public class NodesReloadSecureSettingsRequest extends BaseNodesRequest<NodesRelo
 
     public NodesReloadSecureSettingsRequest(StreamInput in) throws IOException {
         super(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-            final BytesReference bytesRef = in.readOptionalBytesReference();
-            if (bytesRef != null) {
-                byte[] bytes = BytesReference.toBytes(bytesRef);
-                try {
-                    this.secureSettingsPassword = new SecureString(CharArrays.utf8BytesToChars(bytes));
-                } finally {
-                    Arrays.fill(bytes, (byte) 0);
-                }
-            } else {
-                this.secureSettingsPassword = null;
+        final BytesReference bytesRef = in.readOptionalBytesReference();
+        if (bytesRef != null) {
+            byte[] bytes = BytesReference.toBytes(bytesRef);
+            try {
+                this.secureSettingsPassword = new SecureString(CharArrays.utf8BytesToChars(bytes));
+            } finally {
+                Arrays.fill(bytes, (byte) 0);
             }
+        } else {
+            this.secureSettingsPassword = null;
         }
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.cluster.node.stats;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.admin.indices.stats.CommonStatsFlags;
 import org.opensearch.action.support.nodes.BaseNodesRequest;
 import org.opensearch.common.io.stream.StreamInput;
@@ -64,22 +63,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
 
         indices = new CommonStatsFlags(in);
         requestedMetrics.clear();
-        if (in.getVersion().before(LegacyESVersion.V_7_7_0)) {
-            optionallyAddMetric(in.readBoolean(), Metric.OS.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.PROCESS.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.JVM.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.THREAD_POOL.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.FS.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.TRANSPORT.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.HTTP.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.BREAKER.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.SCRIPT.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.DISCOVERY.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.INGEST.metricName());
-            optionallyAddMetric(in.readBoolean(), Metric.ADAPTIVE_SELECTION.metricName());
-        } else {
-            requestedMetrics.addAll(in.readStringList());
-        }
+        requestedMetrics.addAll(in.readStringList());
     }
 
     /**
@@ -200,22 +184,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         indices.writeTo(out);
-        if (out.getVersion().before(LegacyESVersion.V_7_7_0)) {
-            out.writeBoolean(Metric.OS.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.PROCESS.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.JVM.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.THREAD_POOL.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.FS.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.TRANSPORT.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.HTTP.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.BREAKER.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.SCRIPT.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.DISCOVERY.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.INGEST.containedIn(requestedMetrics));
-            out.writeBoolean(Metric.ADAPTIVE_SELECTION.containedIn(requestedMetrics));
-        } else {
-            out.writeStringArray(requestedMetrics.toArray(new String[0]));
-        }
+        out.writeStringArray(requestedMetrics.toArray(new String[0]));
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -144,9 +144,6 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         includeGlobalState = in.readBoolean();
         partial = in.readBoolean();
         includeAliases = in.readBoolean();
-        if (in.getVersion().before(LegacyESVersion.V_7_7_0)) {
-            readSettingsFromStream(in); // formerly the unused settings field
-        }
         indexSettings = readSettingsFromStream(in);
         ignoreIndexSettings = in.readStringArray();
         if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
@@ -170,9 +167,6 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         out.writeBoolean(includeGlobalState);
         out.writeBoolean(partial);
         out.writeBoolean(includeAliases);
-        if (out.getVersion().before(LegacyESVersion.V_7_7_0)) {
-            writeSettingsToStream(Settings.EMPTY, out); // formerly the unused settings field
-        }
         writeSettingsToStream(indexSettings, out);
         out.writeStringArray(ignoreIndexSettings);
         if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsResponse.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.cluster.stats;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.FailedNodeException;
 import org.opensearch.action.support.nodes.BaseNodesResponse;
 import org.opensearch.cluster.ClusterName;
@@ -71,11 +70,9 @@ public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResp
         String clusterUUID = null;
         MappingStats mappingStats = null;
         AnalysisStats analysisStats = null;
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-            clusterUUID = in.readOptionalString();
-            mappingStats = in.readOptionalWriteable(MappingStats::new);
-            analysisStats = in.readOptionalWriteable(AnalysisStats::new);
-        }
+        clusterUUID = in.readOptionalString();
+        mappingStats = in.readOptionalWriteable(MappingStats::new);
+        analysisStats = in.readOptionalWriteable(AnalysisStats::new);
         this.clusterUUID = clusterUUID;
 
         // built from nodes rather than from the stream directly
@@ -132,11 +129,9 @@ public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResp
         super.writeTo(out);
         out.writeVLong(timestamp);
         out.writeOptionalWriteable(status);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-            out.writeOptionalString(clusterUUID);
-            out.writeOptionalWriteable(indicesStats.getMappings());
-            out.writeOptionalWriteable(indicesStats.getAnalysis());
-        }
+        out.writeOptionalString(clusterUUID);
+        out.writeOptionalWriteable(indicesStats.getMappings());
+        out.writeOptionalWriteable(indicesStats.getAnalysis());
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/indices/alias/Alias.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/alias/Alias.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.indices.alias;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchGenerationException;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.ParseField;
@@ -90,11 +89,7 @@ public class Alias implements Writeable, ToXContentFragment {
         indexRouting = in.readOptionalString();
         searchRouting = in.readOptionalString();
         writeIndex = in.readOptionalBoolean();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-            isHidden = in.readOptionalBoolean();
-        } else {
-            isHidden = null;
-        }
+        isHidden = in.readOptionalBoolean();
     }
 
     public Alias(String name) {
@@ -236,9 +231,7 @@ public class Alias implements Writeable, ToXContentFragment {
         out.writeOptionalString(indexRouting);
         out.writeOptionalString(searchRouting);
         out.writeOptionalBoolean(writeIndex);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-            out.writeOptionalBoolean(isHidden);
-        }
+        out.writeOptionalBoolean(isHidden);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -276,10 +276,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
             searchRouting = in.readOptionalString();
             indexRouting = in.readOptionalString();
             writeIndex = in.readOptionalBoolean();
-            // TODO fix for backport of https://github.com/elastic/elasticsearch/pull/52547
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-                isHidden = in.readOptionalBoolean();
-            }
+            isHidden = in.readOptionalBoolean();
             originalAliases = in.readStringArray();
             mustExist = in.readOptionalBoolean();
         }
@@ -294,10 +291,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
             out.writeOptionalString(searchRouting);
             out.writeOptionalString(indexRouting);
             out.writeOptionalBoolean(writeIndex);
-            // TODO fix for backport https://github.com/elastic/elasticsearch/pull/52547
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-                out.writeOptionalBoolean(isHidden);
-            }
+            out.writeOptionalBoolean(isHidden);
             out.writeStringArray(originalAliases);
             out.writeOptionalBoolean(mustExist);
         }

--- a/server/src/main/java/org/opensearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.indices.alias;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchGenerationException;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.AliasesRequest;

--- a/server/src/main/java/org/opensearch/action/bulk/BulkItemResponse.java
+++ b/server/src/main/java/org/opensearch/action/bulk/BulkItemResponse.java
@@ -33,7 +33,6 @@
 package org.opensearch.action.bulk;
 
 import org.opensearch.ExceptionsHelper;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.action.DocWriteRequest.OpType;
@@ -270,11 +269,7 @@ public class BulkItemResponse implements Writeable, StatusToXContentObject {
             cause = in.readException();
             status = ExceptionsHelper.status(cause);
             seqNo = in.readZLong();
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-                term = in.readVLong();
-            } else {
-                term = SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
-            }
+            term = in.readVLong();
             aborted = in.readBoolean();
         }
 
@@ -287,9 +282,7 @@ public class BulkItemResponse implements Writeable, StatusToXContentObject {
             out.writeOptionalString(id);
             out.writeException(cause);
             out.writeZLong(seqNo);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-                out.writeVLong(term);
-            }
+            out.writeVLong(term);
             out.writeBoolean(aborted);
         }
 

--- a/server/src/main/java/org/opensearch/action/fieldcaps/FieldCapabilities.java
+++ b/server/src/main/java/org/opensearch/action/fieldcaps/FieldCapabilities.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.fieldcaps;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
@@ -125,11 +124,7 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
         this.indices = in.readOptionalStringArray();
         this.nonSearchableIndices = in.readOptionalStringArray();
         this.nonAggregatableIndices = in.readOptionalStringArray();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-            meta = in.readMap(StreamInput::readString, i -> i.readSet(StreamInput::readString));
-        } else {
-            meta = Collections.emptyMap();
-        }
+        this.meta = in.readMap(StreamInput::readString, i -> i.readSet(StreamInput::readString));
     }
 
     @Override
@@ -141,9 +136,7 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
         out.writeOptionalStringArray(indices);
         out.writeOptionalStringArray(nonSearchableIndices);
         out.writeOptionalStringArray(nonAggregatableIndices);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-            out.writeMap(meta, StreamOutput::writeString, (o, set) -> o.writeCollection(set, StreamOutput::writeString));
-        }
+        out.writeMap(meta, StreamOutput::writeString, (o, set) -> o.writeCollection(set, StreamOutput::writeString));
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/fieldcaps/IndexFieldCapabilities.java
+++ b/server/src/main/java/org/opensearch/action/fieldcaps/IndexFieldCapabilities.java
@@ -32,17 +32,13 @@
 
 package org.opensearch.action.fieldcaps;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Describes the capabilities of a field in a single index.
@@ -74,42 +70,20 @@ public class IndexFieldCapabilities implements Writeable {
     }
 
     IndexFieldCapabilities(StreamInput in) throws IOException {
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-            this.name = in.readString();
-            this.type = in.readString();
-            this.isSearchable = in.readBoolean();
-            this.isAggregatable = in.readBoolean();
-            this.meta = in.readMap(StreamInput::readString, StreamInput::readString);
-        } else {
-            // Previously we reused the FieldCapabilities class to represent index field capabilities.
-            FieldCapabilities fieldCaps = new FieldCapabilities(in);
-            this.name = fieldCaps.getName();
-            this.type = fieldCaps.getType();
-            this.isSearchable = fieldCaps.isSearchable();
-            this.isAggregatable = fieldCaps.isAggregatable();
-            this.meta = fieldCaps.meta()
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().iterator().next()));
-        }
+        this.name = in.readString();
+        this.type = in.readString();
+        this.isSearchable = in.readBoolean();
+        this.isAggregatable = in.readBoolean();
+        this.meta = in.readMap(StreamInput::readString, StreamInput::readString);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-            out.writeString(name);
-            out.writeString(type);
-            out.writeBoolean(isSearchable);
-            out.writeBoolean(isAggregatable);
-            out.writeMap(meta, StreamOutput::writeString, StreamOutput::writeString);
-        } else {
-            // Previously we reused the FieldCapabilities class to represent index field capabilities.
-            Map<String, Set<String>> wrappedMeta = meta.entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> Collections.singleton(entry.getValue())));
-            FieldCapabilities fieldCaps = new FieldCapabilities(name, type, isSearchable, isAggregatable, null, null, null, wrappedMeta);
-            fieldCaps.writeTo(out);
-        }
+        out.writeString(name);
+        out.writeString(type);
+        out.writeBoolean(isSearchable);
+        out.writeBoolean(isAggregatable);
+        out.writeMap(meta, StreamOutput::writeString, StreamOutput::writeString);
     }
 
     public String getName() {

--- a/server/src/main/java/org/opensearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequest.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.search;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
@@ -237,11 +236,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         requestCache = in.readOptionalBoolean();
         batchedReduceSize = in.readVInt();
         maxConcurrentShardRequests = in.readVInt();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-            preFilterShardSize = in.readOptionalVInt();
-        } else {
-            preFilterShardSize = in.readVInt();
-        }
+        preFilterShardSize = in.readOptionalVInt();
         allowPartialSearchResults = in.readOptionalBoolean();
         localClusterAlias = in.readOptionalString();
         if (localClusterAlias != null) {
@@ -275,11 +270,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         out.writeOptionalBoolean(requestCache);
         out.writeVInt(batchedReduceSize);
         out.writeVInt(maxConcurrentShardRequests);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-            out.writeOptionalVInt(preFilterShardSize);
-        } else {
-            out.writeVInt(preFilterShardSize == null ? DEFAULT_BATCHED_REDUCE_SIZE : preFilterShardSize);
-        }
+        out.writeOptionalVInt(preFilterShardSize);
         out.writeOptionalBoolean(allowPartialSearchResults);
         out.writeOptionalString(localClusterAlias);
         if (localClusterAlias != null) {

--- a/server/src/main/java/org/opensearch/action/search/TransportSearchHelper.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportSearchHelper.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.search;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.io.stream.BytesStreamInput;
@@ -62,18 +61,13 @@ final class TransportSearchHelper {
     }
 
     static String buildScrollId(AtomicArray<? extends SearchPhaseResult> searchPhaseResults, Version version) {
-        boolean includeContextUUID = version.onOrAfter(LegacyESVersion.V_7_7_0);
         try {
             BytesStreamOutput out = new BytesStreamOutput();
-            if (includeContextUUID) {
-                out.writeString(INCLUDE_CONTEXT_UUID);
-            }
+            out.writeString(INCLUDE_CONTEXT_UUID);
             out.writeString(searchPhaseResults.length() == 1 ? ParsedScrollId.QUERY_AND_FETCH_TYPE : ParsedScrollId.QUERY_THEN_FETCH_TYPE);
             out.writeVInt(searchPhaseResults.asList().size());
             for (SearchPhaseResult searchPhaseResult : searchPhaseResults.asList()) {
-                if (includeContextUUID) {
-                    out.writeString(searchPhaseResult.getContextId().getSessionId());
-                }
+                out.writeString(searchPhaseResult.getContextId().getSessionId());
                 out.writeLong(searchPhaseResult.getContextId().getId());
                 SearchShardTarget searchShardTarget = searchPhaseResult.getSearchShardTarget();
                 if (searchShardTarget.getClusterAlias() != null) {

--- a/server/src/main/java/org/opensearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/opensearch/action/support/IndicesOptions.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.action.support;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.io.stream.StreamInput;
@@ -276,21 +275,12 @@ public class IndicesOptions implements ToXContentFragment {
     public void writeIndicesOptions(StreamOutput out) throws IOException {
         EnumSet<Option> options = this.options;
         out.writeEnumSet(options);
-        if (out.getVersion().before(LegacyESVersion.V_7_7_0) && expandWildcards.contains(WildcardStates.HIDDEN)) {
-            final EnumSet<WildcardStates> states = EnumSet.copyOf(expandWildcards);
-            states.remove(WildcardStates.HIDDEN);
-            out.writeEnumSet(states);
-        } else {
-            out.writeEnumSet(expandWildcards);
-        }
+        out.writeEnumSet(expandWildcards);
     }
 
     public static IndicesOptions readIndicesOptions(StreamInput in) throws IOException {
         EnumSet<Option> options = in.readEnumSet(Option.class);
         EnumSet<WildcardStates> states = in.readEnumSet(WildcardStates.class);
-        if (in.getVersion().before(LegacyESVersion.V_7_7_0)) {
-            states.add(WildcardStates.HIDDEN);
-        }
         return new IndicesOptions(options, states);
     }
 

--- a/server/src/main/java/org/opensearch/cluster/coordination/JoinRequest.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/JoinRequest.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.cluster.coordination;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -56,7 +55,7 @@ public class JoinRequest extends TransportRequest {
     /**
      * The minimum term for which the joining node will accept any cluster state publications. If the joining node is in a strictly greater
      * term than the cluster-manager it wants to join then the cluster-manager must enter a new term and hold another election. Doesn't necessarily match
-     * {@link JoinRequest#optionalJoin} and may be zero in join requests sent prior to {@link LegacyESVersion#V_7_7_0}.
+     * {@link JoinRequest#optionalJoin} and may be zero in join requests sent prior to {@code LegacyESVersion#V_7_7_0}.
      */
     private final long minimumTerm;
 
@@ -78,11 +77,7 @@ public class JoinRequest extends TransportRequest {
     public JoinRequest(StreamInput in) throws IOException {
         super(in);
         sourceNode = new DiscoveryNode(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-            minimumTerm = in.readLong();
-        } else {
-            minimumTerm = 0L;
-        }
+        minimumTerm = in.readLong();
         optionalJoin = Optional.ofNullable(in.readOptionalWriteable(Join::new));
     }
 
@@ -90,9 +85,7 @@ public class JoinRequest extends TransportRequest {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         sourceNode.writeTo(out);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-            out.writeLong(minimumTerm);
-        }
+        out.writeLong(minimumTerm);
         out.writeOptionalWriteable(optionalJoin.orElse(null));
     }
 

--- a/server/src/main/java/org/opensearch/cluster/metadata/AliasMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AliasMetadata.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.cluster.metadata;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchGenerationException;
 import org.opensearch.cluster.AbstractDiffable;
 import org.opensearch.cluster.Diff;
@@ -227,10 +226,7 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
         }
 
         out.writeOptionalBoolean(writeIndex());
-
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-            out.writeOptionalBoolean(isHidden());
-        }
+        out.writeOptionalBoolean(isHidden());
     }
 
     public AliasMetadata(StreamInput in) throws IOException {
@@ -253,12 +249,7 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
             searchRoutingValues = emptySet();
         }
         writeIndex = in.readOptionalBoolean();
-
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-            isHidden = in.readOptionalBoolean();
-        } else {
-            isHidden = null;
-        }
+        isHidden = in.readOptionalBoolean();
     }
 
     public static Diff<AliasMetadata> readDiffFrom(StreamInput in) throws IOException {

--- a/server/src/main/java/org/opensearch/cluster/metadata/AutoExpandReplicas.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AutoExpandReplicas.java
@@ -32,7 +32,6 @@
 package org.opensearch.cluster.metadata;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.allocation.RoutingAllocation;
 import org.opensearch.cluster.routing.allocation.decider.Decision;
@@ -137,16 +136,11 @@ public final class AutoExpandReplicas {
     private OptionalInt getDesiredNumberOfReplicas(IndexMetadata indexMetadata, RoutingAllocation allocation) {
         if (enabled) {
             int numMatchingDataNodes = 0;
-            // Only start using new logic once all nodes are migrated to 7.6.0, avoiding disruption during an upgrade
-            if (allocation.nodes().getMinNodeVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-                for (ObjectCursor<DiscoveryNode> cursor : allocation.nodes().getDataNodes().values()) {
-                    Decision decision = allocation.deciders().shouldAutoExpandToNode(indexMetadata, cursor.value, allocation);
-                    if (decision.type() != Decision.Type.NO) {
-                        numMatchingDataNodes++;
-                    }
+            for (ObjectCursor<DiscoveryNode> cursor : allocation.nodes().getDataNodes().values()) {
+                Decision decision = allocation.deciders().shouldAutoExpandToNode(indexMetadata, cursor.value, allocation);
+                if (decision.type() != Decision.Type.NO) {
+                    numMatchingDataNodes++;
                 }
-            } else {
-                numMatchingDataNodes = allocation.nodes().getDataNodes().size();
             }
 
             final int min = getMinReplicas();

--- a/server/src/main/java/org/opensearch/cluster/metadata/ComponentTemplateMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/ComponentTemplateMetadata.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.cluster.metadata;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.cluster.Diff;
 import org.opensearch.cluster.DiffableUtils;
@@ -50,6 +49,8 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+
+import static org.opensearch.cluster.metadata.ComposableIndexTemplateMetadata.MINIMMAL_SUPPORTED_VERSION;
 
 /**
  * {@link ComponentTemplateMetadata} is a custom {@link Metadata} implementation for storing a map
@@ -112,7 +113,7 @@ public class ComponentTemplateMetadata implements Metadata.Custom {
 
     @Override
     public Version getMinimalSupportedVersion() {
-        return LegacyESVersion.V_7_7_0;
+        return MINIMMAL_SUPPORTED_VERSION;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/metadata/ComposableIndexTemplateMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/ComposableIndexTemplateMetadata.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.cluster.metadata;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.cluster.Diff;
 import org.opensearch.cluster.DiffableUtils;
@@ -60,6 +59,8 @@ import java.util.Objects;
 public class ComposableIndexTemplateMetadata implements Metadata.Custom {
     public static final String TYPE = "index_template";
     private static final ParseField INDEX_TEMPLATE = new ParseField("index_template");
+    // minimial supported version when composable templates were introduced
+    protected static Version MINIMMAL_SUPPORTED_VERSION = Version.fromId(7070099);
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<ComposableIndexTemplateMetadata, Void> PARSER = new ConstructingObjectParser<>(
         TYPE,
@@ -117,7 +118,7 @@ public class ComposableIndexTemplateMetadata implements Metadata.Custom {
 
     @Override
     public Version getMinimalSupportedVersion() {
-        return LegacyESVersion.V_7_7_0;
+        return MINIMMAL_SUPPORTED_VERSION;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/metadata/DataStreamMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/DataStreamMetadata.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.cluster.metadata;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.cluster.Diff;
 import org.opensearch.cluster.DiffableUtils;
@@ -50,6 +49,8 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+
+import static org.opensearch.cluster.metadata.ComposableIndexTemplateMetadata.MINIMMAL_SUPPORTED_VERSION;
 
 /**
  * Custom {@link Metadata} implementation for storing a map of {@link DataStream}s and their names.
@@ -113,7 +114,7 @@ public class DataStreamMetadata implements Metadata.Custom {
 
     @Override
     public Version getMinimalSupportedVersion() {
-        return LegacyESVersion.V_7_7_0;
+        return MINIMMAL_SUPPORTED_VERSION;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/metadata/RepositoryMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/RepositoryMetadata.java
@@ -31,8 +31,6 @@
 
 package org.opensearch.cluster.metadata;
 
-import org.opensearch.LegacyESVersion;
-import org.opensearch.Version;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -48,8 +46,6 @@ import java.util.Objects;
  * @opensearch.internal
  */
 public class RepositoryMetadata implements Writeable {
-
-    public static final Version REPO_GEN_IN_CS_VERSION = LegacyESVersion.V_7_6_0;
 
     private final String name;
     private final String type;
@@ -148,13 +144,8 @@ public class RepositoryMetadata implements Writeable {
         name = in.readString();
         type = in.readString();
         settings = Settings.readSettingsFromStream(in);
-        if (in.getVersion().onOrAfter(REPO_GEN_IN_CS_VERSION)) {
-            generation = in.readLong();
-            pendingGeneration = in.readLong();
-        } else {
-            generation = RepositoryData.UNKNOWN_REPO_GEN;
-            pendingGeneration = RepositoryData.EMPTY_REPO_GEN;
-        }
+        generation = in.readLong();
+        pendingGeneration = in.readLong();
     }
 
     /**
@@ -167,10 +158,8 @@ public class RepositoryMetadata implements Writeable {
         out.writeString(name);
         out.writeString(type);
         Settings.writeSettingsToStream(settings, out);
-        if (out.getVersion().onOrAfter(REPO_GEN_IN_CS_VERSION)) {
-            out.writeLong(generation);
-            out.writeLong(pendingGeneration);
-        }
+        out.writeLong(generation);
+        out.writeLong(pendingGeneration);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/routing/RecoverySource.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RecoverySource.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.cluster.routing;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.io.stream.StreamInput;
@@ -282,11 +281,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
             restoreUUID = in.readString();
             snapshot = new Snapshot(in);
             version = Version.readVersion(in);
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-                index = new IndexId(in);
-            } else {
-                index = new IndexId(in.readString(), IndexMetadata.INDEX_UUID_NA_VALUE);
-            }
+            index = new IndexId(in);
             if (FeatureFlags.isEnabled(FeatureFlags.SEARCHABLE_SNAPSHOT) && in.getVersion().onOrAfter(Version.V_2_4_0)) {
                 isSearchableSnapshot = in.readBoolean();
             } else {
@@ -325,11 +320,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
             out.writeString(restoreUUID);
             snapshot.writeTo(out);
             Version.writeVersion(version, out);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-                index.writeTo(out);
-            } else {
-                out.writeString(index.getName());
-            }
+            index.writeTo(out);
             if (FeatureFlags.isEnabled(FeatureFlags.SEARCHABLE_SNAPSHOT) && out.getVersion().onOrAfter(Version.V_2_4_0)) {
                 out.writeBoolean(isSearchableSnapshot);
             }
@@ -399,11 +390,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
         RemoteStoreRecoverySource(StreamInput in) throws IOException {
             restoreUUID = in.readString();
             version = Version.readVersion(in);
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-                index = new IndexId(in);
-            } else {
-                index = new IndexId(in.readString(), IndexMetadata.INDEX_UUID_NA_VALUE);
-            }
+            index = new IndexId(in);
         }
 
         public String restoreUUID() {
@@ -428,11 +415,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
         protected void writeAdditionalFields(StreamOutput out) throws IOException {
             out.writeString(restoreUUID);
             Version.writeVersion(version, out);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-                index.writeTo(out);
-            } else {
-                out.writeString(index.getName());
-            }
+            index.writeTo(out);
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/common/Rounding.java
+++ b/server/src/main/java/org/opensearch/common/Rounding.java
@@ -34,7 +34,6 @@ package org.opensearch.common;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.ArrayUtil;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchException;
 import org.opensearch.common.LocalTimeOffset.Gap;
 import org.opensearch.common.LocalTimeOffset.Overlap;
@@ -1241,9 +1240,6 @@ public abstract class Rounding implements Writeable {
 
         @Override
         public void innerWriteTo(StreamOutput out) throws IOException {
-            if (out.getVersion().before(LegacyESVersion.V_7_6_0)) {
-                throw new IllegalArgumentException("Offset rounding not supported before 7.6.0");
-            }
             delegate.writeTo(out);
             out.writeZLong(offset);
         }

--- a/server/src/main/java/org/opensearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/server/src/main/java/org/opensearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -33,7 +33,6 @@
 package org.opensearch.gateway;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
@@ -236,11 +235,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
         public Request(StreamInput in) throws IOException {
             super(in);
             shardId = new ShardId(in);
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-                customDataPath = in.readString();
-            } else {
-                customDataPath = null;
-            }
+            customDataPath = in.readString();
         }
 
         public Request(ShardId shardId, String customDataPath, DiscoveryNode[] nodes) {
@@ -267,9 +262,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             shardId.writeTo(out);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-                out.writeString(customDataPath);
-            }
+            out.writeString(customDataPath);
         }
     }
 
@@ -317,11 +310,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
         public NodeRequest(StreamInput in) throws IOException {
             super(in);
             shardId = new ShardId(in);
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-                customDataPath = in.readString();
-            } else {
-                customDataPath = null;
-            }
+            customDataPath = in.readString();
         }
 
         public NodeRequest(Request request) {
@@ -333,10 +322,8 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             shardId.writeTo(out);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-                assert customDataPath != null;
-                out.writeString(customDataPath);
-            }
+            assert customDataPath != null;
+            out.writeString(customDataPath);
         }
 
         public ShardId getShardId() {

--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -1155,7 +1155,7 @@ public abstract class Engine implements LifecycleAware, Closeable {
         boolean onlyExpungeDeletes,
         boolean upgrade,
         boolean upgradeOnlyAncientSegments,
-        @Nullable String forceMergeUUID
+        String forceMergeUUID
     ) throws EngineException, IOException;
 
     /**

--- a/server/src/main/java/org/opensearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/RootObjectMapper.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.index.mapper;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.Explicit;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.Strings;
@@ -454,8 +453,7 @@ public class RootObjectMapper extends ObjectMapper {
             }
         }
 
-        final boolean shouldEmitDeprecationWarning = parserContext.indexVersionCreated().onOrAfter(LegacyESVersion.V_7_7_0);
-        if (dynamicTemplateInvalid && shouldEmitDeprecationWarning) {
+        if (dynamicTemplateInvalid) {
             String message = String.format(
                 Locale.ROOT,
                 "dynamic template [%s] has invalid content [%s]",

--- a/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
@@ -995,8 +995,8 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
         this.pendingInSync = new HashSet<>();
         this.routingTable = null;
         this.replicationGroup = null;
-        this.hasAllPeerRecoveryRetentionLeases = indexSettings.getIndexVersionCreated().onOrAfter(LegacyESVersion.V_7_6_0)
-            || (indexSettings.isSoftDeleteEnabled() && indexSettings.getIndexMetadata().getState() == IndexMetadata.State.OPEN);
+        this.hasAllPeerRecoveryRetentionLeases = indexSettings.isSoftDeleteEnabled()
+            && indexSettings.getIndexMetadata().getState() == IndexMetadata.State.OPEN;
         this.fileBasedRecoveryThreshold = IndexSettings.FILE_BASED_RECOVERY_THRESHOLD_SETTING.get(indexSettings.getSettings());
         this.safeCommitInfoSupplier = safeCommitInfoSupplier;
         this.onReplicationGroupUpdated = onReplicationGroupUpdated;

--- a/server/src/main/java/org/opensearch/indices/analysis/AnalysisModule.java
+++ b/server/src/main/java/org/opensearch/indices/analysis/AnalysisModule.java
@@ -33,7 +33,6 @@
 package org.opensearch.indices.analysis;
 
 import org.apache.lucene.analysis.LowerCaseFilter;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.NamedRegistry;
@@ -200,18 +199,11 @@ public final class AnalysisModule {
         preConfiguredTokenFilters.register("lowercase", PreConfiguredTokenFilter.singleton("lowercase", true, LowerCaseFilter::new));
         // Add "standard" for old indices (bwc)
         preConfiguredTokenFilters.register("standard", PreConfiguredTokenFilter.openSearchVersion("standard", true, (reader, version) -> {
-            // This was originally removed in 7_0_0 but due to a cacheing bug it was still possible
+            // This was originally removed in Legacy 7_0_0 but due to a cacheing bug it was still possible
             // in certain circumstances to create a new index referencing the standard token filter
-            // until version 7_5_2
-            if (version.before(LegacyESVersion.V_7_6_0)) {
-                deprecationLogger.deprecate(
-                    "standard_deprecation",
-                    "The [standard] token filter is deprecated and will be removed in a future version."
-                );
-            } else {
-                throw new IllegalArgumentException("The [standard] token filter has been removed.");
-            }
-            return reader;
+            // until legacy version 7_5_2
+            // todo verify this can be removed in 3.0
+            throw new IllegalArgumentException("The [standard] token filter has been removed.");
         }));
         /* Note that "stop" is available in lucene-core but it's pre-built
          * version uses a set of English stop words that are in

--- a/server/src/main/java/org/opensearch/indices/store/TransportNodesListShardStoreMetadata.java
+++ b/server/src/main/java/org/opensearch/indices/store/TransportNodesListShardStoreMetadata.java
@@ -33,7 +33,6 @@
 package org.opensearch.indices.store;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionType;
@@ -336,11 +335,7 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
         public Request(StreamInput in) throws IOException {
             super(in);
             shardId = new ShardId(in);
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-                customDataPath = in.readString();
-            } else {
-                customDataPath = null;
-            }
+            customDataPath = in.readString();
         }
 
         public Request(ShardId shardId, String customDataPath, DiscoveryNode[] nodes) {
@@ -367,9 +362,7 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             shardId.writeTo(out);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-                out.writeString(customDataPath);
-            }
+            out.writeString(customDataPath);
         }
     }
 
@@ -413,11 +406,7 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
         public NodeRequest(StreamInput in) throws IOException {
             super(in);
             shardId = new ShardId(in);
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-                customDataPath = in.readString();
-            } else {
-                customDataPath = null;
-            }
+            customDataPath = in.readString();
         }
 
         public NodeRequest(Request request) {
@@ -429,10 +418,8 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             shardId.writeTo(out);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-                assert customDataPath != null;
-                out.writeString(customDataPath);
-            }
+            assert customDataPath != null;
+            out.writeString(customDataPath);
         }
 
         public ShardId getShardId() {

--- a/server/src/main/java/org/opensearch/ingest/IngestStats.java
+++ b/server/src/main/java/org/opensearch/ingest/IngestStats.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.ingest;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -88,9 +87,7 @@ public class IngestStats implements Writeable, ToXContentFragment {
             for (int j = 0; j < processorsSize; j++) {
                 String processorName = in.readString();
                 String processorType = "_NOT_AVAILABLE";
-                if (in.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-                    processorType = in.readString();
-                }
+                processorType = in.readString();
                 Stats processorStat = new Stats(in);
                 processorStatsPerPipeline.add(new ProcessorStat(processorName, processorType, processorStat));
             }
@@ -112,9 +109,7 @@ public class IngestStats implements Writeable, ToXContentFragment {
                 out.writeVInt(processorStatsForPipeline.size());
                 for (ProcessorStat processorStat : processorStatsForPipeline) {
                     out.writeString(processorStat.getName());
-                    if (out.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-                        out.writeString(processorStat.getType());
-                    }
+                    out.writeString(processorStat.getType());
                     processorStat.getStats().writeTo(out);
                 }
             }

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -332,9 +332,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      * <ul>
      *     <li>All repositories that are read-only, i.e. for which {@link #isReadOnly()} returns {@code true} because there are no
      *     guarantees that another cluster is not writing to the repository at the same time</li>
-     *     <li>The node finds itself in a mixed-version cluster containing nodes older than
-     *     {@link RepositoryMetadata#REPO_GEN_IN_CS_VERSION} where the cluster-manager node does not update the value of
-     *     {@link RepositoryMetadata#generation()} when writing a new {@code index-N} blob</li>
      *     <li>The value of {@link RepositoryMetadata#generation()} for this repository is {@link RepositoryData#UNKNOWN_REPO_GEN}
      *     indicating that no consistent repository generation is tracked in the cluster state yet.</li>
      *     <li>The {@link #uncleanStart} flag is set to {@code true}</li>
@@ -556,7 +553,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         final boolean wasBestEffortConsistency = bestEffortConsistency;
         bestEffortConsistency = uncleanStart
             || isReadOnly()
-            || state.nodes().getMinNodeVersion().before(RepositoryMetadata.REPO_GEN_IN_CS_VERSION)
             || metadata.generation() == RepositoryData.UNKNOWN_REPO_GEN
             || ALLOW_CONCURRENT_MODIFICATION.get(metadata.settings());
         if (isReadOnly()) {

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -36,7 +36,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.TopDocs;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionRunnable;
@@ -1637,11 +1636,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         public CanMatchResponse(StreamInput in) throws IOException {
             super(in);
             this.canMatch = in.readBoolean();
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-                estimatedMinAndMax = in.readOptionalWriteable(MinAndMax::new);
-            } else {
-                estimatedMinAndMax = null;
-            }
+            this.estimatedMinAndMax = in.readOptionalWriteable(MinAndMax::new);
         }
 
         public CanMatchResponse(boolean canMatch, MinAndMax<?> estimatedMinAndMax) {
@@ -1652,9 +1647,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeBoolean(canMatch);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-                out.writeOptionalWriteable(estimatedMinAndMax);
-            }
+            out.writeOptionalWriteable(estimatedMinAndMax);
         }
 
         public boolean canMatch() {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/DateHistogramValuesSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/DateHistogramValuesSourceBuilder.java
@@ -33,7 +33,6 @@
 package org.opensearch.search.aggregations.bucket.composite;
 
 import org.apache.lucene.index.IndexReader;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.Rounding;
 import org.opensearch.common.io.stream.StreamInput;
@@ -136,18 +135,14 @@ public class DateHistogramValuesSourceBuilder extends CompositeValuesSourceBuild
         super(in);
         dateHistogramInterval = new DateIntervalWrapper(in);
         timeZone = in.readOptionalZoneId();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-            offset = in.readLong();
-        }
+        offset = in.readLong();
     }
 
     @Override
     protected void innerWriteTo(StreamOutput out) throws IOException {
         dateHistogramInterval.writeTo(out);
         out.writeOptionalZoneId(timeZone);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-            out.writeLong(offset);
-        }
+        out.writeLong(offset);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -33,7 +33,6 @@
 package org.opensearch.search.aggregations.bucket.composite;
 
 import org.apache.lucene.util.BytesRef;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -117,7 +116,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         }
         this.buckets = in.readList((input) -> new InternalBucket(input, sourceNames, formats, reverseMuls, missingOrders));
         this.afterKey = in.readBoolean() ? new CompositeKey(in) : null;
-        this.earlyTerminated = in.getVersion().onOrAfter(LegacyESVersion.V_7_6_0) ? in.readBoolean() : false;
+        this.earlyTerminated = in.readBoolean();
     }
 
     @Override
@@ -136,10 +135,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         if (afterKey != null) {
             afterKey.writeTo(out);
         }
-
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-            out.writeBoolean(earlyTerminated);
-        }
+        out.writeBoolean(earlyTerminated);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/support/BaseMultiValuesSourceFieldConfig.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/BaseMultiValuesSourceFieldConfig.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.search.aggregations.support;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.Strings;
 import org.opensearch.common.TriConsumer;
@@ -78,11 +77,7 @@ public abstract class BaseMultiValuesSourceFieldConfig implements Writeable, ToX
     }
 
     public BaseMultiValuesSourceFieldConfig(StreamInput in) throws IOException {
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-            this.fieldName = in.readOptionalString();
-        } else {
-            this.fieldName = in.readString();
-        }
+        this.fieldName = in.readOptionalString();
         this.missing = in.readGenericValue();
         this.script = in.readOptionalWriteable(Script::new);
         this.timeZone = in.readOptionalZoneId();
@@ -90,11 +85,7 @@ public abstract class BaseMultiValuesSourceFieldConfig implements Writeable, ToX
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_6_0)) {
-            out.writeOptionalString(fieldName);
-        } else {
-            out.writeString(fieldName);
-        }
+        out.writeOptionalString(fieldName);
         out.writeGenericValue(missing);
         out.writeOptionalWriteable(script);
         out.writeOptionalZoneId(timeZone);

--- a/server/src/main/java/org/opensearch/search/internal/ShardSearchContextId.java
+++ b/server/src/main/java/org/opensearch/search/internal/ShardSearchContextId.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.search.internal;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -56,19 +55,13 @@ public final class ShardSearchContextId implements Writeable {
 
     public ShardSearchContextId(StreamInput in) throws IOException {
         this.id = in.readLong();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-            this.sessionId = in.readString();
-        } else {
-            this.sessionId = "";
-        }
+        this.sessionId = in.readString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeLong(id);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-            out.writeString(sessionId);
-        }
+        out.writeString(sessionId);
     }
 
     public String getSessionId() {

--- a/server/src/main/java/org/opensearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/opensearch/search/internal/ShardSearchRequest.java
@@ -261,13 +261,8 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
         allowPartialSearchResults = in.readBoolean();
         indexRoutings = in.readStringArray();
         preference = in.readOptionalString();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-            canReturnNullResponseIfMatchNoDocs = in.readBoolean();
-            bottomSortValues = in.readOptionalWriteable(SearchSortValuesAndFormats::new);
-        } else {
-            canReturnNullResponseIfMatchNoDocs = false;
-            bottomSortValues = null;
-        }
+        canReturnNullResponseIfMatchNoDocs = in.readBoolean();
+        bottomSortValues = in.readOptionalWriteable(SearchSortValuesAndFormats::new);
         if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
             this.readerId = in.readOptionalWriteable(ShardSearchContextId::new);
             this.keepAlive = in.readOptionalTimeValue();
@@ -337,11 +332,11 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
             out.writeStringArray(indexRoutings);
             out.writeOptionalString(preference);
         }
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0) && asKey == false) {
+        if (asKey == false) {
             out.writeBoolean(canReturnNullResponseIfMatchNoDocs);
             out.writeOptionalWriteable(bottomSortValues);
         }
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0) && asKey == false) {
+        if (asKey == false) {
             out.writeOptionalWriteable(readerId);
             out.writeOptionalTimeValue(keepAlive);
         }

--- a/server/src/main/java/org/opensearch/transport/InboundDecoder.java
+++ b/server/src/main/java/org/opensearch/transport/InboundDecoder.java
@@ -173,8 +173,6 @@ public class InboundDecoder implements Releasable {
         int fixedHeaderSize = TcpHeader.headerSize(remoteVersion);
         if (fixedHeaderSize > reference.length()) {
             return 0;
-        } else if (remoteVersion.before(TcpHeader.VERSION_WITH_HEADER_SIZE)) {
-            return fixedHeaderSize;
         } else {
             int variableHeaderSize = reference.getInt(TcpHeader.VARIABLE_HEADER_SIZE_POSITION);
             int totalHeaderSize = fixedHeaderSize + variableHeaderSize;
@@ -198,11 +196,9 @@ public class InboundDecoder implements Releasable {
             if (invalidVersion != null) {
                 throw invalidVersion;
             } else {
-                if (remoteVersion.onOrAfter(TcpHeader.VERSION_WITH_HEADER_SIZE)) {
-                    // Skip since we already have ensured enough data available
-                    streamInput.readInt();
-                    header.finishParsingHeader(streamInput);
-                }
+                // Skip since we already have ensured enough data available
+                streamInput.readInt();
+                header.finishParsingHeader(streamInput);
             }
             return header;
         }

--- a/server/src/main/java/org/opensearch/transport/OutboundMessage.java
+++ b/server/src/main/java/org/opensearch/transport/OutboundMessage.java
@@ -65,11 +65,8 @@ abstract class OutboundMessage extends NetworkMessage {
         BytesReference reference;
         int variableHeaderLength = -1;
         final long preHeaderPosition = bytesStream.position();
-
-        if (version.onOrAfter(TcpHeader.VERSION_WITH_HEADER_SIZE)) {
-            writeVariableHeader(bytesStream);
-            variableHeaderLength = Math.toIntExact(bytesStream.position() - preHeaderPosition);
-        }
+        writeVariableHeader(bytesStream);
+        variableHeaderLength = Math.toIntExact(bytesStream.position() - preHeaderPosition);
 
         try (CompressibleBytesOutputStream stream = new CompressibleBytesOutputStream(bytesStream, TransportStatus.isCompress(status))) {
             stream.setVersion(version);

--- a/server/src/main/java/org/opensearch/transport/ProxyConnectionStrategy.java
+++ b/server/src/main/java/org/opensearch/transport/ProxyConnectionStrategy.java
@@ -33,7 +33,6 @@
 package org.opensearch.transport;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.cluster.ClusterName;
@@ -365,11 +364,7 @@ public class ProxyConnectionStrategy extends RemoteConnectionStrategy {
 
         private ProxyModeInfo(StreamInput input) throws IOException {
             address = input.readString();
-            if (input.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-                serverName = input.readString();
-            } else {
-                serverName = null;
-            }
+            serverName = input.readString();
             maxSocketConnections = input.readVInt();
             numSocketsConnected = input.readVInt();
         }
@@ -386,9 +381,7 @@ public class ProxyConnectionStrategy extends RemoteConnectionStrategy {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(address);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-                out.writeString(serverName);
-            }
+            out.writeString(serverName);
             out.writeVInt(maxSocketConnections);
             out.writeVInt(numSocketsConnected);
         }

--- a/server/src/main/java/org/opensearch/transport/TcpHeader.java
+++ b/server/src/main/java/org/opensearch/transport/TcpHeader.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.transport;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.common.io.stream.StreamOutput;
 
@@ -44,8 +43,6 @@ import java.io.IOException;
  * @opensearch.internal
  */
 public class TcpHeader {
-
-    public static final Version VERSION_WITH_HEADER_SIZE = LegacyESVersion.V_7_6_0;
 
     public static final int MARKER_BYTES_SIZE = 2;
 
@@ -72,11 +69,7 @@ public class TcpHeader {
     private static final int HEADER_SIZE = PRE_76_HEADER_SIZE + VARIABLE_HEADER_SIZE;
 
     public static int headerSize(Version version) {
-        if (version.onOrAfter(VERSION_WITH_HEADER_SIZE)) {
-            return HEADER_SIZE;
-        } else {
-            return PRE_76_HEADER_SIZE;
-        }
+        return HEADER_SIZE;
     }
 
     private static final byte[] PREFIX = { (byte) 'E', (byte) 'S' };
@@ -91,17 +84,11 @@ public class TcpHeader {
     ) throws IOException {
         output.writeBytes(PREFIX);
         // write the size, the size indicates the remaining message size, not including the size int
-        if (version.onOrAfter(VERSION_WITH_HEADER_SIZE)) {
-            output.writeInt(contentSize + REQUEST_ID_SIZE + STATUS_SIZE + VERSION_ID_SIZE + VARIABLE_HEADER_SIZE);
-        } else {
-            output.writeInt(contentSize + REQUEST_ID_SIZE + STATUS_SIZE + VERSION_ID_SIZE);
-        }
+        output.writeInt(contentSize + REQUEST_ID_SIZE + STATUS_SIZE + VERSION_ID_SIZE + VARIABLE_HEADER_SIZE);
         output.writeLong(requestId);
         output.writeByte(status);
         output.writeInt(version.id);
-        if (version.onOrAfter(VERSION_WITH_HEADER_SIZE)) {
-            assert variableHeaderSize != -1 : "Variable header size not set";
-            output.writeInt(variableHeaderSize);
-        }
+        assert variableHeaderSize != -1 : "Variable header size not set";
+        output.writeInt(variableHeaderSize);
     }
 }

--- a/server/src/main/java/org/opensearch/transport/TransportLogger.java
+++ b/server/src/main/java/org/opensearch/transport/TransportLogger.java
@@ -112,13 +112,7 @@ public final class TransportLogger {
                 sb.append(", request id: ").append(requestId);
                 sb.append(", type: ").append(type);
                 sb.append(", version: ").append(version);
-
-                if (version.onOrAfter(TcpHeader.VERSION_WITH_HEADER_SIZE)) {
-                    sb.append(", header size: ").append(streamInput.readInt()).append('B');
-                } else {
-                    streamInput = decompressingStream(status, streamInput);
-                    InboundHandler.assertRemoteVersion(streamInput, version);
-                }
+                sb.append(", header size: ").append(streamInput.readInt()).append('B');
 
                 // read and discard headers
                 ThreadContext.readHeadersFromStream(streamInput);

--- a/server/src/test/java/org/opensearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/opensearch/ExceptionSerializationTests.java
@@ -383,11 +383,7 @@ public class ExceptionSerializationTests extends OpenSearchTestCase {
         Version version = VersionUtils.randomVersion(random());
         SearchContextMissingException ex = serialize(new SearchContextMissingException(contextId), version);
         assertThat(ex.contextId().getId(), equalTo(contextId.getId()));
-        if (version.onOrAfter(LegacyESVersion.V_7_7_0)) {
-            assertThat(ex.contextId().getSessionId(), equalTo(contextId.getSessionId()));
-        } else {
-            assertThat(ex.contextId().getSessionId(), equalTo(""));
-        }
+        assertThat(ex.contextId().getSessionId(), equalTo(contextId.getSessionId()));
     }
 
     public void testCircuitBreakingException() throws IOException {

--- a/server/src/test/java/org/opensearch/action/OriginalIndicesTests.java
+++ b/server/src/test/java/org/opensearch/action/OriginalIndicesTests.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.common.io.stream.BytesStreamOutput;
@@ -67,14 +66,7 @@ public class OriginalIndicesTests extends OpenSearchTestCase {
             OriginalIndices originalIndices2 = OriginalIndices.readOriginalIndices(in);
 
             assertThat(originalIndices2.indices(), equalTo(originalIndices.indices()));
-            // indices options are not equivalent when sent to an older version and re-read due
-            // to the addition of hidden indices as expand to hidden indices is always true when
-            // read from a prior version
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0) || originalIndices.indicesOptions().expandWildcardsHidden()) {
-                assertThat(originalIndices2.indicesOptions(), equalTo(originalIndices.indicesOptions()));
-            } else if (originalIndices.indicesOptions().expandWildcardsHidden()) {
-                assertThat(originalIndices2.indicesOptions(), equalTo(originalIndices.indicesOptions()));
-            }
+            assertThat(originalIndices2.indicesOptions(), equalTo(originalIndices.indicesOptions()));
         }
     }
 

--- a/server/src/test/java/org/opensearch/action/admin/cluster/shards/ClusterSearchShardsRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/shards/ClusterSearchShardsRequestTests.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.cluster.shards;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.common.io.stream.BytesStreamOutput;
@@ -77,12 +76,7 @@ public class ClusterSearchShardsRequestTests extends OpenSearchTestCase {
                 in.setVersion(version);
                 ClusterSearchShardsRequest deserialized = new ClusterSearchShardsRequest(in);
                 assertArrayEquals(request.indices(), deserialized.indices());
-                // indices options are not equivalent when sent to an older version and re-read due
-                // to the addition of hidden indices as expand to hidden indices is always true when
-                // read from a prior version
-                if (version.onOrAfter(LegacyESVersion.V_7_7_0) || request.indicesOptions().expandWildcardsHidden()) {
-                    assertEquals(request.indicesOptions(), deserialized.indicesOptions());
-                }
+                assertEquals(request.indicesOptions(), deserialized.indicesOptions());
                 assertEquals(request.routing(), deserialized.routing());
                 assertEquals(request.preference(), deserialized.preference());
             }

--- a/server/src/test/java/org/opensearch/action/admin/indices/close/CloseIndexRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/close/CloseIndexRequestTests.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.indices.close;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.support.ActiveShardCount;
 import org.opensearch.action.support.IndicesOptions;
@@ -75,13 +74,8 @@ public class CloseIndexRequestTests extends OpenSearchTestCase {
                     assertEquals(request.clusterManagerNodeTimeout(), in.readTimeValue());
                     assertEquals(request.timeout(), in.readTimeValue());
                     assertArrayEquals(request.indices(), in.readStringArray());
-                    // indices options are not equivalent when sent to an older version and re-read due
-                    // to the addition of hidden indices as expand to hidden indices is always true when
-                    // read from a prior version
                     final IndicesOptions indicesOptions = IndicesOptions.readIndicesOptions(in);
-                    if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0) || request.indicesOptions().expandWildcardsHidden()) {
-                        assertEquals(request.indicesOptions(), indicesOptions);
-                    }
+                    assertEquals(request.indicesOptions(), indicesOptions);
                     assertEquals(request.waitForActiveShards(), ActiveShardCount.readFrom(in));
                 }
             }
@@ -107,12 +101,7 @@ public class CloseIndexRequestTests extends OpenSearchTestCase {
                 assertEquals(sample.clusterManagerNodeTimeout(), deserializedRequest.clusterManagerNodeTimeout());
                 assertEquals(sample.timeout(), deserializedRequest.timeout());
                 assertArrayEquals(sample.indices(), deserializedRequest.indices());
-                // indices options are not equivalent when sent to an older version and re-read due
-                // to the addition of hidden indices as expand to hidden indices is always true when
-                // read from a prior version
-                if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0) || sample.indicesOptions().expandWildcardsHidden()) {
-                    assertEquals(sample.indicesOptions(), deserializedRequest.indicesOptions());
-                }
+                assertEquals(sample.indicesOptions(), deserializedRequest.indicesOptions());
                 assertEquals(sample.waitForActiveShards(), deserializedRequest.waitForActiveShards());
             }
         }

--- a/server/src/test/java/org/opensearch/action/search/TransportSearchHelperTests.java
+++ b/server/src/test/java/org/opensearch/action/search/TransportSearchHelperTests.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.action.search;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.util.concurrent.AtomicArray;
@@ -74,7 +73,6 @@ public class TransportSearchHelperTests extends OpenSearchTestCase {
 
     public void testParseScrollId() {
         final Version version = VersionUtils.randomVersion(random());
-        boolean includeUUID = version.onOrAfter(LegacyESVersion.V_7_7_0);
         final AtomicArray<SearchPhaseResult> queryResults = generateQueryResults();
         String scrollId = TransportSearchHelper.buildScrollId(queryResults, version);
         ParsedScrollId parseScrollId = TransportSearchHelper.parseScrollId(scrollId);
@@ -82,28 +80,16 @@ public class TransportSearchHelperTests extends OpenSearchTestCase {
         assertEquals("node_1", parseScrollId.getContext()[0].getNode());
         assertEquals("cluster_x", parseScrollId.getContext()[0].getClusterAlias());
         assertEquals(1, parseScrollId.getContext()[0].getSearchContextId().getId());
-        if (includeUUID) {
-            assertThat(parseScrollId.getContext()[0].getSearchContextId().getSessionId(), equalTo("a"));
-        } else {
-            assertThat(parseScrollId.getContext()[0].getSearchContextId().getSessionId(), equalTo(""));
-        }
+        assertThat(parseScrollId.getContext()[0].getSearchContextId().getSessionId(), equalTo("a"));
 
         assertEquals("node_2", parseScrollId.getContext()[1].getNode());
         assertEquals("cluster_y", parseScrollId.getContext()[1].getClusterAlias());
         assertEquals(12, parseScrollId.getContext()[1].getSearchContextId().getId());
-        if (includeUUID) {
-            assertThat(parseScrollId.getContext()[1].getSearchContextId().getSessionId(), equalTo("b"));
-        } else {
-            assertThat(parseScrollId.getContext()[1].getSearchContextId().getSessionId(), equalTo(""));
-        }
+        assertThat(parseScrollId.getContext()[1].getSearchContextId().getSessionId(), equalTo("b"));
 
         assertEquals("node_3", parseScrollId.getContext()[2].getNode());
         assertNull(parseScrollId.getContext()[2].getClusterAlias());
         assertEquals(42, parseScrollId.getContext()[2].getSearchContextId().getId());
-        if (includeUUID) {
-            assertThat(parseScrollId.getContext()[2].getSearchContextId().getSessionId(), equalTo("c"));
-        } else {
-            assertThat(parseScrollId.getContext()[2].getSearchContextId().getSessionId(), equalTo(""));
-        }
+        assertThat(parseScrollId.getContext()[2].getSearchContextId().getSessionId(), equalTo("c"));
     }
 }

--- a/server/src/test/java/org/opensearch/transport/InboundDecoderTests.java
+++ b/server/src/test/java/org/opensearch/transport/InboundDecoderTests.java
@@ -153,10 +153,7 @@ public class InboundDecoderTests extends OpenSearchTestCase {
         );
 
         final BytesReference bytes = message.serialize(new BytesStreamOutput());
-        int totalHeaderSize = TcpHeader.headerSize(handshakeCompatVersion);
-        if (handshakeCompatVersion.onOrAfter(TcpHeader.VERSION_WITH_HEADER_SIZE)) {
-            totalHeaderSize += bytes.getInt(TcpHeader.VARIABLE_HEADER_SIZE_POSITION);
-        }
+        int totalHeaderSize = TcpHeader.headerSize(handshakeCompatVersion) + bytes.getInt(TcpHeader.VARIABLE_HEADER_SIZE_POSITION);
 
         InboundDecoder decoder = new InboundDecoder(Version.CURRENT, PageCacheRecycler.NON_RECYCLING_INSTANCE);
         final ArrayList<Object> fragments = new ArrayList<>();
@@ -274,10 +271,7 @@ public class InboundDecoderTests extends OpenSearchTestCase {
         );
 
         final BytesReference bytes = message.serialize(new BytesStreamOutput());
-        int totalHeaderSize = TcpHeader.headerSize(handshakeCompatVersion);
-        if (handshakeCompatVersion.onOrAfter(TcpHeader.VERSION_WITH_HEADER_SIZE)) {
-            totalHeaderSize += bytes.getInt(TcpHeader.VARIABLE_HEADER_SIZE_POSITION);
-        }
+        int totalHeaderSize = TcpHeader.headerSize(handshakeCompatVersion) + bytes.getInt(TcpHeader.VARIABLE_HEADER_SIZE_POSITION);
 
         InboundDecoder decoder = new InboundDecoder(Version.CURRENT, PageCacheRecycler.NON_RECYCLING_INSTANCE);
         final ArrayList<Object> fragments = new ArrayList<>();


### PR DESCRIPTION
Removes all usages of LegacyESVersion.V_7_6_ and LegacyESVersion.V_7_7_ version constants along with ancient API logic.

relates #2747