### PR TITLE
Fix: raise error on malformed CSV.

### DIFF
--- a/plugins/analysis-kuromoji/src/main/java/org/opensearch/index/analysis/KuromojiTokenizerFactory.java
+++ b/plugins/analysis-kuromoji/src/main/java/org/opensearch/index/analysis/KuromojiTokenizerFactory.java
@@ -79,6 +79,9 @@ public class KuromojiTokenizerFactory extends AbstractTokenizerFactory {
 
     private static String parse(String rule, Set<String> dup) {
         String[] values = CSVUtil.parse(rule);
+        if (values.length == 0) {
+            throw new IllegalArgumentException("Malformed csv in user dictionary.");
+        }
         if (dup.add(values[0]) == false) {
             throw new IllegalArgumentException("Found duplicate term [" + values[0] + "] in user dictionary.");
         }

--- a/plugins/analysis-kuromoji/src/test/java/org/opensearch/index/analysis/KuromojiAnalysisTests.java
+++ b/plugins/analysis-kuromoji/src/test/java/org/opensearch/index/analysis/KuromojiAnalysisTests.java
@@ -379,6 +379,15 @@ public class KuromojiAnalysisTests extends OpenSearchTestCase {
         );
     }
 
+    public void testKuromojiAnalyzerEmptyDictRule() throws Exception {
+        Settings settings = Settings.builder()
+            .put("index.analysis.analyzer.my_analyzer.type", "kuromoji")
+            .putList("index.analysis.analyzer.my_analyzer.user_dictionary_rules", "\"")
+            .build();
+        RuntimeException exc = expectThrows(RuntimeException.class, () -> createTestAnalysis(settings));
+        assertThat(exc.getMessage(), equalTo("Line [1]: Malformed csv in user dictionary."));
+    }
+
     public void testKuromojiAnalyzerDuplicateUserDictRule() throws Exception {
         Settings settings = Settings.builder()
             .put("index.analysis.analyzer.my_analyzer.type", "kuromoji")


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Fix: raise error on malformed CSV.
This ships in 2.4, so no CHANGELOG needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
