### PR TITLE
Allow mmap to use new preview JDK-19 APIs in Apache Lucene 9.4+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Apply reproducible builds configuration for OpenSearch plugins through gradle plugin ([#4746](https://github.com/opensearch-project/OpenSearch/pull/4746))
 - Add project health badges to the README.md ([#4843](https://github.com/opensearch-project/OpenSearch/pull/4843))
 - [Test] Add IAE test for deprecated edgeNGram analyzer name ([#5040](https://github.com/opensearch-project/OpenSearch/pull/5040))
+- Allow mmap to use new JDK-19 preview APIs in Apache Lucene 9.4+ ([#5151](https://github.com/opensearch-project/OpenSearch/pull/5151))
 
 ### Dependencies
 - Bumps `log4j-core` from 2.18.0 to 2.19.0

--- a/build.gradle
+++ b/build.gradle
@@ -416,6 +416,9 @@ gradle.projectsEvaluated {
         if (BuildParams.runtimeJavaVersion > JavaVersion.VERSION_17) {
           task.jvmArgs += ["-Djava.security.manager=allow"]
         }
+        if (BuildParams.runtimeJavaVersion >= JavaVersion.VERSION_19) {
+          task.jvmArgs += ["--enable-preview"]
+        }
       }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -316,10 +316,7 @@ allprojects {
     javadoc.options.encoding = 'UTF8'
     javadoc.options.addStringOption('Xdoclint:all,-missing', '-quiet')
     javadoc.options.tags = ["opensearch.internal", "opensearch.api", "opensearch.experimental"]
-    if (BuildParams.runtimeJavaVersion >= JavaVersion.VERSION_19) {
-      javadoc.options.addBooleanOption("-enable-preview", true)
-      javadoc.options.addStringOption("-release", BuildParams.runtimeJavaVersion.majorVersion)
-    }
+    javadoc.options.addStringOption("-release", targetCompatibility.majorVersion)
   }
 
   // support for reproducible builds

--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -78,3 +78,6 @@ ${error.file}
 
 # Explicitly allow security manager (https://bugs.openjdk.java.net/browse/JDK-8270380)
 18-:-Djava.security.manager=allow
+
+# Allow mmap to use new JDK-19 preview APIs in Apache Lucene 9.4 (https://github.com/opensearch-project/OpenSearch/issues/4637)
+19-:--enable-preview


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Allow mmap to use new preview JDK-19 APIs in Apache Lucene 9.4+. When `--enable-preview` is not present:

```
[2022-11-08T14:03:56,502][WARN ][o.a.l.s.MMapDirectory    ] [runTask-0] You are running with Java 19. To make full use of MMapDirectory, please pass '--enable-preview' to the Java command line.
```

With `--enable-preview`:

```
[2022-11-08T14:10:36,009][INFO ][o.a.l.s.MemorySegmentIndexInputProvider] [runTask-0] Using MemorySegmentIndexInput with Java 19
```

### Issues Resolved
Final part of https://github.com/opensearch-project/OpenSearch/issues/4637

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
