### PR TITLE
Increasing timeout of testQuorumRecovery to 90 seconds from 30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed compression support for h2c protocol ([#4944](https://github.com/opensearch-project/OpenSearch/pull/4944))
 - Reject bulk requests with invalid actions ([#5299](https://github.com/opensearch-project/OpenSearch/issues/5299))
 - Support OpenSSL Provider with default Netty allocator ([#5460](https://github.com/opensearch-project/OpenSearch/pull/5460))
+- Increasing timeout of testQuorumRecovery to 90 seconds from 30 ([#5651](https://github.com/opensearch-project/OpenSearch/pull/5651))
 
 ### Security
 

--- a/server/src/internalClusterTest/java/org/opensearch/gateway/QuorumGatewayIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/QuorumGatewayIT.java
@@ -92,7 +92,7 @@ public class QuorumGatewayIT extends OpenSearchIntegTestCase {
                         logger.info("--> done cluster_health, status {}", clusterHealth.getStatus());
                         assertFalse(clusterHealth.isTimedOut());
                         assertEquals(ClusterHealthStatus.YELLOW, clusterHealth.getStatus());
-                    }, 30, TimeUnit.SECONDS);
+                    }, 90, TimeUnit.SECONDS);
 
                     logger.info("--> one node is closed -- index 1 document into the remaining nodes");
                     activeClient.prepareIndex("test")


### PR DESCRIPTION
Signed-off-by: Joshua Palis <jpalis@amazon.com>

### Description
`testQuorumRecovery` is a flaky test that is not reproducible. The test performs a restart upgrade on a 3 node cluster and confirms that the cluster health recovers, using a 30-second timeout. The instances for which this test failed are due to exceeding this time limit. Since this may be just a transient error, increasing the timeout to 90 seconds.  

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/1908

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
