### PR TITLE
[Weighted Routing] Add support for discovered master and remove local weights in the response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add CI bundle pattern to distribution download ([#5348](https://github.com/opensearch-project/OpenSearch/pull/5348))
 - Add support for ppc64le architecture ([#5459](https://github.com/opensearch-project/OpenSearch/pull/5459))
 - Added @gbbafna as an OpenSearch maintainer ([#5668](https://github.com/opensearch-project/OpenSearch/pull/5668))
-- Add support for discovered master and remove local weights ([#5680](https://github.com/opensearch-project/OpenSearch/pull/5680))
+- Add support for discovered cluster manager and remove local weights ([#5680](https://github.
+com/opensearch-project/OpenSearch/pull/5680))
 
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add CI bundle pattern to distribution download ([#5348](https://github.com/opensearch-project/OpenSearch/pull/5348))
 - Add support for ppc64le architecture ([#5459](https://github.com/opensearch-project/OpenSearch/pull/5459))
 - Added @gbbafna as an OpenSearch maintainer ([#5668](https://github.com/opensearch-project/OpenSearch/pull/5668))
+- Add support for discovered master and remove local weights ([#5680](https://github.com/opensearch-project/OpenSearch/pull/5680))
 
 
 ### Dependencies

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/WeightedRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/WeightedRoutingIT.java
@@ -227,7 +227,7 @@ public class WeightedRoutingIT extends OpenSearchIntegTestCase {
         assertEquals(weightedRouting, weightedRoutingResponse.weights());
         assertTrue(weightedRoutingResponse.getDiscoveredClusterManager());
 
-        // get api to fetch local node weight for a node in zone a
+        // get api to fetch local weighted routing for a node in zone a
         weightedRoutingResponse = internalCluster().client(randomFrom(nodes_in_zone_a.get(0), nodes_in_zone_a.get(1)))
             .admin()
             .cluster()
@@ -238,7 +238,7 @@ public class WeightedRoutingIT extends OpenSearchIntegTestCase {
         assertEquals(weightedRouting, weightedRoutingResponse.weights());
         assertTrue(weightedRoutingResponse.getDiscoveredClusterManager());
 
-        // get api to fetch local node weight for a node in zone b
+        // get api to fetch local weighted routing for a node in zone b
         weightedRoutingResponse = internalCluster().client(randomFrom(nodes_in_zone_b.get(0), nodes_in_zone_b.get(1)))
             .admin()
             .cluster()
@@ -249,7 +249,7 @@ public class WeightedRoutingIT extends OpenSearchIntegTestCase {
         assertEquals(weightedRouting, weightedRoutingResponse.weights());
         assertTrue(weightedRoutingResponse.getDiscoveredClusterManager());
 
-        // get api to fetch local node weight for a node in zone c
+        // get api to fetch local weighted routing for a node in zone c
         weightedRoutingResponse = internalCluster().client(randomFrom(nodes_in_zone_c.get(0), nodes_in_zone_c.get(1)))
             .admin()
             .cluster()
@@ -323,7 +323,7 @@ public class WeightedRoutingIT extends OpenSearchIntegTestCase {
         // wait for leader checker to fail
         Thread.sleep(13000);
 
-        // get api to fetch local node weight for a node in zone a
+        // get api to fetch local weighted routing for a node in zone a or b
         ClusterGetWeightedRoutingResponse weightedRoutingResponse = internalCluster().client(
             randomFrom(nodes_in_zone_a.get(0), nodes_in_zone_b.get(0))
         ).admin().cluster().prepareGetWeightedRouting().setAwarenessAttribute("zone").setRequestLocal(true).get();

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/WeightedRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/WeightedRoutingIT.java
@@ -219,7 +219,6 @@ public class WeightedRoutingIT extends OpenSearchIntegTestCase {
             .setRequestLocal(true)
             .get();
         assertEquals(weightedRouting, weightedRoutingResponse.weights());
-        assertEquals("1.0", weightedRoutingResponse.getLocalNodeWeight());
 
         // get api to fetch local node weight for a node in zone b
         weightedRoutingResponse = internalCluster().client(randomFrom(nodes_in_zone_b.get(0), nodes_in_zone_b.get(1)))
@@ -230,7 +229,6 @@ public class WeightedRoutingIT extends OpenSearchIntegTestCase {
             .setRequestLocal(true)
             .get();
         assertEquals(weightedRouting, weightedRoutingResponse.weights());
-        assertEquals("2.0", weightedRoutingResponse.getLocalNodeWeight());
 
         // get api to fetch local node weight for a node in zone c
         weightedRoutingResponse = internalCluster().client(randomFrom(nodes_in_zone_c.get(0), nodes_in_zone_c.get(1)))
@@ -241,7 +239,6 @@ public class WeightedRoutingIT extends OpenSearchIntegTestCase {
             .setRequestLocal(true)
             .get();
         assertEquals(weightedRouting, weightedRoutingResponse.weights());
-        assertEquals("3.0", weightedRoutingResponse.getLocalNodeWeight());
     }
 
     public void testWeightedRoutingMetadataOnOSProcessRestart() throws Exception {

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/WeightedRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/WeightedRoutingIT.java
@@ -13,16 +13,31 @@ import org.opensearch.action.admin.cluster.shards.routing.weighted.delete.Cluste
 import org.opensearch.action.admin.cluster.shards.routing.weighted.get.ClusterGetWeightedRoutingResponse;
 import org.opensearch.action.admin.cluster.shards.routing.weighted.put.ClusterPutWeightedRoutingResponse;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.snapshots.mockstore.MockRepository;
 import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.disruption.NetworkDisruption;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.transport.MockTransportService;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.equalTo;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0, minNumDataNodes = 3)
 public class WeightedRoutingIT extends OpenSearchIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(MockTransportService.TestPlugin.class, MockRepository.Plugin.class);
+    }
 
     public void testPutWeightedRouting() {
         Settings commonSettings = Settings.builder()
@@ -157,6 +172,7 @@ public class WeightedRoutingIT extends OpenSearchIntegTestCase {
             .setAwarenessAttribute("zone")
             .get();
         assertNull(weightedRoutingResponse.weights());
+        assertNull(weightedRoutingResponse.getDiscoveredClusterManager());
     }
 
     public void testGetWeightedRouting_WeightsAreSet() throws IOException {
@@ -209,6 +225,7 @@ public class WeightedRoutingIT extends OpenSearchIntegTestCase {
             .setAwarenessAttribute("zone")
             .get();
         assertEquals(weightedRouting, weightedRoutingResponse.weights());
+        assertTrue(weightedRoutingResponse.getDiscoveredClusterManager());
 
         // get api to fetch local node weight for a node in zone a
         weightedRoutingResponse = internalCluster().client(randomFrom(nodes_in_zone_a.get(0), nodes_in_zone_a.get(1)))
@@ -219,6 +236,7 @@ public class WeightedRoutingIT extends OpenSearchIntegTestCase {
             .setRequestLocal(true)
             .get();
         assertEquals(weightedRouting, weightedRoutingResponse.weights());
+        assertTrue(weightedRoutingResponse.getDiscoveredClusterManager());
 
         // get api to fetch local node weight for a node in zone b
         weightedRoutingResponse = internalCluster().client(randomFrom(nodes_in_zone_b.get(0), nodes_in_zone_b.get(1)))
@@ -229,6 +247,7 @@ public class WeightedRoutingIT extends OpenSearchIntegTestCase {
             .setRequestLocal(true)
             .get();
         assertEquals(weightedRouting, weightedRoutingResponse.weights());
+        assertTrue(weightedRoutingResponse.getDiscoveredClusterManager());
 
         // get api to fetch local node weight for a node in zone c
         weightedRoutingResponse = internalCluster().client(randomFrom(nodes_in_zone_c.get(0), nodes_in_zone_c.get(1)))
@@ -239,6 +258,81 @@ public class WeightedRoutingIT extends OpenSearchIntegTestCase {
             .setRequestLocal(true)
             .get();
         assertEquals(weightedRouting, weightedRoutingResponse.weights());
+        assertTrue(weightedRoutingResponse.getDiscoveredClusterManager());
+
+    }
+
+    public void testGetWeightedRouting_ClusterManagerNotDiscovered() throws Exception {
+
+        Settings commonSettings = Settings.builder()
+            .put("cluster.routing.allocation.awareness.attributes", "zone")
+            .put("cluster.routing.allocation.awareness.force.zone.values", "a,b,c")
+            .put("cluster.fault_detection.leader_check.timeout", 10000 + "ms")
+            .put("cluster.fault_detection.leader_check.retry_count", 1)
+            .build();
+
+        int nodeCountPerAZ = 1;
+
+        logger.info("--> starting a dedicated cluster manager node");
+        String clusterManager = internalCluster().startClusterManagerOnlyNode(Settings.builder().put(commonSettings).build());
+
+        logger.info("--> starting 2 nodes on zones 'a' & 'b' & 'c'");
+        List<String> nodes_in_zone_a = internalCluster().startDataOnlyNodes(
+            nodeCountPerAZ,
+            Settings.builder().put(commonSettings).put("node.attr.zone", "a").build()
+        );
+        List<String> nodes_in_zone_b = internalCluster().startDataOnlyNodes(
+            nodeCountPerAZ,
+            Settings.builder().put(commonSettings).put("node.attr.zone", "b").build()
+        );
+        List<String> nodes_in_zone_c = internalCluster().startDataOnlyNodes(
+            nodeCountPerAZ,
+            Settings.builder().put(commonSettings).put("node.attr.zone", "c").build()
+        );
+
+        logger.info("--> waiting for nodes to form a cluster");
+        ClusterHealthResponse health = client().admin().cluster().prepareHealth().setWaitForNodes("4").execute().actionGet();
+        assertThat(health.isTimedOut(), equalTo(false));
+
+        ensureGreen();
+
+        logger.info("--> setting shard routing weights for weighted round robin");
+        Map<String, Double> weights = Map.of("a", 1.0, "b", 2.0, "c", 3.0);
+        WeightedRouting weightedRouting = new WeightedRouting("zone", weights);
+        // put api call to set weights
+        ClusterPutWeightedRoutingResponse response = client().admin()
+            .cluster()
+            .prepareWeightedRouting()
+            .setWeightedRouting(weightedRouting)
+            .get();
+        assertEquals(response.isAcknowledged(), true);
+
+        Set<String> nodesInOneSide = Stream.of(nodes_in_zone_a.get(0), nodes_in_zone_b.get(0), nodes_in_zone_c.get(0))
+            .collect(Collectors.toCollection(HashSet::new));
+        Set<String> nodesInOtherSide = Stream.of(clusterManager).collect(Collectors.toCollection(HashSet::new));
+
+        NetworkDisruption networkDisruption = new NetworkDisruption(
+            new NetworkDisruption.TwoPartitions(nodesInOneSide, nodesInOtherSide),
+            NetworkDisruption.DISCONNECT
+        );
+        internalCluster().setDisruptionScheme(networkDisruption);
+
+        logger.info("--> network disruption is started");
+        networkDisruption.startDisrupting();
+
+        // wait for leader checker to fail
+        Thread.sleep(13000);
+
+        // get api to fetch local node weight for a node in zone a
+        ClusterGetWeightedRoutingResponse weightedRoutingResponse = internalCluster().client(
+            randomFrom(nodes_in_zone_a.get(0), nodes_in_zone_b.get(0))
+        ).admin().cluster().prepareGetWeightedRouting().setAwarenessAttribute("zone").setRequestLocal(true).get();
+        assertEquals(weightedRouting, weightedRoutingResponse.weights());
+        assertFalse(weightedRoutingResponse.getDiscoveredClusterManager());
+
+        logger.info("--> network disruption is stopped");
+        networkDisruption.stopDisrupting();
+
     }
 
     public void testWeightedRoutingMetadataOnOSProcessRestart() throws Exception {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/get/ClusterGetWeightedRoutingResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/get/ClusterGetWeightedRoutingResponse.java
@@ -79,7 +79,9 @@ public class ClusterGetWeightedRoutingResponse extends ActionResponse implements
         if (weightedRouting != null) {
             weightedRouting.writeTo(out);
         }
-        out.writeOptionalBoolean(discoveredMaster);
+        if (discoveredMaster != null) {
+            out.writeOptionalBoolean(discoveredMaster);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/get/ClusterGetWeightedRoutingResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/get/ClusterGetWeightedRoutingResponse.java
@@ -109,11 +109,11 @@ public class ClusterGetWeightedRoutingResponse extends ActionResponse implements
                 attrKey = parser.currentName();
             } else if (token == XContentParser.Token.VALUE_STRING) {
                 attrValue = parser.text();
-                if (attrKey != null && attrKey.equals(DISCOVERED_MASTER)) {
-                    discoveredMaster = Boolean.parseBoolean(attrValue);
-                } else if (attrKey != null) {
+                if (attrKey != null) {
                     weights.put(attrKey, Double.parseDouble(attrValue));
                 }
+            } else if (token == XContentParser.Token.VALUE_BOOLEAN && attrKey != null && attrKey.equals(DISCOVERED_MASTER)) {
+                discoveredMaster = Boolean.parseBoolean(parser.text());
             } else {
                 throw new OpenSearchParseException("failed to parse weighted routing response");
             }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/get/ClusterGetWeightedRoutingResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/get/ClusterGetWeightedRoutingResponse.java
@@ -31,26 +31,37 @@ import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedT
  * @opensearch.internal
  */
 public class ClusterGetWeightedRoutingResponse extends ActionResponse implements ToXContentObject {
-    private WeightedRouting weightedRouting;
-    private String localNodeWeight;
-    private static final String NODE_WEIGHT = "node_weight";
-
-    public String getLocalNodeWeight() {
-        return localNodeWeight;
+    public WeightedRouting getWeightedRouting() {
+        return weightedRouting;
     }
+
+    private final WeightedRouting weightedRouting;
+
+    public Boolean getDiscoveredMaster() {
+        return discoveredMaster;
+    }
+
+    private final Boolean discoveredMaster;
+
+    private static final String DISCOVERED_MASTER = "discovered_master";
 
     ClusterGetWeightedRoutingResponse() {
         this.weightedRouting = null;
+        this.discoveredMaster = null;
     }
 
-    public ClusterGetWeightedRoutingResponse(String localNodeWeight, WeightedRouting weightedRouting) {
-        this.localNodeWeight = localNodeWeight;
+    public ClusterGetWeightedRoutingResponse(WeightedRouting weightedRouting, Boolean discoveredMaster) {
+        this.discoveredMaster = discoveredMaster;
         this.weightedRouting = weightedRouting;
     }
 
     ClusterGetWeightedRoutingResponse(StreamInput in) throws IOException {
         if (in.available() != 0) {
             this.weightedRouting = new WeightedRouting(in);
+            this.discoveredMaster = in.readOptionalBoolean();
+        } else {
+            this.weightedRouting = null;
+            this.discoveredMaster = null;
         }
     }
 
@@ -68,6 +79,7 @@ public class ClusterGetWeightedRoutingResponse extends ActionResponse implements
         if (weightedRouting != null) {
             weightedRouting.writeTo(out);
         }
+        out.writeOptionalBoolean(discoveredMaster);
     }
 
     @Override
@@ -77,8 +89,8 @@ public class ClusterGetWeightedRoutingResponse extends ActionResponse implements
             for (Map.Entry<String, Double> entry : weightedRouting.weights().entrySet()) {
                 builder.field(entry.getKey(), entry.getValue().toString());
             }
-            if (localNodeWeight != null) {
-                builder.field(NODE_WEIGHT, localNodeWeight);
+            if (discoveredMaster != null) {
+                builder.field(DISCOVERED_MASTER, discoveredMaster);
             }
         }
         builder.endObject();
@@ -89,7 +101,7 @@ public class ClusterGetWeightedRoutingResponse extends ActionResponse implements
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         XContentParser.Token token;
         String attrKey = null, attrValue = null;
-        String localNodeWeight = null;
+        Boolean discoveredMaster = null;
         Map<String, Double> weights = new HashMap<>();
 
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -97,8 +109,8 @@ public class ClusterGetWeightedRoutingResponse extends ActionResponse implements
                 attrKey = parser.currentName();
             } else if (token == XContentParser.Token.VALUE_STRING) {
                 attrValue = parser.text();
-                if (attrKey != null && attrKey.equals(NODE_WEIGHT)) {
-                    localNodeWeight = attrValue;
+                if (attrKey != null && attrKey.equals(DISCOVERED_MASTER)) {
+                    discoveredMaster = Boolean.parseBoolean(attrValue);
                 } else if (attrKey != null) {
                     weights.put(attrKey, Double.parseDouble(attrValue));
                 }
@@ -107,7 +119,7 @@ public class ClusterGetWeightedRoutingResponse extends ActionResponse implements
             }
         }
         WeightedRouting weightedRouting = new WeightedRouting("", weights);
-        return new ClusterGetWeightedRoutingResponse(localNodeWeight, weightedRouting);
+        return new ClusterGetWeightedRoutingResponse(weightedRouting, discoveredMaster);
     }
 
     @Override
@@ -115,11 +127,11 @@ public class ClusterGetWeightedRoutingResponse extends ActionResponse implements
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ClusterGetWeightedRoutingResponse that = (ClusterGetWeightedRoutingResponse) o;
-        return weightedRouting.equals(that.weightedRouting) && localNodeWeight.equals(that.localNodeWeight);
+        return weightedRouting.equals(that.weightedRouting) && discoveredMaster.equals(that.discoveredMaster);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(weightedRouting, localNodeWeight);
+        return Objects.hash(weightedRouting, discoveredMaster);
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/get/ClusterGetWeightedRoutingResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/get/ClusterGetWeightedRoutingResponse.java
@@ -37,31 +37,31 @@ public class ClusterGetWeightedRoutingResponse extends ActionResponse implements
 
     private final WeightedRouting weightedRouting;
 
-    public Boolean getDiscoveredMaster() {
-        return discoveredMaster;
+    public Boolean getDiscoveredClusterManager() {
+        return discoveredClusterManager;
     }
 
-    private final Boolean discoveredMaster;
+    private final Boolean discoveredClusterManager;
 
-    private static final String DISCOVERED_MASTER = "discovered_master";
+    private static final String DISCOVERED_CLUSTER_MANAGER = "discovered_cluster_manager";
 
     ClusterGetWeightedRoutingResponse() {
         this.weightedRouting = null;
-        this.discoveredMaster = null;
+        this.discoveredClusterManager = null;
     }
 
-    public ClusterGetWeightedRoutingResponse(WeightedRouting weightedRouting, Boolean discoveredMaster) {
-        this.discoveredMaster = discoveredMaster;
+    public ClusterGetWeightedRoutingResponse(WeightedRouting weightedRouting, Boolean discoveredClusterManager) {
+        this.discoveredClusterManager = discoveredClusterManager;
         this.weightedRouting = weightedRouting;
     }
 
     ClusterGetWeightedRoutingResponse(StreamInput in) throws IOException {
         if (in.available() != 0) {
             this.weightedRouting = new WeightedRouting(in);
-            this.discoveredMaster = in.readOptionalBoolean();
+            this.discoveredClusterManager = in.readOptionalBoolean();
         } else {
             this.weightedRouting = null;
-            this.discoveredMaster = null;
+            this.discoveredClusterManager = null;
         }
     }
 
@@ -79,8 +79,8 @@ public class ClusterGetWeightedRoutingResponse extends ActionResponse implements
         if (weightedRouting != null) {
             weightedRouting.writeTo(out);
         }
-        if (discoveredMaster != null) {
-            out.writeOptionalBoolean(discoveredMaster);
+        if (discoveredClusterManager != null) {
+            out.writeOptionalBoolean(discoveredClusterManager);
         }
     }
 
@@ -91,8 +91,8 @@ public class ClusterGetWeightedRoutingResponse extends ActionResponse implements
             for (Map.Entry<String, Double> entry : weightedRouting.weights().entrySet()) {
                 builder.field(entry.getKey(), entry.getValue().toString());
             }
-            if (discoveredMaster != null) {
-                builder.field(DISCOVERED_MASTER, discoveredMaster);
+            if (discoveredClusterManager != null) {
+                builder.field(DISCOVERED_CLUSTER_MANAGER, discoveredClusterManager);
             }
         }
         builder.endObject();
@@ -103,7 +103,7 @@ public class ClusterGetWeightedRoutingResponse extends ActionResponse implements
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         XContentParser.Token token;
         String attrKey = null, attrValue = null;
-        Boolean discoveredMaster = null;
+        Boolean discoveredClusterManager = null;
         Map<String, Double> weights = new HashMap<>();
 
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -114,14 +114,14 @@ public class ClusterGetWeightedRoutingResponse extends ActionResponse implements
                 if (attrKey != null) {
                     weights.put(attrKey, Double.parseDouble(attrValue));
                 }
-            } else if (token == XContentParser.Token.VALUE_BOOLEAN && attrKey != null && attrKey.equals(DISCOVERED_MASTER)) {
-                discoveredMaster = Boolean.parseBoolean(parser.text());
+            } else if (token == XContentParser.Token.VALUE_BOOLEAN && attrKey != null && attrKey.equals(DISCOVERED_CLUSTER_MANAGER)) {
+                discoveredClusterManager = Boolean.parseBoolean(parser.text());
             } else {
                 throw new OpenSearchParseException("failed to parse weighted routing response");
             }
         }
         WeightedRouting weightedRouting = new WeightedRouting("", weights);
-        return new ClusterGetWeightedRoutingResponse(weightedRouting, discoveredMaster);
+        return new ClusterGetWeightedRoutingResponse(weightedRouting, discoveredClusterManager);
     }
 
     @Override
@@ -129,11 +129,11 @@ public class ClusterGetWeightedRoutingResponse extends ActionResponse implements
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ClusterGetWeightedRoutingResponse that = (ClusterGetWeightedRoutingResponse) o;
-        return weightedRouting.equals(that.weightedRouting) && discoveredMaster.equals(that.discoveredMaster);
+        return weightedRouting.equals(that.weightedRouting) && discoveredClusterManager.equals(that.discoveredClusterManager);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(weightedRouting, discoveredMaster);
+        return Objects.hash(weightedRouting, discoveredClusterManager);
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/get/TransportGetWeightedRoutingAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/shards/routing/weighted/get/TransportGetWeightedRoutingAction.java
@@ -20,7 +20,6 @@ import org.opensearch.cluster.block.ClusterBlockLevel;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 
 import org.opensearch.cluster.metadata.WeightedRoutingMetadata;
-import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.WeightedRouting;
 import org.opensearch.cluster.routing.WeightedRoutingService;
 import org.opensearch.cluster.service.ClusterService;
@@ -89,19 +88,12 @@ public class TransportGetWeightedRoutingAction extends TransportClusterManagerNo
             weightedRoutingService.verifyAwarenessAttribute(request.getAwarenessAttribute());
             WeightedRoutingMetadata weightedRoutingMetadata = state.metadata().custom(WeightedRoutingMetadata.TYPE);
             ClusterGetWeightedRoutingResponse clusterGetWeightedRoutingResponse = new ClusterGetWeightedRoutingResponse();
-            String weight = null;
             if (weightedRoutingMetadata != null && weightedRoutingMetadata.getWeightedRouting() != null) {
                 WeightedRouting weightedRouting = weightedRoutingMetadata.getWeightedRouting();
-                if (request.local()) {
-                    DiscoveryNode localNode = state.getNodes().getLocalNode();
-                    if (localNode.getAttributes().get(request.getAwarenessAttribute()) != null) {
-                        String attrVal = localNode.getAttributes().get(request.getAwarenessAttribute());
-                        if (weightedRouting.weights().containsKey(attrVal)) {
-                            weight = weightedRouting.weights().get(attrVal).toString();
-                        }
-                    }
-                }
-                clusterGetWeightedRoutingResponse = new ClusterGetWeightedRoutingResponse(weight, weightedRouting);
+                clusterGetWeightedRoutingResponse = new ClusterGetWeightedRoutingResponse(
+                    weightedRouting,
+                    state.nodes().getClusterManagerNodeId() != null
+                );
             }
             listener.onResponse(clusterGetWeightedRoutingResponse);
         } catch (Exception ex) {

--- a/server/src/test/java/org/opensearch/cluster/action/shard/routing/weighted/get/ClusterGetWeightedRoutingResponseTests.java
+++ b/server/src/test/java/org/opensearch/cluster/action/shard/routing/weighted/get/ClusterGetWeightedRoutingResponseTests.java
@@ -21,7 +21,7 @@ public class ClusterGetWeightedRoutingResponseTests extends AbstractXContentTest
     protected ClusterGetWeightedRoutingResponse createTestInstance() {
         Map<String, Double> weights = Map.of("zone_A", 1.0, "zone_B", 0.0, "zone_C", 1.0);
         WeightedRouting weightedRouting = new WeightedRouting("", weights);
-        ClusterGetWeightedRoutingResponse response = new ClusterGetWeightedRoutingResponse("1", weightedRouting);
+        ClusterGetWeightedRoutingResponse response = new ClusterGetWeightedRoutingResponse(weightedRouting, true);
         return response;
     }
 

--- a/server/src/test/java/org/opensearch/cluster/action/shard/routing/weighted/get/TransportGetWeightedRoutingActionTests.java
+++ b/server/src/test/java/org/opensearch/cluster/action/shard/routing/weighted/get/TransportGetWeightedRoutingActionTests.java
@@ -191,7 +191,6 @@ public class TransportGetWeightedRoutingActionTests extends OpenSearchTestCase {
         ClusterState state = clusterService.state();
 
         ClusterGetWeightedRoutingResponse response = ActionTestUtils.executeBlocking(transportGetWeightedRoutingAction, request.request());
-        assertEquals(response.getLocalNodeWeight(), null);
         assertEquals(response.weights(), null);
     }
 
@@ -231,7 +230,8 @@ public class TransportGetWeightedRoutingActionTests extends OpenSearchTestCase {
         ClusterServiceUtils.setState(clusterService, builder);
 
         ClusterGetWeightedRoutingResponse response = ActionTestUtils.executeBlocking(transportGetWeightedRoutingAction, request.request());
-        assertEquals("0.0", response.getLocalNodeWeight());
+        assertEquals(true, response.getDiscoveredMaster());
+        assertEquals(weights, response.getWeightedRouting().weights());
     }
 
     public void testGetWeightedRoutingLocalWeight_WeightsNotSetInMetadata() {
@@ -250,7 +250,7 @@ public class TransportGetWeightedRoutingActionTests extends OpenSearchTestCase {
         ClusterServiceUtils.setState(clusterService, builder);
 
         ClusterGetWeightedRoutingResponse response = ActionTestUtils.executeBlocking(transportGetWeightedRoutingAction, request.request());
-        assertEquals(null, response.getLocalNodeWeight());
+        assertEquals(null, response.getWeightedRouting());
     }
 
     @After

--- a/server/src/test/java/org/opensearch/cluster/action/shard/routing/weighted/get/TransportGetWeightedRoutingActionTests.java
+++ b/server/src/test/java/org/opensearch/cluster/action/shard/routing/weighted/get/TransportGetWeightedRoutingActionTests.java
@@ -230,7 +230,7 @@ public class TransportGetWeightedRoutingActionTests extends OpenSearchTestCase {
         ClusterServiceUtils.setState(clusterService, builder);
 
         ClusterGetWeightedRoutingResponse response = ActionTestUtils.executeBlocking(transportGetWeightedRoutingAction, request.request());
-        assertEquals(true, response.getDiscoveredMaster());
+        assertEquals(true, response.getDiscoveredClusterManager());
         assertEquals(weights, response.getWeightedRouting().weights());
     }
 


### PR DESCRIPTION
Signed-off-by: Anshu Agarwal <anshukag@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The local weights don't add much value since weights are relative and having just the local value gives no indication of how traffic would get distributed.
Discovered master is helpful to understand cases where after weights are set and also that the node is unable to connect to the leader either due to
Master not discovered -- This might happen to newly launched after decommission or even otherwise
Decommissioned -- The node was decommissioned

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
