### PR TITLE
Revert changes in AbstractPointGeometryFieldMapper

### DIFF
--- a/server/src/main/java/org/opensearch/index/mapper/AbstractPointGeometryFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/AbstractPointGeometryFieldMapper.java
@@ -36,14 +36,11 @@ import org.opensearch.OpenSearchParseException;
 import org.opensearch.common.CheckedBiFunction;
 import org.opensearch.common.Explicit;
 import org.opensearch.common.ParseField;
-import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.geo.GeoPoint;
 import org.opensearch.common.geo.GeometryFormat;
 import org.opensearch.common.geo.GeometryParser;
-import org.opensearch.common.xcontent.DeprecationHandler;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
-import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.geometry.Geometry;
 import org.opensearch.geometry.Point;
@@ -245,7 +242,6 @@ public abstract class AbstractPointGeometryFieldMapper<Parsed, Processed> extend
      * @opensearch.internal
      */
     public static class PointParser<P extends ParsedPoint> extends Parser<List<P>> {
-        private static final int MAX_NUMBER_OF_VALUES_IN_ARRAY_FORMAT = 3;
         /**
          * Note that this parser is only used for formatting values.
          */
@@ -285,27 +281,32 @@ public abstract class AbstractPointGeometryFieldMapper<Parsed, Processed> extend
 
         @Override
         public List<P> parse(XContentParser parser) throws IOException, ParseException {
+
             if (parser.currentToken() == XContentParser.Token.START_ARRAY) {
-                parser.nextToken();
-                if (parser.currentToken() == XContentParser.Token.VALUE_NUMBER) {
-                    XContentBuilder xContentBuilder = reconstructArrayXContent(parser);
-                    try (
-                        XContentParser subParser = createParser(
-                            parser.getXContentRegistry(),
-                            parser.getDeprecationHandler(),
-                            xContentBuilder
-                        );
-                    ) {
-                        return Collections.singletonList(process(objectParser.apply(subParser, pointSupplier.get())));
+                XContentParser.Token token = parser.nextToken();
+                P point = pointSupplier.get();
+                ArrayList<P> points = new ArrayList<>();
+                if (token == XContentParser.Token.VALUE_NUMBER) {
+                    double x = parser.doubleValue();
+                    parser.nextToken();
+                    double y = parser.doubleValue();
+                    token = parser.nextToken();
+                    if (token == XContentParser.Token.VALUE_NUMBER) {
+                        GeoPoint.assertZValue(ignoreZValue, parser.doubleValue());
+                    } else if (token != XContentParser.Token.END_ARRAY) {
+                        throw new OpenSearchParseException("field type does not accept > 3 dimensions");
                     }
+
+                    point.resetCoords(x, y);
+                    points.add(process(point));
                 } else {
-                    ArrayList<P> points = new ArrayList<>();
-                    while (parser.currentToken() != XContentParser.Token.END_ARRAY) {
-                        points.add(process(objectParser.apply(parser, pointSupplier.get())));
-                        parser.nextToken();
+                    while (token != XContentParser.Token.END_ARRAY) {
+                        points.add(process(objectParser.apply(parser, point)));
+                        point = pointSupplier.get();
+                        token = parser.nextToken();
                     }
-                    return points;
                 }
+                return points;
             } else if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
                 if (nullValue == null) {
                     return null;
@@ -315,37 +316,6 @@ public abstract class AbstractPointGeometryFieldMapper<Parsed, Processed> extend
             } else {
                 return Collections.singletonList(process(objectParser.apply(parser, pointSupplier.get())));
             }
-        }
-
-        private XContentParser createParser(
-            NamedXContentRegistry namedXContentRegistry,
-            DeprecationHandler deprecationHandler,
-            XContentBuilder xContentBuilder
-        ) throws IOException {
-            XContentParser subParser = xContentBuilder.contentType()
-                .xContent()
-                .createParser(namedXContentRegistry, deprecationHandler, BytesReference.bytes(xContentBuilder).streamInput());
-            subParser.nextToken();
-            return subParser;
-        }
-
-        private XContentBuilder reconstructArrayXContent(XContentParser parser) throws IOException {
-            XContentBuilder builder = XContentFactory.jsonBuilder().startArray();
-            int numberOfValuesAdded = 0;
-            while (parser.currentToken() != XContentParser.Token.END_ARRAY) {
-                if (parser.currentToken() != XContentParser.Token.VALUE_NUMBER) {
-                    throw new OpenSearchParseException("numeric value expected");
-                }
-                builder.value(parser.doubleValue());
-                parser.nextToken();
-
-                // Allows one more value to be added so that the error case can be handled by a parser
-                if (++numberOfValuesAdded > MAX_NUMBER_OF_VALUES_IN_ARRAY_FORMAT) {
-                    break;
-                }
-            }
-            builder.endArray();
-            return builder;
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/index/mapper/GeoPointFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/GeoPointFieldMapperTests.java
@@ -164,12 +164,6 @@ public class GeoPointFieldMapperTests extends FieldMapperTestCase2<GeoPointField
         assertThat(doc.rootDoc().getFields("field"), arrayWithSize(4));
     }
 
-    public void testLatLonInArrayMoreThanThreeValues() throws Exception {
-        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "geo_point").field("ignore_z_value", true)));
-        Exception e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> b.array("field", 1.2, 1.3, 1.4, 1.5))));
-        assertThat(e.getCause().getMessage(), containsString("[geo_point] field type does not accept more than 3 values"));
-    }
-
     public void testLonLatArray() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("field").value(1.3).value(1.2).endArray()));


### PR DESCRIPTION
The change made in AbstractPointGeometryFieldMapper class with commit 050389736599e40c49278e900d5060f75b959282 introduced a performace degradation during point data indexing. Reverting it therefore.

The change is about consolidating array format parsing code for point type in a single place to acheive following benefits.
1. Allow plugins to override array parsing logic. Plugins can add its own parsing logic for point field by providing object parser. However, it cannot override array format. Therefore, plugin have to use whatever implemented in AbstractPointGeometryFieldMapper class.
2. Enhanced code quality by removing duplicated code

There is no change in functionality because 1. There is no change in functionality in OpenSearch and 2. No plugins have its own parsing logic for point data in array format yet.

Signed-off-by: Heemin Kim <heemin@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
