### PR TITLE
[Weighted Routing] Weighted routing metadata to support multiple awareness attributes

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchWeightedRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchWeightedRoutingIT.java
@@ -129,7 +129,11 @@ public class SearchWeightedRoutingIT extends OpenSearchIntegTestCase {
 
         logger.info("--> deleted shard routing weights for weighted round robin");
 
-        ClusterDeleteWeightedRoutingResponse deleteResponse = client().admin().cluster().prepareDeleteWeightedRouting().get();
+        ClusterDeleteWeightedRoutingResponse deleteResponse = client().admin()
+            .cluster()
+            .prepareDeleteWeightedRouting()
+            .setAwarenessAttribute("zone")
+            .get();
         assertEquals(deleteResponse.isAcknowledged(), true);
 
         hitNodes = new HashSet<>();

--- a/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/delete/ClusterDeleteWeightedRoutingRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/delete/ClusterDeleteWeightedRoutingRequest.java
@@ -59,8 +59,8 @@ public class ClusterDeleteWeightedRoutingRequest extends ClusterManagerNodeReque
         out.writeString(awarenessAttribute);
     }
 
-    // @Override
-    // public String toString() {
-    // return "ClusterDeleteWeightedRoutingRequest";
-    // }
+    @Override
+    public String toString() {
+        return "ClusterDeleteWeightedRoutingRequest { awarenessAttribute= " + awarenessAttribute + "}";
+    }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/delete/ClusterDeleteWeightedRoutingRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/delete/ClusterDeleteWeightedRoutingRequest.java
@@ -15,26 +15,48 @@ import org.opensearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
+import static org.opensearch.action.ValidateActions.addValidationError;
+
 /**
  * Request to delete weights for weighted round-robin shard routing policy.
  *
  * @opensearch.internal
  */
 public class ClusterDeleteWeightedRoutingRequest extends ClusterManagerNodeRequest<ClusterDeleteWeightedRoutingRequest> {
+    String awarenessAttribute;
+
+    public String getAwarenessAttribute() {
+        return awarenessAttribute;
+    }
+
+    public void setAwarenessAttribute(String awarenessAttribute) {
+        this.awarenessAttribute = awarenessAttribute;
+    }
+
+    public ClusterDeleteWeightedRoutingRequest(String awarenessAttribute) {
+        this.awarenessAttribute = awarenessAttribute;
+    }
+
     public ClusterDeleteWeightedRoutingRequest() {}
 
     public ClusterDeleteWeightedRoutingRequest(StreamInput in) throws IOException {
         super(in);
+        awarenessAttribute = in.readString();
     }
 
     @Override
     public ActionRequestValidationException validate() {
-        return null;
+        ActionRequestValidationException validationException = null;
+        if (awarenessAttribute == null || awarenessAttribute.isEmpty()) {
+            validationException = addValidationError("Awareness attribute is missing", validationException);
+        }
+        return validationException;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
+        out.writeString(awarenessAttribute);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/delete/ClusterDeleteWeightedRoutingRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/delete/ClusterDeleteWeightedRoutingRequest.java
@@ -59,8 +59,8 @@ public class ClusterDeleteWeightedRoutingRequest extends ClusterManagerNodeReque
         out.writeString(awarenessAttribute);
     }
 
-    @Override
-    public String toString() {
-        return "ClusterDeleteWeightedRoutingRequest";
-    }
+    // @Override
+    // public String toString() {
+    // return "ClusterDeleteWeightedRoutingRequest";
+    // }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/delete/ClusterDeleteWeightedRoutingRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/delete/ClusterDeleteWeightedRoutingRequest.java
@@ -23,7 +23,7 @@ import static org.opensearch.action.ValidateActions.addValidationError;
  * @opensearch.internal
  */
 public class ClusterDeleteWeightedRoutingRequest extends ClusterManagerNodeRequest<ClusterDeleteWeightedRoutingRequest> {
-    String awarenessAttribute;
+    private String awarenessAttribute;
 
     public String getAwarenessAttribute() {
         return awarenessAttribute;

--- a/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/delete/ClusterDeleteWeightedRoutingRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/delete/ClusterDeleteWeightedRoutingRequestBuilder.java
@@ -24,4 +24,9 @@ public class ClusterDeleteWeightedRoutingRequestBuilder extends ClusterManagerNo
     public ClusterDeleteWeightedRoutingRequestBuilder(OpenSearchClient client, ClusterDeleteWeightedRoutingAction action) {
         super(client, action, new ClusterDeleteWeightedRoutingRequest());
     }
+
+    public ClusterDeleteWeightedRoutingRequestBuilder setAwarenessAttribute(String attribute) {
+        request.setAwarenessAttribute(attribute);
+        return this;
+    }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/delete/ClusterDeleteWeightedRoutingResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/delete/ClusterDeleteWeightedRoutingResponse.java
@@ -32,6 +32,5 @@ public class ClusterDeleteWeightedRoutingResponse extends AcknowledgedResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/get/ClusterGetWeightedRoutingRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/get/ClusterGetWeightedRoutingRequest.java
@@ -24,7 +24,7 @@ import static org.opensearch.action.ValidateActions.addValidationError;
  */
 public class ClusterGetWeightedRoutingRequest extends ClusterManagerNodeReadRequest<ClusterGetWeightedRoutingRequest> {
 
-    String awarenessAttribute;
+    private String awarenessAttribute;
 
     public String getAwarenessAttribute() {
         return awarenessAttribute;

--- a/server/src/main/java/org/opensearch/client/Requests.java
+++ b/server/src/main/java/org/opensearch/client/Requests.java
@@ -578,8 +578,8 @@ public class Requests {
      *
      * @return delete weight request
      */
-    public static ClusterDeleteWeightedRoutingRequest deleteWeightedRoutingRequest() {
-        return new ClusterDeleteWeightedRoutingRequest();
+    public static ClusterDeleteWeightedRoutingRequest deleteWeightedRoutingRequest(String attributeName) {
+        return new ClusterDeleteWeightedRoutingRequest(attributeName);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/decommission/DecommissionService.java
+++ b/server/src/main/java/org/opensearch/cluster/decommission/DecommissionService.java
@@ -427,14 +427,14 @@ public class DecommissionService {
 
     private static void ensureToBeDecommissionedAttributeWeighedAway(ClusterState state, DecommissionAttribute decommissionAttribute) {
         WeightedRoutingMetadata weightedRoutingMetadata = state.metadata().weightedRoutingMetadata();
-        if (weightedRoutingMetadata == null) {
+        if (weightedRoutingMetadata.getWeightedRouting(decommissionAttribute.attributeName()) == null) {
             throw new DecommissioningFailedException(
                 decommissionAttribute,
                 "no weights are set to the attribute. Please set appropriate weights before triggering decommission action"
             );
         }
-        WeightedRouting weightedRouting = weightedRoutingMetadata.getWeightedRouting();
-        if (weightedRouting.attributeName().equals(decommissionAttribute.attributeName()) == false) {
+        WeightedRouting weightedRouting = weightedRoutingMetadata.getWeightedRouting(decommissionAttribute.attributeName());
+        if (weightedRouting == null) {
             throw new DecommissioningFailedException(
                 decommissionAttribute,
                 "no weights are specified to attribute [" + decommissionAttribute.attributeName() + "]"

--- a/server/src/main/java/org/opensearch/cluster/decommission/DecommissionService.java
+++ b/server/src/main/java/org/opensearch/cluster/decommission/DecommissionService.java
@@ -427,7 +427,7 @@ public class DecommissionService {
 
     private static void ensureToBeDecommissionedAttributeWeighedAway(ClusterState state, DecommissionAttribute decommissionAttribute) {
         WeightedRoutingMetadata weightedRoutingMetadata = state.metadata().weightedRoutingMetadata();
-        if (weightedRoutingMetadata.getWeightedRouting(decommissionAttribute.attributeName()) == null) {
+        if (weightedRoutingMetadata == null || weightedRoutingMetadata.getWeightedRouting(decommissionAttribute.attributeName()) == null) {
             throw new DecommissioningFailedException(
                 decommissionAttribute,
                 "no weights are set to the attribute. Please set appropriate weights before triggering decommission action"

--- a/server/src/main/java/org/opensearch/cluster/metadata/WeightedRoutingMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/WeightedRoutingMetadata.java
@@ -46,6 +46,7 @@ public class WeightedRoutingMetadata extends AbstractNamedDiffable<Metadata.Cust
         for (WeightedRouting wRouting : this.weightedRoutings) {
             if (wRouting.attributeName().equals(awarenessAttribute)) {
                 weightedRouting = wRouting;
+                break;
             }
         }
         return weightedRouting;

--- a/server/src/main/java/org/opensearch/cluster/metadata/WeightedRoutingMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/WeightedRoutingMetadata.java
@@ -39,12 +39,6 @@ public class WeightedRoutingMetadata extends AbstractNamedDiffable<Metadata.Cust
     private static final Logger logger = LogManager.getLogger(WeightedRoutingMetadata.class);
     public static final String TYPE = "weighted_shard_routing";
     public static final String AWARENESS = "awareness";
-    // private WeightedRouting weightedRouting;
-
-    public List<WeightedRouting> getWeightedRoutings() {
-        return weightedRoutings;
-    }
-
     private List<WeightedRouting> weightedRoutings;
 
     public WeightedRouting getWeightedRouting(String awarenessAttribute) {
@@ -57,10 +51,9 @@ public class WeightedRoutingMetadata extends AbstractNamedDiffable<Metadata.Cust
         return weightedRouting;
     }
 
-    // public WeightedRoutingMetadata setWeightedRouting(WeightedRouting weightedRouting) {
-    // this.weightedRouting = weightedRouting;
-    // return this;
-    // }
+    public List<WeightedRouting> getWeightedRoutings() {
+        return weightedRoutings;
+    }
 
     public WeightedRoutingMetadata(List<WeightedRouting> weightedRoutings) {
         this.weightedRoutings = weightedRoutings;
@@ -72,10 +65,6 @@ public class WeightedRoutingMetadata extends AbstractNamedDiffable<Metadata.Cust
             this.weightedRoutings = in.readList(WeightedRouting::new);
         }
     }
-
-    // public WeightedRoutingMetadata(WeightedRouting weightedRouting) {
-    // this.weightedRouting = weightedRouting;
-    // }
 
     @Override
     public EnumSet<Metadata.XContentContext> context() {

--- a/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
@@ -326,7 +326,7 @@ public class OperationRouting {
     ) {
         if (weightedRoutingMetadata != null) {
             return indexShard.activeInitializingShardsWeightedIt(
-                weightedRoutingMetadata.getWeightedRouting(),
+                weightedRoutingMetadata.getWeightedRouting("zone"),
                 nodes,
                 getWeightedRoutingDefaultWeight()
             );

--- a/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
@@ -83,6 +83,8 @@ public class OperationRouting {
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
+
+    public static final String WEIGHTED_ROUTING_AWARENESS_ATTRIBUTE = "zone";
     private volatile List<String> awarenessAttributes;
     private volatile boolean useAdaptiveReplicaSelection;
     private volatile boolean ignoreAwarenessAttr;
@@ -324,10 +326,10 @@ public class OperationRouting {
         @Nullable Map<String, Long> nodeCounts,
         @Nullable WeightedRoutingMetadata weightedRoutingMetadata
     ) {
-        if (weightedRoutingMetadata != null && weightedRoutingMetadata.getWeightedRouting("zone") != null) {
+        if (weightedRoutingMetadata != null && weightedRoutingMetadata.getWeightedRouting(WEIGHTED_ROUTING_AWARENESS_ATTRIBUTE) != null) {
             // Weighted round-robin supports zone as awareness attribute currently
             return indexShard.activeInitializingShardsWeightedIt(
-                weightedRoutingMetadata.getWeightedRouting("zone"),
+                weightedRoutingMetadata.getWeightedRouting(WEIGHTED_ROUTING_AWARENESS_ATTRIBUTE),
                 nodes,
                 getWeightedRoutingDefaultWeight()
             );

--- a/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
@@ -324,7 +324,7 @@ public class OperationRouting {
         @Nullable Map<String, Long> nodeCounts,
         @Nullable WeightedRoutingMetadata weightedRoutingMetadata
     ) {
-        if (weightedRoutingMetadata != null) {
+        if (weightedRoutingMetadata != null && weightedRoutingMetadata.getWeightedRouting("zone")!=null) {
             // Weighted round-robin supports zone as awareness attribute currently
             return indexShard.activeInitializingShardsWeightedIt(
                 weightedRoutingMetadata.getWeightedRouting("zone"),

--- a/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
@@ -324,7 +324,7 @@ public class OperationRouting {
         @Nullable Map<String, Long> nodeCounts,
         @Nullable WeightedRoutingMetadata weightedRoutingMetadata
     ) {
-        if (weightedRoutingMetadata != null && weightedRoutingMetadata.getWeightedRouting("zone")!=null) {
+        if (weightedRoutingMetadata != null && weightedRoutingMetadata.getWeightedRouting("zone") != null) {
             // Weighted round-robin supports zone as awareness attribute currently
             return indexShard.activeInitializingShardsWeightedIt(
                 weightedRoutingMetadata.getWeightedRouting("zone"),

--- a/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
@@ -325,6 +325,7 @@ public class OperationRouting {
         @Nullable WeightedRoutingMetadata weightedRoutingMetadata
     ) {
         if (weightedRoutingMetadata != null) {
+            // Weighted round-robin supports zone as awareness attribute currently
             return indexShard.activeInitializingShardsWeightedIt(
                 weightedRoutingMetadata.getWeightedRouting("zone"),
                 nodes,

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterDeleteWeightedRoutingAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterDeleteWeightedRoutingAction.java
@@ -35,7 +35,7 @@ public class RestClusterDeleteWeightedRoutingAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return singletonList(new Route(DELETE, "/_cluster/routing/awareness/weights"));
+        return singletonList(new Route(DELETE, "/_cluster/routing/awareness/{attribute}/weights"));
     }
 
     @Override
@@ -45,7 +45,9 @@ public class RestClusterDeleteWeightedRoutingAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        ClusterDeleteWeightedRoutingRequest clusterDeleteWeightedRoutingRequest = Requests.deleteWeightedRoutingRequest();
+        ClusterDeleteWeightedRoutingRequest clusterDeleteWeightedRoutingRequest = Requests.deleteWeightedRoutingRequest(
+            request.param("attribute")
+        );
         return channel -> client.admin()
             .cluster()
             .deleteWeightedRouting(clusterDeleteWeightedRoutingRequest, new RestToXContentListener<>(channel));

--- a/server/src/test/java/org/opensearch/cluster/action/shard/routing/weighted/get/TransportGetWeightedRoutingActionTests.java
+++ b/server/src/test/java/org/opensearch/cluster/action/shard/routing/weighted/get/TransportGetWeightedRoutingActionTests.java
@@ -174,7 +174,7 @@ public class TransportGetWeightedRoutingActionTests extends OpenSearchTestCase {
 
     private ClusterState setWeightedRoutingWeights(ClusterState clusterState, Map<String, Double> weights) {
         WeightedRouting weightedRouting = new WeightedRouting("zone", weights);
-        WeightedRoutingMetadata weightedRoutingMetadata = new WeightedRoutingMetadata(weightedRouting);
+        WeightedRoutingMetadata weightedRoutingMetadata = new WeightedRoutingMetadata(Collections.singletonList(weightedRouting));
         Metadata.Builder metadataBuilder = Metadata.builder(clusterState.metadata());
         metadataBuilder.putCustom(WeightedRoutingMetadata.TYPE, weightedRoutingMetadata);
         clusterState = ClusterState.builder(clusterState).metadata(metadataBuilder).build();

--- a/server/src/test/java/org/opensearch/cluster/decommission/DecommissionServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/decommission/DecommissionServiceTests.java
@@ -39,8 +39,10 @@ import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -358,8 +360,10 @@ public class DecommissionServiceTests extends OpenSearchTestCase {
 
     private void setWeightedRoutingWeights(Map<String, Double> weights) {
         ClusterState clusterState = clusterService.state();
+        List<WeightedRouting> weightedRoutings = new ArrayList<>();
         WeightedRouting weightedRouting = new WeightedRouting("zone", weights);
-        WeightedRoutingMetadata weightedRoutingMetadata = new WeightedRoutingMetadata(weightedRouting);
+        weightedRoutings.add(weightedRouting);
+        WeightedRoutingMetadata weightedRoutingMetadata = new WeightedRoutingMetadata(weightedRoutings);
         Metadata.Builder metadataBuilder = Metadata.builder(clusterState.metadata());
         metadataBuilder.putCustom(WeightedRoutingMetadata.TYPE, weightedRoutingMetadata);
         clusterState = ClusterState.builder(clusterState).metadata(metadataBuilder).build();

--- a/server/src/test/java/org/opensearch/cluster/metadata/WeightedRoutingMetadataTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/WeightedRoutingMetadataTests.java
@@ -13,14 +13,23 @@ import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.test.AbstractXContentTestCase;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class WeightedRoutingMetadataTests extends AbstractXContentTestCase<WeightedRoutingMetadata> {
     @Override
     protected WeightedRoutingMetadata createTestInstance() {
-        Map<String, Double> weights = Map.of("a", 1.0, "b", 1.0, "c", 0.0);
-        WeightedRouting weightedRouting = new WeightedRouting("zone", weights);
-        WeightedRoutingMetadata weightedRoutingMetadata = new WeightedRoutingMetadata(weightedRouting);
+        Map<String, Double> weights1 = Map.of("a", 1.0, "b", 1.0, "c", 0.0);
+        WeightedRouting weightedRouting = new WeightedRouting("zone", weights1);
+        Map<String, Double> weights2 = Map.of("a", 1.0, "b", 0.0, "c", 0.0);
+        WeightedRouting weightedRouting2 = new WeightedRouting("rack", weights2);
+
+        List<WeightedRouting> weightedRoutings = new ArrayList<>();
+        weightedRoutings.add(weightedRouting);
+        weightedRoutings.add(weightedRouting2);
+
+        WeightedRoutingMetadata weightedRoutingMetadata = new WeightedRoutingMetadata(weightedRoutings);
         return weightedRoutingMetadata;
     }
 

--- a/server/src/test/java/org/opensearch/cluster/routing/OperationRoutingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/OperationRoutingTests.java
@@ -789,7 +789,7 @@ public class OperationRoutingTests extends OpenSearchTestCase {
 
     private ClusterState setWeightedRoutingWeights(ClusterState clusterState, Map<String, Double> weights) {
         WeightedRouting weightedRouting = new WeightedRouting("zone", weights);
-        WeightedRoutingMetadata weightedRoutingMetadata = new WeightedRoutingMetadata(weightedRouting);
+        WeightedRoutingMetadata weightedRoutingMetadata = new WeightedRoutingMetadata(Collections.singletonList(weightedRouting));
         Metadata.Builder metadataBuilder = Metadata.builder(clusterState.metadata());
         metadataBuilder.putCustom(WeightedRoutingMetadata.TYPE, weightedRoutingMetadata);
         clusterState = ClusterState.builder(clusterState).metadata(metadataBuilder).build();
@@ -1158,7 +1158,7 @@ public class OperationRoutingTests extends OpenSearchTestCase {
         // add weighted routing weights in metadata
         Map<String, Double> weights = Map.of("a", 1.0, "b", 1.0, "c", 0.0);
         WeightedRouting weightedRouting = new WeightedRouting("zone", weights);
-        WeightedRoutingMetadata weightedRoutingMetadata = new WeightedRoutingMetadata(weightedRouting);
+        WeightedRoutingMetadata weightedRoutingMetadata = new WeightedRoutingMetadata(Collections.singletonList(weightedRouting));
         metadataBuilder.putCustom(WeightedRoutingMetadata.TYPE, weightedRoutingMetadata);
         clusterState.metadata(metadataBuilder);
         clusterState.routingTable(routingTableBuilder.build());

--- a/server/src/test/java/org/opensearch/cluster/routing/WeightedRoutingServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/WeightedRoutingServiceTests.java
@@ -267,12 +267,12 @@ public class WeightedRoutingServiceTests extends OpenSearchTestCase {
         ClusterServiceUtils.setState(clusterService, builder);
 
         ClusterDeleteWeightedRoutingRequest clusterDeleteWeightedRoutingRequest = new ClusterDeleteWeightedRoutingRequest();
+        clusterDeleteWeightedRoutingRequest.setAwarenessAttribute("zone");
         final CountDownLatch countDownLatch = new CountDownLatch(1);
         ActionListener<ClusterDeleteWeightedRoutingResponse> listener = new ActionListener<ClusterDeleteWeightedRoutingResponse>() {
             @Override
             public void onResponse(ClusterDeleteWeightedRoutingResponse clusterDeleteWeightedRoutingResponse) {
                 assertTrue(clusterDeleteWeightedRoutingResponse.isAcknowledged());
-                assertNull(clusterService.state().metadata().weightedRoutingMetadata());
                 countDownLatch.countDown();
             }
 

--- a/server/src/test/java/org/opensearch/cluster/routing/WeightedRoutingServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/WeightedRoutingServiceTests.java
@@ -175,7 +175,7 @@ public class WeightedRoutingServiceTests extends OpenSearchTestCase {
 
     private ClusterState setWeightedRoutingWeights(ClusterState clusterState, Map<String, Double> weights) {
         WeightedRouting weightedRouting = new WeightedRouting("zone", weights);
-        WeightedRoutingMetadata weightedRoutingMetadata = new WeightedRoutingMetadata(weightedRouting);
+        WeightedRoutingMetadata weightedRoutingMetadata = new WeightedRoutingMetadata(Collections.singletonList(weightedRouting));
         Metadata.Builder metadataBuilder = Metadata.builder(clusterState.metadata());
         metadataBuilder.putCustom(WeightedRoutingMetadata.TYPE, weightedRoutingMetadata);
         clusterState = ClusterState.builder(clusterState).metadata(metadataBuilder).build();
@@ -209,7 +209,10 @@ public class WeightedRoutingServiceTests extends OpenSearchTestCase {
             @Override
             public void onResponse(ClusterStateUpdateResponse clusterStateUpdateResponse) {
                 assertTrue(clusterStateUpdateResponse.isAcknowledged());
-                assertEquals(updatedWeightedRouting, clusterService.state().metadata().weightedRoutingMetadata().getWeightedRouting());
+                assertEquals(
+                    updatedWeightedRouting,
+                    clusterService.state().metadata().weightedRoutingMetadata().getWeightedRouting("zone")
+                );
                 countDownLatch.countDown();
             }
 
@@ -240,7 +243,10 @@ public class WeightedRoutingServiceTests extends OpenSearchTestCase {
             @Override
             public void onResponse(ClusterStateUpdateResponse clusterStateUpdateResponse) {
                 assertTrue(clusterStateUpdateResponse.isAcknowledged());
-                assertEquals(updatedWeightedRouting, clusterService.state().metadata().weightedRoutingMetadata().getWeightedRouting());
+                assertEquals(
+                    updatedWeightedRouting,
+                    clusterService.state().metadata().weightedRoutingMetadata().getWeightedRouting("zone")
+                );
                 countDownLatch.countDown();
             }
 
@@ -387,7 +393,10 @@ public class WeightedRoutingServiceTests extends OpenSearchTestCase {
             @Override
             public void onResponse(ClusterStateUpdateResponse clusterStateUpdateResponse) {
                 assertTrue(clusterStateUpdateResponse.isAcknowledged());
-                assertEquals(updatedWeightedRouting, clusterService.state().metadata().weightedRoutingMetadata().getWeightedRouting());
+                assertEquals(
+                    updatedWeightedRouting,
+                    clusterService.state().metadata().weightedRoutingMetadata().getWeightedRouting("zone")
+                );
                 countDownLatch.countDown();
             }
 
@@ -427,6 +436,6 @@ public class WeightedRoutingServiceTests extends OpenSearchTestCase {
         };
         weightedRoutingService.registerWeightedRoutingMetadata(request.request(), listener);
         assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
-        assertEquals(updatedWeightedRouting, clusterService.state().metadata().weightedRoutingMetadata().getWeightedRouting());
+        assertEquals(updatedWeightedRouting, clusterService.state().metadata().weightedRoutingMetadata().getWeightedRouting("zone"));
     }
 }


### PR DESCRIPTION
Signed-off-by: Anshu Agarwal <anshukag@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Currently as part of delete weighted routing api call, weighted routing metadata is cleared off completely from the cluster state without matching the awareness attribute. If weights are set for multiple awareness attributes, then this is not desirable.

This PR adds support for updating weights for multiple awareness attribute and delete specific awareness attribute weights.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/4747

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
