### PR TITLE
Fix TransportReplicationActionTests

### DIFF
--- a/server/src/test/java/org/opensearch/action/support/replication/TransportReplicationActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/replication/TransportReplicationActionTests.java
@@ -204,6 +204,7 @@ public class TransportReplicationActionTests extends OpenSearchTestCase {
         Metadata metadata = Metadata.builder().build();
         ClusterState clusterState = ClusterState.builder(org.opensearch.cluster.ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
             .metadata(metadata)
+            .nodes(clusterService.state().nodes())
             .build();
         setState(clusterService, clusterState);
     }


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Existing gradle checks failures([example](https://github.com/opensearch-project/OpenSearch/pull/5722)),  are happening due to recent change from PR https://github.com/opensearch-project/OpenSearch/pull/5610, which overrides older ClusterService state and does not consider previously added DiscoveryNodes nodes [added here](https://github.com/opensearch-project/OpenSearch/blob/main/test/framework/src/main/java/org/opensearch/test/ClusterServiceUtils.java#L176) into consideration while rebuilding clusterService state. These local nodes are used in tests. This change takes existing discovery nodes for building the cluster state. 


### Issues Resolved
NA

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
