### PR TITLE
Fix flaky test testReplicaReceivesGenIncrease.

### DIFF
--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -1301,7 +1301,8 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                 }
             );
             ids.add(target);
-            countDownLatch.await(1, TimeUnit.SECONDS);
+            countDownLatch.await(30, TimeUnit.SECONDS);
+            assertEquals("Replication should complete successfully", 0, countDownLatch.getCount());
         }
         return ids;
     }

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -1301,9 +1301,9 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                 }
             );
             ids.add(target);
-            countDownLatch.await(30, TimeUnit.SECONDS);
-            assertEquals("Replication should complete successfully", 0, countDownLatch.getCount());
         }
+        countDownLatch.await(30, TimeUnit.SECONDS);
+        assertEquals("Replication should complete successfully", 0, countDownLatch.getCount());
         return ids;
     }
 


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This fixes a race condition in segment replication specific test code where a CountDownLatch would complete before replication.  If the latch completes before the actual replication event the replica state is unpredictable.  This change removes the latch's wait limit of 1 second.

### Issues Resolved
closes #5232

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
