### PR TITLE
[Test] Add IAE test for deprecated edgeNGram analyzer name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update previous release bwc version to 2.5.0 ([#5003](https://github.com/opensearch-project/OpenSearch/pull/5003))
 - Use getParameterCount instead of getParameterTypes ([#4821](https://github.com/opensearch-project/OpenSearch/pull/4821))
 - Remote shard balancer support for searchable snapshots ([#4870](https://github.com/opensearch-project/OpenSearch/pull/4870))
+- [Test] Add IAE test for deprecated edgeNGram analyzer name ([#5040](https://github.com/opensearch-project/OpenSearch/pull/5040))
 ### Dependencies
 - Bumps `log4j-core` from 2.18.0 to 2.19.0
 - Bumps `reactor-netty-http` from 1.0.18 to 1.0.23

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/CommonAnalysisModulePlugin.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/CommonAnalysisModulePlugin.java
@@ -271,7 +271,7 @@ public class CommonAnalysisModulePlugin extends Plugin implements AnalysisPlugin
             if (indexSettings.getIndexVersionCreated().onOrAfter(Version.V_3_0_0)) {
                 throw new IllegalArgumentException(
                     "The [edgeNGram] tokenizer name was deprecated pre 1.0. "
-                        + "Please use the tokenizer name to [edge_ngram] for indices created in versions 3.0 or higher instead."
+                        + "Please change the tokenizer name to [edge_ngram] for indices created in versions 3.0 or higher instead."
                 );
             } else {
                 deprecationLogger.deprecate(
@@ -357,7 +357,7 @@ public class CommonAnalysisModulePlugin extends Plugin implements AnalysisPlugin
             if (indexSettings.getIndexVersionCreated().onOrAfter(Version.V_3_0_0)) {
                 throw new IllegalArgumentException(
                     "The [nGram] tokenizer name was deprecated pre 1.0. "
-                        + "Please use the tokenizer name to [ngram] for indices created in versions 3.0 or higher instead."
+                        + "Please change the tokenizer name to [ngram] for indices created in versions 3.0 or higher instead."
                 );
             } else {
                 deprecationLogger.deprecate(
@@ -373,7 +373,7 @@ public class CommonAnalysisModulePlugin extends Plugin implements AnalysisPlugin
             if (indexSettings.getIndexVersionCreated().onOrAfter(Version.V_3_0_0)) {
                 throw new IllegalArgumentException(
                     "The [edgeNGram] tokenizer name was deprecated pre 1.0. "
-                        + "Please use the tokenizer name to [edge_ngram] for indices created in versions 3.0 or higher instead."
+                        + "Please change the tokenizer name to [edge_ngram] for indices created in versions 3.0 or higher instead."
                 );
             } else {
                 deprecationLogger.deprecate(
@@ -626,7 +626,7 @@ public class CommonAnalysisModulePlugin extends Plugin implements AnalysisPlugin
             if (version.onOrAfter(Version.V_3_0_0)) {
                 throw new IllegalArgumentException(
                     "The [nGram] tokenizer name was deprecated pre 1.0. "
-                        + "Please use the tokenizer name to [ngram] for indices created in versions 3.0 or higher instead."
+                        + "Please change the tokenizer name to [ngram] for indices created in versions 3.0 or higher instead."
                 );
             } else {
                 deprecationLogger.deprecate(
@@ -641,7 +641,7 @@ public class CommonAnalysisModulePlugin extends Plugin implements AnalysisPlugin
             if (version.onOrAfter(Version.V_3_0_0)) {
                 throw new IllegalArgumentException(
                     "The [edgeNGram] tokenizer name was deprecated pre 1.0. "
-                        + "Please use the tokenizer name to [edge_ngram] for indices created in versions 3.0 or higher instead."
+                        + "Please change the tokenizer name to [edge_ngram] for indices created in versions 3.0 or higher instead."
                 );
             } else {
                 deprecationLogger.deprecate(

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/CommonAnalysisModulePlugin.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/CommonAnalysisModulePlugin.java
@@ -268,11 +268,18 @@ public class CommonAnalysisModulePlugin extends Plugin implements AnalysisPlugin
         filters.put("dutch_stem", DutchStemTokenFilterFactory::new);
         filters.put("edge_ngram", EdgeNGramTokenFilterFactory::new);
         filters.put("edgeNGram", (IndexSettings indexSettings, Environment environment, String name, Settings settings) -> {
-            deprecationLogger.deprecate(
-                "edgeNGram_deprecation",
-                "The [edgeNGram] token filter name is deprecated and will be removed in a future version. "
-                    + "Please change the filter name to [edge_ngram] instead."
-            );
+            if (indexSettings.getIndexVersionCreated().onOrAfter(Version.V_3_0_0)) {
+                throw new IllegalArgumentException(
+                    "The [edgeNGram] tokenizer name was deprecated pre 1.0. "
+                        + "Please use the tokenizer name to [edge_ngram] for indices created in versions 3.0 or higher instead."
+                );
+            } else {
+                deprecationLogger.deprecate(
+                    "edgeNGram_deprecation",
+                    "The [edgeNGram] token filter name is deprecated and will be removed in a future version. "
+                        + "Please change the filter name to [edge_ngram] instead."
+                );
+            }
             return new EdgeNGramTokenFilterFactory(indexSettings, environment, name, settings);
         });
         filters.put("elision", requiresAnalysisSettings(ElisionTokenFilterFactory::new));


### PR DESCRIPTION
`edgeNGram` analyzer name was deprecated in legacy versions. In preparation for removal in the next major opensearch version, 
an IAE is thrown. This commit adds a test to ensure the IAE logic remains intact until removal.

