### PR TITLE
[Feature/Identity] Ensure compatibility with Security Plugin by accepting up to two rest handler wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Identity] Introduce Identity Module ([#5583](https://github.com/opensearch-project/OpenSearch/pull/5583))
 - [Identity] Adds Bearer Auth mechanism via internal token handling ([#5611](https://github.com/opensearch-project/OpenSearch/pull/5611))
 - [Identity] Persistence for the Identity module using a System Index ([#5613](https://github.com/opensearch-project/OpenSearch/pull/5613))
+- [Identity] Ensure compatibility with Security Plugin by accepting up to two rest handler wrappers ([#5837](https://github.com/opensearch-project/OpenSearch/pull/5837))

--- a/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/HttpSmokeTestCaseWithIdentity.java
+++ b/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/HttpSmokeTestCaseWithIdentity.java
@@ -128,11 +128,7 @@ public abstract class HttpSmokeTestCaseWithIdentity extends OpenSearchIntegTestC
     }
 
     protected void ensureIdentityIndexIsGreen() {
-        ClusterHealthResponse clusterHealthResponse = client().admin()
-            .cluster()
-            .prepareHealth()
-            .setClusterManagerNodeTimeout("1s")
-            .get();
+        ClusterHealthResponse clusterHealthResponse = client().admin().cluster().prepareHealth().setClusterManagerNodeTimeout("1s").get();
 
         assertTrue(
             ConfigConstants.IDENTITY_DEFAULT_CONFIG_INDEX + " index exists",

--- a/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/HttpSmokeTestCaseWithIdentity.java
+++ b/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/HttpSmokeTestCaseWithIdentity.java
@@ -9,6 +9,11 @@
 package org.opensearch.identity;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.opensearch.action.admin.cluster.node.info.NodeInfo;
+import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
+import org.opensearch.cluster.health.ClusterHealthStatus;
+import org.opensearch.cluster.health.ClusterIndexHealth;
 import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.plugins.Plugin;
@@ -20,6 +25,9 @@ import org.junit.BeforeClass;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoTimeout;
 
 /**
  * Abstract Rest Test Case for IdentityPlugin that installs and enables IdentityPlugin and removes mock
@@ -86,6 +94,53 @@ public abstract class HttpSmokeTestCaseWithIdentity extends OpenSearchIntegTestC
     @Override
     protected boolean ignoreExternalCluster() {
         return true;
+    }
+
+    protected void startNodes() throws Exception {
+        final String clusterManagerNode = internalCluster().startClusterManagerOnlyNode();
+
+        ClusterStateResponse clusterStateResponse = client(clusterManagerNode).admin()
+            .cluster()
+            .prepareState()
+            .setClusterManagerNodeTimeout("1s")
+            .clear()
+            .setNodes(true)
+            .get();
+        assertNotNull(clusterStateResponse.getState().nodes().getClusterManagerNodeId());
+
+        // start another node
+        final String dataNode = internalCluster().startDataOnlyNode();
+        clusterStateResponse = client(dataNode).admin()
+            .cluster()
+            .prepareState()
+            .setClusterManagerNodeTimeout("1s")
+            .clear()
+            .setNodes(true)
+            .setLocal(true)
+            .get();
+        assertNotNull(clusterStateResponse.getState().nodes().getClusterManagerNodeId());
+        // wait for the cluster to form
+        assertNoTimeout(client().admin().cluster().prepareHealth().setWaitForNodes(Integer.toString(2)).get());
+        List<NodeInfo> nodeInfos = client().admin().cluster().prepareNodesInfo().get().getNodes();
+        assertEquals(2, nodeInfos.size());
+
+        Thread.sleep(3000);
+    }
+
+    protected void ensureIdentityIndexIsGreen() {
+        ClusterHealthResponse clusterHealthResponse = client().admin()
+            .cluster()
+            .prepareHealth()
+            .setClusterManagerNodeTimeout("1s")
+            .get();
+
+        assertTrue(
+            ConfigConstants.IDENTITY_DEFAULT_CONFIG_INDEX + " index exists",
+            clusterHealthResponse.getIndices().containsKey(ConfigConstants.IDENTITY_DEFAULT_CONFIG_INDEX)
+        );
+
+        ClusterIndexHealth identityIndexHealth = clusterHealthResponse.getIndices().get(ConfigConstants.IDENTITY_DEFAULT_CONFIG_INDEX);
+        assertEquals(ClusterHealthStatus.GREEN, identityIndexHealth.getStatus());
     }
 
 }

--- a/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/HttpSmokeTestCaseWithIdentity.java
+++ b/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/HttpSmokeTestCaseWithIdentity.java
@@ -124,7 +124,7 @@ public abstract class HttpSmokeTestCaseWithIdentity extends OpenSearchIntegTestC
         List<NodeInfo> nodeInfos = client().admin().cluster().prepareNodesInfo().get().getNodes();
         assertEquals(2, nodeInfos.size());
 
-        Thread.sleep(3000);
+        Thread.sleep(1000);
     }
 
     protected void ensureIdentityIndexIsGreen() {

--- a/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/SecurityPluginCompatibilityIT.java
+++ b/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/SecurityPluginCompatibilityIT.java
@@ -44,7 +44,7 @@ public class SecurityPluginCompatibilityIT extends HttpSmokeTestCaseWithIdentity
     }
 
     @SuppressForbidden(reason = "manipulates system properties for testing")
-    public void testNodeStartsUpWithMultipleRestHandlerWrappers() throws Exception {
+    public void testNodeStartsUpWithTwoRestHandlerWrappers() throws Exception {
         try {
             TemporaryFolder folder = new TemporaryFolder();
             folder.create();

--- a/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/SecurityPluginCompatibilityIT.java
+++ b/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/SecurityPluginCompatibilityIT.java
@@ -51,7 +51,7 @@ public class SecurityPluginCompatibilityIT extends HttpSmokeTestCaseWithIdentity
             File internalUsersYml = folder.newFile("internal_users.yml");
             FileWriter fw1 = new FileWriter(internalUsersYml);
             BufferedWriter bw1 = new BufferedWriter(fw1);
-            // hash is bcrypt hash of 'admin'
+            // hash is a bcrypt hash of 'admin'
             bw1.write("admin:\n  hash: \"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG\"\n");
             bw1.close();
             final String defaultInitDirectory = folder.getRoot().getAbsolutePath();

--- a/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/SecurityPluginCompatibilityIT.java
+++ b/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/SecurityPluginCompatibilityIT.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.identity;
+
+import org.junit.rules.TemporaryFolder;
+import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.opensearch.action.admin.cluster.node.info.NodeInfo;
+import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
+import org.opensearch.cluster.health.ClusterHealthStatus;
+import org.opensearch.cluster.health.ClusterIndexHealth;
+import org.opensearch.common.SuppressForbidden;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.plugins.ActionPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoTimeout;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class SecurityPluginCompatibilityIT extends HttpSmokeTestCaseWithIdentity {
+    public static class RestHandlerWrapperPlugin extends Plugin implements ActionPlugin {
+        public RestHandlerWrapperPlugin() {}
+
+        @Override
+        public UnaryOperator<RestHandler> getRestHandlerWrapper(ThreadContext threadContext) {
+            return UnaryOperator.identity();
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        List<Class<? extends Plugin>> plugins = super.nodePlugins().stream().collect(Collectors.toList());
+        plugins.add(RestHandlerWrapperPlugin.class);
+        return plugins;
+    }
+
+    @SuppressForbidden(reason = "manipulates system properties for testing")
+    public void testOpenSearchNodeStartsUpWithMultipleRestHandlerWrappers() throws Exception {
+        try {
+            TemporaryFolder folder = new TemporaryFolder();
+            folder.create();
+            File internalUsersYml = folder.newFile("internal_users.yml");
+            FileWriter fw1 = new FileWriter(internalUsersYml);
+            BufferedWriter bw1 = new BufferedWriter(fw1);
+            bw1.write("admin:\n"
+                + "  hash: \"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG\"\n"
+                + "\n"
+            );
+            bw1.close();
+            final String defaultInitDirectory = folder.getRoot().getAbsolutePath();
+            System.setProperty("identity.default_init.dir", defaultInitDirectory);
+
+            startNodes();
+
+            ensureIdentityIndexIsGreen();
+        } catch (IOException ioe) {
+            fail("error creating temporary test file in " + this.getClass().getSimpleName());
+        }
+    }
+}

--- a/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/SecurityPluginCompatibilityIT.java
+++ b/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/SecurityPluginCompatibilityIT.java
@@ -9,11 +9,6 @@
 package org.opensearch.identity;
 
 import org.junit.rules.TemporaryFolder;
-import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
-import org.opensearch.action.admin.cluster.node.info.NodeInfo;
-import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
-import org.opensearch.cluster.health.ClusterHealthStatus;
-import org.opensearch.cluster.health.ClusterIndexHealth;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.plugins.ActionPlugin;
@@ -29,8 +24,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
-
-import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoTimeout;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class SecurityPluginCompatibilityIT extends HttpSmokeTestCaseWithIdentity {
@@ -58,10 +51,7 @@ public class SecurityPluginCompatibilityIT extends HttpSmokeTestCaseWithIdentity
             File internalUsersYml = folder.newFile("internal_users.yml");
             FileWriter fw1 = new FileWriter(internalUsersYml);
             BufferedWriter bw1 = new BufferedWriter(fw1);
-            bw1.write("admin:\n"
-                + "  hash: \"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG\"\n"
-                + "\n"
-            );
+            bw1.write("admin:\n  hash: \"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG\"\n");
             bw1.close();
             final String defaultInitDirectory = folder.getRoot().getAbsolutePath();
             System.setProperty("identity.default_init.dir", defaultInitDirectory);

--- a/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/SecurityPluginCompatibilityIT.java
+++ b/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/SecurityPluginCompatibilityIT.java
@@ -51,6 +51,7 @@ public class SecurityPluginCompatibilityIT extends HttpSmokeTestCaseWithIdentity
             File internalUsersYml = folder.newFile("internal_users.yml");
             FileWriter fw1 = new FileWriter(internalUsersYml);
             BufferedWriter bw1 = new BufferedWriter(fw1);
+            // hash is bcrypt hash of 'admin'
             bw1.write("admin:\n  hash: \"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG\"\n");
             bw1.close();
             final String defaultInitDirectory = folder.getRoot().getAbsolutePath();

--- a/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/SecurityPluginCompatibilityIT.java
+++ b/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/SecurityPluginCompatibilityIT.java
@@ -44,7 +44,7 @@ public class SecurityPluginCompatibilityIT extends HttpSmokeTestCaseWithIdentity
     }
 
     @SuppressForbidden(reason = "manipulates system properties for testing")
-    public void testOpenSearchNodeStartsUpWithMultipleRestHandlerWrappers() throws Exception {
+    public void testNodeStartsUpWithMultipleRestHandlerWrappers() throws Exception {
         try {
             TemporaryFolder folder = new TemporaryFolder();
             folder.create();

--- a/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/SecurityPluginCompatibilityIT.java
+++ b/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/SecurityPluginCompatibilityIT.java
@@ -44,7 +44,7 @@ public class SecurityPluginCompatibilityIT extends HttpSmokeTestCaseWithIdentity
     }
 
     @SuppressForbidden(reason = "manipulates system properties for testing")
-    public void testNodeStartsUpWithTwoRestHandlerWrappers() throws Exception {
+    public void testNodeStartsUpWithMultipleRestHandlerWrappers() throws Exception {
         try {
             TemporaryFolder folder = new TemporaryFolder();
             folder.create();

--- a/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/UserPersistenceIT.java
+++ b/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/UserPersistenceIT.java
@@ -38,37 +38,6 @@ public class UserPersistenceIT extends HttpSmokeTestCaseWithIdentity {
         return plugins;
     }
 
-    public void startNodes() throws Exception {
-        final String clusterManagerNode = internalCluster().startClusterManagerOnlyNode();
-
-        ClusterStateResponse clusterStateResponse = client(clusterManagerNode).admin()
-            .cluster()
-            .prepareState()
-            .setClusterManagerNodeTimeout("1s")
-            .clear()
-            .setNodes(true)
-            .get();
-        assertNotNull(clusterStateResponse.getState().nodes().getClusterManagerNodeId());
-
-        // start another node
-        final String dataNode = internalCluster().startDataOnlyNode();
-        clusterStateResponse = client(dataNode).admin()
-            .cluster()
-            .prepareState()
-            .setClusterManagerNodeTimeout("1s")
-            .clear()
-            .setNodes(true)
-            .setLocal(true)
-            .get();
-        assertNotNull(clusterStateResponse.getState().nodes().getClusterManagerNodeId());
-        // wait for the cluster to form
-        assertNoTimeout(client().admin().cluster().prepareHealth().setWaitForNodes(Integer.toString(2)).get());
-        List<NodeInfo> nodeInfos = client().admin().cluster().prepareNodesInfo().get().getNodes();
-        assertEquals(2, nodeInfos.size());
-
-        Thread.sleep(3000);
-    }
-
     @SuppressForbidden(reason = "manipulates system properties for testing")
     public void testUserPersistence() throws Exception {
         try {
@@ -115,19 +84,7 @@ public class UserPersistenceIT extends HttpSmokeTestCaseWithIdentity {
 
             startNodes();
 
-            ClusterHealthResponse clusterHealthResponse = client().admin()
-                .cluster()
-                .prepareHealth()
-                .setClusterManagerNodeTimeout("1s")
-                .get();
-
-            assertTrue(
-                ConfigConstants.IDENTITY_DEFAULT_CONFIG_INDEX + " index exists",
-                clusterHealthResponse.getIndices().containsKey(ConfigConstants.IDENTITY_DEFAULT_CONFIG_INDEX)
-            );
-
-            ClusterIndexHealth identityIndexHealth = clusterHealthResponse.getIndices().get(ConfigConstants.IDENTITY_DEFAULT_CONFIG_INDEX);
-            assertEquals(ClusterHealthStatus.GREEN, identityIndexHealth.getStatus());
+            ensureIdentityIndexIsGreen();
         } catch (IOException ioe) {
             fail("error creating temporary test file in " + this.getClass().getSimpleName());
         }
@@ -165,19 +122,7 @@ public class UserPersistenceIT extends HttpSmokeTestCaseWithIdentity {
 
             startNodes();
 
-            ClusterHealthResponse clusterHealthResponse = client().admin()
-                .cluster()
-                .prepareHealth()
-                .setClusterManagerNodeTimeout("1s")
-                .get();
-
-            assertTrue(
-                ConfigConstants.IDENTITY_DEFAULT_CONFIG_INDEX + " index exists",
-                clusterHealthResponse.getIndices().containsKey(ConfigConstants.IDENTITY_DEFAULT_CONFIG_INDEX)
-            );
-
-            ClusterIndexHealth identityIndexHealth = clusterHealthResponse.getIndices().get(ConfigConstants.IDENTITY_DEFAULT_CONFIG_INDEX);
-            assertThat(identityIndexHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
+            ensureIdentityIndexIsGreen();
         } catch (IOException ioe) {
             fail("error creating temporary test file in " + this.getClass().getSimpleName());
         }

--- a/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/UserPersistenceIT.java
+++ b/sandbox/modules/identity/src/internalClusterTest/java/org/opensearch/identity/UserPersistenceIT.java
@@ -9,11 +9,6 @@
 package org.opensearch.identity;
 
 import org.junit.rules.TemporaryFolder;
-import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
-import org.opensearch.action.admin.cluster.node.info.NodeInfo;
-import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
-import org.opensearch.cluster.health.ClusterHealthStatus;
-import org.opensearch.cluster.health.ClusterIndexHealth;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -25,9 +20,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static org.hamcrest.Matchers.equalTo;
-import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoTimeout;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class UserPersistenceIT extends HttpSmokeTestCaseWithIdentity {

--- a/server/src/test/java/org/opensearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/opensearch/rest/RestControllerTests.java
@@ -275,10 +275,10 @@ public class RestControllerTests extends OpenSearchTestCase {
         AtomicBoolean wrapperCalled = new AtomicBoolean(false);
         final RestHandler handler = (RestRequest request, RestChannel channel, NodeClient client) -> handlerCalled.set(true);
         final HttpServerTransport httpServerTransport = new TestHttpServerTransport();
-        final RestController restController = new RestController(Collections.emptySet(), h -> {
+        final RestController restController = new RestController(Collections.emptySet(), List.of(h -> {
             assertSame(handler, h);
             return (RestRequest request, RestChannel channel, NodeClient client) -> wrapperCalled.set(true);
-        }, client, circuitBreakerService, usageService);
+        }), client, circuitBreakerService, usageService);
         restController.registerHandler(RestRequest.Method.GET, "/wrapped", handler);
         RestRequest request = testRestRequest("/wrapped", "{}", XContentType.JSON);
         AssertingChannel channel = new AssertingChannel(request, true, RestStatus.BAD_REQUEST);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

The identity module uses the same `getRestHandlerWrapper` extension point as the security plugin to wrap rest requests and perform authentication. Currently, there is a limit of one wrapper to ensure that only the security plugin uses the extension point. This PR increases it to 2 and merges the list of wrappers together to perform as one when applying.

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
