### PR TITLE
 Fix for windows failure InternalDistributionArchiveSetupPluginFuncTest

### DIFF
--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/internal/InternalDistributionArchiveSetupPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/internal/InternalDistributionArchiveSetupPluginFuncTest.groovy
@@ -34,6 +34,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
 import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipFile
+import org.gradle.internal.os.OperatingSystem
 import org.opensearch.gradle.fixtures.AbstractGradleFuncTest
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
@@ -142,30 +143,45 @@ class InternalDistributionArchiveSetupPluginFuncTest extends AbstractGradleFuncT
             }
         }
         """
-        when:
-        def result = gradleRunner("copyArchive").build()
 
-        then: "tar task executed and target folder contains plain tar"
-        result.task(':buildProducerTar').outcome == TaskOutcome.SUCCESS
-        result.task(':consumer:copyArchive').outcome == TaskOutcome.SUCCESS
-        file("producer-tar/build/distributions/opensearch-min.tar.gz").exists()
-        file("consumer/build/archives/opensearch-min.tar.gz").exists()
+        if (OperatingSystem.current() != OperatingSystem.WINDOWS) {
+            when:
+            def result = gradleRunner("copyArchive").build()
+            then: "tar task executed and target folder contains plain tar"
+            result.task(':buildProducerTar').outcome == TaskOutcome.SUCCESS
+            result.task(':consumer:copyArchive').outcome == TaskOutcome.SUCCESS
+            file("producer-tar/build/distributions/opensearch-min.tar.gz").exists()
+            file("consumer/build/archives/opensearch-min.tar.gz").exists()
 
-        when:
-        result = gradleRunner("copyDir", "-Pversion=1.0").build()
-        then: "plain copy task executed and target folder contains plain content"
-        result.task(':buildProducer').outcome == TaskOutcome.SUCCESS
-        result.task(':consumer:copyDir').outcome == TaskOutcome.SUCCESS
-        file("producer-tar/build/install/someFile.txt").exists()
-        file("producer-tar/build/install/snapshot-1.0.txt").exists()
-        file("consumer/build/dir/someFile.txt").exists()
+            when:
+            result = gradleRunner("copyDir", "-Pversion=1.0").build()
+            then: "plain copy task executed and target folder contains plain content"
+            result.task(':buildProducer').outcome == TaskOutcome.SUCCESS
+            result.task(':consumer:copyDir').outcome == TaskOutcome.SUCCESS
+            file("producer-tar/build/install/someFile.txt").exists()
+            file("producer-tar/build/install/snapshot-1.0.txt").exists()
+            file("consumer/build/dir/someFile.txt").exists()
 
-        when:
-        gradleRunner("copyDir", "-Pversion=2.0").build()
-        then: "old content is cleared out"
-        file("producer-tar/build/install/someFile.txt").exists()
-        !file("producer-tar/build/install/snapshot-1.0.txt").exists()
-        file("producer-tar/build/install/snapshot-2.0.txt").exists()
+            when:
+            gradleRunner("copyDir", "-Pversion=2.0").build()
+            then: "old content is cleared out"
+            file("producer-tar/build/install/someFile.txt").exists()
+            !file("producer-tar/build/install/snapshot-1.0.txt").exists()
+            file("producer-tar/build/install/snapshot-2.0.txt").exists()
+        } else {
+            when:
+            def result = gradleRunner("copyArchive").build()
+            then: "tar task execution skipped on windows"
+            result.task(':buildProducerTar').outcome == TaskOutcome.SKIPPED
+            result.task(':consumer:copyArchive').outcome == TaskOutcome.NO_SOURCE
+
+            when:
+            result = gradleRunner("copyDir", "-Pversion=1.0").build()
+            then: "plain copy task execution skipped on windows"
+            result.task(':buildProducer').outcome == TaskOutcome.SKIPPED
+            result.task(':consumer:copyDir').outcome == TaskOutcome.NO_SOURCE
+        }
+
     }
 
     private static boolean assertTarPermissionDefaults(File tarArchive) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Failure on windows for the InternalDistributionArchiveSetupPluginFuncTest is unexpected. Fails with "registered distribution provides archives and directory variant". 
This is because - 
- tar task execution is skipped on windows.
- plain copy task execution doesn't execute on windows since source files will not be present. 
To get the test passing again, we check for expected conditions on windows and non-windows machines.

### Issues Resolved
Resolves #5324 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
