### PR TITLE
Add version check during task submission for bwc for static threshold setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix case sensitivity for wildcard queries ([#5462](https://github.com/opensearch-project/OpenSearch/pull/5462))
 - Apply cluster manager throttling settings during bootstrap ([#5524](https://github.com/opensearch-project/OpenSearch/pull/5524))
 - Update thresholds map when cluster manager throttling setting is removed ([#5524](https://github.com/opensearch-project/OpenSearch/pull/5524))
+- Fix backward compatibility for static cluster manager throttling threshold setting ([#5633](https://github.com/opensearch-project/OpenSearch/pull/5633))
 ### Security
 
 [Unreleased 3.0]: https://github.com/opensearch-project/OpenSearch/compare/2.4...HEAD

--- a/server/src/main/java/org/opensearch/OpenSearchException.java
+++ b/server/src/main/java/org/opensearch/OpenSearchException.java
@@ -1613,7 +1613,7 @@ public class OpenSearchException extends RuntimeException implements ToXContentF
             ClusterManagerThrottlingException.class,
             ClusterManagerThrottlingException::new,
             165,
-            Version.V_2_4_0
+            Version.V_2_5_0
         ),
         SNAPSHOT_IN_USE_DELETION_EXCEPTION(
             SnapshotInUseDeletionException.class,

--- a/server/src/main/java/org/opensearch/cluster/service/ClusterManagerTaskThrottler.java
+++ b/server/src/main/java/org/opensearch/cluster/service/ClusterManagerTaskThrottler.java
@@ -51,9 +51,10 @@ public class ClusterManagerTaskThrottler implements TaskBatcherListener {
     private final ConcurrentMap<String, Long> tasksCount;
     private final ConcurrentMap<String, Long> tasksThreshold;
     private final Supplier<Version> minNodeVersionSupplier;
-    // Needed for static threshold settings.
-    // Once all nodes are grater than or equal to 2.5.0 version, then only it will start throttling.
-    // During upgrade, it will wait for all older version nodes to leave the cluster and then only start throttling.
+
+    // Once all nodes are greater than or equal 2.5.0 version, then only it will start throttling.
+    // During upgrade as well, it will wait for all older version nodes to leave the cluster before starting throttling.
+    // This is needed specifically for static setting to enable throttling.
     private AtomicBoolean startThrottling = new AtomicBoolean();
 
     public ClusterManagerTaskThrottler(

--- a/server/src/main/java/org/opensearch/cluster/service/ClusterManagerTaskThrottler.java
+++ b/server/src/main/java/org/opensearch/cluster/service/ClusterManagerTaskThrottler.java
@@ -52,7 +52,7 @@ public class ClusterManagerTaskThrottler implements TaskBatcherListener {
     private final ConcurrentMap<String, Long> tasksThreshold;
     private final Supplier<Version> minNodeVersionSupplier;
     // Needed for static threshold settings.
-    // Once all nodes are higher than 2.5.0 version, then only it will start throttling.
+    // Once all nodes are grater than or equal to 2.5.0 version, then only it will start throttling.
     // During upgrade, it will wait for all older version nodes to leave the cluster and then only start throttling.
     private AtomicBoolean startThrottling = new AtomicBoolean();
 


### PR DESCRIPTION
Signed-off-by: Dhwanil Patel <dhwanip@amazon.com>

### Description
* Changed version of the ClusterManagerThrottlingException.

* BWC for thresholds set via static setting

  When throttling threshold setting is set via static setting (yml) file, it can be updated and feature can throttle the task even when older nodes are present in cluster.

  Added check on task submission of configured task for throttling to check for version check. If older nodes are present, it will not perform throttling to provide backward compatibility. 

  Once all nodes are higher than 2.5.0, it will start throttling based on threshold and wont be disabled again.

### Issues Resolved
#479 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
