### PR TITLE
Make viaNode more deterministic for AwarenessAttributeDecommissionIT tests

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/AwarenessAttributeDecommissionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/AwarenessAttributeDecommissionIT.java
@@ -61,8 +61,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.opensearch.test.NodeRoles.onlyRole;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoTimeout;
@@ -388,18 +386,27 @@ public class AwarenessAttributeDecommissionIT extends OpenSearchIntegTestCase {
 
         logger.info("--> starting 4 data nodes each on zones 'a' & 'b' & 'c'");
         Map<String, List<String>> zoneToNodesMap = new HashMap<>();
-        zoneToNodesMap.put("a", internalCluster().startDataOnlyNodes(
-            dataNodeCountPerAZ,
-            Settings.builder().put(commonSettings).put("node.attr.zone", "a").build()
-        ));
-        zoneToNodesMap.put("b",internalCluster().startDataOnlyNodes(
-            dataNodeCountPerAZ,
-            Settings.builder().put(commonSettings).put("node.attr.zone", "b").build()
-        ));
-        zoneToNodesMap.put("c",internalCluster().startDataOnlyNodes(
-            dataNodeCountPerAZ,
-            Settings.builder().put(commonSettings).put("node.attr.zone", "c").build()
-        ));
+        zoneToNodesMap.put(
+            "a",
+            internalCluster().startDataOnlyNodes(
+                dataNodeCountPerAZ,
+                Settings.builder().put(commonSettings).put("node.attr.zone", "a").build()
+            )
+        );
+        zoneToNodesMap.put(
+            "b",
+            internalCluster().startDataOnlyNodes(
+                dataNodeCountPerAZ,
+                Settings.builder().put(commonSettings).put("node.attr.zone", "b").build()
+            )
+        );
+        zoneToNodesMap.put(
+            "c",
+            internalCluster().startDataOnlyNodes(
+                dataNodeCountPerAZ,
+                Settings.builder().put(commonSettings).put("node.attr.zone", "c").build()
+            )
+        );
         ensureStableCluster(15);
         ClusterHealthResponse health = client().admin()
             .cluster()

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/AwarenessAttributeDecommissionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/AwarenessAttributeDecommissionIT.java
@@ -280,7 +280,7 @@ public class AwarenessAttributeDecommissionIT extends OpenSearchIntegTestCase {
         );
         TransportService clusterManagerTransportService = internalCluster().getInstance(
             TransportService.class,
-            internalCluster().getClusterManagerName()
+            internalCluster().getClusterManagerName(activeNode)
         );
         MockTransportService decommissionedNodeTransportService = (MockTransportService) internalCluster().getInstance(
             TransportService.class,


### PR DESCRIPTION
Signed-off-by: Rishab Nahata <rnnahata@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
With #5252 we attempted to make client requests more deterministic by picking up a node which will not be decommissioned. In that PR we missed to make similar changes when instead of client we request the cluster service from the `internalCluster`.  This PR add changes which will always specify a activeNode before routing request.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
