### PR TITLE
Prettify test failures.

### DIFF
--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -81,9 +81,16 @@ jobs:
         if: ${{ github.event_name == 'pull_request_target' && env.result != 'SUCCESS' }}
         run: |
             TEST_FAILURES=`curl -s "${{ env.workflow_url }}/testReport/api/json?tree=suites\[cases\[status,className,name\]\]" | jq -r '.. | objects | select(.status=="FAILED",.status=="REGRESSION") | (.className + "." +  .name)' | uniq -c | sort -n -r | head -n 10`
-            echo "test_failures<<EOF" >> $GITHUB_ENV
-            echo "$TEST_FAILURES" >> $GITHUB_ENV
-            echo "EOF" >> $GITHUB_ENV
+            if [[ "$TEST_FAILURES" != "" ]]
+            then
+              echo "test_failures<<EOF" >> $GITHUB_ENV
+              echo "" >> $GITHUB_ENV
+              echo "* **TEST FAILURES:**" >> $GITHUB_ENV
+              echo '```' >> $GITHUB_ENV
+              echo "$TEST_FAILURES" >> $GITHUB_ENV
+              echo '```' >> $GITHUB_ENV
+              echo "EOF" >> $GITHUB_ENV
+            fi
 
       - name: Create Comment Flaky
         if: ${{ github.event_name == 'pull_request_target' && success() && env.result != 'SUCCESS' }}
@@ -92,12 +99,7 @@ jobs:
           issue-number: ${{ env.pr_number }}
           body: |
             ### Gradle Check (Jenkins) Run Completed with:
-            * **RESULT:** ${{ env.result }} :grey_exclamation:
-            * **FLAKY TEST FAILURES:**
-            The following tests failed but succeeded upon retry:
-            ```
-            ${{ env.test_failures }}
-            ```
+            * **RESULT:** ${{ env.result }} :grey_exclamation: ${{ env.test_failures }}
             * **URL:** ${{ env.workflow_url }}
             * **CommitID:** ${{ env.pr_from_sha }}
             Please examine the workflow log, locate, and copy-paste the failure below, then iterate to green.


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Don't display an empty section when no test failures. 

Screenshots from https://github.com/dblock/OpenSearch/pull/113.

![Screen Shot 2022-11-17 at 10 20 16 AM](https://user-images.githubusercontent.com/542335/202487840-640bd341-54fe-499e-ade6-d5fa44a61a88.png)

![Screen Shot 2022-11-17 at 10 21 36 AM](https://user-images.githubusercontent.com/542335/202487803-6668ccf5-228d-433a-9ff3-2d02ea5649b4.png)

The message about flaky tests that was added recently is incorrect. You can have legit test failures in this list, and some that were retried and still failed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
