### PR TITLE
[Feature/Identity] Default to Noop Authentication Manager

### DIFF
--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -132,7 +132,7 @@ import org.opensearch.gateway.PersistedClusterStateService;
 import org.opensearch.http.HttpServerTransport;
 import org.opensearch.authn.AuthenticationManager;
 import org.opensearch.identity.Identity;
-import org.opensearch.authn.internal.InternalAuthenticationManager;
+import org.opensearch.identity.noop.NoopAuthenticationManager;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.analysis.AnalysisRegistry;
 import org.opensearch.index.engine.EngineFactory;
@@ -459,7 +459,7 @@ public class Node implements Closeable {
             localNodeFactory = new LocalNodeFactory(settings, nodeEnvironment.nodeId());
 
             // TODO: revisit this
-            final AuthenticationManager authManager = new InternalAuthenticationManager();
+            final AuthenticationManager authManager = new NoopAuthenticationManager();
             Identity.setAuthManager(authManager);
 
             final List<ExecutorBuilder<?>> executorBuilders = pluginsService.getExecutorBuilders(settings);


### PR DESCRIPTION
### Description
Default to Noop Authentication Manager

In tests that require the internal manager we should use `Identity.setAuthManager(...);` to switch systems.

### Check List
- [ ] ~New functionality includes testing.~
  - [X] All tests pass
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
