### PR TITLE
Fix flaky SearchCancellationIT tests to avoid race condition

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
@@ -69,7 +69,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -87,6 +86,10 @@ import static org.hamcrest.Matchers.notNullValue;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE)
 public class SearchCancellationIT extends OpenSearchIntegTestCase {
+
+    private TimeValue requestCancellationTimeout = TimeValue.timeValueSeconds(1);
+    private TimeValue clusterCancellationTimeout = TimeValue.timeValueMillis(1500);
+    private TimeValue keepAlive = TimeValue.timeValueSeconds(5);
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
@@ -233,14 +236,13 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
         List<ScriptedBlockPlugin> plugins = initBlockFactory();
         indexTestData();
 
-        TimeValue cancellationTimeout = new TimeValue(2, TimeUnit.SECONDS);
         ActionFuture<SearchResponse> searchResponse = client().prepareSearch("test")
-            .setCancelAfterTimeInterval(cancellationTimeout)
+            .setCancelAfterTimeInterval(requestCancellationTimeout)
             .setAllowPartialSearchResults(randomBoolean())
             .setQuery(scriptQuery(new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.SCRIPT_NAME, Collections.emptyMap())))
             .execute();
         awaitForBlock(plugins);
-        sleepForAtLeast(cancellationTimeout.getMillis());
+        sleepForAtLeast(requestCancellationTimeout.getMillis());
         // unblock the search thread
         disableBlocks(plugins);
         ensureSearchWasCancelled(searchResponse);
@@ -250,18 +252,19 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
         List<ScriptedBlockPlugin> plugins = initBlockFactory();
         indexTestData();
 
-        TimeValue cancellationTimeout = new TimeValue(2, TimeUnit.SECONDS);
         client().admin()
             .cluster()
             .prepareUpdateSettings()
-            .setPersistentSettings(Settings.builder().put(SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING_KEY, cancellationTimeout).build())
+            .setPersistentSettings(
+                Settings.builder().put(SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING_KEY, clusterCancellationTimeout).build()
+            )
             .get();
         ActionFuture<SearchResponse> searchResponse = client().prepareSearch("test")
             .setAllowPartialSearchResults(randomBoolean())
             .setQuery(scriptQuery(new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.SCRIPT_NAME, Collections.emptyMap())))
             .execute();
         awaitForBlock(plugins);
-        sleepForAtLeast(cancellationTimeout.getMillis());
+        sleepForAtLeast(clusterCancellationTimeout.getMillis());
         // unblock the search thread
         disableBlocks(plugins);
         ensureSearchWasCancelled(searchResponse);
