### PR TITLE
[Remove] LegacyESVersion.V_7_8_* and V_7_9_* constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Remove deprecated serialization logic from pipeline aggs ([#4847](https://github.com/opensearch-project/OpenSearch/pull/4847))
 - Remove unused private methods ([#4926](https://github.com/opensearch-project/OpenSearch/pull/4926))
 - Revert PR 4656 to unblock Windows CI ([#4949](https://github.com/opensearch-project/OpenSearch/pull/4949))
+- Remove LegacyESVersion.V_7_8_ and V_7_9_ Constants ([#4855](https://github.com/opensearch-project/OpenSearch/pull/4855))
 
 ### Fixed
 - `opensearch-service.bat start` and `opensearch-service.bat manager` failing to run ([#4289](https://github.com/opensearch-project/OpenSearch/pull/4289))

--- a/server/src/main/java/org/opensearch/LegacyESVersion.java
+++ b/server/src/main/java/org/opensearch/LegacyESVersion.java
@@ -53,12 +53,6 @@ public class LegacyESVersion extends Version {
     public static final LegacyESVersion V_7_6_2 = new LegacyESVersion(7060299, org.apache.lucene.util.Version.LUCENE_8_4_0);
     public static final LegacyESVersion V_7_7_0 = new LegacyESVersion(7070099, org.apache.lucene.util.Version.LUCENE_8_5_1);
     public static final LegacyESVersion V_7_7_1 = new LegacyESVersion(7070199, org.apache.lucene.util.Version.LUCENE_8_5_1);
-    public static final LegacyESVersion V_7_8_0 = new LegacyESVersion(7080099, org.apache.lucene.util.Version.LUCENE_8_5_1);
-    public static final LegacyESVersion V_7_8_1 = new LegacyESVersion(7080199, org.apache.lucene.util.Version.LUCENE_8_5_1);
-    public static final LegacyESVersion V_7_9_0 = new LegacyESVersion(7090099, org.apache.lucene.util.Version.LUCENE_8_6_0);
-    public static final LegacyESVersion V_7_9_1 = new LegacyESVersion(7090199, org.apache.lucene.util.Version.LUCENE_8_6_2);
-    public static final LegacyESVersion V_7_9_2 = new LegacyESVersion(7090299, org.apache.lucene.util.Version.LUCENE_8_6_2);
-    public static final LegacyESVersion V_7_9_3 = new LegacyESVersion(7090399, org.apache.lucene.util.Version.LUCENE_8_6_2);
     public static final LegacyESVersion V_7_10_0 = new LegacyESVersion(7100099, org.apache.lucene.util.Version.LUCENE_8_7_0);
     public static final LegacyESVersion V_7_10_1 = new LegacyESVersion(7100199, org.apache.lucene.util.Version.LUCENE_8_7_0);
     public static final LegacyESVersion V_7_10_2 = new LegacyESVersion(7100299, org.apache.lucene.util.Version.LUCENE_8_7_0);

--- a/server/src/main/java/org/opensearch/OpenSearchException.java
+++ b/server/src/main/java/org/opensearch/OpenSearchException.java
@@ -1576,13 +1576,13 @@ public class OpenSearchException extends RuntimeException implements ToXContentF
             org.opensearch.indices.recovery.PeerRecoveryNotFound.class,
             org.opensearch.indices.recovery.PeerRecoveryNotFound::new,
             158,
-            LegacyESVersion.V_7_9_0
+            UNKNOWN_VERSION_ADDED
         ),
         NODE_HEALTH_CHECK_FAILURE_EXCEPTION(
             org.opensearch.cluster.coordination.NodeHealthCheckFailureException.class,
             org.opensearch.cluster.coordination.NodeHealthCheckFailureException::new,
             159,
-            LegacyESVersion.V_7_9_0
+            UNKNOWN_VERSION_ADDED
         ),
         NO_SEED_NODE_LEFT_EXCEPTION(
             org.opensearch.transport.NoSeedNodeLeftException.class,

--- a/server/src/main/java/org/opensearch/action/DocWriteRequest.java
+++ b/server/src/main/java/org/opensearch/action/DocWriteRequest.java
@@ -231,8 +231,7 @@ public interface DocWriteRequest<T> extends IndicesRequest, Accountable {
      * Read a document write (index/delete/update) request
      *
      * @param shardId shard id of the request. {@code null} when reading as part of a {@link org.opensearch.action.bulk.BulkRequest}
-     *                that does not have a unique shard id or when reading from a stream of version older than
-     *                {@link org.opensearch.action.bulk.BulkShardRequest#COMPACT_SHARD_ID_VERSION}
+     *                that does not have a unique shard id
      */
     static DocWriteRequest<?> readDocumentRequest(@Nullable ShardId shardId, StreamInput in) throws IOException {
         byte type = in.readByte();

--- a/server/src/main/java/org/opensearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequest.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.action.admin.cluster.configuration;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
 import org.opensearch.cluster.ClusterState;
@@ -110,13 +109,8 @@ public class AddVotingConfigExclusionsRequest extends ClusterManagerNodeRequest<
     public AddVotingConfigExclusionsRequest(StreamInput in) throws IOException {
         super(in);
         nodeDescriptions = in.readStringArray();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_8_0)) {
-            nodeIds = in.readStringArray();
-            nodeNames = in.readStringArray();
-        } else {
-            nodeIds = Strings.EMPTY_ARRAY;
-            nodeNames = Strings.EMPTY_ARRAY;
-        }
+        nodeIds = in.readStringArray();
+        nodeNames = in.readStringArray();
         timeout = in.readTimeValue();
 
         if (nodeDescriptions.length > 0) {
@@ -249,10 +243,8 @@ public class AddVotingConfigExclusionsRequest extends ClusterManagerNodeRequest<
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeStringArray(nodeDescriptions);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_8_0)) {
-            out.writeStringArray(nodeIds);
-            out.writeStringArray(nodeNames);
-        }
+        out.writeStringArray(nodeIds);
+        out.writeStringArray(nodeNames);
         out.writeTimeValue(timeout);
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.cluster.node.stats;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.support.nodes.BaseNodeResponse;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -138,18 +137,10 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         ingestStats = in.readOptionalWriteable(IngestStats::new);
         adaptiveSelectionStats = in.readOptionalWriteable(AdaptiveSelectionStats::new);
         scriptCacheStats = null;
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_8_0)) {
-            if (in.getVersion().before(LegacyESVersion.V_7_9_0)) {
-                scriptCacheStats = in.readOptionalWriteable(ScriptCacheStats::new);
-            } else if (scriptStats != null) {
-                scriptCacheStats = scriptStats.toScriptCacheStats();
-            }
+        if (scriptStats != null) {
+            scriptCacheStats = scriptStats.toScriptCacheStats();
         }
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-            indexingPressureStats = in.readOptionalWriteable(IndexingPressureStats::new);
-        } else {
-            indexingPressureStats = null;
-        }
+        indexingPressureStats = in.readOptionalWriteable(IndexingPressureStats::new);
         if (in.getVersion().onOrAfter(Version.V_1_2_0)) {
             shardIndexingPressureStats = in.readOptionalWriteable(ShardIndexingPressureStats::new);
         } else {
@@ -327,12 +318,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         out.writeOptionalWriteable(discoveryStats);
         out.writeOptionalWriteable(ingestStats);
         out.writeOptionalWriteable(adaptiveSelectionStats);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_8_0) && out.getVersion().before(LegacyESVersion.V_7_9_0)) {
-            out.writeOptionalWriteable(scriptCacheStats);
-        }
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-            out.writeOptionalWriteable(indexingPressureStats);
-        }
+        out.writeOptionalWriteable(indexingPressureStats);
         if (out.getVersion().onOrAfter(Version.V_1_2_0)) {
             out.writeOptionalWriteable(shardIndexingPressureStats);
         }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/tasks/cancel/CancelTasksRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/tasks/cancel/CancelTasksRequest.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.cluster.node.tasks.cancel;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.support.tasks.BaseTasksRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -60,18 +59,14 @@ public class CancelTasksRequest extends BaseTasksRequest<CancelTasksRequest> {
     public CancelTasksRequest(StreamInput in) throws IOException {
         super(in);
         this.reason = in.readString();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_8_0)) {
-            waitForCompletion = in.readBoolean();
-        }
+        waitForCompletion = in.readBoolean();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeString(reason);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_8_0)) {
-            out.writeBoolean(waitForCompletion);
-        }
+        out.writeBoolean(waitForCompletion);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/usage/NodeUsage.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/usage/NodeUsage.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.cluster.node.usage;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.support.nodes.BaseNodeResponse;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.io.stream.StreamInput;
@@ -61,11 +60,7 @@ public class NodeUsage extends BaseNodeResponse implements ToXContentFragment {
         timestamp = in.readLong();
         sinceTime = in.readLong();
         restUsage = (Map<String, Long>) in.readGenericValue();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_8_0)) {
-            aggregationUsage = (Map<String, Object>) in.readGenericValue();
-        } else {
-            aggregationUsage = null;
-        }
+        aggregationUsage = (Map<String, Object>) in.readGenericValue();
     }
 
     /**
@@ -144,9 +139,7 @@ public class NodeUsage extends BaseNodeResponse implements ToXContentFragment {
         out.writeLong(timestamp);
         out.writeLong(sinceTime);
         out.writeGenericValue(restUsage);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_8_0)) {
-            out.writeGenericValue(aggregationUsage);
-        }
+        out.writeGenericValue(aggregationUsage);
     }
 
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/usage/NodesUsageRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/usage/NodesUsageRequest.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.cluster.node.usage;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.support.nodes.BaseNodesRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -52,9 +51,7 @@ public class NodesUsageRequest extends BaseNodesRequest<NodesUsageRequest> {
     public NodesUsageRequest(StreamInput in) throws IOException {
         super(in);
         this.restActions = in.readBoolean();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_8_0)) {
-            this.aggregations = in.readBoolean();
-        }
+        this.aggregations = in.readBoolean();
     }
 
     /**
@@ -116,8 +113,6 @@ public class NodesUsageRequest extends BaseNodesRequest<NodesUsageRequest> {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeBoolean(restActions);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_8_0)) {
-            out.writeBoolean(aggregations);
-        }
+        out.writeBoolean(aggregations);
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -281,11 +281,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
                 isHidden = in.readOptionalBoolean();
             }
             originalAliases = in.readStringArray();
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-                mustExist = in.readOptionalBoolean();
-            } else {
-                mustExist = null;
-            }
+            mustExist = in.readOptionalBoolean();
         }
 
         @Override
@@ -303,9 +299,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
                 out.writeOptionalBoolean(isHidden);
             }
             out.writeStringArray(originalAliases);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-                out.writeOptionalBoolean(mustExist);
-            }
+            out.writeOptionalBoolean(mustExist);
         }
 
         /**

--- a/server/src/main/java/org/opensearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/get/GetIndexResponse.java
@@ -33,7 +33,6 @@
 package org.opensearch.action.admin.indices.get;
 
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.cluster.metadata.AliasMetadata;
@@ -152,14 +151,12 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
         }
         defaultSettings = defaultSettingsMapBuilder.build();
 
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_8_0)) {
-            ImmutableOpenMap.Builder<String, String> dataStreamsMapBuilder = ImmutableOpenMap.builder();
-            int dataStreamsSize = in.readVInt();
-            for (int i = 0; i < dataStreamsSize; i++) {
-                dataStreamsMapBuilder.put(in.readString(), in.readOptionalString());
-            }
-            dataStreams = dataStreamsMapBuilder.build();
+        ImmutableOpenMap.Builder<String, String> dataStreamsMapBuilder = ImmutableOpenMap.builder();
+        int dataStreamsSize = in.readVInt();
+        for (int i = 0; i < dataStreamsSize; i++) {
+            dataStreamsMapBuilder.put(in.readString(), in.readOptionalString());
         }
+        dataStreams = dataStreamsMapBuilder.build();
     }
 
     public String[] indices() {
@@ -272,12 +269,10 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
             out.writeString(indexEntry.key);
             Settings.writeSettingsToStream(indexEntry.value, out);
         }
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_8_0)) {
-            out.writeVInt(dataStreams.size());
-            for (ObjectObjectCursor<String, String> indexEntry : dataStreams) {
-                out.writeString(indexEntry.key);
-                out.writeOptionalString(indexEntry.value);
-            }
+        out.writeVInt(dataStreams.size());
+        for (ObjectObjectCursor<String, String> indexEntry : dataStreams) {
+            out.writeString(indexEntry.key);
+            out.writeOptionalString(indexEntry.value);
         }
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/mapping/put/PutMappingRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/mapping/put/PutMappingRequest.java
@@ -33,7 +33,6 @@
 package org.opensearch.action.admin.indices.mapping.put;
 
 import com.carrotsearch.hppc.ObjectHashSet;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchGenerationException;
 import org.opensearch.Version;
 import org.opensearch.action.ActionRequestValidationException;
@@ -119,9 +118,7 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
         source = in.readString();
         concreteIndex = in.readOptionalWriteable(Index::new);
         origin = in.readOptionalString();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-            writeIndexOnly = in.readBoolean();
-        }
+        writeIndexOnly = in.readBoolean();
     }
 
     public PutMappingRequest() {}
@@ -348,9 +345,7 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
         out.writeString(source);
         out.writeOptionalWriteable(concreteIndex);
         out.writeOptionalString(origin);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-            out.writeBoolean(writeIndexOnly);
-        }
+        out.writeBoolean(writeIndexOnly);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/bulk/BulkItemRequest.java
+++ b/server/src/main/java/org/opensearch/action/bulk/BulkItemRequest.java
@@ -59,8 +59,7 @@ public class BulkItemRequest implements Writeable, Accountable {
     private volatile BulkItemResponse primaryResponse;
 
     /**
-     * @param shardId {@code null} if reading from a stream before {@link BulkShardRequest#COMPACT_SHARD_ID_VERSION} to force BwC read
-     *                            that includes shard id
+     * @param shardId the shard id
      */
     BulkItemRequest(@Nullable ShardId shardId, StreamInput in) throws IOException {
         id = in.readVInt();

--- a/server/src/main/java/org/opensearch/action/bulk/BulkShardResponse.java
+++ b/server/src/main/java/org/opensearch/action/bulk/BulkShardResponse.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.action.bulk;
 
-import org.opensearch.LegacyESVersion;
-import org.opensearch.Version;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.support.WriteResponse;
 import org.opensearch.action.support.replication.ReplicationResponse;
@@ -50,18 +48,13 @@ import java.io.IOException;
  */
 public class BulkShardResponse extends ReplicationResponse implements WriteResponse {
 
-    private static final Version COMPACT_SHARD_ID_VERSION = LegacyESVersion.V_7_9_0;
-
     private final ShardId shardId;
     private final BulkItemResponse[] responses;
 
     BulkShardResponse(StreamInput in) throws IOException {
         super(in);
         shardId = new ShardId(in);
-        responses = in.readArray(
-            in.getVersion().onOrAfter(COMPACT_SHARD_ID_VERSION) ? i -> new BulkItemResponse(shardId, i) : BulkItemResponse::new,
-            BulkItemResponse[]::new
-        );
+        responses = in.readArray(i -> new BulkItemResponse(shardId, i), BulkItemResponse[]::new);
     }
 
     // NOTE: public for testing only
@@ -96,9 +89,6 @@ public class BulkShardResponse extends ReplicationResponse implements WriteRespo
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         shardId.writeTo(out);
-        out.writeArray(
-            out.getVersion().onOrAfter(COMPACT_SHARD_ID_VERSION) ? (o, item) -> item.writeThin(out) : (o, item) -> item.writeTo(o),
-            responses
-        );
+        out.writeArray((o, item) -> item.writeThin(out), responses);
     }
 }

--- a/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java
@@ -36,7 +36,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.SparseFixedBitSet;
 import org.opensearch.Assertions;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.ResourceAlreadyExistsException;
@@ -455,11 +454,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         createIndexRequest.index(index);
         createIndexRequest.cause("auto(bulk api)");
         createIndexRequest.clusterManagerNodeTimeout(timeout);
-        if (minNodeVersion.onOrAfter(LegacyESVersion.V_7_8_0)) {
-            client.execute(AutoCreateAction.INSTANCE, createIndexRequest, listener);
-        } else {
-            client.admin().indices().create(createIndexRequest, listener);
-        }
+        client.execute(AutoCreateAction.INSTANCE, createIndexRequest, listener);
     }
 
     private boolean setResponseFailureIfIndexMatches(

--- a/server/src/main/java/org/opensearch/action/fieldcaps/FieldCapabilitiesIndexRequest.java
+++ b/server/src/main/java/org/opensearch/action/fieldcaps/FieldCapabilitiesIndexRequest.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.fieldcaps;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.IndicesRequest;
@@ -70,8 +69,8 @@ public class FieldCapabilitiesIndexRequest extends ActionRequest implements Indi
         index = in.readOptionalString();
         fields = in.readStringArray();
         originalIndices = OriginalIndices.readOriginalIndices(in);
-        indexFilter = in.getVersion().onOrAfter(LegacyESVersion.V_7_9_0) ? in.readOptionalNamedWriteable(QueryBuilder.class) : null;
-        nowInMillis = in.getVersion().onOrAfter(LegacyESVersion.V_7_9_0) ? in.readLong() : 0L;
+        indexFilter = in.readOptionalNamedWriteable(QueryBuilder.class);
+        nowInMillis = in.readLong();
     }
 
     FieldCapabilitiesIndexRequest(
@@ -133,10 +132,8 @@ public class FieldCapabilitiesIndexRequest extends ActionRequest implements Indi
         out.writeOptionalString(index);
         out.writeStringArray(fields);
         OriginalIndices.writeOriginalIndices(originalIndices, out);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-            out.writeOptionalNamedWriteable(indexFilter);
-            out.writeLong(nowInMillis);
-        }
+        out.writeOptionalNamedWriteable(indexFilter);
+        out.writeLong(nowInMillis);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
+++ b/server/src/main/java/org/opensearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.fieldcaps;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -62,7 +61,7 @@ public class FieldCapabilitiesIndexResponse extends ActionResponse implements Wr
         super(in);
         this.indexName = in.readString();
         this.responseMap = in.readMap(StreamInput::readString, IndexFieldCapabilities::new);
-        this.canMatch = in.getVersion().onOrAfter(LegacyESVersion.V_7_9_0) ? in.readBoolean() : true;
+        this.canMatch = in.readBoolean();
     }
 
     /**
@@ -95,9 +94,7 @@ public class FieldCapabilitiesIndexResponse extends ActionResponse implements Wr
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(indexName);
         out.writeMap(responseMap, StreamOutput::writeString, (valueOut, fc) -> fc.writeTo(valueOut));
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-            out.writeBoolean(canMatch);
-        }
+        out.writeBoolean(canMatch);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/fieldcaps/FieldCapabilitiesRequest.java
+++ b/server/src/main/java/org/opensearch/action/fieldcaps/FieldCapabilitiesRequest.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.fieldcaps;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.IndicesRequest;
@@ -73,8 +72,8 @@ public final class FieldCapabilitiesRequest extends ActionRequest implements Ind
         indicesOptions = IndicesOptions.readIndicesOptions(in);
         mergeResults = in.readBoolean();
         includeUnmapped = in.readBoolean();
-        indexFilter = in.getVersion().onOrAfter(LegacyESVersion.V_7_9_0) ? in.readOptionalNamedWriteable(QueryBuilder.class) : null;
-        nowInMillis = in.getVersion().onOrAfter(LegacyESVersion.V_7_9_0) ? in.readOptionalLong() : null;
+        indexFilter = in.readOptionalNamedWriteable(QueryBuilder.class);
+        nowInMillis = in.readOptionalLong();
     }
 
     public FieldCapabilitiesRequest() {}
@@ -106,10 +105,8 @@ public final class FieldCapabilitiesRequest extends ActionRequest implements Ind
         indicesOptions.writeIndicesOptions(out);
         out.writeBoolean(mergeResults);
         out.writeBoolean(includeUnmapped);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-            out.writeOptionalNamedWriteable(indexFilter);
-            out.writeOptionalLong(nowInMillis);
-        }
+        out.writeOptionalNamedWriteable(indexFilter);
+        out.writeOptionalLong(nowInMillis);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/ingest/SimulateProcessorResult.java
+++ b/server/src/main/java/org/opensearch/action/ingest/SimulateProcessorResult.java
@@ -192,11 +192,8 @@ public class SimulateProcessorResult implements Writeable, ToXContentObject {
         this.processorTag = in.readString();
         this.ingestDocument = in.readOptionalWriteable(WriteableIngestDocument::new);
         this.failure = in.readException();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-            this.description = in.readOptionalString();
-        } else {
-            this.description = null;
-        }
+        this.description = in.readOptionalString();
+
         if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
             this.type = in.readString();
             boolean hasConditional = in.readBoolean();
@@ -216,9 +213,8 @@ public class SimulateProcessorResult implements Writeable, ToXContentObject {
         out.writeString(processorTag);
         out.writeOptionalWriteable(ingestDocument);
         out.writeException(failure);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-            out.writeOptionalString(description);
-        }
+        out.writeOptionalString(description);
+
         if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
             out.writeString(type);
             out.writeBoolean(conditionalWithResult != null);

--- a/server/src/main/java/org/opensearch/cluster/action/index/MappingUpdatedAction.java
+++ b/server/src/main/java/org/opensearch/cluster/action/index/MappingUpdatedAction.java
@@ -32,8 +32,8 @@
 
 package org.opensearch.cluster.action.index;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchException;
+import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.admin.indices.mapping.put.AutoPutMappingAction;
 import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest;
@@ -155,19 +155,16 @@ public class MappingUpdatedAction {
         PutMappingRequest putMappingRequest = new PutMappingRequest();
         putMappingRequest.setConcreteIndex(index);
         putMappingRequest.source(mappingUpdate.toString(), XContentType.JSON);
-        putMappingRequest.clusterManagerNodeTimeout(dynamicMappingUpdateTimeout);
+        putMappingRequest.masterNodeTimeout(dynamicMappingUpdateTimeout);
         putMappingRequest.timeout(TimeValue.ZERO);
-        if (clusterService.state().nodes().getMinNodeVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
+        if (clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.V_3_0_0)) {
             client.execute(
                 AutoPutMappingAction.INSTANCE,
                 putMappingRequest,
                 ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure)
             );
         } else {
-            client.putMapping(
-                putMappingRequest,
-                ActionListener.wrap(r -> listener.onResponse(null), e -> listener.onFailure(unwrapException(e)))
-            );
+            client.putMapping(putMappingRequest, ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure));
         }
     }
 

--- a/server/src/main/java/org/opensearch/cluster/action/index/MappingUpdatedAction.java
+++ b/server/src/main/java/org/opensearch/cluster/action/index/MappingUpdatedAction.java
@@ -155,6 +155,7 @@ public class MappingUpdatedAction {
         putMappingRequest.setConcreteIndex(index);
         putMappingRequest.source(mappingUpdate.toString(), XContentType.JSON);
         putMappingRequest.clusterManagerNodeTimeout(dynamicMappingUpdateTimeout);
+        putMappingRequest.timeout(TimeValue.ZERO);
         client.execute(
             AutoPutMappingAction.INSTANCE,
             putMappingRequest,

--- a/server/src/main/java/org/opensearch/cluster/action/index/MappingUpdatedAction.java
+++ b/server/src/main/java/org/opensearch/cluster/action/index/MappingUpdatedAction.java
@@ -155,7 +155,7 @@ public class MappingUpdatedAction {
         PutMappingRequest putMappingRequest = new PutMappingRequest();
         putMappingRequest.setConcreteIndex(index);
         putMappingRequest.source(mappingUpdate.toString(), XContentType.JSON);
-        putMappingRequest.masterNodeTimeout(dynamicMappingUpdateTimeout);
+        putMappingRequest.clusterManagerNodeTimeout(dynamicMappingUpdateTimeout);
         putMappingRequest.timeout(TimeValue.ZERO);
         if (clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.V_3_0_0)) {
             client.execute(

--- a/server/src/main/java/org/opensearch/cluster/action/index/MappingUpdatedAction.java
+++ b/server/src/main/java/org/opensearch/cluster/action/index/MappingUpdatedAction.java
@@ -33,7 +33,6 @@
 package org.opensearch.cluster.action.index;
 
 import org.opensearch.OpenSearchException;
-import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.admin.indices.mapping.put.AutoPutMappingAction;
 import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest;
@@ -156,16 +155,11 @@ public class MappingUpdatedAction {
         putMappingRequest.setConcreteIndex(index);
         putMappingRequest.source(mappingUpdate.toString(), XContentType.JSON);
         putMappingRequest.clusterManagerNodeTimeout(dynamicMappingUpdateTimeout);
-        putMappingRequest.timeout(TimeValue.ZERO);
-        if (clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.V_3_0_0)) {
-            client.execute(
-                AutoPutMappingAction.INSTANCE,
-                putMappingRequest,
-                ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure)
-            );
-        } else {
-            client.putMapping(putMappingRequest, ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure));
-        }
+        client.execute(
+            AutoPutMappingAction.INSTANCE,
+            putMappingRequest,
+            ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure)
+        );
     }
 
     // todo: this explicit unwrap should not be necessary, but is until guessRootCause is fixed to allow wrapped non-es exception.

--- a/server/src/main/java/org/opensearch/cluster/metadata/ComposableIndexTemplate.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/ComposableIndexTemplate.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.cluster.metadata;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.cluster.AbstractDiffable;
 import org.opensearch.cluster.Diff;
@@ -163,11 +162,7 @@ public class ComposableIndexTemplate extends AbstractDiffable<ComposableIndexTem
         this.priority = in.readOptionalVLong();
         this.version = in.readOptionalVLong();
         this.metadata = in.readMap();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-            this.dataStreamTemplate = in.readOptionalWriteable(DataStreamTemplate::new);
-        } else {
-            this.dataStreamTemplate = null;
-        }
+        this.dataStreamTemplate = in.readOptionalWriteable(DataStreamTemplate::new);
     }
 
     public List<String> indexPatterns() {
@@ -222,9 +217,7 @@ public class ComposableIndexTemplate extends AbstractDiffable<ComposableIndexTem
         out.writeOptionalVLong(this.priority);
         out.writeOptionalVLong(this.version);
         out.writeMap(this.metadata);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-            out.writeOptionalWriteable(dataStreamTemplate);
-        }
+        out.writeOptionalWriteable(dataStreamTemplate);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -33,7 +33,6 @@ package org.opensearch.cluster.metadata;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.ActionListener;
@@ -146,9 +145,6 @@ public class MetadataCreateDataStreamService {
         ClusterState currentState,
         CreateDataStreamClusterStateUpdateRequest request
     ) throws Exception {
-        if (currentState.nodes().getMinNodeVersion().before(LegacyESVersion.V_7_9_0)) {
-            throw new IllegalStateException("data streams require minimum node version of " + LegacyESVersion.V_7_9_0);
-        }
 
         if (currentState.metadata().dataStreams().containsKey(request.name)) {
             throw new ResourceAlreadyExistsException("data_stream [" + request.name + "] already exists");

--- a/server/src/main/java/org/opensearch/index/store/StoreStats.java
+++ b/server/src/main/java/org/opensearch/index/store/StoreStats.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.index.store;
 
-import org.opensearch.LegacyESVersion;
-import org.opensearch.Version;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -55,9 +53,6 @@ public class StoreStats implements Writeable, ToXContentFragment {
      * prior to receiving the list of files in a peer recovery.
      */
     public static final long UNKNOWN_RESERVED_BYTES = -1L;
-
-    public static final Version RESERVED_BYTES_VERSION = LegacyESVersion.V_7_9_0;
-
     private long sizeInBytes;
     private long reservedSize;
 
@@ -67,11 +62,7 @@ public class StoreStats implements Writeable, ToXContentFragment {
 
     public StoreStats(StreamInput in) throws IOException {
         sizeInBytes = in.readVLong();
-        if (in.getVersion().onOrAfter(RESERVED_BYTES_VERSION)) {
-            reservedSize = in.readZLong();
-        } else {
-            reservedSize = UNKNOWN_RESERVED_BYTES;
-        }
+        reservedSize = in.readZLong();
     }
 
     /**
@@ -124,9 +115,7 @@ public class StoreStats implements Writeable, ToXContentFragment {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(sizeInBytes);
-        if (out.getVersion().onOrAfter(RESERVED_BYTES_VERSION)) {
-            out.writeZLong(reservedSize);
-        }
+        out.writeZLong(reservedSize);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/PeerRecoveryTargetService.java
@@ -37,7 +37,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.opensearch.ExceptionsHelper;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchTimeoutException;
 import org.opensearch.action.ActionListener;
@@ -724,11 +723,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                     recoverySettings.retryDelayNetwork(),
                     cause.getMessage()
                 );
-                if (request.sourceNode().getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-                    reestablishRecovery(request, cause.getMessage(), recoverySettings.retryDelayNetwork());
-                } else {
-                    retryRecovery(recoveryId, cause.getMessage(), recoverySettings.retryDelayNetwork(), recoverySettings.activityTimeout());
-                }
+                reestablishRecovery(request, cause.getMessage(), recoverySettings.retryDelayNetwork());
                 return;
             }
 

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoveryTransportRequest.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoveryTransportRequest.java
@@ -32,10 +32,8 @@
 
 package org.opensearch.indices.recovery;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
-import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.transport.TransportRequest;
 
 import java.io.IOException;
@@ -51,11 +49,7 @@ public abstract class RecoveryTransportRequest extends TransportRequest {
 
     RecoveryTransportRequest(StreamInput in) throws IOException {
         super(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-            requestSeqNo = in.readLong();
-        } else {
-            requestSeqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
-        }
+        requestSeqNo = in.readLong();
     }
 
     RecoveryTransportRequest(long requestSeqNo) {
@@ -69,8 +63,6 @@ public abstract class RecoveryTransportRequest extends TransportRequest {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-            out.writeLong(requestSeqNo);
-        }
+        out.writeLong(requestSeqNo);
     }
 }

--- a/server/src/main/java/org/opensearch/indices/recovery/RetryableTransportClient.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RetryableTransportClient.java
@@ -10,7 +10,6 @@ package org.opensearch.indices.recovery;
 
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionListenerResponseHandler;
 import org.opensearch.action.support.RetryableAction;
@@ -99,7 +98,7 @@ public final class RetryableTransportClient {
 
             @Override
             public boolean shouldRetry(Exception e) {
-                return targetNode.getVersion().onOrAfter(LegacyESVersion.V_7_9_0) && retryableException(e);
+                return retryableException(e);
             }
         };
         onGoingRetryableActions.put(key, retryableAction);

--- a/server/src/main/java/org/opensearch/script/ScriptStats.java
+++ b/server/src/main/java/org/opensearch/script/ScriptStats.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.script;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -90,7 +89,7 @@ public class ScriptStats implements Writeable, ToXContentFragment {
         compilations = in.readVLong();
         cacheEvictions = in.readVLong();
         compilationLimitTriggered = in.readVLong();
-        contextStats = in.getVersion().onOrAfter(LegacyESVersion.V_7_9_0) ? in.readList(ScriptContextStats::new) : Collections.emptyList();
+        contextStats = in.readList(ScriptContextStats::new);
     }
 
     @Override
@@ -98,9 +97,7 @@ public class ScriptStats implements Writeable, ToXContentFragment {
         out.writeVLong(compilations);
         out.writeVLong(cacheEvictions);
         out.writeVLong(compilationLimitTriggered);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-            out.writeList(contextStats);
-        }
+        out.writeList(contextStats);
     }
 
     public List<ScriptContextStats> getContextStats() {

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/AbstractPercentilesAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/AbstractPercentilesAggregationBuilder.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.search.aggregations.metrics;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.TriFunction;
@@ -169,14 +168,7 @@ public abstract class AbstractPercentilesAggregationBuilder<T extends AbstractPe
         super(in);
         values = in.readDoubleArray();
         keyed = in.readBoolean();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_8_0)) {
-            percentilesConfig = (PercentilesConfig) in.readOptionalWriteable((Reader<Writeable>) PercentilesConfig::fromStream);
-        } else {
-            int numberOfSignificantValueDigits = in.readVInt();
-            double compression = in.readDouble();
-            PercentilesMethod method = PercentilesMethod.readFromStream(in);
-            percentilesConfig = PercentilesConfig.fromLegacy(method, compression, numberOfSignificantValueDigits);
-        }
+        percentilesConfig = (PercentilesConfig) in.readOptionalWriteable((Reader<Writeable>) PercentilesConfig::fromStream);
         this.valuesField = valuesField;
     }
 
@@ -184,23 +176,7 @@ public abstract class AbstractPercentilesAggregationBuilder<T extends AbstractPe
     protected void innerWriteTo(StreamOutput out) throws IOException {
         out.writeDoubleArray(values);
         out.writeBoolean(keyed);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_8_0)) {
-            out.writeOptionalWriteable(percentilesConfig);
-        } else {
-            // Legacy method serialized both SigFigs and compression, even though we only need one. So we need
-            // to serialize the default for the unused method
-            int numberOfSignificantValueDigits = percentilesConfig.getMethod().equals(PercentilesMethod.HDR)
-                ? ((PercentilesConfig.Hdr) percentilesConfig).getNumberOfSignificantValueDigits()
-                : PercentilesConfig.Hdr.DEFAULT_NUMBER_SIG_FIGS;
-
-            double compression = percentilesConfig.getMethod().equals(PercentilesMethod.TDIGEST)
-                ? ((PercentilesConfig.TDigest) percentilesConfig).getCompression()
-                : PercentilesConfig.TDigest.DEFAULT_COMPRESSION;
-
-            out.writeVInt(numberOfSignificantValueDigits);
-            out.writeDouble(compression);
-            percentilesConfig.getMethod().writeTo(out);
-        }
+        out.writeOptionalWriteable(percentilesConfig);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalScriptedMetric.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalScriptedMetric.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.search.aggregations.metrics;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.util.CollectionUtils;
@@ -48,8 +47,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
-import static java.util.Collections.singletonList;
 
 /**
  * Implementation of scripted metric agg
@@ -72,30 +69,13 @@ public class InternalScriptedMetric extends InternalAggregation implements Scrip
     public InternalScriptedMetric(StreamInput in) throws IOException {
         super(in);
         reduceScript = in.readOptionalWriteable(Script::new);
-        if (in.getVersion().before(LegacyESVersion.V_7_8_0)) {
-            aggregations = singletonList(in.readGenericValue());
-        } else {
-            aggregations = in.readList(StreamInput::readGenericValue);
-        }
+        aggregations = in.readList(StreamInput::readGenericValue);
     }
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeOptionalWriteable(reduceScript);
-        if (out.getVersion().before(LegacyESVersion.V_7_8_0)) {
-            if (aggregations.size() > 1) {
-                /*
-                 * If aggregations has more than one entry we're trying to
-                 * serialize an unreduced aggregation. This *should* only
-                 * happen when we're returning a scripted_metric over cross
-                 * cluster search.
-                 */
-                throw new IllegalArgumentException("scripted_metric doesn't support cross cluster search until 7.8.0");
-            }
-            out.writeGenericValue(aggregations.get(0));
-        } else {
-            out.writeCollection(aggregations, StreamOutput::writeGenericValue);
-        }
+        out.writeCollection(aggregations, StreamOutput::writeGenericValue);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/support/MultiValuesSourceFieldConfig.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/MultiValuesSourceFieldConfig.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.search.aggregations.support;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.Strings;
 import org.opensearch.common.TriFunction;
@@ -89,11 +88,7 @@ public class MultiValuesSourceFieldConfig extends BaseMultiValuesSourceFieldConf
 
     public MultiValuesSourceFieldConfig(StreamInput in) throws IOException {
         super(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_8_0)) {
-            this.filter = in.readOptionalNamedWriteable(QueryBuilder.class);
-        } else {
-            this.filter = null;
-        }
+        this.filter = in.readOptionalNamedWriteable(QueryBuilder.class);
     }
 
     public QueryBuilder getFilter() {
@@ -102,9 +97,7 @@ public class MultiValuesSourceFieldConfig extends BaseMultiValuesSourceFieldConf
 
     @Override
     public void doWriteTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_8_0)) {
-            out.writeOptionalNamedWriteable(filter);
-        }
+        out.writeOptionalNamedWriteable(filter);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/profile/ProfileResult.java
+++ b/server/src/main/java/org/opensearch/search/profile/ProfileResult.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.search.profile;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -104,11 +103,7 @@ public final class ProfileResult implements Writeable, ToXContentObject {
         this.description = in.readString();
         this.nodeTime = in.readLong();
         breakdown = in.readMap(StreamInput::readString, StreamInput::readLong);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-            debug = in.readMap(StreamInput::readString, StreamInput::readGenericValue);
-        } else {
-            debug = org.opensearch.common.collect.Map.of();
-        }
+        debug = in.readMap(StreamInput::readString, StreamInput::readGenericValue);
         children = in.readList(ProfileResult::new);
     }
 
