### PR TITLE
Add detailed message when return "Invalid argument" of IllegalArgumentException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Test] Add IAE test for deprecated edgeNGram analyzer name ([#5040](https://github.com/opensearch-project/OpenSearch/pull/5040))
 - Allow mmap to use new JDK-19 preview APIs in Apache Lucene 9.4+ ([#5151](https://github.com/opensearch-project/OpenSearch/pull/5151))
 - Add feature flag for extensions ([#5211](https://github.com/opensearch-project/OpenSearch/pull/5211))
+- Add detailed error messages when IllegalArgumentException reported ([#5349](https://github.com/opensearch-project/OpenSearch/pull/5349))
 
 ### Dependencies
 - Bumps `log4j-core` from 2.18.0 to 2.19.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Test] Add IAE test for deprecated edgeNGram analyzer name ([#5040](https://github.com/opensearch-project/OpenSearch/pull/5040))
 - Allow mmap to use new JDK-19 preview APIs in Apache Lucene 9.4+ ([#5151](https://github.com/opensearch-project/OpenSearch/pull/5151))
 - Add feature flag for extensions ([#5211](https://github.com/opensearch-project/OpenSearch/pull/5211))
-- Add detailed error messages when IllegalArgumentException reported ([#5349](https://github.com/opensearch-project/OpenSearch/pull/5349))
+- Add detailed error message when IllegalArgumentException reported ([#5350](https://github.com/opensearch-project/OpenSearch/pull/5350))
 
 ### Dependencies
 - Bumps `log4j-core` from 2.18.0 to 2.19.0

--- a/server/src/main/java/org/opensearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/opensearch/ExceptionsHelper.java
@@ -104,7 +104,7 @@ public final class ExceptionsHelper {
             if (t instanceof OpenSearchException) {
                 return t.getClass().getSimpleName() + "[" + t.getMessage() + "]";
             } else if (t instanceof IllegalArgumentException) {
-                return "Invalid argument" + "[" + t.getMessage() + "]";
+                return "Invalid argument [" + t.getMessage() + "]";
             } else if (t instanceof JsonParseException) {
                 return "Failed to parse JSON";
             } else if (t instanceof OpenSearchRejectedExecutionException) {

--- a/server/src/main/java/org/opensearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/opensearch/ExceptionsHelper.java
@@ -104,7 +104,7 @@ public final class ExceptionsHelper {
             if (t instanceof OpenSearchException) {
                 return t.getClass().getSimpleName() + "[" + t.getMessage() + "]";
             } else if (t instanceof IllegalArgumentException) {
-                return "Invalid argument";
+                return "Invalid argument" + "[" + t.getMessage() + "]";
             } else if (t instanceof JsonParseException) {
                 return "Failed to parse JSON";
             } else if (t instanceof OpenSearchRejectedExecutionException) {

--- a/server/src/test/java/org/opensearch/ExceptionsHelperTests.java
+++ b/server/src/test/java/org/opensearch/ExceptionsHelperTests.java
@@ -114,7 +114,7 @@ public class ExceptionsHelperTests extends OpenSearchTestCase {
     }
 
     public void testSummaryMessage() {
-        assertThat(ExceptionsHelper.summaryMessage(new IllegalArgumentException("illegal")), equalTo("Invalid argument"));
+        assertThat(ExceptionsHelper.summaryMessage(new IllegalArgumentException("illegal")), equalTo("Invalid argument [illegal]"));
         assertThat(ExceptionsHelper.summaryMessage(new JsonParseException(null, "illegal")), equalTo("Failed to parse JSON"));
         assertThat(ExceptionsHelper.summaryMessage(new OpenSearchRejectedExecutionException("rejected")), equalTo("Too many requests"));
     }


### PR DESCRIPTION
### Description
This PR is an alternative approach of https://github.com/opensearch-project/OpenSearch/pull/4792 As the previous PR may have some potential compatibility issues. New PR can do the change in a more backward compatible way.

With the setting `http.detailed_errors.enabled: false`:
```
curl -XPUT "http://localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d'
{
"persistent" : {
        "http.detailed_errors.enabled": true
    }
}'
{"error":"Invalid argument","status":400}
```
After change:
```
curl -XPUT "http://localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d'
{
"persistent" : {
        "http.detailed_errors.enabled": true
    }
}'
{"error":"Invalid argument[persistent setting [http.detailed_errors.enabled], not dynamically updateable]","status":400}
```

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/4745

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
