### PR TITLE
[Backport 2.x] Ignore lock file when testing cleanupAndPreserveLatestCommitPoint (#4544)

### DIFF
--- a/server/src/test/java/org/opensearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/opensearch/index/store/StoreTests.java
@@ -1189,8 +1189,10 @@ public class StoreTests extends OpenSearchTestCase {
 
         // we want to ensure commitMetadata files are preserved after calling cleanup
         for (String existingFile : store.directory().listAll()) {
-            assertTrue(commitMetadata.contains(existingFile));
-            assertFalse(additionalSegments.contains(existingFile));
+            if (!IndexWriter.WRITE_LOCK_NAME.equals(existingFile)) {
+                assertTrue(commitMetadata.contains(existingFile));
+                assertFalse(additionalSegments.contains(existingFile));
+            }
         }
         deleteContent(store.directory());
         IOUtils.close(store);


### PR DESCRIPTION

### Description
Backport of flaky test fix #4544 to 2.x.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/4859

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
