### PR TITLE
[Remove] LegacyESVersion.V_7_10_* constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Revert PR 4656 to unblock Windows CI ([#4949](https://github.com/opensearch-project/OpenSearch/pull/4949))
 - Remove LegacyESVersion.V_7_8_ and V_7_9_ Constants ([#4855](https://github.com/opensearch-project/OpenSearch/pull/4855))
 - Remove LegacyESVersion.V_7_6_ and V_7_7_ Constants ([#4837](https://github.com/opensearch-project/OpenSearch/pull/4837))
+- Remove LegacyESVersion.V_7_10_ Constants ([#5018](https://github.com/opensearch-project/OpenSearch/pull/5018))
 
 ### Fixed
 - `opensearch-service.bat start` and `opensearch-service.bat manager` failing to run ([#4289](https://github.com/opensearch-project/OpenSearch/pull/4289))

--- a/distribution/tools/upgrade-cli/src/main/java/org/opensearch/upgrade/ValidateInputTask.java
+++ b/distribution/tools/upgrade-cli/src/main/java/org/opensearch/upgrade/ValidateInputTask.java
@@ -31,7 +31,7 @@ class ValidateInputTask implements UpgradeTask {
         // check if the elasticsearch version is supported
         if (taskInput.getVersion().isPresent()) {
             final Version version = taskInput.getVersion().get();
-            if (version.equals(LegacyESVersion.V_7_10_2) == false) {
+            if (version.equals(LegacyESVersion.fromId(7100299)) == false) {
                 throw new RuntimeException(
                     String.format(Locale.getDefault(), "The installed version %s of elasticsearch is not supported.", version)
                 );

--- a/distribution/tools/upgrade-cli/src/test/java/org/opensearch/upgrade/ValidateInputTaskTests.java
+++ b/distribution/tools/upgrade-cli/src/test/java/org/opensearch/upgrade/ValidateInputTaskTests.java
@@ -39,7 +39,7 @@ public class ValidateInputTaskTests extends OpenSearchTestCase {
 
     public void testUnsupportedEsVersion() {
         TaskInput taskInput = new TaskInput(env);
-        taskInput.setVersion(LegacyESVersion.V_7_10_1);
+        taskInput.setVersion(LegacyESVersion.fromId(7100199));
 
         final RuntimeException e = expectThrows(RuntimeException.class, () -> task.accept(new Tuple<>(taskInput, terminal)));
 
@@ -51,7 +51,7 @@ public class ValidateInputTaskTests extends OpenSearchTestCase {
         taskInput.setEsConfig(PathUtils.get("es_home"));
         taskInput.setCluster("some-cluster");
         taskInput.setNode("some-node");
-        taskInput.setVersion(LegacyESVersion.V_7_10_2);
+        taskInput.setVersion(LegacyESVersion.fromId(7100299));
         taskInput.setBaseUrl("some-url");
         taskInput.setPlugins(Arrays.asList("plugin-1", "plugin-2"));
 

--- a/modules/ingest-common/src/main/java/org/opensearch/ingest/common/GrokProcessorGetAction.java
+++ b/modules/ingest-common/src/main/java/org/opensearch/ingest/common/GrokProcessorGetAction.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.ingest.common;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
@@ -79,7 +78,7 @@ public class GrokProcessorGetAction extends ActionType<GrokProcessorGetAction.Re
 
         Request(StreamInput in) throws IOException {
             super(in);
-            this.sorted = in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0) ? in.readBoolean() : false;
+            this.sorted = in.readBoolean();
         }
 
         @Override
@@ -90,9 +89,7 @@ public class GrokProcessorGetAction extends ActionType<GrokProcessorGetAction.Re
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-                out.writeBoolean(sorted);
-            }
+            out.writeBoolean(sorted);
         }
 
         public boolean sorted() {

--- a/qa/full-cluster-restart/src/test/java/org/opensearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/opensearch/upgrades/FullClusterRestartIT.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.upgrades;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
@@ -72,7 +71,6 @@ import java.util.regex.Pattern;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static org.opensearch.cluster.metadata.IndexNameExpressionResolver.SYSTEM_INDEX_ENFORCEMENT_VERSION;
 import static org.opensearch.cluster.routing.UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING;
 import static org.opensearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY;
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -1441,20 +1439,6 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                     throw new AssertionError(".tasks index does not exist yet");
                 }
             });
-
-            // If we are on 7.x create an alias that includes both a system index and a non-system index so we can be sure it gets
-            // upgraded properly. If we're already on 8.x, skip this part of the test.
-            if (minimumNodeVersion().before(SYSTEM_INDEX_ENFORCEMENT_VERSION)) {
-                // Create an alias to make sure it gets upgraded properly
-                Request putAliasRequest = new Request("POST", "/_aliases");
-                putAliasRequest.setJsonEntity("{\n" +
-                    "  \"actions\": [\n" +
-                    "    {\"add\":  {\"index\":  \".tasks\", \"alias\": \"test-system-alias\"}},\n" +
-                    "    {\"add\":  {\"index\":  \"test_index_reindex\", \"alias\": \"test-system-alias\"}}\n" +
-                    "  ]\n" +
-                    "}");
-                assertThat(client().performRequest(putAliasRequest).getStatusLine().getStatusCode(), is(200));
-            }
         } else {
             assertBusy(() -> {
                 Request clusterStateRequest = new Request("GET", "/_cluster/state/metadata");
@@ -1469,21 +1453,8 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                 XContentTestUtils.JsonMapView tasksIndex = new XContentTestUtils.JsonMapView((Map<String, Object>) indices.get(".tasks"));
                 assertThat(tasksIndex.get("system"), is(true));
 
-                // If .tasks was created in a 7.x version, it should have an alias on it that we need to make sure got upgraded properly.
                 final String tasksCreatedVersionString = tasksIndex.get("settings.index.version.created");
                 assertThat(tasksCreatedVersionString, notNullValue());
-                final Version tasksCreatedVersion = Version.fromId(Integer.parseInt(tasksCreatedVersionString));
-                if (tasksCreatedVersion.before(SYSTEM_INDEX_ENFORCEMENT_VERSION)) {
-                    // Verify that the alias survived the upgrade
-                    Request getAliasRequest = new Request("GET", "/_alias/test-system-alias");
-                    getAliasRequest.setOptions(expectVersionSpecificWarnings(v -> {
-                        v.current(systemIndexWarning);
-                        v.compatible(systemIndexWarning);
-                    }));
-                    Map<String, Object> aliasResponse = entityAsMap(client().performRequest(getAliasRequest));
-                    assertThat(aliasResponse, hasKey(".tasks"));
-                    assertThat(aliasResponse, hasKey("test_index_reindex"));
-                }
             });
         }
     }

--- a/server/src/main/java/org/opensearch/LegacyESVersion.java
+++ b/server/src/main/java/org/opensearch/LegacyESVersion.java
@@ -48,10 +48,6 @@ import java.lang.reflect.Field;
  */
 public class LegacyESVersion extends Version {
 
-    public static final LegacyESVersion V_7_10_0 = new LegacyESVersion(7100099, org.apache.lucene.util.Version.LUCENE_8_7_0);
-    public static final LegacyESVersion V_7_10_1 = new LegacyESVersion(7100199, org.apache.lucene.util.Version.LUCENE_8_7_0);
-    public static final LegacyESVersion V_7_10_2 = new LegacyESVersion(7100299, org.apache.lucene.util.Version.LUCENE_8_7_0);
-
     // todo move back to Version.java if retiring legacy version support
     protected static final ImmutableOpenIntMap<Version> idToVersion;
     protected static final ImmutableOpenMap<String, Version> stringToVersion;

--- a/server/src/main/java/org/opensearch/OpenSearchException.java
+++ b/server/src/main/java/org/opensearch/OpenSearchException.java
@@ -114,7 +114,6 @@ public class OpenSearchException extends RuntimeException implements ToXContentF
     private static final Map<Class<? extends OpenSearchException>, OpenSearchExceptionHandle> CLASS_TO_OPENSEARCH_EXCEPTION_HANDLE;
 
     private static final Pattern OS_METADATA = Pattern.compile("^opensearch\\.");
-    private static final Pattern ES_METADATA = Pattern.compile("^es\\.");
 
     private final Map<String, List<String>> metadata = new HashMap<>();
     private final Map<String, List<String>> headers = new HashMap<>();
@@ -158,16 +157,7 @@ public class OpenSearchException extends RuntimeException implements ToXContentF
         super(in.readOptionalString(), in.readException());
         readStackTrace(this, in);
         headers.putAll(in.readMapOfLists(StreamInput::readString, StreamInput::readString));
-        metadata.putAll(in.readMapOfLists(OpenSearchException::readAndReplace, StreamInput::readString));
-    }
-
-    private static String readAndReplace(StreamInput in) throws IOException {
-        String str = in.readString();
-        return in.getVersion().onOrBefore(LegacyESVersion.V_7_10_2) ? ES_METADATA.matcher(str).replaceFirst("opensearch.") : str;
-    }
-
-    private static void replaceAndWrite(StreamOutput out, String str) throws IOException {
-        out.writeString(out.getVersion().onOrBefore(LegacyESVersion.V_7_10_2) ? OS_METADATA.matcher(str).replaceFirst("es.") : str);
+        metadata.putAll(in.readMapOfLists(StreamInput::readString, StreamInput::readString));
     }
 
     /**
@@ -310,7 +300,7 @@ public class OpenSearchException extends RuntimeException implements ToXContentF
         out.writeException(this.getCause());
         writeStackTraces(this, out, StreamOutput::writeException);
         out.writeMapOfLists(headers, StreamOutput::writeString, StreamOutput::writeString);
-        out.writeMapOfLists(metadata, OpenSearchException::replaceAndWrite, StreamOutput::writeString);
+        out.writeMapOfLists(metadata, StreamOutput::writeString, StreamOutput::writeString);
     }
 
     public static OpenSearchException readException(StreamInput input, int id) throws IOException {
@@ -1588,7 +1578,7 @@ public class OpenSearchException extends RuntimeException implements ToXContentF
             org.opensearch.transport.NoSeedNodeLeftException.class,
             org.opensearch.transport.NoSeedNodeLeftException::new,
             160,
-            LegacyESVersion.V_7_10_0
+            UNKNOWN_VERSION_ADDED
         ),
         REPLICATION_FAILED_EXCEPTION(
             org.opensearch.indices.replication.common.ReplicationFailedException.class,

--- a/server/src/main/java/org/opensearch/Version.java
+++ b/server/src/main/java/org/opensearch/Version.java
@@ -361,7 +361,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
             // we don't have LegacyESVersion.V_6 constants, so set it to its last minor
             return LegacyESVersion.fromId(6080099);
         } else if (major == 2) {
-            return LegacyESVersion.V_7_10_0;
+            return LegacyESVersion.fromId(7100099);
         } else if (major == 6) {
             // force the minimum compatibility for version 6 to 5.6 since we don't reference version 5 anymore
             return LegacyESVersion.fromId(5060099);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/info/NodeInfo.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/info/NodeInfo.java
@@ -33,7 +33,6 @@
 package org.opensearch.action.admin.cluster.node.info;
 
 import org.opensearch.Build;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.support.nodes.BaseNodeResponse;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -99,9 +98,7 @@ public class NodeInfo extends BaseNodeResponse {
         addInfoIfNonNull(HttpInfo.class, in.readOptionalWriteable(HttpInfo::new));
         addInfoIfNonNull(PluginsAndModules.class, in.readOptionalWriteable(PluginsAndModules::new));
         addInfoIfNonNull(IngestInfo.class, in.readOptionalWriteable(IngestInfo::new));
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            addInfoIfNonNull(AggregationInfo.class, in.readOptionalWriteable(AggregationInfo::new));
-        }
+        addInfoIfNonNull(AggregationInfo.class, in.readOptionalWriteable(AggregationInfo::new));
     }
 
     public NodeInfo(
@@ -198,11 +195,7 @@ public class NodeInfo extends BaseNodeResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().before(Version.V_1_0_0)) {
-            out.writeVInt(LegacyESVersion.V_7_10_2.id);
-        } else {
-            out.writeVInt(version.id);
-        }
+        out.writeVInt(version.id);
         Build.writeBuild(build, out);
         if (totalIndexingBuffer == null) {
             out.writeBoolean(false);
@@ -224,8 +217,6 @@ public class NodeInfo extends BaseNodeResponse {
         out.writeOptionalWriteable(getInfo(HttpInfo.class));
         out.writeOptionalWriteable(getInfo(PluginsAndModules.class));
         out.writeOptionalWriteable(getInfo(IngestInfo.class));
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeOptionalWriteable(getInfo(AggregationInfo.class));
-        }
+        out.writeOptionalWriteable(getInfo(AggregationInfo.class));
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.cluster.snapshots.restore;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.support.IndicesOptions;
@@ -146,9 +145,7 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         includeAliases = in.readBoolean();
         indexSettings = readSettingsFromStream(in);
         ignoreIndexSettings = in.readStringArray();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            snapshotUuid = in.readOptionalString();
-        }
+        snapshotUuid = in.readOptionalString();
         if (FeatureFlags.isEnabled(FeatureFlags.SEARCHABLE_SNAPSHOT) && in.getVersion().onOrAfter(Version.V_2_4_0)) {
             storageType = in.readEnum(StorageType.class);
         }
@@ -169,13 +166,7 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         out.writeBoolean(includeAliases);
         writeSettingsToStream(indexSettings, out);
         out.writeStringArray(ignoreIndexSettings);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeOptionalString(snapshotUuid);
-        } else if (snapshotUuid != null) {
-            throw new IllegalStateException(
-                "restricting the snapshot UUID is forbidden in a cluster with version [" + out.getVersion() + "] nodes"
-            );
-        }
+        out.writeOptionalString(snapshotUuid);
         if (FeatureFlags.isEnabled(FeatureFlags.SEARCHABLE_SNAPSHOT) && out.getVersion().onOrAfter(Version.V_2_4_0)) {
             out.writeEnum(storageType);
         }

--- a/server/src/main/java/org/opensearch/action/index/IndexRequest.java
+++ b/server/src/main/java/org/opensearch/action/index/IndexRequest.java
@@ -164,11 +164,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
         }
         ifSeqNo = in.readZLong();
         ifPrimaryTerm = in.readVLong();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            requireAlias = in.readBoolean();
-        } else {
-            requireAlias = false;
-        }
+        requireAlias = in.readBoolean();
     }
 
     public IndexRequest() {
@@ -679,9 +675,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
         }
         out.writeZLong(ifSeqNo);
         out.writeVLong(ifPrimaryTerm);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeBoolean(requireAlias);
-        }
+        out.writeBoolean(requireAlias);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/ingest/SimulateProcessorResult.java
+++ b/server/src/main/java/org/opensearch/action/ingest/SimulateProcessorResult.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.action.ingest;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchException;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.collect.Tuple;
@@ -193,18 +192,12 @@ public class SimulateProcessorResult implements Writeable, ToXContentObject {
         this.ingestDocument = in.readOptionalWriteable(WriteableIngestDocument::new);
         this.failure = in.readException();
         this.description = in.readOptionalString();
-
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            this.type = in.readString();
-            boolean hasConditional = in.readBoolean();
-            if (hasConditional) {
-                this.conditionalWithResult = new Tuple<>(in.readString(), in.readBoolean());
-            } else {
-                this.conditionalWithResult = null; // no condition exists
-            }
+        this.type = in.readString();
+        boolean hasConditional = in.readBoolean();
+        if (hasConditional) {
+            this.conditionalWithResult = new Tuple<>(in.readString(), in.readBoolean());
         } else {
-            this.conditionalWithResult = null;
-            this.type = null;
+            this.conditionalWithResult = null; // no condition exists
         }
     }
 
@@ -214,14 +207,11 @@ public class SimulateProcessorResult implements Writeable, ToXContentObject {
         out.writeOptionalWriteable(ingestDocument);
         out.writeException(failure);
         out.writeOptionalString(description);
-
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeString(type);
-            out.writeBoolean(conditionalWithResult != null);
-            if (conditionalWithResult != null) {
-                out.writeString(conditionalWithResult.v1());
-                out.writeBoolean(conditionalWithResult.v2());
-            }
+        out.writeString(type);
+        out.writeBoolean(conditionalWithResult != null);
+        if (conditionalWithResult != null) {
+            out.writeString(conditionalWithResult.v1());
+            out.writeBoolean(conditionalWithResult.v2());
         }
     }
 

--- a/server/src/main/java/org/opensearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchResponse.java
@@ -33,7 +33,6 @@
 package org.opensearch.action.search;
 
 import org.apache.lucene.search.TotalHits;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.ParseField;
@@ -109,11 +108,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
         scrollId = in.readOptionalString();
         tookInMillis = in.readVLong();
         skippedShards = in.readVInt();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            pointInTimeId = in.readOptionalString();
-        } else {
-            pointInTimeId = null;
-        }
+        pointInTimeId = in.readOptionalString();
     }
 
     public SearchResponse(
@@ -462,9 +457,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
         out.writeOptionalString(scrollId);
         out.writeVLong(tookInMillis);
         out.writeVInt(skippedShards);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeOptionalString(pointInTimeId);
-        }
+        out.writeOptionalString(pointInTimeId);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchTransportService.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.action.search;
 
-import org.opensearch.LegacyESVersion;
-import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionListenerResponseHandler;
 import org.opensearch.action.IndicesRequest;
@@ -494,10 +492,6 @@ public class SearchTransportService {
         }
     }
 
-    static boolean keepStatesInContext(Version version) {
-        return version.before(LegacyESVersion.V_7_10_0);
-    }
-
     public static void registerRequestHandler(TransportService transportService, SearchService searchService) {
         transportService.registerRequestHandler(
             FREE_CONTEXT_SCROLL_ACTION_NAME,
@@ -549,7 +543,7 @@ public class SearchTransportService {
             ShardSearchRequest::new,
             (request, channel, task) -> searchService.executeDfsPhase(
                 request,
-                keepStatesInContext(channel.getVersion()),
+                false,
                 (SearchShardTask) task,
                 new ChannelActionListener<>(channel, DFS_ACTION_NAME, request)
             )
@@ -564,7 +558,7 @@ public class SearchTransportService {
             (request, channel, task) -> {
                 searchService.executeQueryPhase(
                     request,
-                    keepStatesInContext(channel.getVersion()),
+                    false,
                     (SearchShardTask) task,
                     new ChannelActionListener<>(channel, QUERY_ACTION_NAME, request)
                 );

--- a/server/src/main/java/org/opensearch/action/update/UpdateRequest.java
+++ b/server/src/main/java/org/opensearch/action/update/UpdateRequest.java
@@ -33,7 +33,6 @@
 package org.opensearch.action.update;
 
 import org.apache.lucene.util.RamUsageEstimator;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.DocWriteRequest;
@@ -187,11 +186,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
         ifPrimaryTerm = in.readVLong();
         detectNoop = in.readBoolean();
         scriptedUpsert = in.readBoolean();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            requireAlias = in.readBoolean();
-        } else {
-            requireAlias = false;
-        }
+        requireAlias = in.readBoolean();
     }
 
     public UpdateRequest(String index, String id) {
@@ -914,9 +909,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
         out.writeVLong(ifPrimaryTerm);
         out.writeBoolean(detectNoop);
         out.writeBoolean(scriptedUpsert);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeBoolean(requireAlias);
-        }
+        out.writeBoolean(requireAlias);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/coordination/JoinTaskExecutor.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/JoinTaskExecutor.java
@@ -32,7 +32,6 @@
 package org.opensearch.cluster.coordination;
 
 import org.apache.logging.log4j.Logger;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.cluster.ClusterState;
@@ -182,7 +181,7 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
         for (final Task joinTask : joiningNodes) {
             if (joinTask.isBecomeClusterManagerTask() || joinTask.isFinishElectionTask()) {
                 // noop
-            } else if (currentNodes.nodeExistsWithSameRoles(joinTask.node()) && !currentNodes.nodeExistsWithBWCVersion(joinTask.node())) {
+            } else if (currentNodes.nodeExistsWithSameRoles(joinTask.node())) {
                 logger.debug("received a join request for an existing node [{}]", joinTask.node());
             } else {
                 final DiscoveryNode node = joinTask.node();
@@ -340,15 +339,6 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
                             node.getVersion(),
                             channelVersions.get(tmpNode.getId())
                         );
-                    }
-                } else {
-                    // in case existing OpenSearch node is present in the cluster and but there is no connection to that node yet,
-                    // either that node will send new JoinRequest to the cluster-manager/master with version >=1.0, then no issue or
-                    // there is an edge case if doesn't send JoinRequest and connection is established,
-                    // then it can continue to report version as 7.10.2 instead of actual OpenSearch version. So,
-                    // removing the node from cluster state to prevent stale version reporting and let it reconnect.
-                    if (node.getVersion().equals(LegacyESVersion.V_7_10_2)) {
-                        nodesBuilder.remove(node.getId());
                     }
                 }
             }

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -37,7 +37,6 @@ import com.carrotsearch.hppc.cursors.IntObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.opensearch.Assertions;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.admin.indices.rollover.RolloverInfo;
 import org.opensearch.action.support.ActiveShardCount;
@@ -596,8 +595,6 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
     public static final String INDEX_STATE_FILE_PREFIX = "state-";
 
-    static final Version SYSTEM_INDEX_FLAG_ADDED = LegacyESVersion.V_7_10_0;
-
     private final int routingNumShards;
     private final int routingFactor;
     private final int routingPartitionSize;
@@ -1043,11 +1040,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 DiffableUtils.getStringKeySerializer(),
                 ROLLOVER_INFO_DIFF_VALUE_READER
             );
-            if (in.getVersion().onOrAfter(SYSTEM_INDEX_FLAG_ADDED)) {
-                isSystem = in.readBoolean();
-            } else {
-                isSystem = false;
-            }
+            isSystem = in.readBoolean();
         }
 
         @Override
@@ -1066,9 +1059,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             customData.writeTo(out);
             inSyncAllocationIds.writeTo(out);
             rolloverInfos.writeTo(out);
-            if (out.getVersion().onOrAfter(SYSTEM_INDEX_FLAG_ADDED)) {
-                out.writeBoolean(isSystem);
-            }
+            out.writeBoolean(isSystem);
         }
 
         @Override
@@ -1128,9 +1119,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         for (int i = 0; i < rolloverAliasesSize; i++) {
             builder.putRolloverInfo(new RolloverInfo(in));
         }
-        if (in.getVersion().onOrAfter(SYSTEM_INDEX_FLAG_ADDED)) {
-            builder.system(in.readBoolean());
-        }
+        builder.system(in.readBoolean());
         return builder.build();
     }
 
@@ -1167,9 +1156,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         for (ObjectCursor<RolloverInfo> cursor : rolloverInfos.values()) {
             cursor.value.writeTo(out);
         }
-        if (out.getVersion().onOrAfter(SYSTEM_INDEX_FLAG_ADDED)) {
-            out.writeBoolean(isSystem);
-        }
+        out.writeBoolean(isSystem);
     }
 
     public boolean isSystem() {

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -32,9 +32,7 @@
 
 package org.opensearch.cluster.metadata;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchParseException;
-import org.opensearch.Version;
 import org.opensearch.action.IndicesRequest;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.cluster.ClusterState;
@@ -86,7 +84,6 @@ public class IndexNameExpressionResolver {
 
     public static final String EXCLUDED_DATA_STREAMS_KEY = "opensearch.excluded_ds";
     public static final String SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY = "_system_index_access_allowed";
-    public static final Version SYSTEM_INDEX_ENFORCEMENT_VERSION = LegacyESVersion.V_7_10_0;
 
     private final DateMathExpressionResolver dateMathExpressionResolver = new DateMathExpressionResolver();
     private final WildcardExpressionResolver wildcardExpressionResolver = new WildcardExpressionResolver();

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -324,14 +324,12 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         for (int i = 0; i < rolesSize; i++) {
             final String roleName = in.readString();
             final String roleNameAbbreviation = in.readString();
-            final boolean canContainData;
-            canContainData = in.readBoolean();
             final DiscoveryNodeRole role = roleMap.get(roleName);
             if (role == null) {
                 if (in.getVersion().onOrAfter(Version.V_2_1_0)) {
-                    roles.add(new DiscoveryNodeRole.DynamicRole(roleName, roleNameAbbreviation, canContainData));
+                    roles.add(new DiscoveryNodeRole.DynamicRole(roleName, roleNameAbbreviation, in.readBoolean()));
                 } else {
-                    roles.add(new DiscoveryNodeRole.UnknownRole(roleName, roleNameAbbreviation, canContainData));
+                    roles.add(new DiscoveryNodeRole.UnknownRole(roleName, roleNameAbbreviation, in.readBoolean()));
                 }
             } else {
                 assert roleName.equals(role.roleName()) : "role name [" + roleName + "] does not match role [" + role.roleName() + "]";

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.cluster.node;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.io.stream.StreamInput;
@@ -326,11 +325,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
             final String roleName = in.readString();
             final String roleNameAbbreviation = in.readString();
             final boolean canContainData;
-            if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-                canContainData = in.readBoolean();
-            } else {
-                canContainData = roleName.equals(DiscoveryNodeRole.DATA_ROLE.roleName());
-            }
+            canContainData = in.readBoolean();
             final DiscoveryNodeRole role = roleMap.get(roleName);
             if (role == null) {
                 if (in.getVersion().onOrAfter(Version.V_2_1_0)) {
@@ -370,15 +365,9 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
             final DiscoveryNodeRole compatibleRole = role.getCompatibilityRole(out.getVersion());
             out.writeString(compatibleRole.roleName());
             out.writeString(compatibleRole.roleNameAbbreviation());
-            if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-                out.writeBoolean(compatibleRole.canContainData());
-            }
+            out.writeBoolean(compatibleRole.canContainData());
         }
-        if (out.getVersion().before(Version.V_1_0_0) && version.onOrAfter(Version.V_1_0_0)) {
-            Version.writeVersion(LegacyESVersion.V_7_10_2, out);
-        } else {
-            Version.writeVersion(version, out);
-        }
+        Version.writeVersion(version, out);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -324,12 +324,13 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         for (int i = 0; i < rolesSize; i++) {
             final String roleName = in.readString();
             final String roleNameAbbreviation = in.readString();
+            final boolean canContainData = in.readBoolean();
             final DiscoveryNodeRole role = roleMap.get(roleName);
             if (role == null) {
                 if (in.getVersion().onOrAfter(Version.V_2_1_0)) {
-                    roles.add(new DiscoveryNodeRole.DynamicRole(roleName, roleNameAbbreviation, in.readBoolean()));
+                    roles.add(new DiscoveryNodeRole.DynamicRole(roleName, roleNameAbbreviation, canContainData));
                 } else {
-                    roles.add(new DiscoveryNodeRole.UnknownRole(roleName, roleNameAbbreviation, in.readBoolean()));
+                    roles.add(new DiscoveryNodeRole.UnknownRole(roleName, roleNameAbbreviation, canContainData));
                 }
             } else {
                 assert roleName.equals(role.roleName()) : "role name [" + roleName + "] does not match role [" + role.roleName() + "]";

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodes.java
@@ -35,7 +35,6 @@ package org.opensearch.cluster.node;
 import com.carrotsearch.hppc.ObjectHashSet;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.cluster.AbstractDiffable;
 import org.opensearch.cluster.Diff;
@@ -279,18 +278,6 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
     public boolean nodeExistsWithSameRoles(DiscoveryNode discoveryNode) {
         final DiscoveryNode existing = nodes.get(discoveryNode.getId());
         return existing != null && existing.equals(discoveryNode) && existing.getRoles().equals(discoveryNode.getRoles());
-    }
-
-    /**
-     * Determine if the given node exists and has the right version. During upgrade from Elasticsearch version as OpenSearch node run in
-     * BWC mode and can have the version as 7.10.2 in cluster state from older cluster-manager to OpenSearch cluster-manager.
-     */
-    public boolean nodeExistsWithBWCVersion(DiscoveryNode discoveryNode) {
-        final DiscoveryNode existing = nodes.get(discoveryNode.getId());
-        return existing != null
-            && existing.equals(discoveryNode)
-            && existing.getVersion().equals(LegacyESVersion.V_7_10_2)
-            && discoveryNode.getVersion().onOrAfter(Version.V_1_0_0);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/query/InnerHitBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/InnerHitBuilder.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.index.query;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.ParsingException;
@@ -207,11 +206,8 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
         }
         highlightBuilder = in.readOptionalWriteable(HighlightBuilder::new);
         this.innerCollapseBuilder = in.readOptionalWriteable(CollapseBuilder::new);
-
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            if (in.readBoolean()) {
-                fetchFields = in.readList(FieldAndFormat::new);
-            }
+        if (in.readBoolean()) {
+            fetchFields = in.readList(FieldAndFormat::new);
         }
     }
 
@@ -251,12 +247,9 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
         }
         out.writeOptionalWriteable(highlightBuilder);
         out.writeOptionalWriteable(innerCollapseBuilder);
-
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeBoolean(fetchFields != null);
-            if (fetchFields != null) {
-                out.writeList(fetchFields);
-            }
+        out.writeBoolean(fetchFields != null);
+        if (fetchFields != null) {
+            out.writeList(fetchFields);
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/query/MatchPhrasePrefixQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/MatchPhrasePrefixQueryBuilder.java
@@ -34,7 +34,6 @@ package org.opensearch.index.query;
 
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.Query;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.io.stream.StreamInput;
@@ -91,9 +90,7 @@ public class MatchPhrasePrefixQueryBuilder extends AbstractQueryBuilder<MatchPhr
         slop = in.readVInt();
         maxExpansions = in.readVInt();
         analyzer = in.readOptionalString();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            this.zeroTermsQuery = ZeroTermsQuery.readFromStream(in);
-        }
+        this.zeroTermsQuery = ZeroTermsQuery.readFromStream(in);
     }
 
     @Override
@@ -103,9 +100,7 @@ public class MatchPhrasePrefixQueryBuilder extends AbstractQueryBuilder<MatchPhr
         out.writeVInt(slop);
         out.writeVInt(maxExpansions);
         out.writeOptionalString(analyzer);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            zeroTermsQuery.writeTo(out);
-        }
+        zeroTermsQuery.writeTo(out);
     }
 
     /** Returns the field name used in this query. */

--- a/server/src/main/java/org/opensearch/index/query/PrefixQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/PrefixQueryBuilder.java
@@ -36,7 +36,6 @@ import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.Strings;
@@ -98,9 +97,7 @@ public class PrefixQueryBuilder extends AbstractQueryBuilder<PrefixQueryBuilder>
         fieldName = in.readString();
         value = in.readString();
         rewrite = in.readOptionalString();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            caseInsensitive = in.readBoolean();
-        }
+        caseInsensitive = in.readBoolean();
     }
 
     @Override
@@ -108,9 +105,7 @@ public class PrefixQueryBuilder extends AbstractQueryBuilder<PrefixQueryBuilder>
         out.writeString(fieldName);
         out.writeString(value);
         out.writeOptionalString(rewrite);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeBoolean(caseInsensitive);
-        }
+        out.writeBoolean(caseInsensitive);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/query/RegexpQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/RegexpQueryBuilder.java
@@ -38,7 +38,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.Strings;
@@ -112,9 +111,7 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
         syntaxFlagsValue = in.readVInt();
         maxDeterminizedStates = in.readVInt();
         rewrite = in.readOptionalString();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            caseInsensitive = in.readBoolean();
-        }
+        caseInsensitive = in.readBoolean();
     }
 
     @Override
