### PR TITLE
[Extensions]Add query for initialized extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add support for ppc64le architecture ([#5459](https://github.com/opensearch-project/OpenSearch/pull/5459))
 - Added @gbbafna as an OpenSearch maintainer ([#5668](https://github.com/opensearch-project/OpenSearch/pull/5668))
 - Added support for feature flags in opensearch.yml ([#4959](https://github.com/opensearch-project/OpenSearch/pull/4959))
+- Add query for initialized extensions ([#5658](https://github.com/opensearch-project/OpenSearch/pull/5658))
 
 ### Dependencies
 - Bumps `log4j-core` from 2.18.0 to 2.19.0

--- a/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
+++ b/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
@@ -93,7 +93,6 @@ public class DiscoveryExtensionNode extends DiscoveryNode implements Writeable, 
         return false;
     }
 
-
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         return null;

--- a/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
+++ b/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
@@ -84,8 +84,10 @@ public class DiscoveryExtensionNode extends DiscoveryNode implements Writeable, 
 
     public boolean dependenciesContain(ExtensionDependency dependency) {
         for (ExtensionDependency extensiondependency : this.dependencies) {
-            return dependency.getUniqueId().equals(extensiondependency.getUniqueId())
-                && dependency.getVersion().equals(extensiondependency.getVersion());
+            if (dependency.getUniqueId().equals(extensiondependency.getUniqueId())
+                && dependency.getVersion().equals(extensiondependency.getVersion())) {
+                return true;
+            }
         }
         return false;
     }

--- a/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
+++ b/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
@@ -84,11 +84,8 @@ public class DiscoveryExtensionNode extends DiscoveryNode implements Writeable, 
 
     public boolean dependenciesContain(ExtensionDependency dependency) {
         for (ExtensionDependency extensiondependency : this.dependencies) {
-            if (dependency.getUniqueId().equals(extensiondependency.getUniqueId())
-                && dependency.getVersion().equals(extensiondependency.getVersion())) {
-                return true;
-
-            }
+            return dependency.getUniqueId().equals(extensiondependency.getUniqueId())
+                && dependency.getVersion().equals(extensiondependency.getVersion());
         }
         return false;
     }

--- a/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
+++ b/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
@@ -82,6 +82,18 @@ public class DiscoveryExtensionNode extends DiscoveryNode implements Writeable, 
         return dependencies;
     }
 
+    public boolean dependenciesContain(ExtensionDependency dependency) {
+        for (ExtensionDependency extensiondependency : this.dependencies) {
+            if (dependency.getUniqueId().equals(extensiondependency.getUniqueId())
+                && dependency.getVersion().equals(extensiondependency.getVersion())) {
+                return true;
+
+            }
+        }
+        return false;
+    }
+
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         return null;

--- a/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
@@ -23,35 +23,35 @@ import org.opensearch.transport.TransportResponse;
  * @opensearch.internal
  */
 public class ExtensionDependencyResponse extends TransportResponse {
-    private List<DiscoveryExtensionNode> dependencies;
+    private List<DiscoveryExtensionNode> extensionDependencies;
 
-    public ExtensionDependencyResponse(List<DiscoveryExtensionNode> dependencies) {
-        this.dependencies = dependencies;
+    public ExtensionDependencyResponse(List<DiscoveryExtensionNode> extensionDependencies) {
+        this.extensionDependencies = extensionDependencies;
     }
 
     public ExtensionDependencyResponse(StreamInput in) throws IOException {
         int size = in.readVInt();
-        dependencies = new ArrayList<>(size);
+        extensionDependencies = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            dependencies.add(new DiscoveryExtensionNode(in));
+            extensionDependencies.add(new DiscoveryExtensionNode(in));
         }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeVInt(dependencies.size());
-        for (DiscoveryExtensionNode dependency : dependencies) {
+        out.writeVInt(extensionDependencies.size());
+        for (DiscoveryExtensionNode dependency : extensionDependencies) {
             dependency.writeTo(out);
         }
     }
 
     public List<DiscoveryExtensionNode> getExtensionDependency() {
-        return dependencies;
+        return extensionDependencies;
     }
 
     @Override
     public String toString() {
-        return "ExtensionDependencyResponse{extensiondependency=" + dependencies.toString() + '}';
+        return "ExtensionDependencyResponse{extensiondependency=" + extensionDependencies.toString() + '}';
     }
 
     @Override
@@ -59,11 +59,11 @@ public class ExtensionDependencyResponse extends TransportResponse {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ExtensionDependencyResponse that = (ExtensionDependencyResponse) o;
-        return Objects.equals(dependencies, that.dependencies);
+        return Objects.equals(extensionDependencies, that.extensionDependencies);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(dependencies);
+        return Objects.hash(extensionDependencies);
     }
 }

--- a/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
@@ -7,64 +7,63 @@
  * compatible open source license.
  */
 
- package org.opensearch.extensions;
+package org.opensearch.extensions;
 
- import java.io.IOException;
- import java.util.ArrayList;
- import java.util.List;
- import java.util.Objects;
- import org.opensearch.common.io.stream.StreamInput;
- import org.opensearch.common.io.stream.StreamOutput;
- import org.opensearch.transport.TransportResponse;
- 
- /**
-  * The response for getting the Extension Dependency.
-  *
-  * @opensearch.internal
-  */
- public class ExtensionDependencyResponse extends TransportResponse {
-     private List<DiscoveryExtensionNode> dependencies;
- 
-     public ExtensionDependencyResponse(List<DiscoveryExtensionNode> dependencies) {
-         this.dependencies = dependencies;
-     }
- 
-     public ExtensionDependencyResponse(StreamInput in) throws IOException {
-         int size = in.readVInt();
-         dependencies = new ArrayList<>(size);
-         for (int i = 0; i < size; i++) {
-             dependencies.add(new DiscoveryExtensionNode(in));
-         }
-     }
- 
-     @Override
-     public void writeTo(StreamOutput out) throws IOException {
-         out.writeVInt(dependencies.size());
-         for (DiscoveryExtensionNode dependency : dependencies) {
-             dependency.writeTo(out);
-         }
-     }
- 
-     public List<DiscoveryExtensionNode> getExtensionDependency() {
-         return dependencies;
-     }
- 
-     @Override
-     public String toString() {
-         return "ExtensionDependencyResponse{extensiondependency=" + dependencies.toString() + '}';
-     }
- 
-     @Override
-     public boolean equals(Object o) {
-         if (this == o) return true;
-         if (o == null || getClass() != o.getClass()) return false;
-         ExtensionDependencyResponse that = (ExtensionDependencyResponse) o;
-         return Objects.equals(dependencies, that.dependencies);
-     }
- 
-     @Override
-     public int hashCode() {
-         return Objects.hash(dependencies);
-     }
- }
- 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportResponse;
+
+/**
+ * The response for getting the Extension Dependency.
+ *
+ * @opensearch.internal
+ */
+public class ExtensionDependencyResponse extends TransportResponse {
+    private List<DiscoveryExtensionNode> dependencies;
+
+    public ExtensionDependencyResponse(List<DiscoveryExtensionNode> dependencies) {
+        this.dependencies = dependencies;
+    }
+
+    public ExtensionDependencyResponse(StreamInput in) throws IOException {
+        int size = in.readVInt();
+        dependencies = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            dependencies.add(new DiscoveryExtensionNode(in));
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(dependencies.size());
+        for (DiscoveryExtensionNode dependency : dependencies) {
+            dependency.writeTo(out);
+        }
+    }
+
+    public List<DiscoveryExtensionNode> getExtensionDependency() {
+        return dependencies;
+    }
+
+    @Override
+    public String toString() {
+        return "ExtensionDependencyResponse{extensiondependency=" + dependencies.toString() + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ExtensionDependencyResponse that = (ExtensionDependencyResponse) o;
+        return Objects.equals(dependencies, that.dependencies);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dependencies);
+    }
+}

--- a/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
@@ -1,0 +1,70 @@
+/*
+* Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+ package org.opensearch.extensions;
+
+ import java.io.IOException;
+ import java.util.ArrayList;
+ import java.util.List;
+ import java.util.Objects;
+ import org.opensearch.common.io.stream.StreamInput;
+ import org.opensearch.common.io.stream.StreamOutput;
+ import org.opensearch.transport.TransportResponse;
+ 
+ /**
+  * The response for getting the Extension Dependency.
+  *
+  * @opensearch.internal
+  */
+ public class ExtensionDependencyResponse extends TransportResponse {
+     private List<DiscoveryExtensionNode> dependencies;
+ 
+     public ExtensionDependencyResponse(List<DiscoveryExtensionNode> dependencies) {
+         this.dependencies = dependencies;
+     }
+ 
+     public ExtensionDependencyResponse(StreamInput in) throws IOException {
+         int size = in.readVInt();
+         dependencies = new ArrayList<>(size);
+         for (int i = 0; i < size; i++) {
+             dependencies.add(new DiscoveryExtensionNode(in));
+         }
+     }
+ 
+     @Override
+     public void writeTo(StreamOutput out) throws IOException {
+         out.writeVInt(dependencies.size());
+         for (DiscoveryExtensionNode dependency : dependencies) {
+             dependency.writeTo(out);
+         }
+     }
+ 
+     public List<DiscoveryExtensionNode> getExtensionDependency() {
+         return dependencies;
+     }
+ 
+     @Override
+     public String toString() {
+         return "ExtensionDependencyResponse{extensiondependency=" + dependencies.toString() + '}';
+     }
+ 
+     @Override
+     public boolean equals(Object o) {
+         if (this == o) return true;
+         if (o == null || getClass() != o.getClass()) return false;
+         ExtensionDependencyResponse that = (ExtensionDependencyResponse) o;
+         return Objects.equals(dependencies, that.dependencies);
+     }
+ 
+     @Override
+     public int hashCode() {
+         return Objects.hash(dependencies);
+     }
+ }
+ 

--- a/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
@@ -25,7 +25,6 @@ import java.util.Optional;
  */
 public class ExtensionRequest extends TransportRequest {
     private static final Logger logger = LogManager.getLogger(ExtensionRequest.class);
-    private ExtensionsManager.RequestType requestType;
     private final ExtensionsManager.RequestType requestType;
     private final Optional<String> uniqueId;
 

--- a/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
@@ -16,6 +16,7 @@ import org.opensearch.transport.TransportRequest;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * CLusterService Request for Extensibility
@@ -25,28 +26,41 @@ import java.util.Objects;
 public class ExtensionRequest extends TransportRequest {
     private static final Logger logger = LogManager.getLogger(ExtensionRequest.class);
     private ExtensionsManager.RequestType requestType;
+    private final ExtensionsManager.RequestType requestType;
+    private final Optional<String> uniqueId;
 
     public ExtensionRequest(ExtensionsManager.RequestType requestType) {
+        this(requestType, null);
+    }
+
+    public ExtensionRequest(ExtensionsManager.RequestType requestType, Optional<String> uniqueId) {
         this.requestType = requestType;
+        this.uniqueId = uniqueId;
     }
 
     public ExtensionRequest(StreamInput in) throws IOException {
-        super(in);
         this.requestType = in.readEnum(ExtensionsManager.RequestType.class);
+        String id = in.readOptionalString();
+        this.uniqueId = id == null ? Optional.empty() : Optional.of(id);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeEnum(requestType);
+        out.writeOptionalString(uniqueId.orElse(null));
     }
 
     public ExtensionsManager.RequestType getRequestType() {
         return this.requestType;
     }
 
+    public Optional<String> getUniqueId() {
+        return uniqueId;
+    }
+
     public String toString() {
-        return "ExtensionRequest{" + "requestType=" + requestType + '}';
+        return "ExtensionRequest{" + "requestType=" + requestType + "uniqueId=" + uniqueId + '}';
     }
 
     @Override
@@ -54,11 +68,11 @@ public class ExtensionRequest extends TransportRequest {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ExtensionRequest that = (ExtensionRequest) o;
-        return Objects.equals(requestType, that.requestType);
+        return Objects.equals(requestType, that.requestType) && uniqueId.equals(that.uniqueId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(requestType);
+        return Objects.hash(requestType, uniqueId);
     }
 }

--- a/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
@@ -10,6 +10,7 @@ package org.opensearch.extensions;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.transport.TransportRequest;
@@ -32,12 +33,13 @@ public class ExtensionRequest extends TransportRequest {
         this(requestType, null);
     }
 
-    public ExtensionRequest(ExtensionsManager.RequestType requestType, Optional<String> uniqueId) {
+    public ExtensionRequest(ExtensionsManager.RequestType requestType, @Nullable String uniqueId) {
         this.requestType = requestType;
-        this.uniqueId = uniqueId;
+        this.uniqueId = uniqueId == null ? Optional.empty() : Optional.of(uniqueId);
     }
 
     public ExtensionRequest(StreamInput in) throws IOException {
+        super(in);
         this.requestType = in.readEnum(ExtensionsManager.RequestType.class);
         String id = in.readOptionalString();
         this.uniqueId = id == null ? Optional.empty() : Optional.of(id);
@@ -67,7 +69,7 @@ public class ExtensionRequest extends TransportRequest {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ExtensionRequest that = (ExtensionRequest) o;
-        return Objects.equals(requestType, that.requestType) && uniqueId.equals(that.uniqueId);
+        return Objects.equals(requestType, that.requestType) && Objects.equals(uniqueId, that.uniqueId);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -79,6 +80,7 @@ public class ExtensionsManager {
     public static final String REQUEST_EXTENSION_ENVIRONMENT_SETTINGS = "internal:discovery/enviornmentsettings";
     public static final String REQUEST_EXTENSION_ADD_SETTINGS_UPDATE_CONSUMER = "internal:discovery/addsettingsupdateconsumer";
     public static final String REQUEST_EXTENSION_UPDATE_SETTINGS = "internal:discovery/updatesettings";
+    public static final String REQUEST_EXTENSION_DEPENDENCY_INFORMATION = "internal:discovery/dependencyinformation";
     public static final String REQUEST_EXTENSION_REGISTER_CUSTOM_SETTINGS = "internal:discovery/registercustomsettings";
     public static final String REQUEST_EXTENSION_REGISTER_REST_ACTIONS = "internal:discovery/registerrestactions";
     public static final String REQUEST_EXTENSION_REGISTER_TRANSPORT_ACTIONS = "internal:discovery/registertransportactions";
@@ -101,6 +103,7 @@ public class ExtensionsManager {
         REQUEST_EXTENSION_REGISTER_REST_ACTIONS,
         REQUEST_EXTENSION_REGISTER_SETTINGS,
         REQUEST_EXTENSION_ENVIRONMENT_SETTINGS,
+        REQUEST_EXTENSION_DEPENDENCY_INFORMATION,
         CREATE_COMPONENT,
         ON_INDEX_MODULE,
         GET_SETTINGS
@@ -235,6 +238,14 @@ public class ExtensionsManager {
         );
         transportService.registerRequestHandler(
             REQUEST_EXTENSION_ENVIRONMENT_SETTINGS,
+            ThreadPool.Names.GENERIC,
+            false,
+            false,
+            ExtensionRequest::new,
+            ((request, channel, task) -> channel.sendResponse(handleExtensionRequest(request)))
+        );
+        transportService.registerRequestHandler(
+            REQUEST_EXTENSION_DEPENDENCY_INFORMATION,
             ThreadPool.Names.GENERIC,
             false,
             false,
@@ -417,6 +428,16 @@ public class ExtensionsManager {
                 return new ClusterSettingsResponse(clusterService);
             case REQUEST_EXTENSION_ENVIRONMENT_SETTINGS:
                 return new EnvironmentSettingsResponse(this.environmentSettings);
+            case REQUEST_EXTENSION_DEPENDENCY_INFORMATION:
+                String uniqueId = extensionRequest.getUniqueId().orElse(null);
+                if (uniqueId == null) {
+                    return new ExtensionDependencyResponse(extensions);
+                } else {
+                    ExtensionDependency matchingId = new ExtensionDependency(uniqueId, Version.CURRENT);
+                    return new ExtensionDependencyResponse(
+                        extensions.stream().filter(e -> e.dependenciesContain(matchingId)).collect(Collectors.toList())
+                    );
+                }
             default:
                 throw new IllegalArgumentException("Handler not present for the provided request");
         }

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -561,6 +561,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
                 extensionRequest = new ExtensionRequest(in);
                 assertEquals(expectedRequestType, extensionRequest.getRequestType());
+                assertEquals(Optional.empty(), extensionRequest.getUniqueId());
             }
         }
     }

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -528,6 +528,44 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
         assertEquals("Handler not present for the provided request", exception.getMessage());
     }
 
+    public void testExtensionRequest() throws Exception {
+        ExtensionsManager.RequestType expectedRequestType = ExtensionsManager.RequestType.REQUEST_EXTENSION_DEPENDENCY_INFORMATION;
+
+        // Test ExtensionRequest 2 arg constructor
+        String expectedUniqueId = "test uniqueid";
+        ExtensionRequest extensionRequest = new ExtensionRequest(expectedRequestType, expectedUniqueId);
+        assertEquals(expectedRequestType, extensionRequest.getRequestType());
+        assertEquals(expectedUniqueId, extensionRequest.getUniqueId());
+
+        // Test ExtensionRequest StreamInput constructor
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            extensionRequest.writeTo(out);
+            out.flush();
+            try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
+                extensionRequest = new ExtensionRequest(in);
+                assertEquals(expectedRequestType, extensionRequest.getRequestType());
+                assertEquals(expectedUniqueId, extensionRequest.getUniqueId());
+            }
+        }
+
+        // Test ExtensionRequest 1 arg constructor
+        expectedUniqueId = null;
+        extensionRequest = new ExtensionRequest(expectedRequestType, expectedUniqueId);
+        assertEquals(expectedRequestType, extensionRequest.getRequestType());
+        assertEquals(expectedUniqueId, extensionRequest.getUniqueId());
+
+        // Test ExtensionRequest StreamInput constructor
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            extensionRequest.writeTo(out);
+            out.flush();
+            try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
+                extensionRequest = new ExtensionRequest(in);
+                assertEquals(expectedRequestType, extensionRequest.getRequestType());
+                assertEquals(expectedUniqueId, extensionRequest.getUniqueId());
+            }
+        }
+    }
+
     public void testExtensionDependencyResponse() throws Exception {
         String expectedUniqueId = "test uniqueid";
         List<DiscoveryExtensionNode> expectedExtensionsList = new ArrayList<DiscoveryExtensionNode>();

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -528,6 +528,51 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
         assertEquals("Handler not present for the provided request", exception.getMessage());
     }
 
+    public void testExtensionDependencyResponse() throws Exception {
+        String expectedUniqueId = "test uniqueid";
+        List<DiscoveryExtensionNode> expectedExtensionsList = new ArrayList<DiscoveryExtensionNode>();
+        Version expectedVersion = Version.fromString("2.0.0");
+        ExtensionDependency expectedDependency = new ExtensionDependency(expectedUniqueId, expectedVersion);
+
+        expectedExtensionsList.add(
+            new DiscoveryExtensionNode(
+                "firstExtension",
+                "uniqueid1",
+                "uniqueid1",
+                "myIndependentPluginHost1",
+                "127.0.0.0",
+                new TransportAddress(InetAddress.getByName("127.0.0.0"), 9300),
+                new HashMap<String, String>(),
+                Version.fromString("3.0.0"),
+                new PluginInfo(
+                    "firstExtension",
+                    "Fake description 1",
+                    "0.0.7",
+                    Version.fromString("3.0.0"),
+                    "14",
+                    "fakeClass1",
+                    new ArrayList<String>(),
+                    false
+                ),
+                List.of(expectedDependency)
+            )
+        );
+
+        // Test ExtensionDependencyResponse arg constructor
+        ExtensionDependencyResponse extensionDependencyResponse = new ExtensionDependencyResponse(expectedExtensionsList);
+        assertEquals(expectedExtensionsList, extensionDependencyResponse.getExtensionDependency());
+
+        // Test ExtensionDependencyResponse StreamInput constructor
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            extensionDependencyResponse.writeTo(out);
+            out.flush();
+            try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
+                extensionDependencyResponse = new ExtensionDependencyResponse(in);
+                assertEquals(expectedExtensionsList, extensionDependencyResponse.getExtensionDependency());
+            }
+        }
+    }
+
     public void testEnvironmentSettingsResponse() throws Exception {
 
         // Test EnvironmentSettingsResponse arg constructor

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -545,7 +545,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
                 extensionRequest = new ExtensionRequest(in);
                 assertEquals(expectedRequestType, extensionRequest.getRequestType());
-                assertEquals(expectedUniqueId, Optional.of(extensionRequest.getUniqueId()));
+                assertEquals(Optional.of(expectedUniqueId), extensionRequest.getUniqueId());
             }
         }
 
@@ -561,7 +561,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
                 extensionRequest = new ExtensionRequest(in);
                 assertEquals(expectedRequestType, extensionRequest.getRequestType());
-                assertEquals(Optional.empty(), Optional.of(extensionRequest.getUniqueId()));
+                assertEquals(Optional.empty(), extensionRequest.getUniqueId());
             }
         }
     }

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -545,7 +545,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
                 extensionRequest = new ExtensionRequest(in);
                 assertEquals(expectedRequestType, extensionRequest.getRequestType());
