### PR TITLE
Fix dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update Apache Lucene to 9.4.1 ([#4922](https://github.com/opensearch-project/OpenSearch/pull/4922))
 - Bump `woodstox-core` to 6.4.0 ([#4947](https://github.com/opensearch-project/OpenSearch/pull/4947))
 - Update Apache Lucene to 9.5.0-snapshot-a4ef70f ([#4979](https://github.com/opensearch-project/OpenSearch/pull/4979))
-- Exclude jetty-http in hadoop-minicluster, upgrade kotlin-stdlib and snakeyaml ([#4963](https://github.com/opensearch-project/OpenSearch/pull/4963))
+- Upgrade jetty-http, kotlin-stdlib and snakeyaml ([#4963](https://github.com/opensearch-project/OpenSearch/pull/4963))
 
 ### Changed
 - Dependency updates (httpcore, mockito, slf4j, httpasyncclient, commons-codec) ([#4308](https://github.com/opensearch-project/OpenSearch/pull/4308))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update Apache Lucene to 9.4.1 ([#4922](https://github.com/opensearch-project/OpenSearch/pull/4922))
 - Bump `woodstox-core` to 6.4.0 ([#4947](https://github.com/opensearch-project/OpenSearch/pull/4947))
 - Update Apache Lucene to 9.5.0-snapshot-a4ef70f ([#4979](https://github.com/opensearch-project/OpenSearch/pull/4979))
+- Exclude jetty-http in hadoop-minicluster, upgrade kotlin-stdlib and snakeyaml ([#4963](https://github.com/opensearch-project/OpenSearch/pull/4963))
 
 ### Changed
 - Dependency updates (httpcore, mockito, slf4j, httpasyncclient, commons-codec) ([#4308](https://github.com/opensearch-project/OpenSearch/pull/4308))

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -116,7 +116,7 @@ dependencies {
   api 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.10'
   api 'de.thetaphi:forbiddenapis:3.3'
   api 'com.avast.gradle:gradle-docker-compose-plugin:0.15.2'
-  api 'org.yaml:snakeyaml:1.32'
+  api "org.yaml:snakeyaml:${props.getProperty('snakeyaml')}"
   api 'org.apache.maven:maven-model:3.6.2'
   api 'com.networknt:json-schema-validator:1.0.69'
   api "com.fasterxml.jackson.core:jackson-databind:${props.getProperty('jackson_databind')}"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -113,7 +113,7 @@ dependencies {
   api "net.java.dev.jna:jna:5.11.0"
   api 'gradle.plugin.com.github.johnrengelman:shadow:7.1.2'
   api 'org.jdom:jdom2:2.0.6.1'
-  api 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.10'
+  api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${props.getProperty('kotlin')}"
   api 'de.thetaphi:forbiddenapis:3.3'
   api 'com.avast.gradle:gradle-docker-compose-plugin:0.15.2'
   api "org.yaml:snakeyaml:${props.getProperty('snakeyaml')}"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -116,6 +116,7 @@ dependencies {
   api 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.10'
   api 'de.thetaphi:forbiddenapis:3.3'
   api 'com.avast.gradle:gradle-docker-compose-plugin:0.15.2'
+  api 'org.yaml:snakeyaml:1.32'
   api 'org.apache.maven:maven-model:3.6.2'
   api 'com.networknt:json-schema-validator:1.0.69'
   api "com.fasterxml.jackson.core:jackson-databind:${props.getProperty('jackson_databind')}"

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -20,6 +20,7 @@ slf4j             = 1.7.36
 asm               = 9.4
 jettison          = 1.5.1
 woodstox          = 6.4.0
+kotlin            = 1.7.10
 
 # when updating the JNA version, also update the version in buildSrc/build.gradle
 jna               = 5.5.0

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -36,8 +36,6 @@ dependencies {
   api("org.apache.hadoop:hadoop-minicluster:3.3.4") {
     exclude module: 'websocket-client'
     exclude module: 'jettison'
-    exclude module: 'jetty-server'
-    exclude module: 'jetty-http'
   }
   api "org.codehaus.jettison:jettison:${versions.jettison}"
   api "org.apache.commons:commons-compress:1.21"
@@ -53,4 +51,5 @@ dependencies {
   api "org.mockito:mockito-core:${versions.mockito}"
   api "com.google.protobuf:protobuf-java:3.21.8"
   api 'org.jetbrains.kotlin:kotlin-stdlib:1.7.10'
+  api 'org.eclipse.jetty:jetty-server:9.4.49.v20220914'
 }

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -50,6 +50,6 @@ dependencies {
   api 'net.minidev:json-smart:2.4.8'
   api "org.mockito:mockito-core:${versions.mockito}"
   api "com.google.protobuf:protobuf-java:3.21.8"
-  api 'org.jetbrains.kotlin:kotlin-stdlib:1.7.10'
+  api "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
   api 'org.eclipse.jetty:jetty-server:9.4.49.v20220914'
 }

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -36,6 +36,8 @@ dependencies {
   api("org.apache.hadoop:hadoop-minicluster:3.3.4") {
     exclude module: 'websocket-client'
     exclude module: 'jettison'
+    exclude module: 'jetty-server'
+    exclude module: 'jetty-http'
   }
   api "org.codehaus.jettison:jettison:${versions.jettison}"
   api "org.apache.commons:commons-compress:1.21"
@@ -50,4 +52,5 @@ dependencies {
   api 'net.minidev:json-smart:2.4.8'
   api "org.mockito:mockito-core:${versions.mockito}"
   api "com.google.protobuf:protobuf-java:3.21.8"
+  api 'org.jetbrains.kotlin:kotlin-stdlib:1.7.10'
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
* Upgrading`jetty-server` (which brings in `jetty-http`) due to GHSA-cj7v-27pg-wf7q which is brought in by `hadoop-minicluster`.
* Upgrading `kotlin-stdlib` which is brought in through `hadoop-minicluster`. See GHSA-cqj8-47ch-rvvq.
* Upgrading `snakeyaml` which is brought in by `com.avast.gradle:gradle-docker-compose-plugin`. See GHSA-98wm-3w3q-mw94

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
