### PR TITLE
Only run backport workflow it a backport label was added.

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   backport:
+    if: ${{ contains(github.event.label.name, 'backport') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

In #5143 the backport workflow ran because I added a `skip-changelog` label.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
