### PR TITLE
Fix: org.opensearch.clustermanager.ClusterManagerTaskThrottlingIT is flaky.

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/clustermanager/ClusterManagerTaskThrottlingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/clustermanager/ClusterManagerTaskThrottlingIT.java
@@ -164,9 +164,9 @@ public class ClusterManagerTaskThrottlingIT extends OpenSearchIntegTestCase {
 
                 @Override
                 public void onFailure(Exception e) {
+                    timedoutRequest.incrementAndGet();
                     latch.countDown();
                     assertTrue(e instanceof ProcessClusterEventTimeoutException);
-                    timedoutRequest.incrementAndGet();
                 }
             };
             executePutMappingRequests(totalRequest, node, listener);


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

The test creates a latch = number of requests, then every time a request finishes decrements the latch. For all failures it increments a counter. When the latch is at zero, it checks the counter. The counter was incremented after the latch was released, before the counter had a chance to be incremented one last time. 

### Issues Resolved

Closes #5083.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
