### PR TITLE
Fix flaky PitMultiNodeTests including testCreatePitWhileNodeDropWithAllowPartialCreationFalse

### DIFF
--- a/server/src/test/java/org/opensearch/search/PitMultiNodeTests.java
+++ b/server/src/test/java/org/opensearch/search/PitMultiNodeTests.java
@@ -28,6 +28,7 @@ import org.opensearch.action.search.GetAllPitNodesResponse;
 import org.opensearch.action.search.GetAllPitsAction;
 import org.opensearch.action.search.PitTestsUtil;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.Requests;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -36,6 +37,7 @@ import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.action.admin.indices.flush.FlushRequest;
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
 
@@ -337,8 +339,12 @@ public class PitMultiNodeTests extends OpenSearchIntegTestCase {
 
     public void validatePitStats(String index, long expectedPitCurrent, long expectedOpenContexts) throws ExecutionException,
         InterruptedException {
+        // Clear the index transaction log
+        FlushRequest flushRequest = Requests.flushRequest(index);
+        client().admin().indices().flush(flushRequest).get();
+        // Test stats
         IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
-        indicesStatsRequest.indices("index");
+        indicesStatsRequest.indices(index);
         indicesStatsRequest.all();
         IndicesStatsResponse indicesStatsResponse = client().admin().indices().stats(indicesStatsRequest).get();
         long pitCurrent = indicesStatsResponse.getIndex(index).getTotal().search.getTotal().getPitCurrent();


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

#4030 introduced a Point In Time Node Stats API and added stats validation to many PitMultiNodeTests.

Thorough debugging of flaky `testCreatePitWhileNodeDropWithAllowPartialCreationFalse()` revealed that the transLog consistently had a pending commit when the test failed (repro 1/500 runs)

Flushing the index prior to collecting/validating stats resolves this failure (tested 1000 runs) and probably prevents other flaky test results.

_Flushing frequently should be considered a best practice for test hygiene._

### Issues Resolved

Fixes #4259 (which was previously closed associated with an unrelated fix).
Fixes comments https://github.com/opensearch-project/OpenSearch/issues/4089#issuecomment-1311129076 although the issue itself was fixed by a different PR.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
