### PR TITLE
Display test failures in the gradle check status report.

### DIFF
--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -77,6 +77,14 @@ jobs:
               * **URL:** ${{ env.workflow_url }}
               * **CommitID:** ${{ env.pr_from_sha }}
 
+      - name: Extract Test Failure
+        if: ${{ github.event_name == 'pull_request_target' && failure() }}
+        run: |
+            TEST_FAILURES=`curl -s "${{ env.workflow_url }}/testReport/api/json?tree=suites\[cases\[status,className,name\]\]" | jq -r '.. | objects | select(.status=="FAILED",.status=="REGRESSION") | (.className + "." +  .name)' | uniq`
+            echo "test_failures<<EOF" >> $GITHUB_ENV
+            echo "$TEST_FAILURES" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+
       - name: Create Comment Failure
         if: ${{ github.event_name == 'pull_request_target' && failure() }}
         uses: peter-evans/create-or-update-comment@v2
@@ -85,6 +93,8 @@ jobs:
           body: |
               ### Gradle Check (Jenkins) Run Completed with:
               * **RESULT:** ${{ env.result }} :x:
+              * **FAILURES:**
+              ${{ env.test_failures }}
               * **URL:** ${{ env.workflow_url }}
               * **CommitID:** ${{ env.pr_from_sha }}
               Please examine the workflow log, locate, and copy-paste the failure below, then iterate to green.

--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Extract Test Failure
         if: ${{ github.event_name == 'pull_request_target' && failure() }}
         run: |
-            TEST_FAILURES=`curl -s "${{ env.workflow_url }}/testReport/api/json?tree=suites\[cases\[status,className,name\]\]" | jq -r '.. | objects | select(.status=="FAILED",.status=="REGRESSION") | (.className + "." +  .name)' | uniq -c | sort -n -r`
+            TEST_FAILURES=`curl -s "${{ env.workflow_url }}/testReport/api/json?tree=suites\[cases\[status,className,name\]\]" | jq -r '.. | objects | select(.status=="FAILED",.status=="REGRESSION") | (.className + "." +  .name)' | uniq -c | sort -n -r | head -n 10`
             echo "test_failures<<EOF" >> $GITHUB_ENV
             echo "$TEST_FAILURES" >> $GITHUB_ENV
             echo "EOF" >> $GITHUB_ENV

--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Extract Test Failure
         if: ${{ github.event_name == 'pull_request_target' && failure() }}
         run: |
-            TEST_FAILURES=`curl -s "${{ env.workflow_url }}/testReport/api/json?tree=suites\[cases\[status,className,name\]\]" | jq -r '.. | objects | select(.status=="FAILED",.status=="REGRESSION") | (.className + "." +  .name)' | uniq`
+            TEST_FAILURES=`curl -s "${{ env.workflow_url }}/testReport/api/json?tree=suites\[cases\[status,className,name\]\]" | jq -r '.. | objects | select(.status=="FAILED",.status=="REGRESSION") | (.className + "." +  .name)' | uniq -c | sort -n -r`
             echo "test_failures<<EOF" >> $GITHUB_ENV
             echo "$TEST_FAILURES" >> $GITHUB_ENV
             echo "EOF" >> $GITHUB_ENV


### PR DESCRIPTION
Signed-off-by: Daniel (dB.) Doubrovkine <dblock@amazon.com>

### Description

Display test failures in the gradle check status report. 
I tested this by hard-coding a few failed build URIs, so hopefully this doesn't break everything, but to actually open the PR we need a pull request target to work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
