### PR TITLE
Fix length calculation for block based fetching

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
@@ -22,6 +22,7 @@ import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.common.collect.Map;
 import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.ByteSizeUnit;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexNotFoundException;
@@ -42,6 +43,7 @@ public final class SearchableSnapshotIT extends AbstractSnapshotIntegTestCase {
 
     @BeforeClass
     public static void assumeFeatureFlag() {
+        System.setProperty(FeatureFlags.SEARCHABLE_SNAPSHOT, "true");
         assumeTrue(
             "Searchable snapshot feature flag is enabled",
             Boolean.parseBoolean(System.getProperty(FeatureFlags.SEARCHABLE_SNAPSHOT))
@@ -58,6 +60,65 @@ public final class SearchableSnapshotIT extends AbstractSnapshotIntegTestCase {
         final Settings.Builder settings = Settings.builder();
         settings.put("location", randomRepoPath()).put("compress", randomBoolean());
         return settings;
+    }
+
+    private Settings.Builder chunkedRepositorySettings() {
+        final Settings.Builder settings = Settings.builder();
+        settings.put("location", randomRepoPath()).put("compress", randomBoolean());
+        settings.put("chunk_size", 2 << 13, ByteSizeUnit.BYTES);
+        return settings;
+    }
+
+    public void testCreateSearchableSnapshotWithChunks() throws Exception {
+        final int numReplicasIndex = randomIntBetween(1, 4);
+        final String indexName = "test-idx";
+        final String restoredIndexName = indexName + "-copy";
+        final Client client = client();
+
+        Settings.Builder repositorySettings = chunkedRepositorySettings();
+
+        internalCluster().ensureAtLeastNumDataNodes(numReplicasIndex + 1);
+        createIndex(
+            indexName,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, Integer.toString(numReplicasIndex))
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, "1")
+                .build()
+        );
+        ensureGreen();
+        indexRandomDocs(indexName, 1000);
+
+        createRepository("test-repo", "fs", repositorySettings);
+        logger.info("--> snapshot");
+        final CreateSnapshotResponse createSnapshotResponse = client.admin()
+            .cluster()
+            .prepareCreateSnapshot("test-repo", "test-snap")
+            .setWaitForCompletion(true)
+            .setIndices(indexName)
+            .get();
+        MatcherAssert.assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
+        MatcherAssert.assertThat(
+            createSnapshotResponse.getSnapshotInfo().successfulShards(),
+            equalTo(createSnapshotResponse.getSnapshotInfo().totalShards())
+        );
+
+        assertTrue(client.admin().indices().prepareDelete(indexName).get().isAcknowledged());
+
+        internalCluster().ensureAtLeastNumSearchNodes(numReplicasIndex + 1);
+        logger.info("--> restore indices as 'remote_snapshot'");
+        client.admin()
+            .cluster()
+            .prepareRestoreSnapshot("test-repo", "test-snap")
+            .setRenamePattern("(.+)")
+            .setRenameReplacement("$1-copy")
+            .setStorageType(RestoreSnapshotRequest.StorageType.REMOTE_SNAPSHOT)
+            .setWaitForCompletion(true)
+            .execute()
+            .actionGet();
+        ensureGreen();
+
+        assertDocCount(restoredIndexName, 1000L);
+
     }
 
     public void testCreateSearchableSnapshot() throws Exception {

--- a/server/src/main/java/org/opensearch/index/store/remote/file/OnDemandBlockSnapshotIndexInput.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/file/OnDemandBlockSnapshotIndexInput.java
@@ -137,11 +137,11 @@ public class OnDemandBlockSnapshotIndexInput extends OnDemandBlockIndexInput {
         final long partStart = part * partSize;
 
         final long position = blockStart - partStart;
-        final long offset = blockEnd - blockStart - partStart;
+        final long length = blockEnd - blockStart;
 
         BlobFetchRequest blobFetchRequest = BlobFetchRequest.builder()
             .position(position)
-            .length(offset)
+            .length(length)
             .blobName(fileInfo.partName(part))
             .directory(directory)
             .fileName(blockFileName)

--- a/server/src/test/java/org/opensearch/index/store/remote/file/OnDemandBlockSnapshotIndexInputTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/file/OnDemandBlockSnapshotIndexInputTests.java
@@ -143,6 +143,9 @@ public class OnDemandBlockSnapshotIndexInputTests extends OpenSearchTestCase {
 
         doAnswer(invocation -> {
             BlobFetchRequest blobFetchRequest = invocation.getArgument(0);
+            if (blobFetchRequest.getLength() <= 0) {
+                throw new IllegalArgumentException("limit must be non-negative");
+            }
             return CompletableFuture.completedFuture(
                 blobFetchRequest.getDirectory().openInput(blobFetchRequest.getFileName(), IOContext.READ)
             );


### PR DESCRIPTION
Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- Fixes length calculation for on demand block fetching

### Issues Resolved
- N/A

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