@@ -124,9 +121,7 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
         out.writeVInt(syntaxFlagsValue);
         out.writeVInt(maxDeterminizedStates);
         out.writeOptionalString(rewrite);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeBoolean(caseInsensitive);
-        }
+        out.writeBoolean(caseInsensitive);
     }
 
     /** Returns the field name used in this query. */

--- a/server/src/main/java/org/opensearch/index/query/TermQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/TermQueryBuilder.java
@@ -35,7 +35,6 @@ package org.opensearch.index.query;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.io.stream.StreamInput;
@@ -112,17 +111,13 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
      */
     public TermQueryBuilder(StreamInput in) throws IOException {
         super(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            caseInsensitive = in.readBoolean();
-        }
+        caseInsensitive = in.readBoolean();
     }
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         super.doWriteTo(out);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeBoolean(caseInsensitive);
-        }
+        out.writeBoolean(caseInsensitive);
     }
 
     public static TermQueryBuilder fromXContent(XContentParser parser) throws IOException {

--- a/server/src/main/java/org/opensearch/index/query/WildcardQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/WildcardQueryBuilder.java
@@ -36,7 +36,6 @@ import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.Strings;
@@ -109,9 +108,7 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
         fieldName = in.readString();
         value = in.readString();
         rewrite = in.readOptionalString();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            caseInsensitive = in.readBoolean();
-        }
+        caseInsensitive = in.readBoolean();
     }
 
     @Override
