### PR TITLE
Upgrade com.netflix.nebula:nebula-publishing-plugin to 4.6.0.

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -106,7 +106,7 @@ dependencies {
   api 'org.apache.commons:commons-compress:1.21'
   api 'org.apache.ant:ant:1.10.12'
   api 'com.netflix.nebula:gradle-extra-configurations-plugin:7.0.0'
-  api 'com.netflix.nebula:nebula-publishing-plugin:4.4.4'
+  api 'com.netflix.nebula:nebula-publishing-plugin:4.6.0'
   api 'com.netflix.nebula:gradle-info-plugin:7.1.3'
   api 'org.apache.rat:apache-rat:0.13'
   api 'commons-io:commons-io:2.7'


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Upgrade com.netflix.nebula:nebula-publishing-plugin to 4.6.0.
Because this ships in 2.4, skipping CHANGELOG on 2.x.

### Issues Resolved

Part of https://github.com/opensearch-project/OpenSearch/issues/5121.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
