### PR TITLE
Display phase name in stash dump of a test failure.

### DIFF
--- a/test/framework/src/main/java/org/opensearch/test/rest/yaml/OpenSearchClientYamlSuiteTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/yaml/OpenSearchClientYamlSuiteTestCase.java
@@ -420,7 +420,7 @@ public abstract class OpenSearchClientYamlSuiteTestCase extends OpenSearchRestTe
         if (!testCandidate.getSetupSection().isEmpty()) {
             logger.debug("start setup test [{}]", testCandidate.getTestPath());
             for (ExecutableSection executableSection : testCandidate.getSetupSection().getExecutableSections()) {
-                executeSection(executableSection);
+                executeSection("setup", executableSection);
             }
             logger.debug("end setup test [{}]", testCandidate.getTestPath());
         }
@@ -429,12 +429,12 @@ public abstract class OpenSearchClientYamlSuiteTestCase extends OpenSearchRestTe
 
         try {
             for (ExecutableSection executableSection : testCandidate.getTestSection().getExecutableSections()) {
-                executeSection(executableSection);
+                executeSection("execute", executableSection);
             }
         } finally {
             logger.debug("start teardown test [{}]", testCandidate.getTestPath());
             for (ExecutableSection doSection : testCandidate.getTeardownSection().getDoSections()) {
-                executeSection(doSection);
+                executeSection("teardown", doSection);
             }
             logger.debug("end teardown test [{}]", testCandidate.getTestPath());
         }
@@ -443,13 +443,14 @@ public abstract class OpenSearchClientYamlSuiteTestCase extends OpenSearchRestTe
     /**
      * Execute an {@link ExecutableSection}, careful to log its place of origin on failure.
      */
-    private void executeSection(ExecutableSection executableSection) {
+    private void executeSection(String phase, ExecutableSection executableSection) {
         try {
             executableSection.execute(restTestExecutionContext);
         } catch (AssertionError | Exception e) {
             // Dump the stash on failure. Instead of dumping it in true json we escape `\n`s so stack traces are easier to read
             logger.info(
-                "Stash dump on test failure [{}]",
+                "Stash dump on test {} failure [{}]",
+                phase,
                 Strings.toString(restTestExecutionContext.stash(), true, true)
                     .replace("\\n", "\n")
                     .replace("\\r", "\r")


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Looking at failures in https://github.com/opensearch-project/OpenSearch/issues/5219 it's not immediately obvious whether the failure is in setup/execution/teardown. You can deduce it from the above lines, but it doesn't cost much to display it inline with the dump.

Leaving this as draft, should trigger enough gradle failures to see it be useful/not.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
