### PR TITLE
[Remote Translog] Add support for downloading files from remote translog

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -3098,13 +3098,14 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 executeRecovery("from store", recoveryState, recoveryListener, this::recoverFromStore);
                 break;
             case REMOTE_STORE:
-                final String remoteRepo = indexSettings.getRemoteStoreTranslogRepository();
-                executeRecovery(
-                    "from remote store",
-                    recoveryState,
-                    recoveryListener,
-                    l -> restoreFromRemoteStore(repositoriesService.repository(remoteRepo), l)
-                );
+                final Repository remoteTranslogRepo;
+                final String remoteTranslogRepoName = indexSettings.getRemoteStoreTranslogRepository();
+                if (remoteTranslogRepoName != null) {
+                    remoteTranslogRepo = repositoriesService.repository(remoteTranslogRepoName);
+                } else {
+                    remoteTranslogRepo = null;
+                }
+                executeRecovery("from remote store", recoveryState, recoveryListener, l -> restoreFromRemoteStore(remoteTranslogRepo, l));
                 break;
             case PEER:
                 try {

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -2319,10 +2319,10 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         storeRecovery.recoverFromStore(this, listener);
     }
 
-    public void restoreFromRemoteStore(ActionListener<Boolean> listener) {
+    public void restoreFromRemoteStore(Repository repository, ActionListener<Boolean> listener) {
         assert shardRouting.primary() : "recover from store only makes sense if the shard is a primary shard";
         StoreRecovery storeRecovery = new StoreRecovery(shardId, logger);
-        storeRecovery.recoverFromRemoteStore(this, listener);
+        storeRecovery.recoverFromRemoteStore(this, repository, listener);
     }
 
     public void restoreFromRepository(Repository repository, ActionListener<Boolean> listener) {
@@ -3098,7 +3098,13 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 executeRecovery("from store", recoveryState, recoveryListener, this::recoverFromStore);
                 break;
             case REMOTE_STORE:
-                executeRecovery("from remote store", recoveryState, recoveryListener, this::restoreFromRemoteStore);
+                final String remoteRepo = indexSettings.getRemoteStoreTranslogRepository();
+                executeRecovery(
+                    "from remote store",
+                    recoveryState,
+                    recoveryListener,
+                    l -> restoreFromRemoteStore(repositoriesService.repository(remoteRepo), l)
+                );
                 break;
             case PEER:
                 try {

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -60,11 +60,17 @@ import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.snapshots.IndexShardRestoreFailedException;
 import org.opensearch.index.store.Store;
+import org.opensearch.index.translog.RemoteFsTranslog;
 import org.opensearch.index.translog.Translog;
+import org.opensearch.index.translog.transfer.BlobStoreTransferService;
+import org.opensearch.index.translog.transfer.FileTransferTracker;
+import org.opensearch.index.translog.transfer.TranslogTransferManager;
 import org.opensearch.indices.recovery.RecoveryState;
 import org.opensearch.indices.replication.common.ReplicationLuceneIndex;
 import org.opensearch.repositories.IndexId;
 import org.opensearch.repositories.Repository;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -114,13 +120,13 @@ final class StoreRecovery {
         }
     }
 
-    void recoverFromRemoteStore(final IndexShard indexShard, ActionListener<Boolean> listener) {
+    void recoverFromRemoteStore(final IndexShard indexShard, Repository repository, ActionListener<Boolean> listener) {
         if (canRecover(indexShard)) {
             RecoverySource.Type recoveryType = indexShard.recoveryState().getRecoverySource().getType();
             assert recoveryType == RecoverySource.Type.REMOTE_STORE : "expected remote store recovery type but was: " + recoveryType;
             ActionListener.completeWith(recoveryListener(indexShard, listener), () -> {
                 logger.debug("starting recovery from remote store ...");
-                recoverFromRemoteStore(indexShard);
+                recoverFromRemoteStore(indexShard, repository);
                 return true;
             });
         } else {
@@ -435,7 +441,7 @@ final class StoreRecovery {
         });
     }
 
-    private void recoverFromRemoteStore(IndexShard indexShard) throws IndexShardRecoveryException {
+    private void recoverFromRemoteStore(IndexShard indexShard, Repository repository) throws IndexShardRecoveryException {
         final Store remoteStore = indexShard.remoteStore();
         if (remoteStore == null) {
             throw new IndexShardRecoveryException(
@@ -453,9 +459,22 @@ final class StoreRecovery {
             // Download segments from remote segment store
             indexShard.syncSegmentsFromRemoteSegmentStore(true);
 
-            // This creates empty trans-log for now
-            // ToDo: Add code to restore from remote trans-log
-            bootstrap(indexShard, store);
+            if (repository != null) {
+                FileTransferTracker fileTransferTracker = new FileTransferTracker(shardId);
+                assert repository instanceof BlobStoreRepository : "repository should be instance of BlobStoreRepository";
+                BlobStoreRepository blobStoreRepository = (BlobStoreRepository) repository;
+                TranslogTransferManager translogTransferManager = new TranslogTransferManager(
+                    new BlobStoreTransferService(
+                        blobStoreRepository.blobStore(),
+                        indexShard.getThreadPool().executor(ThreadPool.Names.TRANSLOG_TRANSFER)
+                    ),
+                    blobStoreRepository.basePath().add(shardId.getIndex().getUUID()).add(String.valueOf(shardId.id())),
+                    fileTransferTracker,
+                    fileTransferTracker::exclusionFilter
+                );
+                RemoteFsTranslog.download(translogTransferManager, indexShard.shardPath().resolveTranslog(), true);
+            }
+
             assert indexShard.shardRouting.primary() : "only primary shards can recover from store";
             indexShard.recoveryState().getIndex().setFileDetailsComplete();
             indexShard.openEngineAndRecoverFromTranslog();

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -472,7 +472,7 @@ final class StoreRecovery {
                     fileTransferTracker,
                     fileTransferTracker::exclusionFilter
                 );
-                RemoteFsTranslog.download(translogTransferManager, indexShard.shardPath().resolveTranslog(), true);
+                RemoteFsTranslog.download(translogTransferManager, indexShard.shardPath().resolveTranslog());
             }
 
             assert indexShard.shardRouting.primary() : "only primary shards can recover from store";

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -482,7 +482,7 @@ final class StoreRecovery {
         assert repository instanceof BlobStoreRepository : "repository should be instance of BlobStoreRepository";
         BlobStoreRepository blobStoreRepository = (BlobStoreRepository) repository;
         FileTransferTracker fileTransferTracker = new FileTransferTracker(shardId);
-        TranslogTransferManager translogTransferManager = RemoteFsTranslog.buildTranlogTransferManager(
+        TranslogTransferManager translogTransferManager = RemoteFsTranslog.buildTranslogTransferManager(
             blobStoreRepository,
             indexShard.getThreadPool().executor(ThreadPool.Names.TRANSLOG_TRANSFER),
             shardId,

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -113,13 +113,14 @@ public class RemoteFsTranslog extends Translog {
             Map<String, String> generationToPrimaryTermMapper = translogMetadata.getGenerationToPrimaryTermMapper();
             for (long i = translogMetadata.getGeneration(); i >= translogMetadata.getMinTranslogGeneration(); i--) {
                 String generation = Long.toString(i);
-                translogTransferManager.downloadTranslog(
-                    generationToPrimaryTermMapper.get(generation),
-                    generation,
-                    location,
-                    i == translogMetadata.getGeneration()
-                );
+                translogTransferManager.downloadTranslog(generationToPrimaryTermMapper.get(generation), generation, location);
             }
+            // We copy the latest generation .ckp file to translog.ckp so that flows that depend on
+            // existence of translog.ckp file work in the same way
+            Files.copy(
+                location.resolve(Translog.getCommitCheckpointFileName(translogMetadata.getGeneration())),
+                location.resolve(Translog.CHECKPOINT_FILE_NAME)
+            );
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -60,7 +60,7 @@ public class RemoteFsTranslog extends Translog {
         super(config, translogUUID, deletionPolicy, globalCheckpointSupplier, primaryTermSupplier, persistedSequenceNumberConsumer);
         this.blobStoreRepository = blobStoreRepository;
         fileTransferTracker = new FileTransferTracker(shardId);
-        this.translogTransferManager = buildTranlogTransferManager(blobStoreRepository, executorService, shardId, fileTransferTracker);
+        this.translogTransferManager = buildTranslogTransferManager(blobStoreRepository, executorService, shardId, fileTransferTracker);
 
         try {
             download(translogTransferManager, location);
@@ -121,7 +121,7 @@ public class RemoteFsTranslog extends Translog {
         }
     }
 
-    public static TranslogTransferManager buildTranlogTransferManager(
+    public static TranslogTransferManager buildTranslogTransferManager(
         BlobStoreRepository blobStoreRepository,
         ExecutorService executorService,
         ShardId shardId,

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -14,10 +14,14 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.common.blobstore.BlobPath;
+import org.opensearch.common.io.stream.InputStreamStreamInput;
 import org.opensearch.index.translog.transfer.listener.FileTransferListener;
 import org.opensearch.index.translog.transfer.listener.TranslogTransferListener;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -126,6 +130,51 @@ public class TranslogTransferManager {
             translogTransferListener.onUploadFailed(transferSnapshot, ex);
             return false;
         }
+    }
+
+    public boolean downloadTranslog(String primaryTerm, String generation, Path location, boolean latest) throws IOException {
+        logger.info("Downloading translog files with: Primry Term = {}, Generation = {}, Location = {}", primaryTerm, generation, location);
+        String checkpointFilename = "translog-" + generation + ".ckp";
+        if (latest) {
+            checkpointFilename = "translog.ckp";
+        }
+        if (Files.exists(location.resolve(checkpointFilename)) == false) {
+            try (
+                InputStream checkpointFileInputStream = transferService.downloadBlob(
+                    remoteBaseTransferPath.add(primaryTerm),
+                    "translog-" + generation + ".ckp"
+                )
+            ) {
+                Files.copy(checkpointFileInputStream, location.resolve(checkpointFilename));
+            }
+        }
+        String translogFilename = "translog-" + generation + ".tlog";
+        if (Files.exists(location.resolve(translogFilename)) == false) {
+            try (
+                InputStream translogFileInputStream = transferService.downloadBlob(
+                    remoteBaseTransferPath.add(primaryTerm),
+                    "translog-" + generation + ".tlog"
+                )
+            ) {
+                Files.copy(translogFileInputStream, location.resolve(translogFilename));
+            }
+        }
+        return true;
+    }
+
+    public TranslogTransferMetadata readMetadata() throws IOException {
+        List<String> metadataFilenames = new ArrayList<>(transferService.listAll(remoteMetadaTransferPath));
+        if (!metadataFilenames.isEmpty()) {
+            metadataFilenames.sort(TranslogTransferMetadata.METADATA_FILENAME_COMPARATOR);
+            try (
+                InputStreamStreamInput streamInput = new InputStreamStreamInput(
+                    transferService.downloadBlob(remoteMetadaTransferPath, metadataFilenames.get(metadataFilenames.size() - 1))
+                )
+            ) {
+                return new TranslogTransferMetadata(streamInput);
+            }
+        }
+        return null;
     }
 
     private TransferFileSnapshot prepareMetadata(TransferSnapshot transferSnapshot) throws IOException {

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -134,7 +134,7 @@ public class TranslogTransferManager {
     }
 
     public boolean downloadTranslog(String primaryTerm, String generation, Path location) throws IOException {
-        logger.info("Downloading translog files with: Primry Term = {}, Generation = {}, Location = {}", primaryTerm, generation, location);
+        logger.info("Downloading translog files with: Primary Term = {}, Generation = {}, Location = {}", primaryTerm, generation, location);
         // Download Checkpoint file from remote to local FS
         String ckpFileName = Translog.getCommitCheckpointFileName(Long.parseLong(generation));
         downloadToFS(ckpFileName, location, primaryTerm);

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -134,7 +134,12 @@ public class TranslogTransferManager {
     }
 
     public boolean downloadTranslog(String primaryTerm, String generation, Path location) throws IOException {
-        logger.info("Downloading translog files with: Primary Term = {}, Generation = {}, Location = {}", primaryTerm, generation, location);
+        logger.info(
+            "Downloading translog files with: Primary Term = {}, Generation = {}, Location = {}",
+            primaryTerm,
+            generation,
+            location
+        );
         // Download Checkpoint file from remote to local FS
         String ckpFileName = Translog.getCommitCheckpointFileName(Long.parseLong(generation));
         downloadToFS(ckpFileName, location, primaryTerm);

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -53,7 +53,7 @@ public class TranslogTransferMetadata {
 
     private static final String METADATA_CODEC = "md";
 
-    public static final MetadataFilenameComparator METADATA_FILENAME_COMPARATOR = new MetadataFilenameComparator();
+    public static final Comparator<String> METADATA_FILENAME_COMPARATOR = new MetadataFilenameComparator();
 
     public TranslogTransferMetadata(long primaryTerm, long generation, long minTranslogGeneration, int count) {
         this.primaryTerm = primaryTerm;
@@ -157,7 +157,7 @@ public class TranslogTransferMetadata {
             String[] filenameTokens2 = metadaFilename2.split(METADATA_SEPARATOR);
             for (int i = 0; i < filenameTokens1.length; i++) {
                 if (filenameTokens1[i].equals(filenameTokens2[i]) == false) {
-                    return (int) (Long.parseLong(filenameTokens1[i]) - Long.parseLong(filenameTokens2[i]));
+                    return Long.compare(Long.parseLong(filenameTokens1[i]), Long.parseLong(filenameTokens2[i]));
                 }
             }
             return 0;

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -8,8 +8,6 @@
 
 package org.opensearch.index.translog.transfer;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.store.InputStreamDataInput;

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -10,12 +10,11 @@ package org.opensearch.index.translog.transfer;
 
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.DataOutput;
-import org.apache.lucene.store.InputStreamDataInput;
+import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.OutputStreamIndexOutput;
 import org.apache.lucene.util.SetOnce;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.io.stream.BytesStreamOutput;
-import org.opensearch.common.io.stream.StreamInput;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -63,14 +62,14 @@ public class TranslogTransferMetadata {
         this.count = count;
     }
 
-    public TranslogTransferMetadata(StreamInput in) throws IOException {
-        InputStreamDataInput inputStreamDataInput = new InputStreamDataInput(in);
-        CodecUtil.checkHeader(inputStreamDataInput, METADATA_CODEC, CURRENT_VERSION, CURRENT_VERSION);
-        this.primaryTerm = inputStreamDataInput.readLong();
-        this.generation = inputStreamDataInput.readLong();
-        this.minTranslogGeneration = inputStreamDataInput.readLong();
-        this.timeStamp = inputStreamDataInput.readLong();
-        this.generationToPrimaryTermMapper.set(inputStreamDataInput.readMapOfStrings());
+    public TranslogTransferMetadata(IndexInput indexInput) throws IOException {
+        CodecUtil.checksumEntireFile(indexInput);
+        CodecUtil.checkHeader(indexInput, METADATA_CODEC, CURRENT_VERSION, CURRENT_VERSION);
+        this.primaryTerm = indexInput.readLong();
+        this.generation = indexInput.readLong();
+        this.minTranslogGeneration = indexInput.readLong();
+        this.timeStamp = indexInput.readLong();
+        this.generationToPrimaryTermMapper.set(indexInput.readMapOfStrings());
     }
 
     public long getPrimaryTerm() {

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -166,7 +166,9 @@ public class TranslogTransferMetadata {
                     return Long.compare(Long.parseLong(filenameTokens1[i]), Long.parseLong(filenameTokens2[i]));
                 }
             }
-            throw new IllegalArgumentException("TranslogTransferMetadata files " + metadaFilename1 + " and " + metadaFilename2 + " have same primary term and generation");
+            throw new IllegalArgumentException(
+                "TranslogTransferMetadata files " + metadaFilename1 + " and " + metadaFilename2 + " have same primary term and generation"
+            );
         }
     }
 }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -152,13 +152,11 @@ public class TranslogTransferMetadata {
     }
 
     private static class MetadataFilenameComparator implements Comparator<String> {
-        private static final Logger logger = LogManager.getLogger(MetadataFilenameComparator.class);
-
         @Override
-        public int compare(String metadaFilename1, String metadaFilename2) {
+        public int compare(String first, String second) {
             // Format of metadata filename is <Primary Term>__<Generation>__<Timestamp>
-            String[] filenameTokens1 = metadaFilename1.split(METADATA_SEPARATOR);
-            String[] filenameTokens2 = metadaFilename2.split(METADATA_SEPARATOR);
+            String[] filenameTokens1 = first.split(METADATA_SEPARATOR);
+            String[] filenameTokens2 = second.split(METADATA_SEPARATOR);
             // Here, we are not comparing only primary term and generation.
             // Timestamp is not a good measure of comparison in case primary term and generation are same.
             for (int i = 0; i < filenameTokens1.length - 1; i++) {
@@ -167,7 +165,7 @@ public class TranslogTransferMetadata {
                 }
             }
             throw new IllegalArgumentException(
-                "TranslogTransferMetadata files " + metadaFilename1 + " and " + metadaFilename2 + " have same primary term and generation"
+                "TranslogTransferMetadata files " + first + " and " + second + " have same primary term and generation"
             );
         }
     }

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -2812,7 +2812,7 @@ public class IndexShardTests extends IndexShardTestCase {
         DiscoveryNode localNode = new DiscoveryNode("foo", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT);
         target.markAsRecovering("remote_store", new RecoveryState(routing, localNode, null));
         final PlainActionFuture<Boolean> future = PlainActionFuture.newFuture();
-        target.restoreFromRemoteStore(future);
+        target.restoreFromRemoteStore(null, future);
         target.remoteStore().decRef();
 
         assertTrue(future.actionGet());

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
@@ -326,10 +326,17 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
             Files.delete(file);
         }
 
-        translog = create(translogDir, repository, translogUUID);
+        // Creating RemoteFsTranslog with the same location
+        Translog newTranslog = create(translogDir, repository, translogUUID);
         i = 0;
         for (Translog.Operation op : ops) {
-            assertEquals(op, translog.readOperation(locs.get(i++)));
+            assertEquals(op, newTranslog.readOperation(locs.get(i++)));
+        }
+        try {
+            newTranslog.close();
+        } catch (Exception e) {
+            // Ignoring this exception for now. Once the download flow populates FileTracker,
+            // we can remove this try-catch block
         }
     }
 

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
@@ -28,6 +28,7 @@ import org.opensearch.common.blobstore.fs.FsBlobContainer;
 import org.opensearch.common.blobstore.fs.FsBlobStore;
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.bytes.ReleasableBytesReference;
+import org.opensearch.common.io.FileSystemUtils;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.ByteSizeUnit;
@@ -147,11 +148,15 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
     }
 
     private RemoteFsTranslog create(Path path) throws IOException {
+        final String translogUUID = Translog.createEmptyTranslog(path, SequenceNumbers.NO_OPS_PERFORMED, shardId, primaryTerm.get());
+        return create(path, createRepository(), translogUUID);
+    }
+
+    private RemoteFsTranslog create(Path path, BlobStoreRepository repository, String translogUUID) throws IOException {
+        this.repository = repository;
         globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
         final TranslogConfig translogConfig = getTranslogConfig(path);
         final TranslogDeletionPolicy deletionPolicy = createTranslogDeletionPolicy(translogConfig.getIndexSettings());
-        final String translogUUID = Translog.createEmptyTranslog(path, SequenceNumbers.NO_OPS_PERFORMED, shardId, primaryTerm.get());
-        repository = createRepository();
         threadPool = new TestThreadPool(getClass().getName());
         blobStoreTransferService = new BlobStoreTransferService(
             repository.blobStore(),
@@ -294,6 +299,38 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
             assertEquals(op, translog.readOperation(locs.get(i++)));
         }
         assertNull(translog.readOperation(new Translog.Location(100, 0, 0)));
+    }
+
+    public void testReadLocationDownload() throws IOException {
+        ArrayList<Translog.Operation> ops = new ArrayList<>();
+        ArrayList<Translog.Location> locs = new ArrayList<>();
+        locs.add(addToTranslogAndListAndUpload(translog, ops, new Translog.Index("1", 0, primaryTerm.get(), new byte[] { 1 })));
+        locs.add(addToTranslogAndListAndUpload(translog, ops, new Translog.Index("2", 1, primaryTerm.get(), new byte[] { 1 })));
+        locs.add(addToTranslogAndListAndUpload(translog, ops, new Translog.Index("3", 2, primaryTerm.get(), new byte[] { 1 })));
+        translog.sync();
+        int i = 0;
+        for (Translog.Operation op : ops) {
+            assertEquals(op, translog.readOperation(locs.get(i++)));
+        }
+
+        String translogUUID = translog.translogUUID;
+        try {
+            translog.getDeletionPolicy().assertNoOpenTranslogRefs();
+            translog.close();
+        } finally {
+            terminate(threadPool);
+        }
+
+        // Delete translog files to test download flow
+        for (Path file : FileSystemUtils.files(translogDir)) {
+            Files.delete(file);
+        }
+
+        translog = create(translogDir, repository, translogUUID);
+        i = 0;
+        for (Translog.Operation op : ops) {
+            assertEquals(op, translog.readOperation(locs.get(i++)));
+        }
     }
 
     public void testSnapshotWithNewTranslog() throws IOException {

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -221,7 +221,7 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
 
         when(transferService.downloadBlob(any(BlobPath.class), eq("12__235__56823"))).thenThrow(new IOException("Something went wrong"));
 
-        assertThrows(IOException.class, translogTransferManager::readMetadata);
+        assertNull(translogTransferManager.readMetadata());
     }
 
     public void testDownloadTranslog() throws IOException {

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -196,7 +196,7 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
         );
 
         when(transferService.listAll(any(BlobPath.class))).thenReturn(
-            Sets.newHashSet("12__234__56789", "12__235__56823", "12__235__56700")
+            Sets.newHashSet("12__234__56789", "12__235__56823", "12__233__56700")
         );
 
         TranslogTransferMetadata metadata = createTransferSnapshot().getTranslogTransferMetadata();
@@ -216,12 +216,27 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
         );
 
         when(transferService.listAll(any(BlobPath.class))).thenReturn(
-            Sets.newHashSet("12__234__56789", "12__235__56823", "12__235__56700")
+            Sets.newHashSet("12__234__56789", "12__235__56823", "12__233__56700")
         );
 
         when(transferService.downloadBlob(any(BlobPath.class), eq("12__235__56823"))).thenThrow(new IOException("Something went wrong"));
 
         assertNull(translogTransferManager.readMetadata());
+    }
+
+    public void testReadMetadataSamePrimaryTermGeneration() throws IOException {
+        TranslogTransferManager translogTransferManager = new TranslogTransferManager(
+            transferService,
+            remoteBaseTransferPath,
+            null,
+            r -> r
+        );
+
+        when(transferService.listAll(any(BlobPath.class))).thenReturn(
+            Sets.newHashSet("12__234__56789", "12__235__56823", "12__234__56700")
+        );
+
+        assertThrows(IllegalArgumentException.class, translogTransferManager::readMetadata);
     }
 
     public void testDownloadTranslog() throws IOException {


### PR DESCRIPTION
### Description
- Add support to download `.tlg` and `.ckp` files from remote translog.
- Also integrated the download flow with restore API.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
