### PR TITLE
[Remote Store] Add support for refresh level durability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `opencensus-contrib-http-util` from 0.18.0 to 0.31.1 ([#3633](https://github.com/opensearch-project/OpenSearch/pull/3633))
 - Bump `geoip2` from 3.0.1 to 3.0.2 ([#5103](https://github.com/opensearch-project/OpenSearch/pull/5103))
 - Bump gradle-extra-configurations-plugin from 7.0.0 to 8.0.0 ([#4808](https://github.com/opensearch-project/OpenSearch/pull/4808))
+
 ### Changed
+- Add support for refresh level durability ([#5253](https://github.com/opensearch-project/OpenSearch/pull/5253))
+
 ### Deprecated
 - Refactor fuzziness interface on query builders ([#5433](https://github.com/opensearch-project/OpenSearch/pull/5433))
 

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -2748,7 +2748,7 @@ public class InternalEngine extends Engine {
     /**
      * Returned the last local checkpoint value has been refreshed internally.
      */
-    final long lastRefreshedCheckpoint() {
+    public final long lastRefreshedCheckpoint() {
         return lastRefreshedCheckpointListener.refreshedCheckpoint.get();
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -93,10 +93,11 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
                     }
                     try {
                         String lastCommittedLocalSegmentFileName = SegmentInfos.getLastCommitSegmentsFileName(storeDirectory);
-                        if (!remoteDirectory.containsFile(
-                            lastCommittedLocalSegmentFileName,
-                            getChecksumOfLocalFile(lastCommittedLocalSegmentFileName)
-                        )) {
+                        if (lastCommittedLocalSegmentFileName != null
+                            && !remoteDirectory.containsFile(
+                                lastCommittedLocalSegmentFileName,
+                                getChecksumOfLocalFile(lastCommittedLocalSegmentFileName)
+                            )) {
                             deleteStaleCommits();
                         }
                         String segment_info_snapshot_filename = null;
@@ -120,7 +121,7 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
 
                                 boolean uploadStatus = uploadNewSegments(refreshedLocalFiles);
                                 if (uploadStatus) {
-                                    if(segmentFilesFromSnapshot.equals(new HashSet<>(refreshedLocalFiles))) {
+                                    if (segmentFilesFromSnapshot.equals(new HashSet<>(refreshedLocalFiles))) {
                                         segment_info_snapshot_filename = uploadSegmentInfosSnapshot(latestSegmentInfos.get(), segmentInfos);
                                         refreshedLocalFiles.add(segment_info_snapshot_filename);
                                     }

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -111,7 +111,7 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
                                 .filter(file -> file.startsWith(IndexFileNames.SEGMENTS))
                                 .collect(Collectors.toList());
                             Optional<String> latestSegmentInfos = segmentInfosFiles.stream()
-                                .max(Comparator.comparingLong(IndexFileNames::parseGeneration));
+                                .max(Comparator.comparingLong(SegmentInfos::generationFromSegmentsFileName));
 
                             if (latestSegmentInfos.isPresent()) {
                                 Set<String> segmentFilesFromSnapshot = new HashSet<>(refreshedLocalFiles);
@@ -182,7 +182,7 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
         userData.put(SequenceNumbers.MAX_SEQ_NO, Long.toString(processedLocalCheckpoint));
         segmentInfosSnapshot.setUserData(userData, false);
 
-        long commitGeneration = IndexFileNames.parseGeneration(latestSegmentsNFilename);
+        long commitGeneration = SegmentInfos.generationFromSegmentsFileName(latestSegmentsNFilename);
         String segmentInfoSnapshotFilename = SEGMENT_INFO_SNAPSHOT_FILENAME_PREFIX + "__" + commitGeneration;
         try (IndexOutput indexOutput = storeDirectory.createOutput(segmentInfoSnapshotFilename, IOContext.DEFAULT)) {
             segmentInfosSnapshot.write(indexOutput);

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -20,13 +20,11 @@ import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
-import org.opensearch.common.UUIDs;
 import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.index.engine.EngineException;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 
 import java.io.IOException;
-import java.nio.file.NoSuchFileException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -140,7 +138,7 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
                             logger.warn("Exception while reading SegmentInfosSnapshot", e);
                         } finally {
                             try {
-                                if(segment_info_snapshot_filename != null) {
+                                if (segment_info_snapshot_filename != null) {
                                     storeDirectory.deleteFile(segment_info_snapshot_filename);
                                 }
                             } catch (IOException e) {
@@ -162,11 +160,7 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
     String uploadSegmentInfosSnapshot(String latestSegmentsNFilename, SegmentInfos segmentInfosSnapshot) throws IOException {
         long localCheckpoint = indexShard.getEngine().getProcessedLocalCheckpoint();
         String commitGeneration = latestSegmentsNFilename.substring("segments_".length());
-        String segment_info_snapshot_filename = SEGMENT_INFO_SNAPSHOT_FILENAME +
-            "__" +
-            commitGeneration +
-            "__" +
-            localCheckpoint;
+        String segment_info_snapshot_filename = SEGMENT_INFO_SNAPSHOT_FILENAME + "__" + commitGeneration + "__" + localCheckpoint;
         IndexOutput indexOutput = storeDirectory.createOutput(segment_info_snapshot_filename, IOContext.DEFAULT);
         segmentInfosSnapshot.write(indexOutput);
         indexOutput.close();

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -30,7 +30,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -117,8 +116,11 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
                                 // SegmentInfosSnapshot is a snapshot of reader's view of segments and may not contain
                                 // all the segments from last commit if they are merged away but not yet committed.
                                 // Each metadata file in the remote segment store represents a commit and the following
-                                // statement keeps sure that each metadata will always contain all the segments from last commit + refreshed segments.
-                                localSegmentsPostRefresh.addAll(SegmentInfos.readCommit(storeDirectory, latestSegmentInfos.get()).files(true));
+                                // statement keeps sure that each metadata will always contain all the segments from last commit + refreshed
+                                // segments.
+                                localSegmentsPostRefresh.addAll(
+                                    SegmentInfos.readCommit(storeDirectory, latestSegmentInfos.get()).files(true)
+                                );
                                 segmentInfosFiles.stream()
                                     .filter(file -> !file.equals(latestSegmentInfos.get()))
                                     .forEach(localSegmentsPostRefresh::remove);

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -466,28 +466,23 @@ final class StoreRecovery {
             for (String file : storeDirectory.listAll()) {
                 storeDirectory.deleteFile(file);
             }
-            String[] remoteFiles = remoteDirectory.listAll();
             String segmentInfosSnapshotFilename = null;
-            String segmentsNFileName = null;
-            for (String file : remoteFiles) {
+            for (String file : remoteDirectory.listAll()) {
                 storeDirectory.copyFrom(remoteDirectory, file, file, IOContext.DEFAULT);
                 if(file.startsWith("segment_infos_snapshot_filename")) {
                     segmentInfosSnapshotFilename = file;
-                }
-                if(file.startsWith("segments_")) {
-                    segmentsNFileName = file;
                 }
             }
 
             SegmentInfos infos_snapshot = SegmentInfos.readCommit(
                 store.directory(),
                 new BufferedChecksumIndexInput(storeDirectory.openInput(segmentInfosSnapshotFilename, IOContext.DEFAULT)),
-                Integer.parseInt(segmentsNFileName.substring("segments_".length()))
+                Integer.parseInt(segmentInfosSnapshotFilename.split("__")[1])
             );
 
             store.commitSegmentInfos(infos_snapshot,
                 Long.parseLong(segmentInfosSnapshotFilename.split("__")[2]),
-                Long.parseLong(segmentInfosSnapshotFilename.split("__")[1]));
+                Long.parseLong(segmentInfosSnapshotFilename.split("__")[2]));
 
             // This creates empty trans-log for now
             // ToDo: Add code to restore from remote trans-log

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -70,7 +70,6 @@ import org.opensearch.repositories.Repository;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -78,7 +77,6 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.opensearch.common.unit.TimeValue.timeValueMillis;
-import static org.opensearch.index.seqno.SequenceNumbers.LOCAL_CHECKPOINT_KEY;
 
 /**
  * This package private utility class encapsulates the logic to recover an index shard from either an existing index on
@@ -469,7 +467,7 @@ final class StoreRecovery {
             String segmentInfosSnapshotFilename = null;
             for (String file : remoteDirectory.listAll()) {
                 storeDirectory.copyFrom(remoteDirectory, file, file, IOContext.DEFAULT);
-                if(file.startsWith("segment_infos_snapshot_filename")) {
+                if (file.startsWith("segment_infos_snapshot_filename")) {
                     segmentInfosSnapshotFilename = file;
                 }
             }
@@ -480,9 +478,11 @@ final class StoreRecovery {
                 Integer.parseInt(segmentInfosSnapshotFilename.split("__")[1])
             );
 
-            store.commitSegmentInfos(infos_snapshot,
+            store.commitSegmentInfos(
+                infos_snapshot,
                 Long.parseLong(segmentInfosSnapshotFilename.split("__")[2]),
-                Long.parseLong(segmentInfosSnapshotFilename.split("__")[2]));
+                Long.parseLong(segmentInfosSnapshotFilename.split("__")[2])
+            );
 
             // This creates empty trans-log for now
             // ToDo: Add code to restore from remote trans-log

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -488,8 +488,6 @@ final class StoreRecovery {
                     );
                     long processedLocalCheckpoint = Long.parseLong(infosSnapshot.getUserData().get(LOCAL_CHECKPOINT_KEY));
                     store.commitSegmentInfos(infosSnapshot, processedLocalCheckpoint, processedLocalCheckpoint);
-                } catch (IOException e) {
-                    logger.info("Exception while reading {}, falling back to commit level restore", segmentInfosSnapshotFilename);
                 }
             }
 

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -487,7 +487,7 @@ final class StoreRecovery {
                         Integer.parseInt(filenameTokens[1])
                     );
                     store.commitSegmentInfos(infos_snapshot, Long.parseLong(filenameTokens[2]), Long.parseLong(filenameTokens[2]));
-                } catch(IOException e) {
+                } catch (IOException e) {
                     logger.info("Exception while reading {}, falling back to commit level restore", segmentInfosSnapshotFilename);
                 }
             }

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -484,7 +484,7 @@ final class StoreRecovery {
                     SegmentInfos infosSnapshot = SegmentInfos.readCommit(
                         store.directory(),
                         indexInput,
-                        Integer.parseInt(segmentInfosSnapshotFilename.split("__")[1])
+                        Long.parseLong(segmentInfosSnapshotFilename.split("__")[1])
                     );
                     long processedLocalCheckpoint = Long.parseLong(infosSnapshot.getUserData().get(LOCAL_CHECKPOINT_KEY));
                     store.commitSegmentInfos(infosSnapshot, processedLocalCheckpoint, processedLocalCheckpoint);

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -295,7 +295,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory {
 
     public void copyFrom(Directory from, String src, String dest, IOContext context, boolean override) throws IOException {
         String remoteFilename;
-        if(override && segmentsUploadedToRemoteStore.containsKey(dest)) {
+        if (override && segmentsUploadedToRemoteStore.containsKey(dest)) {
             remoteFilename = segmentsUploadedToRemoteStore.get(dest).uploadedFilename;
         } else {
             remoteFilename = getNewRemoteSegmentFilename(dest);

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -2739,7 +2739,10 @@ public class IndexShardTests extends IndexShardTestCase {
     public void testRestoreShardFromRemoteStore() throws IOException {
         IndexShard target = newStartedShard(
             true,
-            Settings.builder().put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true).build(),
+            Settings.builder()
+                .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+                .put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true)
+                .build(),
             new InternalEngineFactory()
         );
 

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -2736,7 +2736,15 @@ public class IndexShardTests extends IndexShardTestCase {
         closeShards(target);
     }
 
-    public void testRestoreShardFromRemoteStore() throws IOException {
+    public void testRefreshLevelRestoreShardFromRemoteStore() throws IOException {
+        testRestoreShardFromRemoteStore(false);
+    }
+
+    public void testCommitLevelRestoreShardFromRemoteStore() throws IOException {
+        testRestoreShardFromRemoteStore(true);
+    }
+
+    public void testRestoreShardFromRemoteStore(boolean performFlush) throws IOException {
         IndexShard target = newStartedShard(
             true,
             Settings.builder()
@@ -2750,7 +2758,9 @@ public class IndexShardTests extends IndexShardTestCase {
         indexDoc(target, "_doc", "2");
         target.refresh("test");
         assertDocs(target, "1", "2");
-        flushShard(target);
+        if (performFlush) {
+            flushShard(target);
+        }
 
         ShardRouting routing = ShardRoutingHelper.initWithSameId(
             target.routingEntry(),

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.index.shard;
 
+import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FilterDirectory;
@@ -29,6 +30,8 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+
+import static org.opensearch.index.shard.RemoteStoreRefreshListener.SEGMENT_INFO_SNAPSHOT_FILENAME;
 
 public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
     private IndexShard indexShard;
@@ -204,13 +207,23 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
     private void verifyUploadedSegments(RemoteSegmentStoreDirectory remoteSegmentStoreDirectory) throws IOException {
         Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> uploadedSegments = remoteSegmentStoreDirectory
             .getSegmentsUploadedToRemoteStore();
+        String segmentsNFilename = null;
         try (GatedCloseable<SegmentInfos> segmentInfosGatedCloseable = indexShard.getSegmentInfosSnapshot()) {
             SegmentInfos segmentInfos = segmentInfosGatedCloseable.get();
             for (String file : segmentInfos.files(true)) {
                 if (!RemoteStoreRefreshListener.EXCLUDE_FILES.contains(file)) {
                     assertTrue(uploadedSegments.containsKey(file));
                 }
+                if (file.startsWith(IndexFileNames.SEGMENTS)) {
+                    segmentsNFilename = file;
+                }
             }
+        }
+        if (segmentsNFilename != null) {
+            String commitGeneration = segmentsNFilename.substring((IndexFileNames.SEGMENTS + "_").length());
+            assertTrue(
+                uploadedSegments.keySet().stream().anyMatch(s -> s.startsWith(SEGMENT_INFO_SNAPSHOT_FILENAME + "__" + commitGeneration))
+            );
         }
     }
 }

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -224,7 +224,11 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
             assertTrue(
                 uploadedSegments.keySet()
                     .stream()
-                    .anyMatch(s -> s.startsWith(SEGMENT_INFO_SNAPSHOT_FILENAME_PREFIX + "__" + Long.parseLong(commitGeneration, Character.MAX_RADIX)))
+                    .anyMatch(
+                        s -> s.startsWith(
+                            SEGMENT_INFO_SNAPSHOT_FILENAME_PREFIX + "__" + Long.parseLong(commitGeneration, Character.MAX_RADIX)
+                        )
+                    )
             );
         }
     }

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -224,7 +224,7 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
             assertTrue(
                 uploadedSegments.keySet()
                     .stream()
-                    .anyMatch(s -> s.startsWith(SEGMENT_INFO_SNAPSHOT_FILENAME_PREFIX + "__" + commitGeneration))
+                    .anyMatch(s -> s.startsWith(SEGMENT_INFO_SNAPSHOT_FILENAME_PREFIX + "__" + Long.parseLong(commitGeneration, Character.MAX_RADIX)))
             );
         }
     }

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreRefreshListenerTests.java
@@ -31,7 +31,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
-import static org.opensearch.index.shard.RemoteStoreRefreshListener.SEGMENT_INFO_SNAPSHOT_FILENAME;
+import static org.opensearch.index.shard.RemoteStoreRefreshListener.SEGMENT_INFO_SNAPSHOT_FILENAME_PREFIX;
 
 public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
     private IndexShard indexShard;
@@ -222,7 +222,9 @@ public class RemoteStoreRefreshListenerTests extends IndexShardTestCase {
         if (segmentsNFilename != null) {
             String commitGeneration = segmentsNFilename.substring((IndexFileNames.SEGMENTS + "_").length());
             assertTrue(
-                uploadedSegments.keySet().stream().anyMatch(s -> s.startsWith(SEGMENT_INFO_SNAPSHOT_FILENAME + "__" + commitGeneration))
+                uploadedSegments.keySet()
+                    .stream()
+                    .anyMatch(s -> s.startsWith(SEGMENT_INFO_SNAPSHOT_FILENAME_PREFIX + "__" + commitGeneration))
             );
         }
     }

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -317,7 +317,7 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
         storeDirectory.close();
     }
 
-    public void testCpoyFromOverride() throws IOException {
+    public void testCopyFromOverride() throws IOException {
         String filename = "_100.si";
         populateMetadata();
         remoteSegmentStoreDirectory.init();

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -317,6 +317,33 @@ public class RemoteSegmentStoreDirectoryTests extends OpenSearchTestCase {
         storeDirectory.close();
     }
 
+    public void testCpoyFromOverride() throws IOException {
+        String filename = "_100.si";
+        populateMetadata();
+        remoteSegmentStoreDirectory.init();
+
+        Directory storeDirectory = LuceneTestCase.newDirectory();
+        IndexOutput indexOutput = storeDirectory.createOutput(filename, IOContext.DEFAULT);
+        indexOutput.writeString("Hello World!");
+        CodecUtil.writeFooter(indexOutput);
+        indexOutput.close();
+        storeDirectory.sync(List.of(filename));
+
+        assertFalse(remoteSegmentStoreDirectory.getSegmentsUploadedToRemoteStore().containsKey(filename));
+        remoteSegmentStoreDirectory.copyFrom(storeDirectory, filename, filename, IOContext.DEFAULT, true);
+        RemoteSegmentStoreDirectory.UploadedSegmentMetadata uploadedSegmentMetadata = remoteSegmentStoreDirectory
+            .getSegmentsUploadedToRemoteStore()
+            .get(filename);
+        assertNotNull(uploadedSegmentMetadata);
+        remoteSegmentStoreDirectory.copyFrom(storeDirectory, filename, filename, IOContext.DEFAULT, true);
+        assertEquals(
+            uploadedSegmentMetadata.toString(),
+            remoteSegmentStoreDirectory.getSegmentsUploadedToRemoteStore().get(filename).toString()
+        );
+
+        storeDirectory.close();
+    }
+
     public void testContainsFile() throws IOException {
         List<String> metadataFiles = List.of("metadata__1__5__abc");
         when(remoteMetadataDirectory.listFilesByPrefix(RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX)).thenReturn(


### PR DESCRIPTION
### Description
- As part of [remote store feature](https://opensearch.org/docs/latest/opensearch/remote) that was introduced in OpenSearch 2.3, segments are uploaded to remote store post each refresh. 
- This means remote segment store contains segments that were part of last refresh.
- But the `_remotestore/_restore` API only supports commit level durability.
- This feature will add refresh level durability support to the restore API.

#### Proposed Solution
- We upload `SegmentInfosSnapshot` during each refresh and keep the information of the uploaded file in the metadata file.
- During restore, if `SegmentInfosSnapshot` is present, we use it as a `SegmentInfos` file and trigger a commit.
- As the snapshot file does not contain latest processed checkpoint (as it is a snapshot of previous `SegmentInfos` file), we pass processed checkpoint as part of filename.

### Issues Resolved
- https://github.com/opensearch-project/OpenSearch/issues/5251

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
