### PR TITLE
[Feature/extensions]Enforce type safety for NamedWriteableRegistryParseRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - Modified EnvironmentSettingsRequest to pass entire Settings object ([#4731](https://github.com/opensearch-project/OpenSearch/pull/4731))
  - Added contentParser method to ExtensionRestRequest ([#4760](https://github.com/opensearch-project/OpenSearch/pull/4760))
  - Enforce type safety for RegisterTransportActionsRequest([#4796](https://github.com/opensearch-project/OpenSearch/pull/4796))
+ - Enforce type safety for NamedWriteableRegistryParseRequest ([#4923](https://github.com/opensearch-project/OpenSearch/pull/4923))
 
 ## [2.x]
 

--- a/server/src/main/java/org/opensearch/common/io/stream/NamedWriteableRegistryParseRequest.java
+++ b/server/src/main/java/org/opensearch/common/io/stream/NamedWriteableRegistryParseRequest.java
@@ -20,7 +20,7 @@ import java.util.Objects;
  */
 public class NamedWriteableRegistryParseRequest extends TransportRequest {
 
-    private final Class categoryClass;
+    private final Class<? extends NamedWriteable> categoryClass;
     private byte[] context;
 
     /**
@@ -28,7 +28,7 @@ public class NamedWriteableRegistryParseRequest extends TransportRequest {
      * @param context StreamInput object to convert into a byte array and transport to the extension
      * @throws IllegalArgumentException if context bytes could not be read
      */
-    public NamedWriteableRegistryParseRequest(Class categoryClass, StreamInput context) {
+    public NamedWriteableRegistryParseRequest(Class<? extends NamedWriteable> categoryClass, StreamInput context) {
         try {
             byte[] streamInputBytes = context.readAllBytes();
             this.categoryClass = categoryClass;
@@ -42,10 +42,11 @@ public class NamedWriteableRegistryParseRequest extends TransportRequest {
      * @param in StreamInput from which class fields are read from
      * @throws IllegalArgumentException if the fully qualified class name is invalid and the class object cannot be generated at runtime
      */
+    @SuppressWarnings("unchecked")
     public NamedWriteableRegistryParseRequest(StreamInput in) throws IOException {
         super(in);
         try {
-            this.categoryClass = Class.forName(in.readString());
+            this.categoryClass = (Class<? extends NamedWriteable>) Class.forName(in.readString());
             this.context = in.readByteArray();
         } catch (ClassNotFoundException e) {
             throw new IllegalArgumentException("Category class definition not found", e);
@@ -85,7 +86,7 @@ public class NamedWriteableRegistryParseRequest extends TransportRequest {
     /**
      * Returns the class instance of the category class sent over by the SDK
      */
-    public Class getCategoryClass() {
+    public Class<? extends NamedWriteable> getCategoryClass() {
         return this.categoryClass;
     }
 

--- a/server/src/main/java/org/opensearch/common/io/stream/NamedWriteableRegistryResponse.java
+++ b/server/src/main/java/org/opensearch/common/io/stream/NamedWriteableRegistryResponse.java
@@ -35,7 +35,6 @@ public class NamedWriteableRegistryResponse extends TransportResponse {
      * @param in StreamInput from which map entries of writeable names and their associated category classes are read from
      * @throws IllegalArgumentException if the fully qualified class name is invalid and the class object cannot be generated at runtime
      */
-    @SuppressWarnings("unchecked")
     public NamedWriteableRegistryResponse(StreamInput in) throws IOException {
         super(in);
         // Stream output for registry map begins with a variable integer that tells us the number of entries being sent across the wire
@@ -44,6 +43,7 @@ public class NamedWriteableRegistryResponse extends TransportResponse {
         for (int i = 0; i < registryEntryCount; i++) {
             try {
                 String name = in.readString();
+                @SuppressWarnings("unchecked")
                 Class<? extends NamedWriteable> categoryClass = (Class<? extends NamedWriteable>) Class.forName(in.readString());
                 registry.put(name, categoryClass);
             } catch (ClassNotFoundException e) {

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsOrchestratorTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsOrchestratorTests.java
@@ -749,7 +749,7 @@ public class ExtensionsOrchestratorTests extends OpenSearchTestCase {
         String requestType = ExtensionsOrchestrator.REQUEST_OPENSEARCH_NAMED_WRITEABLE_REGISTRY;
 
         // Create response to pass to response handler
-        Map<String, Class> responseRegistry = new HashMap<>();
+        Map<String, Class<? extends NamedWriteable>> responseRegistry = new HashMap<>();
         responseRegistry.put(Example.NAME, Example.class);
         NamedWriteableRegistryResponse response = new NamedWriteableRegistryResponse(responseRegistry);
 
@@ -761,10 +761,11 @@ public class ExtensionsOrchestratorTests extends OpenSearchTestCase {
         responseHandler.handleResponse(response);
 
         // Ensure that response entries have been processed correctly into their respective maps
-        Map<DiscoveryNode, Map<Class, Map<String, ExtensionReader>>> extensionsRegistry = responseHandler.getExtensionRegistry();
+        Map<DiscoveryNode, Map<Class<? extends NamedWriteable>, Map<String, ExtensionReader>>> extensionsRegistry = responseHandler
+            .getExtensionRegistry();
         assertEquals(extensionsRegistry.size(), 1);
 
-        Map<Class, Map<String, ExtensionReader>> categoryMap = extensionsRegistry.get(extensionNode);
+        Map<Class<? extends NamedWriteable>, Map<String, ExtensionReader>> categoryMap = extensionsRegistry.get(extensionNode);
         assertEquals(categoryMap.size(), 1);
 
         Map<String, ExtensionReader> readerMap = categoryMap.get(Example.class);
@@ -798,7 +799,7 @@ public class ExtensionsOrchestratorTests extends OpenSearchTestCase {
         String requestType = ExtensionsOrchestrator.REQUEST_OPENSEARCH_PARSE_NAMED_WRITEABLE;
         List<DiscoveryExtension> extensionsList = new ArrayList<>(extensionsOrchestrator.extensionIdMap.values());
         DiscoveryNode extensionNode = extensionsList.get(0);
-        Class categoryClass = Example.class;
+        Class<? extends NamedWriteable> categoryClass = Example.class;
 
         // convert context into an input stream then stream input for mock
         byte[] context = new byte[0];


### PR DESCRIPTION
Signed-off-by: mloufra <mloufra@amazon.com>

### Description
Add generic type for `categoryClass` in `NamedWriteable RegistryParseRequest`, `NamedWriteableRegistryResponse`, `ExtensionNamedWriteableRegistry`, `NamedWriteableRegistryResponseHandler` and `ExtensionsOrchestratorTests` 
Equivalent PR on OpenSearch-sdk-java: https://github.com/opensearch-project/opensearch-sdk-java/pull/203

### Issues Resolved
https://github.com/opensearch-project/opensearch-sdk-java/issues/130


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
