### PR TITLE
[BUG] org.opensearch.repositories.s3.RepositoryS3ClientYamlTestSuiteIT/test {yaml=repository_s3/20_repository_permanent_credentials/Snapshot and Restore with repository-s3 using permanent credentials} flaky

### DIFF
--- a/test/fixtures/minio-fixture/Dockerfile
+++ b/test/fixtures/minio-fixture/Dockerfile
@@ -1,4 +1,4 @@
-FROM minio/minio:RELEASE.2022-06-25T15-50-16Z
+FROM minio/minio:RELEASE.2022-11-17T23-20-09Z
 
 ARG bucket
 ARG accessKey

--- a/test/fixtures/minio-fixture/docker-compose.yml
+++ b/test/fixtures/minio-fixture/docker-compose.yml
@@ -14,6 +14,14 @@ services:
         soft: 4096
     ports:
       - "9000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+    volumes:
+      - type: tmpfs
+        target: /minio/data
     command: ["server", "--console-address", ":9001", "/minio/data"]
   minio-fixture-other:
     build:
@@ -29,6 +37,14 @@ services:
         soft: 4096
     ports:
       - "9000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+    volumes:
+      - type: tmpfs
+        target: /minio/data
     command: ["server", "--console-address", ":9001", "/minio/data"]
   minio-fixture-for-snapshot-tool:
     build:
@@ -44,4 +60,12 @@ services:
         soft: 4096
     ports:
       - "9000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+    volumes:
+      - type: tmpfs
+        target: /minio/data
     command: ["server", "--console-address", ":9001", "/minio/data"]


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixing `org.opensearch.repositories.s3.RepositoryS3ClientYamlTestSuiteIT/test`. Some background on possible causes of such a failure (I was not able to reproduce them locally yet). The `20_repository_permanent_credentials` is using `Minio` under the hood as S3 replacement.  There are 3 basic failure patterns:

```
RepositoryException[[repository_permanent] could not read repository data from index blob]; nested: NoSuchFileException[Blob object [base_integration_tests/index-30894] not found: The specified key does not exist. (Service: Amazon S3; Status Code: 404; Error Code: NoSuchKey; Request ID: P15KX1DMD577FQ5Y; S3 Extended Request ID: XEF7MRXUHU4E4v9cl8TQVPTb6VOy7PYoWCEQRXzvarSYg88VulVCiMvZZ1pxSbgDD5+ZD2sl28E=; Proxy: null)];
	at org.opensearch.repositories.blobstore.BlobStoreRepository.getRepositoryData(BlobStoreRepository.java:1842)
	at org.opensearch.repositories.blobstore.BlobStoreRepository.safeRepositoryData(BlobStoreRepository.java:798)
	at org.opensearch.repositories.blobstore.BlobStoreRepository$2.doRun(BlobStoreRepository.java:731)
	at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:806)
	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1589)
```

```
SnapshotException[[repository_permanent:snapshot-one/tBb-g3U1QsGROobhOKrjGw] failed to update snapshot in repository]; nested: IllegalStateException[Duplicate key docs (attempted merging values [docs/JdXo8HClSeu2GEuqJUgpMQ] and [docs/dB3pskUbQ3S3rsTds_INgw])];
	at org.opensearch.repositories.blobstore.BlobStoreRepository.lambda$finalizeSnapshot$39(BlobStoreRepository.java:1395)
	at org.opensearch.action.ActionListener$1.onFailure(ActionListener.java:88)
	at org.opensearch.action.ActionListener$1.onResponse(ActionListener.java:82)
	at org.opensearch.action.support.GroupedActionListener.onResponse(GroupedActionListener.java:81)
	at org.opensearch.action.ActionRunnable$1.doRun(ActionRunnable.java:61)
	at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:806)
	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

```
RepositoryException[[repository_permanent] concurrent modification of the index-N file, expected current generation [30818] but it was not found in the repository]
	at org.opensearch.repositories.blobstore.BlobStoreRepository.ensureSafeGenerationExists(BlobStoreRepository.java:2205)
	at org.opensearch.repositories.blobstore.BlobStoreRepository.lambda$writeIndexGen$57(BlobStoreRepository.java:2086)
	at org.opensearch.action.ActionListener$1.onResponse(ActionListener.java:80)
	at org.opensearch.common.util.concurrent.ListenableFuture$1.doRun(ListenableFuture.java:126)
	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
```

There is an hypothesis that tests fail sometimes due to Minio's consistency limitations (https://min.io/docs/minio/container/operations/install-deploy-manage/deploy-minio-single-node-single-drive.html#deploy-single-node-single-drive-minio)

```
MinIO’s strict read-after-write and list-after-write consistency model requires local drive filesystems (xfs, ext4, etc.).
```

### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/5219

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
