### PR TITLE
[Remove] Version.V_1_ constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Remove LegacyESVersion.V_7_8_ and V_7_9_ Constants ([#4855](https://github.com/opensearch-project/OpenSearch/pull/4855))
 - Remove LegacyESVersion.V_7_6_ and V_7_7_ Constants ([#4837](https://github.com/opensearch-project/OpenSearch/pull/4837))
 - Remove LegacyESVersion.V_7_10_ Constants ([#5018](https://github.com/opensearch-project/OpenSearch/pull/5018))
+- Remove Version.V_1_ Constants ([#5021](https://github.com/opensearch-project/OpenSearch/pull/5021))
 
 ### Fixed
 - `opensearch-service.bat start` and `opensearch-service.bat manager` failing to run ([#4289](https://github.com/opensearch-project/OpenSearch/pull/4289))

--- a/client/rest-high-level/src/test/java/org/opensearch/client/core/MainResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/core/MainResponseTests.java
@@ -46,21 +46,16 @@ import java.util.Date;
 import static org.hamcrest.Matchers.equalTo;
 
 public class MainResponseTests extends AbstractResponseTestCase<org.opensearch.action.main.MainResponse, MainResponse> {
+    private static String DISTRIBUTION = "opensearch";
+
     @Override
     protected org.opensearch.action.main.MainResponse createServerTestInstance(XContentType xContentType) {
         String clusterUuid = randomAlphaOfLength(10);
         ClusterName clusterName = new ClusterName(randomAlphaOfLength(10));
         String nodeName = randomAlphaOfLength(10);
         final String date = new Date(randomNonNegativeLong()).toString();
-        Version version = VersionUtils.randomVersionBetween(random(), Version.V_1_0_0, Version.CURRENT);
-        Build build = new Build(
-            Build.Type.UNKNOWN,
-            randomAlphaOfLength(8),
-            date,
-            randomBoolean(),
-            version.toString(),
-            version.before(Version.V_1_0_0) ? null : "opensearch"
-        );
+        Version version = VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.CURRENT);
+        Build build = new Build(Build.Type.UNKNOWN, randomAlphaOfLength(8), date, randomBoolean(), version.toString(), DISTRIBUTION);
         return new org.opensearch.action.main.MainResponse(nodeName, version, clusterName, clusterUuid, build);
     }
 

--- a/modules/analysis-common/src/test/java/org/opensearch/analysis/common/EdgeNGramTokenizerTests.java
+++ b/modules/analysis-common/src/test/java/org/opensearch/analysis/common/EdgeNGramTokenizerTests.java
@@ -83,7 +83,7 @@ public class EdgeNGramTokenizerTests extends OpenSearchTokenStreamTestCase {
         {
             try (
                 IndexAnalyzers indexAnalyzers = buildAnalyzers(
-                    VersionUtils.randomVersionBetween(random(), Version.V_1_0_0, VersionUtils.getPreviousVersion(Version.V_3_0_0)),
+                    VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, VersionUtils.getPreviousVersion(Version.V_3_0_0)),
                     "edgeNGram"
                 )
             ) {

--- a/modules/analysis-common/src/test/java/org/opensearch/analysis/common/SynonymsAnalysisTests.java
+++ b/modules/analysis-common/src/test/java/org/opensearch/analysis/common/SynonymsAnalysisTests.java
@@ -230,7 +230,7 @@ public class SynonymsAnalysisTests extends OpenSearchTestCase {
     public void testShingleFilters() {
 
         Settings settings = Settings.builder()
-            .put(IndexMetadata.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_1_0_0, Version.CURRENT))
+            .put(IndexMetadata.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.CURRENT))
             .put("path.home", createTempDir().toString())
             .put("index.analysis.filter.synonyms.type", "synonym")
             .putList("index.analysis.filter.synonyms.synonyms", "programmer, developer")
@@ -289,7 +289,7 @@ public class SynonymsAnalysisTests extends OpenSearchTestCase {
         );
 
         Settings settings = Settings.builder()
-            .put(IndexMetadata.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_1_0_0, Version.CURRENT))
+            .put(IndexMetadata.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.CURRENT))
             .put("path.home", createTempDir().toString())
             .build();
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", settings);
@@ -313,7 +313,7 @@ public class SynonymsAnalysisTests extends OpenSearchTestCase {
     public void testDisallowedTokenFilters() throws IOException {
 
         Settings settings = Settings.builder()
-            .put(IndexMetadata.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_1_0_0, Version.CURRENT))
+            .put(IndexMetadata.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.CURRENT))
             .put("path.home", createTempDir().toString())
             .putList("common_words", "a", "b")
             .put("output_unigrams", "true")

--- a/plugins/analysis-phonetic/src/test/java/org/opensearch/index/analysis/AnalysisPhoneticFactoryTests.java
+++ b/plugins/analysis-phonetic/src/test/java/org/opensearch/index/analysis/AnalysisPhoneticFactoryTests.java
@@ -64,7 +64,7 @@ public class AnalysisPhoneticFactoryTests extends AnalysisFactoryTestCase {
         AnalysisPhoneticPlugin plugin = new AnalysisPhoneticPlugin();
 
         Settings settings = Settings.builder()
-            .put(IndexMetadata.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_1_0_0, Version.CURRENT))
+            .put(IndexMetadata.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.CURRENT))
             .put("path.home", createTempDir().toString())
             .build();
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", settings);

--- a/server/src/main/java/org/opensearch/Version.java
+++ b/server/src/main/java/org/opensearch/Version.java
@@ -75,20 +75,6 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final int V_EMPTY_ID = 0;
     public static final Version V_EMPTY = new Version(V_EMPTY_ID, org.apache.lucene.util.Version.LATEST);
 
-    public static final Version V_1_0_0 = new Version(1000099, org.apache.lucene.util.Version.LUCENE_8_8_2);
-    public static final Version V_1_1_0 = new Version(1010099, org.apache.lucene.util.Version.LUCENE_8_9_0);
-    public static final Version V_1_2_0 = new Version(1020099, org.apache.lucene.util.Version.LUCENE_8_10_1);
-    public static final Version V_1_2_1 = new Version(1020199, org.apache.lucene.util.Version.LUCENE_8_10_1);
-    public static final Version V_1_2_2 = new Version(1020299, org.apache.lucene.util.Version.LUCENE_8_10_1);
-    public static final Version V_1_2_3 = new Version(1020399, org.apache.lucene.util.Version.LUCENE_8_10_1);
-    public static final Version V_1_2_4 = new Version(1020499, org.apache.lucene.util.Version.LUCENE_8_10_1);
-    public static final Version V_1_2_5 = new Version(1020599, org.apache.lucene.util.Version.LUCENE_8_10_1);
-    public static final Version V_1_3_0 = new Version(1030099, org.apache.lucene.util.Version.LUCENE_8_10_1);
-    public static final Version V_1_3_1 = new Version(1030199, org.apache.lucene.util.Version.LUCENE_8_10_1);
-    public static final Version V_1_3_2 = new Version(1030299, org.apache.lucene.util.Version.LUCENE_8_10_1);
-    public static final Version V_1_3_3 = new Version(1030399, org.apache.lucene.util.Version.LUCENE_8_10_1);
-    public static final Version V_1_3_4 = new Version(1030499, org.apache.lucene.util.Version.LUCENE_8_10_1);
-    public static final Version V_1_3_5 = new Version(1030599, org.apache.lucene.util.Version.LUCENE_8_10_1);
     public static final Version V_2_0_0 = new Version(2000099, org.apache.lucene.util.Version.LUCENE_9_1_0);
     public static final Version V_2_0_1 = new Version(2000199, org.apache.lucene.util.Version.LUCENE_9_1_0);
     public static final Version V_2_0_2 = new Version(2000299, org.apache.lucene.util.Version.LUCENE_9_1_0);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.action.admin.cluster.node.stats;
 
-import org.opensearch.Version;
 import org.opensearch.action.support.nodes.BaseNodeResponse;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
@@ -141,12 +140,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
             scriptCacheStats = scriptStats.toScriptCacheStats();
         }
         indexingPressureStats = in.readOptionalWriteable(IndexingPressureStats::new);
-        if (in.getVersion().onOrAfter(Version.V_1_2_0)) {
-            shardIndexingPressureStats = in.readOptionalWriteable(ShardIndexingPressureStats::new);
-        } else {
-            shardIndexingPressureStats = null;
-        }
-
+        shardIndexingPressureStats = in.readOptionalWriteable(ShardIndexingPressureStats::new);
     }
 
     public NodeStats(
@@ -319,9 +313,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         out.writeOptionalWriteable(ingestStats);
         out.writeOptionalWriteable(adaptiveSelectionStats);
         out.writeOptionalWriteable(indexingPressureStats);
-        if (out.getVersion().onOrAfter(Version.V_1_2_0)) {
-            out.writeOptionalWriteable(shardIndexingPressureStats);
-        }
+        out.writeOptionalWriteable(shardIndexingPressureStats);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -87,10 +87,8 @@ public class CommonStatsFlags implements Writeable, Cloneable {
         completionDataFields = in.readStringArray();
         includeSegmentFileSizes = in.readBoolean();
         includeUnloadedSegments = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.V_1_2_0)) {
-            includeAllShardIndexingPressureTrackers = in.readBoolean();
-            includeOnlyTopIndexingPressureMetrics = in.readBoolean();
-        }
+        includeAllShardIndexingPressureTrackers = in.readBoolean();
+        includeOnlyTopIndexingPressureMetrics = in.readBoolean();
     }
 
     @Override
@@ -109,10 +107,8 @@ public class CommonStatsFlags implements Writeable, Cloneable {
         out.writeStringArrayNullable(completionDataFields);
         out.writeBoolean(includeSegmentFileSizes);
         out.writeBoolean(includeUnloadedSegments);
-        if (out.getVersion().onOrAfter(Version.V_1_2_0)) {
-            out.writeBoolean(includeAllShardIndexingPressureTrackers);
-            out.writeBoolean(includeOnlyTopIndexingPressureMetrics);
-        }
+        out.writeBoolean(includeAllShardIndexingPressureTrackers);
+        out.writeBoolean(includeOnlyTopIndexingPressureMetrics);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequest.java
@@ -247,10 +247,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
             finalReduce = true;
         }
         ccsMinimizeRoundtrips = in.readBoolean();
-
-        if (in.getVersion().onOrAfter(Version.V_1_1_0)) {
-            cancelAfterTimeInterval = in.readOptionalTimeValue();
-        }
+        cancelAfterTimeInterval = in.readOptionalTimeValue();
     }
 
     @Override
@@ -278,10 +275,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
             out.writeBoolean(finalReduce);
         }
         out.writeBoolean(ccsMinimizeRoundtrips);
-
-        if (out.getVersion().onOrAfter(Version.V_1_1_0)) {
-            out.writeOptionalTimeValue(cancelAfterTimeInterval);
-        }
+        out.writeOptionalTimeValue(cancelAfterTimeInterval);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/coordination/JoinTaskExecutor.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/JoinTaskExecutor.java
@@ -312,37 +312,6 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
             // this logic is only applicable when OpenSearch node is cluster-manager and is noop for zen discovery node
             return;
         }
-        if (currentNodes.getMinNodeVersion().before(Version.V_1_0_0)) {
-            Map<String, Version> channelVersions = transportService.getChannelVersion(currentNodes);
-            for (DiscoveryNode node : currentNodes) {
-                if (channelVersions.containsKey(node.getId())) {
-                    if (channelVersions.get(node.getId()) != node.getVersion()) {
-                        DiscoveryNode tmpNode = nodesBuilder.get(node.getId());
-                        nodesBuilder.remove(node.getId());
-                        nodesBuilder.add(
-                            new DiscoveryNode(
-                                tmpNode.getName(),
-                                tmpNode.getId(),
-                                tmpNode.getEphemeralId(),
-                                tmpNode.getHostName(),
-                                tmpNode.getHostAddress(),
-                                tmpNode.getAddress(),
-                                tmpNode.getAttributes(),
-                                tmpNode.getRoles(),
-                                channelVersions.get(tmpNode.getId())
-                            )
-                        );
-                        logger.info(
-                            "Refreshed the DiscoveryNode version for node {}:{} from {} to {}",
-                            node.getId(),
-                            node.getAddress(),
-                            node.getVersion(),
-                            channelVersions.get(tmpNode.getId())
-                        );
-                    }
-                }
-            }
-        }
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/health/ClusterStateHealth.java
+++ b/server/src/main/java/org/opensearch/cluster/health/ClusterStateHealth.java
@@ -31,7 +31,6 @@
 
 package org.opensearch.cluster.health;
 
-import org.opensearch.Version;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.IndexRoutingTable;
@@ -154,11 +153,7 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
         unassignedShards = in.readVInt();
         numberOfNodes = in.readVInt();
         numberOfDataNodes = in.readVInt();
-        if (in.getVersion().onOrAfter(Version.V_1_0_0)) {
-            hasDiscoveredClusterManager = in.readBoolean();
-        } else {
-            hasDiscoveredClusterManager = true;
-        }
+        hasDiscoveredClusterManager = in.readBoolean();
         status = ClusterHealthStatus.fromValue(in.readByte());
         int size = in.readVInt();
         indices = new HashMap<>(size);
@@ -262,9 +257,7 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
         out.writeVInt(unassignedShards);
         out.writeVInt(numberOfNodes);
         out.writeVInt(numberOfDataNodes);
-        if (out.getVersion().onOrAfter(Version.V_1_0_0)) {
-            out.writeBoolean(hasDiscoveredClusterManager);
-        }
+        out.writeBoolean(hasDiscoveredClusterManager);
         out.writeByte(status.value());
         out.writeVInt(indices.size());
         for (ClusterIndexHealth indexHealth : this) {

--- a/server/src/main/java/org/opensearch/cluster/metadata/ComposableIndexTemplate.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/ComposableIndexTemplate.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.cluster.metadata;
 
-import org.opensearch.Version;
 import org.opensearch.cluster.AbstractDiffable;
 import org.opensearch.cluster.Diff;
 import org.opensearch.cluster.metadata.DataStream.TimestampField;
@@ -312,11 +311,7 @@ public class ComposableIndexTemplate extends AbstractDiffable<ComposableIndexTem
         }
 
         public DataStreamTemplate(StreamInput in) throws IOException {
-            if (in.getVersion().onOrAfter(Version.V_1_0_0)) {
-                this.timestampField = in.readOptionalWriteable(TimestampField::new);
-            } else {
-                this.timestampField = DataStreamFieldMapper.Defaults.TIMESTAMP_FIELD;
-            }
+            this.timestampField = in.readOptionalWriteable(TimestampField::new);
         }
 
         public TimestampField getTimestampField() {
@@ -335,9 +330,7 @@ public class ComposableIndexTemplate extends AbstractDiffable<ComposableIndexTem
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if (out.getVersion().onOrAfter(Version.V_1_0_0)) {
-                out.writeOptionalWriteable(timestampField);
-            }
+            out.writeOptionalWriteable(timestampField);
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/index/query/IntervalsSourceProvider.java
+++ b/server/src/main/java/org/opensearch/index/query/IntervalsSourceProvider.java
@@ -41,7 +41,6 @@ import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
 import org.apache.lucene.util.automaton.RegExp;
-import org.opensearch.Version;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.io.stream.NamedWriteable;
@@ -154,15 +153,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         public Match(StreamInput in) throws IOException {
             this.query = in.readString();
             this.maxGaps = in.readVInt();
-            if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
-                this.mode = IntervalMode.readFromStream(in);
-            } else {
-                if (in.readBoolean()) {
-                    this.mode = IntervalMode.ORDERED;
-                } else {
-                    this.mode = IntervalMode.UNORDERED;
-                }
-            }
+            this.mode = IntervalMode.readFromStream(in);
             this.analyzer = in.readOptionalString();
             this.filter = in.readOptionalWriteable(IntervalFilter::new);
             this.useField = in.readOptionalString();
@@ -222,11 +213,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(query);
             out.writeVInt(maxGaps);
-            if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
-                mode.writeTo(out);
-            } else {
-                out.writeBoolean(mode == IntervalMode.ORDERED);
-            }
+            mode.writeTo(out);
             out.writeOptionalString(analyzer);
             out.writeOptionalWriteable(filter);
             out.writeOptionalString(useField);
@@ -442,11 +429,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         }
 
         public Combine(StreamInput in) throws IOException {
-            if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
-                this.mode = IntervalMode.readFromStream(in);
-            } else {
-                this.mode = in.readBoolean() ? IntervalMode.ORDERED : IntervalMode.UNORDERED;
-            }
+            this.mode = IntervalMode.readFromStream(in);
             this.subSources = in.readNamedWriteableList(IntervalsSourceProvider.class);
             this.maxGaps = in.readInt();
             this.filter = in.readOptionalWriteable(IntervalFilter::new);
@@ -495,11 +478,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
-                mode.writeTo(out);
-            } else {
-                out.writeBoolean(mode == IntervalMode.ORDERED);
-            }
+            mode.writeTo(out);
             out.writeNamedWriteableList(subSources);
             out.writeInt(maxGaps);
             out.writeOptionalWriteable(filter);
@@ -729,11 +708,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
             this.flags = in.readVInt();
             this.useField = in.readOptionalString();
             this.maxExpansions = in.readOptionalVInt();
-            if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
-                this.caseInsensitive = in.readBoolean();
-            } else {
-                this.caseInsensitive = false;
-            }
+            this.caseInsensitive = in.readBoolean();
         }
 
         @Override
