### PR TITLE
Upgrade the mappings on .tasks index if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix 'org.apache.hc.core5.http.ParseException: Invalid protocol version' under JDK 16+ ([#4827](https://github.com/opensearch-project/OpenSearch/pull/4827))
 - Fixed compression support for h2c protocol ([#4944](https://github.com/opensearch-project/OpenSearch/pull/4944))
 - Reject bulk requests with invalid actions ([#5299](https://github.com/opensearch-project/OpenSearch/issues/5299))
+- after upgrade to OpenSearch 2.0, finished tasks no longer get stored in .tasks index ([#5376](https://github.com/opensearch-project/OpenSearch/issues/5376))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/tasks/TaskResultsService.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResultsService.java
@@ -86,7 +86,7 @@ public class TaskResultsService {
 
     public static final String TASK_RESULT_MAPPING_VERSION_META_FIELD = "version";
 
-    public static final int TASK_RESULT_MAPPING_VERSION = 3; // must match version in task-index-mapping.json
+    public static final int TASK_RESULT_MAPPING_VERSION = 4; // must match version in task-index-mapping.json
 
     /**
      * The backoff policy to use when saving a task result fails. The total wait

--- a/server/src/main/resources/org/opensearch/tasks/task-index-mapping.json
+++ b/server/src/main/resources/org/opensearch/tasks/task-index-mapping.json
@@ -1,7 +1,7 @@
 {
   "_doc" : {
     "_meta": {
-      "version": 3
+      "version": 4
     },
     "dynamic" : "strict",
     "properties" : {


### PR DESCRIPTION
Signed-off-by: Przemek Bruski <pbruskispam@op.pl>

### Description
Upgrade the mappings on .tasks index if needed. This fixes an regression introduced in https://github.com/opensearch-project/OpenSearch/pull/1732

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/5376

### Check List
- [X] New functionality includes testing.
- [X] All tests pass
- [X] New functionality has been documented.
- [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
