### PR TITLE
Fix boundary condition in indexing pressure test

### DIFF
--- a/server/src/test/java/org/opensearch/index/ShardIndexingPressureConcurrentExecutionTests.java
+++ b/server/src/test/java/org/opensearch/index/ShardIndexingPressureConcurrentExecutionTests.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.index;
 
+import org.hamcrest.Matcher;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.opensearch.action.admin.indices.stats.CommonStatsFlags;
 import org.opensearch.cluster.service.ClusterService;
@@ -23,6 +25,10 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
 public class ShardIndexingPressureConcurrentExecutionTests extends OpenSearchTestCase {
 
     private final Settings settings = Settings.builder()
@@ -34,8 +40,8 @@ public class ShardIndexingPressureConcurrentExecutionTests extends OpenSearchTes
         .put(ShardIndexingPressureSettings.REQUEST_SIZE_WINDOW.getKey(), 100)
         .build();
 
-    final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-    final ClusterService clusterService = new ClusterService(settings, clusterSettings, null);
+    private final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+    private final ClusterService clusterService = new ClusterService(settings, clusterSettings, null);
 
     public enum OperationType {
         COORDINATING,
@@ -71,15 +77,11 @@ public class ShardIndexingPressureConcurrentExecutionTests extends OpenSearchTes
             NUM_THREADS * 15,
             shardIndexingPressure.shardStats().getIndexingPressureShardStats(shardId1).getCurrentCombinedCoordinatingAndPrimaryBytes()
         );
-        assertTrue(
+        MatcherAssert.assertThat(
             (double) (NUM_THREADS * 15) / shardIndexingPressure.shardStats()
                 .getIndexingPressureShardStats(shardId1)
-                .getCurrentPrimaryAndCoordinatingLimits() < 0.95
-        );
-        assertTrue(
-            (double) (NUM_THREADS * 15) / shardIndexingPressure.shardStats()
-                .getIndexingPressureShardStats(shardId1)
-                .getCurrentPrimaryAndCoordinatingLimits() > 0.75
+                .getCurrentPrimaryAndCoordinatingLimits(),
+            isInOperatingFactorRange()
         );
 
         for (int i = 0; i < NUM_THREADS; i++) {
@@ -112,15 +114,11 @@ public class ShardIndexingPressureConcurrentExecutionTests extends OpenSearchTes
         Releasable[] releasable = fireConcurrentRequests(NUM_THREADS, shardIndexingPressure, shardId1, 15, OperationType.REPLICA);
 
         assertEquals(NUM_THREADS * 15, shardIndexingPressure.shardStats().getIndexingPressureShardStats(shardId1).getCurrentReplicaBytes());
-        assertTrue(
+        MatcherAssert.assertThat(
             (double) (NUM_THREADS * 15) / shardIndexingPressure.shardStats()
                 .getIndexingPressureShardStats(shardId1)
-                .getCurrentReplicaLimits() < 0.95
-        );
-        assertTrue(
-            (double) (NUM_THREADS * 15) / shardIndexingPressure.shardStats()
-                .getIndexingPressureShardStats(shardId1)
-                .getCurrentReplicaLimits() > 0.75
+                .getCurrentReplicaLimits(),
+            isInOperatingFactorRange()
         );
 
         for (int i = 0; i < NUM_THREADS; i++) {
@@ -1086,5 +1084,12 @@ public class ShardIndexingPressureConcurrentExecutionTests extends OpenSearchTes
         for (Thread t : threads) {
             t.join();
         }
+    }
+
+    private Matcher<Double> isInOperatingFactorRange() {
+        return allOf(
+            greaterThan(ShardIndexingPressureMemoryManager.LOWER_OPERATING_FACTOR.get(settings)),
+            lessThanOrEqualTo(ShardIndexingPressureMemoryManager.UPPER_OPERATING_FACTOR.get(settings))
+        );
     }
 }


### PR DESCRIPTION
This updates the boundary condition in an assertion in two tests in ShardIndexingPressureConcurrentExecutionTests. I could reliably reproduce errors here by running:

```
./gradlew ':server:test' -Dtests.iters=10000 --tests "org.opensearch.index.ShardIndexingPressureConcurrentExecutionTests.testReplicaThreadedUpdateToShardLimits"
```

On every error the value that failed was exactly 0.95 and failed the less than check. The change here is to accept 0.95, and also refactor the test to give a better error message on failure.

### Issues Resolved
Closes #2241
Closes #4215

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
