### PR TITLE
[Feature/extensions] Added default constructors for JSON parsing using Jackson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
  - Enforce type safety for RegisterTransportActionsRequest([#4796](https://github.com/opensearch-project/OpenSearch/pull/4796))
  - Modified local node request to return Discovery Node ([#4862](https://github.com/opensearch-project/OpenSearch/pull/4862))
  - Enforce type safety for NamedWriteableRegistryParseRequest ([#4923](https://github.com/opensearch-project/OpenSearch/pull/4923))
+ - Added default constructor for JSON parsing using Jackson ([#5369](https://github.com/opensearch-project/OpenSearch/pull/5369))
 
 ## [Unreleased 2.x]
 ### Added

--- a/server/src/main/java/org/opensearch/search/aggregations/AbstractAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/AbstractAggregationBuilder.java
@@ -77,6 +77,10 @@ public abstract class AbstractAggregationBuilder<AB extends AbstractAggregationB
         metadata = in.readMap();
     }
 
+    protected AbstractAggregationBuilder() {
+        super();
+    }
+
     @Override
     public final void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);

--- a/server/src/main/java/org/opensearch/search/aggregations/AbstractAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/AbstractAggregationBuilder.java
@@ -77,6 +77,9 @@ public abstract class AbstractAggregationBuilder<AB extends AbstractAggregationB
         metadata = in.readMap();
     }
 
+    /**
+     * Constructor required for Jackson parsing
+     */
     protected AbstractAggregationBuilder() {
         super();
     }

--- a/server/src/main/java/org/opensearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/AggregationBuilder.java
@@ -55,8 +55,6 @@ import java.util.Map;
  *
  * @opensearch.internal
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class AggregationBuilder
     implements
         NamedWriteable,
@@ -67,7 +65,6 @@ public abstract class AggregationBuilder
     protected String name;
     protected AggregatorFactories.Builder factoriesBuilder = AggregatorFactories.builder();
 
-    @JsonCreator
     AggregationBuilder() {}
 
     /**
@@ -109,13 +106,11 @@ public abstract class AggregationBuilder
     public abstract AggregationBuilder subAggregation(PipelineAggregationBuilder aggregation);
 
     /** Return the configured set of subaggregations **/
-    @JsonProperty("subAggregations")
     public Collection<AggregationBuilder> getSubAggregations() {
         return factoriesBuilder.getAggregatorFactories();
     }
 
     /** Return the configured set of pipeline aggregations **/
-    @JsonProperty("pipelineAggregations")
     public Collection<PipelineAggregationBuilder> getPipelineAggregations() {
         return factoriesBuilder.getPipelineAggregatorFactories();
     }

--- a/server/src/main/java/org/opensearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/AggregationBuilder.java
@@ -31,10 +31,6 @@
 
 package org.opensearch.search.aggregations;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.NamedWriteable;

--- a/server/src/main/java/org/opensearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/AggregationBuilder.java
@@ -65,6 +65,9 @@ public abstract class AggregationBuilder
     protected String name;
     protected AggregatorFactories.Builder factoriesBuilder = AggregatorFactories.builder();
 
+    /**
+     * Constructor required for Jackson parsing
+     */
     AggregationBuilder() {}
 
     /**

--- a/server/src/main/java/org/opensearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/AggregationBuilder.java
@@ -68,8 +68,7 @@ public abstract class AggregationBuilder
     protected AggregatorFactories.Builder factoriesBuilder = AggregatorFactories.builder();
 
     @JsonCreator
-    AggregationBuilder() {
-    }
+    AggregationBuilder() {}
 
     /**
      * Constructs a new aggregation builder.

--- a/server/src/main/java/org/opensearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/AggregationBuilder.java
@@ -31,6 +31,10 @@
 
 package org.opensearch.search.aggregations;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.NamedWriteable;
@@ -51,6 +55,8 @@ import java.util.Map;
  *
  * @opensearch.internal
  */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class AggregationBuilder
     implements
         NamedWriteable,
@@ -58,8 +64,12 @@ public abstract class AggregationBuilder
         BaseAggregationBuilder,
         Rewriteable<AggregationBuilder> {
 
-    protected final String name;
+    protected String name;
     protected AggregatorFactories.Builder factoriesBuilder = AggregatorFactories.builder();
+
+    @JsonCreator
+    AggregationBuilder() {
+    }
 
     /**
      * Constructs a new aggregation builder.
@@ -100,11 +110,13 @@ public abstract class AggregationBuilder
     public abstract AggregationBuilder subAggregation(PipelineAggregationBuilder aggregation);
 
     /** Return the configured set of subaggregations **/
+    @JsonProperty("subAggregations")
     public Collection<AggregationBuilder> getSubAggregations() {
         return factoriesBuilder.getAggregatorFactories();
     }
 
     /** Return the configured set of pipeline aggregations **/
+    @JsonProperty("pipelineAggregations")
     public Collection<PipelineAggregationBuilder> getPipelineAggregations() {
         return factoriesBuilder.getPipelineAggregatorFactories();
     }

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/SumAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/SumAggregationBuilder.java
@@ -75,6 +75,10 @@ public class SumAggregationBuilder extends ValuesSourceAggregationBuilder.LeafOn
         super(name);
     }
 
+    private SumAggregationBuilder() {
+        super();
+    }
+
     protected SumAggregationBuilder(
         SumAggregationBuilder clone,
         AggregatorFactories.Builder factoriesBuilder,

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/SumAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/SumAggregationBuilder.java
@@ -75,6 +75,9 @@ public class SumAggregationBuilder extends ValuesSourceAggregationBuilder.LeafOn
         super(name);
     }
 
+    /**
+     * Constructor required for Jackson parsing
+     */
     private SumAggregationBuilder() {
         super();
     }

--- a/server/src/main/java/org/opensearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
@@ -59,6 +59,9 @@ import java.util.Objects;
  */
 public abstract class ValuesSourceAggregationBuilder<AB extends ValuesSourceAggregationBuilder<AB>> extends AbstractAggregationBuilder<AB> {
 
+    /**
+     * Constructor required for Jackson parsing
+     */
     private ValuesSourceAggregationBuilder() {
         super();
     }
@@ -170,6 +173,9 @@ public abstract class ValuesSourceAggregationBuilder<AB extends ValuesSourceAggr
             super(in);
         }
 
+        /**
+         * Constructor required for Jackson parsing
+         */
         public LeafOnly() {
             super();
         }

--- a/server/src/main/java/org/opensearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
@@ -59,6 +59,10 @@ import java.util.Objects;
  */
 public abstract class ValuesSourceAggregationBuilder<AB extends ValuesSourceAggregationBuilder<AB>> extends AbstractAggregationBuilder<AB> {
 
+    private ValuesSourceAggregationBuilder() {
+        super();
+    }
+
     public static <T> void declareFields(
         AbstractObjectParser<? extends ValuesSourceAggregationBuilder<?>, T> objectParser,
         boolean scriptable,
@@ -164,6 +168,10 @@ public abstract class ValuesSourceAggregationBuilder<AB extends ValuesSourceAggr
          */
         protected LeafOnly(StreamInput in) throws IOException {
             super(in);
+        }
+
+        public LeafOnly() {
+            super();
         }
 
         @Override


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

Added default constructor for JSON parsing using Jackson required for SearchRequest of Java Client for Get Detector feature of AD Extension

### Description
Part of https://github.com/opensearch-project/opensearch-sdk-java/issues/214

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