@@ -119,9 +116,7 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
         out.writeString(fieldName);
         out.writeString(value);
         out.writeOptionalString(rewrite);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeBoolean(caseInsensitive);
-        }
+        out.writeBoolean(caseInsensitive);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/stats/IndexingPressureStats.java
+++ b/server/src/main/java/org/opensearch/index/stats/IndexingPressureStats.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.index.stats;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -77,12 +76,7 @@ public class IndexingPressureStats implements Writeable, ToXContentFragment {
         coordinatingRejections = in.readVLong();
         primaryRejections = in.readVLong();
         replicaRejections = in.readVLong();
-
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            memoryLimit = in.readVLong();
-        } else {
-            memoryLimit = -1L;
-        }
+        memoryLimit = in.readVLong();
     }
 
     public IndexingPressureStats(
@@ -128,10 +122,7 @@ public class IndexingPressureStats implements Writeable, ToXContentFragment {
         out.writeVLong(coordinatingRejections);
         out.writeVLong(primaryRejections);
         out.writeVLong(replicaRejections);
-
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeVLong(memoryLimit);
-        }
+        out.writeVLong(memoryLimit);
     }
 
     public long getTotalCombinedCoordinatingAndPrimaryBytes() {

--- a/server/src/main/java/org/opensearch/monitor/fs/FsInfo.java
+++ b/server/src/main/java/org/opensearch/monitor/fs/FsInfo.java
@@ -32,8 +32,6 @@
 
 package org.opensearch.monitor.fs;
 
-import org.opensearch.LegacyESVersion;
-import org.opensearch.cluster.DiskUsage;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -469,10 +467,6 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
             paths[i] = new Path(in);
         }
         this.total = total();
