### PR TITLE
[Bug] Update test to consider OS version > 2.5.0 where extra field added into BytesStreamOutput

### DIFF
--- a/server/src/test/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponsesTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponsesTests.java
@@ -194,9 +194,14 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
         out_gt_1_0.setVersion(new_version);
         clusterHealth.writeTo(out_gt_1_0);
 
+        int bytesStreamOutputCount = 1;
+        if (out_gt_1_0.getVersion().onOrAfter(Version.V_2_5_0)) {
+            bytesStreamOutputCount = 2;
+        }
+
         // The serialized output byte stream will not be same; and different by a boolean field "discovered_master"
         assertNotEquals(out_lt_1_0.size(), out_gt_1_0.size());
-        assertThat(out_gt_1_0.size() - out_lt_1_0.size(), Matchers.equalTo(1));
+        assertEquals(out_gt_1_0.size() - out_lt_1_0.size(), bytesStreamOutputCount);
 
         // Input stream constructed from Version 6_8 or less will not have field "discovered_master";
         // hence fallback to default as no value retained


### PR DESCRIPTION
### Description
Coming from https://github.com/opensearch-project/OpenSearch/pull/5811, the test is failing because of recent change where additional field was added in ClusterHealthResponse https://github.com/opensearch-project/OpenSearch/pull/5788. This also needs changes in the unit test which generates random version above 1.0.0 and fails when generated version >= `2.5.0`

The test fails due to [extra byte](https://github.com/opensearch-project/OpenSearch/blob/2.x/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponse.java#L411) written into the output stream though [assertion](https://github.com/opensearch-project/OpenSearch/blob/2.5/server/src/test/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponsesTests.java#L199) doesn't takes that into consieration.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/5801

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
