### PR TITLE
[Remove] Deprecated serialization logic from pipeline aggs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Always auto release the flood stage block ([#4703](https://github.com/opensearch-project/OpenSearch/pull/4703))
 - Remove LegacyESVersion.V_7_4_ and V_7_5_ Constants ([#4704](https://github.com/opensearch-project/OpenSearch/pull/4704))
 - Remove Legacy Version support from Snapshot/Restore Service ([#4728](https://github.com/opensearch-project/OpenSearch/pull/4728))
+- Remove deprecated serialization logic from pipeline aggs ([#4847](https://github.com/opensearch-project/OpenSearch/pull/4847))
 
 ### Fixed
 - `opensearch-service.bat start` and `opensearch-service.bat manager` failing to run ([#4289](https://github.com/opensearch-project/OpenSearch/pull/4289))

--- a/server/src/main/java/org/opensearch/plugins/SearchPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/SearchPlugin.java
@@ -621,19 +621,13 @@ public interface SearchPlugin {
         PipelineAggregationBuilder,
         ContextParser<String, ? extends PipelineAggregationBuilder>> {
         private final Map<String, Writeable.Reader<? extends InternalAggregation>> resultReaders = new TreeMap<>();
-        /**
-         * Read the aggregator from a stream.
-         * @deprecated Pipelines implemented after 7.8.0 do not need to be sent across the wire
-         */
-        @Deprecated
-        private final Writeable.Reader<? extends PipelineAggregator> aggregatorReader;
 
         /**
          * Specification of a {@link PipelineAggregator}.
          *
          * @param name holds the names by which this aggregation might be parsed. The {@link ParseField#getPreferredName()} is special as it
          *        is the name by under which the readers are registered. So it is the name that the {@link PipelineAggregationBuilder} and
-         *        {@link PipelineAggregator} should return from {@link NamedWriteable#getWriteableName()}. It is an error if
+         *        {@link PipelineAggregator} should return from {@link NamedWriteable#getWriteableName()}.  It is an error if
          *        {@link ParseField#getPreferredName()} conflicts with another registered name, including names from other plugins.
          * @param builderReader the reader registered for this aggregation's builder. Typically, a reference to a constructor that takes a
          *        {@link StreamInput}
@@ -645,7 +639,6 @@ public interface SearchPlugin {
             ContextParser<String, ? extends PipelineAggregationBuilder> parser
         ) {
             super(name, builderReader, parser);
-            this.aggregatorReader = null;
         }
 
         /**
@@ -658,6 +651,7 @@ public interface SearchPlugin {
          * @param builderReader the reader registered for this aggregation's builder. Typically, a reference to a constructor that takes a
          *        {@link StreamInput}
          * @param parser reads the aggregation builder from XContent
+
          */
         public PipelineAggregationSpec(
             String name,
@@ -665,7 +659,6 @@ public interface SearchPlugin {
             ContextParser<String, ? extends PipelineAggregationBuilder> parser
         ) {
             super(name, builderReader, parser);
-            this.aggregatorReader = null;
         }
 
         /**
@@ -677,20 +670,16 @@ public interface SearchPlugin {
          *        {@link ParseField#getPreferredName()} conflicts with another registered name, including names from other plugins.
          * @param builderReader the reader registered for this aggregation's builder. Typically, a reference to a constructor that takes a
          *        {@link StreamInput}
-         * @param aggregatorReader reads the {@link PipelineAggregator} from a stream
          * @param parser reads the aggregation builder from XContent
-         * @deprecated Use {@link PipelineAggregationSpec#PipelineAggregationSpec(ParseField, Writeable.Reader, ContextParser)} for
-         *             pipelines implemented after 7.8.0
+         * @deprecated prefer the ctor that takes a {@link ContextParser}
          */
         @Deprecated
         public PipelineAggregationSpec(
             ParseField name,
             Writeable.Reader<? extends PipelineAggregationBuilder> builderReader,
-            Writeable.Reader<? extends PipelineAggregator> aggregatorReader,
-            ContextParser<String, ? extends PipelineAggregationBuilder> parser
+            PipelineAggregator.Parser parser
         ) {
-            super(name, builderReader, parser);
-            this.aggregatorReader = aggregatorReader;
+            super(name, builderReader, (p, n) -> parser.parse(n, p));
         }
 
         /**
@@ -702,67 +691,15 @@ public interface SearchPlugin {
          *        names from other plugins.
          * @param builderReader the reader registered for this aggregation's builder. Typically, a reference to a constructor that takes a
          *        {@link StreamInput}
-         * @param aggregatorReader reads the {@link PipelineAggregator} from a stream
-         * @param parser reads the aggregation builder from XContent
-         * @deprecated Use {@link PipelineAggregationSpec#PipelineAggregationSpec(String, Writeable.Reader, ContextParser)} for pipelines
-         *             implemented after 7.8.0
-         */
-        @Deprecated
-        public PipelineAggregationSpec(
-            String name,
-            Writeable.Reader<? extends PipelineAggregationBuilder> builderReader,
-            Writeable.Reader<? extends PipelineAggregator> aggregatorReader,
-            ContextParser<String, ? extends PipelineAggregationBuilder> parser
-        ) {
-            super(name, builderReader, parser);
-            this.aggregatorReader = aggregatorReader;
-        }
-
-        /**
-         * Specification of a {@link PipelineAggregator}.
-         *
-         * @param name holds the names by which this aggregation might be parsed. The {@link ParseField#getPreferredName()} is special as it
-         *        is the name by under which the readers are registered. So it is the name that the {@link PipelineAggregationBuilder} and
-         *        {@link PipelineAggregator} should return from {@link NamedWriteable#getWriteableName()}.  It is an error if
-         *        {@link ParseField#getPreferredName()} conflicts with another registered name, including names from other plugins.
-         * @param builderReader the reader registered for this aggregation's builder. Typically, a reference to a constructor that takes a
-         *        {@link StreamInput}
-         * @param aggregatorReader reads the {@link PipelineAggregator} from a stream
-         * @param parser reads the aggregation builder from XContent
-         * @deprecated prefer the ctor that takes a {@link ContextParser}
-         */
-        @Deprecated
-        public PipelineAggregationSpec(
-            ParseField name,
-            Writeable.Reader<? extends PipelineAggregationBuilder> builderReader,
-            Writeable.Reader<? extends PipelineAggregator> aggregatorReader,
-            PipelineAggregator.Parser parser
-        ) {
-            super(name, builderReader, (p, n) -> parser.parse(n, p));
-            this.aggregatorReader = aggregatorReader;
-        }
-
-        /**
-         * Specification of a {@link PipelineAggregator}.
-         *
-         * @param name name by which this aggregation might be parsed or deserialized. Make sure it is the name that the
-         *        {@link PipelineAggregationBuilder} and {@link PipelineAggregator} should return from
-         *        {@link NamedWriteable#getWriteableName()}.  It is an error if this name conflicts with another registered name, including
-         *        names from other plugins.
-         * @param builderReader the reader registered for this aggregation's builder. Typically, a reference to a constructor that takes a
-         *        {@link StreamInput}
-         * @param aggregatorReader reads the {@link PipelineAggregator} from a stream
          * @deprecated prefer the ctor that takes a {@link ContextParser}
          */
         @Deprecated
         public PipelineAggregationSpec(
             String name,
             Writeable.Reader<? extends PipelineAggregationBuilder> builderReader,
-            Writeable.Reader<? extends PipelineAggregator> aggregatorReader,
             PipelineAggregator.Parser parser
         ) {
             super(name, builderReader, (p, n) -> parser.parse(n, p));
-            this.aggregatorReader = aggregatorReader;
         }
 
         /**
@@ -779,15 +716,6 @@ public interface SearchPlugin {
         public PipelineAggregationSpec addResultReader(String writeableName, Writeable.Reader<? extends InternalAggregation> resultReader) {
             resultReaders.put(writeableName, resultReader);
             return this;
-        }
-
-        /**
-         * Read the aggregator from a stream.
-         * @deprecated Pipelines implemented after 7.8.0 do not need to be sent across the wire
-         */
-        @Deprecated
-        public Writeable.Reader<? extends PipelineAggregator> getAggregatorReader() {
-            return aggregatorReader;
         }
 
         /**

--- a/server/src/main/java/org/opensearch/search/SearchModule.java
+++ b/server/src/main/java/org/opensearch/search/SearchModule.java
@@ -211,21 +211,14 @@ import org.opensearch.search.aggregations.metrics.TopHitsAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.ValueCountAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.WeightedAvgAggregationBuilder;
 import org.opensearch.search.aggregations.pipeline.AvgBucketPipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.AvgBucketPipelineAggregator;
 import org.opensearch.search.aggregations.pipeline.BucketScriptPipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.BucketScriptPipelineAggregator;
 import org.opensearch.search.aggregations.pipeline.BucketSelectorPipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.BucketSelectorPipelineAggregator;
 import org.opensearch.search.aggregations.pipeline.BucketSortPipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.BucketSortPipelineAggregator;
 import org.opensearch.search.aggregations.pipeline.CumulativeSumPipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.CumulativeSumPipelineAggregator;
 import org.opensearch.search.aggregations.pipeline.DerivativePipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.DerivativePipelineAggregator;
 import org.opensearch.search.aggregations.pipeline.EwmaModel;
 import org.opensearch.search.aggregations.pipeline.ExtendedStatsBucketParser;
 import org.opensearch.search.aggregations.pipeline.ExtendedStatsBucketPipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.ExtendedStatsBucketPipelineAggregator;
 import org.opensearch.search.aggregations.pipeline.HoltLinearModel;
 import org.opensearch.search.aggregations.pipeline.HoltWintersModel;
 import org.opensearch.search.aggregations.pipeline.InternalBucketMetricValue;
@@ -236,24 +229,15 @@ import org.opensearch.search.aggregations.pipeline.InternalSimpleValue;
 import org.opensearch.search.aggregations.pipeline.InternalStatsBucket;
 import org.opensearch.search.aggregations.pipeline.LinearModel;
 import org.opensearch.search.aggregations.pipeline.MaxBucketPipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.MaxBucketPipelineAggregator;
 import org.opensearch.search.aggregations.pipeline.MinBucketPipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.MinBucketPipelineAggregator;
 import org.opensearch.search.aggregations.pipeline.MovAvgModel;
 import org.opensearch.search.aggregations.pipeline.MovAvgPipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.MovAvgPipelineAggregator;
 import org.opensearch.search.aggregations.pipeline.MovFnPipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.MovFnPipelineAggregator;
 import org.opensearch.search.aggregations.pipeline.PercentilesBucketPipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.PercentilesBucketPipelineAggregator;
-import org.opensearch.search.aggregations.pipeline.PipelineAggregator;
 import org.opensearch.search.aggregations.pipeline.SerialDiffPipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.SerialDiffPipelineAggregator;
 import org.opensearch.search.aggregations.pipeline.SimpleModel;
 import org.opensearch.search.aggregations.pipeline.StatsBucketPipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.StatsBucketPipelineAggregator;
 import org.opensearch.search.aggregations.pipeline.SumBucketPipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.SumBucketPipelineAggregator;
 import org.opensearch.search.aggregations.support.ValuesSourceRegistry;
 import org.opensearch.search.fetch.FetchPhase;
 import org.opensearch.search.fetch.FetchSubPhase;
@@ -710,7 +694,6 @@ public class SearchModule {
             new PipelineAggregationSpec(
                 DerivativePipelineAggregationBuilder.NAME,
                 DerivativePipelineAggregationBuilder::new,
-                DerivativePipelineAggregator::new,
                 DerivativePipelineAggregationBuilder::parse
             ).addResultReader(InternalDerivative::new)
         );
@@ -718,7 +701,6 @@ public class SearchModule {
             new PipelineAggregationSpec(
                 MaxBucketPipelineAggregationBuilder.NAME,
                 MaxBucketPipelineAggregationBuilder::new,
-                MaxBucketPipelineAggregator::new,
                 MaxBucketPipelineAggregationBuilder.PARSER
             )
                 // This bucket is used by many pipeline aggreations.
@@ -728,7 +710,6 @@ public class SearchModule {
             new PipelineAggregationSpec(
                 MinBucketPipelineAggregationBuilder.NAME,
                 MinBucketPipelineAggregationBuilder::new,
-                MinBucketPipelineAggregator::new,
                 MinBucketPipelineAggregationBuilder.PARSER
             )
             /* Uses InternalBucketMetricValue */
@@ -737,7 +718,6 @@ public class SearchModule {
             new PipelineAggregationSpec(
                 AvgBucketPipelineAggregationBuilder.NAME,
                 AvgBucketPipelineAggregationBuilder::new,
-                AvgBucketPipelineAggregator::new,
                 AvgBucketPipelineAggregationBuilder.PARSER
             )
                 // This bucket is used by many pipeline aggreations.
@@ -747,7 +727,6 @@ public class SearchModule {
             new PipelineAggregationSpec(
                 SumBucketPipelineAggregationBuilder.NAME,
                 SumBucketPipelineAggregationBuilder::new,
-                SumBucketPipelineAggregator::new,
                 SumBucketPipelineAggregationBuilder.PARSER
             )
             /* Uses InternalSimpleValue */
@@ -756,7 +735,6 @@ public class SearchModule {
             new PipelineAggregationSpec(
                 StatsBucketPipelineAggregationBuilder.NAME,
                 StatsBucketPipelineAggregationBuilder::new,
-                StatsBucketPipelineAggregator::new,
                 StatsBucketPipelineAggregationBuilder.PARSER
             ).addResultReader(InternalStatsBucket::new)
         );
@@ -764,7 +742,6 @@ public class SearchModule {
             new PipelineAggregationSpec(
                 ExtendedStatsBucketPipelineAggregationBuilder.NAME,
                 ExtendedStatsBucketPipelineAggregationBuilder::new,
-                ExtendedStatsBucketPipelineAggregator::new,
                 new ExtendedStatsBucketParser()
             ).addResultReader(InternalExtendedStatsBucket::new)
         );
@@ -772,7 +749,6 @@ public class SearchModule {
             new PipelineAggregationSpec(
                 PercentilesBucketPipelineAggregationBuilder.NAME,
                 PercentilesBucketPipelineAggregationBuilder::new,
-                PercentilesBucketPipelineAggregator::new,
                 PercentilesBucketPipelineAggregationBuilder.PARSER
             ).addResultReader(InternalPercentilesBucket::new)
         );
@@ -780,7 +756,6 @@ public class SearchModule {
             new PipelineAggregationSpec(
                 MovAvgPipelineAggregationBuilder.NAME,
                 MovAvgPipelineAggregationBuilder::new,
-                MovAvgPipelineAggregator::new,
                 (XContentParser parser, String name) -> MovAvgPipelineAggregationBuilder.parse(
                     movingAverageModelParserRegistry,
                     name,
@@ -792,7 +767,6 @@ public class SearchModule {
             new PipelineAggregationSpec(
                 CumulativeSumPipelineAggregationBuilder.NAME,
                 CumulativeSumPipelineAggregationBuilder::new,
-                CumulativeSumPipelineAggregator::new,
                 CumulativeSumPipelineAggregationBuilder.PARSER
             )
         );
@@ -800,7 +774,6 @@ public class SearchModule {
             new PipelineAggregationSpec(
                 BucketScriptPipelineAggregationBuilder.NAME,
                 BucketScriptPipelineAggregationBuilder::new,
-                BucketScriptPipelineAggregator::new,
                 BucketScriptPipelineAggregationBuilder.PARSER
             )
         );
@@ -808,7 +781,6 @@ public class SearchModule {
             new PipelineAggregationSpec(
                 BucketSelectorPipelineAggregationBuilder.NAME,
                 BucketSelectorPipelineAggregationBuilder::new,
-                BucketSelectorPipelineAggregator::new,
                 BucketSelectorPipelineAggregationBuilder::parse
             )
         );
@@ -816,7 +788,6 @@ public class SearchModule {
             new PipelineAggregationSpec(
                 BucketSortPipelineAggregationBuilder.NAME,
                 BucketSortPipelineAggregationBuilder::new,
-                BucketSortPipelineAggregator::new,
                 BucketSortPipelineAggregationBuilder::parse
             )
         );
@@ -824,7 +795,6 @@ public class SearchModule {
             new PipelineAggregationSpec(
                 SerialDiffPipelineAggregationBuilder.NAME,
                 SerialDiffPipelineAggregationBuilder::new,
-                SerialDiffPipelineAggregator::new,
                 SerialDiffPipelineAggregationBuilder::parse
             )
         );
@@ -832,7 +802,6 @@ public class SearchModule {
             new PipelineAggregationSpec(
                 MovFnPipelineAggregationBuilder.NAME,
                 MovFnPipelineAggregationBuilder::new,
-                MovFnPipelineAggregator::new,
                 MovFnPipelineAggregationBuilder.PARSER
             )
         );
@@ -847,11 +816,6 @@ public class SearchModule {
         namedWriteables.add(
             new NamedWriteableRegistry.Entry(PipelineAggregationBuilder.class, spec.getName().getPreferredName(), spec.getReader())
         );
-        if (spec.getAggregatorReader() != null) {
-            namedWriteables.add(
-                new NamedWriteableRegistry.Entry(PipelineAggregator.class, spec.getName().getPreferredName(), spec.getAggregatorReader())
-            );
-        }
         for (Map.Entry<String, Writeable.Reader<? extends InternalAggregation>> resultReader : spec.getResultReaders().entrySet()) {
             namedWriteables.add(
                 new NamedWriteableRegistry.Entry(InternalAggregation.class, resultReader.getKey(), resultReader.getValue())

--- a/server/src/main/java/org/opensearch/search/aggregations/AggregationPhase.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/AggregationPhase.java
@@ -148,8 +148,7 @@ public class AggregationPhase {
                 throw new AggregationExecutionException("Failed to build aggregation [" + aggregator.name() + "]", e);
             }
         }
-        context.queryResult()
-            .aggregations(new InternalAggregations(aggregations, context.request().source().aggregations()::buildPipelineTree));
+        context.queryResult().aggregations(new InternalAggregations(aggregations));
 
         // disable aggregations so that they don't run on next pages in case of scrolling
         context.aggregations(null);

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/AvgBucketPipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/AvgBucketPipelineAggregator.java
@@ -32,12 +32,10 @@
 
 package org.opensearch.search.aggregations.pipeline;
 
-import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 
-import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -57,18 +55,6 @@ public class AvgBucketPipelineAggregator extends BucketMetricsPipelineAggregator
         Map<String, Object> metadata
     ) {
         super(name, bucketsPaths, gapPolicy, format, metadata);
-    }
-
-    /**
-     * Read from a stream.
-     */
-    public AvgBucketPipelineAggregator(StreamInput in) throws IOException {
-        super(in);
-    }
-
-    @Override
-    public String getWriteableName() {
-        return AvgBucketPipelineAggregationBuilder.NAME;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/BucketMetricsPipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/BucketMetricsPipelineAggregator.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.search.aggregations.pipeline;
 
-import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.Aggregation;
 import org.opensearch.search.aggregations.Aggregations;
@@ -43,7 +41,6 @@ import org.opensearch.search.aggregations.InternalMultiBucketAggregation;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.opensearch.search.aggregations.support.AggregationPath;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -69,24 +66,6 @@ public abstract class BucketMetricsPipelineAggregator extends SiblingPipelineAgg
         this.gapPolicy = gapPolicy;
         this.format = format;
     }
-
-    /**
-     * Read from a stream.
-     */
-    BucketMetricsPipelineAggregator(StreamInput in) throws IOException {
-        super(in);
-        format = in.readNamedWriteable(DocValueFormat.class);
-        gapPolicy = GapPolicy.readFrom(in);
-    }
-
-    @Override
-    public final void doWriteTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteable(format);
-        gapPolicy.writeTo(out);
-        innerWriteTo(out);
-    }
-
-    protected void innerWriteTo(StreamOutput out) throws IOException {}
 
     @Override
     public final InternalAggregation doReduce(Aggregations aggregations, ReduceContext context) {

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/BucketScriptPipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/BucketScriptPipelineAggregator.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.search.aggregations.pipeline;
 
-import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.script.BucketAggregationScript;
 import org.opensearch.script.Script;
 import org.opensearch.search.DocValueFormat;
@@ -43,7 +41,6 @@ import org.opensearch.search.aggregations.InternalAggregations;
 import org.opensearch.search.aggregations.InternalMultiBucketAggregation;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -77,31 +74,6 @@ public class BucketScriptPipelineAggregator extends PipelineAggregator {
         this.script = script;
         this.formatter = formatter;
         this.gapPolicy = gapPolicy;
-    }
-
-    /**
-     * Read from a stream.
-     */
-    @SuppressWarnings("unchecked")
-    public BucketScriptPipelineAggregator(StreamInput in) throws IOException {
-        super(in);
-        script = new Script(in);
-        formatter = in.readNamedWriteable(DocValueFormat.class);
-        gapPolicy = GapPolicy.readFrom(in);
-        bucketsPathsMap = (Map<String, String>) in.readGenericValue();
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        script.writeTo(out);
-        out.writeNamedWriteable(formatter);
-        gapPolicy.writeTo(out);
-        out.writeGenericValue(bucketsPathsMap);
-    }
-
-    @Override
-    public String getWriteableName() {
-        return BucketScriptPipelineAggregationBuilder.NAME;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/BucketSelectorPipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/BucketSelectorPipelineAggregator.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.search.aggregations.pipeline;
 
-import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.script.BucketAggregationSelectorScript;
 import org.opensearch.script.Script;
 import org.opensearch.search.aggregations.InternalAggregation;
@@ -41,7 +39,6 @@ import org.opensearch.search.aggregations.InternalAggregation.ReduceContext;
 import org.opensearch.search.aggregations.InternalMultiBucketAggregation;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -70,29 +67,6 @@ public class BucketSelectorPipelineAggregator extends PipelineAggregator {
         this.bucketsPathsMap = bucketsPathsMap;
         this.script = script;
         this.gapPolicy = gapPolicy;
-    }
-
-    /**
-     * Read from a stream.
-     */
-    @SuppressWarnings("unchecked")
-    public BucketSelectorPipelineAggregator(StreamInput in) throws IOException {
-        super(in);
-        script = new Script(in);
-        gapPolicy = GapPolicy.readFrom(in);
-        bucketsPathsMap = (Map<String, String>) in.readGenericValue();
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        script.writeTo(out);
-        gapPolicy.writeTo(out);
-        out.writeGenericValue(bucketsPathsMap);
-    }
-
-    @Override
-    public String getWriteableName() {
-        return BucketSelectorPipelineAggregationBuilder.NAME;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/BucketSortPipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/BucketSortPipelineAggregator.java
@@ -31,8 +31,6 @@
 
 package org.opensearch.search.aggregations.pipeline;
 
-import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregation.ReduceContext;
 import org.opensearch.search.aggregations.InternalMultiBucketAggregation;
@@ -41,7 +39,6 @@ import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 import org.opensearch.search.sort.FieldSortBuilder;
 import org.opensearch.search.sort.SortOrder;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -73,30 +70,6 @@ public class BucketSortPipelineAggregator extends PipelineAggregator {
         this.from = from;
         this.size = size;
         this.gapPolicy = gapPolicy;
-    }
-
-    /**
-     * Read from a stream.
-     */
-    public BucketSortPipelineAggregator(StreamInput in) throws IOException {
-        super(in);
-        sorts = in.readList(FieldSortBuilder::new);
-        from = in.readVInt();
-        size = in.readOptionalVInt();
-        gapPolicy = GapPolicy.readFrom(in);
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        out.writeList(sorts);
-        out.writeVInt(from);
-        out.writeOptionalVInt(size);
-        gapPolicy.writeTo(out);
-    }
-
-    @Override
-    public String getWriteableName() {
-        return BucketSortPipelineAggregationBuilder.NAME;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/CumulativeSumPipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/CumulativeSumPipelineAggregator.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.search.aggregations.pipeline;
 
-import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregation.ReduceContext;
@@ -43,7 +41,6 @@ import org.opensearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.opensearch.search.aggregations.bucket.histogram.HistogramFactory;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -63,24 +60,6 @@ public class CumulativeSumPipelineAggregator extends PipelineAggregator {
     CumulativeSumPipelineAggregator(String name, String[] bucketsPaths, DocValueFormat formatter, Map<String, Object> metadata) {
         super(name, bucketsPaths, metadata);
         this.formatter = formatter;
-    }
-
-    /**
-     * Read from a stream.
-     */
-    public CumulativeSumPipelineAggregator(StreamInput in) throws IOException {
-        super(in);
-        formatter = in.readNamedWriteable(DocValueFormat.class);
-    }
-
-    @Override
-    public void doWriteTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteable(formatter);
-    }
-
-    @Override
-    public String getWriteableName() {
-        return CumulativeSumPipelineAggregationBuilder.NAME;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/DerivativePipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/DerivativePipelineAggregator.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.search.aggregations.pipeline;
 
-import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregation.ReduceContext;
@@ -43,7 +41,6 @@ import org.opensearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.opensearch.search.aggregations.bucket.histogram.HistogramFactory;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -74,28 +71,6 @@ public class DerivativePipelineAggregator extends PipelineAggregator {
         this.formatter = formatter;
         this.gapPolicy = gapPolicy;
         this.xAxisUnits = xAxisUnits == null ? null : (double) xAxisUnits;
-    }
-
-    /**
-     * Read from a stream.
-     */
-    public DerivativePipelineAggregator(StreamInput in) throws IOException {
-        super(in);
-        formatter = in.readNamedWriteable(DocValueFormat.class);
-        gapPolicy = GapPolicy.readFrom(in);
-        xAxisUnits = in.readOptionalDouble();
-    }
-
-    @Override
-    public void doWriteTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteable(formatter);
-        gapPolicy.writeTo(out);
-        out.writeOptionalDouble(xAxisUnits);
-    }
-
-    @Override
-    public String getWriteableName() {
-        return DerivativePipelineAggregationBuilder.NAME;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/ExtendedStatsBucketPipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/ExtendedStatsBucketPipelineAggregator.java
@@ -32,13 +32,10 @@
 
 package org.opensearch.search.aggregations.pipeline;
 
-import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 
-import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -64,24 +61,6 @@ public class ExtendedStatsBucketPipelineAggregator extends BucketMetricsPipeline
     ) {
         super(name, bucketsPaths, gapPolicy, formatter, metadata);
         this.sigma = sigma;
-    }
-
-    /**
-     * Read from a stream.
-     */
-    public ExtendedStatsBucketPipelineAggregator(StreamInput in) throws IOException {
-        super(in);
-        sigma = in.readDouble();
-    }
-
-    @Override
-    protected void innerWriteTo(StreamOutput out) throws IOException {
-        out.writeDouble(sigma);
-    }
-
-    @Override
-    public String getWriteableName() {
-        return ExtendedStatsBucketPipelineAggregationBuilder.NAME;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/MaxBucketPipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/MaxBucketPipelineAggregator.java
@@ -32,12 +32,10 @@
 
 package org.opensearch.search.aggregations.pipeline;
 
-import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -59,18 +57,6 @@ public class MaxBucketPipelineAggregator extends BucketMetricsPipelineAggregator
         Map<String, Object> metadata
     ) {
         super(name, bucketsPaths, gapPolicy, formatter, metadata);
-    }
-
-    /**
-     * Read from a stream.
-     */
-    public MaxBucketPipelineAggregator(StreamInput in) throws IOException {
-        super(in);
-    }
-
-    @Override
-    public String getWriteableName() {
-        return MaxBucketPipelineAggregationBuilder.NAME;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/MinBucketPipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/MinBucketPipelineAggregator.java
@@ -32,12 +32,10 @@
 
 package org.opensearch.search.aggregations.pipeline;
 
-import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -59,18 +57,6 @@ public class MinBucketPipelineAggregator extends BucketMetricsPipelineAggregator
         Map<String, Object> metadata
     ) {
         super(name, bucketsPaths, gapPolicy, formatter, metadata);
-    }
-
-    /**
-     * Read from a stream.
-     */
-    public MinBucketPipelineAggregator(StreamInput in) throws IOException {
-        super(in);
-    }
-
-    @Override
-    public String getWriteableName() {
-        return MinBucketPipelineAggregationBuilder.NAME;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/MovAvgPipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/MovAvgPipelineAggregator.java
@@ -33,8 +33,6 @@
 package org.opensearch.search.aggregations.pipeline;
 
 import org.opensearch.common.collect.EvictingQueue;
-import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregation.ReduceContext;
@@ -45,7 +43,6 @@ import org.opensearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.opensearch.search.aggregations.bucket.histogram.HistogramFactory;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
@@ -86,34 +83,6 @@ public class MovAvgPipelineAggregator extends PipelineAggregator {
         this.model = model;
         this.predict = predict;
         this.minimize = minimize;
-    }
-
-    /**
-     * Read from a stream.
-     */
-    public MovAvgPipelineAggregator(StreamInput in) throws IOException {
-        super(in);
-        formatter = in.readNamedWriteable(DocValueFormat.class);
-        gapPolicy = GapPolicy.readFrom(in);
-        window = in.readVInt();
-        predict = in.readVInt();
-        model = in.readNamedWriteable(MovAvgModel.class);
-        minimize = in.readBoolean();
-    }
-
-    @Override
-    public void doWriteTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteable(formatter);
-        gapPolicy.writeTo(out);
-        out.writeVInt(window);
-        out.writeVInt(predict);
-        out.writeNamedWriteable(model);
-        out.writeBoolean(minimize);
-    }
-
-    @Override
-    public String getWriteableName() {
-        return MovAvgPipelineAggregationBuilder.NAME;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/MovFnPipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/MovFnPipelineAggregator.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.search.aggregations.pipeline;
 
-import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.script.Script;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.InternalAggregation;
@@ -42,7 +40,6 @@ import org.opensearch.search.aggregations.InternalMultiBucketAggregation;
 import org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.opensearch.search.aggregations.bucket.histogram.HistogramFactory;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -96,31 +93,6 @@ public class MovFnPipelineAggregator extends PipelineAggregator {
         this.gapPolicy = gapPolicy;
         this.window = window;
         this.shift = shift;
-    }
-
-    public MovFnPipelineAggregator(StreamInput in) throws IOException {
-        super(in);
-        script = new Script(in);
-        formatter = in.readNamedWriteable(DocValueFormat.class);
-        gapPolicy = BucketHelpers.GapPolicy.readFrom(in);
-        bucketsPath = in.readString();
-        window = in.readInt();
-        shift = in.readInt();
-    }
-
-    @Override
-    protected void doWriteTo(StreamOutput out) throws IOException {
-        script.writeTo(out);
-        out.writeNamedWriteable(formatter);
-        gapPolicy.writeTo(out);
-        out.writeString(bucketsPath);
-        out.writeInt(window);
-        out.writeInt(shift);
-    }
-
-    @Override
-    public String getWriteableName() {
-        return MovFnPipelineAggregationBuilder.NAME;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/PercentilesBucketPipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/PercentilesBucketPipelineAggregator.java
@@ -32,13 +32,10 @@
 
 package org.opensearch.search.aggregations.pipeline;
 
-import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -67,26 +64,6 @@ public class PercentilesBucketPipelineAggregator extends BucketMetricsPipelineAg
         super(name, bucketsPaths, gapPolicy, formatter, metadata);
         this.percents = percents;
         this.keyed = keyed;
-    }
-
-    /**
-     * Read from a stream.
-     */
-    public PercentilesBucketPipelineAggregator(StreamInput in) throws IOException {
-        super(in);
-        percents = in.readDoubleArray();
-        keyed = in.readBoolean();
-    }
-
-    @Override
-    public void innerWriteTo(StreamOutput out) throws IOException {
-        out.writeDoubleArray(percents);
-        out.writeBoolean(keyed);
-    }
-
-    @Override
-    public String getWriteableName() {
-        return PercentilesBucketPipelineAggregationBuilder.NAME;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/PipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/PipelineAggregator.java
@@ -32,11 +32,7 @@
 
 package org.opensearch.search.aggregations.pipeline;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
-import org.opensearch.common.io.stream.NamedWriteable;
-import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregation.ReduceContext;
@@ -54,7 +50,7 @@ import static java.util.Collections.emptyMap;
  *
  * @opensearch.internal
  */
-public abstract class PipelineAggregator implements NamedWriteable {
+public abstract class PipelineAggregator {
     /**
      * Parse the {@link PipelineAggregationBuilder} from a {@link XContentParser}.
      *
@@ -137,55 +133,6 @@ public abstract class PipelineAggregator implements NamedWriteable {
         this.name = name;
         this.bucketsPaths = bucketsPaths;
         this.metadata = metadata;
-    }
-
-    /**
-     * Read from a stream.
-     * @deprecated pipeline aggregations added after 7.8.0 shouldn't call this
-     */
-    @Deprecated
-    protected PipelineAggregator(StreamInput in) throws IOException {
-        if (in.getVersion().before(LegacyESVersion.V_7_8_0)) {
-            name = in.readString();
-            bucketsPaths = in.readStringArray();
-            metadata = in.readMap();
-        } else {
-            throw new IllegalStateException("Cannot deserialize pipeline [" + getClass() + "] from before 7.8.0");
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     * @deprecated pipeline aggregations added after 7.8.0 shouldn't call this
-     */
-    @Override
-    @Deprecated
-    public final void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().before(LegacyESVersion.V_7_8_0)) {
-            out.writeString(name);
-            out.writeStringArray(bucketsPaths);
-            out.writeMap(metadata);
-            doWriteTo(out);
-        } else {
-            throw new IllegalArgumentException("[" + name + "] is not supported on versions before 7.8.0");
-        }
-    }
-
-    /**
-     * Write the body of the aggregation to the wire.
-     * @deprecated pipeline aggregations added after 7.8.0 don't need to implement this
-     */
-    @Deprecated
-    protected void doWriteTo(StreamOutput out) throws IOException {}
-
-    /**
-     * The name of the writeable object.
-     * @deprecated pipeline aggregations added after 7.8.0 don't need to implement this
-     */
-    @Override
-    @Deprecated
-    public String getWriteableName() {
-        throw new IllegalArgumentException("[" + name + "] is not supported on versions before 7.8.0");
     }
 
     public String name() {

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/SerialDiffPipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/SerialDiffPipelineAggregator.java
@@ -34,8 +34,6 @@ package org.opensearch.search.aggregations.pipeline;
 
 import org.opensearch.common.Nullable;
 import org.opensearch.common.collect.EvictingQueue;
-import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregation.ReduceContext;
@@ -45,7 +43,6 @@ import org.opensearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.opensearch.search.aggregations.bucket.histogram.HistogramFactory;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -76,28 +73,6 @@ public class SerialDiffPipelineAggregator extends PipelineAggregator {
         this.formatter = formatter;
         this.gapPolicy = gapPolicy;
         this.lag = lag;
-    }
-
-    /**
-     * Read from a stream.
-     */
-    public SerialDiffPipelineAggregator(StreamInput in) throws IOException {
-        super(in);
-        formatter = in.readNamedWriteable(DocValueFormat.class);
-        gapPolicy = GapPolicy.readFrom(in);
-        lag = in.readVInt();
-    }
-
-    @Override
-    public void doWriteTo(StreamOutput out) throws IOException {
-        out.writeNamedWriteable(formatter);
-        gapPolicy.writeTo(out);
-        out.writeVInt(lag);
-    }
-
-    @Override
-    public String getWriteableName() {
-        return SerialDiffPipelineAggregationBuilder.NAME;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/SiblingPipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/SiblingPipelineAggregator.java
@@ -32,13 +32,11 @@
 
 package org.opensearch.search.aggregations.pipeline;
 
-import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.search.aggregations.Aggregations;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregation.ReduceContext;
 import org.opensearch.search.aggregations.InternalAggregations;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -50,13 +48,6 @@ import java.util.Map;
 public abstract class SiblingPipelineAggregator extends PipelineAggregator {
     protected SiblingPipelineAggregator(String name, String[] bucketsPaths, Map<String, Object> metadata) {
         super(name, bucketsPaths, metadata);
-    }
-
-    /**
-     * Read from a stream.
-     */
-    SiblingPipelineAggregator(StreamInput in) throws IOException {
-        super(in);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/StatsBucketPipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/StatsBucketPipelineAggregator.java
@@ -32,12 +32,10 @@
 
 package org.opensearch.search.aggregations.pipeline;
 
-import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 
-import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -59,15 +57,6 @@ public class StatsBucketPipelineAggregator extends BucketMetricsPipelineAggregat
         Map<String, Object> metadata
     ) {
         super(name, bucketsPaths, gapPolicy, formatter, metadata);
-    }
-
-    public StatsBucketPipelineAggregator(StreamInput in) throws IOException {
-        super(in);
-    }
-
-    @Override
-    public String getWriteableName() {
-        return StatsBucketPipelineAggregationBuilder.NAME;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/SumBucketPipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/SumBucketPipelineAggregator.java
@@ -32,12 +32,10 @@
 
 package org.opensearch.search.aggregations.pipeline;
 
-import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
 
-import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -56,18 +54,6 @@ public class SumBucketPipelineAggregator extends BucketMetricsPipelineAggregator
         Map<String, Object> metadata
     ) {
         super(name, bucketsPaths, gapPolicy, formatter, metadata);
-    }
-
-    /**
-     * Read from a stream.
-     */
-    public SumBucketPipelineAggregator(StreamInput in) throws IOException {
-        super(in);
-    }
-
-    @Override
-    public String getWriteableName() {
-        return SumBucketPipelineAggregationBuilder.NAME;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/query/QuerySearchResult.java
+++ b/server/src/main/java/org/opensearch/search/query/QuerySearchResult.java
@@ -34,7 +34,6 @@ package org.opensearch.search.query;
 
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.TotalHits;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.io.stream.DelayableWriteable;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -373,10 +372,8 @@ public final class QuerySearchResult extends SearchPhaseResult {
         hasProfileResults = profileShardResults != null;
         serviceTimeEWMA = in.readZLong();
         nodeQueueSize = in.readInt();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            setShardSearchRequest(in.readOptionalWriteable(ShardSearchRequest::new));
-            setRescoreDocIds(new RescoreDocIds(in));
-        }
+        setShardSearchRequest(in.readOptionalWriteable(ShardSearchRequest::new));
+        setRescoreDocIds(new RescoreDocIds(in));
     }
 
     @Override
@@ -424,10 +421,8 @@ public final class QuerySearchResult extends SearchPhaseResult {
         out.writeOptionalWriteable(profileShardResults);
         out.writeZLong(serviceTimeEWMA);
         out.writeInt(nodeQueueSize);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeOptionalWriteable(getShardSearchRequest());
-            getRescoreDocIds().writeTo(out);
-        }
+        out.writeOptionalWriteable(getShardSearchRequest());
+        getRescoreDocIds().writeTo(out);
     }
 
     public TotalHits getTotalHits() {

--- a/server/src/main/java/org/opensearch/search/query/QuerySearchResult.java
+++ b/server/src/main/java/org/opensearch/search/query/QuerySearchResult.java
@@ -94,11 +94,7 @@ public final class QuerySearchResult extends SearchPhaseResult {
 
     public QuerySearchResult(StreamInput in) throws IOException {
         super(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-            isNull = in.readBoolean();
-        } else {
-            isNull = false;
-        }
+        isNull = in.readBoolean();
         if (isNull == false) {
             ShardSearchContextId id = new ShardSearchContextId(in);
             readFromWithId(id, in);
@@ -354,14 +350,8 @@ public final class QuerySearchResult extends SearchPhaseResult {
             }
         }
         setTopDocs(readTopDocs(in));
-        if (in.getVersion().before(LegacyESVersion.V_7_7_0)) {
-            if (hasAggs = in.readBoolean()) {
-                aggregations = DelayableWriteable.referencing(InternalAggregations.readFrom(in));
-            }
-        } else {
-            if (hasAggs = in.readBoolean()) {
-                aggregations = DelayableWriteable.delayed(InternalAggregations::readFrom, in);
-            }
+        if (hasAggs = in.readBoolean()) {
+            aggregations = DelayableWriteable.delayed(InternalAggregations::readFrom, in);
         }
         if (in.readBoolean()) {
             suggest = new Suggest(in);
@@ -378,9 +368,7 @@ public final class QuerySearchResult extends SearchPhaseResult {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_7_0)) {
-            out.writeBoolean(isNull);
-        }
+        out.writeBoolean(isNull);
         if (isNull == false) {
             contextId.writeTo(out);
             writeToNoId(out);
@@ -403,12 +391,7 @@ public final class QuerySearchResult extends SearchPhaseResult {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            if (out.getVersion().before(LegacyESVersion.V_7_7_0)) {
-                InternalAggregations aggs = aggregations.expand();
-                aggs.writeTo(out);
-            } else {
-                aggregations.writeTo(out);
-            }
+            aggregations.writeTo(out);
         }
         if (suggest == null) {
             out.writeBoolean(false);

--- a/server/src/test/java/org/opensearch/search/SearchModuleTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchModuleTests.java
@@ -56,7 +56,6 @@ import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.terms.heuristic.ChiSquare;
 import org.opensearch.search.aggregations.pipeline.AbstractPipelineAggregationBuilder;
 import org.opensearch.search.aggregations.pipeline.DerivativePipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.DerivativePipelineAggregator;
 import org.opensearch.search.aggregations.pipeline.InternalDerivative;
 import org.opensearch.search.aggregations.pipeline.MovAvgModel;
 import org.opensearch.search.aggregations.pipeline.PipelineAggregator;
@@ -193,7 +192,6 @@ public class SearchModuleTests extends OpenSearchTestCase {
                     new PipelineAggregationSpec(
                         DerivativePipelineAggregationBuilder.NAME,
                         DerivativePipelineAggregationBuilder::new,
-                        DerivativePipelineAggregator::new,
                         DerivativePipelineAggregationBuilder::parse
                     ).addResultReader(InternalDerivative::new)
                 );
@@ -375,12 +373,7 @@ public class SearchModuleTests extends OpenSearchTestCase {
             @Override
             public List<PipelineAggregationSpec> getPipelineAggregations() {
                 return singletonList(
-                    new PipelineAggregationSpec(
-                        "test",
-                        TestPipelineAggregationBuilder::new,
-                        TestPipelineAggregator::new,
-                        TestPipelineAggregationBuilder::fromXContent
-                    )
+                    new PipelineAggregationSpec("test", TestPipelineAggregationBuilder::new, TestPipelineAggregationBuilder::fromXContent)
                 );
             }
         }));
@@ -570,20 +563,9 @@ public class SearchModuleTests extends OpenSearchTestCase {
      * Dummy test {@link PipelineAggregator} used to test registering aggregation builders.
      */
     private static class TestPipelineAggregator extends PipelineAggregator {
-        /**
-         * Read from a stream.
-         */
-        TestPipelineAggregator(StreamInput in) throws IOException {
-            super(in);
+        TestPipelineAggregator() {
+            super("test", new String[] {}, null);
         }
-
-        @Override
-        public String getWriteableName() {
-            return "test";
-        }
-
-        @Override
-        protected void doWriteTo(StreamOutput out) throws IOException {}
 
         @Override
         public InternalAggregation reduce(InternalAggregation aggregation, ReduceContext reduceContext) {

--- a/server/src/test/java/org/opensearch/search/aggregations/InternalAggregationsTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/InternalAggregationsTests.java
@@ -43,12 +43,9 @@ import org.opensearch.search.SearchModule;
 import org.opensearch.search.aggregations.bucket.histogram.InternalDateHistogramTests;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.bucket.terms.StringTermsTests;
-import org.opensearch.search.aggregations.pipeline.AvgBucketPipelineAggregationBuilder;
 import org.opensearch.search.aggregations.pipeline.InternalSimpleValueTests;
 import org.opensearch.search.aggregations.pipeline.MaxBucketPipelineAggregationBuilder;
 import org.opensearch.search.aggregations.pipeline.PipelineAggregator;
-import org.opensearch.search.aggregations.pipeline.SiblingPipelineAggregator;
-import org.opensearch.search.aggregations.pipeline.SumBucketPipelineAggregationBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.InternalAggregationTestCase;
 
@@ -91,7 +88,6 @@ public class InternalAggregationsTests extends OpenSearchTestCase {
         );
         List<InternalAggregations> aggs = singletonList(InternalAggregations.from(Collections.singletonList(terms)));
         InternalAggregations reducedAggs = InternalAggregations.topLevelReduce(aggs, maxBucketReduceContext().forPartialReduction());
-        assertEquals(1, reducedAggs.getTopLevelPipelineAggregators().size());
         assertEquals(1, reducedAggs.aggregations.size());
     }
 
@@ -116,7 +112,6 @@ public class InternalAggregationsTests extends OpenSearchTestCase {
             Collections.singletonList(aggs),
             maxBucketReduceContext().forFinalReduction()
         );
-        assertEquals(0, reducedAggs.getTopLevelPipelineAggregators().size());
         assertEquals(2, reducedAggs.aggregations.size());
     }
 
@@ -130,10 +125,6 @@ public class InternalAggregationsTests extends OpenSearchTestCase {
     }
 
     public static InternalAggregations createTestInstance() throws Exception {
-        return createTestInstance(randomPipelineTree());
-    }
-
-    public static InternalAggregations createTestInstance(PipelineAggregator.PipelineTree pipelineTree) throws Exception {
         List<InternalAggregation> aggsList = new ArrayList<>();
         if (randomBoolean()) {
             StringTermsTests stringTermsTests = new StringTermsTests();
@@ -150,23 +141,7 @@ public class InternalAggregationsTests extends OpenSearchTestCase {
             InternalSimpleValueTests simpleValueTests = new InternalSimpleValueTests();
             aggsList.add(simpleValueTests.createTestInstance());
         }
-        return new InternalAggregations(aggsList, () -> pipelineTree);
-    }
-
-    private static PipelineAggregator.PipelineTree randomPipelineTree() {
-        List<PipelineAggregator> topLevelPipelineAggs = new ArrayList<>();
-        if (randomBoolean()) {
-            if (randomBoolean()) {
-                topLevelPipelineAggs.add((SiblingPipelineAggregator) new MaxBucketPipelineAggregationBuilder("name1", "bucket1").create());
-            }
-            if (randomBoolean()) {
-                topLevelPipelineAggs.add((SiblingPipelineAggregator) new AvgBucketPipelineAggregationBuilder("name2", "bucket2").create());
-            }
-            if (randomBoolean()) {
-                topLevelPipelineAggs.add((SiblingPipelineAggregator) new SumBucketPipelineAggregationBuilder("name3", "bucket3").create());
-            }
-        }
-        return new PipelineAggregator.PipelineTree(emptyMap(), topLevelPipelineAggs);
+        return new InternalAggregations(aggsList);
     }
 
     public void testSerialization() throws Exception {

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/SignificanceHeuristicTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/SignificanceHeuristicTests.java
@@ -32,7 +32,6 @@
 package org.opensearch.search.aggregations.bucket.terms;
 
 import org.apache.lucene.util.BytesRef;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.InputStreamStreamInput;
@@ -57,7 +56,6 @@ import org.opensearch.search.aggregations.bucket.terms.heuristic.JLHScore;
 import org.opensearch.search.aggregations.bucket.terms.heuristic.MutualInformation;
 import org.opensearch.search.aggregations.bucket.terms.heuristic.PercentageScore;
 import org.opensearch.search.aggregations.bucket.terms.heuristic.SignificanceHeuristic;
-import org.opensearch.search.aggregations.pipeline.PipelineAggregator;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.InternalAggregationTestCase;
 
@@ -95,9 +93,6 @@ public class SignificanceHeuristicTests extends OpenSearchTestCase {
         ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
         OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
         out.setVersion(version);
-        if (version.before(LegacyESVersion.V_7_8_0)) {
-            sigTerms.mergePipelineTreeForBWCSerialization(PipelineAggregator.PipelineTree.EMPTY);
-        }
         out.writeNamedWriteable(sigTerms);
 
         // read


### PR DESCRIPTION
Removes the deprecated readTo/writeFrom serialization logic from piepline aggs that is no longer used as of Legacy version 7.8.