### PR TITLE
Fix flaky test case - string profiler via global ordinals

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -824,6 +824,7 @@ setup:
       indices.forcemerge:
         index: test_1
         max_num_segments: 1
+        flush: true
 
   - do:
       search:


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

The "string profiler via global ordinals" rest test assumes all documents are in the same segment.  The four commits occasionally are entered into multiple segments.  PR #2226 by @penghuo attempted to fix this using a force merge, which reduced the frequency of these failures but did not eliminate them (reproduced once in 1000 runs).

Setting the `flush` boolean to `true` in this force merge completely resolves these failures (no repro in 2000 runs).

### Issues Resolved

Fixes #1817
Improves fix of #2176

### Check List
~- [ ] New functionality includes testing.~
  ~- [ ] All tests pass~
~- [ ] New functionality has been documented.~
  ~- [ ] New functionality has javadoc added~
- [ ] Commits are signed per the DCO using --signoff
~- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