@@ -803,9 +778,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
             out.writeVInt(flags);
             out.writeOptionalString(useField);
             out.writeOptionalVInt(maxExpansions);
-            if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
-                out.writeBoolean(caseInsensitive);
-            }
+            out.writeBoolean(caseInsensitive);
         }
 
         @Override
@@ -903,11 +876,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
             this.pattern = in.readString();
             this.analyzer = in.readOptionalString();
             this.useField = in.readOptionalString();
-            if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
-                this.maxExpansions = in.readOptionalVInt();
-            } else {
-                this.maxExpansions = null;
-            }
+            this.maxExpansions = in.readOptionalVInt();
         }
 
         @Override
@@ -976,9 +945,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
             out.writeString(pattern);
             out.writeOptionalString(analyzer);
             out.writeOptionalString(useField);
-            if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
-                out.writeOptionalVInt(maxExpansions);
-            }
+            out.writeOptionalVInt(maxExpansions);
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/index/query/functionscore/ScoreFunctionBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/ScoreFunctionBuilder.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.index.query.functionscore;
 
-import org.opensearch.Version;
 import org.opensearch.common.io.stream.NamedWriteable;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -65,17 +64,13 @@ public abstract class ScoreFunctionBuilder<FB extends ScoreFunctionBuilder<FB>> 
      */
     public ScoreFunctionBuilder(StreamInput in) throws IOException {
         weight = checkWeight(in.readOptionalFloat());
-        if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
-            functionName = in.readOptionalString();
-        }
+        functionName = in.readOptionalString();
     }
 
     @Override
     public final void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalFloat(weight);
