### PR TITLE
[Backport] [1.3] [BUG] org.opensearch.repositories.s3.RepositoryS3ClientYamlTestSuiteIT/test {yaml=repository_s3/20_repository_permanent_credentials/Snapshot and Restore with repository-s3 using permanent credentials} flaky (#5325)

### DIFF
--- a/test/fixtures/minio-fixture/Dockerfile
+++ b/test/fixtures/minio-fixture/Dockerfile
@@ -1,4 +1,4 @@
-FROM minio/minio:RELEASE.2019-01-23T23-18-58Z
+FROM minio/minio:RELEASE.2022-11-17T23-20-09Z
 
 ARG bucket
 ARG accessKey

--- a/test/fixtures/minio-fixture/docker-compose.yml
+++ b/test/fixtures/minio-fixture/docker-compose.yml
@@ -8,9 +8,21 @@ services:
         accessKey: "access_key"
         secretKey: "secret_key"
       dockerfile: Dockerfile
+    ulimits:
+      nofile:
+        hard: 4096
+        soft: 4096
     ports:
       - "9000"
-    command: ["server", "/minio/data"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+    volumes:
+      - type: tmpfs
+        target: /minio/data
+    command: ["server", "--console-address", ":9001", "/minio/data"]
   minio-fixture-other:
     build:
       context: .
@@ -21,15 +33,39 @@ services:
       dockerfile: Dockerfile
     ports:
       - "9000"
-    command: ["server", "/minio/data"]
+    ulimits:
+      nofile:
+        hard: 4096
+        soft: 4096
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+    volumes:
+      - type: tmpfs
+        target: /minio/data
+    command: ["server", "--console-address", ":9001", "/minio/data"]
   minio-fixture-for-snapshot-tool:
-      build:
-        context: .
-        args:
-          bucket: "bucket"
-          accessKey: "sn_tool_access_key"
-          secretKey: "sn_tool_secret_key"
-        dockerfile: Dockerfile
-      ports:
-        - "9000"
-      command: ["server", "/minio/data"]
+    build:
+      context: .
+      args:
+        bucket: "bucket"
+        accessKey: "sn_tool_access_key"
+        secretKey: "sn_tool_secret_key"
+      dockerfile: Dockerfile
+    ulimits:
+      nofile:
+        hard: 4096
+        soft: 4096
+    ports:
+      - "9000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+    volumes:
+      - type: tmpfs
+        target: /minio/data
+    command: ["server", "--console-address", ":9001", "/minio/data"]


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/5325 to 1.3