### PR TITLE
[Backport 2.x] Gracefully handle concurrent zone decommission action (#5542)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change http code for DecommissioningFailedException from 500 to 400 ([#5283](https://github.com/opensearch-project/OpenSearch/pull/5283))
 - Pre conditions check before updating weighted routing metadata ([#4955](https://github.com/opensearch-project/OpenSearch/pull/4955))
 - Integrate remote segment store in the failover flow ([#5579](https://github.com/opensearch-project/OpenSearch/pull/5579))
+- Gracefully handle concurrent zone decommission action ([#5542](https://github.com/opensearch-project/OpenSearch/pull/5542))
 
 ### Deprecated
 - Refactor fuzziness interface on query builders ([#5433](https://github.com/opensearch-project/OpenSearch/pull/5433))

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/AwarenessAttributeDecommissionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/AwarenessAttributeDecommissionIT.java
@@ -44,6 +44,8 @@ import org.opensearch.plugins.Plugin;
 import org.opensearch.test.MockLogAppender;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.transport.MockTransportService;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.RemoteTransportException;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportService;
@@ -59,6 +61,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
 import static org.opensearch.test.NodeRoles.onlyRole;
@@ -959,6 +962,114 @@ public class AwarenessAttributeDecommissionIT extends OpenSearchIntegTestCase {
 
         // will wait for cluster to stabilise with a timeout of 2 min as by then all nodes should have joined the cluster
         ensureStableCluster(6, TimeValue.timeValueMinutes(2));
+    }
+
+    public void testConcurrentDecommissionAction() throws Exception {
+        Settings commonSettings = Settings.builder()
+            .put("cluster.routing.allocation.awareness.attributes", "zone")
+            .put("cluster.routing.allocation.awareness.force.zone.values", "a,b,c")
+            .build();
+
+        logger.info("--> start 3 cluster manager nodes on zones 'a' & 'b' & 'c'");
+        internalCluster().startNodes(
+            Settings.builder()
+                .put(commonSettings)
+                .put("node.attr.zone", "a")
+                .put(onlyRole(commonSettings, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE))
+                .build(),
+            Settings.builder()
+                .put(commonSettings)
+                .put("node.attr.zone", "b")
+                .put(onlyRole(commonSettings, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE))
+                .build(),
+            Settings.builder()
+                .put(commonSettings)
+                .put("node.attr.zone", "c")
+                .put(onlyRole(commonSettings, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE))
+                .build()
+        );
+        logger.info("--> start 3 data nodes on zones 'a' & 'b' & 'c'");
+        internalCluster().startNodes(
+            Settings.builder()
+                .put(commonSettings)
+                .put("node.attr.zone", "a")
+                .put(onlyRole(commonSettings, DiscoveryNodeRole.DATA_ROLE))
+                .build(),
+            Settings.builder()
+                .put(commonSettings)
+                .put("node.attr.zone", "b")
+                .put(onlyRole(commonSettings, DiscoveryNodeRole.DATA_ROLE))
+                .build(),
+            Settings.builder()
+                .put(commonSettings)
+                .put("node.attr.zone", "c")
+                .put(onlyRole(commonSettings, DiscoveryNodeRole.DATA_ROLE))
+                .build()
+        );
+
+        ensureStableCluster(6);
+        ClusterHealthResponse health = client().admin()
+            .cluster()
+            .prepareHealth()
+            .setWaitForEvents(Priority.LANGUID)
+            .setWaitForGreenStatus()
+            .setWaitForNodes(Integer.toString(6))
+            .execute()
+            .actionGet();
+        assertFalse(health.isTimedOut());
+
+        logger.info("--> setting shard routing weights for weighted round robin");
+        Map<String, Double> weights = Map.of("a", 0.0, "b", 1.0, "c", 1.0);
+        WeightedRouting weightedRouting = new WeightedRouting("zone", weights);
+
+        ClusterPutWeightedRoutingResponse weightedRoutingResponse = client().admin()
+            .cluster()
+            .prepareWeightedRouting()
+            .setWeightedRouting(weightedRouting)
+            .setVersion(-1)
+            .get();
+        assertTrue(weightedRoutingResponse.isAcknowledged());
+
+        AtomicInteger numRequestAcknowledged = new AtomicInteger();
+        AtomicInteger numRequestUnAcknowledged = new AtomicInteger();
+        AtomicInteger numRequestFailed = new AtomicInteger();
+        int concurrentRuns = randomIntBetween(5, 10);
+        TestThreadPool testThreadPool = null;
+        logger.info("--> starting {} concurrent decommission action in zone {}", concurrentRuns, 'a');
+        try {
+            testThreadPool = new TestThreadPool(AwarenessAttributeDecommissionIT.class.getName());
+            List<Runnable> operationThreads = new ArrayList<>();
+            CountDownLatch countDownLatch = new CountDownLatch(concurrentRuns);
+            for (int i = 0; i < concurrentRuns; i++) {
+                Runnable thread = () -> {
+                    logger.info("Triggering decommission action");
+                    DecommissionAttribute decommissionAttribute = new DecommissionAttribute("zone", "a");
+                    DecommissionRequest decommissionRequest = new DecommissionRequest(decommissionAttribute);
+                    decommissionRequest.setNoDelay(true);
+                    try {
+                        DecommissionResponse decommissionResponse = client().execute(DecommissionAction.INSTANCE, decommissionRequest)
+                            .get();
+                        if (decommissionResponse.isAcknowledged()) {
+                            numRequestAcknowledged.incrementAndGet();
+                        } else {
+                            numRequestUnAcknowledged.incrementAndGet();
+                        }
+                    } catch (Exception e) {
+                        numRequestFailed.incrementAndGet();
+                    }
+                    countDownLatch.countDown();
+                };
+                operationThreads.add(thread);
+            }
+            TestThreadPool finalTestThreadPool = testThreadPool;
+            operationThreads.forEach(runnable -> finalTestThreadPool.executor("generic").execute(runnable));
+            countDownLatch.await();
+        } finally {
+            ThreadPool.terminate(testThreadPool, 500, TimeUnit.MILLISECONDS);
+        }
+        assertEquals(concurrentRuns, numRequestAcknowledged.get() + numRequestUnAcknowledged.get() + numRequestFailed.get());
+        assertEquals(concurrentRuns - 1, numRequestFailed.get());
+        assertEquals(1, numRequestAcknowledged.get() + numRequestUnAcknowledged.get());
     }
 
     private static class WaitForFailedDecommissionState implements ClusterStateObserver.Listener {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/decommission/awareness/put/DecommissionRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/decommission/awareness/put/DecommissionRequest.java
@@ -21,8 +21,6 @@ import java.io.IOException;
 import static org.opensearch.action.ValidateActions.addValidationError;
 
 /**
- * Register decommission request.
- * <p>
  * Registers a decommission request with decommission attribute and timeout
  *
  * @opensearch.internal
@@ -32,7 +30,7 @@ public class DecommissionRequest extends ClusterManagerNodeRequest<DecommissionR
     public static final TimeValue DEFAULT_NODE_DRAINING_TIMEOUT = TimeValue.timeValueSeconds(120);
 
     private DecommissionAttribute decommissionAttribute;
-
+    private String requestID;
     private TimeValue delayTimeout = DEFAULT_NODE_DRAINING_TIMEOUT;
 
     // holder for no_delay param. To avoid draining time timeout.
@@ -49,6 +47,7 @@ public class DecommissionRequest extends ClusterManagerNodeRequest<DecommissionR
         decommissionAttribute = new DecommissionAttribute(in);
         this.delayTimeout = in.readTimeValue();
         this.noDelay = in.readBoolean();
+        this.requestID = in.readOptionalString();
     }
 
     @Override
@@ -57,6 +56,7 @@ public class DecommissionRequest extends ClusterManagerNodeRequest<DecommissionR
         decommissionAttribute.writeTo(out);
         out.writeTimeValue(delayTimeout);
         out.writeBoolean(noDelay);
+        out.writeOptionalString(requestID);
     }
 
     /**
@@ -77,23 +77,43 @@ public class DecommissionRequest extends ClusterManagerNodeRequest<DecommissionR
         return this.decommissionAttribute;
     }
 
-    public void setDelayTimeout(TimeValue delayTimeout) {
+    public DecommissionRequest setDelayTimeout(TimeValue delayTimeout) {
         this.delayTimeout = delayTimeout;
+        return this;
     }
 
     public TimeValue getDelayTimeout() {
         return this.delayTimeout;
     }
 
-    public void setNoDelay(boolean noDelay) {
+    public DecommissionRequest setNoDelay(boolean noDelay) {
         if (noDelay) {
             this.delayTimeout = TimeValue.ZERO;
         }
         this.noDelay = noDelay;
+        return this;
     }
 
     public boolean isNoDelay() {
         return noDelay;
+    }
+
+    /**
+     * Sets id for decommission request
+     *
+     * @param requestID uuid for request
+     * @return this request
+     */
+    public DecommissionRequest setRequestID(String requestID) {
+        this.requestID = requestID;
+        return this;
+    }
+
+    /**
+     * @return Returns id of decommission request
+     */
+    public String requestID() {
+        return requestID;
     }
 
     @Override
@@ -122,6 +142,13 @@ public class DecommissionRequest extends ClusterManagerNodeRequest<DecommissionR
 
     @Override
     public String toString() {
-        return "DecommissionRequest{" + "decommissionAttribute=" + decommissionAttribute + '}';
+        return "DecommissionRequest{"
+            + "decommissionAttribute="
+            + decommissionAttribute
+            + ", delayTimeout="
+            + delayTimeout
+            + ", noDelay="
+            + noDelay
+            + '}';
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/decommission/awareness/put/DecommissionRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/decommission/awareness/put/DecommissionRequestBuilder.java
@@ -46,4 +46,15 @@ public class DecommissionRequestBuilder extends ClusterManagerNodeOperationReque
         request.setNoDelay(noDelay);
         return this;
     }
+
+    /**
+     * Sets request id for decommission request
+     *
+     * @param requestID for decommission request
+     * @return current object
+     */
+    public DecommissionRequestBuilder requestID(String requestID) {
+        request.setRequestID(requestID);
+        return this;
+    }
 }

--- a/server/src/main/java/org/opensearch/cluster/decommission/DecommissionAttributeMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/decommission/DecommissionAttributeMetadata.java
@@ -37,6 +37,7 @@ public class DecommissionAttributeMetadata extends AbstractNamedDiffable<Custom>
 
     private final DecommissionAttribute decommissionAttribute;
     private DecommissionStatus status;
+    private String requestID;
     public static final String attributeType = "awareness";
 
     /**
@@ -45,18 +46,19 @@ public class DecommissionAttributeMetadata extends AbstractNamedDiffable<Custom>
      * @param decommissionAttribute attribute details
      * @param status                current status of the attribute decommission
      */
-    public DecommissionAttributeMetadata(DecommissionAttribute decommissionAttribute, DecommissionStatus status) {
+    public DecommissionAttributeMetadata(DecommissionAttribute decommissionAttribute, DecommissionStatus status, String requestId) {
         this.decommissionAttribute = decommissionAttribute;
         this.status = status;
+        this.requestID = requestId;
     }
 
     /**
-     * Constructs new decommission attribute metadata with status as {@link DecommissionStatus#INIT}
+     * Constructs new decommission attribute metadata with status as {@link DecommissionStatus#INIT} and request id
      *
      * @param decommissionAttribute attribute details
      */
-    public DecommissionAttributeMetadata(DecommissionAttribute decommissionAttribute) {
-        this(decommissionAttribute, DecommissionStatus.INIT);
+    public DecommissionAttributeMetadata(DecommissionAttribute decommissionAttribute, String requestID) {
+        this(decommissionAttribute, DecommissionStatus.INIT, requestID);
     }
 
     /**
@@ -75,6 +77,15 @@ public class DecommissionAttributeMetadata extends AbstractNamedDiffable<Custom>
      */
     public DecommissionStatus status() {
         return this.status;
+    }
+
+    /**
+     * Returns the request id of the decommission
+     *
+     * @return request id
+     */
+    public String requestID() {
+        return this.requestID;
     }
 
     /**
@@ -128,12 +139,13 @@ public class DecommissionAttributeMetadata extends AbstractNamedDiffable<Custom>
         DecommissionAttributeMetadata that = (DecommissionAttributeMetadata) o;
 
         if (!status.equals(that.status)) return false;
+        if (!requestID.equals(that.requestID)) return false;
         return decommissionAttribute.equals(that.decommissionAttribute);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(attributeType, decommissionAttribute, status);
+        return Objects.hash(attributeType, decommissionAttribute, status, requestID);
     }
 
     /**
@@ -152,6 +164,7 @@ public class DecommissionAttributeMetadata extends AbstractNamedDiffable<Custom>
     public DecommissionAttributeMetadata(StreamInput in) throws IOException {
         this.decommissionAttribute = new DecommissionAttribute(in);
         this.status = DecommissionStatus.fromString(in.readString());
+        this.requestID = in.readString();
     }
 
     public static NamedDiff<Custom> readDiffFrom(StreamInput in) throws IOException {
@@ -165,12 +178,14 @@ public class DecommissionAttributeMetadata extends AbstractNamedDiffable<Custom>
     public void writeTo(StreamOutput out) throws IOException {
         decommissionAttribute.writeTo(out);
         out.writeString(status.status());
+        out.writeString(requestID);
     }
 
     public static DecommissionAttributeMetadata fromXContent(XContentParser parser) throws IOException {
         XContentParser.Token token;
         DecommissionAttribute decommissionAttribute = null;
         DecommissionStatus status = null;
+        String requestID = null;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 String currentFieldName = parser.currentName();
@@ -210,6 +225,13 @@ public class DecommissionAttributeMetadata extends AbstractNamedDiffable<Custom>
                         );
                     }
                     status = DecommissionStatus.fromString(parser.text());
+                } else if ("requestID".equals(currentFieldName)) {
+                    if (parser.nextToken() != XContentParser.Token.VALUE_STRING) {
+                        throw new OpenSearchParseException(
+                            "failed to parse status of decommissioning, expected string but found unknown type"
+                        );
+                    }
+                    requestID = parser.text();
                 } else {
                     throw new OpenSearchParseException(
                         "unknown field found [{}], failed to parse the decommission attribute",
@@ -218,7 +240,7 @@ public class DecommissionAttributeMetadata extends AbstractNamedDiffable<Custom>
                 }
             }
         }
-        return new DecommissionAttributeMetadata(decommissionAttribute, status);
+        return new DecommissionAttributeMetadata(decommissionAttribute, status, requestID);
     }
 
     /**
@@ -226,7 +248,7 @@ public class DecommissionAttributeMetadata extends AbstractNamedDiffable<Custom>
      */
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
-        toXContent(decommissionAttribute, status, attributeType, builder, params);
+        toXContent(decommissionAttribute, status, requestID, attributeType, builder, params);
         return builder;
     }
 
@@ -245,6 +267,7 @@ public class DecommissionAttributeMetadata extends AbstractNamedDiffable<Custom>
     public static void toXContent(
         DecommissionAttribute decommissionAttribute,
         DecommissionStatus status,
+        String requestID,
         String attributeType,
         XContentBuilder builder,
         ToXContent.Params params
@@ -253,6 +276,7 @@ public class DecommissionAttributeMetadata extends AbstractNamedDiffable<Custom>
         builder.field(decommissionAttribute.attributeName(), decommissionAttribute.attributeValue());
         builder.endObject();
         builder.field("status", status.status());
+        builder.field("requestID", requestID);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/decommission/DecommissionController.java
+++ b/server/src/main/java/org/opensearch/cluster/decommission/DecommissionController.java
@@ -175,7 +175,8 @@ public class DecommissionController {
                 decommissionAttributeMetadata.validateNewStatus(decommissionStatus);
                 decommissionAttributeMetadata = new DecommissionAttributeMetadata(
                     decommissionAttributeMetadata.decommissionAttribute(),
-                    decommissionStatus
+                    decommissionStatus,
+                    decommissionAttributeMetadata.requestID()
                 );
                 ClusterState newState = ClusterState.builder(currentState)
                     .metadata(Metadata.builder(currentState.metadata()).decommissionAttributeMetadata(decommissionAttributeMetadata))

--- a/server/src/main/java/org/opensearch/cluster/decommission/DecommissionHelper.java
+++ b/server/src/main/java/org/opensearch/cluster/decommission/DecommissionHelper.java
@@ -32,9 +32,10 @@ public class DecommissionHelper {
 
     static ClusterState registerDecommissionAttributeInClusterState(
         ClusterState currentState,
-        DecommissionAttribute decommissionAttribute
+        DecommissionAttribute decommissionAttribute,
+        String requestID
     ) {
-        DecommissionAttributeMetadata decommissionAttributeMetadata = new DecommissionAttributeMetadata(decommissionAttribute);
+        DecommissionAttributeMetadata decommissionAttributeMetadata = new DecommissionAttributeMetadata(decommissionAttribute, requestID);
         return ClusterState.builder(currentState)
             .metadata(Metadata.builder(currentState.metadata()).decommissionAttributeMetadata(decommissionAttributeMetadata))
             .build();

--- a/server/src/main/java/org/opensearch/cluster/decommission/DecommissionService.java
+++ b/server/src/main/java/org/opensearch/cluster/decommission/DecommissionService.java
@@ -28,6 +28,7 @@ import org.opensearch.cluster.routing.WeightedRouting;
 import org.opensearch.cluster.routing.allocation.AllocationService;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Priority;
+import org.opensearch.common.UUIDs;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
@@ -128,7 +129,7 @@ public class DecommissionService {
      * Starts the new decommission request and registers the metadata with status as {@link DecommissionStatus#INIT}
      * Once the status is updated, it tries to exclude to-be-decommissioned cluster manager eligible nodes from Voting Configuration
      *
-     * @param decommissionRequest decommission request Object
+     * @param decommissionRequest request for decommission action
      * @param listener register decommission listener
      */
     public void startDecommissionAction(
@@ -144,12 +145,19 @@ public class DecommissionService {
             public ClusterState execute(ClusterState currentState) {
                 // validates if correct awareness attributes and forced awareness attribute set to the cluster before starting action
                 validateAwarenessAttribute(decommissionAttribute, awarenessAttributes, forcedAwarenessAttributes);
+                if (decommissionRequest.requestID() == null) {
+                    decommissionRequest.setRequestID(UUIDs.randomBase64UUID());
+                }
                 DecommissionAttributeMetadata decommissionAttributeMetadata = currentState.metadata().decommissionAttributeMetadata();
                 // check that request is eligible to proceed and attribute is weighed away
-                ensureEligibleRequest(decommissionAttributeMetadata, decommissionAttribute);
+                ensureEligibleRequest(decommissionAttributeMetadata, decommissionRequest);
                 ensureToBeDecommissionedAttributeWeighedAway(currentState, decommissionAttribute);
 
-                ClusterState newState = registerDecommissionAttributeInClusterState(currentState, decommissionAttribute);
+                ClusterState newState = registerDecommissionAttributeInClusterState(
+                    currentState,
+                    decommissionAttribute,
+                    decommissionRequest.requestID()
+                );
                 // add all 'to-be-decommissioned' cluster manager eligible nodes to voting config exclusion
                 nodeIdsToBeExcluded = filterNodesWithDecommissionAttribute(currentState, decommissionAttribute, true).stream()
                     .map(DiscoveryNode::getId)
@@ -188,6 +196,7 @@ public class DecommissionService {
                 DecommissionAttributeMetadata decommissionAttributeMetadata = newState.metadata().decommissionAttributeMetadata();
                 assert decommissionAttribute.equals(decommissionAttributeMetadata.decommissionAttribute());
                 assert decommissionAttributeMetadata.status().equals(DecommissionStatus.INIT);
+                assert decommissionAttributeMetadata.requestID().equals(decommissionRequest.requestID());
                 assert newState.getVotingConfigExclusions()
                     .stream()
                     .map(CoordinationMetadata.VotingConfigExclusion::getNodeId)
@@ -294,6 +303,7 @@ public class DecommissionService {
     // the action again (retry)
     void drainNodesWithDecommissionedAttribute(DecommissionRequest decommissionRequest) {
         ClusterState state = clusterService.getClusterApplierService().state();
+        assert state.metadata().decommissionAttributeMetadata().requestID().equals(decommissionRequest.requestID());
         Set<DiscoveryNode> decommissionedNodes = filterNodesWithDecommissionAttribute(
             state,
             decommissionRequest.getDecommissionAttribute(),
@@ -456,22 +466,31 @@ public class DecommissionService {
 
     private static void ensureEligibleRequest(
         DecommissionAttributeMetadata decommissionAttributeMetadata,
-        DecommissionAttribute requestedDecommissionAttribute
+        DecommissionRequest decommissionRequest
     ) {
-        String msg = null;
+        String msg;
+        DecommissionAttribute requestedDecommissionAttribute = decommissionRequest.getDecommissionAttribute();
         if (decommissionAttributeMetadata != null) {
             // check if the same attribute is registered and handle it accordingly
             if (decommissionAttributeMetadata.decommissionAttribute().equals(requestedDecommissionAttribute)) {
                 switch (decommissionAttributeMetadata.status()) {
-                    // for INIT and FAILED - we are good to process it again
+                    // for INIT - check if it is eligible internal retry
                     case INIT:
+                        if (decommissionRequest.requestID().equals(decommissionAttributeMetadata.requestID()) == false) {
+                            throw new DecommissioningFailedException(
+                                requestedDecommissionAttribute,
+                                "same request is already in status [INIT]"
+                            );
+                        }
+                        break;
+                    // for FAILED - we are good to process it again
                     case FAILED:
                         break;
                     case DRAINING:
                     case IN_PROGRESS:
                     case SUCCESSFUL:
                         msg = "same request is already in status [" + decommissionAttributeMetadata.status() + "]";
-                        break;
+                        throw new DecommissioningFailedException(requestedDecommissionAttribute, msg);
                     default:
                         throw new IllegalStateException(
                             "unknown status [" + decommissionAttributeMetadata.status() + "] currently registered in metadata"
@@ -484,7 +503,7 @@ public class DecommissionService {
                         msg = "one awareness attribute ["
                             + decommissionAttributeMetadata.decommissionAttribute().toString()
                             + "] already successfully decommissioned, recommission before triggering another decommission";
-                        break;
+                        throw new DecommissioningFailedException(requestedDecommissionAttribute, msg);
                     case DRAINING:
                     case IN_PROGRESS:
                     case INIT:
@@ -492,7 +511,7 @@ public class DecommissionService {
                         msg = "there's an inflight decommission request for attribute ["
                             + decommissionAttributeMetadata.decommissionAttribute().toString()
                             + "] is in progress, cannot process this request";
-                        break;
+                        throw new DecommissioningFailedException(requestedDecommissionAttribute, msg);
                     case FAILED:
                         break;
                     default:
@@ -501,10 +520,6 @@ public class DecommissionService {
                         );
                 }
             }
-        }
-
-        if (msg != null) {
-            throw new DecommissioningFailedException(requestedDecommissionAttribute, msg);
         }
     }
 

--- a/server/src/test/java/org/opensearch/cluster/coordination/JoinTaskExecutorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/JoinTaskExecutorTests.java
@@ -315,7 +315,8 @@ public class JoinTaskExecutorTests extends OpenSearchTestCase {
         );
         DecommissionAttributeMetadata decommissionAttributeMetadata = new DecommissionAttributeMetadata(
             decommissionAttribute,
-            decommissionStatus
+            decommissionStatus,
+            randomAlphaOfLength(10)
         );
         Metadata metadata = Metadata.builder().decommissionAttributeMetadata(decommissionAttributeMetadata).build();
         DiscoveryNode discoveryNode = newDiscoveryNode(Collections.singletonMap("zone", "zone-1"));
@@ -332,7 +333,8 @@ public class JoinTaskExecutorTests extends OpenSearchTestCase {
         );
         DecommissionAttributeMetadata decommissionAttributeMetadata = new DecommissionAttributeMetadata(
             decommissionAttribute,
-            decommissionStatus
+            decommissionStatus,
+            randomAlphaOfLength(10)
         );
         Metadata metadata = Metadata.builder().decommissionAttributeMetadata(decommissionAttributeMetadata).build();
 
@@ -352,7 +354,8 @@ public class JoinTaskExecutorTests extends OpenSearchTestCase {
         DecommissionAttribute decommissionAttribute = new DecommissionAttribute("zone", "zone1");
         DecommissionAttributeMetadata decommissionAttributeMetadata = new DecommissionAttributeMetadata(
             decommissionAttribute,
-            DecommissionStatus.SUCCESSFUL
+            DecommissionStatus.SUCCESSFUL,
+            randomAlphaOfLength(10)
         );
         final ClusterState clusterManagerClusterState = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(
@@ -390,7 +393,8 @@ public class JoinTaskExecutorTests extends OpenSearchTestCase {
         DecommissionAttribute decommissionAttribute = new DecommissionAttribute("zone", "zone-1");
         DecommissionAttributeMetadata decommissionAttributeMetadata = new DecommissionAttributeMetadata(
             decommissionAttribute,
-            DecommissionStatus.FAILED
+            DecommissionStatus.FAILED,
+            randomAlphaOfLength(10)
         );
         Metadata metadata = Metadata.builder().decommissionAttributeMetadata(decommissionAttributeMetadata).build();
 

--- a/server/src/test/java/org/opensearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/NodeJoinTests.java
@@ -847,7 +847,8 @@ public class NodeJoinTests extends OpenSearchTestCase {
     ) {
         DecommissionAttributeMetadata decommissionAttributeMetadata = new DecommissionAttributeMetadata(
             decommissionAttribute,
-            DecommissionStatus.SUCCESSFUL
+            DecommissionStatus.SUCCESSFUL,
+            randomAlphaOfLength(10)
         );
         return ClusterState.builder(clusterState)
             .metadata(Metadata.builder(clusterState.metadata()).decommissionAttributeMetadata(decommissionAttributeMetadata))

--- a/server/src/test/java/org/opensearch/cluster/decommission/DecommissionHelperTests.java
+++ b/server/src/test/java/org/opensearch/cluster/decommission/DecommissionHelperTests.java
@@ -38,7 +38,11 @@ public class DecommissionHelperTests extends OpenSearchTestCase {
 
     public void testRegisterAndDeleteDecommissionAttributeInClusterState() {
         DecommissionAttribute decommissionAttribute = new DecommissionAttribute("zone", "zone2");
-        ClusterState updatedState = registerDecommissionAttributeInClusterState(initialClusterState, decommissionAttribute);
+        ClusterState updatedState = registerDecommissionAttributeInClusterState(
+            initialClusterState,
+            decommissionAttribute,
+            randomAlphaOfLength(10)
+        );
         assertEquals(decommissionAttribute, updatedState.metadata().decommissionAttributeMetadata().decommissionAttribute());
         updatedState = deleteDecommissionAttributeInClusterState(updatedState);
         assertNull(updatedState.metadata().decommissionAttributeMetadata());
@@ -79,13 +83,14 @@ public class DecommissionHelperTests extends OpenSearchTestCase {
         );
         DecommissionAttributeMetadata decommissionAttributeMetadata = new DecommissionAttributeMetadata(
             decommissionAttribute,
-            decommissionStatus
+            decommissionStatus,
+            randomAlphaOfLength(10)
         );
         Metadata metadata = Metadata.builder().putCustom(DecommissionAttributeMetadata.TYPE, decommissionAttributeMetadata).build();
         assertTrue(nodeCommissioned(node2, metadata));
         assertFalse(nodeCommissioned(node1, metadata));
         DecommissionStatus commissionStatus = randomFrom(DecommissionStatus.FAILED, DecommissionStatus.INIT);
-        decommissionAttributeMetadata = new DecommissionAttributeMetadata(decommissionAttribute, commissionStatus);
+        decommissionAttributeMetadata = new DecommissionAttributeMetadata(decommissionAttribute, commissionStatus, randomAlphaOfLength(10));
         metadata = Metadata.builder().putCustom(DecommissionAttributeMetadata.TYPE, decommissionAttributeMetadata).build();
         assertTrue(nodeCommissioned(node2, metadata));
         assertTrue(nodeCommissioned(node1, metadata));

--- a/server/src/test/java/org/opensearch/cluster/decommission/DecommissionServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/decommission/DecommissionServiceTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.cluster.decommission;
 
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
@@ -49,6 +50,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonMap;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.opensearch.cluster.ClusterState.builder;
 import static org.opensearch.cluster.OpenSearchAllocationTestCase.createAllocationService;
 import static org.opensearch.test.ClusterServiceUtils.createClusterService;
@@ -195,13 +199,49 @@ public class DecommissionServiceTests extends OpenSearchTestCase {
         assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
     }
 
+    public void testExternalDecommissionRetryNotAllowed() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        DecommissionStatus oldStatus = DecommissionStatus.INIT;
+        DecommissionAttributeMetadata oldMetadata = new DecommissionAttributeMetadata(
+            new DecommissionAttribute("zone", "zone_1"),
+            oldStatus,
+            randomAlphaOfLength(10)
+        );
+        final ClusterState.Builder builder = builder(clusterService.state());
+        setState(
+            clusterService,
+            builder.metadata(Metadata.builder(clusterService.state().metadata()).decommissionAttributeMetadata(oldMetadata).build())
+        );
+        AtomicReference<Exception> exceptionReference = new AtomicReference<>();
+        ActionListener<DecommissionResponse> listener = new ActionListener<DecommissionResponse>() {
+            @Override
+            public void onResponse(DecommissionResponse decommissionResponse) {
+                fail("on response shouldn't have been called");
+                countDownLatch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                exceptionReference.set(e);
+                countDownLatch.countDown();
+            }
+        };
+        DecommissionRequest request = new DecommissionRequest(new DecommissionAttribute("zone", "zone_1"));
+        decommissionService.startDecommissionAction(request, listener);
+        assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
+        MatcherAssert.assertThat("Expected onFailure to be called", exceptionReference.get(), notNullValue());
+        MatcherAssert.assertThat(exceptionReference.get(), instanceOf(DecommissioningFailedException.class));
+        MatcherAssert.assertThat(exceptionReference.get().getMessage(), containsString("same request is already in status [INIT]"));
+    }
+
     @SuppressWarnings("unchecked")
     public void testDecommissioningFailedWhenAnotherAttributeDecommissioningSuccessful() throws InterruptedException {
         final CountDownLatch countDownLatch = new CountDownLatch(1);
         DecommissionStatus oldStatus = randomFrom(DecommissionStatus.SUCCESSFUL, DecommissionStatus.IN_PROGRESS, DecommissionStatus.INIT);
         DecommissionAttributeMetadata oldMetadata = new DecommissionAttributeMetadata(
             new DecommissionAttribute("zone", "zone_1"),
-            oldStatus
+            oldStatus,
+            randomAlphaOfLength(10)
         );
         final ClusterState.Builder builder = builder(clusterService.state());
         setState(
@@ -233,6 +273,40 @@ public class DecommissionServiceTests extends OpenSearchTestCase {
         assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
     }
 
+    public void testDecommissioningFailedWhenAnotherRequestForSameAttributeIsExecuted() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        DecommissionStatus oldStatus = DecommissionStatus.INIT;
+        DecommissionAttributeMetadata oldMetadata = new DecommissionAttributeMetadata(
+            new DecommissionAttribute("zone", "zone_1"),
+            oldStatus,
+            randomAlphaOfLength(10)
+        );
+        final ClusterState.Builder builder = builder(clusterService.state());
+        setState(
+            clusterService,
+            builder.metadata(Metadata.builder(clusterService.state().metadata()).decommissionAttributeMetadata(oldMetadata).build())
+        );
+        AtomicReference<Exception> exceptionReference = new AtomicReference<>();
+        ActionListener<DecommissionResponse> listener = new ActionListener<DecommissionResponse>() {
+            @Override
+            public void onResponse(DecommissionResponse decommissionResponse) {
+                fail("on response shouldn't have been called");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                assertTrue(e instanceof DecommissioningFailedException);
+                exceptionReference.set(e);
+                countDownLatch.countDown();
+            }
+        };
+        DecommissionRequest request = new DecommissionRequest(new DecommissionAttribute("zone", "zone_1"));
+        decommissionService.startDecommissionAction(request, listener);
+        assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
+        assertTrue(exceptionReference.get() instanceof DecommissioningFailedException);
+        assertThat(exceptionReference.get().getMessage(), Matchers.endsWith("same request is already in status [INIT]"));
+    }
+
     public void testScheduleNodesDecommissionOnTimeout() {
         TransportService mockTransportService = Mockito.mock(TransportService.class);
         ThreadPool mockThreadPool = Mockito.mock(ThreadPool.class);
@@ -249,7 +323,8 @@ public class DecommissionServiceTests extends OpenSearchTestCase {
         DecommissionAttribute decommissionAttribute = new DecommissionAttribute("zone", "zone-2");
         DecommissionAttributeMetadata decommissionAttributeMetadata = new DecommissionAttributeMetadata(
             decommissionAttribute,
-            DecommissionStatus.DRAINING
+            DecommissionStatus.DRAINING,
+            randomAlphaOfLength(10)
         );
         Metadata metadata = Metadata.builder().putCustom(DecommissionAttributeMetadata.TYPE, decommissionAttributeMetadata).build();
         ClusterState state = ClusterState.builder(new ClusterName("test")).metadata(metadata).build();
@@ -268,9 +343,11 @@ public class DecommissionServiceTests extends OpenSearchTestCase {
 
     public void testDrainNodesWithDecommissionedAttributeWithNoDelay() {
         DecommissionAttribute decommissionAttribute = new DecommissionAttribute("zone", "zone-2");
+        String requestID = randomAlphaOfLength(10);
         DecommissionAttributeMetadata decommissionAttributeMetadata = new DecommissionAttributeMetadata(
             decommissionAttribute,
-            DecommissionStatus.INIT
+            DecommissionStatus.INIT,
+            requestID
         );
 
         Metadata metadata = Metadata.builder().putCustom(DecommissionAttributeMetadata.TYPE, decommissionAttributeMetadata).build();
@@ -278,6 +355,7 @@ public class DecommissionServiceTests extends OpenSearchTestCase {
 
         DecommissionRequest request = new DecommissionRequest(decommissionAttribute);
         request.setNoDelay(true);
+        request.setRequestID(requestID);
 
         setState(clusterService, state);
         decommissionService.drainNodesWithDecommissionedAttribute(request);
@@ -289,7 +367,8 @@ public class DecommissionServiceTests extends OpenSearchTestCase {
         DecommissionAttribute decommissionAttribute = new DecommissionAttribute("zone", "zone-2");
         DecommissionAttributeMetadata decommissionAttributeMetadata = new DecommissionAttributeMetadata(
             decommissionAttribute,
-            DecommissionStatus.SUCCESSFUL
+            DecommissionStatus.SUCCESSFUL,
+            randomAlphaOfLength(10)
         );
         final ClusterState.Builder builder = builder(clusterService.state());
         setState(

--- a/server/src/test/java/org/opensearch/cluster/metadata/DecommissionAttributeMetadataSerializationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/DecommissionAttributeMetadataSerializationTests.java
@@ -33,7 +33,7 @@ public class DecommissionAttributeMetadataSerializationTests extends AbstractDif
         String attributeValue = randomAlphaOfLength(6);
         DecommissionAttribute decommissionAttribute = new DecommissionAttribute(attributeName, attributeValue);
         DecommissionStatus decommissionStatus = randomFrom(DecommissionStatus.values());
-        return new DecommissionAttributeMetadata(decommissionAttribute, decommissionStatus);
+        return new DecommissionAttributeMetadata(decommissionAttribute, decommissionStatus, randomAlphaOfLength(10));
     }
 
     @Override
@@ -57,7 +57,11 @@ public class DecommissionAttributeMetadataSerializationTests extends AbstractDif
         if (randomBoolean()) {
             attributeValue = randomAlphaOfLength(6);
         }
-        return new DecommissionAttributeMetadata(new DecommissionAttribute(attributeName, attributeValue), decommissionStatus);
+        return new DecommissionAttributeMetadata(
+            new DecommissionAttribute(attributeName, attributeValue),
+            decommissionStatus,
+            randomAlphaOfLength(10)
+        );
     }
 
     @Override
@@ -77,7 +81,8 @@ public class DecommissionAttributeMetadataSerializationTests extends AbstractDif
         assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
         return new DecommissionAttributeMetadata(
             decommissionAttributeMetadata.decommissionAttribute(),
-            decommissionAttributeMetadata.status()
+            decommissionAttributeMetadata.status(),
+            decommissionAttributeMetadata.requestID()
         );
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/metadata/DecommissionAttributeMetadataTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/DecommissionAttributeMetadataTests.java
@@ -24,7 +24,7 @@ public class DecommissionAttributeMetadataTests extends AbstractNamedWriteableTe
         String attributeValue = randomAlphaOfLength(6);
         DecommissionAttribute decommissionAttribute = new DecommissionAttribute(attributeName, attributeValue);
         DecommissionStatus decommissionStatus = randomFrom(DecommissionStatus.values());
-        return new DecommissionAttributeMetadata(decommissionAttribute, decommissionStatus);
+        return new DecommissionAttributeMetadata(decommissionAttribute, decommissionStatus, randomAlphaOfLength(10));
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/cluster/metadata/DecommissionAttributeMetadataXContentTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/DecommissionAttributeMetadataXContentTests.java
@@ -23,7 +23,7 @@ public class DecommissionAttributeMetadataXContentTests extends AbstractXContent
         String attributeValue = randomAlphaOfLength(6);
         DecommissionAttribute decommissionAttribute = new DecommissionAttribute(attributeName, attributeValue);
         DecommissionStatus decommissionStatus = randomFrom(DecommissionStatus.values());
-        return new DecommissionAttributeMetadata(decommissionAttribute, decommissionStatus);
+        return new DecommissionAttributeMetadata(decommissionAttribute, decommissionStatus, randomAlphaOfLength(10));
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/cluster/routing/WeightedRoutingServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/WeightedRoutingServiceTests.java
@@ -184,7 +184,11 @@ public class WeightedRoutingServiceTests extends OpenSearchTestCase {
 
     private ClusterState setDecommissionAttribute(ClusterState clusterState, DecommissionStatus status) {
         DecommissionAttribute decommissionAttribute = new DecommissionAttribute("zone", "zone_A");
-        DecommissionAttributeMetadata decommissionAttributeMetadata = new DecommissionAttributeMetadata(decommissionAttribute, status);
+        DecommissionAttributeMetadata decommissionAttributeMetadata = new DecommissionAttributeMetadata(
+            decommissionAttribute,
+            status,
+            randomAlphaOfLength(10)
+        );
         Metadata.Builder metadataBuilder = Metadata.builder(clusterState.metadata());
         metadataBuilder.decommissionAttributeMetadata(decommissionAttributeMetadata);
         clusterState = ClusterState.builder(clusterState).metadata(metadataBuilder).build();


### PR DESCRIPTION
* Control concurrency and handle retries during decommissioning of awareness attributes

Signed-off-by: Rishab Nahata <rnnahata@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Backport #5542 

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
