### PR TITLE
Run workflows on all OS versions in GHA.

### DIFF
--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -6,7 +6,10 @@ on:
 jobs:
   # Enforces the update of a changelog file on every pull request
   verify-changelog:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ 'ubuntu-22.04', 'ubuntu-20.04', 'ubuntu-latest' ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/code-hygiene.yml
+++ b/.github/workflows/code-hygiene.yml
@@ -4,7 +4,10 @@ on: [pull_request]
 
 jobs:
   linelint:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ 'ubuntu-22.04', 'ubuntu-20.04', 'ubuntu-latest' ]
     name: Check if all files end in newline
     steps:
       - name: Checkout

--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -16,8 +16,10 @@ jobs:
     permissions:
       contents: read # to fetch code (actions/checkout)
       pull-requests: write # to create or update comment (peter-evans/create-or-update-comment)
-
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ 'ubuntu-22.04', 'ubuntu-20.04', 'ubuntu-latest' ]
     timeout-minutes: 130
     steps:
       - name: Checkout OpenSearch repo

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -7,7 +7,10 @@ permissions:
 jobs:
   linkchecker:
     if: github.repository == 'opensearch-project/OpenSearch'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ 'ubuntu-22.04', 'ubuntu-20.04', 'ubuntu-latest' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lucene-snapshots.yml
+++ b/.github/workflows/lucene-snapshots.yml
@@ -13,7 +13,10 @@ on:
 
 jobs:
   publish-snapshots:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ 'ubuntu-22.04', 'ubuntu-20.04', 'ubuntu-latest' ]
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest] 
+        os: ['ubuntu-22.04', 'ubuntu-20.04', ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -4,7 +4,10 @@ on: [pull_request]
 jobs:
   validate:
     name: Validate
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ 'ubuntu-22.04', 'ubuntu-20.04', 'ubuntu-latest' ]
     steps:
       - uses: actions/checkout@v2
       - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
### Description
Update some CI workflows to run on all available OS versions.
This could be an overkill, but it helps to early detect CI OS templates deprecation or breaking change.

### Issues Resolved
Fixes #4610

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
