### PR TITLE
Fix Flaky test org.opensearch.index.IndexServiceTests.testAsyncTranslogTrimTaskOnClosedIndex

### DIFF
--- a/server/src/test/java/org/opensearch/index/IndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexServiceTests.java
@@ -421,7 +421,7 @@ public class IndexServiceTests extends OpenSearchSingleNodeTestCase {
         final String indexName = "test";
         IndexService indexService = createIndex(
             indexName,
-            Settings.builder().put(TRANSLOG_RETENTION_CHECK_INTERVAL_SETTING.getKey(), "100ms").build()
+            Settings.builder().put(TRANSLOG_RETENTION_CHECK_INTERVAL_SETTING.getKey(), "200ms").build()
         );
 
         Translog translog = IndexShardTestCase.getTranslog(indexService.getShard(0));


### PR DESCRIPTION
Signed-off-by: Rishikesh1159 <rishireddy1159@gmail.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR fixes flaky test  org.opensearch.index.IndexServiceTests.testAsyncTranslogTrimTaskOnClosedIndex by increasing the translog retention check interval.

### Issues Resolved
Resolves #5414 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
