### PR TITLE
[Backport 2.x] Add max_shard_size parameter for Shrink API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Prevent deletion of snapshots that are backing searchable snapshot indexes ([#5069](https://github.com/opensearch-project/OpenSearch/pull/5069))
 - Update to Gradle 7.6 ([#5382](https://github.com/opensearch-project/OpenSearch/pull/5382))
 - Reject bulk requests with invalid actions ([#5299](https://github.com/opensearch-project/OpenSearch/issues/5299))
+- Add max_shard_size parameter for shrink API ([#5229](https://github.com/opensearch-project/OpenSearch/pull/5229))
 ### Dependencies
 - Bump bcpg-fips from 1.0.5.1 to 1.0.7.1 ([#5148](https://github.com/opensearch-project/OpenSearch/pull/5148))
 - Bumps `commons-compress` from 1.21 to 1.22 ([#5104](https://github.com/opensearch-project/OpenSearch/pull/5104))

--- a/client/rest-high-level/src/main/java/org/opensearch/client/indices/ResizeRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/indices/ResizeRequest.java
@@ -39,6 +39,7 @@ import org.opensearch.client.ValidationException;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.unit.ByteSizeValue;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -58,6 +59,7 @@ public class ResizeRequest extends TimedRequest implements Validatable, ToXConte
     private final String targetIndex;
     private Settings settings = Settings.EMPTY;
     private Set<Alias> aliases = new HashSet<>();
+    private ByteSizeValue maxShardSize;
 
     /**
      * Creates a new resize request
@@ -153,6 +155,24 @@ public class ResizeRequest extends TimedRequest implements Validatable, ToXConte
 
     public ActiveShardCount getWaitForActiveShards() {
         return waitForActiveShards;
+    }
+
+    /**
+     * Sets the maximum size of a primary shard in the new shrunken index.
+     * This parameter can be used to calculate the lowest factor of the source index's shards number
+     * which satisfies the maximum shard size requirement.
+     *
+     * @param maxShardSize the maximum size of a primary shard in the new shrunken index
+     */
+    public void setMaxShardSize(ByteSizeValue maxShardSize) {
+        this.maxShardSize = maxShardSize;
+    }
+
+    /**
+     * Returns the maximum size of a primary shard in the new shrunken index.
+     */
+    public ByteSizeValue getMaxShardSize() {
+        return maxShardSize;
     }
 
     @Override

--- a/client/rest-high-level/src/test/java/org/opensearch/client/IndicesRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/IndicesRequestConvertersTests.java
@@ -79,6 +79,7 @@ import org.opensearch.common.util.CollectionUtils;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Assert;
+import org.opensearch.common.unit.ByteSizeValue;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -701,6 +702,8 @@ public class IndicesRequestConvertersTests extends OpenSearchTestCase {
         RequestConvertersTests.setRandomWaitForActiveShards(resizeRequest::setWaitForActiveShards, expectedParams);
         if (resizeType == ResizeType.SPLIT) {
             resizeRequest.setSettings(Settings.builder().put("index.number_of_shards", 2).build());
+        } else if (resizeType == ResizeType.SHRINK) {
+            resizeRequest.setMaxShardSize(new ByteSizeValue(randomIntBetween(1, 1000)));
         }
 
         Request request = function.apply(resizeRequest);

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/40_max_shard_size.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/40_max_shard_size.yml
@@ -1,0 +1,82 @@
+---
+"Shrink index with max_shard_size":
+  # shrink index with max_shard_size parameter, which is used to generate an optimum
+  # number_of_shards for the target index.
+
+  - skip:
+      version: " - 2.4.99"
+      reason: "only available in 2.5+"
+      features: allowed_warnings
+
+  - do:
+      nodes.info:
+        node_id: data:true
+  - set:
+      nodes._arbitrary_key_: node_id
+
+  - do:
+      indices.create:
+        index: source
+        wait_for_active_shards: 1
+        body:
+          settings:
+            # ensure everything is allocated on the same data node
+            index.routing.allocation.include._id: $node_id
+            index.number_of_shards: 3
+            index.number_of_replicas: 0
+  - do:
+      index:
+        index: source
+        id:    "1"
+        body:  { "foo": "hello world" }
+
+  - do:
+      get:
+        index: source
+        id:    "1"
+
+  - match: { _index:   source }
+  - match: { _id:      "1"     }
+  - match: { _source:  { foo: "hello world" } }
+
+  # make it read-only
+  - do:
+      indices.put_settings:
+        index: source
+        body:
+          index.blocks.write: true
+          index.number_of_replicas: 0
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+        index: source
+
+  # shrink with max_shard_size
+  - do:
+      allowed_warnings:
+        - "Parameter [master_timeout] is deprecated and will be removed in 3.0. To support inclusive language, please use [cluster_manager_timeout] instead."
+      indices.shrink:
+        index: "source"
+        target: "new_shrunken_index"
+        wait_for_active_shards: 1
+        master_timeout: 10s
+        body:
+          settings:
+            index.number_of_replicas: 0
+          max_shard_size: "10gb"
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+
+  - do:
+      get:
+        index: "new_shrunken_index"
+        id:    "1"
+
+  - do:
+      indices.get_settings:
+        index: "new_shrunken_index"
+
+  - match: { new_shrunken_index.settings.index.number_of_shards: "1" }

--- a/server/src/main/java/org/opensearch/action/admin/indices/shrink/ResizeRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/shrink/ResizeRequestBuilder.java
@@ -37,6 +37,7 @@ import org.opensearch.action.support.ActiveShardCount;
 import org.opensearch.action.support.master.AcknowledgedRequestBuilder;
 import org.opensearch.client.OpenSearchClient;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.ByteSizeValue;
 
 /**
  * Transport request builder for resizing an index
@@ -93,6 +94,14 @@ public class ResizeRequestBuilder extends AcknowledgedRequestBuilder<ResizeReque
 
     public ResizeRequestBuilder setResizeType(ResizeType type) {
         this.request.setResizeType(type);
+        return this;
+    }
+
+    /**
+     * Sets the maximum size of a primary shard in the new shrunken index.
+     */
+    public ResizeRequestBuilder setMaxShardSize(ByteSizeValue maxShardSize) {
+        this.request.setMaxShardSize(maxShardSize);
         return this;
     }
 }

--- a/server/src/test/java/org/opensearch/action/admin/indices/shrink/TransportResizeActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/shrink/TransportResizeActionTests.java
@@ -38,8 +38,8 @@ import org.opensearch.action.admin.indices.create.CreateIndexClusterStateUpdateR
 import org.opensearch.action.support.ActiveShardCount;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.ClusterState;
-import org.opensearch.cluster.OpenSearchAllocationTestCase;
 import org.opensearch.cluster.EmptyClusterInfoService;
+import org.opensearch.cluster.OpenSearchAllocationTestCase;
 import org.opensearch.cluster.block.ClusterBlocks;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
@@ -52,7 +52,9 @@ import org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocat
 import org.opensearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.opensearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.index.shard.DocsStats;
+import org.opensearch.index.store.StoreStats;
 import org.opensearch.snapshots.EmptySnapshotsInfoService;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.gateway.TestGatewayAllocator;
@@ -107,6 +109,7 @@ public class TransportResizeActionTests extends OpenSearchTestCase {
                     new ResizeRequest("target", "source"),
                     state,
                     (i) -> new DocsStats(Integer.MAX_VALUE, between(1, 1000), between(1, 100)),
+                    new StoreStats(between(1, 10000), between(1, 10000)),
                     "source",
                     "target"
                 )
@@ -121,6 +124,7 @@ public class TransportResizeActionTests extends OpenSearchTestCase {
                 req,
                 clusterState,
                 (i) -> i == 2 || i == 3 ? new DocsStats(Integer.MAX_VALUE / 2, between(1, 1000), between(1, 10000)) : null,
+                new StoreStats(between(1, 10000), between(1, 10000)),
                 "source",
                 "target"
             );
@@ -139,6 +143,7 @@ public class TransportResizeActionTests extends OpenSearchTestCase {
                 req,
                 clusterState,
                 (i) -> new DocsStats(between(10, 1000), between(1, 10), between(1, 10000)),
+                new StoreStats(between(1, 10000), between(1, 10000)),
                 "source",
                 "target"
             );
@@ -167,6 +172,7 @@ public class TransportResizeActionTests extends OpenSearchTestCase {
             new ResizeRequest("target", "source"),
             clusterState,
             (i) -> new DocsStats(between(1, 1000), between(1, 1000), between(0, 10000)),
+            new StoreStats(between(1, 10000), between(1, 10000)),
             "source",
             "target"
         );
@@ -193,13 +199,27 @@ public class TransportResizeActionTests extends OpenSearchTestCase {
         ResizeRequest resizeRequest = new ResizeRequest("target", "source");
         resizeRequest.setResizeType(ResizeType.SPLIT);
         resizeRequest.getTargetIndexRequest().settings(Settings.builder().put("index.number_of_shards", 2).build());
-        TransportResizeAction.prepareCreateIndexRequest(resizeRequest, clusterState, null, "source", "target");
+        TransportResizeAction.prepareCreateIndexRequest(
+            resizeRequest,
+            clusterState,
+            null,
+            new StoreStats(between(1, 10000), between(1, 10000)),
+            "source",
+            "target"
+        );
 
         resizeRequest.getTargetIndexRequest()
             .settings(
                 Settings.builder().put("index.number_of_routing_shards", randomIntBetween(2, 10)).put("index.number_of_shards", 2).build()
             );
-        TransportResizeAction.prepareCreateIndexRequest(resizeRequest, clusterState, null, "source", "target");
+        TransportResizeAction.prepareCreateIndexRequest(
+            resizeRequest,
+            clusterState,
+            null,
+            new StoreStats(between(1, 10000), between(1, 10000)),
+            "source",
+            "target"
+        );
     }
 
     public void testPassNumRoutingShardsAndFail() {
@@ -224,7 +244,14 @@ public class TransportResizeActionTests extends OpenSearchTestCase {
         ResizeRequest resizeRequest = new ResizeRequest("target", "source");
         resizeRequest.setResizeType(ResizeType.SPLIT);
         resizeRequest.getTargetIndexRequest().settings(Settings.builder().put("index.number_of_shards", numShards * 2).build());
-        TransportResizeAction.prepareCreateIndexRequest(resizeRequest, clusterState, null, "source", "target");
+        TransportResizeAction.prepareCreateIndexRequest(
+            resizeRequest,
+            clusterState,
+            null,
+            new StoreStats(between(1, 10000), between(1, 10000)),
+            "source",
+            "target"
+        );
 
         resizeRequest.getTargetIndexRequest()
             .settings(
@@ -233,7 +260,14 @@ public class TransportResizeActionTests extends OpenSearchTestCase {
         ClusterState finalState = clusterState;
         IllegalArgumentException iae = expectThrows(
             IllegalArgumentException.class,
-            () -> TransportResizeAction.prepareCreateIndexRequest(resizeRequest, finalState, null, "source", "target")
+            () -> TransportResizeAction.prepareCreateIndexRequest(
+                resizeRequest,
+                finalState,
+                null,
+                new StoreStats(between(1, 10000), between(1, 10000)),
+                "source",
+                "target"
+            )
         );
         assertEquals("cannot provide index.number_of_routing_shards on resize", iae.getMessage());
     }
@@ -266,6 +300,7 @@ public class TransportResizeActionTests extends OpenSearchTestCase {
             target,
             clusterState,
             (i) -> stats,
+            new StoreStats(between(1, 10000), between(1, 10000)),
             indexName,
             "target"
         );
@@ -274,6 +309,206 @@ public class TransportResizeActionTests extends OpenSearchTestCase {
         assertEquals("1", request.settings().get("index.number_of_shards"));
         assertEquals("shrink_index", request.cause());
         assertEquals(request.waitForActiveShards(), activeShardCount);
+    }
+
+    public void testShrinkWithMaxShardSize() {
+        String indexName = randomAlphaOfLength(10);
+        // create one that won't fail
+        ClusterState clusterState = ClusterState.builder(
+            createClusterState(indexName, 10, 0, Settings.builder().put("index.blocks.write", true).build())
+        ).nodes(DiscoveryNodes.builder().add(newNode("node1"))).build();
+
+        // Cannot set max_shard_size when split or clone
+        ResizeRequest resizeRequestForFailure = new ResizeRequest("target", indexName);
+        ResizeType resizeType = ResizeType.SPLIT;
+        if (randomBoolean()) {
+            resizeType = ResizeType.CLONE;
+        }
+        resizeRequestForFailure.setResizeType(resizeType);
+        resizeRequestForFailure.setMaxShardSize(new ByteSizeValue(100));
+        resizeRequestForFailure.getTargetIndexRequest()
+            .settings(Settings.builder().put("index.number_of_shards", randomIntBetween(1, 100)).build());
+        ClusterState finalState = clusterState;
+        IllegalArgumentException iae = expectThrows(
+            IllegalArgumentException.class,
+            () -> TransportResizeAction.prepareCreateIndexRequest(
+                resizeRequestForFailure,
+                finalState,
+                null,
+                new StoreStats(between(1, 10000), between(1, 10000)),
+                indexName,
+                "target"
+            )
+        );
+        assertEquals("Unsupported parameter [max_shard_size]", iae.getMessage());
+
+        // Cannot set max_shard_size and index.number_of_shards at the same time
+        ResizeRequest resizeRequest = new ResizeRequest("target", indexName);
+        resizeRequest.setResizeType(ResizeType.SHRINK);
+        resizeRequest.setMaxShardSize(new ByteSizeValue(100));
+        resizeRequest.getTargetIndexRequest().settings(Settings.builder().put("index.number_of_shards", randomIntBetween(1, 100)).build());
+        iae = expectThrows(
+            IllegalArgumentException.class,
+            () -> TransportResizeAction.prepareCreateIndexRequest(
+                resizeRequest,
+                finalState,
+                null,
+                new StoreStats(between(1, 10000), between(1, 10000)),
+                indexName,
+                "target"
+            )
+        );
+        assertEquals("Cannot set max_shard_size and index.number_of_shards at the same time!", iae.getMessage());
+
+        AllocationService service = new AllocationService(
+            new AllocationDeciders(Collections.singleton(new MaxRetryAllocationDecider())),
+            new TestGatewayAllocator(),
+            new BalancedShardsAllocator(Settings.EMPTY),
+            EmptyClusterInfoService.INSTANCE,
+            EmptySnapshotsInfoService.INSTANCE
+        );
+        RoutingTable routingTable = service.reroute(clusterState, "reroute").routingTable();
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+        // now we start the shard
+        routingTable = OpenSearchAllocationTestCase.startInitializingShardsAndReroute(service, clusterState, indexName).routingTable();
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+        int numSourceShards = clusterState.metadata().index(indexName).getNumberOfShards();
+        DocsStats stats = new DocsStats(between(0, (IndexWriter.MAX_DOCS) / numSourceShards), between(1, 1000), between(1, 10000));
+
+        // target index's shards number must be the lowest factor of the source index's shards number
+        int expectedShardsNum = 5;
+        resizeRequest.setMaxShardSize(new ByteSizeValue(25));
+        // clear index settings
+        resizeRequest.getTargetIndexRequest().settings(Settings.builder().build());
+        resizeRequest.setWaitForActiveShards(expectedShardsNum);
+        CreateIndexClusterStateUpdateRequest request = TransportResizeAction.prepareCreateIndexRequest(
+            resizeRequest,
+            clusterState,
+            (i) -> stats,
+            new StoreStats(100, between(1, 10000)),
+            indexName,
+            "target"
+        );
+        assertNotNull(request.recoverFrom());
+        assertEquals(indexName, request.recoverFrom().getName());
+        assertEquals(String.valueOf(expectedShardsNum), request.settings().get("index.number_of_shards"));
+        assertEquals("shrink_index", request.cause());
+        assertEquals(request.waitForActiveShards(), ActiveShardCount.from(expectedShardsNum));
+
+        // if max_shard_size is greater than whole of the source primary shards' storage,
+        // then the target index will only have one primary shard.
+        expectedShardsNum = 1;
+        resizeRequest.setMaxShardSize(new ByteSizeValue(1000));
+        // clear index settings
+        resizeRequest.getTargetIndexRequest().settings(Settings.builder().build());
+        resizeRequest.setWaitForActiveShards(expectedShardsNum);
+        request = TransportResizeAction.prepareCreateIndexRequest(
+            resizeRequest,
+            clusterState,
+            (i) -> stats,
+            new StoreStats(100, between(1, 10000)),
+            indexName,
+            "target"
+        );
+        assertNotNull(request.recoverFrom());
+        assertEquals(indexName, request.recoverFrom().getName());
+        assertEquals(String.valueOf(expectedShardsNum), request.settings().get("index.number_of_shards"));
+        assertEquals("shrink_index", request.cause());
+        assertEquals(request.waitForActiveShards(), ActiveShardCount.from(expectedShardsNum));
+
+        // if max_shard_size is less than the primary shard's storage of the source index,
+        // then the target index's shards number will be equal to the source index's.
+        expectedShardsNum = numSourceShards;
+        resizeRequest.setMaxShardSize(new ByteSizeValue(1));
+        // clear index settings
+        resizeRequest.getTargetIndexRequest().settings(Settings.builder().build());
+        resizeRequest.setWaitForActiveShards(expectedShardsNum);
+        request = TransportResizeAction.prepareCreateIndexRequest(
+            resizeRequest,
+            clusterState,
+            (i) -> stats,
+            new StoreStats(100, between(1, 10000)),
+            indexName,
+            "target"
+        );
+        assertNotNull(request.recoverFrom());
+        assertEquals(indexName, request.recoverFrom().getName());
+        assertEquals(String.valueOf(expectedShardsNum), request.settings().get("index.number_of_shards"));
+        assertEquals("shrink_index", request.cause());
+        assertEquals(request.waitForActiveShards(), ActiveShardCount.from(expectedShardsNum));
+    }
+
+    public void testCalculateTargetIndexShardsNum() {
+        String indexName = randomAlphaOfLength(10);
+        ClusterState clusterState = ClusterState.builder(
+            createClusterState(indexName, randomIntBetween(2, 10), 0, Settings.builder().put("index.blocks.write", true).build())
+        ).nodes(DiscoveryNodes.builder().add(newNode("node1"))).build();
+        IndexMetadata indexMetadata = clusterState.metadata().index(indexName);
+
+        assertEquals(TransportResizeAction.calculateTargetIndexShardsNum(null, new StoreStats(100, between(1, 10000)), indexMetadata), 1);
+        assertEquals(
+            TransportResizeAction.calculateTargetIndexShardsNum(
+                new ByteSizeValue(0),
+                new StoreStats(100, between(1, 10000)),
+                indexMetadata
+            ),
+            1
+        );
+        assertEquals(TransportResizeAction.calculateTargetIndexShardsNum(new ByteSizeValue(1), null, indexMetadata), 1);
+        assertEquals(TransportResizeAction.calculateTargetIndexShardsNum(new ByteSizeValue(1), new StoreStats(0, 0), indexMetadata), 1);
+        assertEquals(
+            TransportResizeAction.calculateTargetIndexShardsNum(
+                new ByteSizeValue(1000),
+                new StoreStats(100, between(1, 10000)),
+                indexMetadata
+            ),
+            1
+        );
+        assertEquals(
+            TransportResizeAction.calculateTargetIndexShardsNum(
+                new ByteSizeValue(1),
+                new StoreStats(100, between(1, 10000)),
+                indexMetadata
+            ),
+            indexMetadata.getNumberOfShards()
+        );
+
+        clusterState = ClusterState.builder(
+            createClusterState(indexName, 10, 0, Settings.builder().put("index.blocks.write", true).build())
+        ).nodes(DiscoveryNodes.builder().add(newNode("node1"))).build();
+        indexMetadata = clusterState.metadata().index(indexName);
+        assertEquals(
+            TransportResizeAction.calculateTargetIndexShardsNum(
+                new ByteSizeValue(10),
+                new StoreStats(100, between(1, 10000)),
+                indexMetadata
+            ),
+            10
+        );
+        assertEquals(
+            TransportResizeAction.calculateTargetIndexShardsNum(
+                new ByteSizeValue(12),
+                new StoreStats(100, between(1, 10000)),
+                indexMetadata
+            ),
+            indexMetadata.getNumberOfShards()
+        );
+        assertEquals(
+            TransportResizeAction.calculateTargetIndexShardsNum(
+                new ByteSizeValue(20),
+                new StoreStats(100, between(1, 10000)),
+                indexMetadata
+            ),
+            5
+        );
+        assertEquals(
+            TransportResizeAction.calculateTargetIndexShardsNum(
+                new ByteSizeValue(50),
+                new StoreStats(100, between(1, 10000)),
+                indexMetadata
+            ),
+            2
+        );
     }
 
     private DiscoveryNode newNode(String nodeId) {


### PR DESCRIPTION
### Description
Backport [953a3d](https://github.com/opensearch-project/OpenSearch/commit/953a3d6851632c9b09c8dc15dbff02c8aafac6c1) from #5229 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
