### PR TITLE
Add additional logging for future debugging of HA proxy mode flaky test

### DIFF
--- a/qa/remote-clusters/src/test/java/org/opensearch/cluster/remote/test/RemoteClustersIT.java
+++ b/qa/remote-clusters/src/test/java/org/opensearch/cluster/remote/test/RemoteClustersIT.java
@@ -31,6 +31,7 @@
 
 package org.opensearch.cluster.remote.test;
 
+import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.index.IndexRequest;
@@ -122,6 +123,9 @@ public class RemoteClustersIT extends AbstractMultiClusterRemoteTestCase {
 
         RemoteConnectionInfo rci = cluster1Client().cluster().remoteInfo(new RemoteInfoRequest(), RequestOptions.DEFAULT).getInfos().get(0);
         logger.info("Connection info: {}", rci);
+        if (!rci.isConnected()) {    
+            logger.info("Cluster health: {}", cluster1Client().cluster().health(new ClusterHealthRequest(), RequestOptions.DEFAULT));
+        }
         assertTrue(rci.isConnected());
 
         assertEquals(2L, cluster1Client().search(


### PR DESCRIPTION
Signed-off-by: Ryan Bogan <rbogan@amazon.com>

### Description
The current logging is not sufficient to fix flaky test failures for `testHAProxyModeConnectionWorks` . The failure occurs due to the number of connected sockets being 0.  However, the `RemoteConnectionInfo` containing this data is obtained through a transport request, so the cause of the sockets not connecting is unknown.  Since the error is non-reproducible, this PR adds additional logging when there are no connected sockets, printing out the cluster health at the time of failure.  If the flaky test failure occurs again, there will be more logged information that can hopefully lead to a solution.

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
