### PR TITLE
Improve tests.config property thread safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed compression support for h2c protocol ([#4944](https://github.com/opensearch-project/OpenSearch/pull/4944))
 - Reject bulk requests with invalid actions ([#5299](https://github.com/opensearch-project/OpenSearch/issues/5299))
 - Support OpenSSL Provider with default Netty allocator ([#5460](https://github.com/opensearch-project/OpenSearch/pull/5460))
-- Improve tests.config property thread safety ([#5645](https://github.com/opensearch-project/OpenSearch/pull/5645))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed compression support for h2c protocol ([#4944](https://github.com/opensearch-project/OpenSearch/pull/4944))
 - Reject bulk requests with invalid actions ([#5299](https://github.com/opensearch-project/OpenSearch/issues/5299))
 - Support OpenSSL Provider with default Netty allocator ([#5460](https://github.com/opensearch-project/OpenSearch/pull/5460))
+- Improve tests.config property thread safety ([#5645](https://github.com/opensearch-project/OpenSearch/pull/5645))
 
 ### Security
 

--- a/test/framework/src/main/java/org/opensearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/opensearch/bootstrap/BootstrapForTesting.java
@@ -130,8 +130,9 @@ public class BootstrapForTesting {
                 // java.io.tmpdir
                 FilePermissionUtils.addDirectoryPath(perms, "java.io.tmpdir", javaTmpDir, "read,readlink,write,delete", false);
                 // custom test config file
-                if (Strings.hasLength(System.getProperty("tests.config"))) {
-                    FilePermissionUtils.addSingleFilePath(perms, PathUtils.get(System.getProperty("tests.config")), "read,readlink");
+                String testConfigFile = System.getProperty("tests.config");
+                if (Strings.hasLength(testConfigFile)) {
+                    FilePermissionUtils.addSingleFilePath(perms, PathUtils.get(testConfigFile), "read,readlink");
                 }
                 // intellij hack: intellij test runner wants setIO and will
                 // screw up all test logging without it!


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

The `BootstrapForTesting` class can read the value of an optional `tests.config` system property.  If this property is not set, it returns null.

While there is already a null check, the property is fetched again from the JDK.  If any other test is manipulating this property in the same JVM it could return a different result.  See at least two rare failures:
 - [#1096 (comment)](https://github.com/opensearch-project/OpenSearch/pull/1096#issuecomment-1018841935)
 - [#2726 (comment)](https://github.com/opensearch-project/OpenSearch/pull/2726#issuecomment-1086957605) 

This change makes the null check more robust to any other property manipulation in the JVM.

### Issues Resolved

Fixes #2893

### Check List
~- [ ] New functionality includes testing.~
  ~- [ ] All tests pass~
~- [ ] New functionality has been documented.~
  ~- [ ] New functionality has javadoc added~
- [X] Commits are signed per the DCO using --signoff
~- [] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
