### PR TITLE
[Remote Translog] Trimming based on remote segment upload and cleaning older tlog files 

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
@@ -1124,7 +1124,7 @@ public class OpenSearchNode implements TestClusterConfiguration {
         if (nodeName != null) {
             baseConfig.put("node.name", nodeName);
         }
-        baseConfig.put("path.repo", confPathRepo.toAbsolutePath().toString());
+        baseConfig.put("path.repo", "/Users/gbbafna/git/OpenSearch/build/testclusters/repo");
         baseConfig.put("path.data", confPathData.toAbsolutePath().toString());
         baseConfig.put("path.logs", confPathLogs.toAbsolutePath().toString());
         baseConfig.put("path.shared_data", workingDir.resolve("sharedData").toString());

--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
@@ -1124,7 +1124,7 @@ public class OpenSearchNode implements TestClusterConfiguration {
         if (nodeName != null) {
             baseConfig.put("node.name", nodeName);
         }
-        baseConfig.put("path.repo", "/Users/gbbafna/git/OpenSearch/build/testclusters/repo");
+        baseConfig.put("path.repo", confPathRepo.toAbsolutePath().toString());
         baseConfig.put("path.data", confPathData.toAbsolutePath().toString());
         baseConfig.put("path.logs", confPathLogs.toAbsolutePath().toString());
         baseConfig.put("path.shared_data", workingDir.resolve("sharedData").toString());

--- a/server/src/main/java/org/opensearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NoOpEngine.java
@@ -228,7 +228,7 @@ public final class NoOpEngine extends ReadOnlyEngine {
                 }
 
                 @Override
-                public void minSeqNoRequired(long seqNo) {}
+                public void setMinSeqNoToKeep(long seqNo) {}
             };
         } catch (IOException ex) {
             throw new RuntimeException(ex);

--- a/server/src/main/java/org/opensearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NoOpEngine.java
@@ -226,6 +226,9 @@ public final class NoOpEngine extends ReadOnlyEngine {
                         store.decRef();
                     }
                 }
+
+                @Override
+                public void minSeqNoRequired(long seqNo) {}
             };
         } catch (IOException ex) {
             throw new RuntimeException(ex);

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -144,11 +144,10 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
                                         .filter(file -> !localSegmentsPostRefresh.contains(file))
                                         .collect(Collectors.toSet())
                                         .forEach(localSegmentChecksumMap::remove);
+                                    final long lastRefreshedCheckpoint = ((InternalEngine) indexShard.getEngine())
+                                        .lastRefreshedCheckpoint();
+                                    indexShard.getEngine().translogManager().minSeqNoRequired(lastRefreshedCheckpoint + 1);
                                 }
-                                assert indexShard.getEngine() instanceof InternalEngine : "Expected shard with InternalEngine, got: "
-                                    + indexShard.getEngine().getClass();
-                                final long lastRefreshedCheckpoint = ((InternalEngine) indexShard.getEngine()).lastRefreshedCheckpoint();
-                                indexShard.getEngine().translogManager().minSeqNoRequired(lastRefreshedCheckpoint + 1);
                             }
                         } catch (EngineException e) {
                             logger.warn("Exception while reading SegmentInfosSnapshot", e);

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -145,6 +145,10 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
                                         .collect(Collectors.toSet())
                                         .forEach(localSegmentChecksumMap::remove);
                                 }
+                                assert indexShard.getEngine() instanceof InternalEngine : "Expected shard with InternalEngine, got: "
+                                    + indexShard.getEngine().getClass();
+                                final long lastRefreshedCheckpoint = ((InternalEngine) indexShard.getEngine()).lastRefreshedCheckpoint();
+                                indexShard.getEngine().translogManager().minSeqNoRequired(lastRefreshedCheckpoint + 1);
                             }
                         } catch (EngineException e) {
                             logger.warn("Exception while reading SegmentInfosSnapshot", e);

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -146,7 +146,7 @@ public final class RemoteStoreRefreshListener implements ReferenceManager.Refres
                                         .forEach(localSegmentChecksumMap::remove);
                                     final long lastRefreshedCheckpoint = ((InternalEngine) indexShard.getEngine())
                                         .lastRefreshedCheckpoint();
-                                    indexShard.getEngine().translogManager().minSeqNoRequired(lastRefreshedCheckpoint + 1);
+                                    indexShard.getEngine().translogManager().setMinSeqNoToKeep(lastRefreshedCheckpoint + 1);
                                 }
                             }
                         } catch (EngineException e) {

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
@@ -289,6 +289,11 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
         }
     }
 
