### PR TITLE
Skip geojson test for version below 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix recovery path for searchable snapshots ([4813](https://github.com/opensearch-project/OpenSearch/pull/4813))
 - Fix bug in AwarenessAttributeDecommissionIT([4822](https://github.com/opensearch-project/OpenSearch/pull/4822))
 - Fix 'org.apache.hc.core5.http.ParseException: Invalid protocol version' under JDK 16+ ([#4827](https://github.com/opensearch-project/OpenSearch/pull/4827))
+- [BUG]: flaky test index/80_geo_point/Single point test([#4860](https://github.com/opensearch-project/OpenSearch/pull/4860))
 
 ### Security
 - CVE-2022-25857 org.yaml:snakeyaml DOS vulnerability ([#4341](https://github.com/opensearch-project/OpenSearch/pull/4341))

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/80_geo_point.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/80_geo_point.yml
@@ -12,6 +12,9 @@ setup:
 
 ---
 "Single point test":
+  - skip:
+      version: " - 2.3.99"
+      reason: "geojson format is supported in 2.4 and above"
   - do:
       bulk:
         refresh: true
@@ -75,6 +78,9 @@ setup:
 
 ---
 "Multi points test":
+  - skip:
+      version: " - 2.3.99"
+      reason: "geojson format is supported in 2.4 and above"
   - do:
       bulk:
         refresh: true


### PR DESCRIPTION
Signed-off-by: Heemin Kim <heemin@amazon.com>

### Description
Skip geojson test for version below 2.4

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/4852

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
