### PR TITLE
Add max_shard_size parameter for Shrink API

### DIFF
--- a/client/rest-high-level/src/main/java/org/opensearch/client/indices/ResizeRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/indices/ResizeRequest.java
@@ -39,6 +39,7 @@ import org.opensearch.client.ValidationException;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.unit.ByteSizeValue;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -58,6 +59,7 @@ public class ResizeRequest extends TimedRequest implements Validatable, ToXConte
     private final String targetIndex;
     private Settings settings = Settings.EMPTY;
     private Set<Alias> aliases = new HashSet<>();
+    private ByteSizeValue maxShardSize;
 
     /**
      * Creates a new resize request
@@ -153,6 +155,24 @@ public class ResizeRequest extends TimedRequest implements Validatable, ToXConte
 
     public ActiveShardCount getWaitForActiveShards() {
         return waitForActiveShards;
+    }
+
+    /**
+     * Sets the maximum size of a primary shard in the new shrunken index.
+     * This parameter can be used to calculate the lowest factor of the source index's shards number
+     * which satisfies the maximum shard size requirement.
+     *
+     * @param maxShardSize the maximum size of a primary shard in the new shrunken index
+     */
+    public void setMaxShardSize(ByteSizeValue maxShardSize) {
+        this.maxShardSize = maxShardSize;
+    }
+
+    /**
+     * Returns the maximum size of a primary shard in the new shrunken index.
+     */
+    public ByteSizeValue getMaxShardSize() {
+        return maxShardSize;
     }
 
     @Override

--- a/client/rest-high-level/src/test/java/org/opensearch/client/IndicesRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/IndicesRequestConvertersTests.java
@@ -79,6 +79,7 @@ import org.opensearch.common.util.CollectionUtils;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Assert;
+import org.opensearch.common.unit.ByteSizeValue;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -701,6 +702,9 @@ public class IndicesRequestConvertersTests extends OpenSearchTestCase {
         RequestConvertersTests.setRandomWaitForActiveShards(resizeRequest::setWaitForActiveShards, expectedParams);
         if (resizeType == ResizeType.SPLIT) {
             resizeRequest.setSettings(Settings.builder().put("index.number_of_shards", 2).build());
+        }
+        if (resizeType == ResizeType.SHRINK) {
+            resizeRequest.setMaxShardSize(new ByteSizeValue(randomIntBetween(1, 1000)));
         }
 
         Request request = function.apply(resizeRequest);

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yml
@@ -79,3 +79,32 @@
   - match: { _index:   target }
   - match: { _id:      "1"     }
   - match: { _source:  { foo: "hello world" } }
+
+  # shrink with max_shard_size
+  - do:
+      allowed_warnings:
+        - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
+      indices.shrink:
+        index: "source"
+        target: "new_shrunken_index"
+        wait_for_active_shards: 1
+        master_timeout: 10s
+        body:
+          settings:
+            index.number_of_replicas: 0
+          max_shard_size: "10gb"
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+
+  - do:
+      get:
+        index: "new_shrunken_index"
+        id:    "1"
+
+  - do:
+      indices.get_settings:
+        index: "new_shrunken_index"
+
+  - match: { new_shrunken_index.settings.index.number_of_shards: "1" }

--- a/server/src/main/java/org/opensearch/action/admin/indices/shrink/ResizeRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/shrink/ResizeRequest.java
@@ -46,6 +46,8 @@ import org.opensearch.common.xcontent.ObjectParser;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.Version;
+import org.opensearch.common.unit.ByteSizeValue;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -60,6 +62,8 @@ import static org.opensearch.action.ValidateActions.addValidationError;
 public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements IndicesRequest, ToXContentObject {
 
     public static final ObjectParser<ResizeRequest, Void> PARSER = new ObjectParser<>("resize_request");
+    private static final ParseField MAX_SHARD_SIZE = new ParseField("max_shard_size");
+
     static {
         PARSER.declareField(
             (parser, request, context) -> request.getTargetIndexRequest().settings(parser.map()),
@@ -71,12 +75,19 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
             new ParseField("aliases"),
             ObjectParser.ValueType.OBJECT
         );
+        PARSER.declareField(
+            ResizeRequest::setMaxShardSize,
+            (p, c) -> ByteSizeValue.parseBytesSizeValue(p.text(), MAX_SHARD_SIZE.getPreferredName()),
+            MAX_SHARD_SIZE,
+            ObjectParser.ValueType.STRING
+        );
     }
 
     private CreateIndexRequest targetIndexRequest;
     private String sourceIndex;
     private ResizeType type = ResizeType.SHRINK;
     private Boolean copySettings = true;
+    private ByteSizeValue maxShardSize;
 
     public ResizeRequest(StreamInput in) throws IOException {
         super(in);
@@ -84,6 +95,11 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
         sourceIndex = in.readString();
         type = in.readEnum(ResizeType.class);
         copySettings = in.readOptionalBoolean();
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            if (in.readBoolean()) {
+                maxShardSize = new ByteSizeValue(in);
+            }
+        }
     }
 
     ResizeRequest() {}
@@ -108,6 +124,9 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
         if (type == ResizeType.SPLIT && IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.exists(targetIndexRequest.settings()) == false) {
             validationException = addValidationError("index.number_of_shards is required for split operations", validationException);
         }
+        if (maxShardSize != null && maxShardSize.getBytes() <= 0) {
+            validationException = addValidationError("max_shard_size must be greater than 0", validationException);
+        }
         assert copySettings == null || copySettings;
         return validationException;
     }