+    @Override
+    public void minSeqNoRequired(long seqNo) {
+        translog.minSeqNoRequired(seqNo);
+    }
+
     /**
      * Reads operations from the translog
      * @param location location of translog

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
@@ -290,8 +290,8 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
     }
 
     @Override
-    public void minSeqNoRequired(long seqNo) {
-        translog.setMinSeqNoRequired(seqNo);
+    public void setMinSeqNoToKeep(long seqNo) {
+        translog.setMinSeqNoToKeep(seqNo);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
@@ -291,7 +291,7 @@ public class InternalTranslogManager implements TranslogManager, Closeable {
 
     @Override
     public void minSeqNoRequired(long seqNo) {
-        translog.minSeqNoRequired(seqNo);
+        translog.setMinSeqNoRequired(seqNo);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/translog/NoOpTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/NoOpTranslogManager.java
@@ -96,7 +96,7 @@ public class NoOpTranslogManager implements TranslogManager {
     public void ensureCanFlush() {}
 
     @Override
-    public void minSeqNoRequired(long seqNo) {}
+    public void setMinSeqNoToKeep(long seqNo) {}
 
     @Override
     public int restoreLocalHistoryFromTranslog(long processedCheckpoint, TranslogRecoveryRunner translogRecoveryRunner) throws IOException {

--- a/server/src/main/java/org/opensearch/index/translog/NoOpTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/NoOpTranslogManager.java
@@ -96,6 +96,9 @@ public class NoOpTranslogManager implements TranslogManager {
     public void ensureCanFlush() {}
 
     @Override
+    public void minSeqNoRequired(long seqNo) {}
+
+    @Override
     public int restoreLocalHistoryFromTranslog(long processedCheckpoint, TranslogRecoveryRunner translogRecoveryRunner) throws IOException {
         return 0;
     }

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -47,7 +47,7 @@ public class RemoteFsTranslog extends Translog {
     private final FileTransferTracker fileTransferTracker;
     private volatile long maxRemoteTranslogGenerationUploaded;
 
-    private volatile long minSeqNoRequired;
+    private volatile long minSeqNoToKeep;
 
     public RemoteFsTranslog(
         TranslogConfig config,
@@ -289,7 +289,7 @@ public class RemoteFsTranslog extends Translog {
         assert readLock.isHeldByCurrentThread() || writeLock.isHeldByCurrentThread();
         long minReferencedGen = Math.min(
             deletionPolicy.minTranslogGenRequired(readers, current),
-            minGenerationForSeqNo(Math.min(deletionPolicy.getLocalCheckpointOfSafeCommit() + 1, minSeqNoRequired), current, readers)
+            minGenerationForSeqNo(Math.min(deletionPolicy.getLocalCheckpointOfSafeCommit() + 1, minSeqNoToKeep), current, readers)
         );
         assert minReferencedGen >= getMinFileGeneration() : "deletion policy requires a minReferenceGen of ["
             + minReferencedGen
@@ -304,13 +304,13 @@ public class RemoteFsTranslog extends Translog {
         return minReferencedGen;
     }
 
-    protected void setMinSeqNoRequired(long seqNo) {
-        if (seqNo < this.minSeqNoRequired) {
+    protected void setMinSeqNoToKeep(long seqNo) {
+        if (seqNo < this.minSeqNoToKeep) {
             throw new IllegalArgumentException(
-                "min seq number required can't go backwards: " + "current [" + this.minSeqNoRequired + "] new [" + seqNo + "]"
+                "min seq number required can't go backwards: " + "current [" + this.minSeqNoToKeep + "] new [" + seqNo + "]"
             );
         }
-        this.minSeqNoRequired = seqNo;
+        this.minSeqNoToKeep = seqNo;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -288,11 +288,8 @@ public class RemoteFsTranslog extends Translog {
     protected long getMinReferencedGen() throws IOException {
         assert readLock.isHeldByCurrentThread() || writeLock.isHeldByCurrentThread();
         long minReferencedGen = Math.min(
-            Math.min(
-                deletionPolicy.minTranslogGenRequired(readers, current),
-                minGenerationForSeqNo(deletionPolicy.getLocalCheckpointOfSafeCommit() + 1, current, readers)
-            ),
-            minGenerationForSeqNo(minSeqNoRequired, current, readers)
+            deletionPolicy.minTranslogGenRequired(readers, current),
+            minGenerationForSeqNo(Math.min(deletionPolicy.getLocalCheckpointOfSafeCommit() + 1, minSeqNoRequired), current, readers)
         );
         assert minReferencedGen >= getMinFileGeneration() : "deletion policy requires a minReferenceGen of ["
             + minReferencedGen

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -318,7 +318,7 @@ public class RemoteFsTranslog extends Translog {
         try {
             translogTransferManager.deleteTranslog(primaryTermSupplier.getAsLong(), reader.generation);
         } catch (IOException ignored) {
-            logger.debug("Exception {} while deleting generation {}", ignored, reader.generation);
+            logger.error("Exception {} while deleting generation {}", ignored, reader.generation);
         }
         super.deleteReaderFiles(reader);
     }

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -304,15 +304,21 @@ public class RemoteFsTranslog extends Translog {
         return minReferencedGen;
     }
 
-    protected void minSeqNoRequired(long seqNo) {
+    protected void setMinSeqNoRequired(long seqNo) {
+        if (seqNo < this.minSeqNoRequired) {
+            throw new IllegalArgumentException(
+                "min seq number required can't go backwards: " + "current [" + this.minSeqNoRequired + "] new [" + seqNo + "]"
+            );
+        }
         this.minSeqNoRequired = seqNo;
     }
 
+    @Override
     void deleteReaderFiles(TranslogReader reader) {
         try {
             translogTransferManager.deleteTranslog(primaryTermSupplier.getAsLong(), reader.generation);
         } catch (IOException ignored) {
-
+            logger.debug("Exception {} while deleting generation {}", ignored, reader.generation);
         }
         super.deleteReaderFiles(reader);
     }

--- a/server/src/main/java/org/opensearch/index/translog/Translog.java
+++ b/server/src/main/java/org/opensearch/index/translog/Translog.java
@@ -1804,7 +1804,7 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
     Min Seq number required in translog to restore the complete data .
     This might be required when segments are persisted via other mechanism than flush.
      */
