### PR TITLE
[Backport-2.x]Atomically update cluster state with decommission status and corresponding action

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsAction.java
@@ -44,10 +44,8 @@ import org.opensearch.cluster.ClusterStateObserver.Listener;
 import org.opensearch.cluster.ClusterStateUpdateTask;
 import org.opensearch.cluster.block.ClusterBlockException;
 import org.opensearch.cluster.block.ClusterBlockLevel;
-import org.opensearch.cluster.coordination.CoordinationMetadata;
 import org.opensearch.cluster.coordination.CoordinationMetadata.VotingConfigExclusion;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
-import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Priority;
 import org.opensearch.common.inject.Inject;
@@ -59,6 +57,8 @@ import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.function.Predicate;
+
+import static org.opensearch.action.admin.cluster.configuration.VotingConfigExclusionsHelper.clearExclusionsAndGetState;
 
 /**
  * Transport endpoint action for clearing exclusions to voting config
@@ -166,13 +166,7 @@ public class TransportClearVotingConfigExclusionsAction extends TransportCluster
         clusterService.submitStateUpdateTask("clear-voting-config-exclusions", new ClusterStateUpdateTask(Priority.URGENT) {
             @Override
             public ClusterState execute(ClusterState currentState) {
-                final CoordinationMetadata newCoordinationMetadata = CoordinationMetadata.builder(currentState.coordinationMetadata())
-                    .clearVotingConfigExclusions()
-                    .build();
-                final Metadata newMetadata = Metadata.builder(currentState.metadata())
-                    .coordinationMetadata(newCoordinationMetadata)
-                    .build();
-                return ClusterState.builder(currentState).metadata(newMetadata).build();
+                return clearExclusionsAndGetState(currentState);
             }
 
             @Override

--- a/server/src/main/java/org/opensearch/action/admin/cluster/configuration/VotingConfigExclusionsHelper.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/configuration/VotingConfigExclusionsHelper.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.configuration;
+
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.coordination.CoordinationMetadata;
+import org.opensearch.cluster.coordination.CoordinationMetadata.VotingConfigExclusion;
+import org.opensearch.cluster.metadata.Metadata;
+
+import java.util.Set;
+
+import static org.opensearch.action.admin.cluster.configuration.TransportAddVotingConfigExclusionsAction.MAXIMUM_VOTING_CONFIG_EXCLUSIONS_SETTING;
+
+/**
+ * Static helper utilities for voting config exclusions cluster state updates
+ *
+ * @opensearch.internal
+ */
+public class VotingConfigExclusionsHelper {
+
+    /**
+     * Static helper to update current state with given resolved exclusions
+     *
+     * @param currentState current cluster state
+     * @param resolvedExclusions resolved exclusions from the request
+     * @param finalMaxVotingConfigExclusions max exclusions that be added
+     * @return newly formed cluster state
+     */
+    public static ClusterState addExclusionAndGetState(
+        ClusterState currentState,
+        Set<VotingConfigExclusion> resolvedExclusions,
+        int finalMaxVotingConfigExclusions
+    ) {
+        final CoordinationMetadata.Builder builder = CoordinationMetadata.builder(currentState.coordinationMetadata());
+        resolvedExclusions.forEach(builder::addVotingConfigExclusion);
+        final Metadata newMetadata = Metadata.builder(currentState.metadata()).coordinationMetadata(builder.build()).build();
+        final ClusterState newState = ClusterState.builder(currentState).metadata(newMetadata).build();
+        assert newState.getVotingConfigExclusions().size() <= finalMaxVotingConfigExclusions;
+        return newState;
+    }
+
+    /**
+     * Resolves the exclusion from the request and throws IAE if no nodes matched or maximum exceeded
+     *
+     * @param request AddVotingConfigExclusionsRequest request
+     * @param state current cluster state
+     * @param maxVotingConfigExclusions max number of exclusion acceptable
+     * @return set of VotingConfigExclusion
+     */
+    public static Set<VotingConfigExclusion> resolveVotingConfigExclusionsAndCheckMaximum(
+        AddVotingConfigExclusionsRequest request,
+        ClusterState state,
+        int maxVotingConfigExclusions
+    ) {
+        return request.resolveVotingConfigExclusionsAndCheckMaximum(
+            state,
+            maxVotingConfigExclusions,
+            MAXIMUM_VOTING_CONFIG_EXCLUSIONS_SETTING.getKey()
+        );
+    }
+
+    /**
+     * Clears Voting config exclusion from the given cluster state
+     *
+     * @param currentState current cluster state
+     * @return newly formed cluster state after clearing voting config exclusions
+     */
+    public static ClusterState clearExclusionsAndGetState(ClusterState currentState) {
+        final CoordinationMetadata newCoordinationMetadata = CoordinationMetadata.builder(currentState.coordinationMetadata())
+            .clearVotingConfigExclusions()
+            .build();
+        final Metadata newMetadata = Metadata.builder(currentState.metadata()).coordinationMetadata(newCoordinationMetadata).build();
+        return ClusterState.builder(currentState).metadata(newMetadata).build();
+    }
+}

--- a/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java
@@ -106,7 +106,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static org.opensearch.cluster.coordination.NoClusterManagerBlockService.NO_CLUSTER_MANAGER_BLOCK_ID;
-import static org.opensearch.cluster.decommission.DecommissionService.nodeCommissioned;
+import static org.opensearch.cluster.decommission.DecommissionHelper.nodeCommissioned;
 import static org.opensearch.gateway.ClusterStateUpdaters.hideStateIfNotRecovered;
 import static org.opensearch.gateway.GatewayService.STATE_NOT_RECOVERED_BLOCK;
 import static org.opensearch.monitor.StatusInfo.Status.UNHEALTHY;

