### PR TITLE
[Backport 2.x] Add AutoExpandReplica in the validation of replica count enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Add fix for auto expand replica validation ([#4994](https://github.com/opensearch-project/OpenSearch/pull/4994))
 - Add support for s390x architecture ([#4001](https://github.com/opensearch-project/OpenSearch/pull/4001))
 - Github workflow for changelog verification ([#4085](https://github.com/opensearch-project/OpenSearch/pull/4085))
 - Point in time rest layer changes for create and delete PIT API ([#4064](https://github.com/opensearch-project/OpenSearch/pull/4064))

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/rollover/RolloverIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/rollover/RolloverIT.java
@@ -237,14 +237,12 @@ public class RolloverIT extends OpenSearchIntegTestCase {
             containsString("expected total copies needs to be a multiple of total awareness attributes [2]")
         );
 
-
         client().admin()
             .indices()
             .prepareRolloverIndex("test_alias")
-            .settings(Settings.builder()
-                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
-                .build())
+            .settings(
+                Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build()
+            )
             .alias(new Alias("extra_alias"))
             .waitForActiveShards(0)
             .get();
@@ -252,11 +250,13 @@ public class RolloverIT extends OpenSearchIntegTestCase {
         client().admin()
             .indices()
             .prepareRolloverIndex("test_alias")
-            .settings(Settings.builder()
-                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2)
-                .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
-                .build())
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2)
+                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
+                    .build()
+            )
             .alias(new Alias("extra_alias"))
             .waitForActiveShards(0)
             .get();
@@ -264,23 +264,31 @@ public class RolloverIT extends OpenSearchIntegTestCase {
         client().admin()
             .indices()
             .prepareRolloverIndex("test_alias")
-            .settings(Settings.builder()
-                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2)
-                .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-all")
-                .build())
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2)
+                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-all")
+                    .build()
+            )
             .alias(new Alias("extra_alias"))
             .waitForActiveShards(0)
             .get();
-
 
         final IllegalArgumentException restoreError2 = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin().indices().prepareRolloverIndex("test_alias").settings(Settings.builder()
-                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2)
-                .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-0")
-                .build()).alias(new Alias("extra_alias")).get()
+            () -> client().admin()
+                .indices()
+                .prepareRolloverIndex("test_alias")
+                .settings(
+                    Settings.builder()
+                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2)
+                        .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-0")
+                        .build()
+                )
+                .alias(new Alias("extra_alias"))
+                .get()
         );
 
         assertThat(

--- a/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateNumberOfReplicasIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateNumberOfReplicasIT.java
@@ -626,9 +626,10 @@ public class UpdateNumberOfReplicasIT extends OpenSearchIntegTestCase {
             client().admin()
                 .indices()
                 .prepareUpdateSettings("aware-replica")
-                .setSettings(Settings.builder()
-                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2)
-                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
+                .setSettings(
+                    Settings.builder()
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2)
+                        .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
                 )
                 .execute()
                 .actionGet();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateNumberOfReplicasIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateNumberOfReplicasIT.java
@@ -622,6 +622,18 @@ public class UpdateNumberOfReplicasIT extends OpenSearchIntegTestCase {
                 .actionGet();
             updated++;
 
+            // Since auto expand replica setting take precedence, this should pass
+            client().admin()
+                .indices()
+                .prepareUpdateSettings("aware-replica")
+                .setSettings(Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2)
+                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
+                )
+                .execute()
+                .actionGet();
+            updated++;
+
             // system index - should be able to update
             client().admin()
                 .indices()
@@ -637,14 +649,14 @@ public class UpdateNumberOfReplicasIT extends OpenSearchIntegTestCase {
                 .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2))
                 .execute()
                 .actionGet();
-            fail("should have thrown an exception about the replica  count");
+            fail("should have thrown an exception about the replica count");
 
         } catch (IllegalArgumentException e) {
             assertEquals(
                 "Validation Failed: 1: expected total copies needs to be a multiple of total awareness attributes [2];",
                 e.getMessage()
             );
-            assertEquals(2, updated);
+            assertEquals(3, updated);
         } finally {
             manageReplicaBalanceSetting(false);
         }