@@ -123,6 +142,9 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
         out.writeString(sourceIndex);
         out.writeEnum(type);
         out.writeOptionalBoolean(copySettings);
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            out.writeOptionalWriteable(maxShardSize);
+        }
     }
 
     @Override
@@ -205,6 +227,24 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
         return copySettings;
     }
 
+    /**
+     * Sets the maximum size of a primary shard in the new shrunken index.
+     * This parameter can be used to calculate the lowest factor of the source index's shards number
+     * which satisfies the maximum shard size requirement.
+     *
+     * @param maxShardSize the maximum size of a primary shard in the new shrunken index
+     */
+    public void setMaxShardSize(ByteSizeValue maxShardSize) {
+        this.maxShardSize = maxShardSize;
+    }
+
+    /**
+     * Returns the maximum size of a primary shard in the new shrunken index.
+     */
+    public ByteSizeValue getMaxShardSize() {
+        return maxShardSize;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
@@ -221,6 +261,9 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
                 }
             }
             builder.endObject();
+            if (maxShardSize != null) {
+                builder.field(MAX_SHARD_SIZE.getPreferredName(), maxShardSize);
+            }
         }
         builder.endObject();
         return builder;

--- a/server/src/main/java/org/opensearch/action/admin/indices/shrink/ResizeRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/shrink/ResizeRequestBuilder.java
@@ -37,6 +37,7 @@ import org.opensearch.action.support.ActiveShardCount;
 import org.opensearch.action.support.master.AcknowledgedRequestBuilder;
 import org.opensearch.client.OpenSearchClient;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.ByteSizeValue;
 
 /**
  * Transport request builder for resizing an index
@@ -93,6 +94,14 @@ public class ResizeRequestBuilder extends AcknowledgedRequestBuilder<ResizeReque
 
     public ResizeRequestBuilder setResizeType(ResizeType type) {
         this.request.setResizeType(type);
+        return this;
+    }
+
+    /**
+     * Sets the maximum size of a primary shard in the new shrunken index.
+     */
+    public ResizeRequestBuilder setMaxShardSize(ByteSizeValue maxShardSize) {
+        this.request.setMaxShardSize(maxShardSize);
         return this;
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/shrink/TransportResizeAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/shrink/TransportResizeAction.java
@@ -57,6 +57,8 @@ import org.opensearch.index.shard.DocsStats;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
+import org.opensearch.common.unit.ByteSizeValue;
+import org.opensearch.index.store.StoreStats;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -141,11 +143,12 @@ public class TransportResizeAction extends TransportClusterManagerNodeAction<Res
             .prepareStats(sourceIndex)
             .clear()
             .setDocs(true)
+            .setStore(true)
             .execute(ActionListener.delegateFailure(listener, (delegatedListener, indicesStatsResponse) -> {
                 CreateIndexClusterStateUpdateRequest updateRequest = prepareCreateIndexRequest(resizeRequest, state, i -> {
                     IndexShardStats shard = indicesStatsResponse.getIndex(sourceIndex).getIndexShards().get(i);
                     return shard == null ? null : shard.getPrimary().getDocs();
-                }, sourceIndex, targetIndex);
+                }, indicesStatsResponse.getPrimaries().store, sourceIndex, targetIndex);
                 createIndexService.createIndex(
                     updateRequest,
                     ActionListener.map(
@@ -162,6 +165,7 @@ public class TransportResizeAction extends TransportClusterManagerNodeAction<Res
         final ResizeRequest resizeRequest,
         final ClusterState state,
         final IntFunction<DocsStats> perShardDocStats,
+        final StoreStats primaryShardsStoreStats,
         String sourceIndexName,
         String targetIndexName
     ) {
@@ -176,12 +180,16 @@ public class TransportResizeAction extends TransportClusterManagerNodeAction<Res
         targetIndexSettingsBuilder.remove(IndexMetadata.SETTING_HISTORY_UUID);
         final Settings targetIndexSettings = targetIndexSettingsBuilder.build();
         final int numShards;
+        ByteSizeValue maxShardSize = resizeRequest.getMaxShardSize();
         if (IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.exists(targetIndexSettings)) {
             numShards = IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.get(targetIndexSettings);
+            if (resizeRequest.getResizeType() == ResizeType.SHRINK && maxShardSize != null) {
+                throw new IllegalArgumentException("Cannot set max_shard_size and index.number_of_shards at the same time!");
+            }
         } else {
             assert resizeRequest.getResizeType() != ResizeType.SPLIT : "split must specify the number of shards explicitly";
             if (resizeRequest.getResizeType() == ResizeType.SHRINK) {
-                numShards = 1;
+                numShards = calculateTargetIndexShardsNum(maxShardSize, primaryShardsStoreStats, metadata);
             } else {
                 assert resizeRequest.getResizeType() == ResizeType.CLONE;
                 numShards = metadata.getNumberOfShards();
@@ -248,6 +256,39 @@ public class TransportResizeAction extends TransportClusterManagerNodeAction<Res
             .recoverFrom(metadata.getIndex())
             .resizeType(resizeRequest.getResizeType())
             .copySettings(resizeRequest.getCopySettings() == null ? false : resizeRequest.getCopySettings());
+    }
+
+    /**
+     * Calculate target index's shards number according to maxShardSize and the source index's storage(only primary shards included)
+     * @param maxShardSize the maximum size of a primary shard in the target index
+     * @param sourceIndexShardStoreStats primary shards' store stats of the source index
+     * @param sourceIndexMetaData source index's metadata
+     * @return target index's shards number
+     */
+    protected static int calculateTargetIndexShardsNum(
+        ByteSizeValue maxShardSize,
+        StoreStats sourceIndexShardStoreStats,
+        IndexMetadata sourceIndexMetaData
+    ) {
+        if (maxShardSize == null
+            || sourceIndexShardStoreStats == null
+            || maxShardSize.getBytes() == 0
+            || sourceIndexShardStoreStats.getSizeInBytes() == 0) {
+            return 1;
+        }
+
+        int sourceIndexShardsNum = sourceIndexMetaData.getNumberOfShards();
+        int minValue = (int) Math.ceil((double) sourceIndexShardStoreStats.getSizeInBytes() / maxShardSize.getBytes());
+        if (minValue >= sourceIndexShardsNum) {
+            return sourceIndexShardsNum;
+        }
+
+        for (int i = minValue; i < sourceIndexShardsNum; i++) {
+            if (sourceIndexShardsNum % i == 0) {
+                return i;
+            }
+        }
+        return sourceIndexShardsNum;
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Gao Binlong <gbinlong@amazon.com>

### Description
As the [document](https://opensearch.org/docs/latest/api-reference/index-apis/shrink-index/) mentions that we have a parameter `max_primary_shard_size`, but actually it doesn't exist,  and the parameter is used to generate an optimum `number_of_shards` of the new shrunken index, so it's useful for users. I've implemented the function and changed the parameter's name to `max_shard_size` so that it can be consistent with the similar function in [`Shrink Action`](https://opensearch.org/docs/latest/im-plugin/ism/policies/#shrink) in `Index Management Plugin`.

The main changes of this PR are:

- Add `max_shard_size` parameter for Shrink API.
- Add `max_shard_size` parameter for Shrink API in high level rest client.
- Add unit test, integration test and yaml rest test.


### Issues Resolved
#5170 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
