### PR TITLE
[Test] Renaming PIT tests to IT to fix intermittent test failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Support OpenSSL Provider with default Netty allocator ([#5460](https://github.com/opensearch-project/OpenSearch/pull/5460))
 - Increasing timeout of testQuorumRecovery to 90 seconds from 30 ([#5651](https://github.com/opensearch-project/OpenSearch/pull/5651))
 - [Segment Replication] Fix for peer recovery ([#5344](https://github.com/opensearch-project/OpenSearch/pull/5344))
+- [Test] Renaming PIT tests to IT to fix intermittent test failures ([#5750](https://github.com/opensearch-project/OpenSearch/pull/5750))
 
 ### Security
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/pit/DeletePitMultiNodeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/pit/DeletePitMultiNodeIT.java
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-package org.opensearch.search;
+package org.opensearch.search.pit;
 
 import org.junit.After;
 import org.junit.Before;
@@ -47,7 +47,7 @@ import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE
  * Multi node integration tests for delete PIT use cases
  */
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 2)
-public class DeletePitMultiNodeTests extends OpenSearchIntegTestCase {
+public class DeletePitMultiNodeIT extends OpenSearchIntegTestCase {
 
     @Before
     public void setupIndex() throws ExecutionException, InterruptedException {
@@ -306,7 +306,7 @@ public class DeletePitMultiNodeTests extends OpenSearchIntegTestCase {
         AtomicInteger numDeleteAcknowledged = new AtomicInteger();
         TestThreadPool testThreadPool = null;
         try {
-            testThreadPool = new TestThreadPool(DeletePitMultiNodeTests.class.getName());
+            testThreadPool = new TestThreadPool(DeletePitMultiNodeIT.class.getName());
             List<Runnable> operationThreads = new ArrayList<>();
             CountDownLatch countDownLatch = new CountDownLatch(concurrentRuns);
             for (int i = 0; i < concurrentRuns; i++) {

--- a/server/src/internalClusterTest/java/org/opensearch/search/pit/PitMultiNodeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/pit/PitMultiNodeIT.java
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-package org.opensearch.search;
+package org.opensearch.search.pit;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.junit.After;
@@ -61,7 +61,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
  * Multi node integration tests for PIT creation and search operation with PIT ID.
  */
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 2)
-public class PitMultiNodeTests extends OpenSearchIntegTestCase {
+public class PitMultiNodeIT extends OpenSearchIntegTestCase {
 
     @Before
     public void setupIndex() throws ExecutionException, InterruptedException {
@@ -246,7 +246,7 @@ public class PitMultiNodeTests extends OpenSearchIntegTestCase {
         AtomicInteger numSuccess = new AtomicInteger();
         TestThreadPool testThreadPool = null;
         try {
-            testThreadPool = new TestThreadPool(DeletePitMultiNodeTests.class.getName());
+            testThreadPool = new TestThreadPool(PitMultiNodeIT.class.getName());
             List<Runnable> operationThreads = new ArrayList<>();
             CountDownLatch countDownLatch = new CountDownLatch(concurrentRuns);
             Set<String> createSet = new HashSet<>();
@@ -288,7 +288,7 @@ public class PitMultiNodeTests extends OpenSearchIntegTestCase {
         AtomicInteger numSuccess = new AtomicInteger();
         TestThreadPool testThreadPool = null;
         try {
-            testThreadPool = new TestThreadPool(PitMultiNodeTests.class.getName());
+            testThreadPool = new TestThreadPool(PitMultiNodeIT.class.getName());
             int concurrentRuns = randomIntBetween(20, 50);
 
             List<Runnable> operationThreads = new ArrayList<>();
@@ -431,7 +431,7 @@ public class PitMultiNodeTests extends OpenSearchIntegTestCase {
         AtomicInteger numSuccess = new AtomicInteger();
         TestThreadPool testThreadPool = null;
         try {
-            testThreadPool = new TestThreadPool(PitMultiNodeTests.class.getName());
+            testThreadPool = new TestThreadPool(PitMultiNodeIT.class.getName());
             int concurrentRuns = randomIntBetween(20, 50);
 
             List<Runnable> operationThreads = new ArrayList<>();


### PR DESCRIPTION
We get intermittent failures where 'RestCancellableNodeClient' channels are left behind by rest tests and the PIT integration tests fail.

Renaming tests to IT will make sure they're run in separate JVM where the number of channels are 0.

Signed-off-by: Bharathwaj G <bharath78910@gmail.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR fixes intermittent test failures

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