-        if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
-            out.writeOptionalString(functionName);
-        }
+        out.writeOptionalString(functionName);
         doWriteTo(out);
     }
 

--- a/server/src/main/java/org/opensearch/monitor/jvm/JvmStats.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/JvmStats.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.monitor.jvm;
 
-import org.opensearch.Version;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -554,11 +553,7 @@ public class JvmStats implements Writeable, ToXContentFragment {
             max = in.readVLong();
             peakUsed = in.readVLong();
             peakMax = in.readVLong();
-            if (in.getVersion().onOrAfter(Version.V_1_2_0)) {
-                lastGcStats = new MemoryPoolGcStats(in);
-            } else {
-                lastGcStats = new MemoryPoolGcStats(0, 0);
-            }
+            lastGcStats = new MemoryPoolGcStats(in);
         }
 
         @Override
@@ -568,9 +563,7 @@ public class JvmStats implements Writeable, ToXContentFragment {
             out.writeVLong(max);
             out.writeVLong(peakUsed);
             out.writeVLong(peakMax);
-            if (out.getVersion().onOrAfter(Version.V_1_2_0)) {
-                lastGcStats.writeTo(out);
-            }
+            lastGcStats.writeTo(out);
         }
 
         public String getName() {

--- a/server/src/main/java/org/opensearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginInfo.java
@@ -157,13 +157,9 @@ public class PluginInfo implements Writeable, ToXContentObject {
         this.opensearchVersion = Version.readVersion(in);
         this.javaVersion = in.readString();
         this.classname = in.readString();
-        if (in.getVersion().onOrAfter(Version.V_1_1_0)) {
-            customFolderName = in.readString();
-        } else {
-            customFolderName = this.name;
-        }
-        extendedPlugins = in.readStringList();
-        hasNativeController = in.readBoolean();
+        this.customFolderName = in.readString();
+        this.extendedPlugins = in.readStringList();
+        this.hasNativeController = in.readBoolean();
     }
 
     @Override
@@ -174,12 +170,10 @@ public class PluginInfo implements Writeable, ToXContentObject {
         Version.writeVersion(opensearchVersion, out);
         out.writeString(javaVersion);
         out.writeString(classname);
-        if (out.getVersion().onOrAfter(Version.V_1_1_0)) {
-            if (customFolderName != null) {
-                out.writeString(customFolderName);
-            } else {
-                out.writeString(name);
-            }
+        if (customFolderName != null) {
+            out.writeString(customFolderName);
+        } else {
+            out.writeString(name);
         }
         out.writeStringCollection(extendedPlugins);
         out.writeBoolean(hasNativeController);
@@ -234,11 +228,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
 
         final String customFolderNameValue = propsMap.remove("custom.foldername");
         final String customFolderName;
-        if (opensearchVersion.onOrAfter(Version.V_1_1_0)) {
-            customFolderName = customFolderNameValue;
-        } else {
-            customFolderName = name;
-        }
+        customFolderName = customFolderNameValue;
 
         final String extendedString = propsMap.remove("extended.plugins");
         final List<String> extendedPlugins;

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/CompositeValuesSourceBuilder.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.search.aggregations.bucket.composite;
 
-import org.opensearch.Version;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -83,9 +82,7 @@ public abstract class CompositeValuesSourceBuilder<AB extends CompositeValuesSou
             this.userValueTypeHint = ValueType.readFromStream(in);
         }
         this.missingBucket = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
-            this.missingOrder = MissingOrder.readFromStream(in);
-        }
+        this.missingOrder = MissingOrder.readFromStream(in);
         this.order = SortOrder.readFromStream(in);
         this.format = in.readOptionalString();
     }
