### PR TITLE
[Remote Translog] Reduce number of operations in testConcurrentWriteViewsAndSnapshot

### DIFF
--- a/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
@@ -620,8 +620,8 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
     public void testConcurrentWriteViewsAndSnapshot() throws Throwable {
         final Thread[] writers = new Thread[randomIntBetween(1, 3)];
         final Thread[] readers = new Thread[randomIntBetween(1, 3)];
-        final int flushEveryOps = randomIntBetween(5, 100);
-        final int maxOps = randomIntBetween(200, 1000);
+        final int flushEveryOps = randomIntBetween(5, 10);
+        final int maxOps = randomIntBetween(20, 100);
         final Object signalReaderSomeDataWasIndexed = new Object();
         final AtomicLong idGenerator = new AtomicLong();
         final CyclicBarrier barrier = new CyclicBarrier(writers.length + readers.length + 1);


### PR DESCRIPTION
Signed-off-by: Sachin Kale <kalsac@amazon.com>

### Description
- RemoteFSTranslogTests.testConcurrentWriteViewsAndSnapshot fails if number of operations are very high.
- As this test picks random number of operations, if the number is high, test fails and if it is low, test passes.
- To avoid this flakiness, this change reduce the range of number of operations.
- https://build.ci.opensearch.org/job/gradle-check/9162/testReport/junit/org.opensearch.index.translog/RemoteFSTranslogTests/testConcurrentWriteViewsAndSnapshot/
- This is not a proper solution though. With buffering and garbage collection (https://github.com/opensearch-project/OpenSearch/pull/5662) in place, we should not see this problem.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
