### PR TITLE
[Backport 2.x] Add query for initialized extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on how to add changelog entries.
 
 ## [Unreleased 2.x]
+- Add query for initialized extensions ([#5658](https://github.com/opensearch-project/OpenSearch/pull/5658))
 
 ### Added
 ### Dependencies

--- a/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
+++ b/server/src/main/java/org/opensearch/extensions/DiscoveryExtensionNode.java
@@ -82,6 +82,16 @@ public class DiscoveryExtensionNode extends DiscoveryNode implements Writeable, 
         return dependencies;
     }
 
+    public boolean dependenciesContain(ExtensionDependency dependency) {
+        for (ExtensionDependency extensiondependency : this.dependencies) {
+            if (dependency.getUniqueId().equals(extensiondependency.getUniqueId())
+                && dependency.getVersion().equals(extensiondependency.getVersion())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         return null;

--- a/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionDependencyResponse.java
@@ -1,0 +1,69 @@
+/*
+* Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.extensions;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportResponse;
+
+/**
+ * The response for getting the Extension Dependency.
+ *
+ * @opensearch.internal
+ */
+public class ExtensionDependencyResponse extends TransportResponse {
+    private List<DiscoveryExtensionNode> extensionDependencies;
+
+    public ExtensionDependencyResponse(List<DiscoveryExtensionNode> extensionDependencies) {
+        this.extensionDependencies = extensionDependencies;
+    }
+
+    public ExtensionDependencyResponse(StreamInput in) throws IOException {
+        int size = in.readVInt();
+        extensionDependencies = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            extensionDependencies.add(new DiscoveryExtensionNode(in));
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(extensionDependencies.size());
+        for (DiscoveryExtensionNode dependency : extensionDependencies) {
+            dependency.writeTo(out);
+        }
+    }
+
+    public List<DiscoveryExtensionNode> getExtensionDependency() {
+        return extensionDependencies;
+    }
+
+    @Override
+    public String toString() {
+        return "ExtensionDependencyResponse{extensiondependency=" + extensionDependencies.toString() + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ExtensionDependencyResponse that = (ExtensionDependencyResponse) o;
+        return Objects.equals(extensionDependencies, that.extensionDependencies);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(extensionDependencies);
+    }
+}

--- a/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionRequest.java
@@ -10,12 +10,14 @@ package org.opensearch.extensions;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.transport.TransportRequest;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * CLusterService Request for Extensibility
@@ -24,29 +26,42 @@ import java.util.Objects;
  */
 public class ExtensionRequest extends TransportRequest {
     private static final Logger logger = LogManager.getLogger(ExtensionRequest.class);
-    private ExtensionsManager.RequestType requestType;
+    private final ExtensionsManager.RequestType requestType;
+    private final Optional<String> uniqueId;
 
     public ExtensionRequest(ExtensionsManager.RequestType requestType) {
+        this(requestType, null);
+    }
+
+    public ExtensionRequest(ExtensionsManager.RequestType requestType, @Nullable String uniqueId) {
         this.requestType = requestType;
+        this.uniqueId = uniqueId == null ? Optional.empty() : Optional.of(uniqueId);
     }
 
     public ExtensionRequest(StreamInput in) throws IOException {
         super(in);
         this.requestType = in.readEnum(ExtensionsManager.RequestType.class);
+        String id = in.readOptionalString();
+        this.uniqueId = id == null ? Optional.empty() : Optional.of(id);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeEnum(requestType);
+        out.writeOptionalString(uniqueId.orElse(null));
     }
 
     public ExtensionsManager.RequestType getRequestType() {
         return this.requestType;
     }
 
+    public Optional<String> getUniqueId() {
+        return uniqueId;
+    }
+
     public String toString() {
-        return "ExtensionRequest{" + "requestType=" + requestType + '}';
+        return "ExtensionRequest{" + "requestType=" + requestType + "uniqueId=" + uniqueId + '}';
     }
 
     @Override
@@ -54,11 +69,11 @@ public class ExtensionRequest extends TransportRequest {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ExtensionRequest that = (ExtensionRequest) o;
-        return Objects.equals(requestType, that.requestType);
+        return Objects.equals(requestType, that.requestType) && Objects.equals(uniqueId, that.uniqueId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(requestType);
+        return Objects.hash(requestType, uniqueId);
     }
 }

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -78,6 +79,7 @@ public class ExtensionsManager {
     public static final String REQUEST_EXTENSION_ENVIRONMENT_SETTINGS = "internal:discovery/enviornmentsettings";
     public static final String REQUEST_EXTENSION_ADD_SETTINGS_UPDATE_CONSUMER = "internal:discovery/addsettingsupdateconsumer";
     public static final String REQUEST_EXTENSION_UPDATE_SETTINGS = "internal:discovery/updatesettings";
+    public static final String REQUEST_EXTENSION_DEPENDENCY_INFORMATION = "internal:discovery/dependencyinformation";
     public static final String REQUEST_EXTENSION_REGISTER_CUSTOM_SETTINGS = "internal:discovery/registercustomsettings";
     public static final String REQUEST_EXTENSION_REGISTER_REST_ACTIONS = "internal:discovery/registerrestactions";
     public static final String REQUEST_EXTENSION_REGISTER_TRANSPORT_ACTIONS = "internal:discovery/registertransportactions";
@@ -100,6 +102,7 @@ public class ExtensionsManager {
         REQUEST_EXTENSION_REGISTER_REST_ACTIONS,
         REQUEST_EXTENSION_REGISTER_SETTINGS,
         REQUEST_EXTENSION_ENVIRONMENT_SETTINGS,
+        REQUEST_EXTENSION_DEPENDENCY_INFORMATION,
         CREATE_COMPONENT,
         ON_INDEX_MODULE,
         GET_SETTINGS
@@ -234,6 +237,14 @@ public class ExtensionsManager {
         );
         transportService.registerRequestHandler(
             REQUEST_EXTENSION_ENVIRONMENT_SETTINGS,
+            ThreadPool.Names.GENERIC,
+            false,
+            false,
+            ExtensionRequest::new,
+            ((request, channel, task) -> channel.sendResponse(handleExtensionRequest(request)))
+        );
+        transportService.registerRequestHandler(
+            REQUEST_EXTENSION_DEPENDENCY_INFORMATION,
             ThreadPool.Names.GENERIC,
             false,
             false,
@@ -416,6 +427,16 @@ public class ExtensionsManager {
                 return new ClusterSettingsResponse(clusterService);
             case REQUEST_EXTENSION_ENVIRONMENT_SETTINGS:
                 return new EnvironmentSettingsResponse(this.environmentSettings);
+            case REQUEST_EXTENSION_DEPENDENCY_INFORMATION:
+                String uniqueId = extensionRequest.getUniqueId().orElse(null);
+                if (uniqueId == null) {
+                    return new ExtensionDependencyResponse(extensions);
+                } else {
+                    ExtensionDependency matchingId = new ExtensionDependency(uniqueId, Version.CURRENT);
+                    return new ExtensionDependencyResponse(
+                        extensions.stream().filter(e -> e.dependenciesContain(matchingId)).collect(Collectors.toList())
+                    );
+                }
             default:
                 throw new IllegalArgumentException("Handler not present for the provided request");
         }

--- a/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
+++ b/server/src/test/java/org/opensearch/extensions/ExtensionsManagerTests.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -531,6 +532,88 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
         assertEquals("Handler not present for the provided request", exception.getMessage());
     }
 
+    public void testExtensionRequest() throws Exception {
+        ExtensionsManager.RequestType expectedRequestType = ExtensionsManager.RequestType.REQUEST_EXTENSION_DEPENDENCY_INFORMATION;
+
+        // Test ExtensionRequest 2 arg constructor
+        String expectedUniqueId = "test uniqueid";
+        ExtensionRequest extensionRequest = new ExtensionRequest(expectedRequestType, expectedUniqueId);
+        assertEquals(expectedRequestType, extensionRequest.getRequestType());
+        assertEquals(Optional.of(expectedUniqueId), extensionRequest.getUniqueId());
+
+        // Test ExtensionRequest StreamInput constructor
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            extensionRequest.writeTo(out);
+            out.flush();
+            try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
+                extensionRequest = new ExtensionRequest(in);
+                assertEquals(expectedRequestType, extensionRequest.getRequestType());
+                assertEquals(Optional.of(expectedUniqueId), extensionRequest.getUniqueId());
+            }
+        }
+
+        // Test ExtensionRequest 1 arg constructor
+        extensionRequest = new ExtensionRequest(expectedRequestType);
+        assertEquals(expectedRequestType, extensionRequest.getRequestType());
+        assertEquals(Optional.empty(), extensionRequest.getUniqueId());
+
+        // Test ExtensionRequest StreamInput constructor
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            extensionRequest.writeTo(out);
+            out.flush();
+            try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
+                extensionRequest = new ExtensionRequest(in);
+                assertEquals(expectedRequestType, extensionRequest.getRequestType());
+                assertEquals(Optional.empty(), extensionRequest.getUniqueId());
+            }
+        }
+    }
+
+    public void testExtensionDependencyResponse() throws Exception {
+        String expectedUniqueId = "test uniqueid";
+        List<DiscoveryExtensionNode> expectedExtensionsList = new ArrayList<DiscoveryExtensionNode>();
+        Version expectedVersion = Version.fromString("2.0.0");
+        ExtensionDependency expectedDependency = new ExtensionDependency(expectedUniqueId, expectedVersion);
+
+        expectedExtensionsList.add(
+            new DiscoveryExtensionNode(
+                "firstExtension",
+                "uniqueid1",
+                "uniqueid1",
+                "myIndependentPluginHost1",
+                "127.0.0.0",
+                new TransportAddress(InetAddress.getByName("127.0.0.0"), 9300),
+                new HashMap<String, String>(),
+                Version.fromString("3.0.0"),
+                new PluginInfo(
+                    "firstExtension",
+                    "Fake description 1",
+                    "0.0.7",
+                    Version.fromString("3.0.0"),
+                    "14",
+                    "fakeClass1",
+                    new ArrayList<String>(),
+                    false
+                ),
+                List.of(expectedDependency)
+            )
+        );
+
+        // Test ExtensionDependencyResponse arg constructor
+        ExtensionDependencyResponse extensionDependencyResponse = new ExtensionDependencyResponse(expectedExtensionsList);
+        assertEquals(expectedExtensionsList, extensionDependencyResponse.getExtensionDependency());
+
+        // Test ExtensionDependencyResponse StreamInput constructor
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            extensionDependencyResponse.writeTo(out);
+            out.flush();
+            try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
+                extensionDependencyResponse = new ExtensionDependencyResponse(in);
+                assertEquals(expectedExtensionsList, extensionDependencyResponse.getExtensionDependency());
+            }
+        }
+    }
+
     public void testEnvironmentSettingsResponse() throws Exception {
 
         // Test EnvironmentSettingsResponse arg constructor
@@ -714,7 +797,7 @@ public class ExtensionsManagerTests extends OpenSearchTestCase {
             settings,
             client
         );
-        verify(mockTransportService, times(8)).registerRequestHandler(anyString(), anyString(), anyBoolean(), anyBoolean(), any(), any());
+        verify(mockTransportService, times(9)).registerRequestHandler(anyString(), anyString(), anyBoolean(), anyBoolean(), any(), any());
 
     }
 


### PR DESCRIPTION
### Description
Create a feature to have an extension query to OpenSearch to obtain a list of initialized extensions and determine whether a particular extension is initialized.
Equivalent PR on OpenSearch-sdk-java : https://github.com/opensearch-project/opensearch-sdk-java/pull/300 

Backport of https://github.com/opensearch-project/OpenSearch/pull/5658

### Issues Resolved
fixes https://github.com/opensearch-project/opensearch-sdk-java/issues/149

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
