### PR TITLE
Quote failures.

### DIFF
--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -94,7 +94,9 @@ jobs:
               ### Gradle Check (Jenkins) Run Completed with:
               * **RESULT:** ${{ env.result }} :x:
               * **FAILURES:**
+              ```
               ${{ env.test_failures }}
+              ```
               * **URL:** ${{ env.workflow_url }}
               * **CommitID:** ${{ env.pr_from_sha }}
               Please examine the workflow log, locate, and copy-paste the failure below, then iterate to green.


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

On top of https://github.com/opensearch-project/OpenSearch/pull/5200 to make prettier.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
