### PR TITLE
Backport [2.x] [Segment Replication] Fix bug of replica shard's translog not purging on index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Disable merge on refresh in DiskThresholdDeciderIT ([#4828](https://github.com/opensearch-project/OpenSearch/pull/4828))
 - Better plural stemmer than minimal_english ([#4738](https://github.com/opensearch-project/OpenSearch/pull/4738))
 - Fix AbstractStringFieldDataTestCase tests to account for TotalHits lower bound ([4867](https://github.com/opensearch-project/OpenSearch/pull/4867))
-- [Segment Replication] Fix bug of replica shard's translog not purging on index flush when segment replication is enabled ([4974](https://github.com/opensearch-project/OpenSearch/pull/4974))
+- [Segment Replication] Fix bug of replica shard's translog not purging on index flush when segment replication is enabled ([4975](https://github.com/opensearch-project/OpenSearch/pull/4975))
 -
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Disable merge on refresh in DiskThresholdDeciderIT ([#4828](https://github.com/opensearch-project/OpenSearch/pull/4828))
 - Better plural stemmer than minimal_english ([#4738](https://github.com/opensearch-project/OpenSearch/pull/4738))
 - Fix AbstractStringFieldDataTestCase tests to account for TotalHits lower bound ([4867](https://github.com/opensearch-project/OpenSearch/pull/4867))
+- [Segment Replication] Fix bug of replica shard's translog not purging on index flush when segment replication is enabled ([4974](https://github.com/opensearch-project/OpenSearch/pull/4974))
+-
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
@@ -129,6 +129,7 @@ public class NRTReplicationEngine extends Engine implements LifecycleAware {
         // lower/higher gens are possible from a new primary that was just elected.
         if (incomingGeneration != lastReceivedGen) {
             commitSegmentInfos();
+            translogManager.getDeletionPolicy().setLocalCheckpointOfSafeCommit(seqNo);
             translogManager.rollTranslogGeneration();
         }
         lastReceivedGen = incomingGeneration;

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
@@ -246,16 +246,36 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
             final IndexShard replica = shards.getReplicas().get(0);
             final int numDocs = randomIntBetween(10, 100);
             shards.indexDocs(numDocs);
+            assertEquals(numDocs, primary.translogStats().estimatedNumberOfOperations());
+            assertEquals(numDocs, replica.translogStats().estimatedNumberOfOperations());
+            assertEquals(numDocs, primary.translogStats().getUncommittedOperations());
+            assertEquals(numDocs, replica.translogStats().getUncommittedOperations());
             flushShard(primary, true);
             replicateSegments(primary, shards.getReplicas());
+            assertEquals(0, primary.translogStats().estimatedNumberOfOperations());
+            assertEquals(0, replica.translogStats().estimatedNumberOfOperations());
+            assertEquals(0, primary.translogStats().getUncommittedOperations());
+            assertEquals(0, replica.translogStats().getUncommittedOperations());
 
-            final int totalDocs = numDocs + shards.indexDocs(randomIntBetween(numDocs + 1, numDocs + 10));
-            flushShard(primary);
+            final int additionalDocs = shards.indexDocs(randomIntBetween(numDocs + 1, numDocs + 10));
+
+            final int totalDocs = numDocs + additionalDocs;
+            primary.refresh("test");
+            replicateSegments(primary, shards.getReplicas());
+            assertEquals(additionalDocs, primary.translogStats().estimatedNumberOfOperations());
+            assertEquals(additionalDocs, replica.translogStats().estimatedNumberOfOperations());
+            assertEquals(additionalDocs, primary.translogStats().getUncommittedOperations());
+            assertEquals(additionalDocs, replica.translogStats().getUncommittedOperations());
+            flushShard(primary, true);
             replicateSegments(primary, shards.getReplicas());
 
             assertEqualCommittedSegments(primary, replica);
             assertDocCount(primary, totalDocs);
             assertDocCount(replica, totalDocs);
+            assertEquals(0, primary.translogStats().estimatedNumberOfOperations());
+            assertEquals(0, replica.translogStats().estimatedNumberOfOperations());
+            assertEquals(0, primary.translogStats().getUncommittedOperations());
+            assertEquals(0, replica.translogStats().getUncommittedOperations());
         }
     }
 
@@ -388,16 +408,20 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
             // 2. Create ops that are in the replica's xlog, not in the index.
             // index some more into both but don't replicate. replica will have only numDocs searchable, but should have totalDocs
             // persisted.
-            final int totalDocs = numDocs + shards.indexDocs(randomInt(10));
+            final int additonalDocs = shards.indexDocs(randomInt(10));
+            final int totalDocs = numDocs + additonalDocs;
 
             assertDocCounts(oldPrimary, totalDocs, totalDocs);
             for (IndexShard shard : shards.getReplicas()) {
                 assertDocCounts(shard, totalDocs, numDocs);
             }
+            assertEquals(additonalDocs, nextPrimary.translogStats().estimatedNumberOfOperations());
+            assertEquals(additonalDocs, replica.translogStats().estimatedNumberOfOperations());
+            assertEquals(additonalDocs, nextPrimary.translogStats().getUncommittedOperations());
+            assertEquals(additonalDocs, replica.translogStats().getUncommittedOperations());
 
             // promote the replica
             shards.syncGlobalCheckpoint();
-            assertEquals(totalDocs, nextPrimary.translogStats().estimatedNumberOfOperations());
             shards.promoteReplicaToPrimary(nextPrimary);
 
             // close and start the oldPrimary as a replica.


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR backports https://github.com/opensearch-project/OpenSearch/pull/4928

### Issues Resolved
Resolves https://github.com/opensearch-project/OpenSearch/issues/4927

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
