### PR TITLE
Wrr validation

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/AwarenessAttributeDecommissionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/AwarenessAttributeDecommissionIT.java
@@ -206,7 +206,10 @@ public class AwarenessAttributeDecommissionIT extends OpenSearchIntegTestCase {
                 DecommissioningFailedException.class,
                 () -> client().execute(DecommissionAction.INSTANCE, decommissionRequest).actionGet()
             );
-            assertTrue(ex.getMessage().contains("no weights are set to the attribute. Please set appropriate weights before triggering decommission action"));
+            assertTrue(
+                ex.getMessage()
+                    .contains("no weights are set to the attribute. Please set appropriate weights before triggering decommission action")
+            );
         });
 
         logger.info("--> setting shard routing weights for weighted round robin");

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/AwarenessAttributeDecommissionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/AwarenessAttributeDecommissionIT.java
@@ -20,11 +20,15 @@ import org.opensearch.action.admin.cluster.decommission.awareness.get.GetDecommi
 import org.opensearch.action.admin.cluster.decommission.awareness.put.DecommissionAction;
 import org.opensearch.action.admin.cluster.decommission.awareness.put.DecommissionRequest;
 import org.opensearch.action.admin.cluster.decommission.awareness.put.DecommissionResponse;
+import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.opensearch.action.admin.cluster.shards.routing.weighted.put.ClusterPutWeightedRoutingResponse;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.decommission.DecommissionAttribute;
 import org.opensearch.cluster.decommission.DecommissionStatus;
+import org.opensearch.cluster.decommission.DecommissioningFailedException;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
+import org.opensearch.cluster.routing.WeightedRouting;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Priority;
 import org.opensearch.common.settings.Settings;