-                assertEquals(expectedUniqueId, extensionRequest.getUniqueId());
+                assertEquals(expectedUniqueId, Optional.of(extensionRequest.getUniqueId()));
             }
         }
 
@@ -561,7 +561,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
                 extensionRequest = new ExtensionRequest(in);
                 assertEquals(expectedRequestType, extensionRequest.getRequestType());
-                assertEquals(Optional.empty(), extensionRequest.getUniqueId());
+                assertEquals(Optional.empty(), Optional.of(extensionRequest.getUniqueId()));
             }
         }
     }

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -756,7 +756,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             settings,
             client
         );
-        verify(mockTransportService, times(8)).registerRequestHandler(anyString(), anyString(), anyBoolean(), anyBoolean(), any(), any());
+        verify(mockTransportService, times(9)).registerRequestHandler(anyString(), anyString(), anyBoolean(), anyBoolean(), any(), any());
 
     }
 

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -533,10 +533,10 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
         ExtensionsManager.RequestType expectedRequestType = ExtensionsManager.RequestType.REQUEST_EXTENSION_DEPENDENCY_INFORMATION;
 
         // Test ExtensionRequest 2 arg constructor
-        Optional<String> expectedUniqueId = Optional.of("test uniqueid");
-        ExtensionRequest extensionRequest = new ExtensionRequest(expectedRequestType, expectedUniqueId.orElse(null));
+        String expectedUniqueId = "test uniqueid";
+        ExtensionRequest extensionRequest = new ExtensionRequest(expectedRequestType, expectedUniqueId);
         assertEquals(expectedRequestType, extensionRequest.getRequestType());