-    protected void setMinSeqNoRequired(long seqNo) {}
+    protected void setMinSeqNoToKeep(long seqNo) {}
 
     /**
      * deletes all files associated with a reader. package-private to be able to simulate node failures at this point

--- a/server/src/main/java/org/opensearch/index/translog/Translog.java
+++ b/server/src/main/java/org/opensearch/index/translog/Translog.java
@@ -1800,7 +1800,11 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
         return minReferencedGen;
     }
 
-    protected void minSeqNoRequired(long seqNo) {}
+    /*
+    Min Seq number required in translog to restore the complete data .
+    This might be required when segments are persisted via other mechanism than flush.
+     */
+    protected void setMinSeqNoRequired(long seqNo) {}
 
     /**
      * deletes all files associated with a reader. package-private to be able to simulate node failures at this point

--- a/server/src/main/java/org/opensearch/index/translog/Translog.java
+++ b/server/src/main/java/org/opensearch/index/translog/Translog.java
@@ -1684,7 +1684,7 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
         }
     }
 
-    private static long minGenerationForSeqNo(long seqNo, TranslogWriter writer, List<TranslogReader> readers) {
+    static long minGenerationForSeqNo(long seqNo, TranslogWriter writer, List<TranslogReader> readers) {
         long minGen = writer.generation;
         for (final TranslogReader reader : readers) {
             if (seqNo <= reader.getCheckpoint().maxEffectiveSeqNo()) {
@@ -1781,7 +1781,7 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
         }
     }
 
-    private long getMinReferencedGen() throws IOException {
+    protected long getMinReferencedGen() throws IOException {
         assert readLock.isHeldByCurrentThread() || writeLock.isHeldByCurrentThread();
         long minReferencedGen = Math.min(
             deletionPolicy.minTranslogGenRequired(readers, current),
@@ -1799,6 +1799,8 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
             + "]";
         return minReferencedGen;
     }
+
+    protected void minSeqNoRequired(long seqNo) {}
 
     /**
      * deletes all files associated with a reader. package-private to be able to simulate node failures at this point

--- a/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
@@ -119,4 +119,10 @@ public interface TranslogManager {
      * Checks if the translog has a pending recovery
      */
     void ensureCanFlush();
