### PR TITLE
[Backport] [1.x] Use BuildParams.isCi() instead of checking env var (#5368)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -388,9 +388,11 @@ subprojects {
   apply plugin: "org.gradle.test-retry"
   tasks.withType(Test).configureEach {
     retry {
+      if (BuildParams.isCi()) {
+        maxRetries = 3
+        maxFailures = 10
+      }
       failOnPassedAfterRetry = false
-      maxRetries = 3
-      maxFailures = 10
     }
   }
 }


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/5368 to `1.x`