### PR TITLE
Fix URLDecodeProcessor random test failure

### DIFF
--- a/modules/ingest-common/src/main/java/org/opensearch/ingest/common/URLDecodeProcessor.java
+++ b/modules/ingest-common/src/main/java/org/opensearch/ingest/common/URLDecodeProcessor.java
@@ -32,8 +32,8 @@
 
 package org.opensearch.ingest.common;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -48,11 +48,7 @@ public final class URLDecodeProcessor extends AbstractStringProcessor<String> {
     }
 
     public static String apply(String value) {
-        try {
-            return URLDecoder.decode(value, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalArgumentException("Could not URL-decode value.", e);
-        }
+        return URLDecoder.decode(value, StandardCharsets.UTF_8);
     }
 
     @Override

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/URLDecodeProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/URLDecodeProcessorTests.java
@@ -32,13 +32,14 @@
 
 package org.opensearch.ingest.common;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 public class URLDecodeProcessorTests extends AbstractStringProcessorTestCase<String> {
     @Override
     protected String modifyInput(String input) {
-        return "Hello%20G%C3%BCnter" + input;
+        return "Hello%20G%C3%BCnter" + urlEncode(input);
     }
 
     @Override
@@ -48,10 +49,10 @@ public class URLDecodeProcessorTests extends AbstractStringProcessorTestCase<Str
 
     @Override
     protected String expectedResult(String input) {
-        try {
-            return "Hello Günter" + URLDecoder.decode(input, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalArgumentException("invalid");
-        }
+        return "Hello Günter" + URLDecoder.decode(urlEncode(input), StandardCharsets.UTF_8);
+    }
+
+    private static String urlEncode(String s) {
+        return URLEncoder.encode(s, StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
The randomly-generated input for this test may contain non-URL-safe characters (such as `%`) so it needs to be URL encoded as well.

### Issues Resolved
Closes #5327

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