-        if (in.getVersion().before(LegacyESVersion.V_7_10_0)) {
-            in.readOptionalWriteable(DiskUsage::new); // previously leastDiskEstimate
-            in.readOptionalWriteable(DiskUsage::new); // previously mostDiskEstimate
-        }
     }
 
     @Override
@@ -482,10 +476,6 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
         out.writeVInt(paths.length);
         for (Path path : paths) {
             path.writeTo(out);
-        }
-        if (out.getVersion().before(LegacyESVersion.V_7_10_0)) {
-            out.writeOptionalWriteable(null); // previously leastDiskEstimate
-            out.writeOptionalWriteable(null); // previously mostDiskEstimate
         }
     }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilder.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.search.aggregations.bucket.histogram;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.Rounding;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -186,9 +185,7 @@ public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuil
         dateHistogramInterval = new DateIntervalWrapper(in);
         offset = in.readLong();
         extendedBounds = in.readOptionalWriteable(LongBounds::new);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            hardBounds = in.readOptionalWriteable(LongBounds::new);
-        }
+        hardBounds = in.readOptionalWriteable(LongBounds::new);
     }
 
     @Override
@@ -204,9 +201,7 @@ public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuil
         dateHistogramInterval.writeTo(out);
         out.writeLong(offset);
         out.writeOptionalWriteable(extendedBounds);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeOptionalWriteable(hardBounds);