@@ -118,9 +113,7 @@ public final class ProfileResult implements Writeable, ToXContentObject {
         out.writeString(description);
         out.writeLong(nodeTime);            // not Vlong because can be negative
         out.writeMap(breakdown, StreamOutput::writeString, StreamOutput::writeLong);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-            out.writeMap(debug, StreamOutput::writeString, StreamOutput::writeGenericValue);
-        }
+        out.writeMap(debug, StreamOutput::writeString, StreamOutput::writeGenericValue);
         out.writeList(children);
     }
 

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -38,7 +38,6 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.StepListener;
@@ -542,13 +541,8 @@ public class RestoreService implements ClusterStateApplier {
                                     final Settings.Builder indexSettingsBuilder = Settings.builder()
                                         .put(snapshotIndexMetadata.getSettings())
                                         .put(IndexMetadata.SETTING_INDEX_UUID, currentIndexMetadata.getIndexUUID());
-                                    // Only add a restore uuid if either all nodes in the cluster support it (version >= 7.9) or if the
-                                    // index itself was created after 7.9 and thus won't be restored to a node that doesn't support the
-                                    // setting anyway
-                                    if (snapshotIndexMetadata.getCreationVersion().onOrAfter(LegacyESVersion.V_7_9_0)
-                                        || currentState.nodes().getMinNodeVersion().onOrAfter(LegacyESVersion.V_7_9_0)) {
-                                        indexSettingsBuilder.put(SETTING_HISTORY_UUID, UUIDs.randomBase64UUID());
-                                    }
+                                    // add a restore uuid
+                                    indexSettingsBuilder.put(SETTING_HISTORY_UUID, UUIDs.randomBase64UUID());
                                     indexMdBuilder.settings(indexSettingsBuilder);
                                     IndexMetadata updatedIndexMetadata = indexMdBuilder.index(renamedIndexName).build();
                                     rtBuilder.addAsRestore(updatedIndexMetadata, recoverySource);

--- a/server/src/main/java/org/opensearch/tasks/TaskCancellationService.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskCancellationService.java
@@ -35,7 +35,6 @@ package org.opensearch.tasks;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.StepListener;
@@ -214,11 +213,7 @@ public class TaskCancellationService {
             parentTaskId = TaskId.readFromStream(in);
             ban = in.readBoolean();
             reason = ban ? in.readString() : null;
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_7_8_0)) {
-                waitForCompletion = in.readBoolean();
-            } else {
-                waitForCompletion = false;
-            }
+            waitForCompletion = in.readBoolean();
         }
 
         @Override