--- a/server/src/main/java/org/opensearch/cluster/coordination/JoinTaskExecutor.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/JoinTaskExecutor.java
@@ -61,7 +61,7 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
-import static org.opensearch.cluster.decommission.DecommissionService.nodeCommissioned;
+import static org.opensearch.cluster.decommission.DecommissionHelper.nodeCommissioned;
 import static org.opensearch.gateway.GatewayService.STATE_NOT_RECOVERED_BLOCK;
 
 /**

--- a/server/src/main/java/org/opensearch/cluster/decommission/DecommissionHelper.java
+++ b/server/src/main/java/org/opensearch/cluster/decommission/DecommissionHelper.java
@@ -1,0 +1,124 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.decommission;
+
+import org.opensearch.action.admin.cluster.configuration.AddVotingConfigExclusionsRequest;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.coordination.CoordinationMetadata.VotingConfigExclusion;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.Strings;
+import org.opensearch.common.unit.TimeValue;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import static org.opensearch.action.admin.cluster.configuration.VotingConfigExclusionsHelper.resolveVotingConfigExclusionsAndCheckMaximum;
+import static org.opensearch.action.admin.cluster.configuration.VotingConfigExclusionsHelper.addExclusionAndGetState;
+
+/**
+ * Static helper utilities to execute decommission
+ *
+ * @opensearch.internal
+ */
+public class DecommissionHelper {
+
+    static ClusterState registerDecommissionAttributeInClusterState(
+        ClusterState currentState,
+        DecommissionAttribute decommissionAttribute
+    ) {
+        DecommissionAttributeMetadata decommissionAttributeMetadata = new DecommissionAttributeMetadata(decommissionAttribute);
+        return ClusterState.builder(currentState)
+            .metadata(Metadata.builder(currentState.metadata()).decommissionAttributeMetadata(decommissionAttributeMetadata))
+            .build();
+    }
+
+    static ClusterState deleteDecommissionAttributeInClusterState(ClusterState currentState) {
+        Metadata metadata = currentState.metadata();
+        Metadata.Builder mdBuilder = Metadata.builder(metadata);
+        mdBuilder.removeCustom(DecommissionAttributeMetadata.TYPE);
+        return ClusterState.builder(currentState).metadata(mdBuilder).build();
+    }
+
+    static ClusterState addVotingConfigExclusionsForNodesToBeDecommissioned(
+        ClusterState currentState,
+        Set<String> nodeIdsToBeExcluded,
+        TimeValue decommissionActionTimeout,
+        final int maxVotingConfigExclusions
+    ) {
+        AddVotingConfigExclusionsRequest request = new AddVotingConfigExclusionsRequest(
+            Strings.EMPTY_ARRAY,
+            nodeIdsToBeExcluded.toArray(String[]::new),
+            Strings.EMPTY_ARRAY,
+            decommissionActionTimeout
+        );
+        Set<VotingConfigExclusion> resolvedExclusion = resolveVotingConfigExclusionsAndCheckMaximum(
+            request,
+            currentState,
+            maxVotingConfigExclusions
+        );
+        return addExclusionAndGetState(currentState, resolvedExclusion, maxVotingConfigExclusions);
+    }
+
+    static Set<DiscoveryNode> filterNodesWithDecommissionAttribute(
+        ClusterState clusterState,
+        DecommissionAttribute decommissionAttribute,
+        boolean onlyClusterManagerNodes
+    ) {
+        Set<DiscoveryNode> nodesWithDecommissionAttribute = new HashSet<>();
+        Iterator<DiscoveryNode> nodesIter = onlyClusterManagerNodes
+            ? clusterState.nodes().getClusterManagerNodes().valuesIt()
+            : clusterState.nodes().getNodes().valuesIt();
+
+        while (nodesIter.hasNext()) {
+            final DiscoveryNode node = nodesIter.next();
+            if (nodeHasDecommissionedAttribute(node, decommissionAttribute)) {
+                nodesWithDecommissionAttribute.add(node);
+            }
+        }
+        return nodesWithDecommissionAttribute;
+    }
+
+    /**
+     * Utility method to check if the node has decommissioned attribute
+     *
+     * @param discoveryNode node to check on
+     * @param decommissionAttribute attribute to be checked with
+     * @return true or false based on whether node has decommissioned attribute
+     */
+    public static boolean nodeHasDecommissionedAttribute(DiscoveryNode discoveryNode, DecommissionAttribute decommissionAttribute) {
+        String nodeAttributeValue = discoveryNode.getAttributes().get(decommissionAttribute.attributeName());
+        return nodeAttributeValue != null && nodeAttributeValue.equals(decommissionAttribute.attributeValue());
+    }
+
+    /**
+     * Utility method to check if the node is commissioned or not
+     *
+     * @param discoveryNode node to check on
+     * @param metadata metadata present current which will be used to check the commissioning status of the node
+     * @return if the node is commissioned or not
+     */
+    public static boolean nodeCommissioned(DiscoveryNode discoveryNode, Metadata metadata) {
+        DecommissionAttributeMetadata decommissionAttributeMetadata = metadata.decommissionAttributeMetadata();
+        if (decommissionAttributeMetadata != null) {
+            DecommissionAttribute decommissionAttribute = decommissionAttributeMetadata.decommissionAttribute();
+            DecommissionStatus status = decommissionAttributeMetadata.status();
+            if (decommissionAttribute != null && status != null) {
+                if (nodeHasDecommissionedAttribute(discoveryNode, decommissionAttribute)
+                    && (status.equals(DecommissionStatus.IN_PROGRESS)
+                        || status.equals(DecommissionStatus.SUCCESSFUL)
+                        || status.equals(DecommissionStatus.DRAINING))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/server/src/main/java/org/opensearch/cluster/decommission/DecommissionService.java
+++ b/server/src/main/java/org/opensearch/cluster/decommission/DecommissionService.java
@@ -18,9 +18,10 @@ import org.opensearch.action.admin.cluster.decommission.awareness.put.Decommissi
 import org.opensearch.action.admin.cluster.decommission.awareness.put.DecommissionRequest;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterStateObserver;
+import org.opensearch.cluster.ClusterStateObserver.Listener;
 import org.opensearch.cluster.ClusterStateUpdateTask;
 import org.opensearch.cluster.NotClusterManagerException;
-import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.coordination.CoordinationMetadata;
 import org.opensearch.cluster.metadata.WeightedRoutingMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.WeightedRouting;
@@ -35,14 +36,19 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static org.opensearch.action.admin.cluster.configuration.TransportAddVotingConfigExclusionsAction.MAXIMUM_VOTING_CONFIG_EXCLUSIONS_SETTING;
+import static org.opensearch.action.admin.cluster.configuration.VotingConfigExclusionsHelper.clearExclusionsAndGetState;
+import static org.opensearch.cluster.decommission.DecommissionHelper.addVotingConfigExclusionsForNodesToBeDecommissioned;
+import static org.opensearch.cluster.decommission.DecommissionHelper.deleteDecommissionAttributeInClusterState;
+import static org.opensearch.cluster.decommission.DecommissionHelper.filterNodesWithDecommissionAttribute;
+import static org.opensearch.cluster.decommission.DecommissionHelper.nodeHasDecommissionedAttribute;
+import static org.opensearch.cluster.decommission.DecommissionHelper.registerDecommissionAttributeInClusterState;
 import static org.opensearch.cluster.routing.allocation.decider.AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING;
 import static org.opensearch.cluster.routing.allocation.decider.AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_FORCE_GROUP_SETTING;
 
@@ -54,8 +60,7 @@ import static org.opensearch.cluster.routing.allocation.decider.AwarenessAllocat
  * <ul>
  * <li>Initiates nodes decommissioning by adding custom metadata with the attribute and state as {@link DecommissionStatus#INIT}</li>
  * <li>Remove to-be-decommissioned cluster-manager eligible nodes from voting config and wait for its abdication if it is active leader</li>
- * <li>Triggers weigh away for nodes having given awareness attribute to drain.</li>
- * <li>Once weighed away, the service triggers nodes decommission. This marks the decommission status as {@link DecommissionStatus#IN_PROGRESS}</li>
+ * <li>After the draining timeout, the service triggers nodes decommission. This marks the decommission status as {@link DecommissionStatus#IN_PROGRESS}</li>
  * <li>Once the decommission is successful, the service clears the voting config and marks the status as {@link DecommissionStatus#SUCCESSFUL}</li>
  * <li>If service fails at any step, it makes best attempt to mark the status as {@link DecommissionStatus#FAILED} and to clear voting config exclusion</li>
  * </ul>
@@ -72,6 +77,7 @@ public class DecommissionService {
     private final DecommissionController decommissionController;
     private volatile List<String> awarenessAttributes;
     private volatile Map<String, List<String>> forcedAwarenessAttributes;
+    private volatile int maxVotingConfigExclusions;
 
     @Inject
     public DecommissionService(
@@ -94,6 +100,8 @@ public class DecommissionService {
             CLUSTER_ROUTING_ALLOCATION_AWARENESS_FORCE_GROUP_SETTING,
             this::setForcedAwarenessAttributes
         );
+        maxVotingConfigExclusions = MAXIMUM_VOTING_CONFIG_EXCLUSIONS_SETTING.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(MAXIMUM_VOTING_CONFIG_EXCLUSIONS_SETTING, this::setMaxVotingConfigExclusions);
     }
 
     private void setAwarenessAttributes(List<String> awarenessAttributes) {
@@ -112,6 +120,10 @@ public class DecommissionService {
         this.forcedAwarenessAttributes = forcedAwarenessAttributes;
     }
 
+    private void setMaxVotingConfigExclusions(int maxVotingConfigExclusions) {
+        this.maxVotingConfigExclusions = maxVotingConfigExclusions;
+    }
+
     /**
      * Starts the new decommission request and registers the metadata with status as {@link DecommissionStatus#INIT}
      * Once the status is updated, it tries to exclude to-be-decommissioned cluster manager eligible nodes from Voting Configuration
@@ -126,20 +138,37 @@ public class DecommissionService {
         final DecommissionAttribute decommissionAttribute = decommissionRequest.getDecommissionAttribute();
         // register the metadata with status as INIT as first step
         clusterService.submitStateUpdateTask("decommission [" + decommissionAttribute + "]", new ClusterStateUpdateTask(Priority.URGENT) {
+            private Set<String> nodeIdsToBeExcluded;
+
             @Override
             public ClusterState execute(ClusterState currentState) {
                 // validates if correct awareness attributes and forced awareness attribute set to the cluster before starting action
                 validateAwarenessAttribute(decommissionAttribute, awarenessAttributes, forcedAwarenessAttributes);
                 DecommissionAttributeMetadata decommissionAttributeMetadata = currentState.metadata().decommissionAttributeMetadata();
-                // check that request is eligible to proceed
+                // check that request is eligible to proceed and attribute is weighed away
                 ensureEligibleRequest(decommissionAttributeMetadata, decommissionAttribute);
-                // ensure attribute is weighed away
                 ensureToBeDecommissionedAttributeWeighedAway(currentState, decommissionAttribute);
-                decommissionAttributeMetadata = new DecommissionAttributeMetadata(decommissionAttribute);
-                logger.info("registering decommission metadata [{}] to execute action", decommissionAttributeMetadata.toString());
-                return ClusterState.builder(currentState)
-                    .metadata(Metadata.builder(currentState.metadata()).decommissionAttributeMetadata(decommissionAttributeMetadata))
-                    .build();
+
+                ClusterState newState = registerDecommissionAttributeInClusterState(currentState, decommissionAttribute);
+                // add all 'to-be-decommissioned' cluster manager eligible nodes to voting config exclusion
+                nodeIdsToBeExcluded = filterNodesWithDecommissionAttribute(currentState, decommissionAttribute, true).stream()
+                    .map(DiscoveryNode::getId)
+                    .collect(Collectors.toSet());
+                logger.info(
+                    "resolved cluster manager eligible nodes [{}] that should be added to voting config exclusion",
+                    nodeIdsToBeExcluded.toString()
+                );
+                newState = addVotingConfigExclusionsForNodesToBeDecommissioned(
+                    newState,
+                    nodeIdsToBeExcluded,
+                    TimeValue.timeValueSeconds(120), // TODO - update it with request timeout
+                    maxVotingConfigExclusions
+                );
+                logger.debug(
+                    "registering decommission metadata [{}] to execute action",
+                    newState.metadata().decommissionAttributeMetadata().toString()
+                );
+                return newState;
             }
 
             @Override
@@ -158,160 +187,111 @@ public class DecommissionService {
             public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
                 DecommissionAttributeMetadata decommissionAttributeMetadata = newState.metadata().decommissionAttributeMetadata();
                 assert decommissionAttribute.equals(decommissionAttributeMetadata.decommissionAttribute());
-                logger.info(
+                assert decommissionAttributeMetadata.status().equals(DecommissionStatus.INIT);
+                assert newState.getVotingConfigExclusions()
+                    .stream()
+                    .map(CoordinationMetadata.VotingConfigExclusion::getNodeId)
+                    .collect(Collectors.toSet())
+                    .containsAll(nodeIdsToBeExcluded);
+                logger.debug(
                     "registered decommission metadata for attribute [{}] with status [{}]",
                     decommissionAttributeMetadata.decommissionAttribute(),
                     decommissionAttributeMetadata.status()
                 );
-                decommissionClusterManagerNodes(decommissionRequest, listener);
+
+                final ClusterStateObserver observer = new ClusterStateObserver(
+                    clusterService,
+                    TimeValue.timeValueSeconds(120), // TODO - update it with request timeout
+                    logger,
+                    threadPool.getThreadContext()
+                );
+
+                final Predicate<ClusterState> allNodesRemovedAndAbdicated = clusterState -> {
+                    final Set<String> votingConfigNodeIds = clusterState.getLastCommittedConfiguration().getNodeIds();
+                    return nodeIdsToBeExcluded.stream().noneMatch(votingConfigNodeIds::contains)
+                        && clusterState.nodes().getClusterManagerNodeId() != null
+                        && nodeIdsToBeExcluded.contains(clusterState.nodes().getClusterManagerNodeId()) == false;
+                };
+
+                final Listener clusterStateListener = new Listener() {
+                    @Override
+                    public void onNewClusterState(ClusterState state) {
+                        logger.info(
+                            "successfully removed decommissioned cluster manager eligible nodes [{}] from voting config ",
+                            nodeIdsToBeExcluded.toString()
+                        );
+                        if (state.nodes().isLocalNodeElectedClusterManager()) {
+                            if (nodeHasDecommissionedAttribute(clusterService.localNode(), decommissionAttribute)) {
+                                // this is an unexpected state, as after exclusion of nodes having decommission attribute,
+                                // this local node shouldn't have had the decommission attribute. Will send the failure response to the user
+                                String errorMsg =
+                                    "unexpected state encountered [local node is to-be-decommissioned leader] while executing decommission request";
+                                logger.error(errorMsg);
+                                // will go ahead and clear the voting config and mark the status as failed
+                                decommissionController.updateMetadataWithDecommissionStatus(
+                                    DecommissionStatus.FAILED,
+                                    statusUpdateListener()
+                                );
+                                listener.onFailure(new IllegalStateException(errorMsg));
+                            } else {
+                                logger.info("will proceed to drain decommissioned nodes as local node is eligible to process the request");
+                                // we are good here to send the response now as the request is processed by an eligible active leader
+                                // and to-be-decommissioned cluster manager is no more part of Voting Configuration
+                                listener.onResponse(new DecommissionResponse(true));
+                                drainNodesWithDecommissionedAttribute(decommissionRequest);
+                            }
+                        } else {
+                            // explicitly calling listener.onFailure with NotClusterManagerException as the local node is not leader
+                            // this will ensures that request is retried until cluster manager times out
+                            logger.info(
+                                "local node is not eligible to process the request, "
+                                    + "throwing NotClusterManagerException to attempt a retry on an eligible node"
+                            );
+                            listener.onFailure(
+                                new NotClusterManagerException(
+                                    "node ["
+                                        + transportService.getLocalNode().toString()
+                                        + "] not eligible to execute decommission request. Will retry until timeout."
+                                )
+                            );
+                        }
+                    }
+
+                    @Override
+                    public void onClusterServiceClose() {
+                        String errorMsg = "cluster service closed while waiting for abdication of to-be-decommissioned leader";
+                        logger.error(errorMsg);
+                        listener.onFailure(new DecommissioningFailedException(decommissionAttribute, errorMsg));
+                    }
+
+                    @Override
+                    public void onTimeout(TimeValue timeout) {
+                        String errorMsg = "timed out ["
+                            + timeout.toString()
+                            + "] while removing to-be-decommissioned cluster manager eligible nodes ["
+                            + nodeIdsToBeExcluded.toString()
+                            + "] from voting config";
+                        logger.error(errorMsg);
+                        listener.onFailure(new OpenSearchTimeoutException(errorMsg));
+                        // will go ahead and clear the voting config and mark the status as failed
+                        decommissionController.updateMetadataWithDecommissionStatus(DecommissionStatus.FAILED, statusUpdateListener());
+                    }
+                };
+
+                // In case the cluster state is already processed even before this code is executed
+                // therefore testing first before attaching the listener
+                if (allNodesRemovedAndAbdicated.test(newState)) {
+                    clusterStateListener.onNewClusterState(newState);
+                } else {
+                    logger.debug("waiting to abdicate to-be-decommissioned leader");
+                    observer.waitForNextChange(clusterStateListener, allNodesRemovedAndAbdicated); // TODO add request timeout here
+                }
             }
         });
     }
 
-    private synchronized void decommissionClusterManagerNodes(
-        final DecommissionRequest decommissionRequest,
-        ActionListener<DecommissionResponse> listener
-    ) {
-        final DecommissionAttribute decommissionAttribute = decommissionRequest.getDecommissionAttribute();
-        ClusterState state = clusterService.getClusterApplierService().state();
-        // since here metadata is already registered with INIT, we can guarantee that no new node with decommission attribute can further
-        // join the cluster
-        // and hence in further request lifecycle we are sure that no new to-be-decommission leader will join the cluster
-        Set<DiscoveryNode> clusterManagerNodesToBeDecommissioned = filterNodesWithDecommissionAttribute(state, decommissionAttribute, true);
-        logger.info(
-            "resolved cluster manager eligible nodes [{}] that should be removed from Voting Configuration",
-            clusterManagerNodesToBeDecommissioned.toString()
-        );
-
-        // remove all 'to-be-decommissioned' cluster manager eligible nodes from voting config
-        Set<String> nodeIdsToBeExcluded = clusterManagerNodesToBeDecommissioned.stream()
-            .map(DiscoveryNode::getId)
-            .collect(Collectors.toSet());
-
-        final Predicate<ClusterState> allNodesRemovedAndAbdicated = clusterState -> {
-            final Set<String> votingConfigNodeIds = clusterState.getLastCommittedConfiguration().getNodeIds();
-            return nodeIdsToBeExcluded.stream().noneMatch(votingConfigNodeIds::contains)
-                && nodeIdsToBeExcluded.contains(clusterState.nodes().getClusterManagerNodeId()) == false
-                && clusterState.nodes().getClusterManagerNodeId() != null;
-        };
-
-        ActionListener<Void> exclusionListener = new ActionListener<Void>() {
-            @Override
-            public void onResponse(Void unused) {
-                if (clusterService.getClusterApplierService().state().nodes().isLocalNodeElectedClusterManager()) {
-                    if (nodeHasDecommissionedAttribute(clusterService.localNode(), decommissionAttribute)) {
-                        // this is an unexpected state, as after exclusion of nodes having decommission attribute,
-                        // this local node shouldn't have had the decommission attribute. Will send the failure response to the user
-                        String errorMsg =
-                            "unexpected state encountered [local node is to-be-decommissioned leader] while executing decommission request";
-                        logger.error(errorMsg);
-                        // will go ahead and clear the voting config and mark the status as false
-                        clearVotingConfigExclusionAndUpdateStatus(false, false);
-                        // we can send the failure response to the user here
-                        listener.onFailure(new IllegalStateException(errorMsg));
-                    } else {
-                        logger.info("will attempt to fail decommissioned nodes as local node is eligible to process the request");
-                        // we are good here to send the response now as the request is processed by an eligible active leader
-                        // and to-be-decommissioned cluster manager is no more part of Voting Configuration and no more to-be-decommission
-                        // nodes can be part of Voting Config
-                        listener.onResponse(new DecommissionResponse(true));
-                        drainNodesWithDecommissionedAttribute(decommissionRequest);
-                    }
-                } else {
-                    // explicitly calling listener.onFailure with NotClusterManagerException as the local node is not the cluster manager
-                    // this will ensures that request is retried until cluster manager times out
-                    logger.info(
-                        "local node is not eligible to process the request, "
-                            + "throwing NotClusterManagerException to attempt a retry on an eligible node"
-                    );
-                    listener.onFailure(
-                        new NotClusterManagerException(
-                            "node ["
-                                + transportService.getLocalNode().toString()
-                                + "] not eligible to execute decommission request. Will retry until timeout."
-                        )
-                    );
-                }
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                listener.onFailure(e);
-                // attempting to mark the status as FAILED
-                clearVotingConfigExclusionAndUpdateStatus(false, false);
-            }
-        };
-
-        if (allNodesRemovedAndAbdicated.test(state)) {
-            exclusionListener.onResponse(null);
-        } else {
-            logger.debug("sending transport request to remove nodes [{}] from voting config", nodeIdsToBeExcluded.toString());
-            // send a transport request to exclude to-be-decommissioned cluster manager eligible nodes from voting config
-            decommissionController.excludeDecommissionedNodesFromVotingConfig(nodeIdsToBeExcluded, new ActionListener<Void>() {
-                @Override
-                public void onResponse(Void unused) {
-                    logger.info(
-                        "successfully removed decommissioned cluster manager eligible nodes [{}] from voting config ",
-                        clusterManagerNodesToBeDecommissioned.toString()
-                    );
-                    final ClusterStateObserver abdicationObserver = new ClusterStateObserver(
-                        clusterService,
-                        TimeValue.timeValueSeconds(60L),
-                        logger,
-                        threadPool.getThreadContext()
-                    );
-                    final ClusterStateObserver.Listener abdicationListener = new ClusterStateObserver.Listener() {
-                        @Override
-                        public void onNewClusterState(ClusterState state) {
-                            logger.debug("to-be-decommissioned node is no more the active leader");
-                            exclusionListener.onResponse(null);
-                        }
-
-                        @Override
-                        public void onClusterServiceClose() {
-                            String errorMsg = "cluster service closed while waiting for abdication of to-be-decommissioned leader";
-                            logger.warn(errorMsg);
-                            listener.onFailure(new DecommissioningFailedException(decommissionAttribute, errorMsg));
-                        }
-
-                        @Override
-                        public void onTimeout(TimeValue timeout) {
-                            logger.info("timed out while waiting for abdication of to-be-decommissioned leader");
-                            clearVotingConfigExclusionAndUpdateStatus(false, false);
-                            listener.onFailure(
-                                new OpenSearchTimeoutException(
-                                    "timed out [{}] while waiting for abdication of to-be-decommissioned leader",
-                                    timeout.toString()
-                                )
-                            );
-                        }
-                    };
-                    // In case the cluster state is already processed even before this code is executed
-                    // therefore testing first before attaching the listener
-                    ClusterState currentState = clusterService.getClusterApplierService().state();
-                    if (allNodesRemovedAndAbdicated.test(currentState)) {
-                        abdicationListener.onNewClusterState(currentState);
-                    } else {
-                        logger.debug("waiting to abdicate to-be-decommissioned leader");
-                        abdicationObserver.waitForNextChange(abdicationListener, allNodesRemovedAndAbdicated);
-                    }
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    logger.error(
-                        new ParameterizedMessage(
-                            "failure in removing to-be-decommissioned cluster manager eligible nodes [{}] from voting config",
-                            nodeIdsToBeExcluded.toString()
-                        ),
-                        e
-                    );
-                    exclusionListener.onFailure(e);
-                }
-            });
-        }
-    }
-
+    // TODO - after registering the new status check if any node which is not excluded still present in decommissioned zone. If yes, start
+    // the action again (retry)
     void drainNodesWithDecommissionedAttribute(DecommissionRequest decommissionRequest) {
         ClusterState state = clusterService.getClusterApplierService().state();
         Set<DiscoveryNode> decommissionedNodes = filterNodesWithDecommissionAttribute(
@@ -342,8 +322,10 @@ public class DecommissionService {
                         ),
                         e
                     );
-                    // since we are not able to update the status, we will clear the voting config exclusion we have set earlier
-                    clearVotingConfigExclusionAndUpdateStatus(false, false);
+                    // This decommission state update call will most likely fail as the state update call to 'DRAINING'
+                    // failed. But attempting it anyways as FAILED update might still pass as it doesn't have dependency on
+                    // the current state
+                    decommissionController.updateMetadataWithDecommissionStatus(DecommissionStatus.FAILED, statusUpdateListener());
                 }
             });
         }
@@ -385,12 +367,17 @@ public class DecommissionService {
                     new ActionListener<Void>() {
                         @Override
                         public void onResponse(Void unused) {
-                            clearVotingConfigExclusionAndUpdateStatus(true, true);
+                            // will clear the voting config exclusion and mark the status as successful
+                            decommissionController.updateMetadataWithDecommissionStatus(
+                                DecommissionStatus.SUCCESSFUL,
+                                statusUpdateListener()
+                            );
                         }
 
                         @Override
                         public void onFailure(Exception e) {
-                            clearVotingConfigExclusionAndUpdateStatus(false, false);
+                            // will go ahead and clear the voting config and mark the status as failed
+                            decommissionController.updateMetadataWithDecommissionStatus(DecommissionStatus.FAILED, statusUpdateListener());
                         }
                     }
                 );
@@ -406,51 +393,12 @@ public class DecommissionService {
                     ),
                     e
                 );
-                // since we are not able to update the status, we will clear the voting config exclusion we have set earlier
-                clearVotingConfigExclusionAndUpdateStatus(false, false);
-            }
-        });
-    }
-
-    private void clearVotingConfigExclusionAndUpdateStatus(boolean decommissionSuccessful, boolean waitForRemoval) {
-        decommissionController.clearVotingConfigExclusion(new ActionListener<Void>() {
-            @Override
-            public void onResponse(Void unused) {
-                logger.info(
-                    "successfully cleared voting config exclusion after completing decommission action, proceeding to update metadata"
-                );
-                DecommissionStatus updateStatusWith = decommissionSuccessful ? DecommissionStatus.SUCCESSFUL : DecommissionStatus.FAILED;
-                decommissionController.updateMetadataWithDecommissionStatus(updateStatusWith, statusUpdateListener());
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                logger.debug(
-                    new ParameterizedMessage("failure in clearing voting config exclusion after processing decommission request"),
-                    e
-                );
+                // This decommission state update call will most likely fail as the state update call to 'DRAINING'
+                // failed. But attempting it anyways as FAILED update might still pass as it doesn't have dependency on
+                // the current state
                 decommissionController.updateMetadataWithDecommissionStatus(DecommissionStatus.FAILED, statusUpdateListener());
             }
-        }, waitForRemoval);
-    }
-
-    private Set<DiscoveryNode> filterNodesWithDecommissionAttribute(
-        ClusterState clusterState,
-        DecommissionAttribute decommissionAttribute,
-        boolean onlyClusterManagerNodes
-    ) {
-        Set<DiscoveryNode> nodesWithDecommissionAttribute = new HashSet<>();
-        Iterator<DiscoveryNode> nodesIter = onlyClusterManagerNodes
-            ? clusterState.nodes().getClusterManagerNodes().valuesIt()
-            : clusterState.nodes().getNodes().valuesIt();
-
-        while (nodesIter.hasNext()) {
-            final DiscoveryNode node = nodesIter.next();
-            if (nodeHasDecommissionedAttribute(node, decommissionAttribute)) {
-                nodesWithDecommissionAttribute.add(node);
-            }
-        }
-        return nodesWithDecommissionAttribute;
+        });
     }
 
     private static void validateAwarenessAttribute(
@@ -577,80 +525,28 @@ public class DecommissionService {
          * Once the excluded nodes have stopped, clear the voting configuration exclusions with DELETE /_cluster/voting_config_exclusions.
          * And hence it is safe to remove the exclusion if any. User should make conscious choice before decommissioning awareness attribute.
          */
-        decommissionController.clearVotingConfigExclusion(new ActionListener<Void>() {
-            @Override
-            public void onResponse(Void unused) {
-                logger.info("successfully cleared voting config exclusion for deleting the decommission.");
-                deleteDecommissionState(listener);
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                logger.error("Failure in clearing voting config during delete_decommission request.", e);
-                listener.onFailure(e);
-            }
-        }, false);
-    }
-
-    void deleteDecommissionState(ActionListener<DeleteDecommissionStateResponse> listener) {
-        clusterService.submitStateUpdateTask("delete_decommission_state", new ClusterStateUpdateTask(Priority.URGENT) {
+        clusterService.submitStateUpdateTask("delete-decommission-state", new ClusterStateUpdateTask(Priority.URGENT) {
             @Override
             public ClusterState execute(ClusterState currentState) {
+                ClusterState newState = clearExclusionsAndGetState(currentState);
                 logger.info("Deleting the decommission attribute from the cluster state");
-                Metadata metadata = currentState.metadata();
-                Metadata.Builder mdBuilder = Metadata.builder(metadata);
-                mdBuilder.removeCustom(DecommissionAttributeMetadata.TYPE);
-                return ClusterState.builder(currentState).metadata(mdBuilder).build();
+                newState = deleteDecommissionAttributeInClusterState(newState);
+                return newState;
             }
 
             @Override
             public void onFailure(String source, Exception e) {
-                logger.error(() -> new ParameterizedMessage("Failed to clear decommission attribute. [{}]", source), e);
+                logger.error(() -> new ParameterizedMessage("failure during recommission action [{}]", source), e);
                 listener.onFailure(e);
             }
 
             @Override
             public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                // Cluster state processed for deleting the decommission attribute.
+                logger.info("successfully cleared voting config exclusion and decommissioned attribute");
                 assert newState.metadata().decommissionAttributeMetadata() == null;
+                assert newState.coordinationMetadata().getVotingConfigExclusions().isEmpty();
                 listener.onResponse(new DeleteDecommissionStateResponse(true));
             }
         });
-    }
-
-    /**
-     * Utility method to check if the node has decommissioned attribute
-     *
-     * @param discoveryNode node to check on
-     * @param decommissionAttribute attribute to be checked with
-     * @return true or false based on whether node has decommissioned attribute
-     */
-    public static boolean nodeHasDecommissionedAttribute(DiscoveryNode discoveryNode, DecommissionAttribute decommissionAttribute) {
-        String nodeAttributeValue = discoveryNode.getAttributes().get(decommissionAttribute.attributeName());
-        return nodeAttributeValue != null && nodeAttributeValue.equals(decommissionAttribute.attributeValue());
-    }
-
-    /**
-     * Utility method to check if the node is commissioned or not
-     *
-     * @param discoveryNode node to check on
-     * @param metadata metadata present current which will be used to check the commissioning status of the node
-     * @return if the node is commissioned or not
-     */
-    public static boolean nodeCommissioned(DiscoveryNode discoveryNode, Metadata metadata) {
-        DecommissionAttributeMetadata decommissionAttributeMetadata = metadata.decommissionAttributeMetadata();
-        if (decommissionAttributeMetadata != null) {
-            DecommissionAttribute decommissionAttribute = decommissionAttributeMetadata.decommissionAttribute();
-            DecommissionStatus status = decommissionAttributeMetadata.status();
-            if (decommissionAttribute != null && status != null) {
-                if (nodeHasDecommissionedAttribute(discoveryNode, decommissionAttribute)
-                    && (status.equals(DecommissionStatus.IN_PROGRESS)
-                        || status.equals(DecommissionStatus.SUCCESSFUL)
-                        || status.equals(DecommissionStatus.DRAINING))) {
-                    return false;
-                }
-            }
-        }
-        return true;
     }
 }

--- a/server/src/test/java/org/opensearch/action/admin/cluster/configuration/VotingConfigExclusionsHelperTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/configuration/VotingConfigExclusionsHelperTests.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.configuration;
+
+import org.junit.BeforeClass;
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.coordination.CoordinationMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodeRole;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.common.Strings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Set;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static org.opensearch.action.admin.cluster.configuration.VotingConfigExclusionsHelper.addExclusionAndGetState;
+import static org.opensearch.action.admin.cluster.configuration.VotingConfigExclusionsHelper.clearExclusionsAndGetState;
+import static org.opensearch.action.admin.cluster.configuration.VotingConfigExclusionsHelper.resolveVotingConfigExclusionsAndCheckMaximum;
+
+public class VotingConfigExclusionsHelperTests extends OpenSearchTestCase {
+
+    private static DiscoveryNode localNode, otherNode1, otherNode2, otherDataNode;
+    private static CoordinationMetadata.VotingConfigExclusion localNodeExclusion, otherNode1Exclusion, otherNode2Exclusion;
+    private static ClusterState initialClusterState;
+
+    public void testAddExclusionAndGetState() {
+        ClusterState updatedState = addExclusionAndGetState(initialClusterState, Set.of(localNodeExclusion), 2);
+        assertTrue(updatedState.coordinationMetadata().getVotingConfigExclusions().contains(localNodeExclusion));
+        assertEquals(1, updatedState.coordinationMetadata().getVotingConfigExclusions().size());
+    }
+
+    public void testResolveVotingConfigExclusions() {
+        AddVotingConfigExclusionsRequest request = new AddVotingConfigExclusionsRequest(
+            Strings.EMPTY_ARRAY,
+            new String[] { "other1" },
+            Strings.EMPTY_ARRAY,
+            TimeValue.timeValueSeconds(30)
+        );
+        Set<CoordinationMetadata.VotingConfigExclusion> votingConfigExclusions = resolveVotingConfigExclusionsAndCheckMaximum(
+            request,
+            initialClusterState,
+            10
+        );
+        assertEquals(1, votingConfigExclusions.size());
+        assertTrue(votingConfigExclusions.contains(otherNode1Exclusion));
+    }
+
+    public void testResolveVotingConfigExclusionFailsWhenLimitExceeded() {
+        AddVotingConfigExclusionsRequest request = new AddVotingConfigExclusionsRequest(
+            Strings.EMPTY_ARRAY,
+            new String[] { "other1", "other2" },
+            Strings.EMPTY_ARRAY,
+            TimeValue.timeValueSeconds(30)
+        );
+        expectThrows(IllegalArgumentException.class, () -> resolveVotingConfigExclusionsAndCheckMaximum(request, initialClusterState, 1));
+    }
+
+    public void testClearExclusionAndGetState() {
+        ClusterState updatedState = addExclusionAndGetState(initialClusterState, Set.of(localNodeExclusion), 2);
+        assertTrue(updatedState.coordinationMetadata().getVotingConfigExclusions().contains(localNodeExclusion));
+        updatedState = clearExclusionsAndGetState(updatedState);
+        assertTrue(updatedState.coordinationMetadata().getVotingConfigExclusions().isEmpty());
+    }
+
+    @BeforeClass
+    public static void createBaseClusterState() {
+        localNode = makeDiscoveryNode("local");
+        localNodeExclusion = new CoordinationMetadata.VotingConfigExclusion(localNode);
+        otherNode1 = makeDiscoveryNode("other1");
+        otherNode1Exclusion = new CoordinationMetadata.VotingConfigExclusion(otherNode1);
+        otherNode2 = makeDiscoveryNode("other2");
+        otherNode2Exclusion = new CoordinationMetadata.VotingConfigExclusion(otherNode2);
+        otherDataNode = new DiscoveryNode("data", "data", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT);
+        final CoordinationMetadata.VotingConfiguration allNodesConfig = CoordinationMetadata.VotingConfiguration.of(
+            localNode,
+            otherNode1,
+            otherNode2
+        );
+        initialClusterState = ClusterState.builder(new ClusterName("cluster"))
+            .nodes(
+                new DiscoveryNodes.Builder().add(localNode)
+                    .add(otherNode1)
+                    .add(otherNode2)
+                    .add(otherDataNode)
+                    .localNodeId(localNode.getId())
+                    .clusterManagerNodeId(localNode.getId())
+            )
+            .metadata(
+                Metadata.builder()
+                    .coordinationMetadata(
+                        CoordinationMetadata.builder()
+                            .lastAcceptedConfiguration(allNodesConfig)
+                            .lastCommittedConfiguration(allNodesConfig)
+                            .build()
+                    )
+            )
+            .build();
+    }
+
+    private static DiscoveryNode makeDiscoveryNode(String name) {
+        return new DiscoveryNode(
+            name,
+            name,
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            singleton(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE),
+            Version.CURRENT
+        );
+    }
+}

--- a/server/src/test/java/org/opensearch/cluster/decommission/DecommissionHelperTests.java
+++ b/server/src/test/java/org/opensearch/cluster/decommission/DecommissionHelperTests.java
@@ -1,0 +1,142 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.decommission;
+
+import org.junit.BeforeClass;
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.coordination.CoordinationMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodeRole;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import static org.opensearch.cluster.decommission.DecommissionHelper.addVotingConfigExclusionsForNodesToBeDecommissioned;
+import static org.opensearch.cluster.decommission.DecommissionHelper.deleteDecommissionAttributeInClusterState;
+import static org.opensearch.cluster.decommission.DecommissionHelper.filterNodesWithDecommissionAttribute;
+import static org.opensearch.cluster.decommission.DecommissionHelper.nodeCommissioned;
+import static org.opensearch.cluster.decommission.DecommissionHelper.registerDecommissionAttributeInClusterState;
+
+public class DecommissionHelperTests extends OpenSearchTestCase {
+
+    private static DiscoveryNode node1, node2, node3, dataNode;
+    private static ClusterState initialClusterState;
+
+    public void testRegisterAndDeleteDecommissionAttributeInClusterState() {
+        DecommissionAttribute decommissionAttribute = new DecommissionAttribute("zone", "zone2");
+        ClusterState updatedState = registerDecommissionAttributeInClusterState(initialClusterState, decommissionAttribute);
+        assertEquals(decommissionAttribute, updatedState.metadata().decommissionAttributeMetadata().decommissionAttribute());
+        updatedState = deleteDecommissionAttributeInClusterState(updatedState);
+        assertNull(updatedState.metadata().decommissionAttributeMetadata());
+    }
+
+    public void testAddVotingConfigExclusionsForNodesToBeDecommissioned() {
+        Set<String> nodeIdToBeExcluded = Set.of("node2");
+        ClusterState updatedState = addVotingConfigExclusionsForNodesToBeDecommissioned(
+            initialClusterState,
+            nodeIdToBeExcluded,
+            TimeValue.timeValueMinutes(1),
+            10
+        );
+        CoordinationMetadata.VotingConfigExclusion v1 = new CoordinationMetadata.VotingConfigExclusion(node2);
+        assertTrue(
+            updatedState.coordinationMetadata().getVotingConfigExclusions().contains(new CoordinationMetadata.VotingConfigExclusion(node2))
+        );
+        assertEquals(1, updatedState.coordinationMetadata().getVotingConfigExclusions().size());
+    }
+
+    public void testFilterNodes() {
+        DecommissionAttribute decommissionAttribute = new DecommissionAttribute("zone", "zone1");
+        Set<DiscoveryNode> filteredNodes = filterNodesWithDecommissionAttribute(initialClusterState, decommissionAttribute, true);
+        assertTrue(filteredNodes.contains(node1));
+        assertEquals(1, filteredNodes.size());
+        filteredNodes = filterNodesWithDecommissionAttribute(initialClusterState, decommissionAttribute, false);
+        assertTrue(filteredNodes.contains(node1));
+        assertTrue(filteredNodes.contains(dataNode));
+        assertEquals(2, filteredNodes.size());
+    }
+
+    public void testNodeCommissioned() {
+        DecommissionAttribute decommissionAttribute = new DecommissionAttribute("zone", "zone1");
+        DecommissionStatus decommissionStatus = randomFrom(
+            DecommissionStatus.IN_PROGRESS,
+            DecommissionStatus.DRAINING,
+            DecommissionStatus.SUCCESSFUL
+        );
+        DecommissionAttributeMetadata decommissionAttributeMetadata = new DecommissionAttributeMetadata(
+            decommissionAttribute,
+            decommissionStatus
+        );
+        Metadata metadata = Metadata.builder().putCustom(DecommissionAttributeMetadata.TYPE, decommissionAttributeMetadata).build();
+        assertTrue(nodeCommissioned(node2, metadata));
+        assertFalse(nodeCommissioned(node1, metadata));
+        DecommissionStatus commissionStatus = randomFrom(DecommissionStatus.FAILED, DecommissionStatus.INIT);
+        decommissionAttributeMetadata = new DecommissionAttributeMetadata(decommissionAttribute, commissionStatus);
+        metadata = Metadata.builder().putCustom(DecommissionAttributeMetadata.TYPE, decommissionAttributeMetadata).build();
+        assertTrue(nodeCommissioned(node2, metadata));
+        assertTrue(nodeCommissioned(node1, metadata));
+        metadata = Metadata.builder().removeCustom(DecommissionAttributeMetadata.TYPE).build();
+        assertTrue(nodeCommissioned(node2, metadata));
+        assertTrue(nodeCommissioned(node1, metadata));
+    }
+
+    @BeforeClass
+    public static void createBaseClusterState() {
+        node1 = makeDiscoveryNode("node1", "zone1");
+        node2 = makeDiscoveryNode("node2", "zone2");
+        node3 = makeDiscoveryNode("node3", "zone3");
+        dataNode = new DiscoveryNode(
+            "data",
+            "data",
+            buildNewFakeTransportAddress(),
+            singletonMap("zone", "zone1"),
+            emptySet(),
+            Version.CURRENT
+        );
+        final CoordinationMetadata.VotingConfiguration allNodesConfig = CoordinationMetadata.VotingConfiguration.of(node1, node2, node3);
+        initialClusterState = ClusterState.builder(new ClusterName("cluster"))
+            .nodes(
+                new DiscoveryNodes.Builder().add(node1)
+                    .add(node2)
+                    .add(node3)
+                    .add(dataNode)
+                    .localNodeId(node1.getId())
+                    .clusterManagerNodeId(node1.getId())
+            )
+            .metadata(
+                Metadata.builder()
+                    .coordinationMetadata(
+                        CoordinationMetadata.builder()
+                            .lastAcceptedConfiguration(allNodesConfig)
+                            .lastCommittedConfiguration(allNodesConfig)
+                            .build()
+                    )
+            )
+            .build();
+    }
+
+    private static DiscoveryNode makeDiscoveryNode(String name, String zone) {
+        return new DiscoveryNode(
+            name,
+            name,
+            buildNewFakeTransportAddress(),
+            singletonMap("zone", zone),
+            singleton(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE),
+            Version.CURRENT
+        );
+    }
+}


### PR DESCRIPTION
…nding action (#5093)

* Atomically update the cluster state with decommission status and its corresponding action in the same execute call

Signed-off-by: Rishab Nahata <rnnahata@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Backport - https://github.com/opensearch-project/OpenSearch/pull/5093

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