-        }
+        out.writeOptionalWriteable(hardBounds);
     }
 
     /** Get the current interval in milliseconds that is set on this builder. */

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/HistogramAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/HistogramAggregationBuilder.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.search.aggregations.bucket.histogram;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -165,18 +164,8 @@ public class HistogramAggregationBuilder extends ValuesSourceAggregationBuilder<
         minDocCount = in.readVLong();
         interval = in.readDouble();
         offset = in.readDouble();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            extendedBounds = in.readOptionalWriteable(DoubleBounds::new);
-            hardBounds = in.readOptionalWriteable(DoubleBounds::new);
-        } else {
-            double minBound = in.readDouble();
-            double maxBound = in.readDouble();
-            if (minBound == Double.POSITIVE_INFINITY && maxBound == Double.NEGATIVE_INFINITY) {
-                extendedBounds = null;
-            } else {
-                extendedBounds = new DoubleBounds(minBound, maxBound);
-            }
-        }
+        extendedBounds = in.readOptionalWriteable(DoubleBounds::new);
+        hardBounds = in.readOptionalWriteable(DoubleBounds::new);
     }
 
     @Override
@@ -186,18 +175,8 @@ public class HistogramAggregationBuilder extends ValuesSourceAggregationBuilder<
         out.writeVLong(minDocCount);
         out.writeDouble(interval);
         out.writeDouble(offset);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeOptionalWriteable(extendedBounds);