@@ -37,6 +41,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static org.opensearch.test.NodeRoles.onlyRole;
@@ -102,6 +107,17 @@ public class AwarenessAttributeDecommissionIT extends OpenSearchIntegTestCase {
 
         ensureStableCluster(6);
 
+        logger.info("--> setting shard routing weights for weighted round robin");
+        Map<String, Double> weights = Map.of("a", 1.0, "b", 1.0, "c", 0.0);
+        WeightedRouting weightedRouting = new WeightedRouting("zone", weights);
+
+        ClusterPutWeightedRoutingResponse weightedRoutingResponse = client().admin()
+            .cluster()
+            .prepareWeightedRouting()
+            .setWeightedRouting(weightedRouting)
+            .get();
+        assertTrue(weightedRoutingResponse.isAcknowledged());
+
         logger.info("--> starting decommissioning nodes in zone {}", 'c');
         DecommissionAttribute decommissionAttribute = new DecommissionAttribute("zone", "c");
         DecommissionRequest decommissionRequest = new DecommissionRequest(decommissionAttribute);
@@ -161,5 +177,55 @@ public class AwarenessAttributeDecommissionIT extends OpenSearchIntegTestCase {
         // will wait for cluster to stabilise with a timeout of 2 min (findPeerInterval for decommissioned nodes)
         // as by then all nodes should have joined the cluster
         ensureStableCluster(6, TimeValue.timeValueMinutes(2));
+    }
+
+    public void testDecommissionFailedWhenAttributeNotWeighedAway() throws Exception {
+        Settings commonSettings = Settings.builder()
+            .put("cluster.routing.allocation.awareness.attributes", "zone")
+            .put("cluster.routing.allocation.awareness.force.zone.values", "a,b,c")
+            .build();
+        // Start 3 cluster manager eligible nodes
+        internalCluster().startClusterManagerOnlyNodes(3, Settings.builder().put(commonSettings).build());
+        // start 3 data nodes
+        internalCluster().startDataOnlyNodes(3, Settings.builder().put(commonSettings).build());
+        ensureStableCluster(6);
+        ClusterHealthResponse health = client().admin()
+            .cluster()
+            .prepareHealth()
+            .setWaitForEvents(Priority.LANGUID)
+            .setWaitForGreenStatus()
+            .setWaitForNodes(Integer.toString(6))
+            .execute()
+            .actionGet();
+        assertFalse(health.isTimedOut());
+
+        DecommissionAttribute decommissionAttribute = new DecommissionAttribute("zone", "c");
+        DecommissionRequest decommissionRequest = new DecommissionRequest(decommissionAttribute);
+        assertBusy(() -> {
+            DecommissioningFailedException ex = expectThrows(
+                DecommissioningFailedException.class,
+                () -> client().execute(DecommissionAction.INSTANCE, decommissionRequest).actionGet()
+            );
+            assertTrue(ex.getMessage().contains("no weights are set to the attribute. Please set appropriate weights before triggering decommission action"));
+        });
+
+        logger.info("--> setting shard routing weights for weighted round robin");
+        Map<String, Double> weights = Map.of("a", 1.0, "b", 1.0, "c", 1.0);
+        WeightedRouting weightedRouting = new WeightedRouting("zone", weights);
+
+        ClusterPutWeightedRoutingResponse weightedRoutingResponse = client().admin()
+            .cluster()
+            .prepareWeightedRouting()
+            .setWeightedRouting(weightedRouting)
+            .get();
+        assertTrue(weightedRoutingResponse.isAcknowledged());
+
+        assertBusy(() -> {
+            DecommissioningFailedException ex = expectThrows(
+                DecommissioningFailedException.class,
+                () -> client().execute(DecommissionAction.INSTANCE, decommissionRequest).actionGet()
+            );
+            assertTrue(ex.getMessage().contains("weight for decommissioned attribute is expected to be [0.0] but found [1.0]"));
+        });
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/routing/WeightedRoutingService.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/WeightedRoutingService.java
@@ -161,12 +161,11 @@ public class WeightedRoutingService {
 
     public void ensureNoDecommissionActionOngoing(ClusterState state) {
         DecommissionAttributeMetadata decommissionAttributeMetadata = state.metadata().decommissionAttributeMetadata();
-        if (decommissionAttributeMetadata != null
-            && decommissionAttributeMetadata.status().equals(DecommissionStatus.FAILED) == false) {
+        if (decommissionAttributeMetadata != null && decommissionAttributeMetadata.status().equals(DecommissionStatus.FAILED) == false) {
             throw new IllegalStateException(
                 "a decommission action is ongoing with status ["
-                + decommissionAttributeMetadata.status().status()
-                + "], cannot update weight during this state"
+                    + decommissionAttributeMetadata.status().status()
+                    + "], cannot update weight during this state"
             );
         }
     }

--- a/server/src/main/java/org/opensearch/cluster/routing/WeightedRoutingService.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/WeightedRoutingService.java
@@ -19,6 +19,8 @@ import org.opensearch.action.admin.cluster.shards.routing.weighted.put.ClusterPu
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterStateUpdateTask;
 import org.opensearch.cluster.ack.ClusterStateUpdateResponse;
+import org.opensearch.cluster.decommission.DecommissionAttributeMetadata;
+import org.opensearch.cluster.decommission.DecommissionStatus;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.metadata.WeightedRoutingMetadata;
 import org.opensearch.cluster.routing.allocation.decider.AwarenessAllocationDecider;
@@ -68,6 +70,8 @@ public class WeightedRoutingService {
         clusterService.submitStateUpdateTask("update_weighted_routing", new ClusterStateUpdateTask(Priority.URGENT) {
             @Override
             public ClusterState execute(ClusterState currentState) {
+                // verify currently no decommission action is ongoing
+                ensureNoDecommissionActionOngoing(currentState);
                 Metadata metadata = currentState.metadata();
                 Metadata.Builder mdBuilder = Metadata.builder(currentState.metadata());
                 WeightedRoutingMetadata weightedRoutingMetadata = metadata.custom(WeightedRoutingMetadata.TYPE);
@@ -152,6 +156,18 @@ public class WeightedRoutingService {
                 validationException
             );
             throw validationException;
+        }
+    }
+
+    public void ensureNoDecommissionActionOngoing(ClusterState state) {
+        DecommissionAttributeMetadata decommissionAttributeMetadata = state.metadata().decommissionAttributeMetadata();
+        if (decommissionAttributeMetadata != null
+            && decommissionAttributeMetadata.status().equals(DecommissionStatus.FAILED) == false) {
+            throw new IllegalStateException(
+                "a decommission action is ongoing with status ["
+                + decommissionAttributeMetadata.status().status()
+                + "], cannot update weight during this state"
+            );
         }
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/decommission/DecommissionServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/decommission/DecommissionServiceTests.java
@@ -15,16 +15,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
-import org.opensearch.action.admin.cluster.configuration.TransportAddVotingConfigExclusionsAction;
-import org.opensearch.action.admin.cluster.configuration.TransportClearVotingConfigExclusionsAction;
 import org.opensearch.action.admin.cluster.decommission.awareness.delete.DeleteDecommissionStateResponse;
 import org.opensearch.action.admin.cluster.decommission.awareness.put.DecommissionResponse;
 import org.opensearch.action.admin.cluster.configuration.ClearVotingConfigExclusionsRequest;
-import org.opensearch.action.support.ActionFilters;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.coordination.CoordinationMetadata;
-import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.metadata.WeightedRoutingMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -36,7 +32,6 @@ import org.opensearch.cluster.routing.allocation.decider.AwarenessAllocationDeci
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.test.ClusterServiceUtils;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.transport.MockTransport;
@@ -191,7 +186,10 @@ public class DecommissionServiceTests extends OpenSearchTestCase {
             @Override
             public void onFailure(Exception e) {
                 assertTrue(e instanceof DecommissioningFailedException);
-                assertThat(e.getMessage(), Matchers.containsString("weight for decommissioned attribute is expected to be [0.0] but found [1.0]"));
+                assertThat(
+                    e.getMessage(),
+                    Matchers.containsString("weight for decommissioned attribute is expected to be [0.0] but found [1.0]")
+                );
                 countDownLatch.countDown();
             }
         };
@@ -211,14 +209,18 @@ public class DecommissionServiceTests extends OpenSearchTestCase {
             @Override
             public void onFailure(Exception e) {
                 assertTrue(e instanceof DecommissioningFailedException);
-                assertThat(e.getMessage(), Matchers.containsString("no weights are set to the attribute. Please set appropriate weights before triggering decommission action"));
+                assertThat(
+                    e.getMessage(),
+                    Matchers.containsString(
+                        "no weights are set to the attribute. Please set appropriate weights before triggering decommission action"
+                    )
+                );
                 countDownLatch.countDown();
             }
         };
         decommissionService.startDecommissionAction(decommissionAttribute, listener);
         assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
     }
-
 
     @SuppressWarnings("unchecked")
     public void testDecommissioningFailedWhenAnotherAttributeDecommissioningSuccessful() throws InterruptedException {

--- a/server/src/test/java/org/opensearch/cluster/decommission/DecommissionServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/decommission/DecommissionServiceTests.java
@@ -15,21 +15,29 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
+import org.opensearch.action.admin.cluster.configuration.TransportAddVotingConfigExclusionsAction;
+import org.opensearch.action.admin.cluster.configuration.TransportClearVotingConfigExclusionsAction;
 import org.opensearch.action.admin.cluster.decommission.awareness.delete.DeleteDecommissionStateResponse;
 import org.opensearch.action.admin.cluster.decommission.awareness.put.DecommissionResponse;
 import org.opensearch.action.admin.cluster.configuration.ClearVotingConfigExclusionsRequest;
+import org.opensearch.action.support.ActionFilters;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.coordination.CoordinationMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.metadata.WeightedRoutingMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.routing.WeightedRouting;
 import org.opensearch.cluster.routing.allocation.AllocationService;
 import org.opensearch.cluster.routing.allocation.decider.AwarenessAllocationDecider;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.test.ClusterServiceUtils;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.transport.MockTransport;
 import org.opensearch.threadpool.TestThreadPool;
@@ -169,6 +177,49 @@ public class DecommissionServiceTests extends OpenSearchTestCase {
         assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
     }
 
+    public void testDecommissionNotStartedWithoutWeighingAwayAttribute_1() throws InterruptedException {
+        Map<String, Double> weights = Map.of("zone_1", 1.0, "zone_2", 1.0, "zone_3", 0.0);
+        setWeightedRoutingWeights(weights);
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        DecommissionAttribute decommissionAttribute = new DecommissionAttribute("zone", "zone_1");
+        ActionListener<DecommissionResponse> listener = new ActionListener<DecommissionResponse>() {
+            @Override
+            public void onResponse(DecommissionResponse decommissionResponse) {
+                fail("on response shouldn't have been called");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                assertTrue(e instanceof DecommissioningFailedException);
+                assertThat(e.getMessage(), Matchers.containsString("weight for decommissioned attribute is expected to be [0.0] but found [1.0]"));
+                countDownLatch.countDown();
+            }
+        };
+        decommissionService.startDecommissionAction(decommissionAttribute, listener);
+        assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
+    }
+
+    public void testDecommissionNotStartedWithoutWeighingAwayAttribute_2() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        DecommissionAttribute decommissionAttribute = new DecommissionAttribute("zone", "zone_1");
+        ActionListener<DecommissionResponse> listener = new ActionListener<DecommissionResponse>() {
+            @Override
+            public void onResponse(DecommissionResponse decommissionResponse) {
+                fail("on response shouldn't have been called");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                assertTrue(e instanceof DecommissioningFailedException);
+                assertThat(e.getMessage(), Matchers.containsString("no weights are set to the attribute. Please set appropriate weights before triggering decommission action"));
+                countDownLatch.countDown();
+            }
+        };
+        decommissionService.startDecommissionAction(decommissionAttribute, listener);
+        assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
+    }
+
+
     @SuppressWarnings("unchecked")
     public void testDecommissioningFailedWhenAnotherAttributeDecommissioningSuccessful() throws InterruptedException {
         final CountDownLatch countDownLatch = new CountDownLatch(1);
@@ -284,6 +335,17 @@ public class DecommissionServiceTests extends OpenSearchTestCase {
         };
         decommissionService.deleteDecommissionState(listener);
         assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
+    }
+
+    private void setWeightedRoutingWeights(Map<String, Double> weights) {
+        ClusterState clusterState = clusterService.state();
+        WeightedRouting weightedRouting = new WeightedRouting("zone", weights);
+        WeightedRoutingMetadata weightedRoutingMetadata = new WeightedRoutingMetadata(weightedRouting);
+        Metadata.Builder metadataBuilder = Metadata.builder(clusterState.metadata());
+        metadataBuilder.putCustom(WeightedRoutingMetadata.TYPE, weightedRoutingMetadata);
+        clusterState = ClusterState.builder(clusterState).metadata(metadataBuilder).build();
+        ClusterState.Builder builder = ClusterState.builder(clusterState);
+        ClusterServiceUtils.setState(clusterService, builder);
     }
 
     private ClusterState addDataNodes(ClusterState clusterState, String zone, String... nodeIds) {

--- a/server/src/test/java/org/opensearch/cluster/routing/WeightedRoutingServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/WeightedRoutingServiceTests.java
@@ -8,8 +8,10 @@
 
 package org.opensearch.cluster.routing;
 
+import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Before;
+import org.opensearch.OpenSearchTimeoutException;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.admin.cluster.shards.routing.weighted.delete.ClusterDeleteWeightedRoutingRequest;
@@ -21,6 +23,9 @@ import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ack.ClusterStateUpdateResponse;
+import org.opensearch.cluster.decommission.DecommissionAttribute;
+import org.opensearch.cluster.decommission.DecommissionAttributeMetadata;
+import org.opensearch.cluster.decommission.DecommissionStatus;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.metadata.WeightedRoutingMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -43,6 +48,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class WeightedRoutingServiceTests extends OpenSearchTestCase {
     private ThreadPool threadPool;
@@ -173,6 +183,15 @@ public class WeightedRoutingServiceTests extends OpenSearchTestCase {
         return clusterState;
     }
 
+    private ClusterState setDecommissionAttribute(ClusterState clusterState, DecommissionStatus status) {
+        DecommissionAttribute decommissionAttribute = new DecommissionAttribute("zone", "zone_A");
+        DecommissionAttributeMetadata decommissionAttributeMetadata = new DecommissionAttributeMetadata(decommissionAttribute, status);
+        Metadata.Builder metadataBuilder = Metadata.builder(clusterState.metadata());
+        metadataBuilder.decommissionAttributeMetadata(decommissionAttributeMetadata);
+        clusterState = ClusterState.builder(clusterState).metadata(metadataBuilder).build();
+        return clusterState;
+    }
+
     public void testRegisterWeightedRoutingMetadataWithChangedWeights() throws InterruptedException {
         Map<String, Double> weights = Map.of("zone_A", 1.0, "zone_B", 1.0, "zone_C", 1.0);
         ClusterState state = clusterService.state();
@@ -275,5 +294,74 @@ public class WeightedRoutingServiceTests extends OpenSearchTestCase {
         } catch (Exception e) {
             fail("verify awareness attribute should not fail");
         }
+    }
+
+    public void testAddWeightedRoutingFailsWhenDecommissionOngoing() throws InterruptedException {
+        Map<String, Double> weights = Map.of("zone_A", 1.0, "zone_B", 1.0, "zone_C", 1.0);
+        DecommissionStatus status = randomFrom(DecommissionStatus.INIT, DecommissionStatus.IN_PROGRESS, DecommissionStatus.SUCCESSFUL);
+        ClusterState state = clusterService.state();
+        state = setWeightedRoutingWeights(state, weights);
+        state = setDecommissionAttribute(state, status);
+        ClusterState.Builder builder = ClusterState.builder(state);
+        ClusterServiceUtils.setState(clusterService, builder);
+
+        ClusterPutWeightedRoutingRequestBuilder request = new ClusterPutWeightedRoutingRequestBuilder(
+            client,
+            ClusterAddWeightedRoutingAction.INSTANCE
+        );
+        WeightedRouting updatedWeightedRouting = new WeightedRouting("zone", weights);
+        request.setWeightedRouting(updatedWeightedRouting);
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        final AtomicReference<Exception> exceptionReference = new AtomicReference<>();
+        ActionListener<ClusterStateUpdateResponse> listener = new ActionListener<ClusterStateUpdateResponse>() {
+            @Override
+            public void onResponse(ClusterStateUpdateResponse clusterStateUpdateResponse) {
+                countDownLatch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                exceptionReference.set(e);
+                countDownLatch.countDown();
+            }
+        };
+        weightedRoutingService.registerWeightedRoutingMetadata(request.request(), listener);
+        assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
+        MatcherAssert.assertThat("Expected onFailure to be called", exceptionReference.get(), notNullValue());
+        MatcherAssert.assertThat(exceptionReference.get(), instanceOf(IllegalStateException.class));
+        MatcherAssert.assertThat(exceptionReference.get().getMessage(), containsString("a decommission action is ongoing with status"));
+    }
+
+    public void testAddWeightedRoutingPassesWhenDecommissionFailed() throws InterruptedException {
+        Map<String, Double> weights = Map.of("zone_A", 1.0, "zone_B", 1.0, "zone_C", 1.0);
+        DecommissionStatus status = DecommissionStatus.FAILED;
+        ClusterState state = clusterService.state();
+        state = setWeightedRoutingWeights(state, weights);
+        state = setDecommissionAttribute(state, status);
+        ClusterState.Builder builder = ClusterState.builder(state);
+        ClusterServiceUtils.setState(clusterService, builder);
+
+        ClusterPutWeightedRoutingRequestBuilder request = new ClusterPutWeightedRoutingRequestBuilder(
+            client,
+            ClusterAddWeightedRoutingAction.INSTANCE
+        );
+        WeightedRouting updatedWeightedRouting = new WeightedRouting("zone", weights);
+        request.setWeightedRouting(updatedWeightedRouting);
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        final AtomicReference<Exception> exceptionReference = new AtomicReference<>();
+        ActionListener<ClusterStateUpdateResponse> listener = new ActionListener<ClusterStateUpdateResponse>() {
+            @Override
+            public void onResponse(ClusterStateUpdateResponse clusterStateUpdateResponse) {
+                assertTrue(clusterStateUpdateResponse.isAcknowledged());
+                assertEquals(updatedWeightedRouting, clusterService.state().metadata().weightedRoutingMetadata().getWeightedRouting());
+                countDownLatch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+            }
+        };
+        weightedRoutingService.registerWeightedRoutingMetadata(request.request(), listener);
+        assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/routing/WeightedRoutingServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/WeightedRoutingServiceTests.java
@@ -11,7 +11,6 @@ package org.opensearch.cluster.routing;
 import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Before;
-import org.opensearch.OpenSearchTimeoutException;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.admin.cluster.shards.routing.weighted.delete.ClusterDeleteWeightedRoutingRequest;
@@ -358,8 +357,7 @@ public class WeightedRoutingServiceTests extends OpenSearchTestCase {
             }
 
             @Override
-            public void onFailure(Exception e) {
-            }
+            public void onFailure(Exception e) {}
         };
         weightedRoutingService.registerWeightedRoutingMetadata(request.request(), listener);
         assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));


### PR DESCRIPTION
### Description
1. Fail weight update call if decommission action is in process
2. Fail Decommission call if the attribute is not weighed away

### Issues Resolved
#4838

### Check List
- [X] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
