### PR TITLE
[Backport] [2.4] OpenJDK Update (October 2022 Patch releases) (#4997)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update Apache Lucene to 9.4.1 ([#4922](https://github.com/opensearch-project/OpenSearch/pull/4922))
 - Bump `woodstox-core` to 6.4.0 ([#4951](https://github.com/opensearch-project/OpenSearch/pull/4951))
 - Upgrade jetty-http, kotlin-stdlib and snakeyaml ([#4982](https://github.com/opensearch-project/OpenSearch/pull/4982))
+- OpenJDK Update (October 2022 Patch releases) ([#4997](https://github.com/opensearch-project/OpenSearch/pull/4997))
 
 ### Changed
 - Dependency updates (httpcore, mockito, slf4j, httpasyncclient, commons-codec) ([#4308](https://github.com/opensearch-project/OpenSearch/pull/4308))

--- a/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java
@@ -75,9 +75,9 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public class DistroTestPlugin implements Plugin<Project> {
-    private static final String SYSTEM_JDK_VERSION = "11.0.16+8";
+    private static final String SYSTEM_JDK_VERSION = "11.0.17+8";
     private static final String SYSTEM_JDK_VENDOR = "adoptium";
-    private static final String GRADLE_JDK_VERSION = "17.0.4+8";
+    private static final String GRADLE_JDK_VERSION = "17.0.5+8";
     private static final String GRADLE_JDK_VENDOR = "adoptium";
 
     // all distributions used by distro tests. this is temporary until tests are per distribution

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -2,7 +2,7 @@ opensearch        = 2.4.0
 lucene            = 9.4.1
 
 bundled_jdk_vendor = adoptium
-bundled_jdk = 17.0.4+8
+bundled_jdk = 17.0.5+8
 
 
 


### PR DESCRIPTION
Backport 34b6b09474ab83be856c3afc20fb101c63244ee6 from #4997.