### PR TITLE
Correct permissions of jackson-databind "the correct way"

### DIFF
--- a/server/src/main/resources/org/opensearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/security.policy
@@ -79,6 +79,12 @@ grant codeBase "${codebase.jna}" {
   permission java.lang.RuntimePermission "accessDeclaredMembers";
 };
 
+grant codeBase "${codebase.jackson-databind}" {
+  // Jackson Databind needs access to declared members and makes them visible
+  permission java.lang.RuntimePermission "accessDeclaredMembers";
+  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+};
+
 //// Everything else:
 
 grant {
@@ -100,9 +106,6 @@ grant {
   permission jdk.net.NetworkPermission "getOption.TCP_KEEPCOUNT";
   permission jdk.net.NetworkPermission "setOption.TCP_KEEPCOUNT";
 
-  permission java.lang.RuntimePermission "accessDeclaredMembers";
-  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
-  
   // Allow read access to all system properties
   permission java.util.PropertyPermission "*", "read";
 

--- a/server/src/test/java/org/opensearch/common/settings/WriteableSettingTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/WriteableSettingTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.common.settings;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.opensearch.Version;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.bytes.BytesReference;
@@ -462,6 +463,7 @@ public class WriteableSettingTests extends OpenSearchTestCase {
         }
     }
 
+    @Ignore("https://github.com/opensearch-project/OpenSearch/issues/5504")
     @SuppressForbidden(reason = "The only way to test these is via reflection")
     public void testExceptionHandling() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
         // abuse reflection to change default value, no way to do this with given Setting class


### PR DESCRIPTION
### Description
[Describe what this change achieves]

### Issues Resolved
This is to demonstrate how to fix #5504 the "correct way"

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
