### PR TITLE
[Bug] Send replicated boolean on supported versions

### DIFF
--- a/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/opensearch/index/seqno/ReplicationTracker.java
@@ -712,7 +712,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
             this.globalCheckpoint = in.readZLong();
             this.inSync = in.readBoolean();
             this.tracked = in.readBoolean();
-            if (in.getVersion().onOrAfter(Version.CURRENT)) {
+            if (in.getVersion().onOrAfter(Version.V_2_5_0)) {
                 this.replicated = in.readBoolean();
             } else {
                 this.replicated = true;
@@ -725,7 +725,9 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
             out.writeZLong(globalCheckpoint);
             out.writeBoolean(inSync);
             out.writeBoolean(tracked);
-            out.writeBoolean(replicated);
+            if (out.getVersion().onOrAfter(Version.V_2_5_0)) {
+                out.writeBoolean(replicated);
+            }
         }
 
         /**


### PR DESCRIPTION
### Description
As part of https://github.com/opensearch-project/OpenSearch/pull/5282, we introduced a boolean flag in CheckpointState class inside ReplicationTracker. Consider the case when bwc tests ran in 2.x branch. 

This fails on `2.x` because `Version.CURRENT` in `in.getVersion().onOrAfter(Version.CURRENT)` returns 2.5.0 (2.5 Current is `2.5.0` and 2.x has `2.6.0`) which means it always goes in `else` condition. BUT, the write to outputstream is unconditional which means the minor version (2.5.0 already containing https://github.com/opensearch-project/OpenSearch/pull/5282 change) does write it to output stream. The correct fix here is:
1. Replace Version.CURRENT with specific version. Version.CURRENT changes with branch.
2. Update output stream write to be conditional so that it writes only when it is supported. 

```
if (in.getVersion().onOrAfter(Version.V_2_5_0)) {
    this.replicated = in.readBoolean();
} else {
    this.replicated = true;
}
```

### Issues Resolved
NA

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
