### PR TITLE
Change number of shards and fix typo.

### DIFF
--- a/server/src/test/java/org/opensearch/cluster/routing/OperationRoutingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/OperationRoutingTests.java
@@ -888,7 +888,7 @@ public class OperationRoutingTests extends OpenSearchTestCase {
 
     public void testWeightedOperationRoutingWeightUndefinedForOneZone() throws Exception {
         final int numIndices = 2;
-        final int numShards = 3;
+        final int numShards = 4;
         final int numReplicas = 2;
         // setting up indices
         final String[] indexNames = new String[numIndices];
@@ -952,7 +952,7 @@ public class OperationRoutingTests extends OpenSearchTestCase {
             selectedNodes = new HashSet<>();
             setting = Settings.builder().put("cluster.routing.allocation.awareness.attributes", "zone").build();
 
-            // Updating weighted round robin weights in cluster state
+            // Updating weighted round-robin weights in cluster state
             weights = Map.of("a", 0.0, "b", 1.0);
 
             state = setWeightedRoutingWeights(state, weights);


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

DCOed https://github.com/opensearch-project/OpenSearch/pull/4980.

Confirmed that this can be reproduced and that the change fixes the issue.

```
./gradlew ':server:test' --tests "org.opensearch.cluster.routing.OperationRoutingTests.testWeightedOperationRoutingWeightUndefinedForOneZone" -Dtests.seed=B1745FEE14F29C02 -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=ar-EG -Dtests.timezone=Asia/Magadan -Druntime.java=17
```

### Issues Resolved

Closes #4881.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
