### PR TITLE
[Backport 2.x] In-flight cancellation of SearchShardTask based on resource consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update GeoGrid base class access modifier to support extensibility ([#4921](https://github.com/opensearch-project/OpenSearch/pull/4921))
 - Build no-jdk distributions as part of release build ([#4902](https://github.com/opensearch-project/OpenSearch/pull/4902))
 - Use getParameterCount instead of getParameterTypes ([#4821](https://github.com/opensearch-project/OpenSearch/pull/4821))
+- Added in-flight cancellation of SearchShardTask based on resource consumption ([#4565](https://github.com/opensearch-project/OpenSearch/pull/4565))
 
 ### Dependencies
 - Bumps `com.diffplug.spotless` from 6.9.1 to 6.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Build no-jdk distributions as part of release build ([#4902](https://github.com/opensearch-project/OpenSearch/pull/4902))
 - Use getParameterCount instead of getParameterTypes ([#4821](https://github.com/opensearch-project/OpenSearch/pull/4821))
 - Added in-flight cancellation of SearchShardTask based on resource consumption ([#4565](https://github.com/opensearch-project/OpenSearch/pull/4565))
+- Added resource usage trackers for in-flight cancellation of SearchShardTask ([#4805](https://github.com/opensearch-project/OpenSearch/pull/4805))
 
 ### Dependencies
 - Bumps `com.diffplug.spotless` from 6.9.1 to 6.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Use getParameterCount instead of getParameterTypes ([#4821](https://github.com/opensearch-project/OpenSearch/pull/4821))
 - Added in-flight cancellation of SearchShardTask based on resource consumption ([#4565](https://github.com/opensearch-project/OpenSearch/pull/4565))
 - Added resource usage trackers for in-flight cancellation of SearchShardTask ([#4805](https://github.com/opensearch-project/OpenSearch/pull/4805))
+- Added search backpressure stats API ([#4932](https://github.com/opensearch-project/OpenSearch/pull/4932))
 
 ### Dependencies
 - Bumps `com.diffplug.spotless` from 6.9.1 to 6.10.0

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
@@ -56,6 +56,7 @@ import org.opensearch.monitor.process.ProcessStats;
 import org.opensearch.node.AdaptiveSelectionStats;
 import org.opensearch.script.ScriptCacheStats;
 import org.opensearch.script.ScriptStats;
+import org.opensearch.search.backpressure.stats.SearchBackpressureStats;
 import org.opensearch.threadpool.ThreadPoolStats;
 import org.opensearch.transport.TransportStats;
 
@@ -119,6 +120,9 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
     @Nullable
     private ShardIndexingPressureStats shardIndexingPressureStats;
 
+    @Nullable
+    private SearchBackpressureStats searchBackpressureStats;
+
     public NodeStats(StreamInput in) throws IOException {
         super(in);
         timestamp = in.readVLong();
@@ -156,6 +160,11 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
             shardIndexingPressureStats = null;
         }
 
+        if (in.getVersion().onOrAfter(Version.V_2_4_0)) {
+            searchBackpressureStats = in.readOptionalWriteable(SearchBackpressureStats::new);
+        } else {
+            searchBackpressureStats = null;
+        }
     }
 
     public NodeStats(
@@ -176,7 +185,8 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         @Nullable AdaptiveSelectionStats adaptiveSelectionStats,
         @Nullable ScriptCacheStats scriptCacheStats,
         @Nullable IndexingPressureStats indexingPressureStats,
-        @Nullable ShardIndexingPressureStats shardIndexingPressureStats
+        @Nullable ShardIndexingPressureStats shardIndexingPressureStats,
+        @Nullable SearchBackpressureStats searchBackpressureStats
     ) {
         super(node);
         this.timestamp = timestamp;
@@ -196,6 +206,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         this.scriptCacheStats = scriptCacheStats;
         this.indexingPressureStats = indexingPressureStats;
         this.shardIndexingPressureStats = shardIndexingPressureStats;
+        this.searchBackpressureStats = searchBackpressureStats;
     }
 
     public long getTimestamp() {
@@ -305,6 +316,11 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         return shardIndexingPressureStats;
     }
 
+    @Nullable
+    public SearchBackpressureStats getSearchBackpressureStats() {
+        return searchBackpressureStats;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
@@ -335,6 +351,9 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         }
         if (out.getVersion().onOrAfter(Version.V_1_2_0)) {
             out.writeOptionalWriteable(shardIndexingPressureStats);
+        }
+        if (out.getVersion().onOrAfter(Version.V_2_4_0)) {
+            out.writeOptionalWriteable(searchBackpressureStats);
         }
     }
 
@@ -407,6 +426,9 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         }
         if (getShardIndexingPressureStats() != null) {
             getShardIndexingPressureStats().toXContent(builder, params);
+        }
+        if (getSearchBackpressureStats() != null) {
+            getSearchBackpressureStats().toXContent(builder, params);
         }
         return builder;
     }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -237,7 +237,8 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         ADAPTIVE_SELECTION("adaptive_selection"),
         SCRIPT_CACHE("script_cache"),
         INDEXING_PRESSURE("indexing_pressure"),
-        SHARD_INDEXING_PRESSURE("shard_indexing_pressure");
+        SHARD_INDEXING_PRESSURE("shard_indexing_pressure"),
+        SEARCH_BACKPRESSURE("search_backpressure");
 
         private String metricName;
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -118,7 +118,8 @@ public class TransportNodesStatsAction extends TransportNodesAction<
             NodesStatsRequest.Metric.ADAPTIVE_SELECTION.containedIn(metrics),
             NodesStatsRequest.Metric.SCRIPT_CACHE.containedIn(metrics),
             NodesStatsRequest.Metric.INDEXING_PRESSURE.containedIn(metrics),
-            NodesStatsRequest.Metric.SHARD_INDEXING_PRESSURE.containedIn(metrics)
+            NodesStatsRequest.Metric.SHARD_INDEXING_PRESSURE.containedIn(metrics),
+            NodesStatsRequest.Metric.SEARCH_BACKPRESSURE.containedIn(metrics)
         );
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -162,6 +162,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<
             false,
             false,
             false,
+            false,
             false
         );
         List<ShardStats> shardsStats = new ArrayList<>();

--- a/server/src/main/java/org/opensearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterModule.java
@@ -96,7 +96,6 @@ import org.opensearch.plugins.ClusterPlugin;
 import org.opensearch.script.ScriptMetadata;
 import org.opensearch.snapshots.SnapshotsInfoService;
 import org.opensearch.tasks.Task;
-import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.tasks.TaskResultsService;
 
 import java.util.ArrayList;
@@ -402,7 +401,6 @@ public class ClusterModule extends AbstractModule {
         bind(NodeMappingRefreshAction.class).asEagerSingleton();
         bind(MappingUpdatedAction.class).asEagerSingleton();
         bind(TaskResultsService.class).asEagerSingleton();
-        bind(TaskResourceTrackingService.class).asEagerSingleton();
         bind(AllocationDeciders.class).toInstance(allocationDeciders);
         bind(ShardsAllocator.class).toInstance(shardsAllocator);
     }

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -45,6 +45,9 @@ import org.opensearch.index.ShardIndexingPressureStore;
 import org.opensearch.search.backpressure.settings.NodeDuressSettings;
 import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
 import org.opensearch.search.backpressure.settings.SearchShardTaskSettings;
+import org.opensearch.search.backpressure.trackers.CpuUsageTracker;
+import org.opensearch.search.backpressure.trackers.ElapsedTimeTracker;
+import org.opensearch.search.backpressure.trackers.HeapUsageTracker;
 import org.opensearch.tasks.TaskManager;
 import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.watcher.ResourceWatcherService;
@@ -596,11 +599,12 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 NodeDuressSettings.SETTING_NUM_SUCCESSIVE_BREACHES,
                 NodeDuressSettings.SETTING_CPU_THRESHOLD,
                 NodeDuressSettings.SETTING_HEAP_THRESHOLD,
-                SearchShardTaskSettings.SETTING_TOTAL_HEAP_THRESHOLD,
-                SearchShardTaskSettings.SETTING_HEAP_THRESHOLD,
-                SearchShardTaskSettings.SETTING_HEAP_VARIANCE_THRESHOLD,
-                SearchShardTaskSettings.SETTING_CPU_TIME_THRESHOLD,
-                SearchShardTaskSettings.SETTING_ELAPSED_TIME_THRESHOLD
+                SearchShardTaskSettings.SETTING_TOTAL_HEAP_PERCENT_THRESHOLD,
+                HeapUsageTracker.SETTING_HEAP_PERCENT_THRESHOLD,
+                HeapUsageTracker.SETTING_HEAP_VARIANCE_THRESHOLD,
+                HeapUsageTracker.SETTING_HEAP_MOVING_AVERAGE_WINDOW_SIZE,
+                CpuUsageTracker.SETTING_CPU_TIME_MILLIS_THRESHOLD,
+                ElapsedTimeTracker.SETTING_ELAPSED_TIME_MILLIS_THRESHOLD
             )
         )
     );

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -42,6 +42,9 @@ import org.opensearch.index.IndexingPressure;
 import org.opensearch.index.ShardIndexingPressureMemoryManager;
 import org.opensearch.index.ShardIndexingPressureSettings;
 import org.opensearch.index.ShardIndexingPressureStore;
+import org.opensearch.search.backpressure.settings.NodeDuressSettings;
+import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
+import org.opensearch.search.backpressure.settings.SearchShardTaskSettings;
 import org.opensearch.tasks.TaskManager;
 import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.watcher.ResourceWatcherService;
@@ -582,7 +585,22 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 ShardIndexingPressureMemoryManager.MAX_OUTSTANDING_REQUESTS,
                 IndexingPressure.MAX_INDEXING_BYTES,
                 TaskResourceTrackingService.TASK_RESOURCE_TRACKING_ENABLED,
-                TaskManager.TASK_RESOURCE_CONSUMERS_ENABLED
+                TaskManager.TASK_RESOURCE_CONSUMERS_ENABLED,
+
+                // Settings related to search backpressure
+                SearchBackpressureSettings.SETTING_ENABLED,
+                SearchBackpressureSettings.SETTING_ENFORCED,
+                SearchBackpressureSettings.SETTING_CANCELLATION_RATIO,
+                SearchBackpressureSettings.SETTING_CANCELLATION_RATE,
+                SearchBackpressureSettings.SETTING_CANCELLATION_BURST,
+                NodeDuressSettings.SETTING_NUM_SUCCESSIVE_BREACHES,
+                NodeDuressSettings.SETTING_CPU_THRESHOLD,
+                NodeDuressSettings.SETTING_HEAP_THRESHOLD,
+                SearchShardTaskSettings.SETTING_TOTAL_HEAP_THRESHOLD,
+                SearchShardTaskSettings.SETTING_HEAP_THRESHOLD,
+                SearchShardTaskSettings.SETTING_HEAP_VARIANCE_THRESHOLD,
+                SearchShardTaskSettings.SETTING_CPU_TIME_THRESHOLD,
+                SearchShardTaskSettings.SETTING_ELAPSED_TIME_THRESHOLD
             )
         )
     );

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -591,8 +591,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 TaskManager.TASK_RESOURCE_CONSUMERS_ENABLED,
 
                 // Settings related to search backpressure
-                SearchBackpressureSettings.SETTING_ENABLED,
-                SearchBackpressureSettings.SETTING_ENFORCED,
+                SearchBackpressureSettings.SETTING_MODE,
                 SearchBackpressureSettings.SETTING_CANCELLATION_RATIO,
                 SearchBackpressureSettings.SETTING_CANCELLATION_RATE,
                 SearchBackpressureSettings.SETTING_CANCELLATION_BURST,

--- a/server/src/main/java/org/opensearch/common/util/MovingAverage.java
+++ b/server/src/main/java/org/opensearch/common/util/MovingAverage.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.util;
+
+/**
+ * MovingAverage is used to calculate the moving average of last 'n' observations.
+ *
+ * @opensearch.internal
+ */
+public class MovingAverage {
+    private final int windowSize;
+    private final long[] observations;
+
+    private long count = 0;
+    private long sum = 0;
+    private double average = 0;
+
+    public MovingAverage(int windowSize) {
+        if (windowSize <= 0) {
+            throw new IllegalArgumentException("window size must be greater than zero");
+        }
+
+        this.windowSize = windowSize;
+        this.observations = new long[windowSize];
+    }
+
+    /**
+     * Records a new observation and evicts the n-th last observation.
+     */
+    public synchronized double record(long value) {
+        long delta = value - observations[(int) (count % observations.length)];
+        observations[(int) (count % observations.length)] = value;
+
+        count++;
+        sum += delta;
+        average = (double) sum / Math.min(count, observations.length);
+        return average;
+    }
+
+    public double getAverage() {
+        return average;
+    }
+
+    public long getCount() {
+        return count;
+    }
+
+    public boolean isReady() {
+        return count >= windowSize;
+    }
+}

--- a/server/src/main/java/org/opensearch/common/util/Streak.java
+++ b/server/src/main/java/org/opensearch/common/util/Streak.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.util;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Streak is a data structure that keeps track of the number of successive successful events.
+ *
+ * @opensearch.internal
+ */
+public class Streak {
+    private final AtomicInteger successiveSuccessfulEvents = new AtomicInteger();
+
+    public int record(boolean isSuccessful) {
+        if (isSuccessful) {
+            return successiveSuccessfulEvents.incrementAndGet();
+        } else {
+            successiveSuccessfulEvents.set(0);
+            return 0;
+        }
+    }
+
+    public int length() {
+        return successiveSuccessfulEvents.get();
+    }
+}

--- a/server/src/main/java/org/opensearch/common/util/TokenBucket.java
+++ b/server/src/main/java/org/opensearch/common/util/TokenBucket.java
@@ -1,0 +1,124 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.util;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
+
+/**
+ * TokenBucket is used to limit the number of operations at a constant rate while allowing for short bursts.
+ *
+ * @opensearch.internal
+ */
+public class TokenBucket {
+    /**
+     * Defines a monotonically increasing counter.
+     *
+     * Usage examples:
+     * 1. clock = System::nanoTime can be used to perform rate-limiting per unit time
+     * 2. clock = AtomicLong::get can be used to perform rate-limiting per unit number of operations
+     */
+    private final LongSupplier clock;
+
+    /**
+     * Defines the number of tokens added to the bucket per clock cycle.
+     */
+    private final double rate;
+
+    /**
+     * Defines the capacity and the maximum number of operations that can be performed per clock cycle before
+     * the bucket runs out of tokens.
+     */
+    private final double burst;
+
+    /**
+     * Defines the current state of the token bucket.
+     */
+    private final AtomicReference<State> state;
+
+    public TokenBucket(LongSupplier clock, double rate, double burst) {
+        this(clock, rate, burst, burst);
+    }
+
+    public TokenBucket(LongSupplier clock, double rate, double burst, double initialTokens) {
+        if (rate <= 0.0) {
+            throw new IllegalArgumentException("rate must be greater than zero");
+        }
+
+        if (burst <= 0.0) {
+            throw new IllegalArgumentException("burst must be greater than zero");
+        }
+
+        this.clock = clock;
+        this.rate = rate;
+        this.burst = burst;
+        this.state = new AtomicReference<>(new State(Math.min(initialTokens, burst), clock.getAsLong()));
+    }
+
+    /**
+     * If there are enough tokens in the bucket, it requests/deducts 'n' tokens and returns true.
+     * Otherwise, returns false and leaves the bucket untouched.
+     */
+    public boolean request(double n) {
+        if (n <= 0) {
+            throw new IllegalArgumentException("requested tokens must be greater than zero");
+        }
+
+        // Refill tokens
+        State currentState, updatedState;
+        do {
+            currentState = state.get();
+            long now = clock.getAsLong();
+            double incr = (now - currentState.lastRefilledAt) * rate;
+            updatedState = new State(Math.min(currentState.tokens + incr, burst), now);
+        } while (state.compareAndSet(currentState, updatedState) == false);
+
+        // Deduct tokens
+        do {
+            currentState = state.get();
+            if (currentState.tokens < n) {
+                return false;
+            }
+            updatedState = new State(currentState.tokens - n, currentState.lastRefilledAt);
+        } while (state.compareAndSet(currentState, updatedState) == false);
+
+        return true;
+    }
+
+    public boolean request() {
+        return request(1.0);
+    }
+
+    /**
+     * Represents an immutable token bucket state.
+     */
+    private static class State {
+        final double tokens;
+        final double lastRefilledAt;
+
+        public State(double tokens, double lastRefilledAt) {
+            this.tokens = tokens;
+            this.lastRefilledAt = lastRefilledAt;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            State state = (State) o;
+            return Double.compare(state.tokens, tokens) == 0 && Double.compare(state.lastRefilledAt, lastRefilledAt) == 0;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(tokens, lastRefilledAt);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/common/util/TokenBucket.java
+++ b/server/src/main/java/org/opensearch/common/util/TokenBucket.java
@@ -101,9 +101,9 @@ public class TokenBucket {
      */
     private static class State {
         final double tokens;
-        final double lastRefilledAt;
+        final long lastRefilledAt;
 
-        public State(double tokens, double lastRefilledAt) {
+        public State(double tokens, long lastRefilledAt) {
             this.tokens = tokens;
             this.lastRefilledAt = lastRefilledAt;
         }
@@ -113,7 +113,7 @@ public class TokenBucket {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             State state = (State) o;
-            return Double.compare(state.tokens, tokens) == 0 && Double.compare(state.lastRefilledAt, lastRefilledAt) == 0;
+            return Double.compare(state.tokens, tokens) == 0 && lastRefilledAt == state.lastRefilledAt;
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -45,6 +45,10 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.indices.replication.SegmentReplicationSourceFactory;
 import org.opensearch.indices.replication.SegmentReplicationTargetService;
 import org.opensearch.indices.replication.SegmentReplicationSourceService;
+import org.opensearch.search.backpressure.SearchBackpressureService;
+import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
+import org.opensearch.tasks.TaskResourceTrackingService;
+import org.opensearch.threadpool.RunnableTaskExecutionListener;
 import org.opensearch.index.store.RemoteSegmentStoreDirectoryFactory;
 import org.opensearch.watcher.ResourceWatcherService;
 import org.opensearch.Assertions;
@@ -796,6 +800,23 @@ public class Node implements Closeable {
             // development. Then we can deprecate Getter and Setter for IndexingPressureService in ClusterService (#478).
             clusterService.setIndexingPressureService(indexingPressureService);
 
+            final TaskResourceTrackingService taskResourceTrackingService = new TaskResourceTrackingService(
+                settings,
+                clusterService.getClusterSettings(),
+                threadPool
+            );
+
+            final SearchBackpressureSettings searchBackpressureSettings = new SearchBackpressureSettings(
+                settings,
+                clusterService.getClusterSettings()
+            );
+
+            final SearchBackpressureService searchBackpressureService = new SearchBackpressureService(
+                searchBackpressureSettings,
+                taskResourceTrackingService,
+                threadPool
+            );
+
             final RecoverySettings recoverySettings = new RecoverySettings(settings, settingsModule.getClusterSettings());
             RepositoriesModule repositoriesModule = new RepositoriesModule(
                 this.environment,
@@ -883,7 +904,8 @@ public class Node implements Closeable {
                 responseCollectorService,
                 searchTransportService,
                 indexingPressureService,
-                searchModule.getValuesSourceRegistry().getUsageService()
+                searchModule.getValuesSourceRegistry().getUsageService(),
+                searchBackpressureService
             );
 
             final SearchService searchService = newSearchService(
@@ -941,6 +963,8 @@ public class Node implements Closeable {
                 b.bind(AnalysisRegistry.class).toInstance(analysisModule.getAnalysisRegistry());
                 b.bind(IngestService.class).toInstance(ingestService);
                 b.bind(IndexingPressureService.class).toInstance(indexingPressureService);
+                b.bind(TaskResourceTrackingService.class).toInstance(taskResourceTrackingService);
+                b.bind(SearchBackpressureService.class).toInstance(searchBackpressureService);
                 b.bind(UsageService.class).toInstance(usageService);
                 b.bind(AggregationUsageService.class).toInstance(searchModule.getValuesSourceRegistry().getUsageService());
                 b.bind(NamedWriteableRegistry.class).toInstance(namedWriteableRegistry);
@@ -1104,6 +1128,7 @@ public class Node implements Closeable {
         injector.getInstance(SearchService.class).start();
         injector.getInstance(FsHealthService.class).start();
         nodeService.getMonitorService().start();
+        nodeService.getSearchBackpressureService().start();
 
         final ClusterService clusterService = injector.getInstance(ClusterService.class);
 
@@ -1259,6 +1284,7 @@ public class Node implements Closeable {
         injector.getInstance(NodeConnectionsService.class).stop();
         injector.getInstance(FsHealthService.class).stop();
         nodeService.getMonitorService().stop();
+        nodeService.getSearchBackpressureService().stop();
         injector.getInstance(GatewayService.class).stop();
         injector.getInstance(SearchService.class).stop();
         injector.getInstance(TransportService.class).stop();
@@ -1318,6 +1344,7 @@ public class Node implements Closeable {
         toClose.add(injector.getInstance(Discovery.class));
         toClose.add(() -> stopWatch.stop().start("monitor"));
         toClose.add(nodeService.getMonitorService());
+        toClose.add(nodeService.getSearchBackpressureService());
         toClose.add(() -> stopWatch.stop().start("fsHealth"));
         toClose.add(injector.getInstance(FsHealthService.class));
         toClose.add(() -> stopWatch.stop().start("gateway"));

--- a/server/src/main/java/org/opensearch/node/NodeService.java
+++ b/server/src/main/java/org/opensearch/node/NodeService.java
@@ -173,7 +173,8 @@ public class NodeService implements Closeable {
         boolean adaptiveSelection,
         boolean scriptCache,
         boolean indexingPressure,
-        boolean shardIndexingPressure
+        boolean shardIndexingPressure,
+        boolean searchBackpressure
     ) {
         // for indices stats we want to include previous allocated shards stats as well (it will
         // only be applied to the sensible ones to use, like refresh/merge/flush/indexing stats)
@@ -195,7 +196,8 @@ public class NodeService implements Closeable {
             adaptiveSelection ? responseCollectorService.getAdaptiveStats(searchTransportService.getPendingSearchRequests()) : null,
             scriptCache ? scriptService.cacheStats() : null,
             indexingPressure ? this.indexingPressureService.nodeStats() : null,
-            shardIndexingPressure ? this.indexingPressureService.shardStats(indices) : null
+            shardIndexingPressure ? this.indexingPressureService.shardStats(indices) : null,
+            searchBackpressure ? this.searchBackpressureService.nodeStats() : null
         );
     }
 

--- a/server/src/main/java/org/opensearch/node/NodeService.java
+++ b/server/src/main/java/org/opensearch/node/NodeService.java
@@ -53,6 +53,7 @@ import org.opensearch.monitor.MonitorService;
 import org.opensearch.plugins.PluginsService;
 import org.opensearch.script.ScriptService;
 import org.opensearch.search.aggregations.support.AggregationUsageService;
+import org.opensearch.search.backpressure.SearchBackpressureService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
@@ -81,6 +82,7 @@ public class NodeService implements Closeable {
     private final SearchTransportService searchTransportService;
     private final IndexingPressureService indexingPressureService;
     private final AggregationUsageService aggregationUsageService;
+    private final SearchBackpressureService searchBackpressureService;
 
     private final Discovery discovery;
 
@@ -101,7 +103,8 @@ public class NodeService implements Closeable {
         ResponseCollectorService responseCollectorService,
         SearchTransportService searchTransportService,
         IndexingPressureService indexingPressureService,
-        AggregationUsageService aggregationUsageService
+        AggregationUsageService aggregationUsageService,
+        SearchBackpressureService searchBackpressureService
     ) {
         this.settings = settings;
         this.threadPool = threadPool;
@@ -119,6 +122,7 @@ public class NodeService implements Closeable {
         this.searchTransportService = searchTransportService;
         this.indexingPressureService = indexingPressureService;
         this.aggregationUsageService = aggregationUsageService;
+        this.searchBackpressureService = searchBackpressureService;
         clusterService.addStateApplier(ingestService);
     }
 
@@ -201,6 +205,10 @@ public class NodeService implements Closeable {
 
     public MonitorService getMonitorService() {
         return monitorService;
+    }
+
+    public SearchBackpressureService getSearchBackpressureService() {
+        return searchBackpressureService;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/backpressure/SearchBackpressureService.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/SearchBackpressureService.java
@@ -17,6 +17,9 @@ import org.opensearch.common.util.TokenBucket;
 import org.opensearch.monitor.jvm.JvmStats;
 import org.opensearch.monitor.process.ProcessProbe;
 import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
+import org.opensearch.search.backpressure.trackers.CpuUsageTracker;
+import org.opensearch.search.backpressure.trackers.ElapsedTimeTracker;
+import org.opensearch.search.backpressure.trackers.HeapUsageTracker;
 import org.opensearch.search.backpressure.trackers.NodeDuressTracker;
 import org.opensearch.search.backpressure.trackers.TaskResourceUsageTracker;
 import org.opensearch.tasks.CancellableTask;
@@ -29,7 +32,6 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -84,7 +86,7 @@ public class SearchBackpressureService extends AbstractLifecycleComponent
                     () -> JvmStats.jvmStats().getMem().getHeapUsedPercent() / 100.0 >= settings.getNodeDuressSettings().getHeapThreshold()
                 )
             ),
-            Collections.emptyList()
+            List.of(new CpuUsageTracker(settings), new HeapUsageTracker(settings), new ElapsedTimeTracker(settings, System::nanoTime))
         );
     }
 
@@ -97,7 +99,7 @@ public class SearchBackpressureService extends AbstractLifecycleComponent
         List<TaskResourceUsageTracker> taskResourceUsageTrackers
     ) {
         this.settings = settings;
-        this.settings.setListener(this);
+        this.settings.addListener(this);
         this.taskResourceTrackingService = taskResourceTrackingService;
         this.taskResourceTrackingService.addTaskCompletionListener(this);
         this.threadPool = threadPool;
@@ -181,10 +183,10 @@ public class SearchBackpressureService extends AbstractLifecycleComponent
      * Returns true if the increase in heap usage is due to search requests.
      */
     boolean isHeapUsageDominatedBySearch(List<CancellableTask> searchShardTasks) {
-        long runningTasksHeapUsage = searchShardTasks.stream().mapToLong(task -> task.getTotalResourceStats().getMemoryInBytes()).sum();
-        long searchTasksHeapThreshold = getSettings().getSearchShardTaskSettings().getTotalHeapThresholdBytes();
-        if (runningTasksHeapUsage < searchTasksHeapThreshold) {
-            logger.debug("heap usage not dominated by search requests [{}/{}]", runningTasksHeapUsage, searchTasksHeapThreshold);
+        long usage = searchShardTasks.stream().mapToLong(task -> task.getTotalResourceStats().getMemoryInBytes()).sum();
+        long threshold = getSettings().getSearchShardTaskSettings().getTotalHeapBytesThreshold();
+        if (usage < threshold) {
+            logger.debug("heap usage not dominated by search requests [{}/{}]", usage, threshold);
             return false;
         }
 
@@ -213,7 +215,7 @@ public class SearchBackpressureService extends AbstractLifecycleComponent
         List<Runnable> callbacks = new ArrayList<>();
 
         for (TaskResourceUsageTracker tracker : taskResourceUsageTrackers) {
-            Optional<TaskCancellation.Reason> reason = tracker.cancellationReason(task);
+            Optional<TaskCancellation.Reason> reason = tracker.checkAndMaybeGetCancellationReason(task);
             if (reason.isPresent()) {
                 reasons.add(reason.get());
                 callbacks.add(tracker::incrementCancellations);

--- a/server/src/main/java/org/opensearch/search/backpressure/SearchBackpressureService.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/SearchBackpressureService.java
@@ -1,0 +1,311 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.common.component.AbstractLifecycleComponent;
+import org.opensearch.common.util.TokenBucket;
+import org.opensearch.monitor.jvm.JvmStats;
+import org.opensearch.monitor.process.ProcessProbe;
+import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
+import org.opensearch.search.backpressure.trackers.NodeDuressTracker;
+import org.opensearch.search.backpressure.trackers.TaskResourceUsageTracker;
+import org.opensearch.tasks.CancellableTask;
+import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskCancellation;
+import org.opensearch.tasks.TaskResourceTrackingService;
+import org.opensearch.tasks.TaskResourceTrackingService.TaskCompletionListener;
+import org.opensearch.threadpool.Scheduler;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
+
+/**
+ * SearchBackpressureService is responsible for monitoring and cancelling in-flight search tasks if they are
+ * breaching resource usage limits when the node is in duress.
+ *
+ * @opensearch.internal
+ */
+public class SearchBackpressureService extends AbstractLifecycleComponent
+    implements
+        TaskCompletionListener,
+        SearchBackpressureSettings.Listener {
+    private static final Logger logger = LogManager.getLogger(SearchBackpressureService.class);
+
+    private volatile Scheduler.Cancellable scheduledFuture;
+
+    private final SearchBackpressureSettings settings;
+    private final TaskResourceTrackingService taskResourceTrackingService;
+    private final ThreadPool threadPool;
+    private final LongSupplier timeNanosSupplier;
+
+    private final List<NodeDuressTracker> nodeDuressTrackers;
+    private final List<TaskResourceUsageTracker> taskResourceUsageTrackers;
+
+    private final AtomicReference<TokenBucket> taskCancellationRateLimiter = new AtomicReference<>();
+    private final AtomicReference<TokenBucket> taskCancellationRatioLimiter = new AtomicReference<>();
+
+    // Currently, only the state of SearchShardTask is being tracked.
+    // This can be generalized to Map<TaskType, SearchBackpressureState> once we start supporting cancellation of SearchTasks as well.
+    private final SearchBackpressureState state = new SearchBackpressureState();
+
+    public SearchBackpressureService(
+        SearchBackpressureSettings settings,
+        TaskResourceTrackingService taskResourceTrackingService,
+        ThreadPool threadPool
+    ) {
+        this(
+            settings,
+            taskResourceTrackingService,
+            threadPool,
+            System::nanoTime,
+            List.of(
+                new NodeDuressTracker(
+                    () -> ProcessProbe.getInstance().getProcessCpuPercent() / 100.0 >= settings.getNodeDuressSettings().getCpuThreshold()
+                ),
+                new NodeDuressTracker(
+                    () -> JvmStats.jvmStats().getMem().getHeapUsedPercent() / 100.0 >= settings.getNodeDuressSettings().getHeapThreshold()
+                )
+            ),
+            Collections.emptyList()
+        );
+    }
+
+    public SearchBackpressureService(
+        SearchBackpressureSettings settings,
+        TaskResourceTrackingService taskResourceTrackingService,
+        ThreadPool threadPool,
+        LongSupplier timeNanosSupplier,
+        List<NodeDuressTracker> nodeDuressTrackers,
+        List<TaskResourceUsageTracker> taskResourceUsageTrackers
+    ) {
+        this.settings = settings;
+        this.settings.setListener(this);
+        this.taskResourceTrackingService = taskResourceTrackingService;
+        this.taskResourceTrackingService.addTaskCompletionListener(this);
+        this.threadPool = threadPool;
+        this.timeNanosSupplier = timeNanosSupplier;
+        this.nodeDuressTrackers = nodeDuressTrackers;
+        this.taskResourceUsageTrackers = taskResourceUsageTrackers;
+
+        this.taskCancellationRateLimiter.set(
+            new TokenBucket(timeNanosSupplier, getSettings().getCancellationRateNanos(), getSettings().getCancellationBurst())
+        );
+
+        this.taskCancellationRatioLimiter.set(
+            new TokenBucket(state::getCompletionCount, getSettings().getCancellationRatio(), getSettings().getCancellationBurst())
+        );
+    }
+
+    void doRun() {
+        if (getSettings().isEnabled() == false) {
+            return;
+        }
+
+        if (isNodeInDuress() == false) {
+            return;
+        }
+
+        // We are only targeting in-flight cancellation of SearchShardTask for now.
+        List<CancellableTask> searchShardTasks = getSearchShardTasks();
+
+        // Force-refresh usage stats of these tasks before making a cancellation decision.
+        taskResourceTrackingService.refreshResourceStats(searchShardTasks.toArray(new Task[0]));
+
+        // Skip cancellation if the increase in heap usage is not due to search requests.
+        if (isHeapUsageDominatedBySearch(searchShardTasks) == false) {
+            return;
+        }
+
+        for (TaskCancellation taskCancellation : getTaskCancellations(searchShardTasks)) {
+            logger.debug(
+                "cancelling task [{}] due to high resource consumption [{}]",
+                taskCancellation.getTask().getId(),
+                taskCancellation.getReasonString()
+            );
+
+            if (getSettings().isEnforced() == false) {
+                continue;
+            }
+
+            // Independently remove tokens from both token buckets.
+            boolean rateLimitReached = taskCancellationRateLimiter.get().request() == false;
+            boolean ratioLimitReached = taskCancellationRatioLimiter.get().request() == false;
+
+            // Stop cancelling tasks if there are no tokens in either of the two token buckets.
+            if (rateLimitReached && ratioLimitReached) {
+                logger.debug("task cancellation limit reached");
+                state.incrementLimitReachedCount();
+                break;
+            }
+
+            taskCancellation.cancel();
+            state.incrementCancellationCount();
+        }
+    }
+
+    /**
+     * Returns true if the node is in duress consecutively for the past 'n' observations.
+     */
+    boolean isNodeInDuress() {
+        boolean isNodeInDuress = false;
+        int numSuccessiveBreaches = getSettings().getNodeDuressSettings().getNumSuccessiveBreaches();
+
+        for (NodeDuressTracker tracker : nodeDuressTrackers) {
+            if (tracker.check() >= numSuccessiveBreaches) {
+                isNodeInDuress = true;  // not breaking the loop so that each tracker's streak gets updated.
+            }
+        }
+
+        return isNodeInDuress;
+    }
+
+    /**
+     * Returns true if the increase in heap usage is due to search requests.
+     */
+    boolean isHeapUsageDominatedBySearch(List<CancellableTask> searchShardTasks) {
+        long runningTasksHeapUsage = searchShardTasks.stream().mapToLong(task -> task.getTotalResourceStats().getMemoryInBytes()).sum();
+        long searchTasksHeapThreshold = getSettings().getSearchShardTaskSettings().getTotalHeapThresholdBytes();
+        if (runningTasksHeapUsage < searchTasksHeapThreshold) {
+            logger.debug("heap usage not dominated by search requests [{}/{}]", runningTasksHeapUsage, searchTasksHeapThreshold);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Filters and returns the list of currently running SearchShardTasks.
+     */
+    List<CancellableTask> getSearchShardTasks() {
+        return taskResourceTrackingService.getResourceAwareTasks()
+            .values()
+            .stream()
+            .filter(task -> task instanceof SearchShardTask)
+            .map(task -> (CancellableTask) task)
+            .collect(Collectors.toUnmodifiableList());
+    }
+
+    /**
+     * Returns a TaskCancellation wrapper containing the list of reasons (possibly zero), along with an overall
+     * cancellation score for the given task. Cancelling a task with a higher score has better chance of recovering the
+     * node from duress.
+     */
+    TaskCancellation getTaskCancellation(CancellableTask task) {
+        List<TaskCancellation.Reason> reasons = new ArrayList<>();
+        List<Runnable> callbacks = new ArrayList<>();
+
+        for (TaskResourceUsageTracker tracker : taskResourceUsageTrackers) {
+            Optional<TaskCancellation.Reason> reason = tracker.cancellationReason(task);
+            if (reason.isPresent()) {
+                reasons.add(reason.get());
+                callbacks.add(tracker::incrementCancellations);
+            }
+        }
+
+        return new TaskCancellation(task, reasons, callbacks);
+    }
+
+    /**
+     * Returns a list of TaskCancellations sorted by descending order of their cancellation scores.
+     */
+    List<TaskCancellation> getTaskCancellations(List<CancellableTask> tasks) {
+        return tasks.stream()
+            .map(this::getTaskCancellation)
+            .filter(TaskCancellation::isEligibleForCancellation)
+            .sorted(Comparator.reverseOrder())
+            .collect(Collectors.toUnmodifiableList());
+    }
+
+    SearchBackpressureSettings getSettings() {
+        return settings;
+    }
+
+    SearchBackpressureState getState() {
+        return state;
+    }
+
+    @Override
+    public void onTaskCompleted(Task task) {
+        if (getSettings().isEnabled() == false) {
+            return;
+        }
+
+        if (task instanceof SearchShardTask == false) {
+            return;
+        }
+
+        SearchShardTask searchShardTask = (SearchShardTask) task;
+        if (searchShardTask.isCancelled() == false) {
+            state.incrementCompletionCount();
+        }
+
+        List<Exception> exceptions = new ArrayList<>();
+        for (TaskResourceUsageTracker tracker : taskResourceUsageTrackers) {
+            try {
+                tracker.update(searchShardTask);
+            } catch (Exception e) {
+                exceptions.add(e);
+            }
+        }
+        ExceptionsHelper.maybeThrowRuntimeAndSuppress(exceptions);
+    }
+
+    @Override
+    public void onCancellationRatioChanged() {
+        taskCancellationRatioLimiter.set(
+            new TokenBucket(state::getCompletionCount, getSettings().getCancellationRatio(), getSettings().getCancellationBurst())
+        );
+    }
+
+    @Override
+    public void onCancellationRateChanged() {
+        taskCancellationRateLimiter.set(
+            new TokenBucket(timeNanosSupplier, getSettings().getCancellationRateNanos(), getSettings().getCancellationBurst())
+        );
+    }
+
+    @Override
+    public void onCancellationBurstChanged() {
+        onCancellationRatioChanged();
+        onCancellationRateChanged();
+    }
+
+    @Override
+    protected void doStart() {
+        scheduledFuture = threadPool.scheduleWithFixedDelay(() -> {
+            try {
+                doRun();
+            } catch (Exception e) {
+                logger.debug("failure in search search backpressure", e);
+            }
+        }, getSettings().getInterval(), ThreadPool.Names.GENERIC);
+    }
+
+    @Override
+    protected void doStop() {
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel();
+        }
+    }
+
+    @Override
+    protected void doClose() throws IOException {}
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/SearchBackpressureState.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/SearchBackpressureState.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Tracks the current state of task completions and cancellations.
+ *
+ * @opensearch.internal
+ */
+public class SearchBackpressureState {
+    /**
+     * The number of successful task completions.
+     */
+    private final AtomicLong completionCount = new AtomicLong();
+
+    /**
+     * The number of task cancellations due to limit breaches.
+     */
+    private final AtomicLong cancellationCount = new AtomicLong();
+
+    /**
+     * The number of times task cancellation limit was reached.
+     */
+    private final AtomicLong limitReachedCount = new AtomicLong();
+
+    public long getCompletionCount() {
+        return completionCount.get();
+    }
+
+    long incrementCompletionCount() {
+        return completionCount.incrementAndGet();
+    }
+
+    public long getCancellationCount() {
+        return cancellationCount.get();
+    }
+
+    long incrementCancellationCount() {
+        return cancellationCount.incrementAndGet();
+    }
+
+    public long getLimitReachedCount() {
+        return limitReachedCount.get();
+    }
+
+    long incrementLimitReachedCount() {
+        return limitReachedCount.incrementAndGet();
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/package-info.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * This package contains classes responsible for search backpressure.
+ */
+package org.opensearch.search.backpressure;

--- a/server/src/main/java/org/opensearch/search/backpressure/settings/NodeDuressSettings.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/settings/NodeDuressSettings.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.settings;
+
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+
+/**
+ * Defines the settings for a node to be considered in duress.
+ *
+ * @opensearch.internal
+ */
+public class NodeDuressSettings {
+    private static class Defaults {
+        private static final int NUM_SUCCESSIVE_BREACHES = 3;
+        private static final double CPU_THRESHOLD = 0.9;
+        private static final double HEAP_THRESHOLD = 0.7;
+    }
+
+    /**
+     * Defines the number of successive limit breaches after the node is marked "in duress".
+     */
+    private volatile int numSuccessiveBreaches;
+    public static final Setting<Integer> SETTING_NUM_SUCCESSIVE_BREACHES = Setting.intSetting(
+        "search_backpressure.node_duress.num_successive_breaches",
+        Defaults.NUM_SUCCESSIVE_BREACHES,
+        1,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the CPU usage threshold (in percentage) for a node to be considered "in duress".
+     */
+    private volatile double cpuThreshold;
+    public static final Setting<Double> SETTING_CPU_THRESHOLD = Setting.doubleSetting(
+        "search_backpressure.node_duress.cpu_threshold",
+        Defaults.CPU_THRESHOLD,
+        0.0,
+        1.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the heap usage threshold (in percentage) for a node to be considered "in duress".
+     */
+    private volatile double heapThreshold;
+    public static final Setting<Double> SETTING_HEAP_THRESHOLD = Setting.doubleSetting(
+        "search_backpressure.node_duress.heap_threshold",
+        Defaults.HEAP_THRESHOLD,
+        0.0,
+        1.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    public NodeDuressSettings(Settings settings, ClusterSettings clusterSettings) {
+        numSuccessiveBreaches = SETTING_NUM_SUCCESSIVE_BREACHES.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_NUM_SUCCESSIVE_BREACHES, this::setNumSuccessiveBreaches);
+
+        cpuThreshold = SETTING_CPU_THRESHOLD.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_CPU_THRESHOLD, this::setCpuThreshold);
+
+        heapThreshold = SETTING_HEAP_THRESHOLD.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_HEAP_THRESHOLD, this::setHeapThreshold);
+    }
+
+    public int getNumSuccessiveBreaches() {
+        return numSuccessiveBreaches;
+    }
+
+    private void setNumSuccessiveBreaches(int numSuccessiveBreaches) {
+        this.numSuccessiveBreaches = numSuccessiveBreaches;
+    }
+
+    public double getCpuThreshold() {
+        return cpuThreshold;
+    }
+
+    private void setCpuThreshold(double cpuThreshold) {
+        this.cpuThreshold = cpuThreshold;
+    }
+
+    public double getHeapThreshold() {
+        return heapThreshold;
+    }
+
+    private void setHeapThreshold(double heapThreshold) {
+        this.heapThreshold = heapThreshold;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/settings/SearchBackpressureMode.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/settings/SearchBackpressureMode.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.settings;
+
+/**
+ * Defines the search backpressure mode.
+ */
+public enum SearchBackpressureMode {
+    /**
+     * SearchBackpressureService is completely disabled.
+     */
+    DISABLED("disabled"),
+
+    /**
+     * SearchBackpressureService only monitors the resource usage of running tasks.
+     */
+    MONITOR_ONLY("monitor_only"),
+
+    /**
+     * SearchBackpressureService monitors and rejects tasks that exceed resource usage thresholds.
+     */
+    ENFORCED("enforced");
+
+    private final String name;
+
+    SearchBackpressureMode(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static SearchBackpressureMode fromName(String name) {
+        switch (name) {
+            case "disabled":
+                return DISABLED;
+            case "monitor_only":
+                return MONITOR_ONLY;
+            case "enforced":
+                return ENFORCED;
+        }
+
+        throw new IllegalArgumentException("Invalid SearchBackpressureMode: " + name);
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/settings/SearchBackpressureSettings.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/settings/SearchBackpressureSettings.java
@@ -1,0 +1,213 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.settings;
+
+import org.apache.lucene.util.SetOnce;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Settings related to search backpressure and cancellation of in-flight requests.
+ *
+ * @opensearch.internal
+ */
+public class SearchBackpressureSettings {
+    private static class Defaults {
+        private static final long INTERVAL = 1000;
+
+        private static final boolean ENABLED = true;
+        private static final boolean ENFORCED = false;
+
+        private static final double CANCELLATION_RATIO = 0.1;
+        private static final double CANCELLATION_RATE = 0.003;
+        private static final double CANCELLATION_BURST = 10.0;
+    }
+
+    /**
+     * Defines the interval (in millis) at which the SearchBackpressureService monitors and cancels tasks.
+     */
+    private final TimeValue interval;
+    public static final Setting<Long> SETTING_INTERVAL = Setting.longSetting(
+        "search_backpressure.interval",
+        Defaults.INTERVAL,
+        1,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines whether search backpressure is enabled or not.
+     */
+    private volatile boolean enabled;
+    public static final Setting<Boolean> SETTING_ENABLED = Setting.boolSetting(
+        "search_backpressure.enabled",
+        Defaults.ENABLED,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines whether in-flight cancellation of tasks is enabled or not.
+     */
+    private volatile boolean enforced;
+    public static final Setting<Boolean> SETTING_ENFORCED = Setting.boolSetting(
+        "search_backpressure.enforced",
+        Defaults.ENFORCED,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the percentage of tasks to cancel relative to the number of successful task completions.
+     * In other words, it is the number of tokens added to the bucket on each successful task completion.
+     */
+    private volatile double cancellationRatio;
+    public static final Setting<Double> SETTING_CANCELLATION_RATIO = Setting.doubleSetting(
+        "search_backpressure.cancellation_ratio",
+        Defaults.CANCELLATION_RATIO,
+        0.0,
+        1.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the number of tasks to cancel per unit time (in millis).
+     * In other words, it is the number of tokens added to the bucket each millisecond.
+     */
+    private volatile double cancellationRate;
+    public static final Setting<Double> SETTING_CANCELLATION_RATE = Setting.doubleSetting(
+        "search_backpressure.cancellation_rate",
+        Defaults.CANCELLATION_RATE,
+        0.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the maximum number of tasks that can be cancelled before being rate-limited.
+     */
+    private volatile double cancellationBurst;
+    public static final Setting<Double> SETTING_CANCELLATION_BURST = Setting.doubleSetting(
+        "search_backpressure.cancellation_burst",
+        Defaults.CANCELLATION_BURST,
+        1.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Callback listeners.
+     */
+    public interface Listener {
+        void onCancellationRatioChanged();
+
+        void onCancellationRateChanged();
+
+        void onCancellationBurstChanged();
+    }
+
+    private final SetOnce<Listener> listener = new SetOnce<>();
+    private final NodeDuressSettings nodeDuressSettings;
+    private final SearchShardTaskSettings searchShardTaskSettings;
+
+    public SearchBackpressureSettings(Settings settings, ClusterSettings clusterSettings) {
+        this.nodeDuressSettings = new NodeDuressSettings(settings, clusterSettings);
+        this.searchShardTaskSettings = new SearchShardTaskSettings(settings, clusterSettings);
+
+        interval = new TimeValue(SETTING_INTERVAL.get(settings));
+
+        enabled = SETTING_ENABLED.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_ENABLED, this::setEnabled);
+
+        enforced = SETTING_ENFORCED.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_ENFORCED, this::setEnforced);
+
+        cancellationRatio = SETTING_CANCELLATION_RATIO.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_CANCELLATION_RATIO, this::setCancellationRatio);
+
+        cancellationRate = SETTING_CANCELLATION_RATE.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_CANCELLATION_RATE, this::setCancellationRate);
+
+        cancellationBurst = SETTING_CANCELLATION_BURST.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_CANCELLATION_BURST, this::setCancellationBurst);
+    }
+
+    public void setListener(Listener listener) {
+        this.listener.set(listener);
+    }
+
+    public NodeDuressSettings getNodeDuressSettings() {
+        return nodeDuressSettings;
+    }
+
+    public SearchShardTaskSettings getSearchShardTaskSettings() {
+        return searchShardTaskSettings;
+    }
+
+    public TimeValue getInterval() {
+        return interval;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    private void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isEnforced() {
+        return enforced;
+    }
+
+    private void setEnforced(boolean enforced) {
+        this.enforced = enforced;
+    }
+
+    public double getCancellationRatio() {
+        return cancellationRatio;
+    }
+
+    private void setCancellationRatio(double cancellationRatio) {
+        this.cancellationRatio = cancellationRatio;
+        if (listener.get() != null) {
+            listener.get().onCancellationRatioChanged();
+        }
+    }
+
+    public double getCancellationRate() {
+        return cancellationRate;
+    }
+
+    public double getCancellationRateNanos() {
+        return getCancellationRate() / TimeUnit.MILLISECONDS.toNanos(1); // rate per nanoseconds
+    }
+
+    private void setCancellationRate(double cancellationRate) {
+        this.cancellationRate = cancellationRate;
+        if (listener.get() != null) {
+            listener.get().onCancellationRateChanged();
+        }
+    }
+
+    public double getCancellationBurst() {
+        return cancellationBurst;
+    }
+
+    private void setCancellationBurst(double cancellationBurst) {
+        this.cancellationBurst = cancellationBurst;
+        if (listener.get() != null) {
+            listener.get().onCancellationBurstChanged();
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/settings/SearchShardTaskSettings.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/settings/SearchShardTaskSettings.java
@@ -22,139 +22,37 @@ public class SearchShardTaskSettings {
     private static final long HEAP_SIZE_BYTES = JvmStats.jvmStats().getMem().getHeapMax().getBytes();
 
     private static class Defaults {
-        private static final double TOTAL_HEAP_THRESHOLD = 0.05;
-        private static final double HEAP_THRESHOLD = 0.005;
-        private static final double HEAP_VARIANCE_THRESHOLD = 2.0;
-        private static final long CPU_TIME_THRESHOLD = 15;
-        private static final long ELAPSED_TIME_THRESHOLD = 30000;
+        private static final double TOTAL_HEAP_PERCENT_THRESHOLD = 0.05;
     }
 
     /**
      * Defines the heap usage threshold (in percentage) for the sum of heap usages across all search shard tasks
      * before in-flight cancellation is applied.
      */
-    private volatile double totalHeapThreshold;
-    public static final Setting<Double> SETTING_TOTAL_HEAP_THRESHOLD = Setting.doubleSetting(
-        "search_backpressure.search_shard_task.total_heap_threshold",
-        Defaults.TOTAL_HEAP_THRESHOLD,
+    private volatile double totalHeapPercentThreshold;
+    public static final Setting<Double> SETTING_TOTAL_HEAP_PERCENT_THRESHOLD = Setting.doubleSetting(
+        "search_backpressure.search_shard_task.total_heap_percent_threshold",
+        Defaults.TOTAL_HEAP_PERCENT_THRESHOLD,
         0.0,
         1.0,
-        Setting.Property.Dynamic,
-        Setting.Property.NodeScope
-    );
-
-    /**
-     * Defines the heap usage threshold (in percentage) for an individual task before it is considered for cancellation.
-     */
-    private volatile double heapThreshold;
-    public static final Setting<Double> SETTING_HEAP_THRESHOLD = Setting.doubleSetting(
-        "search_backpressure.search_shard_task.heap_threshold",
-        Defaults.HEAP_THRESHOLD,
-        0.0,
-        1.0,
-        Setting.Property.Dynamic,
-        Setting.Property.NodeScope
-    );
-
-    /**
-     * Defines the heap usage variance for an individual task before it is considered for cancellation.
-     * A task is considered for cancellation when taskHeapUsage is greater than or equal to heapUsageMovingAverage * variance.
-     */
-    private volatile double heapVarianceThreshold;
-    public static final Setting<Double> SETTING_HEAP_VARIANCE_THRESHOLD = Setting.doubleSetting(
-        "search_backpressure.search_shard_task.heap_variance",
-        Defaults.HEAP_VARIANCE_THRESHOLD,
-        0.0,
-        Setting.Property.Dynamic,
-        Setting.Property.NodeScope
-    );
-
-    /**
-     * Defines the CPU usage threshold (in millis) for an individual task before it is considered for cancellation.
-     */
-    private volatile long cpuTimeThreshold;
-    public static final Setting<Long> SETTING_CPU_TIME_THRESHOLD = Setting.longSetting(
-        "search_backpressure.search_shard_task.cpu_time_threshold",
-        Defaults.CPU_TIME_THRESHOLD,
-        0,
-        Setting.Property.Dynamic,
-        Setting.Property.NodeScope
-    );
-
-    /**
-     * Defines the elapsed time threshold (in millis) for an individual task before it is considered for cancellation.
-     */
-    private volatile long elapsedTimeThreshold;
-    public static final Setting<Long> SETTING_ELAPSED_TIME_THRESHOLD = Setting.longSetting(
-        "search_backpressure.search_shard_task.elapsed_time_threshold",
-        Defaults.ELAPSED_TIME_THRESHOLD,
-        0,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
 
     public SearchShardTaskSettings(Settings settings, ClusterSettings clusterSettings) {
-        totalHeapThreshold = SETTING_TOTAL_HEAP_THRESHOLD.get(settings);
-        clusterSettings.addSettingsUpdateConsumer(SETTING_TOTAL_HEAP_THRESHOLD, this::setTotalHeapThreshold);
-
-        heapThreshold = SETTING_HEAP_THRESHOLD.get(settings);
-        clusterSettings.addSettingsUpdateConsumer(SETTING_HEAP_THRESHOLD, this::setHeapThreshold);
-
-        heapVarianceThreshold = SETTING_HEAP_VARIANCE_THRESHOLD.get(settings);
-        clusterSettings.addSettingsUpdateConsumer(SETTING_HEAP_VARIANCE_THRESHOLD, this::setHeapVarianceThreshold);
-
-        cpuTimeThreshold = SETTING_CPU_TIME_THRESHOLD.get(settings);
-        clusterSettings.addSettingsUpdateConsumer(SETTING_CPU_TIME_THRESHOLD, this::setCpuTimeThreshold);
-
-        elapsedTimeThreshold = SETTING_ELAPSED_TIME_THRESHOLD.get(settings);
-        clusterSettings.addSettingsUpdateConsumer(SETTING_ELAPSED_TIME_THRESHOLD, this::setElapsedTimeThreshold);
+        totalHeapPercentThreshold = SETTING_TOTAL_HEAP_PERCENT_THRESHOLD.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_TOTAL_HEAP_PERCENT_THRESHOLD, this::setTotalHeapPercentThreshold);
     }
 
-    public double getTotalHeapThreshold() {
-        return totalHeapThreshold;
+    public double getTotalHeapPercentThreshold() {
+        return totalHeapPercentThreshold;
     }
 
-    public long getTotalHeapThresholdBytes() {
-        return (long) (HEAP_SIZE_BYTES * getTotalHeapThreshold());
+    public long getTotalHeapBytesThreshold() {
+        return (long) (HEAP_SIZE_BYTES * getTotalHeapPercentThreshold());
     }
 
-    private void setTotalHeapThreshold(double totalHeapThreshold) {
-        this.totalHeapThreshold = totalHeapThreshold;
-    }
-
-    public double getHeapThreshold() {
-        return heapThreshold;
-    }
-
-    public long getHeapThresholdBytes() {
-        return (long) (HEAP_SIZE_BYTES * getHeapThreshold());
-    }
-
-    private void setHeapThreshold(double heapThreshold) {
-        this.heapThreshold = heapThreshold;
-    }
-
-    public double getHeapVarianceThreshold() {
-        return heapVarianceThreshold;
-    }
-
-    private void setHeapVarianceThreshold(double heapVarianceThreshold) {
-        this.heapVarianceThreshold = heapVarianceThreshold;
-    }
-
-    public long getCpuTimeThreshold() {
-        return cpuTimeThreshold;
-    }
-
-    private void setCpuTimeThreshold(long cpuTimeThreshold) {
-        this.cpuTimeThreshold = cpuTimeThreshold;
-    }
-
-    public long getElapsedTimeThreshold() {
-        return elapsedTimeThreshold;
-    }
-
-    private void setElapsedTimeThreshold(long elapsedTimeThreshold) {
-        this.elapsedTimeThreshold = elapsedTimeThreshold;
+    private void setTotalHeapPercentThreshold(double totalHeapPercentThreshold) {
+        this.totalHeapPercentThreshold = totalHeapPercentThreshold;
     }
 }

--- a/server/src/main/java/org/opensearch/search/backpressure/settings/SearchShardTaskSettings.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/settings/SearchShardTaskSettings.java
@@ -1,0 +1,160 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.settings;
+
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.monitor.jvm.JvmStats;
+
+/**
+ * Defines the settings related to the cancellation of SearchShardTasks.
+ *
+ * @opensearch.internal
+ */
+public class SearchShardTaskSettings {
+    private static final long HEAP_SIZE_BYTES = JvmStats.jvmStats().getMem().getHeapMax().getBytes();
+
+    private static class Defaults {
+        private static final double TOTAL_HEAP_THRESHOLD = 0.05;
+        private static final double HEAP_THRESHOLD = 0.005;
+        private static final double HEAP_VARIANCE_THRESHOLD = 2.0;
+        private static final long CPU_TIME_THRESHOLD = 15;
+        private static final long ELAPSED_TIME_THRESHOLD = 30000;
+    }
+
+    /**
+     * Defines the heap usage threshold (in percentage) for the sum of heap usages across all search shard tasks
+     * before in-flight cancellation is applied.
+     */
+    private volatile double totalHeapThreshold;
+    public static final Setting<Double> SETTING_TOTAL_HEAP_THRESHOLD = Setting.doubleSetting(
+        "search_backpressure.search_shard_task.total_heap_threshold",
+        Defaults.TOTAL_HEAP_THRESHOLD,
+        0.0,
+        1.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the heap usage threshold (in percentage) for an individual task before it is considered for cancellation.
+     */
+    private volatile double heapThreshold;
+    public static final Setting<Double> SETTING_HEAP_THRESHOLD = Setting.doubleSetting(
+        "search_backpressure.search_shard_task.heap_threshold",
+        Defaults.HEAP_THRESHOLD,
+        0.0,
+        1.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the heap usage variance for an individual task before it is considered for cancellation.
+     * A task is considered for cancellation when taskHeapUsage is greater than or equal to heapUsageMovingAverage * variance.
+     */
+    private volatile double heapVarianceThreshold;
+    public static final Setting<Double> SETTING_HEAP_VARIANCE_THRESHOLD = Setting.doubleSetting(
+        "search_backpressure.search_shard_task.heap_variance",
+        Defaults.HEAP_VARIANCE_THRESHOLD,
+        0.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the CPU usage threshold (in millis) for an individual task before it is considered for cancellation.
+     */
+    private volatile long cpuTimeThreshold;
+    public static final Setting<Long> SETTING_CPU_TIME_THRESHOLD = Setting.longSetting(
+        "search_backpressure.search_shard_task.cpu_time_threshold",
+        Defaults.CPU_TIME_THRESHOLD,
+        0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the elapsed time threshold (in millis) for an individual task before it is considered for cancellation.
+     */
+    private volatile long elapsedTimeThreshold;
+    public static final Setting<Long> SETTING_ELAPSED_TIME_THRESHOLD = Setting.longSetting(
+        "search_backpressure.search_shard_task.elapsed_time_threshold",
+        Defaults.ELAPSED_TIME_THRESHOLD,
+        0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    public SearchShardTaskSettings(Settings settings, ClusterSettings clusterSettings) {
+        totalHeapThreshold = SETTING_TOTAL_HEAP_THRESHOLD.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_TOTAL_HEAP_THRESHOLD, this::setTotalHeapThreshold);
+
+        heapThreshold = SETTING_HEAP_THRESHOLD.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_HEAP_THRESHOLD, this::setHeapThreshold);
+
+        heapVarianceThreshold = SETTING_HEAP_VARIANCE_THRESHOLD.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_HEAP_VARIANCE_THRESHOLD, this::setHeapVarianceThreshold);
+
+        cpuTimeThreshold = SETTING_CPU_TIME_THRESHOLD.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_CPU_TIME_THRESHOLD, this::setCpuTimeThreshold);
+
+        elapsedTimeThreshold = SETTING_ELAPSED_TIME_THRESHOLD.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SETTING_ELAPSED_TIME_THRESHOLD, this::setElapsedTimeThreshold);
+    }
+
+    public double getTotalHeapThreshold() {
+        return totalHeapThreshold;
+    }
+
+    public long getTotalHeapThresholdBytes() {
+        return (long) (HEAP_SIZE_BYTES * getTotalHeapThreshold());
+    }
+
+    private void setTotalHeapThreshold(double totalHeapThreshold) {
+        this.totalHeapThreshold = totalHeapThreshold;
+    }
+
+    public double getHeapThreshold() {
+        return heapThreshold;
+    }
+
+    public long getHeapThresholdBytes() {
+        return (long) (HEAP_SIZE_BYTES * getHeapThreshold());
+    }
+
+    private void setHeapThreshold(double heapThreshold) {
+        this.heapThreshold = heapThreshold;
+    }
+
+    public double getHeapVarianceThreshold() {
+        return heapVarianceThreshold;
+    }
+
+    private void setHeapVarianceThreshold(double heapVarianceThreshold) {
+        this.heapVarianceThreshold = heapVarianceThreshold;
+    }
+
+    public long getCpuTimeThreshold() {
+        return cpuTimeThreshold;
+    }
+
+    private void setCpuTimeThreshold(long cpuTimeThreshold) {
+        this.cpuTimeThreshold = cpuTimeThreshold;
+    }
+
+    public long getElapsedTimeThreshold() {
+        return elapsedTimeThreshold;
+    }
+
+    private void setElapsedTimeThreshold(long elapsedTimeThreshold) {
+        this.elapsedTimeThreshold = elapsedTimeThreshold;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/settings/package-info.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/settings/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * This package contains settings for search backpressure.
+ */
+package org.opensearch.search.backpressure.settings;

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/SearchBackpressureStats.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/SearchBackpressureStats.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.stats;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.xcontent.ToXContentFragment;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.search.backpressure.settings.SearchBackpressureMode;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Stats related to search backpressure.
+ */
+public class SearchBackpressureStats implements ToXContentFragment, Writeable {
+    private final SearchShardTaskStats searchShardTaskStats;
+    private final SearchBackpressureMode mode;
+
+    public SearchBackpressureStats(SearchShardTaskStats searchShardTaskStats, SearchBackpressureMode mode) {
+        this.searchShardTaskStats = searchShardTaskStats;
+        this.mode = mode;
+    }
+
+    public SearchBackpressureStats(StreamInput in) throws IOException {
+        this(new SearchShardTaskStats(in), SearchBackpressureMode.fromName(in.readString()));
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.startObject("search_backpressure")
+            .field("search_shard_task", searchShardTaskStats)
+            .field("mode", mode.getName())
+            .endObject();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        searchShardTaskStats.writeTo(out);
+        out.writeString(mode.getName());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SearchBackpressureStats that = (SearchBackpressureStats) o;
+        return searchShardTaskStats.equals(that.searchShardTaskStats) && mode == that.mode;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(searchShardTaskStats, mode);
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/SearchShardTaskStats.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/SearchShardTaskStats.java
@@ -1,0 +1,98 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.stats;
+
+import org.opensearch.common.collect.MapBuilder;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.xcontent.ToXContentObject;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.search.backpressure.trackers.CpuUsageTracker;
+import org.opensearch.search.backpressure.trackers.ElapsedTimeTracker;
+import org.opensearch.search.backpressure.trackers.HeapUsageTracker;
+import org.opensearch.search.backpressure.trackers.TaskResourceUsageTracker;
+import org.opensearch.search.backpressure.trackers.TaskResourceUsageTrackerType;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Stats related to cancelled search shard tasks.
+ */
+public class SearchShardTaskStats implements ToXContentObject, Writeable {
+    private final long cancellationCount;
+    private final long limitReachedCount;
+    private final Map<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> resourceUsageTrackerStats;
+
+    public SearchShardTaskStats(
+        long cancellationCount,
+        long limitReachedCount,
+        Map<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> resourceUsageTrackerStats
+    ) {
+        this.cancellationCount = cancellationCount;
+        this.limitReachedCount = limitReachedCount;
+        this.resourceUsageTrackerStats = resourceUsageTrackerStats;
+    }
+
+    public SearchShardTaskStats(StreamInput in) throws IOException {
+        this.cancellationCount = in.readVLong();
+        this.limitReachedCount = in.readVLong();
+
+        MapBuilder<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> builder = new MapBuilder<>();
+        builder.put(TaskResourceUsageTrackerType.CPU_USAGE_TRACKER, in.readOptionalWriteable(CpuUsageTracker.Stats::new));
+        builder.put(TaskResourceUsageTrackerType.HEAP_USAGE_TRACKER, in.readOptionalWriteable(HeapUsageTracker.Stats::new));
+        builder.put(TaskResourceUsageTrackerType.ELAPSED_TIME_TRACKER, in.readOptionalWriteable(ElapsedTimeTracker.Stats::new));
+        this.resourceUsageTrackerStats = builder.immutableMap();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+
+        builder.startObject("resource_tracker_stats");
+        for (Map.Entry<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> entry : resourceUsageTrackerStats.entrySet()) {
+            builder.field(entry.getKey().getName(), entry.getValue());
+        }
+        builder.endObject();
+
+        builder.startObject("cancellation_stats")
+            .field("cancellation_count", cancellationCount)
+            .field("cancellation_limit_reached_count", limitReachedCount)
+            .endObject();
+
+        return builder.endObject();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(cancellationCount);
+        out.writeVLong(limitReachedCount);
+
+        out.writeOptionalWriteable(resourceUsageTrackerStats.get(TaskResourceUsageTrackerType.CPU_USAGE_TRACKER));
+        out.writeOptionalWriteable(resourceUsageTrackerStats.get(TaskResourceUsageTrackerType.HEAP_USAGE_TRACKER));
+        out.writeOptionalWriteable(resourceUsageTrackerStats.get(TaskResourceUsageTrackerType.ELAPSED_TIME_TRACKER));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SearchShardTaskStats that = (SearchShardTaskStats) o;
+        return cancellationCount == that.cancellationCount
+            && limitReachedCount == that.limitReachedCount
+            && resourceUsageTrackerStats.equals(that.resourceUsageTrackerStats);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cancellationCount, limitReachedCount, resourceUsageTrackerStats);
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/package-info.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * This package contains models required for the search backpressure stats API response.
+ */
+package org.opensearch.search.backpressure.stats;

--- a/server/src/main/java/org/opensearch/search/backpressure/trackers/CpuUsageTracker.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/trackers/CpuUsageTracker.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.trackers;
+
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
+import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskCancellation;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.opensearch.search.backpressure.trackers.TaskResourceUsageTrackerType.CPU_USAGE_TRACKER;
+
+/**
+ * CpuUsageTracker evaluates if the task has consumed too many CPU cycles than allowed.
+ *
+ * @opensearch.internal
+ */
+public class CpuUsageTracker extends TaskResourceUsageTracker {
+    private static class Defaults {
+        private static final long CPU_TIME_MILLIS_THRESHOLD = 15000;
+    }
+
+    /**
+     * Defines the CPU usage threshold (in millis) for an individual task before it is considered for cancellation.
+     */
+    private volatile long cpuTimeMillisThreshold;
+    public static final Setting<Long> SETTING_CPU_TIME_MILLIS_THRESHOLD = Setting.longSetting(
+        "search_backpressure.search_shard_task.cpu_time_millis_threshold",
+        Defaults.CPU_TIME_MILLIS_THRESHOLD,
+        0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    public CpuUsageTracker(SearchBackpressureSettings settings) {
+        this.cpuTimeMillisThreshold = SETTING_CPU_TIME_MILLIS_THRESHOLD.get(settings.getSettings());
+        settings.getClusterSettings().addSettingsUpdateConsumer(SETTING_CPU_TIME_MILLIS_THRESHOLD, this::setCpuTimeMillisThreshold);
+    }
+
+    @Override
+    public String name() {
+        return CPU_USAGE_TRACKER.getName();
+    }
+
+    @Override
+    public Optional<TaskCancellation.Reason> checkAndMaybeGetCancellationReason(Task task) {
+        long usage = task.getTotalResourceStats().getCpuTimeInNanos();
+        long threshold = getCpuTimeNanosThreshold();
+
+        if (usage < threshold) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+            new TaskCancellation.Reason(
+                "cpu usage exceeded ["
+                    + new TimeValue(usage, TimeUnit.NANOSECONDS)
+                    + " >= "
+                    + new TimeValue(threshold, TimeUnit.NANOSECONDS)
+                    + "]",
+                1  // TODO: fine-tune the cancellation score/weight
+            )
+        );
+    }
+
+    public long getCpuTimeNanosThreshold() {
+        return TimeUnit.MILLISECONDS.toNanos(cpuTimeMillisThreshold);
+    }
+
+    public void setCpuTimeMillisThreshold(long cpuTimeMillisThreshold) {
+        this.cpuTimeMillisThreshold = cpuTimeMillisThreshold;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/trackers/CpuUsageTracker.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/trackers/CpuUsageTracker.java
@@ -9,11 +9,17 @@
 package org.opensearch.search.backpressure.trackers;
 
 import org.opensearch.common.settings.Setting;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
+import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskCancellation;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -78,5 +84,60 @@ public class CpuUsageTracker extends TaskResourceUsageTracker {
 
     public void setCpuTimeMillisThreshold(long cpuTimeMillisThreshold) {
         this.cpuTimeMillisThreshold = cpuTimeMillisThreshold;
+    }
+
+    @Override
+    public TaskResourceUsageTracker.Stats stats(List<? extends Task> activeTasks) {
+        long currentMax = activeTasks.stream().mapToLong(t -> t.getTotalResourceStats().getCpuTimeInNanos()).max().orElse(0);
+        long currentAvg = (long) activeTasks.stream().mapToLong(t -> t.getTotalResourceStats().getCpuTimeInNanos()).average().orElse(0);
+        return new Stats(getCancellations(), currentMax, currentAvg);
+    }
+
+    /**
+     * Stats related to CpuUsageTracker.
+     */
+    public static class Stats implements TaskResourceUsageTracker.Stats {
+        private final long cancellationCount;
+        private final long currentMax;
+        private final long currentAvg;
+
+        public Stats(long cancellationCount, long currentMax, long currentAvg) {
+            this.cancellationCount = cancellationCount;
+            this.currentMax = currentMax;
+            this.currentAvg = currentAvg;
+        }
+
+        public Stats(StreamInput in) throws IOException {
+            this(in.readVLong(), in.readVLong(), in.readVLong());
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder.startObject()
+                .field("cancellation_count", cancellationCount)
+                .humanReadableField("current_max_millis", "current_max", new TimeValue(currentMax, TimeUnit.NANOSECONDS))
+                .humanReadableField("current_avg_millis", "current_avg", new TimeValue(currentAvg, TimeUnit.NANOSECONDS))
+                .endObject();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVLong(cancellationCount);
+            out.writeVLong(currentMax);
+            out.writeVLong(currentAvg);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Stats stats = (Stats) o;
+            return cancellationCount == stats.cancellationCount && currentMax == stats.currentMax && currentAvg == stats.currentAvg;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(cancellationCount, currentMax, currentAvg);
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/search/backpressure/trackers/ElapsedTimeTracker.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/trackers/ElapsedTimeTracker.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.trackers;
+
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
+import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskCancellation;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+
+import static org.opensearch.search.backpressure.trackers.TaskResourceUsageTrackerType.ELAPSED_TIME_TRACKER;
+
+/**
+ * ElapsedTimeTracker evaluates if the task has been running for more time than allowed.
+ *
+ * @opensearch.internal
+ */
+public class ElapsedTimeTracker extends TaskResourceUsageTracker {
+    private static class Defaults {
+        private static final long ELAPSED_TIME_MILLIS_THRESHOLD = 30000;
+    }
+
+    /**
+     * Defines the elapsed time threshold (in millis) for an individual task before it is considered for cancellation.
+     */
+    private volatile long elapsedTimeMillisThreshold;
+    public static final Setting<Long> SETTING_ELAPSED_TIME_MILLIS_THRESHOLD = Setting.longSetting(
+        "search_backpressure.search_shard_task.elapsed_time_millis_threshold",
+        Defaults.ELAPSED_TIME_MILLIS_THRESHOLD,
+        0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    private final LongSupplier timeNanosSupplier;
+
+    public ElapsedTimeTracker(SearchBackpressureSettings settings, LongSupplier timeNanosSupplier) {
+        this.timeNanosSupplier = timeNanosSupplier;
+        this.elapsedTimeMillisThreshold = SETTING_ELAPSED_TIME_MILLIS_THRESHOLD.get(settings.getSettings());
+        settings.getClusterSettings().addSettingsUpdateConsumer(SETTING_ELAPSED_TIME_MILLIS_THRESHOLD, this::setElapsedTimeMillisThreshold);
+    }
+
+    @Override
+    public String name() {
+        return ELAPSED_TIME_TRACKER.getName();
+    }
+
+    @Override
+    public Optional<TaskCancellation.Reason> checkAndMaybeGetCancellationReason(Task task) {
+        long usage = timeNanosSupplier.getAsLong() - task.getStartTimeNanos();
+        long threshold = getElapsedTimeNanosThreshold();
+
+        if (usage < threshold) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+            new TaskCancellation.Reason(
+                "elapsed time exceeded ["
+                    + new TimeValue(usage, TimeUnit.NANOSECONDS)
+                    + " >= "
+                    + new TimeValue(threshold, TimeUnit.NANOSECONDS)
+                    + "]",
+                1  // TODO: fine-tune the cancellation score/weight
+            )
+        );
+    }
+
+    public long getElapsedTimeNanosThreshold() {
+        return TimeUnit.MILLISECONDS.toNanos(elapsedTimeMillisThreshold);
+    }
+
+    public void setElapsedTimeMillisThreshold(long elapsedTimeMillisThreshold) {
+        this.elapsedTimeMillisThreshold = elapsedTimeMillisThreshold;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/trackers/HeapUsageTracker.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/trackers/HeapUsageTracker.java
@@ -1,0 +1,148 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.trackers;
+
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.unit.ByteSizeValue;
+import org.opensearch.common.util.MovingAverage;
+import org.opensearch.monitor.jvm.JvmStats;
+import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
+import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskCancellation;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.opensearch.search.backpressure.trackers.TaskResourceUsageTrackerType.HEAP_USAGE_TRACKER;
+
+/**
+ * HeapUsageTracker evaluates if the task has consumed too much heap than allowed.
+ * It also compares the task's heap usage against a historical moving average of previously completed tasks.
+ *
+ * @opensearch.internal
+ */
+public class HeapUsageTracker extends TaskResourceUsageTracker {
+    private static final long HEAP_SIZE_BYTES = JvmStats.jvmStats().getMem().getHeapMax().getBytes();
+
+    private static class Defaults {
+        private static final double HEAP_PERCENT_THRESHOLD = 0.005;
+        private static final double HEAP_VARIANCE_THRESHOLD = 2.0;
+        private static final int HEAP_MOVING_AVERAGE_WINDOW_SIZE = 100;
+    }
+
+    /**
+     * Defines the heap usage threshold (in percentage) for an individual task before it is considered for cancellation.
+     */
+    private volatile double heapPercentThreshold;
+    public static final Setting<Double> SETTING_HEAP_PERCENT_THRESHOLD = Setting.doubleSetting(
+        "search_backpressure.search_shard_task.heap_percent_threshold",
+        Defaults.HEAP_PERCENT_THRESHOLD,
+        0.0,
+        1.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the heap usage variance for an individual task before it is considered for cancellation.
+     * A task is considered for cancellation when taskHeapUsage is greater than or equal to heapUsageMovingAverage * variance.
+     */
+    private volatile double heapVarianceThreshold;
+    public static final Setting<Double> SETTING_HEAP_VARIANCE_THRESHOLD = Setting.doubleSetting(
+        "search_backpressure.search_shard_task.heap_variance",
+        Defaults.HEAP_VARIANCE_THRESHOLD,
+        0.0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Defines the window size to calculate the moving average of heap usage of completed tasks.
+     */
+    private volatile int heapMovingAverageWindowSize;
+    public static final Setting<Integer> SETTING_HEAP_MOVING_AVERAGE_WINDOW_SIZE = Setting.intSetting(
+        "search_backpressure.search_shard_task.heap_moving_average_window_size",
+        Defaults.HEAP_MOVING_AVERAGE_WINDOW_SIZE,
+        0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    private final AtomicReference<MovingAverage> movingAverageReference;
+
+    public HeapUsageTracker(SearchBackpressureSettings settings) {
+        heapPercentThreshold = SETTING_HEAP_PERCENT_THRESHOLD.get(settings.getSettings());
+        settings.getClusterSettings().addSettingsUpdateConsumer(SETTING_HEAP_PERCENT_THRESHOLD, this::setHeapPercentThreshold);
+
+        heapVarianceThreshold = SETTING_HEAP_VARIANCE_THRESHOLD.get(settings.getSettings());
+        settings.getClusterSettings().addSettingsUpdateConsumer(SETTING_HEAP_VARIANCE_THRESHOLD, this::setHeapVarianceThreshold);
+
+        heapMovingAverageWindowSize = SETTING_HEAP_MOVING_AVERAGE_WINDOW_SIZE.get(settings.getSettings());
+        settings.getClusterSettings()
+            .addSettingsUpdateConsumer(SETTING_HEAP_MOVING_AVERAGE_WINDOW_SIZE, this::setHeapMovingAverageWindowSize);
+
+        this.movingAverageReference = new AtomicReference<>(new MovingAverage(heapMovingAverageWindowSize));
+    }
+
+    @Override
+    public String name() {
+        return HEAP_USAGE_TRACKER.getName();
+    }
+
+    @Override
+    public void update(Task task) {
+        movingAverageReference.get().record(task.getTotalResourceStats().getMemoryInBytes());
+    }
+
+    @Override
+    public Optional<TaskCancellation.Reason> checkAndMaybeGetCancellationReason(Task task) {
+        MovingAverage movingAverage = movingAverageReference.get();
+
+        // There haven't been enough measurements.
+        if (movingAverage.isReady() == false) {
+            return Optional.empty();
+        }
+
+        double currentUsage = task.getTotalResourceStats().getMemoryInBytes();
+        double averageUsage = movingAverage.getAverage();
+        double allowedUsage = averageUsage * getHeapVarianceThreshold();
+
+        if (currentUsage < getHeapBytesThreshold() || currentUsage < allowedUsage) {
+            return Optional.empty();
+        }
+
+        return Optional.of(
+            new TaskCancellation.Reason(
+                "heap usage exceeded [" + new ByteSizeValue((long) currentUsage) + " >= " + new ByteSizeValue((long) allowedUsage) + "]",
+                (int) (currentUsage / averageUsage)  // TODO: fine-tune the cancellation score/weight
+            )
+        );
+    }
+
+    public long getHeapBytesThreshold() {
+        return (long) (HEAP_SIZE_BYTES * heapPercentThreshold);
+    }
+
+    public void setHeapPercentThreshold(double heapPercentThreshold) {
+        this.heapPercentThreshold = heapPercentThreshold;
+    }
+
+    public double getHeapVarianceThreshold() {
+        return heapVarianceThreshold;
+    }
+
+    public void setHeapVarianceThreshold(double heapVarianceThreshold) {
+        this.heapVarianceThreshold = heapVarianceThreshold;
+    }
+
+    public void setHeapMovingAverageWindowSize(int heapMovingAverageWindowSize) {
+        this.heapMovingAverageWindowSize = heapMovingAverageWindowSize;
+        this.movingAverageReference.set(new MovingAverage(heapMovingAverageWindowSize));
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/trackers/NodeDuressTracker.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/trackers/NodeDuressTracker.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.trackers;
+
+import org.opensearch.common.util.Streak;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * NodeDuressTracker is used to check if the node is in duress.
+ *
+ * @opensearch.internal
+ */
+public class NodeDuressTracker {
+    /**
+     * Tracks the number of consecutive breaches.
+     */
+    private final Streak breaches = new Streak();
+
+    /**
+     * Predicate that returns true when the node is in duress.
+     */
+    private final BooleanSupplier isNodeInDuress;
+
+    public NodeDuressTracker(BooleanSupplier isNodeInDuress) {
+        this.isNodeInDuress = isNodeInDuress;
+    }
+
+    /**
+     * Evaluates the predicate and returns the number of consecutive breaches.
+     */
+    public int check() {
+        return breaches.record(isNodeInDuress.getAsBoolean());
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/trackers/TaskResourceUsageTracker.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/trackers/TaskResourceUsageTracker.java
@@ -41,10 +41,10 @@ public abstract class TaskResourceUsageTracker {
     /**
      * Notifies the tracker to update its state when a task execution completes.
      */
-    public abstract void update(Task task);
+    public void update(Task task) {}
 
     /**
      * Returns the cancellation reason for the given task, if it's eligible for cancellation.
      */
-    public abstract Optional<TaskCancellation.Reason> cancellationReason(Task task);
+    public abstract Optional<TaskCancellation.Reason> checkAndMaybeGetCancellationReason(Task task);
 }

--- a/server/src/main/java/org/opensearch/search/backpressure/trackers/TaskResourceUsageTracker.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/trackers/TaskResourceUsageTracker.java
@@ -8,9 +8,12 @@
 
 package org.opensearch.search.backpressure.trackers;
 
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.tasks.TaskCancellation;
 import org.opensearch.tasks.Task;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -47,4 +50,14 @@ public abstract class TaskResourceUsageTracker {
      * Returns the cancellation reason for the given task, if it's eligible for cancellation.
      */
     public abstract Optional<TaskCancellation.Reason> checkAndMaybeGetCancellationReason(Task task);
+
+    /**
+     * Returns the tracker's state as seen in the stats API.
+     */
+    public abstract Stats stats(List<? extends Task> activeTasks);
+
+    /**
+     * Represents the tracker's state as seen in the stats API.
+     */
+    public interface Stats extends ToXContentObject, Writeable {}
 }

--- a/server/src/main/java/org/opensearch/search/backpressure/trackers/TaskResourceUsageTracker.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/trackers/TaskResourceUsageTracker.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.trackers;
+
+import org.opensearch.tasks.TaskCancellation;
+import org.opensearch.tasks.Task;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * TaskResourceUsageTracker is used to track completions and cancellations of search related tasks.
+ *
+ * @opensearch.internal
+ */
+public abstract class TaskResourceUsageTracker {
+    /**
+     * Counts the number of cancellations made due to this tracker.
+     */
+    private final AtomicLong cancellations = new AtomicLong();
+
+    public long incrementCancellations() {
+        return cancellations.incrementAndGet();
+    }
+
+    public long getCancellations() {
+        return cancellations.get();
+    }
+
+    /**
+     * Returns a unique name for this tracker.
+     */
+    public abstract String name();
+
+    /**
+     * Notifies the tracker to update its state when a task execution completes.
+     */
+    public abstract void update(Task task);
+
+    /**
+     * Returns the cancellation reason for the given task, if it's eligible for cancellation.
+     */
+    public abstract Optional<TaskCancellation.Reason> cancellationReason(Task task);
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/trackers/TaskResourceUsageTrackerType.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/trackers/TaskResourceUsageTrackerType.java
@@ -25,4 +25,17 @@ public enum TaskResourceUsageTrackerType {
     public String getName() {
         return name;
     }
+
+    public static TaskResourceUsageTrackerType fromName(String name) {
+        switch (name) {
+            case "cpu_usage_tracker":
+                return CPU_USAGE_TRACKER;
+            case "heap_usage_tracker":
+                return HEAP_USAGE_TRACKER;
+            case "elapsed_time_tracker":
+                return ELAPSED_TIME_TRACKER;
+        }
+
+        throw new IllegalArgumentException("Invalid TaskResourceUsageTrackerType: " + name);
+    }
 }

--- a/server/src/main/java/org/opensearch/search/backpressure/trackers/TaskResourceUsageTrackerType.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/trackers/TaskResourceUsageTrackerType.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.trackers;
+
+/**
+ * Defines the type of TaskResourceUsageTracker.
+ */
+public enum TaskResourceUsageTrackerType {
+    CPU_USAGE_TRACKER("cpu_usage_tracker"),
+    HEAP_USAGE_TRACKER("heap_usage_tracker"),
+    ELAPSED_TIME_TRACKER("elapsed_time_tracker");
+
+    private final String name;
+
+    TaskResourceUsageTrackerType(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/backpressure/trackers/package-info.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/trackers/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * This package contains trackers to check if resource usage limits are breached on a node or task level.
+ */
+package org.opensearch.search.backpressure.trackers;

--- a/server/src/main/java/org/opensearch/tasks/CancellableTask.java
+++ b/server/src/main/java/org/opensearch/tasks/CancellableTask.java
@@ -71,7 +71,7 @@ public abstract class CancellableTask extends Task {
     /**
      * This method is called by the task manager when this task is cancelled.
      */
-    final void cancel(String reason) {
+    public void cancel(String reason) {
         assert reason != null;
         if (cancelled.compareAndSet(false, true)) {
             this.reason = reason;

--- a/server/src/main/java/org/opensearch/tasks/TaskCancellation.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskCancellation.java
@@ -15,7 +15,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * TaskCancellation is a wrapper for a task and its cancellation reasons.
+ * TaskCancellation represents a task eligible for cancellation.
+ * It doesn't guarantee that the task will actually get cancelled or not; that decision is left to the caller.
+ *
+ * It contains a list of cancellation reasons along with callbacks that are invoked when cancel() is called.
  *
  * @opensearch.internal
  */

--- a/server/src/main/java/org/opensearch/tasks/TaskCancellation.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskCancellation.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.tasks;
+
+import org.opensearch.ExceptionsHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * TaskCancellation is a wrapper for a task and its cancellation reasons.
+ *
+ * @opensearch.internal
+ */
+public class TaskCancellation implements Comparable<TaskCancellation> {
+    private final CancellableTask task;
+    private final List<Reason> reasons;
+    private final List<Runnable> onCancelCallbacks;
+
+    public TaskCancellation(CancellableTask task, List<Reason> reasons, List<Runnable> onCancelCallbacks) {
+        this.task = task;
+        this.reasons = reasons;
+        this.onCancelCallbacks = onCancelCallbacks;
+    }
+
+    public CancellableTask getTask() {
+        return task;
+    }
+
+    public List<Reason> getReasons() {
+        return reasons;
+    }
+
+    public String getReasonString() {
+        return reasons.stream().map(Reason::getMessage).collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Cancels the task and invokes all onCancelCallbacks.
+     */
+    public void cancel() {
+        if (isEligibleForCancellation() == false) {
+            return;
+        }
+
+        task.cancel(getReasonString());
+
+        List<Exception> exceptions = new ArrayList<>();
+        for (Runnable callback : onCancelCallbacks) {
+            try {
+                callback.run();
+            } catch (Exception e) {
+                exceptions.add(e);
+            }
+        }
+        ExceptionsHelper.maybeThrowRuntimeAndSuppress(exceptions);
+    }
+
+    /**
+     * Returns the sum of all cancellation scores.
+     *
+     * A zero score indicates no reason to cancel the task.
+     * A task with a higher score suggests greater possibility of recovering the node when it is cancelled.
+     */
+    public int totalCancellationScore() {
+        return reasons.stream().mapToInt(Reason::getCancellationScore).sum();
+    }
+
+    /**
+     * A task is eligible for cancellation if it has one or more cancellation reasons, and is not already cancelled.
+     */
+    public boolean isEligibleForCancellation() {
+        return (task.isCancelled() == false) && (reasons.size() > 0);
+    }
+
+    @Override
+    public int compareTo(TaskCancellation other) {
+        return Integer.compare(totalCancellationScore(), other.totalCancellationScore());
+    }
+
+    /**
+     * Represents the cancellation reason for a task.
+     */
+    public static class Reason {
+        private final String message;
+        private final int cancellationScore;
+
+        public Reason(String message, int cancellationScore) {
+            this.message = message;
+            this.cancellationScore = cancellationScore;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public int getCancellationScore() {
+            return cancellationScore;
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -709,6 +709,7 @@ public class NodeStatsTests extends OpenSearchTestCase {
             adaptiveSelectionStats,
             scriptCacheStats,
             null,
+            null,
             null
         );
     }

--- a/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
+++ b/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
@@ -185,6 +185,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -205,6 +206,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -216,6 +218,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 new FsInfo(0, null, node3FSInfo),
+                null,
                 null,
                 null,
                 null,
@@ -276,6 +279,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -296,6 +300,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -307,6 +312,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 new FsInfo(0, null, node3FSInfo),
+                null,
                 null,
                 null,
                 null,

--- a/server/src/test/java/org/opensearch/common/StreakTests.java
+++ b/server/src/test/java/org/opensearch/common/StreakTests.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common;
+
+import org.opensearch.common.util.Streak;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class StreakTests extends OpenSearchTestCase {
+
+    public void testStreak() {
+        Streak streak = new Streak();
+
+        // Streak starts with zero.
+        assertEquals(0, streak.length());
+
+        // Streak increases on successive successful events.
+        streak.record(true);
+        assertEquals(1, streak.length());
+        streak.record(true);
+        assertEquals(2, streak.length());
+        streak.record(true);
+        assertEquals(3, streak.length());
+
+        // Streak resets to zero after an unsuccessful event.
+        streak.record(false);
+        assertEquals(0, streak.length());
+    }
+}

--- a/server/src/test/java/org/opensearch/common/util/MovingAverageTests.java
+++ b/server/src/test/java/org/opensearch/common/util/MovingAverageTests.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.util;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class MovingAverageTests extends OpenSearchTestCase {
+
+    public void testMovingAverage() {
+        MovingAverage ma = new MovingAverage(5);
+
+        // No observations
+        assertEquals(0.0, ma.getAverage(), 0.0);
+        assertEquals(0, ma.getCount());
+
+        // Not enough observations
+        ma.record(1);
+        ma.record(2);
+        ma.record(3);
+        assertEquals(2.0, ma.getAverage(), 0.0);
+        assertEquals(3, ma.getCount());
+        assertFalse(ma.isReady());
+
+        // Enough observations
+        ma.record(4);
+        ma.record(5);
+        ma.record(6);
+        assertEquals(4, ma.getAverage(), 0.0);
+        assertEquals(6, ma.getCount());
+        assertTrue(ma.isReady());
+    }
+
+    public void testMovingAverageWithZeroSize() {
+        try {
+            new MovingAverage(0);
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("window size must be greater than zero"));
+            return;
+        }
+
+        fail("exception should have been thrown");
+    }
+}

--- a/server/src/test/java/org/opensearch/common/util/StreakTests.java
+++ b/server/src/test/java/org/opensearch/common/util/StreakTests.java
@@ -6,9 +6,8 @@
  * compatible open source license.
  */
 
-package org.opensearch.common;
+package org.opensearch.common.util;
 
-import org.opensearch.common.util.Streak;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class StreakTests extends OpenSearchTestCase {

--- a/server/src/test/java/org/opensearch/common/util/TokenBucketTests.java
+++ b/server/src/test/java/org/opensearch/common/util/TokenBucketTests.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.util;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+
+public class TokenBucketTests extends OpenSearchTestCase {
+
+    public void testTokenBucket() {
+        AtomicLong mockTimeNanos = new AtomicLong();
+        LongSupplier mockTimeNanosSupplier = mockTimeNanos::get;
+
+        // Token bucket that refills at 2 tokens/second and allows short bursts up to 3 operations.
+        TokenBucket tokenBucket = new TokenBucket(mockTimeNanosSupplier, 2.0 / TimeUnit.SECONDS.toNanos(1), 3);
+
+        // Three operations succeed, fourth fails.
+        assertTrue(tokenBucket.request());
+        assertTrue(tokenBucket.request());
+        assertTrue(tokenBucket.request());
+        assertFalse(tokenBucket.request());
+
+        // Clock moves ahead by one second. Two operations succeed, third fails.
+        mockTimeNanos.addAndGet(TimeUnit.SECONDS.toNanos(1));
+        assertTrue(tokenBucket.request());
+        assertTrue(tokenBucket.request());
+        assertFalse(tokenBucket.request());
+
+        // Clock moves ahead by half a second. One operation succeeds, second fails.
+        mockTimeNanos.addAndGet(TimeUnit.MILLISECONDS.toNanos(500));
+        assertTrue(tokenBucket.request());
+        assertFalse(tokenBucket.request());
+
+        // Clock moves ahead by many seconds, but the token bucket should be capped at the 'burst' capacity.
+        mockTimeNanos.addAndGet(TimeUnit.SECONDS.toNanos(10));
+        assertTrue(tokenBucket.request());
+        assertTrue(tokenBucket.request());
+        assertTrue(tokenBucket.request());
+        assertFalse(tokenBucket.request());
+
+        // Ability to request fractional tokens.
+        mockTimeNanos.addAndGet(TimeUnit.MILLISECONDS.toNanos(250));
+        assertFalse(tokenBucket.request(1.0));
+        assertTrue(tokenBucket.request(0.5));
+    }
+
+    public void testTokenBucketWithInvalidRate() {
+        try {
+            new TokenBucket(System::nanoTime, -1, 2);
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("rate must be greater than zero"));
+            return;
+        }
+
+        fail("exception should have been thrown");
+    }
+
+    public void testTokenBucketWithInvalidBurst() {
+        try {
+            new TokenBucket(System::nanoTime, 1, 0);
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("burst must be greater than zero"));
+            return;
+        }
+
+        fail("exception should have been thrown");
+    }
+}

--- a/server/src/test/java/org/opensearch/search/backpressure/SearchBackpressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/SearchBackpressureServiceTests.java
@@ -132,7 +132,7 @@ public class SearchBackpressureServiceTests extends OpenSearchTestCase {
             public void update(Task task) {}
 
             @Override
-            public Optional<TaskCancellation.Reason> cancellationReason(Task task) {
+            public Optional<TaskCancellation.Reason> checkAndMaybeGetCancellationReason(Task task) {
                 if (task.getTotalResourceStats().getCpuTimeInNanos() < 300) {
                     return Optional.empty();
                 }
@@ -167,10 +167,10 @@ public class SearchBackpressureServiceTests extends OpenSearchTestCase {
         service.doRun();
         service.doRun();
 
-        // Mocking 'settings' with predictable searchHeapThresholdBytes so that cancellation logic doesn't get skipped.
+        // Mocking 'settings' with predictable totalHeapBytesThreshold so that cancellation logic doesn't get skipped.
         long taskHeapUsageBytes = 500;
         SearchShardTaskSettings shardTaskSettings = mock(SearchShardTaskSettings.class);
-        when(shardTaskSettings.getTotalHeapThresholdBytes()).thenReturn(taskHeapUsageBytes);
+        when(shardTaskSettings.getTotalHeapBytesThreshold()).thenReturn(taskHeapUsageBytes);
         when(settings.getSearchShardTaskSettings()).thenReturn(shardTaskSettings);
 
         // Create a mix of low and high resource usage tasks (60 low + 15 high resource usage tasks).

--- a/server/src/test/java/org/opensearch/search/backpressure/SearchBackpressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/SearchBackpressureServiceTests.java
@@ -1,0 +1,213 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure;
+
+import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
+import org.opensearch.search.backpressure.settings.SearchShardTaskSettings;
+import org.opensearch.search.backpressure.trackers.NodeDuressTracker;
+import org.opensearch.search.backpressure.trackers.TaskResourceUsageTracker;
+import org.opensearch.tasks.CancellableTask;
+import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskCancellation;
+import org.opensearch.tasks.TaskResourceTrackingService;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.search.backpressure.SearchBackpressureTestHelpers.createMockTaskWithResourceStats;
+
+public class SearchBackpressureServiceTests extends OpenSearchTestCase {
+
+    public void testIsNodeInDuress() {
+        TaskResourceTrackingService mockTaskResourceTrackingService = mock(TaskResourceTrackingService.class);
+        ThreadPool mockThreadPool = mock(ThreadPool.class);
+
+        AtomicReference<Double> cpuUsage = new AtomicReference<>();
+        AtomicReference<Double> heapUsage = new AtomicReference<>();
+        NodeDuressTracker cpuUsageTracker = new NodeDuressTracker(() -> cpuUsage.get() >= 0.5);
+        NodeDuressTracker heapUsageTracker = new NodeDuressTracker(() -> heapUsage.get() >= 0.5);
+
+        SearchBackpressureSettings settings = new SearchBackpressureSettings(
+            Settings.EMPTY,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+
+        SearchBackpressureService service = new SearchBackpressureService(
+            settings,
+            mockTaskResourceTrackingService,
+            mockThreadPool,
+            System::nanoTime,
+            List.of(cpuUsageTracker, heapUsageTracker),
+            Collections.emptyList()
+        );
+
+        // Node not in duress.
+        cpuUsage.set(0.0);
+        heapUsage.set(0.0);
+        assertFalse(service.isNodeInDuress());
+
+        // Node in duress; but not for many consecutive data points.
+        cpuUsage.set(1.0);
+        heapUsage.set(1.0);
+        assertFalse(service.isNodeInDuress());
+
+        // Node in duress for consecutive data points.
+        assertFalse(service.isNodeInDuress());
+        assertTrue(service.isNodeInDuress());
+
+        // Node not in duress anymore.
+        cpuUsage.set(0.0);
+        heapUsage.set(0.0);
+        assertFalse(service.isNodeInDuress());
+    }
+
+    public void testTrackerStateUpdateOnTaskCompletion() {
+        TaskResourceTrackingService mockTaskResourceTrackingService = mock(TaskResourceTrackingService.class);
+        ThreadPool mockThreadPool = mock(ThreadPool.class);
+        LongSupplier mockTimeNanosSupplier = () -> TimeUnit.SECONDS.toNanos(1234);
+        TaskResourceUsageTracker mockTaskResourceUsageTracker = mock(TaskResourceUsageTracker.class);
+
+        SearchBackpressureSettings settings = new SearchBackpressureSettings(
+            Settings.EMPTY,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+
+        SearchBackpressureService service = new SearchBackpressureService(
+            settings,
+            mockTaskResourceTrackingService,
+            mockThreadPool,
+            mockTimeNanosSupplier,
+            Collections.emptyList(),
+            List.of(mockTaskResourceUsageTracker)
+        );
+
+        // Record task completions to update the tracker state. Tasks other than SearchShardTask are ignored.
+        service.onTaskCompleted(createMockTaskWithResourceStats(CancellableTask.class, 100, 200));
+        for (int i = 0; i < 100; i++) {
+            service.onTaskCompleted(createMockTaskWithResourceStats(SearchShardTask.class, 100, 200));
+        }
+        assertEquals(100, service.getState().getCompletionCount());
+        verify(mockTaskResourceUsageTracker, times(100)).update(any());
+    }
+
+    public void testInFlightCancellation() {
+        TaskResourceTrackingService mockTaskResourceTrackingService = mock(TaskResourceTrackingService.class);
+        ThreadPool mockThreadPool = mock(ThreadPool.class);
+        AtomicLong mockTime = new AtomicLong(0);
+        LongSupplier mockTimeNanosSupplier = mockTime::get;
+        NodeDuressTracker mockNodeDuressTracker = new NodeDuressTracker(() -> true);
+
+        TaskResourceUsageTracker mockTaskResourceUsageTracker = new TaskResourceUsageTracker() {
+            @Override
+            public String name() {
+                return "mock_tracker";
+            }
+
+            @Override
+            public void update(Task task) {}
+
+            @Override
+            public Optional<TaskCancellation.Reason> cancellationReason(Task task) {
+                if (task.getTotalResourceStats().getCpuTimeInNanos() < 300) {
+                    return Optional.empty();
+                }
+
+                return Optional.of(new TaskCancellation.Reason("limits exceeded", 5));
+            }
+        };
+
+        // Mocking 'settings' with predictable rate limiting thresholds.
+        SearchBackpressureSettings settings = spy(
+            new SearchBackpressureSettings(
+                Settings.builder()
+                    .put(SearchBackpressureSettings.SETTING_ENFORCED.getKey(), true)
+                    .put(SearchBackpressureSettings.SETTING_CANCELLATION_RATIO.getKey(), 0.1)
+                    .put(SearchBackpressureSettings.SETTING_CANCELLATION_RATE.getKey(), 0.003)
+                    .put(SearchBackpressureSettings.SETTING_CANCELLATION_BURST.getKey(), 10.0)
+                    .build(),
+                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+            )
+        );
+
+        SearchBackpressureService service = new SearchBackpressureService(
+            settings,
+            mockTaskResourceTrackingService,
+            mockThreadPool,
+            mockTimeNanosSupplier,
+            List.of(mockNodeDuressTracker),
+            List.of(mockTaskResourceUsageTracker)
+        );
+
+        // Run two iterations so that node is marked 'in duress' from the third iteration onwards.
+        service.doRun();
+        service.doRun();
+
+        // Mocking 'settings' with predictable searchHeapThresholdBytes so that cancellation logic doesn't get skipped.
+        long taskHeapUsageBytes = 500;
+        SearchShardTaskSettings shardTaskSettings = mock(SearchShardTaskSettings.class);
+        when(shardTaskSettings.getTotalHeapThresholdBytes()).thenReturn(taskHeapUsageBytes);
+        when(settings.getSearchShardTaskSettings()).thenReturn(shardTaskSettings);
+
+        // Create a mix of low and high resource usage tasks (60 low + 15 high resource usage tasks).
+        Map<Long, Task> activeTasks = new HashMap<>();
+        for (long i = 0; i < 75; i++) {
+            if (i % 5 == 0) {
+                activeTasks.put(i, createMockTaskWithResourceStats(SearchShardTask.class, 500, taskHeapUsageBytes));
+            } else {
+                activeTasks.put(i, createMockTaskWithResourceStats(SearchShardTask.class, 100, taskHeapUsageBytes));
+            }
+        }
+        doReturn(activeTasks).when(mockTaskResourceTrackingService).getResourceAwareTasks();
+
+        // There are 15 tasks eligible for cancellation but only 10 will be cancelled (burst limit).
+        service.doRun();
+        assertEquals(10, service.getState().getCancellationCount());
+        assertEquals(1, service.getState().getLimitReachedCount());
+
+        // If the clock or completed task count haven't made sufficient progress, we'll continue to be rate-limited.
+        service.doRun();
+        assertEquals(10, service.getState().getCancellationCount());
+        assertEquals(2, service.getState().getLimitReachedCount());
+
+        // Simulate task completion to replenish some tokens.
+        // This will add 2 tokens (task count delta * cancellationRatio) to 'rateLimitPerTaskCompletion'.
+        for (int i = 0; i < 20; i++) {
+            service.onTaskCompleted(createMockTaskWithResourceStats(SearchShardTask.class, 100, taskHeapUsageBytes));
+        }
+        service.doRun();
+        assertEquals(12, service.getState().getCancellationCount());
+        assertEquals(3, service.getState().getLimitReachedCount());
+
+        // Fast-forward the clock by one second to replenish some tokens.
+        // This will add 3 tokens (time delta * rate) to 'rateLimitPerTime'.
+        mockTime.addAndGet(TimeUnit.SECONDS.toNanos(1));
+        service.doRun();
+        assertEquals(15, service.getState().getCancellationCount());
+        assertEquals(3, service.getState().getLimitReachedCount());  // no more tasks to cancel; limit not reached
+    }
+}

--- a/server/src/test/java/org/opensearch/search/backpressure/SearchBackpressureServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/SearchBackpressureServiceTests.java
@@ -9,12 +9,19 @@
 package org.opensearch.search.backpressure;
 
 import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.search.backpressure.settings.SearchBackpressureMode;
 import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
 import org.opensearch.search.backpressure.settings.SearchShardTaskSettings;
 import org.opensearch.search.backpressure.trackers.NodeDuressTracker;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.search.backpressure.stats.SearchBackpressureStats;
+import org.opensearch.search.backpressure.stats.SearchShardTaskStats;
 import org.opensearch.search.backpressure.trackers.TaskResourceUsageTracker;
+import org.opensearch.search.backpressure.trackers.TaskResourceUsageTrackerType;
 import org.opensearch.tasks.CancellableTask;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskCancellation;
@@ -22,10 +29,12 @@ import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -125,7 +134,7 @@ public class SearchBackpressureServiceTests extends OpenSearchTestCase {
         TaskResourceUsageTracker mockTaskResourceUsageTracker = new TaskResourceUsageTracker() {
             @Override
             public String name() {
-                return "mock_tracker";
+                return TaskResourceUsageTrackerType.CPU_USAGE_TRACKER.getName();
             }
 
             @Override
@@ -139,13 +148,18 @@ public class SearchBackpressureServiceTests extends OpenSearchTestCase {
 
                 return Optional.of(new TaskCancellation.Reason("limits exceeded", 5));
             }
+
+            @Override
+            public Stats stats(List<? extends Task> activeTasks) {
+                return new MockStats(getCancellations());
+            }
         };
 
         // Mocking 'settings' with predictable rate limiting thresholds.
         SearchBackpressureSettings settings = spy(
             new SearchBackpressureSettings(
                 Settings.builder()
-                    .put(SearchBackpressureSettings.SETTING_ENFORCED.getKey(), true)
+                    .put(SearchBackpressureSettings.SETTING_MODE.getKey(), "enforced")
                     .put(SearchBackpressureSettings.SETTING_CANCELLATION_RATIO.getKey(), 0.1)
                     .put(SearchBackpressureSettings.SETTING_CANCELLATION_RATE.getKey(), 0.003)
                     .put(SearchBackpressureSettings.SETTING_CANCELLATION_BURST.getKey(), 10.0)
@@ -209,5 +223,48 @@ public class SearchBackpressureServiceTests extends OpenSearchTestCase {
         service.doRun();
         assertEquals(15, service.getState().getCancellationCount());
         assertEquals(3, service.getState().getLimitReachedCount());  // no more tasks to cancel; limit not reached
+
+        // Verify search backpressure stats.
+        SearchBackpressureStats expectedStats = new SearchBackpressureStats(
+            new SearchShardTaskStats(15, 3, Map.of(TaskResourceUsageTrackerType.CPU_USAGE_TRACKER, new MockStats(15))),
+            SearchBackpressureMode.ENFORCED
+        );
+        SearchBackpressureStats actualStats = service.nodeStats();
+        assertEquals(expectedStats, actualStats);
+    }
+
+    private static class MockStats implements TaskResourceUsageTracker.Stats {
+        private final long cancellationCount;
+
+        public MockStats(long cancellationCount) {
+            this.cancellationCount = cancellationCount;
+        }
+
+        public MockStats(StreamInput in) throws IOException {
+            this(in.readVLong());
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder.startObject().field("cancellation_count", cancellationCount).endObject();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVLong(cancellationCount);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            MockStats mockStats = (MockStats) o;
+            return cancellationCount == mockStats.cancellationCount;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(cancellationCount);
+        }
     }
 }

--- a/server/src/test/java/org/opensearch/search/backpressure/stats/SearchBackpressureStatsTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/stats/SearchBackpressureStatsTests.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.stats;
+
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.search.backpressure.settings.SearchBackpressureMode;
+import org.opensearch.test.AbstractWireSerializingTestCase;
+
+public class SearchBackpressureStatsTests extends AbstractWireSerializingTestCase<SearchBackpressureStats> {
+    @Override
+    protected Writeable.Reader<SearchBackpressureStats> instanceReader() {
+        return SearchBackpressureStats::new;
+    }
+
+    @Override
+    protected SearchBackpressureStats createTestInstance() {
+        return randomInstance();
+    }
+
+    public static SearchBackpressureStats randomInstance() {
+        return new SearchBackpressureStats(
+            SearchShardTaskStatsTests.randomInstance(),
+            randomFrom(SearchBackpressureMode.DISABLED, SearchBackpressureMode.MONITOR_ONLY, SearchBackpressureMode.ENFORCED)
+        );
+    }
+}

--- a/server/src/test/java/org/opensearch/search/backpressure/stats/SearchShardTaskStatsTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/stats/SearchShardTaskStatsTests.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.stats;
+
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.search.backpressure.trackers.CpuUsageTracker;
+import org.opensearch.search.backpressure.trackers.ElapsedTimeTracker;
+import org.opensearch.search.backpressure.trackers.HeapUsageTracker;
+import org.opensearch.search.backpressure.trackers.TaskResourceUsageTracker;
+import org.opensearch.search.backpressure.trackers.TaskResourceUsageTrackerType;
+import org.opensearch.test.AbstractWireSerializingTestCase;
+
+import java.util.Map;
+
+public class SearchShardTaskStatsTests extends AbstractWireSerializingTestCase<SearchShardTaskStats> {
+    @Override
+    protected Writeable.Reader<SearchShardTaskStats> instanceReader() {
+        return SearchShardTaskStats::new;
+    }
+
+    @Override
+    protected SearchShardTaskStats createTestInstance() {
+        return randomInstance();
+    }
+
+    public static SearchShardTaskStats randomInstance() {
+        Map<TaskResourceUsageTrackerType, TaskResourceUsageTracker.Stats> resourceUsageTrackerStats = Map.of(
+            TaskResourceUsageTrackerType.CPU_USAGE_TRACKER,
+            new CpuUsageTracker.Stats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong()),
+            TaskResourceUsageTrackerType.HEAP_USAGE_TRACKER,
+            new HeapUsageTracker.Stats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong()),
+            TaskResourceUsageTrackerType.ELAPSED_TIME_TRACKER,
+            new ElapsedTimeTracker.Stats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong())
+        );
+
+        return new SearchShardTaskStats(randomNonNegativeLong(), randomNonNegativeLong(), resourceUsageTrackerStats);
+    }
+}

--- a/server/src/test/java/org/opensearch/search/backpressure/trackers/CpuUsageTrackerTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/trackers/CpuUsageTrackerTests.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.trackers;
+
+import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
+import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskCancellation;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Optional;
+
+import static org.opensearch.search.backpressure.SearchBackpressureTestHelpers.createMockTaskWithResourceStats;
+
+public class CpuUsageTrackerTests extends OpenSearchTestCase {
+    private static final SearchBackpressureSettings mockSettings = new SearchBackpressureSettings(
+        Settings.builder()
+            .put(CpuUsageTracker.SETTING_CPU_TIME_MILLIS_THRESHOLD.getKey(), 15)  // 15 ms
+            .build(),
+        new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+    );
+
+    public void testEligibleForCancellation() {
+        Task task = createMockTaskWithResourceStats(SearchShardTask.class, 200000000, 200);
+        CpuUsageTracker tracker = new CpuUsageTracker(mockSettings);
+
+        Optional<TaskCancellation.Reason> reason = tracker.checkAndMaybeGetCancellationReason(task);
+        assertTrue(reason.isPresent());
+        assertEquals(1, reason.get().getCancellationScore());
+        assertEquals("cpu usage exceeded [200ms >= 15ms]", reason.get().getMessage());
+    }
+
+    public void testNotEligibleForCancellation() {
+        Task task = createMockTaskWithResourceStats(SearchShardTask.class, 5000000, 200);
+        CpuUsageTracker tracker = new CpuUsageTracker(mockSettings);
+
+        Optional<TaskCancellation.Reason> reason = tracker.checkAndMaybeGetCancellationReason(task);
+        assertFalse(reason.isPresent());
+    }
+}

--- a/server/src/test/java/org/opensearch/search/backpressure/trackers/ElapsedTimeTrackerTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/trackers/ElapsedTimeTrackerTests.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.trackers;
+
+import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
+import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskCancellation;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Optional;
+
+import static org.opensearch.search.backpressure.SearchBackpressureTestHelpers.createMockTaskWithResourceStats;
+
+public class ElapsedTimeTrackerTests extends OpenSearchTestCase {
+
+    private static final SearchBackpressureSettings mockSettings = new SearchBackpressureSettings(
+        Settings.builder()
+            .put(ElapsedTimeTracker.SETTING_ELAPSED_TIME_MILLIS_THRESHOLD.getKey(), 100) // 100 ms
+            .build(),
+        new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+    );
+
+    public void testEligibleForCancellation() {
+        Task task = createMockTaskWithResourceStats(SearchShardTask.class, 1, 1, 0);
+        ElapsedTimeTracker tracker = new ElapsedTimeTracker(mockSettings, () -> 200000000);
+
+        Optional<TaskCancellation.Reason> reason = tracker.checkAndMaybeGetCancellationReason(task);
+        assertTrue(reason.isPresent());
+        assertEquals(1, reason.get().getCancellationScore());
+        assertEquals("elapsed time exceeded [200ms >= 100ms]", reason.get().getMessage());
+    }
+
+    public void testNotEligibleForCancellation() {
+        Task task = createMockTaskWithResourceStats(SearchShardTask.class, 1, 1, 150000000);
+        ElapsedTimeTracker tracker = new ElapsedTimeTracker(mockSettings, () -> 200000000);
+
+        Optional<TaskCancellation.Reason> reason = tracker.checkAndMaybeGetCancellationReason(task);
+        assertFalse(reason.isPresent());
+    }
+}

--- a/server/src/test/java/org/opensearch/search/backpressure/trackers/HeapUsageTrackerTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/trackers/HeapUsageTrackerTests.java
@@ -1,0 +1,83 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.trackers;
+
+import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
+import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskCancellation;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.opensearch.search.backpressure.SearchBackpressureTestHelpers.createMockTaskWithResourceStats;
+
+public class HeapUsageTrackerTests extends OpenSearchTestCase {
+    private static final long HEAP_BYTES_THRESHOLD = 100;
+    private static final int HEAP_MOVING_AVERAGE_WINDOW_SIZE = 100;
+
+    private static final SearchBackpressureSettings mockSettings = new SearchBackpressureSettings(
+        Settings.builder()
+            .put(HeapUsageTracker.SETTING_HEAP_VARIANCE_THRESHOLD.getKey(), 2.0)
+            .put(HeapUsageTracker.SETTING_HEAP_MOVING_AVERAGE_WINDOW_SIZE.getKey(), HEAP_MOVING_AVERAGE_WINDOW_SIZE)
+            .build(),
+        new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+    );
+
+    public void testEligibleForCancellation() {
+        HeapUsageTracker tracker = spy(new HeapUsageTracker(mockSettings));
+        when(tracker.getHeapBytesThreshold()).thenReturn(HEAP_BYTES_THRESHOLD);
+        Task task = createMockTaskWithResourceStats(SearchShardTask.class, 1, 50);
+
+        // Record enough observations to make the moving average 'ready'.
+        for (int i = 0; i < HEAP_MOVING_AVERAGE_WINDOW_SIZE; i++) {
+            tracker.update(task);
+        }
+
+        // Task that has heap usage >= heapBytesThreshold and (movingAverage * heapVariance).
+        task = createMockTaskWithResourceStats(SearchShardTask.class, 1, 200);
+        Optional<TaskCancellation.Reason> reason = tracker.checkAndMaybeGetCancellationReason(task);
+        assertTrue(reason.isPresent());
+        assertEquals(4, reason.get().getCancellationScore());
+        assertEquals("heap usage exceeded [200b >= 100b]", reason.get().getMessage());
+    }
+
+    public void testNotEligibleForCancellation() {
+        Task task;
+        Optional<TaskCancellation.Reason> reason;
+        HeapUsageTracker tracker = spy(new HeapUsageTracker(mockSettings));
+        when(tracker.getHeapBytesThreshold()).thenReturn(HEAP_BYTES_THRESHOLD);
+
+        // Task with heap usage < heapBytesThreshold.
+        task = createMockTaskWithResourceStats(SearchShardTask.class, 1, 99);
+
+        // Not enough observations.
+        reason = tracker.checkAndMaybeGetCancellationReason(task);
+        assertFalse(reason.isPresent());
+
+        // Record enough observations to make the moving average 'ready'.
+        for (int i = 0; i < HEAP_MOVING_AVERAGE_WINDOW_SIZE; i++) {
+            tracker.update(task);
+        }
+
+        // Task with heap usage < heapBytesThreshold should not be cancelled.
+        reason = tracker.checkAndMaybeGetCancellationReason(task);
+        assertFalse(reason.isPresent());
+
+        // Task with heap usage between heapBytesThreshold and (movingAverage * heapVariance) should not be cancelled.
+        double allowedHeapUsage = 99.0 * 2.0;
+        task = createMockTaskWithResourceStats(SearchShardTask.class, 1, randomLongBetween(99, (long) allowedHeapUsage - 1));
+        reason = tracker.checkAndMaybeGetCancellationReason(task);
+        assertFalse(reason.isPresent());
+    }
+}

--- a/server/src/test/java/org/opensearch/search/backpressure/trackers/NodeDuressTrackerTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/trackers/NodeDuressTrackerTests.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure.trackers;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class NodeDuressTrackerTests extends OpenSearchTestCase {
+
+    public void testNodeDuressTracker() {
+        AtomicReference<Double> cpuUsage = new AtomicReference<>(0.0);
+        NodeDuressTracker tracker = new NodeDuressTracker(() -> cpuUsage.get() >= 0.5);
+
+        // Node not in duress.
+        assertEquals(0, tracker.check());
+
+        // Node in duress; the streak must keep increasing.
+        cpuUsage.set(0.7);
+        assertEquals(1, tracker.check());
+        assertEquals(2, tracker.check());
+        assertEquals(3, tracker.check());
+
+        // Node not in duress anymore.
+        cpuUsage.set(0.3);
+        assertEquals(0, tracker.check());
+        assertEquals(0, tracker.check());
+    }
+}

--- a/server/src/test/java/org/opensearch/tasks/TaskCancellationTests.java
+++ b/server/src/test/java/org/opensearch/tasks/TaskCancellationTests.java
@@ -67,6 +67,11 @@ public class TaskCancellationTests extends OpenSearchTestCase {
             public Optional<TaskCancellation.Reason> checkAndMaybeGetCancellationReason(Task task) {
                 return Optional.empty();
             }
+
+            @Override
+            public Stats stats(List<? extends Task> activeTasks) {
+                return null;
+            }
         };
     }
 }

--- a/server/src/test/java/org/opensearch/tasks/TaskCancellationTests.java
+++ b/server/src/test/java/org/opensearch/tasks/TaskCancellationTests.java
@@ -64,7 +64,7 @@ public class TaskCancellationTests extends OpenSearchTestCase {
             public void update(Task task) {}
 
             @Override
-            public Optional<TaskCancellation.Reason> cancellationReason(Task task) {
+            public Optional<TaskCancellation.Reason> checkAndMaybeGetCancellationReason(Task task) {
                 return Optional.empty();
             }
         };

--- a/server/src/test/java/org/opensearch/tasks/TaskCancellationTests.java
+++ b/server/src/test/java/org/opensearch/tasks/TaskCancellationTests.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.tasks;
+
+import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.search.backpressure.trackers.TaskResourceUsageTracker;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class TaskCancellationTests extends OpenSearchTestCase {
+
+    public void testTaskCancellation() {
+        SearchShardTask mockTask = new SearchShardTask(123L, "", "", "", null, Collections.emptyMap());
+
+        TaskResourceUsageTracker mockTracker1 = createMockTaskResourceUsageTracker("mock_tracker_1");
+        TaskResourceUsageTracker mockTracker2 = createMockTaskResourceUsageTracker("mock_tracker_2");
+        TaskResourceUsageTracker mockTracker3 = createMockTaskResourceUsageTracker("mock_tracker_3");
+
+        List<TaskCancellation.Reason> reasons = new ArrayList<>();
+        List<Runnable> callbacks = List.of(mockTracker1::incrementCancellations, mockTracker2::incrementCancellations);
+        TaskCancellation taskCancellation = new TaskCancellation(mockTask, reasons, callbacks);
+
+        // Task does not have any reason to be cancelled.
+        assertEquals(0, taskCancellation.totalCancellationScore());
+        assertFalse(taskCancellation.isEligibleForCancellation());
+        taskCancellation.cancel();
+        assertEquals(0, mockTracker1.getCancellations());
+        assertEquals(0, mockTracker2.getCancellations());
+        assertEquals(0, mockTracker3.getCancellations());
+
+        // Task has one or more reasons to be cancelled.
+        reasons.add(new TaskCancellation.Reason("limits exceeded 1", 10));
+        reasons.add(new TaskCancellation.Reason("limits exceeded 2", 20));
+        reasons.add(new TaskCancellation.Reason("limits exceeded 3", 5));
+        assertEquals(35, taskCancellation.totalCancellationScore());
+        assertTrue(taskCancellation.isEligibleForCancellation());
+
+        // Cancel the task and validate the cancellation reason and invocation of callbacks.
+        taskCancellation.cancel();
+        assertTrue(mockTask.getReasonCancelled().contains("limits exceeded 1, limits exceeded 2, limits exceeded 3"));
+        assertEquals(1, mockTracker1.getCancellations());
+        assertEquals(1, mockTracker2.getCancellations());
+        assertEquals(0, mockTracker3.getCancellations());
+    }
+
+    private static TaskResourceUsageTracker createMockTaskResourceUsageTracker(String name) {
+        return new TaskResourceUsageTracker() {
+            @Override
+            public String name() {
+                return name;
+            }
+
+            @Override
+            public void update(Task task) {}
+
+            @Override
+            public Optional<TaskCancellation.Reason> cancellationReason(Task task) {
+                return Optional.empty();
+            }
+        };
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/cluster/MockInternalClusterInfoService.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/MockInternalClusterInfoService.java
@@ -114,7 +114,8 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
                 nodeStats.getAdaptiveSelectionStats(),
                 nodeStats.getScriptCacheStats(),
                 nodeStats.getIndexingPressureStats(),
-                nodeStats.getShardIndexingPressureStats()
+                nodeStats.getShardIndexingPressureStats(),
+                nodeStats.getSearchBackpressureStats()
             );
         }).collect(Collectors.toList());
     }

--- a/test/framework/src/main/java/org/opensearch/search/backpressure/SearchBackpressureTestHelpers.java
+++ b/test/framework/src/main/java/org/opensearch/search/backpressure/SearchBackpressureTestHelpers.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.backpressure;
+
+import org.opensearch.tasks.CancellableTask;
+import org.opensearch.tasks.TaskResourceUsage;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SearchBackpressureTestHelpers extends OpenSearchTestCase {
+
+    public static <T extends CancellableTask> T createMockTaskWithResourceStats(Class<T> type, long cpuUsage, long heapUsage) {
+        return createMockTaskWithResourceStats(type, cpuUsage, heapUsage, 0);
+    }
+
+    public static <T extends CancellableTask> T createMockTaskWithResourceStats(
+        Class<T> type,
+        long cpuUsage,
+        long heapUsage,
+        long startTimeNanos
+    ) {
+        T task = mock(type);
+        when(task.getTotalResourceStats()).thenReturn(new TaskResourceUsage(cpuUsage, heapUsage));
+        when(task.getStartTimeNanos()).thenReturn(startTimeNanos);
+
+        AtomicBoolean isCancelled = new AtomicBoolean(false);
+        doAnswer(invocation -> {
+            isCancelled.set(true);
+            return null;
+        }).when(task).cancel(anyString());
+        doAnswer(invocation -> isCancelled.get()).when(task).isCancelled();
+
+        return task;
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
@@ -2625,6 +2625,7 @@ public final class InternalTestCluster extends TestCluster {
                     false,
                     false,
                     false,
+                    false,
                     false
                 );
                 assertThat(


### PR DESCRIPTION
### Description
This feature aims to identify and cancel resource intensive SearchShardTasks if they have breached certain thresholds. This will help in terminating problematic queries which can put nodes in duress and degrade the cluster performance.

This backport PR combines changes from:
* https://github.com/opensearch-project/OpenSearch/pull/4575
* https://github.com/opensearch-project/OpenSearch/pull/4805
* https://github.com/opensearch-project/OpenSearch/pull/4932

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/1181

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Ketan Verma [ketan9495@gmail.com](mailto:ketan9495@gmail.com)