### PR TITLE
Update CHANGELOG for 2.4 release

### DIFF
--- a/release-notes/opensearch.release-notes-2.4.0.md
+++ b/release-notes/opensearch.release-notes-2.4.0.md
@@ -1,14 +1,4 @@
-# CHANGELOG
-Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
-
-## [Unreleased 2.x]
-### Added
-### Dependencies
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
+## 2022-11-04 Version 2.4.0 Release Notes
 
 ## [2.4]
 ### Added


### PR DESCRIPTION
The CHANGELOG was a bit of a mess. I've tried to fix it up. Please review and let me know what you think. Ultimately I intend to copy this content to a `release-notes/opensearch.release-notes-2.4.0.md`. Then maybe the CHANGELOG file should be emptied out since it would then track changes _after_ the 2.4 release?

---

There are a few changes in this commit:
 - For new features (e.g. Point in Time Search), I've replaced all the incremental commits with a single line pointing to the main GitHub issue describing the feature.
 - The 2.x section was mostly wrong with either duplicates or incorrect entries. I've consolidated it into the main 2.4 section (which was previously labeled as 'unreleased')
 - All changes related to flaky test fixes, GitHub workflows, etc have been removed as they are not useful to users reading a CHANGELOG.


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
