### PR TITLE
Adding @gbbafna to OpenSearch maintainers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added experimental support for extensions ([#5347](https://github.com/opensearch-project/OpenSearch/pull/5347)), ([#5518](https://github.com/opensearch-project/OpenSearch/pull/5518), ([#5597](https://github.com/opensearch-project/OpenSearch/pull/5597)), ([#5615](https://github.com/opensearch-project/OpenSearch/pull/5615)))
 - Add CI bundle pattern to distribution download ([#5348](https://github.com/opensearch-project/OpenSearch/pull/5348))
 - Add support for ppc64le architecture ([#5459](https://github.com/opensearch-project/OpenSearch/pull/5459))
+- Added @gbbafna as an OpenSearch maintainer ([#5668](https://github.com/opensearch-project/OpenSearch/pull/5668))
 
 
 ### Dependencies

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,6 @@
 - [Current Maintainers](#current-maintainers)
 - [Emeritus](#emeritus)
-
+  
 ## Current Maintainers
 
 | Maintainer | GitHub ID | Affiliation |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,6 @@
 - [Current Maintainers](#current-maintainers)
 - [Emeritus](#emeritus)
-  
+
 ## Current Maintainers
 
 | Maintainer | GitHub ID | Affiliation |
@@ -11,6 +11,7 @@
 | Bukhtawar Khan | [Bukhtawar](https://github.com/Bukhtawar) | Amazon |
 | Charlotte Henkle | [CEHENKLE](https://github.com/CEHENKLE) | Amazon |
 | Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock) | Amazon |
+| Gaurav Bafna | [gbbafna](https://github.com/gbbafna) | Amazon |
 | Himanshu Setia | [setiah](https://github.com/setiah) | Amazon |
 | Kartik Ganesh | [kartg](https://github.com/kartg) | Amazon |
 | Kunal Kotwani | [kotwanikunal](https://github.com/kotwanikunal) | Amazon |


### PR DESCRIPTION
Signed-off-by: Bukhtawar Khan <bukhtawa@amazon.com>

### Description
I nominated Gaurav Bafna (@gbbafna) to be a co-maintainer for Opensearch through our [nomination process](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md#nomination). The maintainers have agreed, and Gaurav has kindly accepted.

Gaurav is the [lead](https://github.com/opensearch-project/cross-cluster-replication/pulls?page=1&q=is%3Apr+gbbafna) author and maintainer of [Cross Cluster Replication Feature](https://github.com/opensearch-project/cross-cluster-replication) and reviewed/approved significant core contributions like Zonal decommissioning, Weighted shard routing, Master Task Throttling and Remote Store. He personally has also contributed [5 PRs](https://github.com/opensearch-project/OpenSearch/pulls/gbbafna) into OpenSearch and [49 PRs](https://github.com/opensearch-project/cross-cluster-replication/pulls?q=is%3Apr+author%3Agbbafna+is%3Aclosed) for cross cluster replication. He is actively filing key bugs and issues . Gaurav has reviewed 128 PRs and opened [48 issues](https://github.com/issues?q=is%3Aissue+author%3Agbbafna+archived%3Afalse+is%3Aclosed) till now across Cross Cluster Replication and OpenSearch. 


Some of Gaurav’s notable code contributions and reviews were:
* [Cross Cluster Replication Feature](https://github.com/opensearch-project/cross-cluster-replication/graphs/contributors)
* [Request Level Durability Feature](https://github.com/opensearch-project/OpenSearch/issues/5476)
* [Replica Count Enforcement](https://github.com/opensearch-project/OpenSearch/pull/3462)
* [Allow writes in case of no master](https://github.com/opensearch-project/OpenSearch/pull/3621)
* Reviewed and approved [2 major PRs](https://github.com/opensearch-project/OpenSearch/pulls?q=is%3Apr+gbbafna++dhwanil+) as part of [Master Throttling](https://github.com/opensearch-project/OpenSearch/issues/479).
* Reviewed and approved [4 major PRs](https://github.com/opensearch-project/OpenSearch/issues/3957) as part of zonal decommissioning
* Reviewed and approved [Weighted Shard Routing](https://github.com/opensearch-project/OpenSearch/pull/4241) .
* Reviewed[ Awareness Health API](https://github.com/opensearch-project/OpenSearch/pull/5231)
* Reviewed major PRs in Remote Store :
* [Remote Segment](https://github.com/opensearch-project/OpenSearch/pulls?q=is%3Apr+gbbafna++remote)
* [Primary term validation for no-op replication](https://github.com/opensearch-project/OpenSearch/pull/4954)

Gaurav is active in the project, thoughtfully reviewing and commenting on pull requests examples [Refresh level durability,](https://github.com/opensearch-project/OpenSearch/pull/5253#discussion_r1035709412) [Primary term validation for no-op Replication](https://github.com/opensearch-project/OpenSearch/pull/4954#discussion_r1015078002), [Zonal decommissioning](https://github.com/opensearch-project/OpenSearch/pull/4084#discussion_r960552502) ,[ Weighted shard routing ](https://github.com/opensearch-project/OpenSearch/pull/4241#discussion_r964485038), [Awareness Health API](https://github.com/opensearch-project/OpenSearch/pull/5231#discussion_r1049425858) .
### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