+
+    /**
+     *
+     * @param seqNo : operations >= should be persisted
+     */
+    void minSeqNoRequired(long seqNo);
 }

--- a/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
@@ -125,5 +125,5 @@ public interface TranslogManager {
      * @param seqNo : operations greater or equal to seqNo should be persisted
      * This might be required when segments are persisted via other mechanism than flush.
      */
-    void minSeqNoRequired(long seqNo);
+    void setMinSeqNoToKeep(long seqNo);
 }

--- a/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
@@ -122,7 +122,7 @@ public interface TranslogManager {
 
     /**
      *
-     * @param seqNo : operations >= should be persisted
+     * @param seqNo : operations greater or equal to seqNo should be persisted
      */
     void minSeqNoRequired(long seqNo);
 }

--- a/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
@@ -123,6 +123,7 @@ public interface TranslogManager {
     /**
      *
      * @param seqNo : operations greater or equal to seqNo should be persisted
+     * This might be required when segments are persisted via other mechanism than flush.
      */
     void minSeqNoRequired(long seqNo);
 }

--- a/server/src/main/java/org/opensearch/index/translog/TranslogWriter.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogWriter.java
@@ -359,7 +359,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
      *
      * Note: any exception during the sync process will be interpreted as a tragic exception and the writer will be closed before
      * raising the exception.
