### PR TITLE
Adding depth check in doc parser for deep nested document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix 'org.apache.hc.core5.http.ParseException: Invalid protocol version' under JDK 16+ ([#4827](https://github.com/opensearch-project/OpenSearch/pull/4827))
 - Fix compression support for h2c protocol ([#4944](https://github.com/opensearch-project/OpenSearch/pull/4944))
 - Support OpenSSL Provider with default Netty allocator ([#5460](https://github.com/opensearch-project/OpenSearch/pull/5460))
-- Increasing timeout of testQuorumRecovery to 90 seconds from 30 ([#5651](https://github.com/opensearch-project/OpenSearch/pull/5651))
 - Added depth check in doc parser for deep nested document ([#5199](https://github.com/opensearch-project/OpenSearch/pull/5199))
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix 'org.apache.hc.core5.http.ParseException: Invalid protocol version' under JDK 16+ ([#4827](https://github.com/opensearch-project/OpenSearch/pull/4827))
 - Fix compression support for h2c protocol ([#4944](https://github.com/opensearch-project/OpenSearch/pull/4944))
 - Support OpenSSL Provider with default Netty allocator ([#5460](https://github.com/opensearch-project/OpenSearch/pull/5460))
+- Increasing timeout of testQuorumRecovery to 90 seconds from 30 ([#5651](https://github.com/opensearch-project/OpenSearch/pull/5651))
+- Added depth check in doc parser for deep nested document ([#5199](https://github.com/opensearch-project/OpenSearch/pull/5199))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
@@ -427,6 +427,8 @@ final class DocumentParser {
     ) throws IOException {
         assert token == XContentParser.Token.FIELD_NAME || token == XContentParser.Token.END_OBJECT;
         String[] paths = null;
+        context.incrementFieldCurrentDepth();
+        context.checkFieldDepthLimit();
         while (token != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
@@ -454,6 +456,7 @@ final class DocumentParser {
             }
             token = parser.nextToken();
         }
+        context.decrementFieldCurrentDepth();
     }
 
     private static void nested(ParseContext context, ObjectMapper.Nested nested) {

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
@@ -425,38 +425,41 @@ final class DocumentParser {
         String currentFieldName,
         XContentParser.Token token
     ) throws IOException {
-        assert token == XContentParser.Token.FIELD_NAME || token == XContentParser.Token.END_OBJECT;
-        String[] paths = null;
-        context.incrementFieldCurrentDepth();
-        context.checkFieldDepthLimit();
-        while (token != XContentParser.Token.END_OBJECT) {
-            if (token == XContentParser.Token.FIELD_NAME) {
-                currentFieldName = parser.currentName();
-                paths = splitAndValidatePath(currentFieldName);
-                if (containsDisabledObjectMapper(mapper, paths)) {
-                    parser.nextToken();
-                    parser.skipChildren();
+        try {
+            assert token == XContentParser.Token.FIELD_NAME || token == XContentParser.Token.END_OBJECT;
+            String[] paths = null;
+            context.incrementFieldCurrentDepth();
+            context.checkFieldDepthLimit();
+            while (token != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    currentFieldName = parser.currentName();
+                    paths = splitAndValidatePath(currentFieldName);
+                    if (containsDisabledObjectMapper(mapper, paths)) {
+                        parser.nextToken();
+                        parser.skipChildren();
+                    }
+                } else if (token == XContentParser.Token.START_OBJECT) {
+                    parseObject(context, mapper, currentFieldName, paths);
+                } else if (token == XContentParser.Token.START_ARRAY) {
+                    parseArray(context, mapper, currentFieldName, paths);
+                } else if (token == XContentParser.Token.VALUE_NULL) {
+                    parseNullValue(context, mapper, currentFieldName, paths);
+                } else if (token == null) {
+                    throw new MapperParsingException(
+                        "object mapping for ["
+                            + mapper.name()
+                            + "] tried to parse field ["
+                            + currentFieldName
+                            + "] as object, but got EOF, has a concrete value been provided to it?"
+                    );
+                } else if (token.isValue()) {
+                    parseValue(context, mapper, currentFieldName, token, paths);
                 }
-            } else if (token == XContentParser.Token.START_OBJECT) {
-                parseObject(context, mapper, currentFieldName, paths);
-            } else if (token == XContentParser.Token.START_ARRAY) {
-                parseArray(context, mapper, currentFieldName, paths);
-            } else if (token == XContentParser.Token.VALUE_NULL) {
-                parseNullValue(context, mapper, currentFieldName, paths);
-            } else if (token == null) {
-                throw new MapperParsingException(
-                    "object mapping for ["
-                        + mapper.name()
-                        + "] tried to parse field ["
-                        + currentFieldName
-                        + "] as object, but got EOF, has a concrete value been provided to it?"
-                );
-            } else if (token.isValue()) {
-                parseValue(context, mapper, currentFieldName, token, paths);
+                token = parser.nextToken();
             }
-            token = parser.nextToken();
+        } finally {
+            context.decrementFieldCurrentDepth();
         }
-        context.decrementFieldCurrentDepth();
     }
 
     private static void nested(ParseContext context, ObjectMapper.Nested nested) {
@@ -566,54 +569,60 @@ final class DocumentParser {
 
     private static void parseArray(ParseContext context, ObjectMapper parentMapper, String lastFieldName, String[] paths)
         throws IOException {
-        String arrayFieldName = lastFieldName;
-        context.incrementFieldArrayDepth();
-        context.checkFieldArrayDepthLimit();
+        try {
+            String arrayFieldName = lastFieldName;
+            context.incrementFieldArrayDepth();
+            context.checkFieldArrayDepthLimit();
 
-        Mapper mapper = getMapper(context, parentMapper, lastFieldName, paths);
-        if (mapper != null) {
-            // There is a concrete mapper for this field already. Need to check if the mapper
-            // expects an array, if so we pass the context straight to the mapper and if not
-            // we serialize the array components
-            if (parsesArrayValue(mapper)) {
-                parseObjectOrField(context, mapper);
-            } else {
-                parseNonDynamicArray(context, parentMapper, lastFieldName, arrayFieldName);
-            }
-        } else {
-            arrayFieldName = paths[paths.length - 1];
-            lastFieldName = arrayFieldName;
-            Tuple<Integer, ObjectMapper> parentMapperTuple = getDynamicParentMapper(context, paths, parentMapper);
-            parentMapper = parentMapperTuple.v2();
-            ObjectMapper.Dynamic dynamic = dynamicOrDefault(parentMapper, context);
-            if (dynamic == ObjectMapper.Dynamic.STRICT) {
-                throw new StrictDynamicMappingException(parentMapper.fullPath(), arrayFieldName);
-            } else if (dynamic == ObjectMapper.Dynamic.TRUE) {
-                Mapper.Builder builder = context.root().findTemplateBuilder(context, arrayFieldName, XContentFieldType.OBJECT);
-                if (builder == null) {
-                    parseNonDynamicArray(context, parentMapper, lastFieldName, arrayFieldName);
+            Mapper mapper = getMapper(context, parentMapper, lastFieldName, paths);
+            if (mapper != null) {
+                // There is a concrete mapper for this field already. Need to check if the mapper
+                // expects an array, if so we pass the context straight to the mapper and if not
+                // we serialize the array components
+                if (parsesArrayValue(mapper)) {
+                    parseObjectOrField(context, mapper);
                 } else {
-                    Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.indexSettings().getSettings(), context.path());
-                    mapper = builder.build(builderContext);
-                    assert mapper != null;
-                    if (parsesArrayValue(mapper)) {
-                        context.addDynamicMapper(mapper);
-                        context.path().add(arrayFieldName);
-                        parseObjectOrField(context, mapper);
-                        context.path().remove();
-                    } else {
-                        parseNonDynamicArray(context, parentMapper, lastFieldName, arrayFieldName);
-                    }
+                    parseNonDynamicArray(context, parentMapper, lastFieldName, arrayFieldName);
                 }
             } else {
-                // TODO: shouldn't this skip, not parse?
-                parseNonDynamicArray(context, parentMapper, lastFieldName, arrayFieldName);
+                arrayFieldName = paths[paths.length - 1];
+                lastFieldName = arrayFieldName;
+                Tuple<Integer, ObjectMapper> parentMapperTuple = getDynamicParentMapper(context, paths, parentMapper);
+                parentMapper = parentMapperTuple.v2();
+                ObjectMapper.Dynamic dynamic = dynamicOrDefault(parentMapper, context);
+                if (dynamic == ObjectMapper.Dynamic.STRICT) {
+                    throw new StrictDynamicMappingException(parentMapper.fullPath(), arrayFieldName);
+                } else if (dynamic == ObjectMapper.Dynamic.TRUE) {
+                    Mapper.Builder builder = context.root().findTemplateBuilder(context, arrayFieldName, XContentFieldType.OBJECT);
+                    if (builder == null) {
+                        parseNonDynamicArray(context, parentMapper, lastFieldName, arrayFieldName);
+                    } else {
+                        Mapper.BuilderContext builderContext = new Mapper.BuilderContext(
+                            context.indexSettings().getSettings(),
+                            context.path()
+                        );
+                        mapper = builder.build(builderContext);
+                        assert mapper != null;
+                        if (parsesArrayValue(mapper)) {
+                            context.addDynamicMapper(mapper);
+                            context.path().add(arrayFieldName);
+                            parseObjectOrField(context, mapper);
+                            context.path().remove();
+                        } else {
+                            parseNonDynamicArray(context, parentMapper, lastFieldName, arrayFieldName);
+                        }
+                    }
+                } else {
+                    // TODO: shouldn't this skip, not parse?
+                    parseNonDynamicArray(context, parentMapper, lastFieldName, arrayFieldName);
+                }
+                for (int i = 0; i < parentMapperTuple.v1(); i++) {
+                    context.path().remove();
+                }
             }
-            for (int i = 0; i < parentMapperTuple.v1(); i++) {
-                context.path().remove();
-            }
+        } finally {
+            context.decrementFieldArrayDepth();
         }
-        context.decrementFieldArrayDepth();
     }
 
     private static boolean parsesArrayValue(Mapper mapper) {

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
@@ -567,6 +567,8 @@ final class DocumentParser {
     private static void parseArray(ParseContext context, ObjectMapper parentMapper, String lastFieldName, String[] paths)
         throws IOException {
         String arrayFieldName = lastFieldName;
+        context.incrementFieldArrayDepth();
+        context.checkFieldArrayDepthLimit();
 
         Mapper mapper = getMapper(context, parentMapper, lastFieldName, paths);
         if (mapper != null) {
@@ -611,6 +613,7 @@ final class DocumentParser {
                 context.path().remove();
             }
         }
+        context.decrementFieldArrayDepth();
     }
 
     private static boolean parsesArrayValue(Mapper mapper) {

--- a/server/src/main/java/org/opensearch/index/mapper/ParseContext.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ParseContext.java
@@ -38,6 +38,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.OpenSearchParseException;
 import org.opensearch.index.IndexSettings;
 
 import java.util.ArrayList;
@@ -312,6 +313,21 @@ public abstract class ParseContext implements Iterable<ParseContext.Document> {
         public Collection<String> getIgnoredFields() {
             return in.getIgnoredFields();
         }
+
+        @Override
+        public void incrementFieldCurrentDepth() {
+            in.incrementFieldCurrentDepth();
+        }
+
+        @Override
+        public void decrementFieldCurrentDepth() {
+            in.decrementFieldCurrentDepth();
+        }
+
+        @Override
+        public void checkFieldDepthLimit() {
+            in.checkFieldDepthLimit();
+        }
     }
 
     /**
@@ -345,6 +361,10 @@ public abstract class ParseContext implements Iterable<ParseContext.Document> {
 
         private long numNestedDocs;
 
+        private long currentFieldDepth;
+
+        private final long maxAllowedFieldDepth;
+
         private final List<Mapper> dynamicMappers;
 
         private boolean docsReversed = false;
@@ -371,6 +391,8 @@ public abstract class ParseContext implements Iterable<ParseContext.Document> {
             this.dynamicMappers = new ArrayList<>();
             this.maxAllowedNumNestedDocs = indexSettings.getMappingNestedDocsLimit();
             this.numNestedDocs = 0L;
+            this.currentFieldDepth = 0L;
+            this.maxAllowedFieldDepth = indexSettings.getMappingDepthLimit();
         }
 
         @Override
@@ -522,6 +544,34 @@ public abstract class ParseContext implements Iterable<ParseContext.Document> {
         public Collection<String> getIgnoredFields() {
             return Collections.unmodifiableCollection(ignoredFields);
         }
+
+        @Override
+        public void incrementFieldCurrentDepth() {
+            this.currentFieldDepth++;
+        }
+
+        @Override
+        public void decrementFieldCurrentDepth() {
+            if (this.currentFieldDepth > 0) {
+                this.currentFieldDepth--;
+            }
+        }
+
+        @Override
+        public void checkFieldDepthLimit() {
+            if (this.currentFieldDepth > maxAllowedFieldDepth) {
+                this.currentFieldDepth = 0;
+                throw new OpenSearchParseException(
+                    "The depth of the field has exceeded the allowed limit of ["
+                        + maxAllowedFieldDepth
+                        + "]."
+                        + " This limit can be set by changing the ["
+                        + MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING.getKey()
+                        + "] index level setting."
+                );
+            }
+        }
+
     }
 
     /**
@@ -687,4 +737,11 @@ public abstract class ParseContext implements Iterable<ParseContext.Document> {
      * Get dynamic mappers created while parsing.
      */
     public abstract List<Mapper> getDynamicMappers();
+
+    public abstract void incrementFieldCurrentDepth();
+
+    public abstract void decrementFieldCurrentDepth();
+
+    public abstract void checkFieldDepthLimit();
+
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Added a depth level check within the document parser context. The depth level is incremented for each nested object parsing and decremented when parsing is done. If the depth level crosses a threshold, document parser throws a parsing exception and an error is returned in the response, stating the reason of the failure

### Issues Resolved
Closes issue (#5195)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
