### PR TITLE
[Backport 2.x] Fix for failing checkExtraction, checkLicense and checkNotice tasks f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed randomly failing test ([4774](https://github.com/opensearch-project/OpenSearch/pull/4774))
 - Fix recovery path for searchable snapshots ([4813](https://github.com/opensearch-project/OpenSearch/pull/4813))
 - Fix a bug on handling an invalid array value for point type field #4900([#4900](https://github.com/opensearch-project/OpenSearch/pull/4900))
-
+- Fix for failing checkExtraction, checkLicense and checkNotice tasks for windows gradle check ([#4941](https://github.com/opensearch-project/OpenSearch/pull/4941))
 ### Security
 - CVE-2022-25857 org.yaml:snakeyaml DOS vulnerability ([#4341](https://github.com/opensearch-project/OpenSearch/pull/4341))
 

--- a/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionArchiveCheckPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionArchiveCheckPlugin.java
@@ -73,12 +73,14 @@ public class InternalDistributionArchiveCheckPlugin implements Plugin<Project> {
             .create("distributionArchiveCheck", DistributionArchiveCheckExtension.class);
 
         File archiveExtractionDir = calculateArchiveExtractionDir(project);
-
         // sanity checks if archives can be extracted
         TaskProvider<Copy> checkExtraction = registerCheckExtractionTask(project, buildDistTask, archiveExtractionDir);
+        checkExtraction.configure(InternalDistributionArchiveSetupPlugin.configure(buildTaskName));
         TaskProvider<Task> checkLicense = registerCheckLicenseTask(project, checkExtraction);
+        checkLicense.configure(InternalDistributionArchiveSetupPlugin.configure(buildTaskName));
 
         TaskProvider<Task> checkNotice = registerCheckNoticeTask(project, checkExtraction);
+        checkNotice.configure(InternalDistributionArchiveSetupPlugin.configure(buildTaskName));
         TaskProvider<Task> checkTask = project.getTasks().named("check");
         checkTask.configure(task -> {
             task.dependsOn(checkExtraction);
@@ -118,7 +120,7 @@ public class InternalDistributionArchiveCheckPlugin implements Plugin<Project> {
     }
 
     private TaskProvider<Task> registerCheckLicenseTask(Project project, TaskProvider<Copy> checkExtraction) {
-        TaskProvider<Task> checkLicense = project.getTasks().register("checkLicense", task -> {
+        return project.getTasks().register("checkLicense", task -> {
             task.dependsOn(checkExtraction);
             task.doLast(new Action<Task>() {
                 @Override
@@ -138,7 +140,6 @@ public class InternalDistributionArchiveCheckPlugin implements Plugin<Project> {
                 }
             });
         });
-        return checkLicense;
     }
 
     private TaskProvider<Copy> registerCheckExtractionTask(Project project, TaskProvider<Task> buildDistTask, File archiveExtractionDir) {

--- a/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionArchiveSetupPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionArchiveSetupPlugin.java
@@ -87,7 +87,7 @@ public class InternalDistributionArchiveSetupPlugin implements Plugin<Project> {
         configureTarDefaults(project);
     }
 
-    private Action<Task> configure(String name) {
+    static Action<Task> configure(String name) {
         return (Task task) -> task.onlyIf(s -> {
             if (OperatingSystem.current().isWindows()) {
                 // On Windows, include only Windows distributions and integTestZip


### PR DESCRIPTION
…or windows gradle check (#4941)

* Fix for failing checkExtraction and checkLicense tasks

Signed-off-by: Poojita Raj <poojiraj@amazon.com>

* changelog added

Signed-off-by: Poojita Raj <poojiraj@amazon.com>

Signed-off-by: Poojita Raj <poojiraj@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
