### PR TITLE
add `.worktrees/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ testfixtures_shared/
 
 # build files generated
 doc-tools/missing-doclet/bin/
+
+# used for backporting
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add dev guide for dealing with flakey tests ([4868](https://github.com/opensearch-project/OpenSearch/pull/4868))
 - Update pull request template ([#4851](https://github.com/opensearch-project/OpenSearch/pull/4851))
 - Added missing no-jdk distributions ([#4722](https://github.com/opensearch-project/OpenSearch/pull/4722))
+- Added `.worktrees` (used for worktrees, e.g. for backporting) to `.gitignore` ([#4885](https://github.com/opensearch-project/OpenSearch/pull/4885))
 
 ### Dependencies
 - Bumps `log4j-core` from 2.18.0 to 2.19.0


### PR DESCRIPTION
the `.worktrees/` folder is used in the guide for manual backporting as the location where to create the worktree for the backport branch.

as this is inside of the repository the folder will be reported as an untracked file. to avoid this, i've now added it to `.gitignore`.

though it might be better to create the worktree outside of the repository, the documentation on it doesn't comment explicitly on using it inside of the main worktree, however none of the examples do that.

Signed-off-by: Ralph Ursprung <Ralph.Ursprung@avaloq.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
see commit message. feel free to use this PR to instead discuss whether the worktrees shouldn't be managed outside of the repo instead (= changing the message for manual backports and maybe also the scripts for the automated backports if they also use this path).

### Issues Resolved
n/a

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
