### PR TITLE
[Backport 2.x] Fix test failing due to too long http line exception (#5278)

### DIFF
--- a/test/framework/src/main/java/org/opensearch/test/rest/yaml/ClientYamlTestClient.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/yaml/ClientYamlTestClient.java
@@ -57,6 +57,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -190,7 +192,7 @@ public class ClientYamlTestClient implements Closeable {
             }
             String contentType = entity.getContentType().getValue();
             // randomly test the GET with source param instead of GET/POST with body
-            if (sendBodyAsSourceParam(supportedMethods, contentType, entity.getContentLength())) {
+            if (sendBodyAsSourceParam(supportedMethods, contentType, entity)) {
                 logger.debug("sending the request body as source param with GET method");
                 queryStringParams.put("source", EntityUtils.toString(entity));
                 queryStringParams.put("source_content_type", contentType);
@@ -247,11 +249,12 @@ public class ClientYamlTestClient implements Closeable {
         request.setOptions(options);
     }
 
-    private static boolean sendBodyAsSourceParam(List<String> supportedMethods, String contentType, long contentLength) {
+    private static boolean sendBodyAsSourceParam(List<String> supportedMethods, String contentType, HttpEntity entity) throws IOException {
         if (false == supportedMethods.contains(HttpGet.METHOD_NAME)) {
             // The API doesn't claim to support GET anyway
             return false;
         }
+        long contentLength = entity.getContentLength();
         if (contentLength < 0) {
             // Negative length means "unknown" or "huge" in this case. Either way we can't send it as a parameter
             return false;
@@ -265,7 +268,18 @@ public class ClientYamlTestClient implements Closeable {
             // We can only encode JSON or YAML this way.
             return false;
         }
-        return RandomizedTest.rarely();
+
+        return RandomizedTest.rarely() && isUrlEncodedLengthUnderLimit(entity);
+    }
+
+    /*
+     * There is a limit of 4096 bytes for the HTTP line, otherwise there will be too_long_http_line_exception.
+     * We check if the length of the url-encoded source parameter is less than 3000, leaving remaining for
+     * url and other params.
+     */
+    private static boolean isUrlEncodedLengthUnderLimit(HttpEntity entity) throws IOException {
+        String encoded = URLEncoder.encode(EntityUtils.toString(entity), StandardCharsets.UTF_8);
+        return encoded.length() < 3000;
     }
 
     private ClientYamlSuiteRestApi restApi(String apiName) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Backport #5278 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>