### PR TITLE
Retry tests only on CI server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -450,13 +450,16 @@ gradle.projectsEvaluated {
 }
 
 // test retry configuration
+boolean isCiServer = System.getenv().containsKey("CI")
 subprojects {
   apply plugin: "org.gradle.test-retry"
   tasks.withType(Test).configureEach {
     retry {
+      if (isCiServer) {
+        maxRetries = 3
+        maxFailures = 10
+      }
       failOnPassedAfterRetry = false
-      maxRetries = 3
-      maxFailures = 10
     }
   }
 }


### PR DESCRIPTION
Retrying all tests by default is not great when developing tests. This behavior could be missed by a developer and result in new flakiness being introduced. This change will only enable retries when the "CI" environment variable is present.

I've tested this prevents retries in a dev environment, and I've tested that if I set the `CI` environment variable then it does retry, but I haven't actually tested it in the real Jenkins environment. However, the code here was copied straight from the retry plugin's README, and [this Jenkins page](https://build.ci.opensearch.org/env-vars.html/) does suggest that the environment variable is set.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