@@ -286,13 +289,12 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
     public void testCancellationDuringFetchPhaseUsingRequestParameter() throws Exception {
         List<ScriptedBlockPlugin> plugins = initBlockFactory();
         indexTestData();
-        TimeValue cancellationTimeout = new TimeValue(2, TimeUnit.SECONDS);
         ActionFuture<SearchResponse> searchResponse = client().prepareSearch("test")
-            .setCancelAfterTimeInterval(cancellationTimeout)
+            .setCancelAfterTimeInterval(requestCancellationTimeout)
             .addScriptField("test_field", new Script(ScriptType.INLINE, "mockscript", SCRIPT_NAME, Collections.emptyMap()))
             .execute();
         awaitForBlock(plugins);
-        sleepForAtLeast(cancellationTimeout.getMillis());
+        sleepForAtLeast(requestCancellationTimeout.getMillis());
         // unblock the search thread
         disableBlocks(plugins);
         ensureSearchWasCancelled(searchResponse);
@@ -304,7 +306,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
 
         logger.info("Executing search");
         ActionFuture<SearchResponse> searchResponse = client().prepareSearch("test")
-            .setScroll(TimeValue.timeValueSeconds(10))
+            .setScroll(keepAlive)
             .setSize(5)
             .setQuery(scriptQuery(new Script(ScriptType.INLINE, "mockscript", SCRIPT_NAME, Collections.emptyMap())))
             .execute();
@@ -323,16 +325,15 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
     public void testCancellationOfFirstScrollSearchRequestUsingRequestParameter() throws Exception {
         List<ScriptedBlockPlugin> plugins = initBlockFactory();
         indexTestData();
-        TimeValue cancellationTimeout = new TimeValue(2, TimeUnit.SECONDS);
         ActionFuture<SearchResponse> searchResponse = client().prepareSearch("test")
-            .setScroll(TimeValue.timeValueSeconds(10))
-            .setCancelAfterTimeInterval(cancellationTimeout)
+            .setScroll(keepAlive)
+            .setCancelAfterTimeInterval(requestCancellationTimeout)
             .setSize(5)
             .setQuery(scriptQuery(new Script(ScriptType.INLINE, "mockscript", SCRIPT_NAME, Collections.emptyMap())))
             .execute();
 
         awaitForBlock(plugins);
-        sleepForAtLeast(cancellationTimeout.getMillis());
+        sleepForAtLeast(requestCancellationTimeout.getMillis());
         // unblock the search thread
         disableBlocks(plugins);
         SearchResponse response = ensureSearchWasCancelled(searchResponse);
@@ -352,7 +353,6 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
         disableBlocks(plugins);
 
         logger.info("Executing search");
-        TimeValue keepAlive = TimeValue.timeValueSeconds(5);
         SearchResponse searchResponse = client().prepareSearch("test")
             .setScroll(keepAlive)
             .setSize(2)
@@ -392,11 +392,9 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
 
         // Disable block so the first request would pass
         disableBlocks(plugins);
-        TimeValue keepAlive = TimeValue.timeValueSeconds(5);
-        TimeValue cancellationTimeout = TimeValue.timeValueSeconds(2);
         SearchResponse searchResponse = client().prepareSearch("test")
             .setScroll(keepAlive)
-            .setCancelAfterTimeInterval(cancellationTimeout)
+            .setCancelAfterTimeInterval(requestCancellationTimeout)
             .setSize(2)
             .setQuery(scriptQuery(new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.SCRIPT_NAME, Collections.emptyMap())))
             .get();
@@ -416,7 +414,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .execute();
 
         awaitForBlock(plugins);
-        sleepForAtLeast(cancellationTimeout.getMillis());
+        sleepForAtLeast(requestCancellationTimeout.getMillis());
         // unblock the search thread
         disableBlocks(plugins);
 
@@ -430,11 +428,12 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
     public void testDisableCancellationAtRequestLevel() throws Exception {
         List<ScriptedBlockPlugin> plugins = initBlockFactory();
         indexTestData();
-        TimeValue cancellationTimeout = new TimeValue(2, TimeUnit.SECONDS);
         client().admin()
             .cluster()
             .prepareUpdateSettings()
-            .setPersistentSettings(Settings.builder().put(SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING_KEY, cancellationTimeout).build())
+            .setPersistentSettings(
+                Settings.builder().put(SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING_KEY, clusterCancellationTimeout).build()
+            )
             .get();
         ActionFuture<SearchResponse> searchResponse = client().prepareSearch("test")
             .setAllowPartialSearchResults(randomBoolean())
@@ -442,7 +441,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .setQuery(scriptQuery(new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.SCRIPT_NAME, Collections.emptyMap())))
             .execute();
         awaitForBlock(plugins);
-        sleepForAtLeast(cancellationTimeout.getMillis());
+        sleepForAtLeast(clusterCancellationTimeout.getMillis());
         // unblock the search thread
         disableBlocks(plugins);
         // ensure search was successful since cancellation was disabled at request level
@@ -452,7 +451,6 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
     public void testDisableCancellationAtClusterLevel() throws Exception {
         List<ScriptedBlockPlugin> plugins = initBlockFactory();
         indexTestData();
-        TimeValue cancellationTimeout = new TimeValue(2, TimeUnit.SECONDS);
         client().admin()
             .cluster()
             .prepareUpdateSettings()
@@ -463,7 +461,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .setQuery(scriptQuery(new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.SCRIPT_NAME, Collections.emptyMap())))
             .execute();
         awaitForBlock(plugins);
-        sleepForAtLeast(cancellationTimeout.getMillis());
+        sleepForAtLeast(clusterCancellationTimeout.getMillis());
         // unblock the search thread
         disableBlocks(plugins);
         // ensure search was successful since cancellation was disabled at request level
@@ -497,11 +495,12 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
     public void testMSearchChildRequestCancellationWithClusterLevelTimeout() throws Exception {
         List<ScriptedBlockPlugin> plugins = initBlockFactory();
         indexTestData();
-        TimeValue cancellationTimeout = new TimeValue(2, TimeUnit.SECONDS);
         client().admin()
             .cluster()
             .prepareUpdateSettings()
-            .setPersistentSettings(Settings.builder().put(SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING_KEY, cancellationTimeout).build())
+            .setPersistentSettings(
+                Settings.builder().put(SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING_KEY, clusterCancellationTimeout).build()
+            )
             .get();
         ActionFuture<MultiSearchResponse> mSearchResponse = client().prepareMultiSearch()
             .setMaxConcurrentSearchRequests(2)
@@ -522,7 +521,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             )
             .execute();
         awaitForBlock(plugins);
-        sleepForAtLeast(cancellationTimeout.getMillis());
+        sleepForAtLeast(clusterCancellationTimeout.getMillis());
         // unblock the search thread
         disableBlocks(plugins);
         // both child requests are expected to fail
@@ -539,8 +538,6 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
     public void testMSearchChildReqCancellationWithHybridTimeout() throws Exception {
         List<ScriptedBlockPlugin> plugins = initBlockFactory();
         indexTestData();
-        TimeValue reqCancellationTimeout = new TimeValue(2, TimeUnit.SECONDS);
-        TimeValue clusterCancellationTimeout = new TimeValue(3, TimeUnit.SECONDS);
         client().admin()
             .cluster()
             .prepareUpdateSettings()
@@ -553,7 +550,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .add(
                 client().prepareSearch("test")
                     .setAllowPartialSearchResults(randomBoolean())
-                    .setCancelAfterTimeInterval(reqCancellationTimeout)
+                    .setCancelAfterTimeInterval(requestCancellationTimeout)
                     .setQuery(
                         scriptQuery(new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.SCRIPT_NAME, Collections.emptyMap()))
                     )
@@ -576,7 +573,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             )
             .execute();
         awaitForBlock(plugins);
-        sleepForAtLeast(Math.max(reqCancellationTimeout.getMillis(), clusterCancellationTimeout.getMillis()));
+        sleepForAtLeast(Math.max(requestCancellationTimeout.getMillis(), clusterCancellationTimeout.getMillis()));
         // unblock the search thread
         disableBlocks(plugins);
         // only first and last child request are expected to fail

--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
@@ -584,7 +584,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
     }
 
     /**
-     * Sleeps for the specified number of milliseconds plus a 100ms buffer to account for system timer/sheduler inaccuracies.
+     * Sleeps for the specified number of milliseconds plus a 100ms buffer to account for system timer/scheduler inaccuracies.
      *
      * @param milliseconds The minimum time to sleep
      * @throws InterruptedException if interrupted during sleep

--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
@@ -241,7 +241,8 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .execute();
         awaitForBlock(plugins);
         // sleep for cancellation timeout to ensure scheduled cancellation task is actually executed
-        Thread.sleep(cancellationTimeout.getMillis());
+        // add 100ms to account for multithreading and sleep inaccuracies
+        Thread.sleep(cancellationTimeout.getMillis() + 100L);
         // unblock the search thread
         disableBlocks(plugins);
         ensureSearchWasCancelled(searchResponse);
@@ -263,7 +264,8 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .execute();
         awaitForBlock(plugins);
         // sleep for cluster cancellation timeout to ensure scheduled cancellation task is actually executed
-        Thread.sleep(cancellationTimeout.getMillis());
+        // add 100ms to account for multithreading and sleep inaccuracies
+        Thread.sleep(cancellationTimeout.getMillis() + 100L);
         // unblock the search thread
         disableBlocks(plugins);
         ensureSearchWasCancelled(searchResponse);
@@ -295,7 +297,8 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .execute();
         awaitForBlock(plugins);
         // sleep for request cancellation timeout to ensure scheduled cancellation task is actually executed
-        Thread.sleep(cancellationTimeout.getMillis());
+        // add 100ms to account for multithreading and sleep inaccuracies
+        Thread.sleep(cancellationTimeout.getMillis() + 100L);
         // unblock the search thread
         disableBlocks(plugins);
         ensureSearchWasCancelled(searchResponse);
@@ -335,7 +338,9 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .execute();
 
         awaitForBlock(plugins);
-        Thread.sleep(cancellationTimeout.getMillis());
+        // sleep for request cancellation timeout to ensure scheduled cancellation task is actually executed
+        // add 100ms to account for multithreading and sleep inaccuracies
+        Thread.sleep(cancellationTimeout.getMillis() + 100L);
         disableBlocks(plugins);
         SearchResponse response = ensureSearchWasCancelled(searchResponse);
         if (response != null) {
@@ -419,7 +424,8 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
 
         awaitForBlock(plugins);
         // sleep for cancellation timeout to ensure there is no scheduled task for cancellation
-        Thread.sleep(cancellationTimeout.getMillis());
+        // add 100ms to account for multithreading and sleep inaccuracies
+        Thread.sleep(cancellationTimeout.getMillis() + 100L);
         disableBlocks(plugins);
 
         // wait for response and ensure there is no failure
@@ -445,7 +451,8 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .execute();
         awaitForBlock(plugins);
         // sleep for cancellation timeout to ensure there is no scheduled task for cancellation
-        Thread.sleep(cancellationTimeout.getMillis());
+        // add 100ms to account for multithreading and sleep inaccuracies
+        Thread.sleep(cancellationTimeout.getMillis() + 100L);
         // unblock the search thread
         disableBlocks(plugins);
         // ensure search was successful since cancellation was disabled at request level
@@ -467,7 +474,8 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .execute();
         awaitForBlock(plugins);
         // sleep for cancellation timeout to ensure there is no scheduled task for cancellation
-        Thread.sleep(cancellationTimeout.getMillis());
+        // add 100ms to account for multithreading and sleep inaccuracies
+        Thread.sleep(cancellationTimeout.getMillis() + 100L);
         // unblock the search thread
         disableBlocks(plugins);
         // ensure search was successful since cancellation was disabled at request level
@@ -527,7 +535,8 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .execute();
         awaitForBlock(plugins);
         // sleep for cluster cancellation timeout to ensure scheduled cancellation task is actually executed
-        Thread.sleep(cancellationTimeout.getMillis());
+        // add 100ms to account for multithreading and sleep inaccuracies
+        Thread.sleep(cancellationTimeout.getMillis() + 100L);
         // unblock the search thread
         disableBlocks(plugins);
         // both child requests are expected to fail
@@ -582,7 +591,8 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .execute();
         awaitForBlock(plugins);
         // sleep for cluster cancellation timeout to ensure scheduled cancellation task is actually executed
-        Thread.sleep(Math.max(reqCancellationTimeout.getMillis(), clusterCancellationTimeout.getMillis()));
+        // add 100ms to account for multithreading and sleep inaccuracies
+        Thread.sleep(Math.max(reqCancellationTimeout.getMillis(), clusterCancellationTimeout.getMillis()) + 100L);
         // unblock the search thread
         disableBlocks(plugins);
         // only first and last child request are expected to fail

--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
@@ -240,9 +240,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .setQuery(scriptQuery(new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.SCRIPT_NAME, Collections.emptyMap())))
             .execute();
         awaitForBlock(plugins);
-        // sleep for cancellation timeout to ensure scheduled cancellation task is actually executed
-        // add 100ms to account for multithreading and sleep inaccuracies
-        Thread.sleep(cancellationTimeout.getMillis() + 100L);
+        sleepForAtLeast(cancellationTimeout.getMillis());
         // unblock the search thread
         disableBlocks(plugins);
         ensureSearchWasCancelled(searchResponse);
@@ -263,9 +261,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .setQuery(scriptQuery(new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.SCRIPT_NAME, Collections.emptyMap())))
             .execute();
         awaitForBlock(plugins);
-        // sleep for cluster cancellation timeout to ensure scheduled cancellation task is actually executed
-        // add 100ms to account for multithreading and sleep inaccuracies
-        Thread.sleep(cancellationTimeout.getMillis() + 100L);
+        sleepForAtLeast(cancellationTimeout.getMillis());
         // unblock the search thread
         disableBlocks(plugins);
         ensureSearchWasCancelled(searchResponse);
@@ -296,9 +292,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .addScriptField("test_field", new Script(ScriptType.INLINE, "mockscript", SCRIPT_NAME, Collections.emptyMap()))
             .execute();
         awaitForBlock(plugins);
-        // sleep for request cancellation timeout to ensure scheduled cancellation task is actually executed
-        // add 100ms to account for multithreading and sleep inaccuracies
-        Thread.sleep(cancellationTimeout.getMillis() + 100L);
+        sleepForAtLeast(cancellationTimeout.getMillis());
         // unblock the search thread
         disableBlocks(plugins);
         ensureSearchWasCancelled(searchResponse);
@@ -338,9 +332,8 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .execute();
 
         awaitForBlock(plugins);
-        // sleep for request cancellation timeout to ensure scheduled cancellation task is actually executed
-        // add 100ms to account for multithreading and sleep inaccuracies
-        Thread.sleep(cancellationTimeout.getMillis() + 100L);
+        sleepForAtLeast(cancellationTimeout.getMillis());
+        // unblock the search thread
         disableBlocks(plugins);
         SearchResponse response = ensureSearchWasCancelled(searchResponse);
         if (response != null) {
@@ -423,9 +416,8 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .execute();
 
         awaitForBlock(plugins);
-        // sleep for cancellation timeout to ensure there is no scheduled task for cancellation
-        // add 100ms to account for multithreading and sleep inaccuracies
-        Thread.sleep(cancellationTimeout.getMillis() + 100L);
+        sleepForAtLeast(cancellationTimeout.getMillis());
+        // unblock the search thread
         disableBlocks(plugins);
 
         // wait for response and ensure there is no failure
@@ -450,9 +442,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .setQuery(scriptQuery(new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.SCRIPT_NAME, Collections.emptyMap())))
             .execute();
         awaitForBlock(plugins);
-        // sleep for cancellation timeout to ensure there is no scheduled task for cancellation
-        // add 100ms to account for multithreading and sleep inaccuracies
-        Thread.sleep(cancellationTimeout.getMillis() + 100L);
+        sleepForAtLeast(cancellationTimeout.getMillis());
         // unblock the search thread
         disableBlocks(plugins);
         // ensure search was successful since cancellation was disabled at request level
@@ -473,9 +463,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             .setQuery(scriptQuery(new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.SCRIPT_NAME, Collections.emptyMap())))
             .execute();
         awaitForBlock(plugins);
-        // sleep for cancellation timeout to ensure there is no scheduled task for cancellation
-        // add 100ms to account for multithreading and sleep inaccuracies
-        Thread.sleep(cancellationTimeout.getMillis() + 100L);
+        sleepForAtLeast(cancellationTimeout.getMillis());
         // unblock the search thread
         disableBlocks(plugins);
         // ensure search was successful since cancellation was disabled at request level
@@ -534,9 +522,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             )
             .execute();
         awaitForBlock(plugins);
-        // sleep for cluster cancellation timeout to ensure scheduled cancellation task is actually executed
-        // add 100ms to account for multithreading and sleep inaccuracies
-        Thread.sleep(cancellationTimeout.getMillis() + 100L);
+        sleepForAtLeast(cancellationTimeout.getMillis());
         // unblock the search thread
         disableBlocks(plugins);
         // both child requests are expected to fail
@@ -590,9 +576,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
             )
             .execute();
         awaitForBlock(plugins);
-        // sleep for cluster cancellation timeout to ensure scheduled cancellation task is actually executed
-        // add 100ms to account for multithreading and sleep inaccuracies
-        Thread.sleep(Math.max(reqCancellationTimeout.getMillis(), clusterCancellationTimeout.getMillis()) + 100L);
+        sleepForAtLeast(Math.max(reqCancellationTimeout.getMillis(), clusterCancellationTimeout.getMillis()));
         // unblock the search thread
         disableBlocks(plugins);
         // only first and last child request are expected to fail
@@ -600,6 +584,16 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
         expectedFailedRequests.add(0);
         expectedFailedRequests.add(2);
         ensureMSearchWasCancelled(mSearchResponse, expectedFailedRequests);
+    }
+
+    /**
+     * Sleeps for the specified number of milliseconds plus a 100ms buffer to account for system timer/sheduler inaccuracies.
+     *
+     * @param milliseconds The minimum time to sleep
+     * @throws InterruptedException if interrupted during sleep
+     */
+    private static void sleepForAtLeast(long milliseconds) throws InterruptedException {
+        Thread.sleep(milliseconds + 100L);
     }
 
     public static class ScriptedBlockPlugin extends MockScriptPlugin {


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

[`Thread.sleep()`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Thread.html#sleep(long)) does not sleep for precise amounts:
> Causes the currently executing thread to sleep (temporarily cease execution) for the specified number of milliseconds, **subject to the precision and accuracy of system timers and schedulers**.

Tests in the `SearchCancellationIT` class relied on sleeping for exactly the cancellation timeout, which creates potential race conditions and occasional test failures.

This PR adds an extra 100ms of sleep time before checking the cancellation status.

### Issues Resolved
Fixes #2242 
Fixes #2311
Fixes #2763

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