--- a/server/src/internalClusterTest/java/org/opensearch/indices/template/SimpleIndexTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/template/SimpleIndexTemplateIT.java
@@ -1032,6 +1032,7 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
 
     public void testAwarenessReplicaBalance() throws IOException {
         manageReplicaBalanceSetting(true);
+        int updated = 0;
         try {
             client().admin()
                 .indices()
@@ -1039,6 +1040,15 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
                 .setPatterns(Arrays.asList("a*", "b*"))
                 .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1))
                 .get();
+            updated++;
+
+            client().admin()
+                .indices()
+                .preparePutTemplate("template_1")
+                .setPatterns(Arrays.asList("a*", "b*"))
+                .setSettings(Settings.builder().put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1"))
+                .get();
+            updated++;
 
             client().admin()
                 .indices()
@@ -1053,6 +1063,7 @@ public class SimpleIndexTemplateIT extends OpenSearchIntegTestCase {
                 "index_template [template_1] invalid, cause [Validation Failed: 1: expected total copies needs to be a multiple of total awareness attributes [2];]",
                 e.getMessage()
             );
+            assertEquals(2, updated);
         } finally {
             manageReplicaBalanceSetting(false);
         }

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/RestoreSnapshotIT.java
@@ -1003,7 +1003,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 IllegalArgumentException.class,
                 () -> clusterAdmin().prepareRestoreSnapshot("test-repo", "snapshot-0")
                     .setRenamePattern("test-index")
-                    .setRenameReplacement("new-index")
+                    .setRenameReplacement("new-index-2")
                     .setIndexSettings(
                         Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, 1).put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-2").build()
                     )
@@ -1036,7 +1036,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
 
             restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("test-repo", "snapshot-0")
                 .setRenamePattern("test-index")
-                .setRenameReplacement("new-index")
+                .setRenameReplacement("new-index-3")
                 .setIndexSettings(
                     Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, 0).put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1").build()
                 )

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/RestoreSnapshotIT.java
@@ -999,6 +999,23 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 containsString("expected total copies needs to be a multiple of total awareness attributes [2]")
             );
 
+            final IllegalArgumentException restoreError2 = expectThrows(
+                IllegalArgumentException.class,
+                () -> clusterAdmin().prepareRestoreSnapshot("test-repo", "snapshot-0")
+                    .setRenamePattern("test-index")
+                    .setRenameReplacement("new-index")
+                    .setIndexSettings(Settings.builder()
+                        .put(SETTING_NUMBER_OF_REPLICAS, 1)
+                        .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-2")
+                        .build())
+                    .setIndices("test-index")
+                    .get()
+            );
+            assertThat(
+                restoreError2.getMessage(),
+                containsString("expected max cap on auto expand to be a multiple of total awareness attributes [2]")
+            );
+
             RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("test-repo", "snapshot-0")
                 .setRenamePattern(".system-index")
                 .setRenameReplacement(".system-index-restore-1")
@@ -1013,6 +1030,18 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 .setRenamePattern("test-index")
                 .setRenameReplacement("new-index")
                 .setIndexSettings(Settings.builder().put("index.number_of_replicas", 1).build())
+                .setWaitForCompletion(true)
+                .setIndices("test-index")
+                .execute()
+                .actionGet();
+
+            restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("test-repo", "snapshot-0")
+                .setRenamePattern("test-index")
+                .setRenameReplacement("new-index")
+                .setIndexSettings(Settings.builder()
+                    .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
+                    .build())
                 .setWaitForCompletion(true)
                 .setIndices("test-index")
                 .execute()

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/RestoreSnapshotIT.java
@@ -1004,10 +1004,9 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 () -> clusterAdmin().prepareRestoreSnapshot("test-repo", "snapshot-0")
                     .setRenamePattern("test-index")
                     .setRenameReplacement("new-index")
-                    .setIndexSettings(Settings.builder()
-                        .put(SETTING_NUMBER_OF_REPLICAS, 1)
-                        .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-2")
-                        .build())
+                    .setIndexSettings(
+                        Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, 1).put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-2").build()
+                    )
                     .setIndices("test-index")
                     .get()
             );
@@ -1038,10 +1037,9 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("test-repo", "snapshot-0")
                 .setRenamePattern("test-index")
                 .setRenameReplacement("new-index")
-                .setIndexSettings(Settings.builder()
-                    .put(SETTING_NUMBER_OF_REPLICAS, 0)
-                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
-                    .build())
+                .setIndexSettings(
+                    Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, 0).put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1").build()
+                )
                 .setWaitForCompletion(true)
                 .setIndices("test-index")
                 .execute()

