### PR TITLE
Fix race condition in testThrottlingForSingleNode.

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/clustermanager/ClusterManagerTaskThrottlingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/clustermanager/ClusterManagerTaskThrottlingIT.java
@@ -116,8 +116,8 @@ public class ClusterManagerTaskThrottlingIT extends OpenSearchIntegTestCase {
             ActionListener listener = new ActionListener() {
                 @Override
                 public void onResponse(Object o) {
-                    latch.countDown();
                     successfulRequest.incrementAndGet();
+                    latch.countDown();
                 }
 
                 @Override


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Missed this one. It failed in https://github.com/opensearch-project/OpenSearch/pull/5153

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
