### PR TITLE
[Backport] [2.3] Compatibility issue with /_mget: RHLC 2.x connected to OpenSearch Cluster 1.x (#4812)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [Bug]: gradle check failing with java heap OutOfMemoryError (([#4328](https://github.com/opensearch-project/OpenSearch/
 - `opensearch.bat` fails to execute when install path includes spaces ([#4362](https://github.com/opensearch-project/OpenSearch/pull/4362))
 - Getting security exception due to access denied 'java.lang.RuntimePermission' 'accessDeclaredMembers' when trying to get snapshot with S3 IRSA ([#4469](https://github.com/opensearch-project/OpenSearch/pull/4469))
+- Compatibility issue with /_mget: RHLC 2.x connected to OpenSearch Cluster 1.x ([#4812](https://github.com/opensearch-project/OpenSearch/pull/4812))
 
 ### Security
 - CVE-2022-25857 org.yaml:snakeyaml DOS vulnerability ([#4341](https://github.com/opensearch-project/OpenSearch/pull/4341))

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -38,6 +38,10 @@ apply plugin: 'opensearch.standalone-test'
 apply from : "$rootDir/gradle/bwc-test.gradle"
 apply plugin: 'opensearch.rest-resources'
 
+dependencies {
+  testImplementation project(":client:rest-high-level")
+}
+
 restResources {
   restTests {
     includeCore '*'

--- a/qa/mixed-cluster/src/test/java/org/opensearch/backwards/SearchingIT.java
+++ b/qa/mixed-cluster/src/test/java/org/opensearch/backwards/SearchingIT.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.backwards;
+
+import org.apache.http.HttpHost;
+import org.opensearch.action.get.MultiGetRequest;
+import org.opensearch.action.get.MultiGetResponse;
+import org.opensearch.client.Request;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.Response;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.test.rest.OpenSearchRestTestCase;
+import org.opensearch.test.rest.yaml.ObjectPath;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class SearchingIT extends OpenSearchRestTestCase {
+    public void testMultiGet() throws Exception {
+        final Set<HttpHost> nodes = buildNodes();
+
+        final MultiGetRequest multiGetRequest = new MultiGetRequest();
+        multiGetRequest.add("index", "id1");
+
+        try (RestHighLevelClient client = new RestHighLevelClient(RestClient.builder(nodes.toArray(HttpHost[]::new)))) {
+            MultiGetResponse response = client.mget(multiGetRequest, RequestOptions.DEFAULT);
+            assertEquals(1, response.getResponses().length);
+    
+            assertTrue(response.getResponses()[0].isFailed());
+            assertNotNull(response.getResponses()[0].getFailure());
+            assertEquals(response.getResponses()[0].getFailure().getId(), "id1");
+            assertEquals(response.getResponses()[0].getFailure().getIndex(), "index");
+            assertThat(response.getResponses()[0].getFailure().getMessage(), containsString("no such index [index]"));
+       }
+    }
+
+    private Set<HttpHost> buildNodes() throws IOException, URISyntaxException {
+        Response response = client().performRequest(new Request("GET", "_nodes"));
+        ObjectPath objectPath = ObjectPath.createFromResponse(response);
+        Map<String, Object> nodesAsMap = objectPath.evaluate("nodes");
+        final Set<HttpHost> nodes = new HashSet<>();
+        for (String id : nodesAsMap.keySet()) {
+            nodes.add(HttpHost.create((String) objectPath.evaluate("nodes." + id + ".http.publish_address")));
+        }
+
+        return nodes;
+    }
+}

--- a/server/src/main/java/org/opensearch/action/get/MultiGetResponse.java
+++ b/server/src/main/java/org/opensearch/action/get/MultiGetResponse.java
@@ -63,6 +63,10 @@ public class MultiGetResponse extends ActionResponse implements Iterable<MultiGe
     private static final ParseField ID = new ParseField("_id");
     private static final ParseField ERROR = new ParseField("error");
     private static final ParseField DOCS = new ParseField("docs");
+    // In mixed clusters, the 1.x cluster could still return the '_type' in the response payload, it has to
+    // be handled gracefully
+    @Deprecated(forRemoval = true)
+    private static final ParseField TYPE = new ParseField("_type");
 
     /**
      * Represents a failure.
@@ -212,6 +216,7 @@ public class MultiGetResponse extends ActionResponse implements Iterable<MultiGe
                     currentFieldName = parser.currentName();
                     if (INDEX.match(currentFieldName, parser.getDeprecationHandler()) == false
                         && ID.match(currentFieldName, parser.getDeprecationHandler()) == false
+                        && TYPE.match(currentFieldName, parser.getDeprecationHandler()) == false
                         && ERROR.match(currentFieldName, parser.getDeprecationHandler()) == false) {
                         getResult = GetResult.fromXContentEmbedded(parser, index, id);
                     }


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/4812 to `2.3`