-            out.writeOptionalWriteable(hardBounds);
-        } else {
-            if (extendedBounds != null) {
-                out.writeDouble(extendedBounds.getMin());
-                out.writeDouble(extendedBounds.getMax());
-            } else {
-                out.writeDouble(Double.POSITIVE_INFINITY);
-                out.writeDouble(Double.NEGATIVE_INFINITY);
-            }
-        }
+        out.writeOptionalWriteable(extendedBounds);
+        out.writeOptionalWriteable(hardBounds);
     }
 
     /** Get the current interval that is set on this builder. */

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalTerms.java
@@ -32,7 +32,6 @@
 package org.opensearch.search.aggregations.bucket.terms;
 
 import org.apache.lucene.util.PriorityQueue;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -255,20 +254,14 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
     protected InternalTerms(StreamInput in) throws IOException {
         super(in);
         reduceOrder = InternalOrder.Streams.readOrder(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            order = InternalOrder.Streams.readOrder(in);
-        } else {
-            order = reduceOrder;
-        }
+        order = InternalOrder.Streams.readOrder(in);
         requiredSize = readSize(in);
         minDocCount = in.readVLong();
     }
 
     @Override
     protected final void doWriteTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            reduceOrder.writeTo(out);
-        }
+        reduceOrder.writeTo(out);
         order.writeTo(out);
         writeSize(requiredSize, out);
         out.writeVLong(minDocCount);