@@ -105,9 +102,7 @@ public abstract class CompositeValuesSourceBuilder<AB extends CompositeValuesSou
             userValueTypeHint.writeTo(out);
         }
         out.writeBoolean(missingBucket);
-        if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
-            missingOrder.writeTo(out);
-        }
+        missingOrder.writeTo(out);
         order.writeTo(out);
         out.writeOptionalString(format);
         innerWriteTo(out);

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -33,7 +33,6 @@
 package org.opensearch.search.aggregations.bucket.composite;
 
 import org.apache.lucene.util.BytesRef;
-import org.opensearch.Version;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -108,12 +107,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
             formats.add(in.readNamedWriteable(DocValueFormat.class));
         }
         this.reverseMuls = in.readIntArray();
-        if (in.getVersion().onOrAfter(Version.V_1_3_0)) {
-            this.missingOrders = in.readArray(MissingOrder::readFromStream, MissingOrder[]::new);
-        } else {
-            this.missingOrders = new MissingOrder[reverseMuls.length];
-            Arrays.fill(this.missingOrders, MissingOrder.DEFAULT);
-        }
+        this.missingOrders = in.readArray(MissingOrder::readFromStream, MissingOrder[]::new);
         this.buckets = in.readList((input) -> new InternalBucket(input, sourceNames, formats, reverseMuls, missingOrders));
         this.afterKey = in.readBoolean() ? new CompositeKey(in) : null;
         this.earlyTerminated = in.readBoolean();
@@ -127,9 +121,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
             out.writeNamedWriteable(format);
         }
         out.writeIntArray(reverseMuls);
