### PR TITLE
Use timeout support of the IndexSearcher instead of custom implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Copy `build.sh` over from opensearch-build ([#4887](https://github.com/opensearch-project/OpenSearch/pull/4887))
 - Add project health badges to the README.md ([#4843](https://github.com/opensearch-project/OpenSearch/pull/4843))
 - Added changes for graceful node decommission ([#4586](https://github.com/opensearch-project/OpenSearch/pull/4586))
+- Use timeout support of the IndexSearcher instead of custom implementation([#4906](https://github.com/opensearch-project/OpenSearch/pull/4906))
+
 ### Dependencies
 - Bumps `log4j-core` from 2.18.0 to 2.19.0
 - Bumps `reactor-netty-http` from 1.0.18 to 1.0.23

--- a/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
@@ -85,7 +85,6 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.opensearch.action.search.SearchShardTask;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.index.mapper.DateFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
@@ -106,7 +105,6 @@ import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.sort.SortAndFormats;
 import org.opensearch.tasks.TaskCancelledException;
 import org.opensearch.test.TestSearchContext;
-import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -119,14 +117,9 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.opensearch.search.query.TopDocsCollectorContext.hasInfMaxScore;
 
 public class QueryPhaseTests extends IndexShardTestCase {
@@ -1084,58 +1077,6 @@ public class QueryPhaseTests extends IndexShardTestCase {
                 expectThrows(TaskCancelledException.class, () -> new QueryPhase().preProcess(context));
             }
         }
-    }
-
-    public void testQueryTimeoutChecker() throws Exception {
-        long timeCacheLifespan = ThreadPool.ESTIMATED_TIME_INTERVAL_SETTING.get(Settings.EMPTY).millis();
-        long timeTolerance = timeCacheLifespan / 20;
-
-        // should throw time exceed exception for sure after timeCacheLifespan*2+timeTolerance (next's next cached time is available)
-        assertThrows(
-            QueryPhase.TimeExceededException.class,
-            () -> createTimeoutCheckerThenWaitThenRun(timeCacheLifespan, timeCacheLifespan * 2 + timeTolerance, true, false)
-        );
-
-        // should not throw time exceed exception after timeCacheLifespan+timeTolerance because new cached time - init time < timeout
-        createTimeoutCheckerThenWaitThenRun(timeCacheLifespan, timeCacheLifespan + timeTolerance, true, false);
-
-        // should not throw time exceed exception after timeout < timeCacheLifespan when cached time didn't change
-        createTimeoutCheckerThenWaitThenRun(timeCacheLifespan / 2, timeCacheLifespan / 2 + timeTolerance, false, true);
-        createTimeoutCheckerThenWaitThenRun(timeCacheLifespan / 4, timeCacheLifespan / 2 + timeTolerance, false, true);
-    }
-
-    private void createTimeoutCheckerThenWaitThenRun(
-        long timeout,
-        long sleepAfterCreation,
-        boolean checkCachedTimeChanged,
-        boolean checkCachedTimeHasNotChanged
-    ) throws Exception {
-        long timeCacheLifespan = ThreadPool.ESTIMATED_TIME_INTERVAL_SETTING.get(Settings.EMPTY).millis();
-        long timeTolerance = timeCacheLifespan / 20;
-        long currentTimeDiffWithCachedTime = TimeValue.nsecToMSec(System.nanoTime()) - threadPool.relativeTimeInMillis();
-        // need to run this test approximately at the start of cached time window
-        long timeToAlignTimeWithCachedTimeOffset = timeCacheLifespan - currentTimeDiffWithCachedTime + timeTolerance;
-        Thread.sleep(timeToAlignTimeWithCachedTimeOffset);
-
-        long initialRelativeCachedTime = threadPool.relativeTimeInMillis();
-        SearchContext mockedSearchContext = mock(SearchContext.class);
-        when(mockedSearchContext.timeout()).thenReturn(TimeValue.timeValueMillis(timeout));
-        when(mockedSearchContext.getRelativeTimeInMillis()).thenAnswer(invocation -> threadPool.relativeTimeInMillis());
-        when(mockedSearchContext.getRelativeTimeInMillis(eq(false))).thenCallRealMethod();
-        Runnable queryTimeoutChecker = QueryPhase.createQueryTimeoutChecker(mockedSearchContext);
-        // make sure next time slot become available
-        Thread.sleep(sleepAfterCreation);
-        if (checkCachedTimeChanged) {
-            assertNotEquals(initialRelativeCachedTime, threadPool.relativeTimeInMillis());
-        }
-        if (checkCachedTimeHasNotChanged) {
-            assertEquals(initialRelativeCachedTime, threadPool.relativeTimeInMillis());
-        }
-        queryTimeoutChecker.run();
-        verify(mockedSearchContext, times(1)).timeout();
-        verify(mockedSearchContext, times(1)).getRelativeTimeInMillis(eq(false));
-        verify(mockedSearchContext, atLeastOnce()).getRelativeTimeInMillis();
-        verifyNoMoreInteractions(mockedSearchContext);
     }
 
     private static class TestSearchContextWithRewriteAndCancellation extends TestSearchContext {


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
In Apache Lucene 9.3, the `IndexSearcher` has been enhanced to support timeouts. The OpenSearch uses custom implementation (based on cancellable runnable and timeout checker) in order to cancel search queries by timeout. For more context, check https://issues.apache.org/jira/browse/LUCENE-10151 please.

### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/4487

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
