### PR TITLE
[Backport 2.3] copy `build.sh` over from opensearch-build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump version to 2.3.1 and add 2.3.0 to BWC versions ([#4511](https://github.com/opensearch-project/OpenSearch/pull/4511))
 - Add BWC version 1.3.7 ([#4711](https://github.com/opensearch-project/OpenSearch/pull/4711))
 - Bumps `jettison` from 1.5.0 to 1.5.1 ([#4712](https://github.com/opensearch-project/OpenSearch/pull/4712))
+- Copy `build.sh` over from opensearch-build ([#4887](https://github.com/opensearch-project/OpenSearch/pull/4887))
 
 ### Dependencies
 - Dependency updates: asm 9.3 -> 9.4, bytebuddy 1.12.12 -> 1.12.18 ([#4889](https://github.com/opensearch-project/OpenSearch/pull/4889))

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-q QUALIFIER\t[Optional] Version qualifier."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, default is 'uname -s'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, default is 'uname -m'."
+    echo -e "-d DISTRIBUTION\t[Optional] Distribution, default is 'tar'."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:q:s:o:p:a:d:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        q)
+            QUALIFIER=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        d)
+            DISTRIBUTION=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+mkdir -p $OUTPUT/maven/org/opensearch
+
+# Build project and publish to maven local.
+./gradlew publishToMavenLocal -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+
+# Publish to existing test repo, using this to stage release versions of the artifacts that can be released from the same build.
+./gradlew publishNebulaPublicationToTestRepository -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+
+# Copy maven publications to be promoted
+cp -r ./build/local-test-repo/org/opensearch "${OUTPUT}"/maven/org
+
+# Assemble distribution artifact
+# see https://github.com/opensearch-project/OpenSearch/blob/main/settings.gradle#L34 for other distribution targets
+
+[ -z "$PLATFORM" ] && PLATFORM=$(uname -s | awk '{print tolower($0)}')
+[ -z "$ARCHITECTURE" ] && ARCHITECTURE=`uname -m`
+[ -z "$DISTRIBUTION" ] && DISTRIBUTION="tar"
+
+case $PLATFORM-$DISTRIBUTION-$ARCHITECTURE in
+    linux-tar-x64|darwin-tar-x64)
+        PACKAGE="tar"
+        EXT="tar.gz"
+        TYPE="archives"
+        TARGET="$PLATFORM-$PACKAGE"
+        SUFFIX="$PLATFORM-x64"
+        ;;
+    linux-tar-arm64|darwin-tar-arm64)
+        PACKAGE="tar"
+        EXT="tar.gz"
+        TYPE="archives"
+        TARGET="$PLATFORM-arm64-$PACKAGE"
+        SUFFIX="$PLATFORM-arm64"
+        ;;
+    linux-rpm-x64)
+        PACKAGE="rpm"
+        EXT="rpm"
+        TYPE="packages"
+        TARGET="rpm"
+        SUFFIX="x86_64"
+        ;;
+    linux-rpm-arm64)
+        PACKAGE="rpm"
+        EXT="rpm"
+        TYPE="packages"
+        TARGET="arm64-rpm"
+        SUFFIX="aarch64"
+        ;;
+    windows-zip-x64)
+        PACKAGE="zip"
+        EXT="zip"
+        TYPE="archives"
+        TARGET="$PLATFORM-$PACKAGE"
+        SUFFIX="$PLATFORM-x64"
+        ;;
+    windows-zip-arm64)
+        PACKAGE="zip"
+        EXT="zip"
+        TYPE="archives"
+        TARGET="$PLATFORM-arm64-$PACKAGE"
+        SUFFIX="$PLATFORM-arm64"
+        ;;
+    *)
+        echo "Unsupported platform-distribution-architecture combination: $PLATFORM-$DISTRIBUTION-$ARCHITECTURE"
+        exit 1
+        ;;
+esac
+
+echo "Building OpenSearch for $PLATFORM-$DISTRIBUTION-$ARCHITECTURE"
+
+./gradlew :distribution:$TYPE:$TARGET:assemble -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+
+# Copy artifact to dist folder in bundle build output
+[[ "$SNAPSHOT" == "true" ]] && IDENTIFIER="-SNAPSHOT"
+ARTIFACT_BUILD_NAME=`ls distribution/$TYPE/$TARGET/build/distributions/ | grep "opensearch-min.*$SUFFIX.$EXT"`
+mkdir -p "${OUTPUT}/dist"
+cp distribution/$TYPE/$TARGET/build/distributions/$ARTIFACT_BUILD_NAME "${OUTPUT}"/dist/$ARTIFACT_BUILD_NAME
+
+echo "Building core plugins..."
+mkdir -p "${OUTPUT}/core-plugins"
+cd plugins
+../gradlew assemble -Dbuild.snapshot="$SNAPSHOT" -Dbuild.version_qualifier=$QUALIFIER
+cd ..
+for plugin in plugins/*; do
+  PLUGIN_NAME=$(basename "$plugin")
+  if [ -d "$plugin" ] && [ "examples" != "$PLUGIN_NAME" ]; then
+    PLUGIN_ARTIFACT_BUILD_NAME=`ls "$plugin"/build/distributions/ | grep "$PLUGIN_NAME.*$IDENTIFIER.zip"`
+    cp "$plugin"/build/distributions/"$PLUGIN_ARTIFACT_BUILD_NAME" "${OUTPUT}"/core-plugins/"$PLUGIN_ARTIFACT_BUILD_NAME"
+  fi
+done


### PR DESCRIPTION
the build script should be located in this repository instead of centrally in [opensearch-build][] to allow per-branch specific builds (newer versions might have newer requirements, which currently cannot be reflected).

the file was copied 1:1 from `scripts/components/OpenSearch/build.sh` as of commit 9e1aa38 in the [opensearch-build][] repository.

this is part of opensearch-build#99 and needs to be backported to all active branches because the file here will only be used by the build once the central one in opensearch-build has been removed which in turn can only happen when all active branches have the `build.sh`.

[opensearch-build]: https://github.com/opensearch-project/opensearch-build

Signed-off-by: Ralph Ursprung <Ralph.Ursprung@avaloq.com>

Signed-off-by: Ralph Ursprung <Ralph.Ursprung@avaloq.com>
(cherry picked from commit e3572464859d728c64d5a6f85e8ba0bd51314a5d)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
