### PR TITLE
[Backport 2.x] Add cluster manager throttling task stats in nodes stats API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 2.x]
 
 ### Added
+- Added cluster manager throttling stats in nodes/stats API ([#5790](https://github.com/opensearch-project/OpenSearch/pull/5790))
 ### Dependencies
 - Update nebula-publishing-plugin to 19.2.0 ([#5704](https://github.com/opensearch-project/OpenSearch/pull/5704))
 ### Changed

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -238,7 +238,8 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         SCRIPT_CACHE("script_cache"),
         INDEXING_PRESSURE("indexing_pressure"),
         SHARD_INDEXING_PRESSURE("shard_indexing_pressure"),
-        SEARCH_BACKPRESSURE("search_backpressure");
+        SEARCH_BACKPRESSURE("search_backpressure"),
+        CLUSTER_MANAGER_THROTTLING("cluster_manager_throttling");
 
         private String metricName;
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -119,7 +119,8 @@ public class TransportNodesStatsAction extends TransportNodesAction<
             NodesStatsRequest.Metric.SCRIPT_CACHE.containedIn(metrics),
             NodesStatsRequest.Metric.INDEXING_PRESSURE.containedIn(metrics),
             NodesStatsRequest.Metric.SHARD_INDEXING_PRESSURE.containedIn(metrics),
-            NodesStatsRequest.Metric.SEARCH_BACKPRESSURE.containedIn(metrics)
+            NodesStatsRequest.Metric.SEARCH_BACKPRESSURE.containedIn(metrics),
+            NodesStatsRequest.Metric.CLUSTER_MANAGER_THROTTLING.containedIn(metrics)
         );
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -163,6 +163,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<
             false,
             false,
             false,
+            false,
             false
         );
         List<ShardStats> shardsStats = new ArrayList<>();

--- a/server/src/main/java/org/opensearch/cluster/service/ClusterManagerThrottlingStats.java
+++ b/server/src/main/java/org/opensearch/cluster/service/ClusterManagerThrottlingStats.java
@@ -8,18 +8,30 @@
 
 package org.opensearch.cluster.service;
 
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.metrics.CounterMetric;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.ToXContentFragment;
+import org.opensearch.common.xcontent.XContentBuilder;
 
+import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Contains stats of Cluster Manager Task Throttling.
  * It stores the total cumulative count of throttled tasks per task type.
  */
-public class ClusterManagerThrottlingStats implements ClusterManagerTaskThrottlerListener {
+public class ClusterManagerThrottlingStats implements ClusterManagerTaskThrottlerListener, Writeable, ToXContentFragment {
 
-    private Map<String, CounterMetric> throttledTasksCount = new ConcurrentHashMap<>();
+    private Map<String, CounterMetric> throttledTasksCount;
+
+    public ClusterManagerThrottlingStats() {
+        throttledTasksCount = new ConcurrentHashMap<>();
+    }
 
     private void incrementThrottlingCount(String type, final int counts) {
         throttledTasksCount.computeIfAbsent(type, k -> new CounterMetric()).inc(counts);
@@ -38,5 +50,60 @@ public class ClusterManagerThrottlingStats implements ClusterManagerTaskThrottle
     @Override
     public void onThrottle(String type, int counts) {
         incrementThrottlingCount(type, counts);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(throttledTasksCount.size());
+        for (Map.Entry<String, CounterMetric> entry : throttledTasksCount.entrySet()) {
+            out.writeString(entry.getKey());
+            out.writeVInt((int) entry.getValue().count());
+        }
+    }
+
+    public ClusterManagerThrottlingStats(StreamInput in) throws IOException {
+        int throttledTaskEntries = in.readVInt();
+        throttledTasksCount = new ConcurrentHashMap<>();
+        for (int i = 0; i < throttledTaskEntries; i++) {
+            String taskType = in.readString();
+            int throttledTaskCount = in.readVInt();
+            onThrottle(taskType, throttledTaskCount);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject("cluster_manager_throttling");
+        builder.startObject("stats");
+        builder.field("total_throttled_tasks", getTotalThrottledTaskCount());
+        builder.startObject("throttled_tasks_per_task_type");
+        for (Map.Entry<String, CounterMetric> entry : throttledTasksCount.entrySet()) {
+            builder.field(entry.getKey(), entry.getValue().count());
+        }
+        builder.endObject();
+        builder.endObject();
+        return builder.endObject();
+    }
+
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o != null && this.getClass() == o.getClass()) {
+            ClusterManagerThrottlingStats that = (ClusterManagerThrottlingStats) o;
+
+            if (this.throttledTasksCount.size() == that.throttledTasksCount.size()) {
+                for (Map.Entry<String, CounterMetric> entry : this.throttledTasksCount.entrySet()) {
+                    if (that.throttledTasksCount.get(entry.getKey()).count() != entry.getValue().count()) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public int hashCode() {
+        return Objects.hash(this.throttledTasksCount);
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/service/ClusterManagerThrottlingStats.java
+++ b/server/src/main/java/org/opensearch/cluster/service/ClusterManagerThrottlingStats.java
@@ -18,7 +18,6 @@ import org.opensearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -104,6 +103,10 @@ public class ClusterManagerThrottlingStats implements ClusterManagerTaskThrottle
     }
 
     public int hashCode() {
-        return Objects.hash(this.throttledTasksCount);
+        Map<String, Long> countMap = new ConcurrentHashMap<>();
+        for (Map.Entry<String, CounterMetric> entry : this.throttledTasksCount.entrySet()) {
+            countMap.put(entry.getKey(), entry.getValue().count());
+        }
+        return countMap.hashCode();
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/opensearch/cluster/service/MasterService.java
@@ -607,6 +607,13 @@ public class MasterService extends AbstractLifecycleComponent {
     }
 
     /**
+     * Returns the stats of throttled pending tasks.
+     */
+    public ClusterManagerThrottlingStats getThrottlingStats() {
+        return throttlingStats;
+    }
+
+    /**
      * Returns the min version of nodes in cluster
      */
     public Version getMinNodeVersion() {

--- a/server/src/main/java/org/opensearch/node/NodeService.java
+++ b/server/src/main/java/org/opensearch/node/NodeService.java
@@ -83,6 +83,7 @@ public class NodeService implements Closeable {
     private final IndexingPressureService indexingPressureService;
     private final AggregationUsageService aggregationUsageService;
     private final SearchBackpressureService searchBackpressureService;
+    private final ClusterService clusterService;
 
     private final Discovery discovery;
 
@@ -123,6 +124,7 @@ public class NodeService implements Closeable {
         this.indexingPressureService = indexingPressureService;
         this.aggregationUsageService = aggregationUsageService;
         this.searchBackpressureService = searchBackpressureService;
+        this.clusterService = clusterService;
         clusterService.addStateApplier(ingestService);
     }
 
@@ -174,7 +176,8 @@ public class NodeService implements Closeable {
         boolean scriptCache,
         boolean indexingPressure,
         boolean shardIndexingPressure,
-        boolean searchBackpressure
+        boolean searchBackpressure,
+        boolean clusterManagerThrottling
     ) {
         // for indices stats we want to include previous allocated shards stats as well (it will
         // only be applied to the sensible ones to use, like refresh/merge/flush/indexing stats)
@@ -197,7 +200,8 @@ public class NodeService implements Closeable {
             scriptCache ? scriptService.cacheStats() : null,
             indexingPressure ? this.indexingPressureService.nodeStats() : null,
             shardIndexingPressure ? this.indexingPressureService.shardStats(indices) : null,
-            searchBackpressure ? this.searchBackpressureService.nodeStats() : null
+            searchBackpressure ? this.searchBackpressureService.nodeStats() : null,
+            clusterManagerThrottling ? this.clusterService.getClusterManagerService().getThrottlingStats() : null
         );
     }
 

--- a/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
+++ b/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
@@ -186,6 +186,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -207,6 +208,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -218,6 +220,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 new FsInfo(0, null, node3FSInfo),
+                null,
                 null,
                 null,
                 null,
@@ -280,6 +283,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -301,6 +305,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -312,6 +317,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 new FsInfo(0, null, node3FSInfo),
+                null,
                 null,
                 null,
                 null,

--- a/server/src/test/java/org/opensearch/cluster/service/ClusterManagerThrottlingStatsTests.java
+++ b/server/src/test/java/org/opensearch/cluster/service/ClusterManagerThrottlingStatsTests.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.service;
+
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.test.AbstractWireSerializingTestCase;
+
+public class ClusterManagerThrottlingStatsTests extends AbstractWireSerializingTestCase<ClusterManagerThrottlingStats> {
+    @Override
+    protected Writeable.Reader<ClusterManagerThrottlingStats> instanceReader() {
+        return ClusterManagerThrottlingStats::new;
+    }
+
+    @Override
+    protected ClusterManagerThrottlingStats createTestInstance() {
+        return randomInstance();
+    }
+
+    public static ClusterManagerThrottlingStats randomInstance() {
+        ClusterManagerThrottlingStats randomStats = new ClusterManagerThrottlingStats();
+        randomStats.onThrottle(randomAlphaOfLengthBetween(3, 10), randomInt());
+        return randomStats;
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/cluster/MockInternalClusterInfoService.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/MockInternalClusterInfoService.java
@@ -115,7 +115,8 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
                 nodeStats.getScriptCacheStats(),
                 nodeStats.getIndexingPressureStats(),
                 nodeStats.getShardIndexingPressureStats(),
-                nodeStats.getSearchBackpressureStats()
+                nodeStats.getSearchBackpressureStats(),
+                nodeStats.getClusterManagerThrottlingStats()
             );
         }).collect(Collectors.toList());
     }

--- a/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
@@ -2686,6 +2686,7 @@ public final class InternalTestCluster extends TestCluster {
                     false,
                     false,
                     false,
+                    false,
                     false
                 );
                 assertThat(


### PR DESCRIPTION
### Description
Backport throttling stats PR to 2.x.

Original PR : https://github.com/opensearch-project/OpenSearch/pull/5790/commits

### Issues Resolved
#479 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
