### PR TITLE
Fix IndexShardTests.testRestoreShardFromRemoteStore on Windows.

### DIFF
--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -2764,8 +2764,21 @@ public class IndexShardTests extends IndexShardTestCase {
 
         // Delete files in store directory to restore from remote directory
         Directory storeDirectory = target.store().directory();
+
         for (String file : storeDirectory.listAll()) {
             storeDirectory.deleteFile(file);
+            // Windows has buggy File delete logic where AccessDeniedExceptions
+            // are thrown when there is an open file handle on a particular file. FSDirectory attempts to resolve this with hacks by
+            // swallowing the exceptions and moving the file to a pending delete state
+            // to retry in the future while being filtered from listAll invocations.
+            // However, this logic is also buggy and after the first delete attempt we are left in a state where the file is still on disk
+            // and not pending delete.
+            // A second attempt to delete the file will properly move it to pending deletion, and be filtered from listAll.
+            if (Arrays.asList(storeDirectory.listAll()).contains(file) && storeDirectory.getPendingDeletions().contains(file) == false) {
+                logger.info("File {} was not deleted and is not pending delete, attempting delete again...", file);
+                storeDirectory.deleteFile(file);
+                assertTrue(storeDirectory.getPendingDeletions().contains(file));
+            }
         }
 
         assertEquals(0, storeDirectory.listAll().length);


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix IndexShardTests.testRestoreShardFromRemoteStore on Windows.

Windows has buggy File delete logic where AccessDeniedExceptions are thrown when there is an open file handle on a particular file. [FSDirectory](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/store/FSDirectory.java#LL344) attempts to resolve this with hacks by swallowing the exceptions and moving the file to a pending delete state to retry in the future while being filtered from listAll invocations.
However, this logic is also buggy and after the first delete attempt we are left in a state where the file is still on disk and not pending delete.  This is because FSDirectory#maybeDeletePendingFiles will execute and attempt to delete the purged files again, which hits a NoSuchFileException that is also swallowed.  
A second attempt to delete the file will properly move it to pending deletion, and be filtered from listAll.

### Issues Resolved
related #1448 
closes #5209

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
