### PR TITLE
[Feature/extensions]Added query for initialized extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
  - Updated settings registration changes to reflect main ([5532](https://github.com/opensearch-project/OpenSearch/pull/5532))
  - Added dependency information to Extensions ([#5438](https://github.com/opensearch-project/OpenSearch/pull/5438))
  - Renaming tests to be consistent with main branch ([#5571](https://github.com/opensearch-project/OpenSearch/pull/5571))
+ - Added query for initialized extensions([#5628](https://github.com/opensearch-project/OpenSearch/pull/5628))
 
 ## [Unreleased 2.x]
 ### Added

--- a/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
+++ b/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
@@ -84,11 +84,10 @@ public class DiscoveryExtensionNode extends DiscoveryNode implements Writeable, 
 
     public boolean dependenciesContain(ExtensionDependency dependency) {
         for (ExtensionDependency extensiondependency : this.dependencies) {
-            if (dependency.getUniqueId().equals(extensiondependency.getUniqueId())) {
-                if(dependency.getVersion().equals(extensiondependency.getVersion())) {
-                    return true;
-                }
-                return false;
+            if (dependency.getUniqueId().equals(extensiondependency.getUniqueId())
+                && dependency.getVersion().equals(extensiondependency.getVersion())) {
+                return true;
+
             }
         }
         return false;

--- a/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
+++ b/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
@@ -84,9 +84,10 @@ public class DiscoveryExtensionNode extends DiscoveryNode implements Writeable, 
 
     public boolean dependenciesContain(ExtensionDependency dependency) {
         for (ExtensionDependency extensiondependency : this.dependencies) {
-            // TODO also compare version
             if (dependency.getUniqueId().equals(extensiondependency.getUniqueId())) {
-                return true;
+                if(dependency.getVersion().equals(extensiondependency.getVersion())) {
+                    return true;
+                }
             }
         }
         return false;

--- a/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
+++ b/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
@@ -88,6 +88,7 @@ public class DiscoveryExtensionNode extends DiscoveryNode implements Writeable, 
                 if(dependency.getVersion().equals(extensiondependency.getVersion())) {
                     return true;
                 }
+                return false;
             }
         }
         return false;

--- a/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
+++ b/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
@@ -82,11 +82,10 @@ public class DiscoveryExtensionNode extends DiscoveryNode implements Writeable, 
         return dependencies;
     }
 
-
     public boolean dependenciesContain(ExtensionDependency dependency) {
-        for(ExtensionDependency extensiondependency : this.dependencies){
-            //TODO also compare version
-            if(dependency.getUniqueId().equals(extensiondependency.getUniqueId())){
+        for (ExtensionDependency extensiondependency : this.dependencies) {
+            // TODO also compare version
+            if (dependency.getUniqueId().equals(extensiondependency.getUniqueId())) {
                 return true;
             }
         }

--- a/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
+++ b/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
@@ -82,6 +82,17 @@ public class DiscoveryExtensionNode extends DiscoveryNode implements Writeable, 
         return dependencies;
     }
 
+
+    public boolean dependenciesContain(ExtensionDependency dependency) {
+        for(ExtensionDependency extensiondependency : this.dependencies){
+            //TODO also compare version
+            if(dependency.getUniqueId().equals(extensiondependency.getUniqueId())){
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         return null;

--- a/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
@@ -1,0 +1,57 @@
+package org.opensearch.extensions;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportResponse;
+
+public class ExtensionDependencyResponse extends TransportResponse  {
+    private List<DiscoveryExtensionNode> dependency;
+
+    public ExtensionDependencyResponse(List<DiscoveryExtensionNode> dependency) {
+        this.dependency = dependency;
+    }
+
+    public ExtensionDependencyResponse(StreamInput in) throws IOException {
+        super(in);
+        int size = in.readVInt();
+        dependency = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            dependency.add(new DiscoveryExtensionNode(in));
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(dependency.size());
+        for (DiscoveryExtensionNode dependency : dependency) {
+            dependency.writeTo(out);
+        }
+    }
+
+    public List<DiscoveryExtensionNode> getExtensionDependency() {
+        return dependency;
+    }
+
+
+    @Override
+    public String toString() {
+        return "ExtensionDependencyResponse{extensiondependency=" + dependency.toString() + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ExtensionDependencyResponse that = (ExtensionDependencyResponse) o;
+        return Objects.equals(dependency, that.dependency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dependency);
+    }
+}

--- a/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
@@ -40,7 +40,6 @@ public class ExtensionDependencyResponse extends TransportResponse {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
         out.writeVInt(dependency.size());
         for (DiscoveryExtensionNode dependency : dependency) {
             dependency.writeTo(out);

--- a/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
@@ -40,6 +40,7 @@ public class ExtensionDependencyResponse extends TransportResponse {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
         out.writeVInt(dependency.size());
         for (DiscoveryExtensionNode dependency : dependency) {
             dependency.writeTo(out);

--- a/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
@@ -23,36 +23,35 @@ import org.opensearch.transport.TransportResponse;
  * @opensearch.internal
  */
 public class ExtensionDependencyResponse extends TransportResponse {
-    private List<DiscoveryExtensionNode> dependency;
+    private List<DiscoveryExtensionNode> dependencies;
 
-    public ExtensionDependencyResponse(List<DiscoveryExtensionNode> dependency) {
-        this.dependency = dependency;
+    public ExtensionDependencyResponse(List<DiscoveryExtensionNode> dependencies) {
+        this.dependencies = dependencies;
     }
 
     public ExtensionDependencyResponse(StreamInput in) throws IOException {
-        super(in);
         int size = in.readVInt();
-        dependency = new ArrayList<>(size);
+        dependencies = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            dependency.add(new DiscoveryExtensionNode(in));
+            dependencies.add(new DiscoveryExtensionNode(in));
         }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeVInt(dependency.size());
-        for (DiscoveryExtensionNode dependency : dependency) {
+        out.writeVInt(dependencies.size());
+        for (DiscoveryExtensionNode dependency : dependencies) {
             dependency.writeTo(out);
         }
     }
 
     public List<DiscoveryExtensionNode> getExtensionDependency() {
-        return dependency;
+        return dependencies;
     }
 
     @Override
     public String toString() {
-        return "ExtensionDependencyResponse{extensiondependency=" + dependency.toString() + '}';
+        return "ExtensionDependencyResponse{extensiondependency=" + dependencies.toString() + '}';
     }
 
     @Override
@@ -60,11 +59,11 @@ public class ExtensionDependencyResponse extends TransportResponse {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ExtensionDependencyResponse that = (ExtensionDependencyResponse) o;
-        return Objects.equals(dependency, that.dependency);
+        return Objects.equals(dependencies, that.dependencies);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(dependency);
+        return Objects.hash(dependencies);
     }
 }

--- a/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
@@ -17,6 +17,11 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.transport.TransportResponse;
 
+/**
+ * The response for getting the Extension Dependency.
+ *
+ * @opensearch.internal
+ */
 public class ExtensionDependencyResponse extends TransportResponse {
     private List<DiscoveryExtensionNode> dependency;
 

--- a/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.extensions;
 
 import java.io.IOException;

--- a/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
@@ -8,7 +8,7 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.transport.TransportResponse;
 
-public class ExtensionDependencyResponse extends TransportResponse  {
+public class ExtensionDependencyResponse extends TransportResponse {
     private List<DiscoveryExtensionNode> dependency;
 
     public ExtensionDependencyResponse(List<DiscoveryExtensionNode> dependency) {
@@ -35,7 +35,6 @@ public class ExtensionDependencyResponse extends TransportResponse  {
     public List<DiscoveryExtensionNode> getExtensionDependency() {
         return dependency;
     }
-
 
     @Override
     public String toString() {

--- a/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
@@ -28,10 +28,6 @@ public class ExtensionRequest extends TransportRequest {
     private final ExtensionsManager.RequestType requestType;
     private final String uniqueId;
 
-    public ExtensionRequest(ExtensionsManager.RequestType requestType) {
-        this(requestType, null);
-    }
-
     public ExtensionRequest(ExtensionsManager.RequestType requestType, String uniqueId) {
         this.requestType = requestType;
         this.uniqueId = uniqueId;

--- a/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
@@ -10,7 +10,6 @@ package org.opensearch.extensions;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.common.Nullable;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.transport.TransportRequest;
@@ -27,27 +26,29 @@ import java.util.Optional;
 public class ExtensionRequest extends TransportRequest {
     private static final Logger logger = LogManager.getLogger(ExtensionRequest.class);
     private final ExtensionsManager.RequestType requestType;
-    private final String uniqueId;
+    private final Optional<String> uniqueId;
+    private String id;
 
     public ExtensionRequest(ExtensionsManager.RequestType requestType) {
         this(requestType, null);
     }
 
-    public ExtensionRequest(ExtensionsManager.RequestType requestType, String uniqueId) {
+    public ExtensionRequest(ExtensionsManager.RequestType requestType, Optional<String> uniqueId) {
         this.requestType = requestType;
         this.uniqueId = uniqueId;
     }
 
     public ExtensionRequest(StreamInput in) throws IOException {
         this.requestType = in.readEnum(ExtensionsManager.RequestType.class);
-        this.uniqueId = in.readString();
+        this.uniqueId = id == null ? Optional.empty() : Optional.of(id);
+        id = in.readOptionalString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeEnum(requestType);
-        out.writeString(uniqueId);
+        out.writeOptionalString(id);
     }
 
     public ExtensionsManager.RequestType getRequestType() {
@@ -55,7 +56,7 @@ public class ExtensionRequest extends TransportRequest {
     }
 
     public Optional<String> getUniqueId() {
-        return uniqueId == null ? Optional.empty() : Optional.of(uniqueId);
+        return uniqueId == null ? Optional.empty() : uniqueId;
     }
 
     public String toString() {

--- a/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
@@ -28,6 +28,10 @@ public class ExtensionRequest extends TransportRequest {
     private final ExtensionsManager.RequestType requestType;
     private final String uniqueId;
 
+    public ExtensionRequest(ExtensionsManager.RequestType requestType) {
+        this(requestType, null);
+    }
+
     public ExtensionRequest(ExtensionsManager.RequestType requestType, String uniqueId) {
         this.requestType = requestType;
         this.uniqueId = uniqueId;

--- a/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
@@ -17,6 +17,7 @@ import org.opensearch.transport.TransportRequest;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * CLusterService Request for Extensibility
@@ -38,25 +39,23 @@ public class ExtensionRequest extends TransportRequest {
     }
 
     public ExtensionRequest(StreamInput in) throws IOException {
-        super(in);
         this.requestType = in.readEnum(ExtensionsManager.RequestType.class);
-        this.uniqueId = in.readOptionalString();
+        this.uniqueId = in.readString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeEnum(requestType);
-        out.writeOptionalString(uniqueId);
+        out.writeString(uniqueId);
     }
 
     public ExtensionsManager.RequestType getRequestType() {
         return this.requestType;
     }
 
-    @Nullable
-    public String getUniqueId() {
-        return uniqueId;
+    public Optional<String> getUniqueId() {
+        return uniqueId == null ? Optional.empty() : Optional.of(uniqueId);
     }
 
     public String toString() {
@@ -68,13 +67,7 @@ public class ExtensionRequest extends TransportRequest {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ExtensionRequest that = (ExtensionRequest) o;
-        if (uniqueId == null) {
-            return Objects.equals(requestType, that.requestType) && true;
-        } else if (that.uniqueId == null) {
-            return Objects.equals(requestType, that.requestType) && false;
-        } else {
-            return Objects.equals(requestType, that.requestType) && uniqueId.equals(that.uniqueId);
-        }
+        return Objects.equals(requestType, that.requestType) && uniqueId.equals(that.uniqueId);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
@@ -27,7 +27,6 @@ public class ExtensionRequest extends TransportRequest {
     private static final Logger logger = LogManager.getLogger(ExtensionRequest.class);
     private final ExtensionsManager.RequestType requestType;
     private final Optional<String> uniqueId;
-    private String id;
 
     public ExtensionRequest(ExtensionsManager.RequestType requestType) {
         this(requestType, null);
@@ -40,15 +39,15 @@ public class ExtensionRequest extends TransportRequest {
 
     public ExtensionRequest(StreamInput in) throws IOException {
         this.requestType = in.readEnum(ExtensionsManager.RequestType.class);
+        String id = in.readOptionalString();
         this.uniqueId = id == null ? Optional.empty() : Optional.of(id);
-        id = in.readOptionalString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeEnum(requestType);
-        out.writeOptionalString(id);
+        out.writeOptionalString(uniqueId.orElse(null));
     }
 
     public ExtensionsManager.RequestType getRequestType() {
@@ -56,7 +55,7 @@ public class ExtensionRequest extends TransportRequest {
     }
 
     public Optional<String> getUniqueId() {
-        return uniqueId == null ? Optional.empty() : uniqueId;
+        return uniqueId;
     }
 
     public String toString() {

--- a/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
@@ -10,6 +10,7 @@ package org.opensearch.extensions;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.transport.TransportRequest;
@@ -24,29 +25,42 @@ import java.util.Objects;
  */
 public class ExtensionRequest extends TransportRequest {
     private static final Logger logger = LogManager.getLogger(ExtensionRequest.class);
-    private ExtensionsManager.RequestType requestType;
+    private final ExtensionsManager.RequestType requestType;
+    private final String uniqueId;
 
     public ExtensionRequest(ExtensionsManager.RequestType requestType) {
+        this(requestType, null);
+    }
+
+    public ExtensionRequest(ExtensionsManager.RequestType requestType, String uniqueId){
         this.requestType = requestType;
+        this.uniqueId = uniqueId;
     }
 
     public ExtensionRequest(StreamInput in) throws IOException {
         super(in);
         this.requestType = in.readEnum(ExtensionsManager.RequestType.class);
+        this.uniqueId = in.readOptionalString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeEnum(requestType);
+        out.writeOptionalString(uniqueId);
     }
 
     public ExtensionsManager.RequestType getRequestType() {
         return this.requestType;
     }
 
+    @Nullable
+    public String getUniqueId(){
+        return uniqueId;
+    }
+
     public String toString() {
-        return "ExtensionRequest{" + "requestType=" + requestType + '}';
+        return "ExtensionRequest{" + "requestType=" + requestType + "uniqueId=" + uniqueId + '}';
     }
 
     @Override
@@ -54,11 +68,20 @@ public class ExtensionRequest extends TransportRequest {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ExtensionRequest that = (ExtensionRequest) o;
-        return Objects.equals(requestType, that.requestType);
+        if(uniqueId == null){
+            return Objects.equals(requestType, that.requestType) && true;
+            if(that.uniqueId == null){
+                return Objects.equals(requestType, that.requestType) && true;
+            }else{
+                return Objects.equals(requestType, that.requestType) && false;
+            }
+        }else{
+            return Objects.equals(requestType, that.requestType) && Object.equals(uniqueId, that.uniqueId);
+        }
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(requestType);
+        return Objects.hash(requestType, uniqueId);
     }
 }

--- a/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
@@ -32,7 +32,7 @@ public class ExtensionRequest extends TransportRequest {
         this(requestType, null);
     }
 
-    public ExtensionRequest(ExtensionsManager.RequestType requestType, String uniqueId){
+    public ExtensionRequest(ExtensionsManager.RequestType requestType, String uniqueId) {
         this.requestType = requestType;
         this.uniqueId = uniqueId;
     }
@@ -55,7 +55,7 @@ public class ExtensionRequest extends TransportRequest {
     }
 
     @Nullable
-    public String getUniqueId(){
+    public String getUniqueId() {
         return uniqueId;
     }
 
@@ -68,15 +68,12 @@ public class ExtensionRequest extends TransportRequest {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ExtensionRequest that = (ExtensionRequest) o;
-        if(uniqueId == null){
+        if (uniqueId == null) {
             return Objects.equals(requestType, that.requestType) && true;
-            if(that.uniqueId == null){
-                return Objects.equals(requestType, that.requestType) && true;
-            }else{
-                return Objects.equals(requestType, that.requestType) && false;
-            }
-        }else{
-            return Objects.equals(requestType, that.requestType) && Object.equals(uniqueId, that.uniqueId);
+        } else if (that.uniqueId == null) {
+            return Objects.equals(requestType, that.requestType) && false;
+        } else {
+            return Objects.equals(requestType, that.requestType) && uniqueId.equals(that.uniqueId);
         }
     }
 

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -438,7 +438,12 @@ public class ExtensionsManager {
             case REQUEST_EXTENSION_ENVIRONMENT_SETTINGS:
                 return new EnvironmentSettingsResponse(this.environmentSettings);
             case REQUEST_EXTENSION_DEPENDENCY_INFORMATION:
-                String uniqueId = extensionRequest.getUniqueId().stream().filter(x -> x.length() == 1).findFirst().map(Object::toString).orElse(null);
+                String uniqueId = extensionRequest.getUniqueId()
+                    .stream()
+                    .filter(x -> x.length() == 1)
+                    .findFirst()
+                    .map(Object::toString)
+                    .orElse(null);
                 if (uniqueId == null) {
                     return new ExtensionDependencyResponse(extensions);
                 } else {

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -588,10 +588,6 @@ public class ExtensionsManager {
         return REQUEST_EXTENSION_ENVIRONMENT_SETTINGS;
     }
 
-    public static String getRequestExtensionDependencyInformation() {
-        return REQUEST_EXTENSION_DEPENDENCY_INFORMATION;
-    }
-
     public static String getRequestExtensionAddSettingsUpdateConsumer() {
         return REQUEST_EXTENSION_ADD_SETTINGS_UPDATE_CONSUMER;
     }

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -438,7 +438,7 @@ public class ExtensionsManager {
             case REQUEST_EXTENSION_ENVIRONMENT_SETTINGS:
                 return new EnvironmentSettingsResponse(this.environmentSettings);
             case REQUEST_EXTENSION_DEPENDENCY_INFORMATION:
-                String uniqueId = extensionRequest.getUniqueId();
+                String uniqueId = extensionRequest.getUniqueId().stream().filter(x -> x.length() == 1).findFirst().map(Object::toString).orElse(null);
                 if (uniqueId == null) {
                     return new ExtensionDependencyResponse(extensions);
                 } else {

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -438,12 +438,7 @@ public class ExtensionsManager {
             case REQUEST_EXTENSION_ENVIRONMENT_SETTINGS:
                 return new EnvironmentSettingsResponse(this.environmentSettings);
             case REQUEST_EXTENSION_DEPENDENCY_INFORMATION:
-                String uniqueId = extensionRequest.getUniqueId()
-                    .stream()
-                    .filter(x -> x.length() == 1)
-                    .findFirst()
-                    .map(Object::toString)
-                    .orElse(null);
+                String uniqueId = extensionRequest.getUniqueId().orElse(null);
                 if (uniqueId == null) {
                     return new ExtensionDependencyResponse(extensions);
                 } else {

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -439,14 +439,13 @@ public class ExtensionsManager {
                 return new EnvironmentSettingsResponse(this.environmentSettings);
             case REQUEST_EXTENSION_DEPENDENCY_INFORMATION:
                 String uniqueId = extensionRequest.getUniqueId();
-                if(uniqueId == null){
+                if (uniqueId == null) {
                     return new ExtensionDependencyResponse(extensions);
-                }else{
+                } else {
                     ExtensionDependency matchingId = new ExtensionDependency(uniqueId, Version.CURRENT);
-                    return new ExtensionDependencyResponse(extensions
-                    .stream()
-                    .filter(e -> e.dependenciesContain(matchingId))
-                    .collect(Collectors.toList()));
+                    return new ExtensionDependencyResponse(
+                        extensions.stream().filter(e -> e.dependenciesContain(matchingId)).collect(Collectors.toList())
+                    );
                 }
             default:
                 throw new IllegalArgumentException("Handler not present for the provided request");

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -517,7 +517,12 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
         ExtensionRequest environmentSettingsRequest = new ExtensionRequest(
             ExtensionsManager.RequestType.REQUEST_EXTENSION_ENVIRONMENT_SETTINGS
         );
+
         assertEquals(EnvironmentSettingsResponse.class, extensionsManager.handleExtensionRequest(environmentSettingsRequest).getClass());
+
+        ExtensionRequest extensionDependencyRequest = new ExtensionRequest(ExtensionsManager.RequestType.REQUEST_EXTENSION_DEPENDENCY_INFORMATION);
+
+        assertEquals(ExtensionDependencyResponse.class, extensionsManager.handleExtensionRequest(extensionDependencyRequest).getClass());
 
         ExtensionRequest exceptionRequest = new ExtensionRequest(ExtensionsManager.RequestType.GET_SETTINGS);
         Exception exception = expectThrows(Exception.class, () -> extensionsManager.handleExtensionRequest(exceptionRequest));
@@ -552,6 +557,51 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
 
                 environmentSettingsResponse = new EnvironmentSettingsResponse(in);
                 assertEquals(settings, environmentSettingsResponse.getEnvironmentSettings());
+            }
+        }
+    }
+
+    public void testExtensionDependencyResponse() throws Exception {
+        String expectedUniqueId = "test uniqueid";
+        List<DiscoveryExtensionNode> expectedExtensionsList = new ArrayList<DiscoveryExtensionNode>();
+        Version expectedVersion = Version.fromString("2.0.0");
+        ExtensionDependency expectedDependency = new ExtensionDependency(expectedUniqueId, expectedVersion);
+
+        expectedExtensionsList.add(
+            new DiscoveryExtensionNode(
+                "firstExtension",
+                "uniqueid1",
+                "uniqueid1",
+                "myIndependentPluginHost1",
+                "127.0.0.0",
+                new TransportAddress(InetAddress.getByName("127.0.0.0"), 9300),
+                new HashMap<String, String>(),
+                Version.fromString("3.0.0"),
+                new PluginInfo(
+                    "firstExtension",
+                    "Fake description 1",
+                    "0.0.7",
+                    Version.fromString("3.0.0"),
+                    "14",
+                    "fakeClass1",
+                    new ArrayList<String>(),
+                    false
+                ),
+                List.of(expectedDependency)
+            )
+        );
+        
+        //Test ExtensionDependencyResponse arg constructor
+        ExtensionDependencyResponse extensionDependencyResponse = new ExtensionDependencyResponse(expectedExtensionsList);
+        assertEquals(expectedExtensionsList , extensionDependencyResponse.getExtensionDependency());
+
+        //Test ExtensionDependencyResponse StreamInput constructor
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            extensionDependencyResponse.writeTo(out);
+            out.flush();
+            try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
+                extensionDependencyResponse = new ExtensionDependencyResponse(in);
+                assertEquals(expectedExtensionsList , extensionDependencyResponse.getExtensionDependency());
             }
         }
     }

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -520,7 +520,9 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
 
         assertEquals(EnvironmentSettingsResponse.class, extensionsManager.handleExtensionRequest(environmentSettingsRequest).getClass());
 
-        ExtensionRequest extensionDependencyRequest = new ExtensionRequest(ExtensionsManager.RequestType.REQUEST_EXTENSION_DEPENDENCY_INFORMATION);
+        ExtensionRequest extensionDependencyRequest = new ExtensionRequest(
+            ExtensionsManager.RequestType.REQUEST_EXTENSION_DEPENDENCY_INFORMATION
+        );
 
         assertEquals(ExtensionDependencyResponse.class, extensionsManager.handleExtensionRequest(extensionDependencyRequest).getClass());
 
@@ -590,18 +592,18 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
                 List.of(expectedDependency)
             )
         );
-        
-        //Test ExtensionDependencyResponse arg constructor
-        ExtensionDependencyResponse extensionDependencyResponse = new ExtensionDependencyResponse(expectedExtensionsList);
-        assertEquals(expectedExtensionsList , extensionDependencyResponse.getExtensionDependency());
 
-        //Test ExtensionDependencyResponse StreamInput constructor
+        // Test ExtensionDependencyResponse arg constructor
+        ExtensionDependencyResponse extensionDependencyResponse = new ExtensionDependencyResponse(expectedExtensionsList);
+        assertEquals(expectedExtensionsList, extensionDependencyResponse.getExtensionDependency());
+
+        // Test ExtensionDependencyResponse StreamInput constructor
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             extensionDependencyResponse.writeTo(out);
             out.flush();
             try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
                 extensionDependencyResponse = new ExtensionDependencyResponse(in);
-                assertEquals(expectedExtensionsList , extensionDependencyResponse.getExtensionDependency());
+                assertEquals(expectedExtensionsList, extensionDependencyResponse.getExtensionDependency());
             }
         }
     }

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -776,7 +776,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             settings,
             client
         );
-        verify(mockTransportService, times(9)).registerRequestHandler(anyString(), anyString(), anyBoolean(), anyBoolean(), any(), any());
+        verify(mockTransportService, times(10)).registerRequestHandler(anyString(), anyString(), anyBoolean(), anyBoolean(), any(), any());
     }
 
     public void testOnIndexModule() throws Exception {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Create a feature to have an extension query to OpenSearch to obtain a list of initialized extensions and determine whether a particular extension is initialized.
Equivalent PR on OpenSearch-sdk-java : https://github.com/opensearch-project/opensearch-sdk-java/pull/300 
### Issues Resolved
fixes https://github.com/opensearch-project/opensearch-sdk-java/issues/149

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
