### PR TITLE
Fix flaky test AggregationsTests.testFromXContent

### DIFF
--- a/server/src/test/java/org/opensearch/search/aggregations/AggregationsTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/AggregationsTests.java
@@ -101,7 +101,6 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -116,60 +115,56 @@ import static org.opensearch.test.XContentTestUtils.insertRandomFields;
  *
  */
 public class AggregationsTests extends OpenSearchTestCase {
-    private static final List<InternalAggregationTestCase<?>> aggsTests = getAggsTests();
-
-    private static List<InternalAggregationTestCase<?>> getAggsTests() {
-        List<InternalAggregationTestCase<?>> aggsTests = new ArrayList<>();
-        aggsTests.add(new InternalCardinalityTests());
-        aggsTests.add(new InternalTDigestPercentilesTests());
-        aggsTests.add(new InternalTDigestPercentilesRanksTests());
-        aggsTests.add(new InternalHDRPercentilesTests());
-        aggsTests.add(new InternalHDRPercentilesRanksTests());
-        aggsTests.add(new InternalPercentilesBucketTests());
-        aggsTests.add(new InternalMinTests());
-        aggsTests.add(new InternalMaxTests());
-        aggsTests.add(new InternalAvgTests());
-        aggsTests.add(new InternalWeightedAvgTests());
-        aggsTests.add(new InternalSumTests());
-        aggsTests.add(new InternalValueCountTests());
-        aggsTests.add(new InternalSimpleValueTests());
-        aggsTests.add(new InternalDerivativeTests());
-        aggsTests.add(new InternalBucketMetricValueTests());
-        aggsTests.add(new InternalStatsTests());
-        aggsTests.add(new InternalStatsBucketTests());
-        aggsTests.add(new InternalExtendedStatsTests());
-        aggsTests.add(new InternalExtendedStatsBucketTests());
-        aggsTests.add(new InternalGeoCentroidTests());
-        aggsTests.add(new InternalHistogramTests());
-        aggsTests.add(new InternalDateHistogramTests());
-        aggsTests.add(new InternalAutoDateHistogramTests());
-        aggsTests.add(new InternalVariableWidthHistogramTests());
-        aggsTests.add(new LongTermsTests());
-        aggsTests.add(new DoubleTermsTests());
-        aggsTests.add(new StringTermsTests());
-        aggsTests.add(new LongRareTermsTests());
-        aggsTests.add(new StringRareTermsTests());
-        aggsTests.add(new InternalMissingTests());
-        aggsTests.add(new InternalNestedTests());
-        aggsTests.add(new InternalReverseNestedTests());
-        aggsTests.add(new InternalGlobalTests());
-        aggsTests.add(new InternalFilterTests());
-        aggsTests.add(new InternalSamplerTests());
-        aggsTests.add(new InternalRangeTests());
-        aggsTests.add(new InternalDateRangeTests());
-        aggsTests.add(new InternalGeoDistanceTests());
-        aggsTests.add(new InternalFiltersTests());
-        aggsTests.add(new InternalAdjacencyMatrixTests());
-        aggsTests.add(new SignificantLongTermsTests());
-        aggsTests.add(new SignificantStringTermsTests());
-        aggsTests.add(new InternalScriptedMetricTests());
-        aggsTests.add(new InternalBinaryRangeTests());
-        aggsTests.add(new InternalTopHitsTests());
-        aggsTests.add(new InternalCompositeTests());
-        aggsTests.add(new InternalMedianAbsoluteDeviationTests());
-        aggsTests.add(new InternalMultiTermsTests());
-        return Collections.unmodifiableList(aggsTests);
-    }
+    private static final List<InternalAggregationTestCase<?>> aggsTests = List.of(
+        new InternalCardinalityTests(),
+        new InternalTDigestPercentilesTests(),
+        new InternalTDigestPercentilesRanksTests(),
+        new InternalHDRPercentilesTests(),
+        new InternalHDRPercentilesRanksTests(),
+        new InternalPercentilesBucketTests(),
+        new InternalMinTests(),
+        new InternalMaxTests(),
+        new InternalAvgTests(),
+        new InternalWeightedAvgTests(),
+        new InternalSumTests(),
+        new InternalValueCountTests(),
+        new InternalSimpleValueTests(),
+        new InternalDerivativeTests(),
+        new InternalBucketMetricValueTests(),
+        new InternalStatsTests(),
+        new InternalStatsBucketTests(),
+        new InternalExtendedStatsTests(),
+        new InternalExtendedStatsBucketTests(),
+        new InternalGeoCentroidTests(),
+        new InternalHistogramTests(),
+        new InternalDateHistogramTests(),
+        new InternalAutoDateHistogramTests(),
+        new InternalVariableWidthHistogramTests(),
+        new LongTermsTests(),
+        new DoubleTermsTests(),
+        new StringTermsTests(),
+        new LongRareTermsTests(),
+        new StringRareTermsTests(),
+        new InternalMissingTests(),
+        new InternalNestedTests(),
+        new InternalReverseNestedTests(),
+        new InternalGlobalTests(),
+        new InternalFilterTests(),
+        new InternalSamplerTests(),
+        new InternalRangeTests(),
+        new InternalDateRangeTests(),
+        new InternalGeoDistanceTests(),
+        new InternalFiltersTests(),
+        new InternalAdjacencyMatrixTests(),
+        new SignificantLongTermsTests(),
+        new SignificantStringTermsTests(),
+        new InternalScriptedMetricTests(),
+        new InternalBinaryRangeTests(),
+        new InternalTopHitsTests(),
+        new InternalCompositeTests(),
+        new InternalMedianAbsoluteDeviationTests(),
+        new InternalMultiTermsTests()
+    );
 
     @Override
     protected NamedXContentRegistry xContentRegistry() {
@@ -226,7 +221,7 @@ public class AggregationsTests extends OpenSearchTestCase {
     private void parseAndAssert(boolean addRandomFields) throws IOException {
         XContentType xContentType = randomFrom(XContentType.values());
         final ToXContent.Params params = new ToXContent.MapParams(singletonMap(RestSearchAction.TYPED_KEYS_PARAM, "true"));
-        Aggregations aggregations = createTestInstance();
+        Aggregations aggregations = createTestInstance(1, 0, 3);
         BytesReference originalBytes = toShuffledXContent(aggregations, xContentType, params, randomBoolean());
         BytesReference mutated;
         if (addRandomFields) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Based on the seed, the recursive `createTestInstance` method generates too many aggregations resulting in an exception. This change reduces the number of generated aggregations.

### Issues Resolved
#4969

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>