-        assertEquals(expectedUniqueId, extensionRequest.getUniqueId());
+        assertEquals(Optional.of(expectedUniqueId), extensionRequest.getUniqueId());
 
         // Test ExtensionRequest StreamInput constructor
         try (BytesStreamOutput out = new BytesStreamOutput()) {
@@ -550,8 +550,9 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
         }
 
         // Test ExtensionRequest 1 arg constructor
-        extensionRequest = new ExtensionRequest(expectedRequestType, null);
+        extensionRequest = new ExtensionRequest(expectedRequestType);
         assertEquals(expectedRequestType, extensionRequest.getRequestType());
+        assertEquals(Optional.empty(), extensionRequest.getUniqueId());
 
         // Test ExtensionRequest StreamInput constructor
         try (BytesStreamOutput out = new BytesStreamOutput()) {

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -532,8 +533,8 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
         ExtensionsManager.RequestType expectedRequestType = ExtensionsManager.RequestType.REQUEST_EXTENSION_DEPENDENCY_INFORMATION;
 
         // Test ExtensionRequest 2 arg constructor
-        String expectedUniqueId = "test uniqueid";
-        ExtensionRequest extensionRequest = new ExtensionRequest(expectedRequestType, expectedUniqueId);
+        Optional<String> expectedUniqueId = Optional.of("test uniqueid");
+        ExtensionRequest extensionRequest = new ExtensionRequest(expectedRequestType, expectedUniqueId.orElse(null));
         assertEquals(expectedRequestType, extensionRequest.getRequestType());
         assertEquals(expectedUniqueId, extensionRequest.getUniqueId());
 
@@ -549,10 +550,8 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
         }
 
         // Test ExtensionRequest 1 arg constructor
-        expectedUniqueId = null;
-        extensionRequest = new ExtensionRequest(expectedRequestType, expectedUniqueId);
+        extensionRequest = new ExtensionRequest(expectedRequestType, null);
         assertEquals(expectedRequestType, extensionRequest.getRequestType());
-        assertEquals(expectedUniqueId, extensionRequest.getUniqueId());
 
         // Test ExtensionRequest StreamInput constructor
         try (BytesStreamOutput out = new BytesStreamOutput()) {
@@ -561,7 +560,6 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
                 extensionRequest = new ExtensionRequest(in);
                 assertEquals(expectedRequestType, extensionRequest.getRequestType());
-                assertEquals(expectedUniqueId, extensionRequest.getUniqueId());
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Frank Lou <mloufra@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Create a feature to have an extension query to OpenSearch to obtain a list of initialized extensions and determine whether a particular extension is initialized.
Equivalent PR on OpenSearch-sdk-java : https://github.com/opensearch-project/opensearch-sdk-java/pull/300 

### Issues Resolved
fixes https://github.com/opensearch-project/opensearch-sdk-java/issues/149

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