--- a/server/src/main/java/org/opensearch/cluster/metadata/AutoExpandReplicas.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AutoExpandReplicas.java
@@ -59,7 +59,7 @@ public final class AutoExpandReplicas {
     // the value we recognize in the "max" position to mean all the nodes
     private static final String ALL_NODES_VALUE = "all";
 
-    private static final AutoExpandReplicas FALSE_INSTANCE = new AutoExpandReplicas(0, 0, false);
+    private static final AutoExpandReplicas FALSE_INSTANCE = new AutoExpandReplicas(-1, -1, false);
 
     public static final Setting<AutoExpandReplicas> SETTING = new Setting<>(
         IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS,
@@ -69,7 +69,7 @@ public final class AutoExpandReplicas {
         Property.IndexScope
     );
 
-    private static AutoExpandReplicas parse(String value) {
+    public static AutoExpandReplicas parse(String value) {
         final int min;
         final int max;
         if (Booleans.isFalse(value)) {
@@ -132,6 +132,10 @@ public final class AutoExpandReplicas {
 
     int getMaxReplicas(int numDataNodes) {
         return Math.min(maxReplicas, numDataNodes - 1);
+    }
+
+    int getMaxReplicas() {
+        return maxReplicas;
     }
 
     private OptionalInt getDesiredNumberOfReplicas(IndexMetadata indexMetadata, RoutingAllocation allocation) {

--- a/server/src/main/java/org/opensearch/cluster/metadata/AutoExpandReplicas.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AutoExpandReplicas.java
@@ -137,9 +137,11 @@ public final class AutoExpandReplicas {
     public int getMaxReplicas() {
         return maxReplicas;
     }
+
     public boolean isEnabled() {
         return enabled;
     }
+
     private OptionalInt getDesiredNumberOfReplicas(IndexMetadata indexMetadata, RoutingAllocation allocation) {
         if (enabled) {
             int numMatchingDataNodes = 0;

--- a/server/src/main/java/org/opensearch/cluster/metadata/AutoExpandReplicas.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AutoExpandReplicas.java
@@ -59,7 +59,7 @@ public final class AutoExpandReplicas {
     // the value we recognize in the "max" position to mean all the nodes
     private static final String ALL_NODES_VALUE = "all";
 
-    private static final AutoExpandReplicas FALSE_INSTANCE = new AutoExpandReplicas(-1, -1, false);
+    private static final AutoExpandReplicas FALSE_INSTANCE = new AutoExpandReplicas(0, 0, false);
 
     public static final Setting<AutoExpandReplicas> SETTING = new Setting<>(
         IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS,
@@ -69,7 +69,7 @@ public final class AutoExpandReplicas {
         Property.IndexScope
     );
 
-    public static AutoExpandReplicas parse(String value) {
+    private static AutoExpandReplicas parse(String value) {
         final int min;
         final int max;
         if (Booleans.isFalse(value)) {
@@ -134,10 +134,12 @@ public final class AutoExpandReplicas {
         return Math.min(maxReplicas, numDataNodes - 1);
     }
 
-    int getMaxReplicas() {
+    public int getMaxReplicas() {
         return maxReplicas;
     }
-
+    public boolean isEnabled() {
+        return enabled;
+    }
     private OptionalInt getDesiredNumberOfReplicas(IndexMetadata indexMetadata, RoutingAllocation allocation) {
         if (enabled) {
             int numMatchingDataNodes = 0;

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1205,9 +1205,8 @@ public class MetadataCreateIndexService {
                 IndexMetadata.SETTING_NUMBER_OF_REPLICAS,
                 INDEX_NUMBER_OF_REPLICAS_SETTING.getDefault(Settings.EMPTY)
             );
-            int autoExpandMaxCap = AutoExpandReplicas.parse(settings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false"))
-                .getMaxReplicas();
-            Optional<String> error = awarenessReplicaBalance.validate(replicaCount, autoExpandMaxCap);
+            AutoExpandReplicas autoExpandReplica = AutoExpandReplicas.SETTING.get(settings);
+            Optional<String> error = awarenessReplicaBalance.validate(replicaCount, autoExpandReplica);
             if (error.isPresent()) {
                 validationErrors.add(error.get());
             }

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1205,7 +1205,8 @@ public class MetadataCreateIndexService {
                 IndexMetadata.SETTING_NUMBER_OF_REPLICAS,
                 INDEX_NUMBER_OF_REPLICAS_SETTING.getDefault(Settings.EMPTY)
             );
-            int autoExpandMaxCap = AutoExpandReplicas.parse(settings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false")).getMaxReplicas();
+            int autoExpandMaxCap = AutoExpandReplicas.parse(settings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false"))
+                .getMaxReplicas();
             Optional<String> error = awarenessReplicaBalance.validate(replicaCount, autoExpandMaxCap);
             if (error.isPresent()) {
                 validationErrors.add(error.get());

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1205,7 +1205,8 @@ public class MetadataCreateIndexService {
                 IndexMetadata.SETTING_NUMBER_OF_REPLICAS,
                 INDEX_NUMBER_OF_REPLICAS_SETTING.getDefault(Settings.EMPTY)
             );
-            Optional<String> error = awarenessReplicaBalance.validate(replicaCount);
+            int autoExpandMaxCap = AutoExpandReplicas.parse(settings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false")).getMaxReplicas();
+            Optional<String> error = awarenessReplicaBalance.validate(replicaCount, autoExpandMaxCap);
             if (error.isPresent()) {
                 validationErrors.add(error.get());
             }

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -201,7 +201,9 @@ public class MetadataUpdateSettingsService {
                             for (Index index : request.indices()) {
                                 if (index.getName().charAt(0) != '.') {
                                     // No replica count validation for system indices
-                                    Optional<String> error = awarenessReplicaBalance.validate(updatedNumberOfReplicas);
+                                    Optional<String> error = awarenessReplicaBalance.validate(updatedNumberOfReplicas,
+                                            AutoExpandReplicas.parse(openSettings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false")).getMaxReplicas());
+
                                     if (error.isPresent()) {
                                         ValidationException ex = new ValidationException();
                                         ex.addValidationError(error.get());

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -201,8 +201,11 @@ public class MetadataUpdateSettingsService {
                             for (Index index : request.indices()) {
                                 if (index.getName().charAt(0) != '.') {
                                     // No replica count validation for system indices
-                                    Optional<String> error = awarenessReplicaBalance.validate(updatedNumberOfReplicas,
-                                            AutoExpandReplicas.parse(openSettings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false")).getMaxReplicas());
+                                    Optional<String> error = awarenessReplicaBalance.validate(
+                                        updatedNumberOfReplicas,
+                                        AutoExpandReplicas.parse(openSettings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false"))
+                                            .getMaxReplicas()
+                                    );
 
                                     if (error.isPresent()) {
                                         ValidationException ex = new ValidationException();

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -203,8 +203,7 @@ public class MetadataUpdateSettingsService {
                                     // No replica count validation for system indices
                                     Optional<String> error = awarenessReplicaBalance.validate(
                                         updatedNumberOfReplicas,
-                                        AutoExpandReplicas.parse(openSettings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false"))
-                                            .getMaxReplicas()
+                                        AutoExpandReplicas.SETTING.get(openSettings)
                                     );
 
                                     if (error.isPresent()) {

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/AwarenessReplicaBalance.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/AwarenessReplicaBalance.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.cluster.routing.allocation;
 
+import org.opensearch.cluster.metadata.AutoExpandReplicas;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
@@ -101,8 +102,8 @@ public class AwarenessReplicaBalance {
         return awarenessAttributes;
     }
 
-    public Optional<String> validate(int replicaCount, int autoExpandMaxCap) {
-        if (autoExpandMaxCap == -1) {
+    public Optional<String> validate(int replicaCount, AutoExpandReplicas autoExpandReplica) {
+        if (!autoExpandReplica.isEnabled()) {
             if ((replicaCount + 1) % maxAwarenessAttributes() != 0) {
                 String errorMessage = "expected total copies needs to be a multiple of total awareness attributes ["
                     + maxAwarenessAttributes()
@@ -110,7 +111,7 @@ public class AwarenessReplicaBalance {
                 return Optional.of(errorMessage);
             }
         } else {
-            if ((autoExpandMaxCap + 1) % maxAwarenessAttributes() != 0) {
+            if ((autoExpandReplica.getMaxReplicas() != Integer.MAX_VALUE) && ((autoExpandReplica.getMaxReplicas() + 1) % maxAwarenessAttributes() != 0)) {
                 String errorMessage = "expected max cap on auto expand to be a multiple of total awareness attributes ["
                     + maxAwarenessAttributes()
                     + "]";

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/AwarenessReplicaBalance.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/AwarenessReplicaBalance.java
@@ -101,12 +101,21 @@ public class AwarenessReplicaBalance {
         return awarenessAttributes;
     }
 
-    public Optional<String> validate(int replicaCount) {
-        if ((replicaCount + 1) % maxAwarenessAttributes() != 0) {
-            String errorMessage = "expected total copies needs to be a multiple of total awareness attributes ["
-                + maxAwarenessAttributes()
-                + "]";
-            return Optional.of(errorMessage);
+    public Optional<String> validate(int replicaCount, int autoExpandMaxCap) {
+        if(autoExpandMaxCap == -1) {
+            if ((replicaCount + 1) % maxAwarenessAttributes() != 0) {
+                String errorMessage = "expected total copies needs to be a multiple of total awareness attributes ["
+                    + maxAwarenessAttributes()
+                    + "]";
+                return Optional.of(errorMessage);
+            }
+        } else {
+            if ((autoExpandMaxCap + 1) % maxAwarenessAttributes() != 0) {
+                String errorMessage = "expected max cap on auto expand to be a multiple of total awareness attributes ["
+                    + maxAwarenessAttributes()
+                    + "]";
+                return Optional.of(errorMessage);
+            }
         }
         return Optional.empty();
     }

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/AwarenessReplicaBalance.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/AwarenessReplicaBalance.java
@@ -103,16 +103,16 @@ public class AwarenessReplicaBalance {
     }
 
     public Optional<String> validate(int replicaCount, AutoExpandReplicas autoExpandReplica) {
-        if (!autoExpandReplica.isEnabled()) {
-            if ((replicaCount + 1) % maxAwarenessAttributes() != 0) {
-                String errorMessage = "expected total copies needs to be a multiple of total awareness attributes ["
+        if (autoExpandReplica.isEnabled()) {
+            if ((autoExpandReplica.getMaxReplicas() != Integer.MAX_VALUE) && ((autoExpandReplica.getMaxReplicas() + 1) % maxAwarenessAttributes() != 0)) {
+                String errorMessage = "expected max cap on auto expand to be a multiple of total awareness attributes ["
                     + maxAwarenessAttributes()
                     + "]";
                 return Optional.of(errorMessage);
             }
         } else {
-            if ((autoExpandReplica.getMaxReplicas() != Integer.MAX_VALUE) && ((autoExpandReplica.getMaxReplicas() + 1) % maxAwarenessAttributes() != 0)) {
-                String errorMessage = "expected max cap on auto expand to be a multiple of total awareness attributes ["
+            if ((replicaCount + 1) % maxAwarenessAttributes() != 0) {
+                String errorMessage = "expected total copies needs to be a multiple of total awareness attributes ["
                     + maxAwarenessAttributes()
                     + "]";
                 return Optional.of(errorMessage);

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/AwarenessReplicaBalance.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/AwarenessReplicaBalance.java
@@ -102,7 +102,7 @@ public class AwarenessReplicaBalance {
     }
 
     public Optional<String> validate(int replicaCount, int autoExpandMaxCap) {
-        if(autoExpandMaxCap == -1) {
+        if (autoExpandMaxCap == -1) {
             if ((replicaCount + 1) % maxAwarenessAttributes() != 0) {
                 String errorMessage = "expected total copies needs to be a multiple of total awareness attributes ["
                     + maxAwarenessAttributes()

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/AwarenessReplicaBalance.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/AwarenessReplicaBalance.java
@@ -104,7 +104,8 @@ public class AwarenessReplicaBalance {
 
     public Optional<String> validate(int replicaCount, AutoExpandReplicas autoExpandReplica) {
         if (autoExpandReplica.isEnabled()) {
-            if ((autoExpandReplica.getMaxReplicas() != Integer.MAX_VALUE) && ((autoExpandReplica.getMaxReplicas() + 1) % maxAwarenessAttributes() != 0)) {
+            if ((autoExpandReplica.getMaxReplicas() != Integer.MAX_VALUE)
+                && ((autoExpandReplica.getMaxReplicas() + 1) % maxAwarenessAttributes() != 0)) {
                 String errorMessage = "expected max cap on auto expand to be a multiple of total awareness attributes ["
                     + maxAwarenessAttributes()
                     + "]";

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/AwarenessReplicaBalanceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/AwarenessReplicaBalanceTests.java
@@ -30,11 +30,11 @@ public class AwarenessReplicaBalanceTests extends OpenSearchAllocationTestCase {
         AwarenessReplicaBalance awarenessReplicaBalance = new AwarenessReplicaBalance(settings, EMPTY_CLUSTER_SETTINGS);
         assertThat(awarenessReplicaBalance.maxAwarenessAttributes(), equalTo(1));
 
-        assertEquals(awarenessReplicaBalance.validate(0,-1), Optional.empty());
+        assertEquals(awarenessReplicaBalance.validate(0, -1), Optional.empty());
         assertEquals(awarenessReplicaBalance.validate(1, -1), Optional.empty());
-        assertEquals(awarenessReplicaBalance.validate(0,0), Optional.empty());
+        assertEquals(awarenessReplicaBalance.validate(0, 0), Optional.empty());
         assertEquals(awarenessReplicaBalance.validate(0, 1), Optional.empty());
-        assertEquals(awarenessReplicaBalance.validate(1,0), Optional.empty());
+        assertEquals(awarenessReplicaBalance.validate(1, 0), Optional.empty());
         assertEquals(awarenessReplicaBalance.validate(1, 1), Optional.empty());
     }
 

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/AwarenessReplicaBalanceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/AwarenessReplicaBalanceTests.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS;
-import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 
 public class AwarenessReplicaBalanceTests extends OpenSearchAllocationTestCase {
 
@@ -30,7 +29,7 @@ public class AwarenessReplicaBalanceTests extends OpenSearchAllocationTestCase {
     public void testNoForcedAwarenessAttribute() {
         Settings settings = Settings.builder()
             .put("cluster.routing.allocation.awareness.attributes", "rack_id")
-            .put(SETTING_AUTO_EXPAND_REPLICAS,"0-1")
+            .put(SETTING_AUTO_EXPAND_REPLICAS, "0-1")
             .build();
         AutoExpandReplicas autoExpandReplica = AutoExpandReplicas.SETTING.get(settings);
         AwarenessReplicaBalance awarenessReplicaBalance = new AwarenessReplicaBalance(settings, EMPTY_CLUSTER_SETTINGS);
@@ -47,7 +46,7 @@ public class AwarenessReplicaBalanceTests extends OpenSearchAllocationTestCase {
             .put(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_FORCE_GROUP_SETTING.getKey() + "zone.values", "a, b")
             .put(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_FORCE_GROUP_SETTING.getKey() + "rack.values", "c, d, e")
             .put(AwarenessReplicaBalance.CLUSTER_ROUTING_ALLOCATION_AWARENESS_BALANCE_SETTING.getKey(), true)
-            .put(SETTING_AUTO_EXPAND_REPLICAS,"0-2")
+            .put(SETTING_AUTO_EXPAND_REPLICAS, "0-2")
             .build();
 
         AwarenessReplicaBalance awarenessReplicaBalance = new AwarenessReplicaBalance(settings, EMPTY_CLUSTER_SETTINGS);
@@ -63,7 +62,7 @@ public class AwarenessReplicaBalanceTests extends OpenSearchAllocationTestCase {
             .put(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_FORCE_GROUP_SETTING.getKey() + "zone.values", "a, b")
             .put(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_FORCE_GROUP_SETTING.getKey() + "rack.values", "c, d, e")
             .put(AwarenessReplicaBalance.CLUSTER_ROUTING_ALLOCATION_AWARENESS_BALANCE_SETTING.getKey(), true)
-            .put(SETTING_AUTO_EXPAND_REPLICAS,"0-all")
+            .put(SETTING_AUTO_EXPAND_REPLICAS, "0-all")
             .build();
 
         awarenessReplicaBalance = new AwarenessReplicaBalance(settings, EMPTY_CLUSTER_SETTINGS);
@@ -79,7 +78,7 @@ public class AwarenessReplicaBalanceTests extends OpenSearchAllocationTestCase {
             .put(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_FORCE_GROUP_SETTING.getKey() + "zone.values", "a, b")
             .put(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_FORCE_GROUP_SETTING.getKey() + "rack.values", "c, d, e")
             .put(AwarenessReplicaBalance.CLUSTER_ROUTING_ALLOCATION_AWARENESS_BALANCE_SETTING.getKey(), true)
-            .put(SETTING_AUTO_EXPAND_REPLICAS,"0-1")
+            .put(SETTING_AUTO_EXPAND_REPLICAS, "0-1")
             .build();
 
         awarenessReplicaBalance = new AwarenessReplicaBalance(settings, EMPTY_CLUSTER_SETTINGS);
@@ -121,7 +120,7 @@ public class AwarenessReplicaBalanceTests extends OpenSearchAllocationTestCase {
         Settings settings = Settings.builder()
             .put(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.getKey(), "zone, rack")
             .put(AwarenessReplicaBalance.CLUSTER_ROUTING_ALLOCATION_AWARENESS_BALANCE_SETTING.getKey(), true)
-            .put(SETTING_AUTO_EXPAND_REPLICAS,"0-1")
+            .put(SETTING_AUTO_EXPAND_REPLICAS, "0-1")
             .build();
 
         AwarenessReplicaBalance awarenessReplicaBalance = new AwarenessReplicaBalance(settings, EMPTY_CLUSTER_SETTINGS);

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/AwarenessReplicaBalanceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/AwarenessReplicaBalanceTests.java
@@ -30,8 +30,12 @@ public class AwarenessReplicaBalanceTests extends OpenSearchAllocationTestCase {
         AwarenessReplicaBalance awarenessReplicaBalance = new AwarenessReplicaBalance(settings, EMPTY_CLUSTER_SETTINGS);
         assertThat(awarenessReplicaBalance.maxAwarenessAttributes(), equalTo(1));
 
-        assertEquals(awarenessReplicaBalance.validate(0), Optional.empty());
-        assertEquals(awarenessReplicaBalance.validate(1), Optional.empty());
+        assertEquals(awarenessReplicaBalance.validate(0,-1), Optional.empty());
+        assertEquals(awarenessReplicaBalance.validate(1, -1), Optional.empty());
+        assertEquals(awarenessReplicaBalance.validate(0,0), Optional.empty());
+        assertEquals(awarenessReplicaBalance.validate(0, 1), Optional.empty());
+        assertEquals(awarenessReplicaBalance.validate(1,0), Optional.empty());
+        assertEquals(awarenessReplicaBalance.validate(1, 1), Optional.empty());
     }
 
     public void testForcedAwarenessAttribute() {
@@ -44,11 +48,18 @@ public class AwarenessReplicaBalanceTests extends OpenSearchAllocationTestCase {
 
         AwarenessReplicaBalance awarenessReplicaBalance = new AwarenessReplicaBalance(settings, EMPTY_CLUSTER_SETTINGS);
         assertThat(awarenessReplicaBalance.maxAwarenessAttributes(), equalTo(3));
-        assertEquals(awarenessReplicaBalance.validate(2), Optional.empty());
+        assertEquals(awarenessReplicaBalance.validate(2, -1), Optional.empty());
+        assertEquals(awarenessReplicaBalance.validate(1, 2), Optional.empty());
+        assertEquals(awarenessReplicaBalance.validate(0, 2), Optional.empty());
         assertEquals(
-            awarenessReplicaBalance.validate(1),
+            awarenessReplicaBalance.validate(1, -1),
             Optional.of("expected total copies needs to be a multiple of total awareness attributes [3]")
         );
+        assertEquals(
+            awarenessReplicaBalance.validate(1, 1),
+            Optional.of("expected max cap on auto expand to be a multiple of total awareness attributes [3]")
+        );
+
     }
 
     public void testForcedAwarenessAttributeDisabled() {
@@ -59,8 +70,10 @@ public class AwarenessReplicaBalanceTests extends OpenSearchAllocationTestCase {
 
         AwarenessReplicaBalance awarenessReplicaBalance = new AwarenessReplicaBalance(settings, EMPTY_CLUSTER_SETTINGS);
         assertThat(awarenessReplicaBalance.maxAwarenessAttributes(), equalTo(1));
-        assertEquals(awarenessReplicaBalance.validate(0), Optional.empty());
-        assertEquals(awarenessReplicaBalance.validate(1), Optional.empty());
+        assertEquals(awarenessReplicaBalance.validate(0, -1), Optional.empty());
+        assertEquals(awarenessReplicaBalance.validate(1, -1), Optional.empty());
+        assertEquals(awarenessReplicaBalance.validate(0, 0), Optional.empty());
+        assertEquals(awarenessReplicaBalance.validate(0, 1), Optional.empty());
     }
 
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Backporting the changes merged in #4994. 
