### PR TITLE
[Backport 1.x] Fix dependencies (#4963)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump reactor-netty-http to 1.0.24 in repository-azure ([#4920](https://github.com/opensearch-project/OpenSearch/pull/4920))
 - Bump `tika` from 2.4.0 to 2.5.0 ([#4929](https://github.com/opensearch-project/OpenSearch/pull/4929))
 - Bump `woodstox-core` to 6.4.0 ([#4950](https://github.com/opensearch-project/OpenSearch/pull/4950))
-- Upgrade jetty-http, kotlin-stdlib and snakeyaml ([#]())
+- Upgrade jetty-http, kotlin-stdlib and snakeyaml ([#4981](https://github.com/opensearch-project/OpenSearch/pull/4981))
 ### Changed
 - Dependency updates (httpcore, mockito, slf4j, httpasyncclient, commons-codec) ([#4308](https://github.com/opensearch-project/OpenSearch/pull/4308))
 - Use RemoteSegmentStoreDirectory instead of RemoteDirectory ([#4240](https://github.com/opensearch-project/OpenSearch/pull/4240))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump reactor-netty-http to 1.0.24 in repository-azure ([#4920](https://github.com/opensearch-project/OpenSearch/pull/4920))
 - Bump `tika` from 2.4.0 to 2.5.0 ([#4929](https://github.com/opensearch-project/OpenSearch/pull/4929))
 - Bump `woodstox-core` to 6.4.0 ([#4950](https://github.com/opensearch-project/OpenSearch/pull/4950))
+- Upgrade jetty-http, kotlin-stdlib and snakeyaml ([#]())
 ### Changed
 - Dependency updates (httpcore, mockito, slf4j, httpasyncclient, commons-codec) ([#4308](https://github.com/opensearch-project/OpenSearch/pull/4308))
 - Use RemoteSegmentStoreDirectory instead of RemoteDirectory ([#4240](https://github.com/opensearch-project/OpenSearch/pull/4240))

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -114,6 +114,7 @@ dependencies {
   api 'com.github.jengelman.gradle.plugins:shadow:6.0.0'
   api 'de.thetaphi:forbiddenapis:3.2'
   api 'com.avast.gradle:gradle-docker-compose-plugin:0.12.1'
+  api "org.yaml:snakeyaml:${props.getProperty('snakeyaml')}"
   api 'org.apache.maven:maven-model:3.6.2'
   api 'com.networknt:json-schema-validator:1.0.36'
   api "com.fasterxml.jackson.core:jackson-databind:${props.getProperty('jackson_databind')}"

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -18,6 +18,7 @@ log4j             = 2.17.1
 slf4j             = 1.6.2
 jettison          = 1.5.1
 woodstox          = 6.4.0
+kotlin            = 1.7.10
 
 # when updating the JNA version, also update the version in buildSrc/build.gradle
 jna               = 5.5.0

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -47,4 +47,6 @@ dependencies {
   api "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
   api "com.fasterxml.woodstox:woodstox-core:${versions.woodstox}"
   api 'net.minidev:json-smart:2.4.8'
+  api "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
+  api 'org.eclipse.jetty:jetty-server:9.4.49.v20220914'
 }


### PR DESCRIPTION
* Upgrading kotlin-stdlib and excluding jetty-http

Signed-off-by: Vacha Shah <vachshah@amazon.com>

* Upgrading indirect snakeyaml dependency

Signed-off-by: Vacha Shah <vachshah@amazon.com>

* Update CHANGELOG

Signed-off-by: Vacha Shah <vachshah@amazon.com>

* Using snakeyaml version from version file

Signed-off-by: Vacha Shah <vachshah@amazon.com>

* Upgrading jetty-http instead of excluding since it is used

Signed-off-by: Vacha Shah <vachshah@amazon.com>

* Extracting kotlin version

Signed-off-by: Vacha Shah <vachshah@amazon.com>

Signed-off-by: Vacha Shah <vachshah@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Backport #4963 to 1.x

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