@@ -229,9 +224,7 @@ public class TaskCancellationService {
             if (ban) {
                 out.writeString(reason);
             }
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_7_8_0)) {
-                out.writeBoolean(waitForCompletion);
-            }
+            out.writeBoolean(waitForCompletion);
         }
     }
 

--- a/server/src/test/java/org/opensearch/cluster/action/index/MappingUpdatedActionTests.java
+++ b/server/src/test/java/org/opensearch/cluster/action/index/MappingUpdatedActionTests.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.cluster.action.index;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.admin.indices.mapping.put.AutoPutMappingAction;
@@ -156,7 +155,7 @@ public class MappingUpdatedActionTests extends OpenSearchTestCase {
 
     public void testSendUpdateMappingUsingPutMappingAction() {
         DiscoveryNodes nodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("first", buildNewFakeTransportAddress(), LegacyESVersion.V_7_8_0))
+            .add(new DiscoveryNode("first", buildNewFakeTransportAddress(), Version.V_2_0_0))
             .build();
         ClusterState clusterState = ClusterState.builder(new ClusterName("_name")).nodes(nodes).build();
         ClusterService clusterService = mock(ClusterService.class);
@@ -178,7 +177,7 @@ public class MappingUpdatedActionTests extends OpenSearchTestCase {
         Settings indexSettings = Settings.builder().put(SETTING_VERSION_CREATED, Version.CURRENT).build();
         final Mapper.BuilderContext context = new Mapper.BuilderContext(indexSettings, new ContentPath());
         RootObjectMapper rootObjectMapper = new RootObjectMapper.Builder("name").build(context);
-        Mapping update = new Mapping(LegacyESVersion.V_7_8_0, rootObjectMapper, new MetadataFieldMapper[0], Map.of());
+        Mapping update = new Mapping(Version.V_2_0_0, rootObjectMapper, new MetadataFieldMapper[0], Map.of());
 
         mua.sendUpdateMapping(new Index("name", "uuid"), update, ActionListener.wrap(() -> {}));
         verify(indicesAdminClient).putMapping(any(), any());
@@ -186,7 +185,7 @@ public class MappingUpdatedActionTests extends OpenSearchTestCase {
 
     public void testSendUpdateMappingUsingAutoPutMappingAction() {
         DiscoveryNodes nodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("first", buildNewFakeTransportAddress(), LegacyESVersion.V_7_9_0))
+            .add(new DiscoveryNode("first", buildNewFakeTransportAddress(), Version.V_3_0_0))
             .build();
         ClusterState clusterState = ClusterState.builder(new ClusterName("_name")).nodes(nodes).build();
         ClusterService clusterService = mock(ClusterService.class);
@@ -208,7 +207,7 @@ public class MappingUpdatedActionTests extends OpenSearchTestCase {
         Settings indexSettings = Settings.builder().put(SETTING_VERSION_CREATED, Version.CURRENT).build();
         final Mapper.BuilderContext context = new Mapper.BuilderContext(indexSettings, new ContentPath());
         RootObjectMapper rootObjectMapper = new RootObjectMapper.Builder("name").build(context);
-        Mapping update = new Mapping(LegacyESVersion.V_7_9_0, rootObjectMapper, new MetadataFieldMapper[0], Map.of());
+        Mapping update = new Mapping(Version.V_3_0_0, rootObjectMapper, new MetadataFieldMapper[0], Map.of());
 
         mua.sendUpdateMapping(new Index("name", "uuid"), update, ActionListener.wrap(() -> {}));
         verify(indicesAdminClient).execute(eq(AutoPutMappingAction.INSTANCE), any(), any());

--- a/server/src/test/java/org/opensearch/cluster/action/index/MappingUpdatedActionTests.java
+++ b/server/src/test/java/org/opensearch/cluster/action/index/MappingUpdatedActionTests.java
@@ -153,36 +153,6 @@ public class MappingUpdatedActionTests extends OpenSearchTestCase {
         assertTrue(fut2.isDone());
     }
 
-    public void testSendUpdateMappingUsingPutMappingAction() {
-        DiscoveryNodes nodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("first", buildNewFakeTransportAddress(), Version.V_2_0_0))
-            .build();
-        ClusterState clusterState = ClusterState.builder(new ClusterName("_name")).nodes(nodes).build();
-        ClusterService clusterService = mock(ClusterService.class);
-        when(clusterService.state()).thenReturn(clusterState);
-
-        IndicesAdminClient indicesAdminClient = mock(IndicesAdminClient.class);
-        AdminClient adminClient = mock(AdminClient.class);
-        when(adminClient.indices()).thenReturn(indicesAdminClient);
-        Client client = mock(Client.class);
-        when(client.admin()).thenReturn(adminClient);
-
-        MappingUpdatedAction mua = new MappingUpdatedAction(
-            Settings.EMPTY,
-            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
-            clusterService
-        );
-        mua.setClient(client);
-
-        Settings indexSettings = Settings.builder().put(SETTING_VERSION_CREATED, Version.CURRENT).build();
-        final Mapper.BuilderContext context = new Mapper.BuilderContext(indexSettings, new ContentPath());
-        RootObjectMapper rootObjectMapper = new RootObjectMapper.Builder("name").build(context);
-        Mapping update = new Mapping(Version.V_2_0_0, rootObjectMapper, new MetadataFieldMapper[0], Map.of());
-
-        mua.sendUpdateMapping(new Index("name", "uuid"), update, ActionListener.wrap(() -> {}));
-        verify(indicesAdminClient).putMapping(any(), any());
-    }
-
     public void testSendUpdateMappingUsingAutoPutMappingAction() {
         DiscoveryNodes nodes = DiscoveryNodes.builder()
             .add(new DiscoveryNode("first", buildNewFakeTransportAddress(), Version.V_3_0_0))

--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeTests.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeTests.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.cluster.node;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
@@ -153,11 +152,11 @@ public class DiscoveryNodeTests extends OpenSearchTestCase {
 
         {
             BytesStreamOutput streamOutput = new BytesStreamOutput();
-            streamOutput.setVersion(LegacyESVersion.V_7_9_0);
+            streamOutput.setVersion(Version.V_2_0_0);
             node.writeTo(streamOutput);
 
             StreamInput in = StreamInput.wrap(streamOutput.bytes().toBytesRef().bytes);
-            in.setVersion(LegacyESVersion.V_7_9_0);
+            in.setVersion(Version.V_2_0_0);
             DiscoveryNode serialized = new DiscoveryNode(in);
             assertThat(serialized.getRoles().stream().map(DiscoveryNodeRole::roleName).collect(Collectors.joining()), equalTo("data"));
         }

--- a/server/src/test/java/org/opensearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ParametrizedMapperTests.java
@@ -33,7 +33,6 @@
 package org.opensearch.index.mapper;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.common.Strings;
 import org.opensearch.common.compress.CompressedXContent;
@@ -443,7 +442,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
     public void testDeprecatedParameters() {
         // 'index' is declared explicitly, 'store' is not, but is one of the previously always-accepted params
         String mapping = "{\"type\":\"test_mapper\",\"index\":false,\"store\":true,\"required\":\"value\"}";
-        TestMapper mapper = fromMapping(mapping, LegacyESVersion.V_7_8_0);
+        TestMapper mapper = fromMapping(mapping, Version.V_1_0_0);
         assertWarnings("Parameter [store] has no effect on type [test_mapper] and will be removed in future");
         assertFalse(mapper.index);
         assertEquals("{\"field\":{\"type\":\"test_mapper\",\"index\":false,\"required\":\"value\"}}", Strings.toString(mapper));


### PR DESCRIPTION
Removes all usages of LegacyESVersion.V_7_8_ and LegacyESVersion.V_7_9 version constants along with ancient API logic.

relates #2747