-     * @return
+     * @return  <code>true</code> if this call caused an actual sync operation
      */
     public boolean sync() throws IOException {
         return syncUpTo(Long.MAX_VALUE);

--- a/server/src/main/java/org/opensearch/index/translog/transfer/BlobStoreTransferService.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/BlobStoreTransferService.java
@@ -19,6 +19,7 @@ import org.opensearch.index.translog.transfer.FileSnapshot.TransferFileSnapshot;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
@@ -73,6 +74,11 @@ public class BlobStoreTransferService implements TransferService {
     @Override
     public InputStream downloadBlob(Iterable<String> path, String fileName) throws IOException {
         return blobStore.blobContainer((BlobPath) path).readBlob(fileName);
+    }
+
+    @Override
+    public void deleteBlobs(Iterable<String> path, List<String> fileNames) throws IOException {
+        blobStore.blobContainer((BlobPath) path).deleteBlobsIgnoringIfNotExists(fileNames);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/translog/transfer/FileTransferTracker.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/FileTransferTracker.java
@@ -55,6 +55,11 @@ public class FileTransferTracker implements FileTransferListener {
         add(fileSnapshot.getName(), TransferState.FAILED);
     }
 
+    @Override
+    public void onDelete(String name) {
+        fileTransferTracker.remove(name);
+    }
+
     public Set<TransferFileSnapshot> exclusionFilter(Set<TransferFileSnapshot> original) {
         return original.stream()
             .filter(fileSnapshot -> fileTransferTracker.get(fileSnapshot.getName()) != TransferState.SUCCESS)

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TransferService.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TransferService.java
@@ -13,6 +13,7 @@ import org.opensearch.index.translog.transfer.FileSnapshot.TransferFileSnapshot;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -41,6 +42,8 @@ public interface TransferService {
      * @throws IOException the exception while transferring the data
      */
     void uploadBlob(final TransferFileSnapshot fileSnapshot, Iterable<String> remotePath) throws IOException;
+
+    void deleteBlobs(Iterable<String> path, List<String> fileNames) throws IOException;
 
     /**
      * Lists the files

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TransferService.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TransferService.java
@@ -55,8 +55,8 @@ public interface TransferService {
 
     /**
      *
-     * @param path
-     * @param fileName
+     * @param path  the remote path from where download should be made
+     * @param fileName the name of the file
      * @return inputstream of the remote file
      * @throws IOException the exception while reading the data
      */

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -200,8 +200,8 @@ public class TranslogTransferManager {
         String translogFilename = Translog.getFilename(generation);
         // ToDo - Take care of metadata file cleanup
         // https://github.com/opensearch-project/OpenSearch/issues/5677
-        fileTransferListener.onDelete(ckpFileName);
-        fileTransferListener.onDelete(translogFilename);
+        fileTransferTracker.onDelete(ckpFileName);
+        fileTransferTracker.onDelete(translogFilename);
         List<String> files = List.of(ckpFileName, translogFilename);
         transferService.deleteBlobs(remoteBaseTransferPath.add(String.valueOf(primaryTerm)), files);
     }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -198,6 +198,9 @@ public class TranslogTransferManager {
     public void deleteTranslog(long primaryTerm, long generation) throws IOException {
         String ckpFileName = Translog.getCommitCheckpointFileName(generation);
         String translogFilename = Translog.getFilename(generation);
+        // ToDo - Take care of metadata file cleanup
+        fileTransferListener.onDelete(ckpFileName);
+        fileTransferListener.onDelete(translogFilename);
         List<String> files = List.of(ckpFileName, translogFilename);
         transferService.deleteBlobs(remoteBaseTransferPath.add(String.valueOf(primaryTerm)), files);
     }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -199,6 +199,7 @@ public class TranslogTransferManager {
         String ckpFileName = Translog.getCommitCheckpointFileName(generation);
         String translogFilename = Translog.getFilename(generation);
         // ToDo - Take care of metadata file cleanup
+        // https://github.com/opensearch-project/OpenSearch/issues/5677
         fileTransferListener.onDelete(ckpFileName);
         fileTransferListener.onDelete(translogFilename);
         List<String> files = List.of(ckpFileName, translogFilename);

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -194,4 +194,11 @@ public class TranslogTransferManager {
             translogTransferMetadata.getPrimaryTerm()
         );
     }
+
+    public void deleteTranslog(long primaryTerm, long generation) throws IOException {
+        String ckpFileName = Translog.getCommitCheckpointFileName(generation);
+        String translogFilename = Translog.getFilename(generation);
+        List<String> files = List.of(ckpFileName, translogFilename);
+        transferService.deleteBlobs(remoteBaseTransferPath.add(String.valueOf(primaryTerm)), files);
+    }
 }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/listener/FileTransferListener.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/listener/FileTransferListener.java
@@ -11,7 +11,7 @@ package org.opensearch.index.translog.transfer.listener;
 import org.opensearch.index.translog.transfer.FileSnapshot.TransferFileSnapshot;
 
 /**
- * The listener to be invoked on the completion or failure of a {@link TransferFileSnapshot}
+ * The listener to be invoked on the completion or failure of a {@link TransferFileSnapshot} or deletion of file
  *
  * @opensearch.internal
  */
@@ -29,4 +29,6 @@ public interface FileTransferListener {
      * @param e the exception while processing the {@link TransferFileSnapshot}
      */
     void onFailure(TransferFileSnapshot fileSnapshot, Exception e);
+
+    void onDelete(String name);
 }

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
@@ -499,7 +499,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
         // expose the new checkpoint (simulating a commit), before we trim the translog
         translog.deletionPolicy.setLocalCheckpointOfSafeCommit(0);
         // simulating the remote segment upload .
-        translog.setMinSeqNoRequired(0);
+        translog.setMinSeqNoToKeep(0);
         // This should not trim anything
         translog.trimUnreferencedReaders();
         assertEquals(translog.allUploaded().size(), 4);
@@ -514,7 +514,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
         );
 
         // This should trim tlog-2.* files as it contains seq no 0
-        translog.setMinSeqNoRequired(1);
+        translog.setMinSeqNoToKeep(1);
         translog.trimUnreferencedReaders();
         assertEquals(translog.allUploaded().size(), 2);
         assertEquals(
@@ -716,7 +716,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
                                 // expose the new checkpoint (simulating a commit), before we trim the translog
                                 lastCommittedLocalCheckpoint.set(localCheckpoint);
                                 deletionPolicy.setLocalCheckpointOfSafeCommit(localCheckpoint);
-                                translog.setMinSeqNoRequired(localCheckpoint + 1);
+                                translog.setMinSeqNoToKeep(localCheckpoint + 1);
                                 translog.trimUnreferencedReaders();
                             }
                         }

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
@@ -499,7 +499,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
         // expose the new checkpoint (simulating a commit), before we trim the translog
         translog.deletionPolicy.setLocalCheckpointOfSafeCommit(0);
         // simulating the remote segment upload .
-        translog.minSeqNoRequired(0);
+        translog.setMinSeqNoRequired(0);
         // This should not trim anything
         translog.trimUnreferencedReaders();
         assertEquals(translog.allUploaded().size(), 4);
@@ -514,7 +514,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
         );
 
         // This should trim tlog-2.* files as it contains seq no 0
-        translog.minSeqNoRequired(1);
+        translog.setMinSeqNoRequired(1);
         translog.trimUnreferencedReaders();
         assertEquals(translog.allUploaded().size(), 2);
         assertEquals(
@@ -716,7 +716,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
                                 // expose the new checkpoint (simulating a commit), before we trim the translog
                                 lastCommittedLocalCheckpoint.set(localCheckpoint);
                                 deletionPolicy.setLocalCheckpointOfSafeCommit(localCheckpoint);
-                                translog.minSeqNoRequired(localCheckpoint + 1);
+                                translog.setMinSeqNoRequired(localCheckpoint + 1);
                                 translog.trimUnreferencedReaders();
                             }
                         }

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -86,7 +86,9 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
                 }
 
                 @Override
-                public void onDelete(String name) {}
+                public void onDelete(String name) {
+                }
+            }
         );
 
         assertTrue(translogTransferManager.transferSnapshot(createTransferSnapshot(), new TranslogTransferListener() {

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -84,7 +84,9 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
                 public void onFailure(TransferFileSnapshot fileSnapshot, Exception e) {
                     fileTransferFailed.incrementAndGet();
                 }
-            }
+
+                @Override
+                public void onDelete(String name) {}
         );
 
         assertTrue(translogTransferManager.transferSnapshot(createTransferSnapshot(), new TranslogTransferListener() {

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -86,8 +86,7 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
                 }
 
                 @Override
-                public void onDelete(String name) {
-                }
+                public void onDelete(String name) {}
             }
         );
 


### PR DESCRIPTION
Signed-off-by: Gaurav Bafna <gbbafna@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

After any segment uploaded to remote store , we will update `minSeqNoRequired` for `Translog`.  This is implemented only for `RemoteFSTranslog` . 

`minSeqNoRequired` will be used to preserve generations to be trimmed till it is uploaded to remote store. 

Once uploaded , post trimming, remote translog will be cleaned up as well along with local tlog files. 

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/5567

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
