### PR TITLE
Add thread id in log output

### DIFF
--- a/test/framework/src/main/java/org/opensearch/common/logging/TestThreadInfoPatternConverter.java
+++ b/test/framework/src/main/java/org/opensearch/common/logging/TestThreadInfoPatternConverter.java
@@ -73,7 +73,7 @@ public class TestThreadInfoPatternConverter extends LogEventPatternConverter {
         }
     }
 
-    private static final Pattern OPENSEARCH_THREAD_NAME_PATTERN = Pattern.compile("opensearch\\[(.+)\\]\\[.+\\].+");
+    private static final Pattern OPENSEARCH_THREAD_NAME_PATTERN = Pattern.compile("opensearch\\[(.+)\\]\\[(.+)\\]\\[(.+)\\].+");
     private static final Pattern TEST_THREAD_NAME_PATTERN = Pattern.compile("TEST-.+\\.(.+)-seed#\\[.+\\]");
     private static final Pattern TEST_SUITE_INIT_THREAD_NAME_PATTERN = Pattern.compile("SUITE-.+-worker");
     private static final Pattern NOT_YET_NAMED_NODE_THREAD_NAME_PATTERN = Pattern.compile("test_SUITE-CHILD_VM.+cluster\\[T#(.+)\\]");
@@ -82,7 +82,7 @@ public class TestThreadInfoPatternConverter extends LogEventPatternConverter {
         Matcher m = OPENSEARCH_THREAD_NAME_PATTERN.matcher(threadName);
         if (m.matches()) {
             // Thread looks like a node thread so use the node name
-            return m.group(1);
+            return m.group(1) + " " + m.group(2) + " " + m.group(3);
         }
         m = TEST_THREAD_NAME_PATTERN.matcher(threadName);
         if (m.matches()) {

--- a/test/framework/src/main/java/org/opensearch/common/logging/TestThreadInfoPatternConverter.java
+++ b/test/framework/src/main/java/org/opensearch/common/logging/TestThreadInfoPatternConverter.java
@@ -81,7 +81,7 @@ public class TestThreadInfoPatternConverter extends LogEventPatternConverter {
     static String threadInfo(String threadName) {
         Matcher m = OPENSEARCH_THREAD_NAME_PATTERN.matcher(threadName);
         if (m.matches()) {
-            // Thread looks like a node thread so use the node name
+            // Thread looks like a node thread so use the node name, thread pool and thread number
             return m.group(1) + " " + m.group(2) + " " + m.group(3);
         }
         m = TEST_THREAD_NAME_PATTERN.matcher(threadName);

--- a/test/framework/src/main/resources/log4j2-test.properties
+++ b/test/framework/src/main/resources/log4j2-test.properties
@@ -12,7 +12,7 @@
 appender.console.type = Console
 appender.console.name = console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%test_thread_info]%marker [Thread %tid] %m%n
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%tn] %m%n
 
 rootLogger.level = ${sys:tests.opensearch.logger.level:-info}
 rootLogger.appenderRef.console.ref = console

--- a/test/framework/src/main/resources/log4j2-test.properties
+++ b/test/framework/src/main/resources/log4j2-test.properties
@@ -12,7 +12,7 @@
 appender.console.type = Console
 appender.console.name = console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%test_thread_info]%marker %m%n
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%test_thread_info]%marker [Thread %tid] %m%n
 
 rootLogger.level = ${sys:tests.opensearch.logger.level:-info}
 rootLogger.appenderRef.console.ref = console

--- a/test/framework/src/main/resources/log4j2-test.properties
+++ b/test/framework/src/main/resources/log4j2-test.properties
@@ -12,7 +12,7 @@
 appender.console.type = Console
 appender.console.name = console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%tn] %m%n
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%test_thread_info]%marker %m%n
 
 rootLogger.level = ${sys:tests.opensearch.logger.level:-info}
 rootLogger.appenderRef.console.ref = console

