### PR TITLE
Properly skip OnDemandBlockSnapshotIndexInputTests.testVariousBlockSize on Windows

### DIFF
--- a/server/src/test/java/org/opensearch/index/store/remote/file/OnDemandBlockSnapshotIndexInputTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/file/OnDemandBlockSnapshotIndexInputTests.java
@@ -53,7 +53,6 @@ public class OnDemandBlockSnapshotIndexInputTests extends OpenSearchTestCase {
 
     @Before
     public void init() {
-        assumeFalse("Awaiting Windows fix https://github.com/opensearch-project/OpenSearch/issues/5396", Constants.WINDOWS);
         transferManager = mock(TransferManager.class);
         lockFactory = SimpleFSLockFactory.INSTANCE;
         path = LuceneTestCase.createTempDir("OnDemandBlockSnapshotIndexInputTests");
@@ -69,6 +68,7 @@ public class OnDemandBlockSnapshotIndexInputTests extends OpenSearchTestCase {
     }
 
     public void testVariousBlockSize() throws Exception {
+        assumeFalse("Awaiting Windows fix https://github.com/opensearch-project/OpenSearch/issues/5396", Constants.WINDOWS);
         int fileSize = 29360128;
         int blockSizeShift;
 


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
PR https://github.com/opensearch-project/OpenSearch/pull/5397 skipped this test in @Before block but still frequently throws a TestCouldNotBeSkippedException - CI run https://build.ci.opensearch.org/job/gradle-check/7840/testReport/junit/org.opensearch.index.store.remote.file/OnDemandBlockSnapshotIndexInputTests/testVariousBlockSize/.  This is caused by the after block still executing and throwing  an exception while cleaning the directory created at the path in @Before.  Moving the assumption to the individual test prevents this exception by ensuring the path exists.

Validated manually on Windows 10.


### Issues Resolved
related https://github.com/opensearch-project/OpenSearch/issues/5396

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