-        if (out.getVersion().onOrAfter(Version.V_1_3_0)) {
-            out.writeArray((output, order) -> order.writeTo(output), missingOrders);
-        }
+        out.writeArray((output, order) -> order.writeTo(output), missingOrders);
         out.writeList(buckets);
         out.writeBoolean(afterKey != null);
         if (afterKey != null) {

--- a/server/src/main/java/org/opensearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/opensearch/transport/TransportHandshaker.java
@@ -83,19 +83,6 @@ final class TransportHandshaker {
             // we also have no payload on the request but the response will contain the actual version of the node we talk
             // to as the payload.
             Version minCompatVersion = version.minimumCompatibilityVersion();
-            if (version.onOrAfter(Version.V_1_0_0) && version.before(Version.V_2_0_0)) {
-                // the minCompatibleVersion for OpenSearch 1.x is sent as 6.7.99 instead of 6.8.0
-                // as this helps in (indirectly) identifying the remote node version during handle HandshakeRequest itself
-                // and then send appropriate version (7.10.2/ OpenSearch 1.x version) in response.
-                // The advantage of doing this is early identification of remote node version as otherwise
-                // if OpenSearch node also sends 6.8.0, there is no way to differentiate ES 7.x version from
-                // OpenSearch version and OpenSearch node will end up sending BC version to both ES & OpenSearch remote node.
-                // Sending only BC version to ElasticSearch node provide easy deprecation path for this BC version logic
-                // in OpenSearch 2.0.0.
-                minCompatVersion = Version.fromId(6079999);
-            } else if (version.before(Version.V_3_0_0)) {
-                minCompatVersion = Version.fromId(7099999);
-            }
             handshakeRequestSender.sendRequest(node, channel, requestId, minCompatVersion);
 
             threadPool.schedule(

--- a/server/src/test/java/org/opensearch/BuildTests.java
+++ b/server/src/test/java/org/opensearch/BuildTests.java
@@ -301,9 +301,7 @@ public class BuildTests extends OpenSearchTestCase {
 
         final List<Version> versions = Version.getDeclaredVersions(Version.class);
 
-        final Version post10OpenSearchVersion = randomFrom(
-            versions.stream().filter(v -> v.onOrAfter(Version.V_1_0_0)).collect(Collectors.toList())
-        );
+        final Version post10OpenSearchVersion = randomFrom(versions.stream().collect(Collectors.toList()));
         final WriteableBuild post10OpenSearch = copyWriteable(
             dockerBuild,
             writableRegistry(),

--- a/server/src/test/java/org/opensearch/VersionTests.java
+++ b/server/src/test/java/org/opensearch/VersionTests.java
@@ -49,7 +49,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import static org.opensearch.Version.V_1_3_0;
+import static org.opensearch.Version.V_2_3_0;
 import static org.opensearch.Version.MASK;
 import static org.opensearch.test.VersionUtils.allVersions;
 import static org.opensearch.test.VersionUtils.randomOpenSearchVersion;
@@ -67,31 +67,31 @@ import static org.hamcrest.Matchers.sameInstance;
 public class VersionTests extends OpenSearchTestCase {
 
     public void testVersionComparison() {
-        Version V_1_1_1 = Version.fromString("1.1.1");
-        assertThat(V_1_1_1.before(V_1_3_0), is(true));
-        assertThat(V_1_1_1.before(V_1_1_1), is(false));
-        assertThat(V_1_3_0.before(V_1_1_1), is(false));
+        Version V_2_1_1 = Version.fromString("2.1.1");
+        assertThat(V_2_1_1.before(V_2_3_0), is(true));
+        assertThat(V_2_1_1.before(V_2_1_1), is(false));
+        assertThat(V_2_3_0.before(V_2_1_1), is(false));
 
-        assertThat(V_1_1_1.onOrBefore(V_1_3_0), is(true));
-        assertThat(V_1_1_1.onOrBefore(V_1_1_1), is(true));
-        assertThat(V_1_3_0.onOrBefore(V_1_1_1), is(false));
+        assertThat(V_2_1_1.onOrBefore(V_2_3_0), is(true));
+        assertThat(V_2_1_1.onOrBefore(V_2_1_1), is(true));
+        assertThat(V_2_3_0.onOrBefore(V_2_1_1), is(false));
 
-        assertThat(V_1_1_1.after(V_1_3_0), is(false));
-        assertThat(V_1_1_1.after(V_1_1_1), is(false));
-        assertThat(V_1_3_0.after(V_1_1_1), is(true));
+        assertThat(V_2_1_1.after(V_2_3_0), is(false));
+        assertThat(V_2_1_1.after(V_2_1_1), is(false));
+        assertThat(V_2_3_0.after(V_2_1_1), is(true));
 
-        assertThat(V_1_1_1.onOrAfter(V_1_3_0), is(false));
-        assertThat(V_1_1_1.onOrAfter(V_1_1_1), is(true));
-        assertThat(V_1_3_0.onOrAfter(V_1_1_1), is(true));
+        assertThat(V_2_1_1.onOrAfter(V_2_3_0), is(false));
+        assertThat(V_2_1_1.onOrAfter(V_2_1_1), is(true));
+        assertThat(V_2_3_0.onOrAfter(V_2_1_1), is(true));
 
         assertTrue(Version.fromString("1.0.0-alpha2").onOrAfter(Version.fromString("1.0.0-alpha1")));
         assertTrue(Version.fromString("1.0.0").onOrAfter(Version.fromString("1.0.0-beta2")));
         assertTrue(Version.fromString("1.0.0-rc1").onOrAfter(Version.fromString("1.0.0-beta24")));
         assertTrue(Version.fromString("1.0.0-alpha24").before(Version.fromString("1.0.0-beta0")));
 
-        assertThat(V_1_1_1, is(lessThan(V_1_3_0)));
-        assertThat(V_1_1_1.compareTo(V_1_1_1), is(0));
-        assertThat(V_1_3_0, is(greaterThan(V_1_1_1)));
+        assertThat(V_2_1_1, is(lessThan(V_2_3_0)));
+        assertThat(V_2_1_1.compareTo(V_2_1_1), is(0));
+        assertThat(V_2_3_0, is(greaterThan(V_2_1_1)));
     }
 
     public void testMin() {
@@ -120,7 +120,7 @@ public class VersionTests extends OpenSearchTestCase {
 
     public void testMinimumIndexCompatibilityVersion() {
         // note: all Legacy compatibility support will be removed in OpenSearch 3.0
-        assertEquals(LegacyESVersion.fromId(6000026), V_1_3_0.minimumIndexCompatibilityVersion());
+        assertEquals(LegacyESVersion.fromId(6000026), V_2_3_0.minimumIndexCompatibilityVersion());
         assertEquals(LegacyESVersion.fromId(7000099), Version.fromId(2000099).minimumIndexCompatibilityVersion());
         assertEquals(LegacyESVersion.fromId(7000099), Version.fromId(2010000).minimumIndexCompatibilityVersion());
         assertEquals(LegacyESVersion.fromId(7000099), Version.fromId(2000001).minimumIndexCompatibilityVersion());
@@ -181,7 +181,7 @@ public class VersionTests extends OpenSearchTestCase {
 
     public void testIndexCreatedVersion() {
         // an actual index has a IndexMetadata.SETTING_INDEX_UUID
-        final Version version = Version.V_1_0_0;
+        final Version version = Version.CURRENT;
         assertEquals(
             version,
             Version.indexCreated(

--- a/server/src/test/java/org/opensearch/VersionTests.java
+++ b/server/src/test/java/org/opensearch/VersionTests.java
@@ -120,7 +120,6 @@ public class VersionTests extends OpenSearchTestCase {
 
     public void testMinimumIndexCompatibilityVersion() {
         // note: all Legacy compatibility support will be removed in OpenSearch 3.0
-        assertEquals(LegacyESVersion.fromId(6000026), V_2_3_0.minimumIndexCompatibilityVersion());
         assertEquals(LegacyESVersion.fromId(7000099), Version.fromId(2000099).minimumIndexCompatibilityVersion());
         assertEquals(LegacyESVersion.fromId(7000099), Version.fromId(2010000).minimumIndexCompatibilityVersion());
         assertEquals(LegacyESVersion.fromId(7000099), Version.fromId(2000001).minimumIndexCompatibilityVersion());

--- a/server/src/test/java/org/opensearch/action/main/MainResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/main/MainResponseTests.java
@@ -57,14 +57,14 @@ public class MainResponseTests extends AbstractSerializingTestCase<MainResponse>
         ClusterName clusterName = new ClusterName(randomAlphaOfLength(10));
         String nodeName = randomAlphaOfLength(10);
         final String date = new Date(randomNonNegativeLong()).toString();
-        Version version = VersionUtils.randomVersionBetween(random(), Version.V_1_0_0, Version.CURRENT);
+        Version version = VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.CURRENT);
         Build build = new Build(
             Build.Type.UNKNOWN,
             randomAlphaOfLength(8),
             date,
             randomBoolean(),
             version.toString(),
-            version.onOrAfter(Version.V_1_0_0) ? randomAlphaOfLength(10) : ""
+            randomAlphaOfLength(10)
         );
         return new MainResponse(nodeName, version, clusterName, clusterUuid, build);
     }

--- a/server/src/test/java/org/opensearch/action/search/MultiSearchRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/search/MultiSearchRequestTests.java
@@ -418,15 +418,10 @@ public class MultiSearchRequestTests extends OpenSearchTestCase {
         Version version = VersionUtils.randomVersion(random());
         MultiSearchRequest originalRequest = RestMultiSearchAction.parseRequest(restRequest, null, true);
         MultiSearchRequest deserializedRequest = copyWriteable(originalRequest, writableRegistry(), MultiSearchRequest::new, version);
-
-        if (version.before(Version.V_1_1_0)) {
-            assertNull(deserializedRequest.requests().get(0).getCancelAfterTimeInterval());
-        } else {
-            assertEquals(
-                originalRequest.requests().get(0).getCancelAfterTimeInterval(),
-                deserializedRequest.requests().get(0).getCancelAfterTimeInterval()
-            );
-        }
+        assertEquals(
+            originalRequest.requests().get(0).getCancelAfterTimeInterval(),
+            deserializedRequest.requests().get(0).getCancelAfterTimeInterval()
+        );
     }
 
     public void testWritingExpandWildcards() throws IOException {

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestTests.java
@@ -110,12 +110,7 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         assertEquals(searchRequest.getLocalClusterAlias(), deserializedRequest.getLocalClusterAlias());
         assertEquals(searchRequest.getAbsoluteStartMillis(), deserializedRequest.getAbsoluteStartMillis());
         assertEquals(searchRequest.isFinalReduce(), deserializedRequest.isFinalReduce());
-
-        if (version.onOrAfter(Version.V_1_1_0)) {
-            assertEquals(searchRequest.getCancelAfterTimeInterval(), deserializedRequest.getCancelAfterTimeInterval());
-        } else {
-            assertNull(deserializedRequest.getCancelAfterTimeInterval());
-        }
+        assertEquals(searchRequest.getCancelAfterTimeInterval(), deserializedRequest.getCancelAfterTimeInterval());
     }
 
     public void testIllegalArguments() {

--- a/server/src/test/java/org/opensearch/action/support/IndicesOptionsTests.java
+++ b/server/src/test/java/org/opensearch/action/support/IndicesOptionsTests.java
@@ -65,7 +65,7 @@ public class IndicesOptionsTests extends OpenSearchTestCase {
     public void testSerialization() throws Exception {
         int iterations = randomIntBetween(5, 20);
         for (int i = 0; i < iterations; i++) {
-            Version version = randomVersionBetween(random(), Version.V_1_0_0, null);
+            Version version = randomVersionBetween(random(), Version.V_2_0_0, null);
             IndicesOptions indicesOptions = IndicesOptions.fromOptions(
                 randomBoolean(),
                 randomBoolean(),

--- a/server/src/test/java/org/opensearch/cluster/metadata/AutoExpandReplicasTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/AutoExpandReplicasTests.java
@@ -243,7 +243,7 @@ public class AutoExpandReplicasTests extends OpenSearchTestCase {
         try {
             List<DiscoveryNode> allNodes = new ArrayList<>();
             DiscoveryNode oldNode = createNode(
-                VersionUtils.randomVersionBetween(random(), Version.V_1_0_0, Version.V_1_2_1),
+                VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.V_2_2_1),
                 DiscoveryNodeRole.CLUSTER_MANAGER_ROLE,
                 DiscoveryNodeRole.DATA_ROLE
             ); // local node is the cluster-manager
@@ -265,7 +265,7 @@ public class AutoExpandReplicasTests extends OpenSearchTestCase {
                 state = cluster.reroute(state, new ClusterRerouteRequest());
             }
 
-            DiscoveryNode newNode = createNode(Version.V_1_3_0, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE, DiscoveryNodeRole.DATA_ROLE); // local
+            DiscoveryNode newNode = createNode(Version.V_2_3_0, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE, DiscoveryNodeRole.DATA_ROLE); // local
                                                                                                                                       // node
                                                                                                                                       // is
                                                                                                                                       // the

--- a/server/src/test/java/org/opensearch/common/lucene/uid/VersionsTests.java
+++ b/server/src/test/java/org/opensearch/common/lucene/uid/VersionsTests.java
@@ -216,8 +216,8 @@ public class VersionsTests extends OpenSearchTestCase {
 
     public void testLuceneVersionOnUnknownVersions() {
         // between two known versions, should use the lucene version of the previous version
-        Version version = Version.fromString("1.1.50");
-        assertEquals(VersionUtils.getPreviousVersion(Version.fromString("1.1.3")).luceneVersion, version.luceneVersion);
+        Version version = Version.fromString("2.1.50");
+        assertEquals(VersionUtils.getPreviousVersion(Version.fromString("2.1.3")).luceneVersion, version.luceneVersion);
 
         // too old version, major should be the oldest supported lucene version minus 1
         version = LegacyESVersion.fromString("5.2.1");

--- a/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
@@ -723,7 +723,7 @@ public class IndexSettingsTests extends OpenSearchTestCase {
     public void testSoftDeletesDefaultSetting() {
         // enabled by default on 7.0+ or later
         {
-            Version createdVersion = VersionUtils.randomVersionBetween(random(), Version.V_1_0_0, Version.CURRENT);
+            Version createdVersion = VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.CURRENT);
             Settings settings = Settings.builder().put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), createdVersion).build();
             assertTrue(IndexSettings.INDEX_SOFT_DELETES_SETTING.get(settings));
         }
@@ -731,7 +731,7 @@ public class IndexSettingsTests extends OpenSearchTestCase {
 
     public void testIgnoreTranslogRetentionSettingsIfSoftDeletesEnabled() {
         Settings.Builder settings = Settings.builder()
-            .put(IndexMetadata.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_1_0_0, Version.CURRENT));
+            .put(IndexMetadata.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.CURRENT));
         if (randomBoolean()) {
             settings.put(IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.getKey(), randomPositiveTimeValue());
         }

--- a/server/src/test/java/org/opensearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ParametrizedMapperTests.java
@@ -442,7 +442,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
     public void testDeprecatedParameters() {
         // 'index' is declared explicitly, 'store' is not, but is one of the previously always-accepted params
         String mapping = "{\"type\":\"test_mapper\",\"index\":false,\"store\":true,\"required\":\"value\"}";
-        TestMapper mapper = fromMapping(mapping, Version.V_1_0_0);
+        TestMapper mapper = fromMapping(mapping, Version.V_2_0_0);
         assertWarnings("Parameter [store] has no effect on type [test_mapper] and will be removed in future");
         assertFalse(mapper.index);
         assertEquals("{\"field\":{\"type\":\"test_mapper\",\"index\":false,\"required\":\"value\"}}", Strings.toString(mapper));

--- a/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
@@ -88,7 +88,7 @@ public class PluginInfoTests extends OpenSearchTestCase {
             "version",
             "1.0",
             "opensearch.version",
-            Version.V_1_0_0.toString(),
+            Version.V_2_0_0.toString(),
             "java.version",
             System.getProperty("java.specification.version"),
             "classname",

--- a/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginInfoTests.java
@@ -77,34 +77,6 @@ public class PluginInfoTests extends OpenSearchTestCase {
         assertThat(info.getExtendedPlugins(), empty());
     }
 
-    public void testReadFromPropertiesWithFolderNameAndVersionBefore() throws Exception {
-        Path pluginDir = createTempDir().resolve("fake-plugin");
-        PluginTestUtil.writePluginProperties(
-            pluginDir,
-            "description",
-            "fake desc",
-            "name",
-            "my_plugin",
-            "version",
-            "1.0",
-            "opensearch.version",
-            Version.V_2_0_0.toString(),
-            "java.version",
-            System.getProperty("java.specification.version"),
-            "classname",
-            "FakePlugin",
-            "custom.foldername",
-            "custom-folder"
-        );
-        PluginInfo info = PluginInfo.readFromProperties(pluginDir);
-        assertEquals("my_plugin", info.getName());
-        assertEquals("fake desc", info.getDescription());
-        assertEquals("1.0", info.getVersion());
-        assertEquals("FakePlugin", info.getClassname());
-        assertEquals("my_plugin", info.getTargetFolderName());
-        assertThat(info.getExtendedPlugins(), empty());
-    }
-
     public void testReadFromPropertiesWithFolderNameAndVersionAfter() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         PluginTestUtil.writePluginProperties(

--- a/server/src/test/java/org/opensearch/transport/InboundDecoderTests.java
+++ b/server/src/test/java/org/opensearch/transport/InboundDecoderTests.java
@@ -326,7 +326,7 @@ public class InboundDecoderTests extends OpenSearchTestCase {
         ise = InboundDecoder.ensureVersionCompatibility(Version.V_2_0_0, version, true);
         assertNull(ise);
 
-        ise = InboundDecoder.ensureVersionCompatibility(Version.V_1_0_0, version, false);
+        ise = InboundDecoder.ensureVersionCompatibility(Version.fromId(1000099), version, false);
         assertEquals(
             "Received message from unsupported version: [1.0.0] minimal compatible version is: ["
                 + version.minimumCompatibilityVersion()

--- a/server/src/test/java/org/opensearch/transport/InboundDecoderTests.java
+++ b/server/src/test/java/org/opensearch/transport/InboundDecoderTests.java
@@ -326,7 +326,7 @@ public class InboundDecoderTests extends OpenSearchTestCase {
         ise = InboundDecoder.ensureVersionCompatibility(Version.V_2_0_0, version, true);
         assertNull(ise);
 
-        ise = InboundDecoder.ensureVersionCompatibility(Version.fromId(1000099), version, false);
+        ise = InboundDecoder.ensureVersionCompatibility(VersionUtils.V_1_0_0, version, false);
         assertEquals(
             "Received message from unsupported version: [1.0.0] minimal compatible version is: ["
                 + version.minimumCompatibilityVersion()

--- a/server/src/test/java/org/opensearch/transport/TransportHandshakerTests.java
+++ b/server/src/test/java/org/opensearch/transport/TransportHandshakerTests.java
@@ -189,11 +189,6 @@ public class TransportHandshakerTests extends OpenSearchTestCase {
     }
 
     private Version getMinCompatibilityVersionForHandshakeRequest() {
-        if (Version.CURRENT.onOrAfter(Version.V_1_0_0) && Version.CURRENT.major == 1) {
-            return Version.fromId(6079999);
-        } else if (Version.CURRENT.onOrAfter(Version.V_2_0_0) && Version.CURRENT.major == 2) {
-            return Version.fromId(7099999);
-        }
         return Version.CURRENT.minimumCompatibilityVersion();
     }
 }

--- a/test/framework/src/main/java/org/opensearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/opensearch/test/VersionUtils.java
@@ -102,29 +102,6 @@ public class VersionUtils {
             stableVersions = currentMajor;
         }
 
-        // remove last minor unless it's the first OpenSearch version.
-        // all Legacy ES versions are released, so we don't exclude any.
-        if (current.equals(Version.V_1_0_0) == false) {
-            List<Version> lastMinorLine = stableVersions.get(stableVersions.size() - 1);
-            if (lastMinorLine.get(lastMinorLine.size() - 1) instanceof LegacyESVersion == false) {
-                // if the last minor line is Legacy there are no more staged releases; do nothing
-                // otherwise the last minor line is (by definition) staged and unreleased
-                Version lastMinor = moveLastToUnreleased(stableVersions, unreleasedVersions);
-                // no more staged legacy bugfixes so skip;
-                if (lastMinor instanceof LegacyESVersion == false && lastMinor.revision == 0) {
-                    // this is not a legacy version; remove the staged bugfix
-                    if (stableVersions.get(stableVersions.size() - 1).size() == 1) {
-                        // a minor is being staged, which is also unreleased
-                        moveLastToUnreleased(stableVersions, unreleasedVersions);
-                    }
-                    // remove the next bugfix
-                    if (stableVersions.isEmpty() == false) {
-                        moveLastToUnreleased(stableVersions, unreleasedVersions);
-                    }
-                }
-            }
-        }
-
         // If none of the previous major was released, then the last minor and bugfix of the old version was not released either.
         if (previousMajor.isEmpty()) {
             assert currentMajor.isEmpty() : currentMajor;

--- a/test/framework/src/main/java/org/opensearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/opensearch/test/VersionUtils.java
@@ -49,6 +49,9 @@ import java.util.stream.Stream;
 
 /** Utilities for selecting versions in tests */
 public class VersionUtils {
+    // version 1.0 is removed; this is used purely to retain consistent logic for migrations
+    @Deprecated
+    public static Version V_1_0_0 = Version.fromId(1000099 ^ Version.MASK);
 
     /**
      * Sort versions that have backwards compatibility guarantees from
@@ -104,7 +107,7 @@ public class VersionUtils {
 
         // remove last minor unless it's the first OpenSearch version.
         // all Legacy ES versions are released, so we don't exclude any.
-        if (current.equals(Version.fromId(1000099 ^ Version.MASK)) == false) {
+        if (current.equals(V_1_0_0) == false) {
             List<Version> lastMinorLine = stableVersions.get(stableVersions.size() - 1);
             if (lastMinorLine.get(lastMinorLine.size() - 1) instanceof LegacyESVersion == false) {
                 // if the last minor line is Legacy there are no more staged releases; do nothing

--- a/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
@@ -1004,12 +1004,6 @@ public abstract class OpenSearchRestTestCase extends OpenSearchTestCase {
     }
 
     protected static void expectSoftDeletesWarning(Request request, String indexName) {
-        final List<String> esExpectedWarnings = Collections.singletonList(
-            "Creating indices with soft-deletes disabled is deprecated and will be removed in future Elasticsearch versions. "
-                + "Please do not specify value for setting [index.soft_deletes.enabled] of index ["
-                + indexName
-                + "]."
-        );
         final List<String> opensearchExpectedWarnings = Collections.singletonList(
             "Creating indices with soft-deletes disabled is deprecated and will be removed in future OpenSearch versions. "
                 + "Please do not specify value for setting [index.soft_deletes.enabled] of index ["

--- a/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
@@ -537,15 +537,6 @@ public abstract class OpenSearchRestTestCase extends OpenSearchTestCase {
 
     private void wipeCluster() throws Exception {
 
-        // Clean up SLM policies before trying to wipe snapshots so that no new ones get started by SLM after wiping
-        if (nodeVersions.first().before(Version.V_1_0_0)) { // SLM was introduced
-                                                            // in version 7.4
-            if (preserveSLMPoliciesUponCompletion() == false) {
-                // Clean up SLM policies before trying to wipe snapshots so that no new ones get started by SLM after wiping
-                deleteAllSLMPolicies();
-            }
-        }
-
         SetOnce<Map<String, List<Map<?, ?>>>> inProgressSnapshots = new SetOnce<>();
         if (waitForAllSnapshotsWiped()) {
             AtomicReference<Map<String, List<Map<?, ?>>>> snapshots = new AtomicReference<>();
@@ -1026,23 +1017,8 @@ public abstract class OpenSearchRestTestCase extends OpenSearchTestCase {
                 + "]."
         );
         final Builder requestOptions = RequestOptions.DEFAULT.toBuilder();
-        if (nodeVersions.stream().allMatch(version -> version.before(Version.V_1_0_0))) {
-            requestOptions.setWarningsHandler(warnings -> warnings.equals(esExpectedWarnings) == false);
-            request.setOptions(requestOptions);
-        } else if (nodeVersions.stream().anyMatch(version -> version.before(Version.V_1_0_0))) {
-            requestOptions.setWarningsHandler(warnings -> warnings.isEmpty() == false && warnings.equals(esExpectedWarnings) == false);
-            request.setOptions(requestOptions);
-        }
-
-        if (nodeVersions.stream().allMatch(version -> version.onOrAfter(Version.V_1_0_0))) {
-            requestOptions.setWarningsHandler(warnings -> warnings.equals(opensearchExpectedWarnings) == false);
-            request.setOptions(requestOptions);
-        } else if (nodeVersions.stream().anyMatch(version -> version.onOrAfter(Version.V_1_0_0))) {
-            requestOptions.setWarningsHandler(
-                warnings -> warnings.isEmpty() == false && warnings.equals(opensearchExpectedWarnings) == false
-            );
-            request.setOptions(requestOptions);
-        }
+        requestOptions.setWarningsHandler(warnings -> warnings.equals(opensearchExpectedWarnings) == false);
+        request.setOptions(requestOptions);
     }
 
     protected static Map<String, Object> getIndexSettings(String index) throws IOException {


### PR DESCRIPTION
Removes all usages of OpenSearch Version.V_1_ version constants along with unused API logic.