--- a/test/framework/src/test/java/org/opensearch/common/logging/TestThreadInfoPatternConverterTests.java
+++ b/test/framework/src/test/java/org/opensearch/common/logging/TestThreadInfoPatternConverterTests.java
@@ -49,8 +49,10 @@ public class TestThreadInfoPatternConverterTests extends OpenSearchTestCase {
     public void testThreadInfo() {
         // Threads that are part of a node get the node name
         String nodeName = randomAlphaOfLength(5);
-        String threadName = OpenSearchExecutors.threadName(nodeName, randomAlphaOfLength(20)) + "[T#" + between(0, 1000) + "]";
-        assertEquals(nodeName, threadInfo(threadName));
+        String threadPool = randomAlphaOfLength(20);
+        String threadNumber = "T#" + between(0, 1000);
+        String threadName = OpenSearchExecutors.threadName(nodeName, threadPool + "][" + threadNumber + "]");
+        assertEquals(nodeName + " " + threadPool + " " + threadNumber, threadInfo(threadName));
 
         // Test threads get the test name
         assertEquals(getTestName(), threadInfo(Thread.currentThread().getName()));


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
This change adds thread id in the test log output. As per nature of OpenSearch engine, there are multiple threads active at a time, it is not easy to identify logs belonging to a specific thread. This enables user to perform search and filter logs specific to a thread.

Sample output
```
[2022-12-24T09:33:44,483][DEBUG][o.o.t.TransportService   ] [node_t2] [Thread 92] Action: internal:index/shard/replication/get_checkpoint_info
[2022-12-24T09:33:44,483][TRACE][o.o.i.b.in_flight_requests] [node_t2] [Thread 92] [in_flight_requests] Adjusted breaker by [16440] bytes, now [16492]
[2022-12-24T09:33:44,483][TRACE][o.o.t.TransportLogger    ] [node_t2] [Thread 92] NioSocketChannel{localAddress=/127.0.0.1:49825, remoteAddress=127.0.0.1/127.0.0.1:49809} [length: 376, request id: 17, type: request, version: 3.0.0, header size: 56B, action: internal:index/shard/replication/get_checkpoint_info] WRITE: 376B
[2022-12-24T09:33:44,483][TRACE][o.o.i.b.in_flight_requests] [node_t2] [Thread 90] [in_flight_requests] Adjusted breaker by [-16440] bytes, now [52]
[2022-12-24T09:33:44,483][TRACE][o.o.t.T.tracer           ] [node_t2] [Thread 90] [17][internal:index/shard/replication/get_checkpoint_info] sent to [{node_t0}{dM8siREPSiWwHR7XSLdLQA}{JRWGmH00R-e7Ud-I0mlbXw}{127.0.0.1}{127.0.0.1:49809}{dimr}{shard_indexing_pressure_enabled=true}] (timeout: [1m])
[2022-12-24T09:33:44,484][TRACE][o.o.i.b.in_flight_requests] [node_t0] [Thread 45] [in_flight_requests] Adding [297b][internal:index/shard/replication/get_checkpoint_info] to used bytes [new used: [833b], limit: 3221225472 [3gb], estimate: 1666 [1.6kb]]
[2022-12-24T09:33:44,484][TRACE][o.o.t.TransportLogger    ] [node_t0] [Thread 45] NioSocketChannel{localAddress=/127.0.0.1:49809, remoteAddress=/127.0.0.1:49825} [length: 376, request id: 17, type: request, version: 3.0.0, action: internal:index/shard/replication/get_checkpoint_info] READ: 376B
[2022-12-24T09:33:44,484][TRACE][o.o.t.T.tracer           ] [node_t0] [Thread 45] [17][internal:index/shard/replication/get_checkpoint_info] received request
[2022-12-24T09:33:44,484][TRACE][o.o.t.TaskManager        ] [node_t0] [Thread 49] register 84 [transport] [internal:index/shard/replication/get_checkpoint_info] []
```

### Issues Resolved
NA

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