@@ -437,7 +430,7 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
 
         final List<B> reducedBuckets;
         /**
-         * Buckets returned by a partial reduce or a shard response are sorted by key since {@link LegacyESVersion#V_7_10_0}.
+         * Buckets returned by a partial reduce or a shard response are sorted by key.
          * That allows to perform a merge sort when reducing multiple aggregations together.
          * For backward compatibility, we disable the merge sort and use ({@link InternalTerms#reduceLegacy} if any of
          * the provided aggregations use a different {@link InternalTerms#reduceOrder}.

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.search.aggregations.metrics;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.Strings;
@@ -163,11 +162,8 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
         trackScores = in.readBoolean();
         version = in.readBoolean();
         seqNoAndPrimaryTerm = in.readBoolean();
-
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            if (in.readBoolean()) {
-                fetchFields = in.readList(FieldAndFormat::new);
-            }
+        if (in.readBoolean()) {
+            fetchFields = in.readList(FieldAndFormat::new);
         }
     }
 
@@ -197,12 +193,9 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
         out.writeBoolean(trackScores);
         out.writeBoolean(version);
         out.writeBoolean(seqNoAndPrimaryTerm);
-
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeBoolean(fetchFields != null);
-            if (fetchFields != null) {
-                out.writeList(fetchFields);
-            }
+        out.writeBoolean(fetchFields != null);
+        if (fetchFields != null) {
+            out.writeList(fetchFields);
         }
     }
 

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.search.builder;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchException;
 import org.opensearch.common.Booleans;
 import org.opensearch.common.Nullable;
@@ -261,14 +260,10 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         sliceBuilder = in.readOptionalWriteable(SliceBuilder::new);
         collapse = in.readOptionalWriteable(CollapseBuilder::new);
         trackTotalHitsUpTo = in.readOptionalInt();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            if (in.readBoolean()) {
-                fetchFields = in.readList(FieldAndFormat::new);
-            }
+        if (in.readBoolean()) {
+            fetchFields = in.readList(FieldAndFormat::new);
         }
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            pointInTimeBuilder = in.readOptionalWriteable(PointInTimeBuilder::new);
-        }
+        pointInTimeBuilder = in.readOptionalWriteable(PointInTimeBuilder::new);
     }
 
     @Override
@@ -323,15 +318,11 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         out.writeOptionalWriteable(sliceBuilder);
         out.writeOptionalWriteable(collapse);
         out.writeOptionalInt(trackTotalHitsUpTo);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeBoolean(fetchFields != null);
-            if (fetchFields != null) {
-                out.writeList(fetchFields);
-            }
+        out.writeBoolean(fetchFields != null);
+        if (fetchFields != null) {
+            out.writeList(fetchFields);
         }
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeOptionalWriteable(pointInTimeBuilder);
-        }
+        out.writeOptionalWriteable(pointInTimeBuilder);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/dfs/DfsSearchResult.java
+++ b/server/src/main/java/org/opensearch/search/dfs/DfsSearchResult.java
@@ -38,7 +38,6 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.CollectionStatistics;
 import org.apache.lucene.search.TermStatistics;
 import org.apache.lucene.util.BytesRef;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.collect.HppcMaps;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -79,9 +78,7 @@ public class DfsSearchResult extends SearchPhaseResult {
         fieldStatistics = readFieldStats(in);
 
         maxDoc = in.readVInt();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            setShardSearchRequest(in.readOptionalWriteable(ShardSearchRequest::new));
-        }
+        setShardSearchRequest(in.readOptionalWriteable(ShardSearchRequest::new));
     }
 
     public DfsSearchResult(ShardSearchContextId contextId, SearchShardTarget shardTarget, ShardSearchRequest shardSearchRequest) {
@@ -133,9 +130,7 @@ public class DfsSearchResult extends SearchPhaseResult {
         writeTermStats(out, termStatistics);
         writeFieldStats(out, fieldStatistics);
         out.writeVInt(maxDoc);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeOptionalWriteable(getShardSearchRequest());
-        }
+        out.writeOptionalWriteable(getShardSearchRequest());
     }
 
     public static void writeFieldStats(StreamOutput out, ObjectObjectHashMap<String, CollectionStatistics> fieldStatistics)

--- a/server/src/main/java/org/opensearch/search/fetch/ShardFetchSearchRequest.java
+++ b/server/src/main/java/org/opensearch/search/fetch/ShardFetchSearchRequest.java
@@ -34,7 +34,6 @@ package org.opensearch.search.fetch;
 
 import com.carrotsearch.hppc.IntArrayList;
 import org.apache.lucene.search.ScoreDoc;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.IndicesRequest;
 import org.opensearch.action.OriginalIndices;
 import org.opensearch.action.support.IndicesOptions;
@@ -79,26 +78,18 @@ public class ShardFetchSearchRequest extends ShardFetchRequest implements Indice
     public ShardFetchSearchRequest(StreamInput in) throws IOException {
         super(in);
         originalIndices = OriginalIndices.readOriginalIndices(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            shardSearchRequest = in.readOptionalWriteable(ShardSearchRequest::new);
-            rescoreDocIds = new RescoreDocIds(in);
-            aggregatedDfs = in.readOptionalWriteable(AggregatedDfs::new);
-        } else {
-            shardSearchRequest = null;
-            rescoreDocIds = RescoreDocIds.EMPTY;
-            aggregatedDfs = null;
-        }
+        shardSearchRequest = in.readOptionalWriteable(ShardSearchRequest::new);
+        rescoreDocIds = new RescoreDocIds(in);
+        aggregatedDfs = in.readOptionalWriteable(AggregatedDfs::new);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         OriginalIndices.writeOriginalIndices(originalIndices, out);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeOptionalWriteable(shardSearchRequest);
-            rescoreDocIds.writeTo(out);
-            out.writeOptionalWriteable(aggregatedDfs);
-        }
+        out.writeOptionalWriteable(shardSearchRequest);
+        rescoreDocIds.writeTo(out);
+        out.writeOptionalWriteable(aggregatedDfs);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/opensearch/search/internal/ShardSearchRequest.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.search.internal;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.IndicesRequest;
 import org.opensearch.action.OriginalIndices;
@@ -263,13 +262,8 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
         preference = in.readOptionalString();
         canReturnNullResponseIfMatchNoDocs = in.readBoolean();
         bottomSortValues = in.readOptionalWriteable(SearchSortValuesAndFormats::new);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            this.readerId = in.readOptionalWriteable(ShardSearchContextId::new);
-            this.keepAlive = in.readOptionalTimeValue();
-        } else {
-            this.readerId = null;
-            this.keepAlive = null;
-        }
+        readerId = in.readOptionalWriteable(ShardSearchContextId::new);
+        keepAlive = in.readOptionalTimeValue();
         originalIndices = OriginalIndices.readOriginalIndices(in);
         assert keepAlive == null || readerId != null : "readerId: " + readerId + " keepAlive: " + keepAlive;
     }

--- a/server/src/main/java/org/opensearch/search/query/QuerySearchRequest.java
+++ b/server/src/main/java/org/opensearch/search/query/QuerySearchRequest.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.search.query;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.IndicesRequest;
 import org.opensearch.action.OriginalIndices;
 import org.opensearch.action.search.SearchShardTask;
@@ -80,11 +79,7 @@ public class QuerySearchRequest extends TransportRequest implements IndicesReque
         contextId = new ShardSearchContextId(in);
         dfs = new AggregatedDfs(in);
         originalIndices = OriginalIndices.readOriginalIndices(in);
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            this.shardSearchRequest = in.readOptionalWriteable(ShardSearchRequest::new);
-        } else {
-            this.shardSearchRequest = null;
-        }
+        shardSearchRequest = in.readOptionalWriteable(ShardSearchRequest::new);
     }
 
     @Override
@@ -93,9 +88,7 @@ public class QuerySearchRequest extends TransportRequest implements IndicesReque
         contextId.writeTo(out);
         dfs.writeTo(out);
         OriginalIndices.writeOriginalIndices(originalIndices, out);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeOptionalWriteable(shardSearchRequest);
-        }
+        out.writeOptionalWriteable(shardSearchRequest);
     }
 
     public ShardSearchContextId contextId() {

--- a/server/src/main/java/org/opensearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/opensearch/transport/TransportHandshaker.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.transport;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -130,16 +129,7 @@ final class TransportHandshaker {
                     + "]; resetting"
             );
         }
-        // 1. if remote node is 7.x, then StreamInput version would be 6.8.0
-        // 2. if remote node is 6.8 then it would be 5.6.0
-        // 3. if remote node is OpenSearch 1.x then it would be 6.7.99
-        if ((this.version.onOrAfter(Version.V_1_0_0) && this.version.before(Version.V_3_0_0))
-            && (stream.getVersion().equals(LegacyESVersion.fromId(6080099)) || stream.getVersion().equals(Version.fromId(5060099)))) {
-            // send 7.10.2 in response to ensure compatibility w/ Legacy 7.10.x nodes for rolling upgrade support
-            channel.sendResponse(new HandshakeResponse(LegacyESVersion.V_7_10_2));
-        } else {
-            channel.sendResponse(new HandshakeResponse(this.version));
-        }
+        channel.sendResponse(new HandshakeResponse(this.version));
     }
 
     TransportResponseHandler<HandshakeResponse> removeHandlerForHandshake(long requestId) {

--- a/server/src/main/java/org/opensearch/transport/TransportService.java
+++ b/server/src/main/java/org/opensearch/transport/TransportService.java
@@ -35,7 +35,6 @@ package org.opensearch.transport;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionListenerResponseHandler;
@@ -612,22 +611,14 @@ public class TransportService extends AbstractLifecycleComponent
             super(in);
             discoveryNode = in.readOptionalWriteable(DiscoveryNode::new);
             clusterName = new ClusterName(in);
-            Version tmpVersion = Version.readVersion(in);
-            if (in.getVersion().onOrBefore(LegacyESVersion.V_7_10_2)) {
-                tmpVersion = LegacyESVersion.V_7_10_2;
-            }
-            version = tmpVersion;
+            version = Version.readVersion(in);
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeOptionalWriteable(discoveryNode);
             clusterName.writeTo(out);
-            if (out.getVersion().before(Version.V_1_0_0)) {
-                Version.writeVersion(LegacyESVersion.V_7_10_2, out);
-            } else {
-                Version.writeVersion(version, out);
-            }
+            Version.writeVersion(version, out);
         }
 
         public DiscoveryNode getDiscoveryNode() {

--- a/server/src/main/java/org/opensearch/transport/TransportStats.java
+++ b/server/src/main/java/org/opensearch/transport/TransportStats.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.transport;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -67,11 +66,7 @@ public class TransportStats implements Writeable, ToXContentFragment {
 
     public TransportStats(StreamInput in) throws IOException {
         serverOpen = in.readVLong();
-        if (in.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            totalOutboundConnections = in.readVLong();
-        } else {
-            totalOutboundConnections = 0L;
-        }
+        totalOutboundConnections = in.readVLong();
         rxCount = in.readVLong();
         rxSize = in.readVLong();
         txCount = in.readVLong();
@@ -81,9 +76,7 @@ public class TransportStats implements Writeable, ToXContentFragment {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(serverOpen);
-        if (out.getVersion().onOrAfter(LegacyESVersion.V_7_10_0)) {
-            out.writeVLong(totalOutboundConnections);
-        }
+        out.writeVLong(totalOutboundConnections);
         out.writeVLong(rxCount);
         out.writeVLong(rxSize);
         out.writeVLong(txCount);

--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodesTests.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodesTests.java
@@ -501,35 +501,6 @@ public class DiscoveryNodesTests extends OpenSearchTestCase {
         assertEquals(LegacyESVersion.fromString("5.1.0"), build.getMinNodeVersion());
     }
 
-    public void testNodeExistsWithBWCVersion() {
-        DiscoveryNodes.Builder discoBuilder = DiscoveryNodes.builder();
-        DiscoveryNode node_1 = new DiscoveryNode(
-            "name_" + 1,
-            "node_" + 1,
-            buildNewFakeTransportAddress(),
-            Collections.emptyMap(),
-            new HashSet<>(randomSubsetOf(DiscoveryNodeRole.BUILT_IN_ROLES)),
-            LegacyESVersion.fromString("7.10.2")
-        );
-        DiscoveryNode node_2 = new DiscoveryNode(
-            "name_" + 2,
-            "node_" + 2,
-            buildNewFakeTransportAddress(),
-            Collections.emptyMap(),
-            new HashSet<>(randomSubsetOf(DiscoveryNodeRole.BUILT_IN_ROLES)),
-            LegacyESVersion.fromString("7.9.0")
-        );
-        discoBuilder.add(node_1);
-        discoBuilder.add(node_2);
-
-        discoBuilder.localNodeId("name_1");
-        discoBuilder.clusterManagerNodeId("name_2");
-        DiscoveryNodes build = discoBuilder.build();
-        assertTrue(build.nodeExistsWithBWCVersion(buildDiscoveryNodeFromExisting(node_1, Version.CURRENT)));
-        assertFalse(build.nodeExistsWithBWCVersion(buildDiscoveryNodeFromExisting(node_2, LegacyESVersion.fromString("7.10.2"))));
-        assertFalse(build.nodeExistsWithBWCVersion(buildDiscoveryNodeFromExisting(node_1, LegacyESVersion.fromString("6.8.0"))));
-    }
-
     private DiscoveryNode buildDiscoveryNodeFromExisting(DiscoveryNode existing, Version newVersion) {
         return new DiscoveryNode(
             existing.getName(),


### PR DESCRIPTION
Removes all usages of LegacyESVersion.V_7_10_ version constants along with ancient API logic.

closes #2747