### PR TITLE
Change version check for cluster manager throttling setting to 2.5

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/service/ClusterManagerTaskThrottler.java
+++ b/server/src/main/java/org/opensearch/cluster/service/ClusterManagerTaskThrottler.java
@@ -115,8 +115,8 @@ public class ClusterManagerTaskThrottler implements TaskBatcherListener {
     void validateSetting(final Settings settings) {
         Map<String, Settings> groups = settings.getAsGroups();
         if (groups.size() > 0) {
-            if (minNodeVersionSupplier.get().compareTo(Version.V_2_4_0) < 0) {
-                throw new IllegalArgumentException("All the nodes in cluster should be on version later than or equal to 2.4.0");
+            if (minNodeVersionSupplier.get().compareTo(Version.V_2_5_0) < 0) {
+                throw new IllegalArgumentException("All the nodes in cluster should be on version later than or equal to 2.5.0");
             }
         }
         for (String key : groups.keySet()) {

--- a/server/src/test/java/org/opensearch/cluster/service/ClusterManagerTaskThrottlerTests.java
+++ b/server/src/test/java/org/opensearch/cluster/service/ClusterManagerTaskThrottlerTests.java
@@ -83,7 +83,7 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
     }
 
     public void testValidateSettingsForDifferentVersion() {
-        DiscoveryNode clusterManagerNode = getClusterManagerNode(Version.V_2_4_0);
+        DiscoveryNode clusterManagerNode = getClusterManagerNode(Version.V_2_5_0);
         DiscoveryNode dataNode = getDataNode(Version.V_2_0_0);
         setState(
             clusterService,
@@ -116,8 +116,8 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
     }
 
     public void testValidateSettingsForTaskWihtoutRetryOnDataNode() {
-        DiscoveryNode clusterManagerNode = getClusterManagerNode(Version.V_2_4_0);
-        DiscoveryNode dataNode = getDataNode(Version.V_2_4_0);
+        DiscoveryNode clusterManagerNode = getClusterManagerNode(Version.V_2_5_0);
+        DiscoveryNode dataNode = getDataNode(Version.V_2_5_0);
         setState(
             clusterService,
             ClusterStateCreationUtils.state(clusterManagerNode, clusterManagerNode, new DiscoveryNode[] { clusterManagerNode, dataNode })
@@ -140,8 +140,8 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
     }
 
     public void testUpdateSettingsForNullValue() {
-        DiscoveryNode clusterManagerNode = getClusterManagerNode(Version.V_2_4_0);
-        DiscoveryNode dataNode = getDataNode(Version.V_2_4_0);
+        DiscoveryNode clusterManagerNode = getClusterManagerNode(Version.V_2_5_0);
+        DiscoveryNode dataNode = getDataNode(Version.V_2_5_0);
         setState(
             clusterService,
             ClusterStateCreationUtils.state(clusterManagerNode, clusterManagerNode, new DiscoveryNode[] { clusterManagerNode, dataNode })
@@ -169,8 +169,8 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
     }
 
     public void testSettingsOnBootstrap() {
-        DiscoveryNode clusterManagerNode = getClusterManagerNode(Version.V_2_4_0);
-        DiscoveryNode dataNode = getDataNode(Version.V_2_4_0);
+        DiscoveryNode clusterManagerNode = getClusterManagerNode(Version.V_2_5_0);
+        DiscoveryNode dataNode = getDataNode(Version.V_2_5_0);
         setState(
             clusterService,
             ClusterStateCreationUtils.state(clusterManagerNode, clusterManagerNode, new DiscoveryNode[] { clusterManagerNode, dataNode })
@@ -194,8 +194,8 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
     }
 
     public void testValidateSettingsForUnknownTask() {
-        DiscoveryNode clusterManagerNode = getClusterManagerNode(Version.V_2_4_0);
-        DiscoveryNode dataNode = getDataNode(Version.V_2_4_0);
+        DiscoveryNode clusterManagerNode = getClusterManagerNode(Version.V_2_5_0);
+        DiscoveryNode dataNode = getDataNode(Version.V_2_5_0);
         setState(
             clusterService,
             ClusterStateCreationUtils.state(clusterManagerNode, clusterManagerNode, new DiscoveryNode[] { clusterManagerNode, dataNode })
@@ -216,8 +216,8 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
     }
 
     public void testUpdateThrottlingLimitForBasicSanity() {
-        DiscoveryNode clusterManagerNode = getClusterManagerNode(Version.V_2_4_0);
-        DiscoveryNode dataNode = getDataNode(Version.V_2_4_0);
+        DiscoveryNode clusterManagerNode = getClusterManagerNode(Version.V_2_5_0);
+        DiscoveryNode dataNode = getDataNode(Version.V_2_5_0);
         setState(
             clusterService,
             ClusterStateCreationUtils.state(clusterManagerNode, clusterManagerNode, new DiscoveryNode[] { clusterManagerNode, dataNode })
@@ -246,8 +246,8 @@ public class ClusterManagerTaskThrottlerTests extends OpenSearchTestCase {
     }
 
     public void testValidateSettingForLimit() {
-        DiscoveryNode clusterManagerNode = getClusterManagerNode(Version.V_2_4_0);
-        DiscoveryNode dataNode = getDataNode(Version.V_2_4_0);
+        DiscoveryNode clusterManagerNode = getClusterManagerNode(Version.V_2_5_0);
+        DiscoveryNode dataNode = getDataNode(Version.V_2_5_0);
         setState(
             clusterService,
             ClusterStateCreationUtils.state(clusterManagerNode, clusterManagerNode, new DiscoveryNode[] { clusterManagerNode, dataNode })


### PR DESCRIPTION
Signed-off-by: Dhwanil Patel <dhwanip@amazon.com>

### Description
Cluster manager throttling is releasing with 2.5 version, earlier it was planned to release with 2.4 version so we had 2.4 version check for throttling threshold settings.

Changing this version check to 2.5 version.

### Issues Resolved
#479 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
