### PR TITLE
[Remote Translog] Use InputStream that supports mark and reset while uploading translog files

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/transfer/FileSnapshot.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/FileSnapshot.java
@@ -9,11 +9,9 @@
 package org.opensearch.index.translog.transfer;
 
 import org.opensearch.common.Nullable;
-import org.opensearch.common.io.stream.InputStreamStreamInput;
 import org.opensearch.common.lucene.store.ByteArrayIndexInput;
 import org.opensearch.common.lucene.store.InputStreamIndexInput;
 import org.opensearch.core.internal.io.IOUtils;
-import org.opensearch.index.translog.BufferedChecksumStreamInput;
 
 import java.io.BufferedInputStream;
 import java.io.Closeable;
@@ -23,6 +21,7 @@ import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -68,14 +67,8 @@ public class FileSnapshot implements Closeable {
 
     public InputStream inputStream() throws IOException {
         return fileChannel != null
-            ? new BufferedChecksumStreamInput(
-                new InputStreamStreamInput(new BufferedInputStream(Channels.newInputStream(fileChannel))),
-                name
-            )
-            : new BufferedChecksumStreamInput(
-                new InputStreamStreamInput(new InputStreamIndexInput(new ByteArrayIndexInput(this.name, content), content.length)),
-                name
-            );
+            ? new BufferedInputStream(Channels.newInputStream(fileChannel))
+            : new InputStreamIndexInput(new ByteArrayIndexInput(this.name, content), content.length);
     }
 
     @Override
@@ -88,9 +81,7 @@ public class FileSnapshot implements Closeable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         FileSnapshot other = (FileSnapshot) o;
-        return Objects.equals(this.name, other.name)
-            && Objects.equals(this.content, other.content)
-            && Objects.equals(this.path, other.path);
+        return Objects.equals(this.name, other.name) && Arrays.equals(this.content, other.content) && Objects.equals(this.path, other.path);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/translog/transfer/FileSnapshot.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/FileSnapshot.java
@@ -11,6 +11,8 @@ package org.opensearch.index.translog.transfer;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.io.stream.BytesStreamInput;
 import org.opensearch.common.io.stream.InputStreamStreamInput;
+import org.opensearch.common.lucene.store.ByteArrayIndexInput;
+import org.opensearch.common.lucene.store.InputStreamIndexInput;
 import org.opensearch.core.internal.io.IOUtils;
 import org.opensearch.index.translog.BufferedChecksumStreamInput;
 
@@ -66,11 +68,8 @@ public class FileSnapshot implements Closeable {
 
     public InputStream inputStream() throws IOException {
         return fileChannel != null
-            ? new BufferedChecksumStreamInput(
-                new InputStreamStreamInput(Channels.newInputStream(fileChannel), fileChannel.size()),
-                path.toString()
-            )
-            : new BufferedChecksumStreamInput(new BytesStreamInput(content), name);
+            ? new InputStreamIndexInput(new ByteArrayIndexInput("", Channels.newInputStream(fileChannel).readAllBytes()), fileChannel.size())
+            : new InputStreamIndexInput(new ByteArrayIndexInput("", content), content.length);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/translog/transfer/FileSnapshot.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/FileSnapshot.java
@@ -68,8 +68,8 @@ public class FileSnapshot implements Closeable {
 
     public InputStream inputStream() throws IOException {
         return fileChannel != null
-            ? new InputStreamIndexInput(new ByteArrayIndexInput("", Channels.newInputStream(fileChannel).readAllBytes()), fileChannel.size())
-            : new InputStreamIndexInput(new ByteArrayIndexInput("", content), content.length);
+            ? new InputStreamIndexInput(new ByteArrayIndexInput(this.name, Channels.newInputStream(fileChannel).readAllBytes()), fileChannel.size())
+            : new InputStreamIndexInput(new ByteArrayIndexInput(this.name, content), content.length);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/translog/transfer/FileSnapshot.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/FileSnapshot.java
@@ -9,9 +9,11 @@
 package org.opensearch.index.translog.transfer;
 
 import org.opensearch.common.Nullable;
+import org.opensearch.common.io.stream.InputStreamStreamInput;
 import org.opensearch.common.lucene.store.ByteArrayIndexInput;
 import org.opensearch.common.lucene.store.InputStreamIndexInput;
 import org.opensearch.core.internal.io.IOUtils;
+import org.opensearch.index.translog.BufferedChecksumStreamInput;
 
 import java.io.BufferedInputStream;
 import java.io.Closeable;
@@ -66,8 +68,14 @@ public class FileSnapshot implements Closeable {
 
     public InputStream inputStream() throws IOException {
         return fileChannel != null
-            ? new BufferedInputStream(Channels.newInputStream(fileChannel))
-            : new InputStreamIndexInput(new ByteArrayIndexInput(this.name, content), content.length);
+            ? new BufferedChecksumStreamInput(
+                new InputStreamStreamInput(new BufferedInputStream(Channels.newInputStream(fileChannel))),
+                name
+            )
+            : new BufferedChecksumStreamInput(
+                new InputStreamStreamInput(new InputStreamIndexInput(new ByteArrayIndexInput(this.name, content), content.length)),
+                name
+            );
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/translog/transfer/FileSnapshot.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/FileSnapshot.java
@@ -9,13 +9,11 @@
 package org.opensearch.index.translog.transfer;
 
 import org.opensearch.common.Nullable;
-import org.opensearch.common.io.stream.BytesStreamInput;
-import org.opensearch.common.io.stream.InputStreamStreamInput;
 import org.opensearch.common.lucene.store.ByteArrayIndexInput;
 import org.opensearch.common.lucene.store.InputStreamIndexInput;
 import org.opensearch.core.internal.io.IOUtils;
-import org.opensearch.index.translog.BufferedChecksumStreamInput;
 
+import java.io.BufferedInputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -68,7 +66,7 @@ public class FileSnapshot implements Closeable {
 
     public InputStream inputStream() throws IOException {
         return fileChannel != null
-            ? new InputStreamIndexInput(new ByteArrayIndexInput(this.name, Channels.newInputStream(fileChannel).readAllBytes()), fileChannel.size())
+            ? new BufferedInputStream(Channels.newInputStream(fileChannel))
             : new InputStreamIndexInput(new ByteArrayIndexInput(this.name, content), content.length);
     }
 

--- a/server/src/test/java/org/opensearch/index/translog/transfer/FileSnapshotTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/FileSnapshotTests.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.translog.transfer;
+
+import org.junit.After;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class FileSnapshotTests extends OpenSearchTestCase {
+
+    FileSnapshot fileSnapshot;
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        fileSnapshot.close();
+    }
+
+    public void testFileSnapshotPath() throws IOException {
+        Path file = createTempFile();
+        Files.writeString(file, "hello");
+        fileSnapshot = new FileSnapshot.TransferFileSnapshot(file, 12);
+
+        assertFileSnapshotProperties(file);
+
+        try (FileSnapshot sameFileSnapshot = new FileSnapshot.TransferFileSnapshot(file, 12)) {
+            assertEquals(sameFileSnapshot, fileSnapshot);
+        }
+
+        try (FileSnapshot sameFileDiffPTSnapshot = new FileSnapshot.TransferFileSnapshot(file, 34)) {
+            assertNotEquals(sameFileDiffPTSnapshot, fileSnapshot);
+        }
+    }
+
+    public void testFileSnapshotContent() throws IOException {
+        Path file = createTempFile();
+        Files.writeString(file, "hello");
+        fileSnapshot = new FileSnapshot.TransferFileSnapshot(file.getFileName().toString(), Files.readAllBytes(file), 23);
+
+        assertFileSnapshotProperties(file);
+
+        try (
+            FileSnapshot sameFileSnapshot = new FileSnapshot.TransferFileSnapshot(
+                file.getFileName().toString(),
+                Files.readAllBytes(file),
+                23
+            )
+        ) {
+            assertEquals(sameFileSnapshot, fileSnapshot);
+        }
+
+        try (
+            FileSnapshot anotherFileSnapshot = new FileSnapshot.TransferFileSnapshot(
+                file.getFileName().toString(),
+                Files.readAllBytes(createTempFile()),
+                23
+            )
+        ) {
+            assertNotEquals(anotherFileSnapshot, fileSnapshot);
+        }
+    }
+
+    private void assertFileSnapshotProperties(Path file) throws IOException {
+        assertEquals(file.getFileName().toString(), fileSnapshot.getName());
+        assertEquals(Files.size(file), fileSnapshot.getContentLength());
+        assertTrue(fileSnapshot.inputStream().markSupported());
+    }
+}


### PR DESCRIPTION
### Description
- Currently, we use [Channels.newInputStream](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/translog/transfer/FileSnapshot.java#L70) while uploading translog files.
- But as per the documentation of [method](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/channels/Channels.html#newInputStream(java.nio.channels.AsynchronousByteChannel)), it does not support mark and reset methods of InputStream.
- This creates issues during upload of the translog files, if upload fails and remote store client tries to retry the upload, it fails as resetting the stream is not possible.
- Solution is to pass InputStream that supports mark and reset while uploading the translog and checkpoint files.

### Issues Resolved
- https://github.com/opensearch-project/OpenSearch/issues/5843

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
