### PR TITLE
Fix bug in SlicedInputStream with zero length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix bug in AwarenessAttributeDecommissionIT([4822](https://github.com/opensearch-project/OpenSearch/pull/4822))
 - Fix 'org.apache.hc.core5.http.ParseException: Invalid protocol version' under JDK 16+ ([#4827](https://github.com/opensearch-project/OpenSearch/pull/4827))
 - [BUG]: flaky test index/80_geo_point/Single point test([#4860](https://github.com/opensearch-project/OpenSearch/pull/4860))
+- Fix bug in SlicedInputStream with zero length ([#4863](https://github.com/opensearch-project/OpenSearch/pull/4863))
 
 ### Security
 - CVE-2022-25857 org.yaml:snakeyaml DOS vulnerability ([#4341](https://github.com/opensearch-project/OpenSearch/pull/4341))

--- a/server/src/main/java/org/opensearch/index/snapshots/blobstore/SlicedInputStream.java
+++ b/server/src/main/java/org/opensearch/index/snapshots/blobstore/SlicedInputStream.java
@@ -35,6 +35,7 @@ import org.opensearch.core.internal.io.IOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
 
 /**
  *  A {@link SlicedInputStream} is a logical
@@ -100,6 +101,11 @@ public abstract class SlicedInputStream extends InputStream {
 
     @Override
     public final int read(byte[] buffer, int offset, int length) throws IOException {
+        Objects.checkFromIndexSize(offset, length, buffer.length);
+        if (length == 0) {
+            return 0;
+        }
+
         final InputStream stream = currentStream();
         if (stream == null) {
             return -1;


### PR DESCRIPTION
Per the contract of InputStream#read(byte[], int, int):

    If len is zero, then no bytes are read and 0 is returned

SlicedInputStream had a bug where if a zero length was passed then it would drain all the underlying streams and return -1. This was uncovered by using InputStream#readAllBytes in new code under development. The only existing usage of SlicedInputStream should not be vulnerable to this bug.

I've also added a check for invalid arguments and created tests to ensure the proper exceptions are thrown per the InputStream contract. In the test I've replaced a "readFully" method with an equivalent "readNBytes" that was introduced in Java 11.

Signed-off-by: Andrew Ross <andrross@amazon.com>

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
