### PR TITLE
[Segment Replication] Update force segment replication round to be synchronous

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationBaseIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationBaseIT.java
@@ -1,0 +1,180 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication;
+
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.routing.IndexRoutingTable;
+import org.opensearch.cluster.routing.IndexShardRoutingTable;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.common.Nullable;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.index.Index;
+import org.opensearch.index.IndexModule;
+import org.opensearch.index.IndexService;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.store.Store;
+import org.opensearch.index.store.StoreFileMetadata;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.transport.MockTransportService;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static org.opensearch.test.OpenSearchIntegTestCase.client;
+import static org.opensearch.test.OpenSearchTestCase.assertBusy;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
+
+public class SegmentReplicationBaseIT extends OpenSearchIntegTestCase {
+
+    protected static final String INDEX_NAME = "test-idx-1";
+    protected static final int SHARD_COUNT = 1;
+    protected static final int REPLICA_COUNT = 1;
+
+    @Override
+    protected Settings featureFlagSettings() {
+        return Settings.builder().put(super.featureFlagSettings()).put(FeatureFlags.REPLICATION_TYPE, "true").build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return asList(MockTransportService.TestPlugin.class);
+    }
+
+    @Override
+    protected boolean addMockInternalEngine() {
+        return false;
+    }
+
+    @Override
+    public Settings indexSettings() {
+        return Settings.builder()
+            .put(super.indexSettings())
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, SHARD_COUNT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, REPLICA_COUNT)
+            .put(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.getKey(), false)
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .build();
+    }
+
+    @Nullable
+    protected ShardRouting getShardRoutingForNodeName(String nodeName) {
+        final ClusterState state = getClusterState();
+        for (IndexShardRoutingTable shardRoutingTable : state.routingTable().index(INDEX_NAME)) {
+            for (ShardRouting shardRouting : shardRoutingTable.activeShards()) {
+                final String nodeId = shardRouting.currentNodeId();
+                final DiscoveryNode discoveryNode = state.nodes().resolveNode(nodeId);
+                if (discoveryNode.getName().equals(nodeName)) {
+                    return shardRouting;
+                }
+            }
+        }
+        return null;
+    }
+
+    protected void assertDocCounts(int expectedDocCount, String... nodeNames) {
+        for (String node : nodeNames) {
+            assertHitCount(client(node).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedDocCount);
+        }
+    }
+
+    protected ClusterState getClusterState() {
+        return client(internalCluster().getClusterManagerName()).admin().cluster().prepareState().get().getState();
+    }
+
+    protected DiscoveryNode getNodeContainingPrimaryShard() {
+        final ClusterState state = getClusterState();
+        final ShardRouting primaryShard = state.routingTable().index(INDEX_NAME).shard(0).primaryShard();
+        return state.nodes().resolveNode(primaryShard.currentNodeId());
+    }
+
+    /**
+     * Waits until all given nodes have at least the expected docCount.
+     *
+     * @param docCount - Expected Doc count.
+     * @param nodes    - List of node names.
+     */
+    protected void waitForSearchableDocs(long docCount, List<String> nodes) throws Exception {
+        // wait until the replica has the latest segment generation.
+        assertBusy(() -> {
+            for (String node : nodes) {
+                final SearchResponse response = client(node).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get();
+                final long hits = response.getHits().getTotalHits().value;
+                if (hits < docCount) {
+                    fail("Expected search hits on node: " + node + " to be at least " + docCount + " but was: " + hits);
+                }
+            }
+        }, 1, TimeUnit.MINUTES);
+    }
+
+    protected void waitForSearchableDocs(long docCount, String... nodes) throws Exception {
+        waitForSearchableDocs(docCount, Arrays.stream(nodes).collect(Collectors.toList()));
+    }
+
+    protected void verifyStoreContent() throws Exception {
+        assertBusy(() -> {
+            final ClusterState clusterState = getClusterState();
+            for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
+                for (IndexShardRoutingTable shardRoutingTable : indexRoutingTable) {
+                    final ShardRouting primaryRouting = shardRoutingTable.primaryShard();
+                    final String indexName = primaryRouting.getIndexName();
+                    final List<ShardRouting> replicaRouting = shardRoutingTable.replicaShards();
+                    final IndexShard primaryShard = getIndexShard(clusterState, primaryRouting, indexName);
+                    final Map<String, StoreFileMetadata> primarySegmentMetadata = primaryShard.getSegmentMetadataMap();
+                    for (ShardRouting replica : replicaRouting) {
+                        IndexShard replicaShard = getIndexShard(clusterState, replica, indexName);
+                        final Store.RecoveryDiff recoveryDiff = Store.segmentReplicationDiff(
+                            primarySegmentMetadata,
+                            replicaShard.getSegmentMetadataMap()
+                        );
+                        if (recoveryDiff.missing.isEmpty() == false || recoveryDiff.different.isEmpty() == false) {
+                            fail(
+                                "Expected no missing or different segments between primary and replica but diff was missing: "
+                                    + recoveryDiff.missing
+                                    + " Different: "
+                                    + recoveryDiff.different
+                                    + " Primary Replication Checkpoint : "
+                                    + primaryShard.getLatestReplicationCheckpoint()
+                                    + " Replica Replication Checkpoint: "
+                                    + replicaShard.getLatestReplicationCheckpoint()
+                            );
+                        }
+                        // calls to readCommit will fail if a valid commit point and all its segments are not in the store.
+                        replicaShard.store().readLastCommittedSegmentsInfo();
+                    }
+                }
+            }
+        }, 1, TimeUnit.MINUTES);
+    }
+
+    private IndexShard getIndexShard(ClusterState state, ShardRouting routing, String indexName) {
+        return getIndexShard(state.nodes().get(routing.currentNodeId()).getName(), indexName);
+    }
+
+    protected IndexShard getIndexShard(String node, String indexName) {
+        final Index index = resolveIndex(indexName);
+        IndicesService indicesService = internalCluster().getInstance(IndicesService.class, node);
+        IndexService indexService = indicesService.indexServiceSafe(index);
+        final Optional<Integer> shardId = indexService.shardIds().stream().findFirst();
+        return indexService.getShard(shardId.get());
+    }
+
+}

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
@@ -31,9 +31,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 
 /**
  * This test class verifies primary shard relocation with segment replication as replication strategy.
@@ -329,8 +326,12 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationBaseIT {
         assertEquals(clusterHealthResponse.isTimedOut(), false);
         ensureGreen(INDEX_NAME);
 
-        // Get mock transport service from newPrimary, halt recovery during segment replication (during handoff) to allow indexing in parallel.
-        MockTransportService mockTargetTransportService = ((MockTransportService) internalCluster().getInstance(TransportService.class, newPrimary));
+        // Get mock transport service from newPrimary, halt recovery during segment replication (during handoff) to allow indexing in
+        // parallel.
+        MockTransportService mockTargetTransportService = ((MockTransportService) internalCluster().getInstance(
+            TransportService.class,
+            newPrimary
+        ));
         CountDownLatch blockSegRepLatch = new CountDownLatch(1);
         CountDownLatch waitForIndexingLatch = new CountDownLatch(1);
         mockTargetTransportService.addSendBehavior(

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
@@ -59,7 +59,7 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationIT {
      */
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
     public void testPrimaryRelocation() throws Exception {
-        final String oldPrimary = internalCluster().startNode(featureFlagSettings());
+        final String oldPrimary = internalCluster().startNode();
         createIndex(1);
         final String replica = internalCluster().startNode(featureFlagSettings());
         ensureGreen(INDEX_NAME);

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
@@ -135,6 +135,7 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationIT {
      * failure, more documents are ingested and verified on replica; which confirms older primary still refreshing the
      * replicas.
      */
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
     public void testPrimaryRelocationWithSegRepFailure() throws Exception {
         final String oldPrimary = internalCluster().startNode(featureFlagSettings());
         createIndex(1);

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
@@ -819,7 +819,7 @@ public abstract class RecoverySourceHandler {
             );
 
             if (request.isPrimaryRelocation()) {
-                logger.info("performing relocation hand-off");
+                logger.trace("performing relocation hand-off");
                 final Runnable forceSegRepRunnable = shard.indexSettings().isSegRepEnabled()
                     ? recoveryTarget::forceSegmentFileSync
                     : () -> {};

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
@@ -819,7 +819,7 @@ public abstract class RecoverySourceHandler {
             );
 
             if (request.isPrimaryRelocation()) {
-                logger.trace("performing relocation hand-off");
+                logger.info("performing relocation hand-off");
                 final Runnable forceSegRepRunnable = shard.indexSettings().isSegRepEnabled()
                     ? recoveryTarget::forceSegmentFileSync
                     : () -> {};
@@ -834,7 +834,7 @@ public abstract class RecoverySourceHandler {
                  */
             }
             stopWatch.stop();
-            logger.trace("finalizing recovery took [{}]", stopWatch.totalTime());
+            logger.info("finalizing recovery took [{}]", stopWatch.totalTime());
             listener.onResponse(null);
         }, listener::onFailure);
     }

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
@@ -818,34 +818,24 @@ public abstract class RecoverySourceHandler {
                 logger
             );
 
-            final StepListener<Void> handoffListener = new StepListener<>();
             if (request.isPrimaryRelocation()) {
                 logger.trace("performing relocation hand-off");
-                final Consumer<StepListener> forceSegRepConsumer = shard.indexSettings().isSegRepEnabled()
+                final Runnable forceSegRepRunnable = shard.indexSettings().isSegRepEnabled()
                     ? recoveryTarget::forceSegmentFileSync
-                    : res -> res.onResponse(null);
+                    : () -> {};
                 // TODO: make relocated async
                 // this acquires all IndexShard operation permits and will thus delay new recoveries until it is done
                 cancellableThreads.execute(
-                    () -> shard.relocated(
-                        request.targetAllocationId(),
-                        recoveryTarget::handoffPrimaryContext,
-                        forceSegRepConsumer,
-                        handoffListener
-                    )
+                    () -> shard.relocated(request.targetAllocationId(), recoveryTarget::handoffPrimaryContext, forceSegRepRunnable)
                 );
                 /*
                  * if the recovery process fails after disabling primary mode on the source shard, both relocation source and
                  * target are failed (see {@link IndexShard#updateRoutingEntry}).
                  */
-            } else {
-                handoffListener.onResponse(null);
             }
-            handoffListener.whenComplete(res -> {
-                stopWatch.stop();
-                logger.trace("finalizing recovery took [{}]", stopWatch.totalTime());
-                listener.onResponse(null);
-            }, listener::onFailure);
+            stopWatch.stop();
+            logger.trace("finalizing recovery took [{}]", stopWatch.totalTime());
+            listener.onResponse(null);
         }, listener::onFailure);
     }
 

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoveryTarget.java
@@ -217,7 +217,7 @@ public class RecoveryTarget extends ReplicationTarget implements RecoveryTargetH
     }
 
     @Override
-    public void forceSegmentFileSync(ActionListener<Void> listener) {
+    public void forceSegmentFileSync() {
         throw new UnsupportedOperationException("Method not supported on target!");
     }
 

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoveryTargetHandler.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoveryTargetHandler.java
@@ -58,9 +58,8 @@ public interface RecoveryTargetHandler extends FileChunkWriter {
      *
      * This function is used to force a sync target primary node with source (old primary). This is to avoid segment files
      * conflict with replicas when target is promoted as primary.
-     * @param listener segment replication event listener
      */
-    void forceSegmentFileSync(ActionListener<Void> listener);
+    void forceSegmentFileSync();
 
     /**
      * The finalize request refreshes the engine now that new segments are available, enables garbage collection of tombstone files, updates

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -2703,27 +2703,13 @@ public class IndexShardTests extends IndexShardTestCase {
         IndexShardTestCase.updateRoutingEntry(indexShard, routing);
         assertTrue(indexShard.isSyncNeeded());
         try {
-            indexShard.relocated(
-                routing.getTargetRelocatingShard().allocationId().getId(),
-                primaryContext -> {},
-                r -> r.onResponse(null),
-                new ActionListener<>() {
-                    @Override
-                    public void onResponse(Void unused) {
-                        assertTrue(indexShard.isRelocatedPrimary());
-                        assertFalse(indexShard.isSyncNeeded());
-                        assertFalse(indexShard.getReplicationTracker().isPrimaryMode());
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        fail(e.toString());
-                    }
-                }
-            );
+            indexShard.relocated(routing.getTargetRelocatingShard().allocationId().getId(), primaryContext -> {}, () -> {});
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
+        assertTrue(indexShard.isRelocatedPrimary());
+        assertFalse(indexShard.isSyncNeeded());
+        assertFalse(indexShard.getReplicationTracker().isPrimaryMode());
         closeShards(indexShard);
     }
 

--- a/server/src/test/java/org/opensearch/indices/recovery/LocalStorePeerRecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/recovery/LocalStorePeerRecoverySourceHandlerTests.java
@@ -1117,7 +1117,7 @@ public class LocalStorePeerRecoverySourceHandlerTests extends OpenSearchTestCase
         public void finalizeRecovery(long globalCheckpoint, long trimAboveSeqNo, ActionListener<Void> listener) {}
 
         @Override
-        public void forceSegmentFileSync(ActionListener<Void> listener) {}
+        public void forceSegmentFileSync() {}
 
         @Override
         public void handoffPrimaryContext(ReplicationTracker.PrimaryContext primaryContext) {}

--- a/test/framework/src/main/java/org/opensearch/index/replication/OpenSearchIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/replication/OpenSearchIndexLevelReplicationTestCase.java
@@ -545,7 +545,7 @@ public abstract class OpenSearchIndexLevelReplicationTestCase extends IndexShard
                 markAsRecovering,
                 inSyncIds,
                 routingTable,
-                (a, b) -> null
+                (a) -> null
             );
             OpenSearchIndexLevelReplicationTestCase.this.startReplicaAfterRecovery(replica, primary, inSyncIds, routingTable);
             computeReplicationTargets();

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -66,6 +66,7 @@ import org.opensearch.common.blobstore.fs.FsBlobContainer;
 import org.opensearch.common.blobstore.fs.FsBlobStore;
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.concurrent.GatedCloseable;
+import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lucene.uid.Versions;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
@@ -150,11 +151,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.contains;
@@ -248,6 +251,12 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
 
     protected Store createStore(ShardId shardId, IndexSettings indexSettings, Directory directory) throws IOException {
         return new Store(shardId, indexSettings, directory, new DummyShardLock(shardId));
+    }
+
+    protected Releasable acquirePrimaryOperationPermitBlockingly(IndexShard indexShard) throws ExecutionException, InterruptedException {
+        PlainActionFuture<Releasable> fut = new PlainActionFuture<>();
+        indexShard.acquirePrimaryOperationPermit(fut, ThreadPool.Names.WRITE, "");
+        return fut.get();
     }
 
     /**
@@ -838,7 +847,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
     }
 
     protected void recoverReplica(IndexShard replica, IndexShard primary, boolean startReplica) throws IOException {
-        recoverReplica(replica, primary, startReplica, (a, b) -> null);
+        recoverReplica(replica, primary, startReplica, (a) -> null);
     }
 
     /** recovers a replica from the given primary **/
@@ -846,7 +855,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
         IndexShard replica,
         IndexShard primary,
         boolean startReplica,
-        BiFunction<List<IndexShard>, ActionListener<Void>, List<SegmentReplicationTarget>> replicatePrimaryFunction
+        Function<List<IndexShard>, List<SegmentReplicationTarget>> replicatePrimaryFunction
     ) throws IOException {
         recoverReplica(
             replica,
@@ -865,7 +874,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
         final boolean markAsRecovering,
         final boolean markAsStarted
     ) throws IOException {
-        recoverReplica(replica, primary, targetSupplier, markAsRecovering, markAsStarted, (a, b) -> null);
+        recoverReplica(replica, primary, targetSupplier, markAsRecovering, markAsStarted, (a) -> null);
     }
 
     /** recovers a replica from the given primary **/
@@ -875,7 +884,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
         final BiFunction<IndexShard, DiscoveryNode, RecoveryTarget> targetSupplier,
         final boolean markAsRecovering,
         final boolean markAsStarted,
-        final BiFunction<List<IndexShard>, ActionListener<Void>, List<SegmentReplicationTarget>> replicatePrimaryFunction
+        final Function<List<IndexShard>, List<SegmentReplicationTarget>> replicatePrimaryFunction
     ) throws IOException {
         IndexShardRoutingTable.Builder newRoutingTable = new IndexShardRoutingTable.Builder(replica.shardId());
         newRoutingTable.addShard(primary.routingEntry());
@@ -908,7 +917,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
         final boolean markAsRecovering,
         final Set<String> inSyncIds,
         final IndexShardRoutingTable routingTable,
-        final BiFunction<List<IndexShard>, ActionListener<Void>, List<SegmentReplicationTarget>> replicatePrimaryFunction
+        final Function<List<IndexShard>, List<SegmentReplicationTarget>> replicatePrimaryFunction
     ) throws IOException {
         final DiscoveryNode pNode = getFakeDiscoNode(primary.routingEntry().currentNodeId());
         final DiscoveryNode rNode = getFakeDiscoNode(replica.routingEntry().currentNodeId());
@@ -1319,11 +1328,8 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
      * @param replicaShards - Replicas that will be updated.
      * @return {@link List} List of target components orchestrating replication.
      */
-    public final List<SegmentReplicationTarget> replicateSegments(
-        IndexShard primaryShard,
-        List<IndexShard> replicaShards,
-        ActionListener<Void>... listeners
-    ) throws IOException, InterruptedException {
+    public final List<SegmentReplicationTarget> replicateSegments(IndexShard primaryShard, List<IndexShard> replicaShards)
+        throws IOException, InterruptedException {
         final CountDownLatch countDownLatch = new CountDownLatch(replicaShards.size());
         Map<String, StoreFileMetadata> primaryMetadata;
         try (final GatedCloseable<SegmentInfos> segmentInfosSnapshot = primaryShard.getSegmentInfosSnapshot()) {
@@ -1346,13 +1352,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                             assertTrue(recoveryDiff.missing.isEmpty());
                             assertTrue(recoveryDiff.different.isEmpty());
                             assertEquals(recoveryDiff.identical.size(), primaryMetadata.size());
-                            for (ActionListener<Void> listener : listeners) {
-                                listener.onResponse(null);
-                            }
                         } catch (Exception e) {
-                            for (ActionListener<Void> listener : listeners) {
-                                listener.onFailure(e);
-                            }
                             throw ExceptionsHelper.convertToRuntime(e);
                         } finally {
                             countDownLatch.countDown();

--- a/test/framework/src/main/java/org/opensearch/indices/recovery/AsyncRecoveryTarget.java
+++ b/test/framework/src/main/java/org/opensearch/indices/recovery/AsyncRecoveryTarget.java
@@ -46,7 +46,7 @@ import org.opensearch.indices.replication.SegmentReplicationTarget;
 
 import java.util.List;
 import java.util.concurrent.Executor;
-import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * Wraps a {@link RecoveryTarget} to make all remote calls to be executed asynchronously using the provided {@code executor}.
@@ -59,14 +59,14 @@ public class AsyncRecoveryTarget implements RecoveryTargetHandler {
 
     private final IndexShard replica;
 
-    private final BiFunction<List<IndexShard>, ActionListener<Void>, List<SegmentReplicationTarget>> replicatePrimaryFunction;
+    private final Function<List<IndexShard>, List<SegmentReplicationTarget>> replicatePrimaryFunction;
 
     public AsyncRecoveryTarget(RecoveryTargetHandler target, Executor executor) {
         this.executor = executor;
         this.target = target;
         this.primary = null;
         this.replica = null;
-        this.replicatePrimaryFunction = (a, b) -> null;
+        this.replicatePrimaryFunction = (a) -> null;
     }
 
     public AsyncRecoveryTarget(
@@ -74,7 +74,7 @@ public class AsyncRecoveryTarget implements RecoveryTargetHandler {
         Executor executor,
         IndexShard primary,
         IndexShard replica,
-        BiFunction<List<IndexShard>, ActionListener<Void>, List<SegmentReplicationTarget>> replicatePrimaryFunction
+        Function<List<IndexShard>, List<SegmentReplicationTarget>> replicatePrimaryFunction
     ) {
         this.executor = executor;
         this.target = target;
@@ -89,8 +89,8 @@ public class AsyncRecoveryTarget implements RecoveryTargetHandler {
     }
 
     @Override
-    public void forceSegmentFileSync(ActionListener<Void> listener) {
-        executor.execute(() -> this.replicatePrimaryFunction.apply(List.of(primary, replica), listener));
+    public void forceSegmentFileSync() {
+        this.replicatePrimaryFunction.apply(List.of(primary, replica));
     }
 
     @Override

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -62,7 +62,6 @@ import org.opensearch.action.admin.indices.refresh.RefreshResponse;
 import org.opensearch.action.admin.indices.segments.IndexSegments;
 import org.opensearch.action.admin.indices.segments.IndexShardSegments;
 import org.opensearch.action.admin.indices.segments.IndicesSegmentResponse;
-import org.opensearch.action.admin.indices.segments.IndicesSegmentsRequest;
 import org.opensearch.action.admin.indices.segments.ShardSegments;
 import org.opensearch.action.admin.indices.template.put.PutIndexTemplateRequestBuilder;
 import org.opensearch.action.bulk.BulkRequestBuilder;
@@ -85,7 +84,6 @@ import org.opensearch.cluster.coordination.OpenSearchNodeCommand;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
-import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.IndexRoutingTable;
 import org.opensearch.cluster.routing.IndexShardRoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
@@ -127,7 +125,6 @@ import org.opensearch.env.TestEnvironment;
 import org.opensearch.http.HttpInfo;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexModule;
-import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.MergePolicyConfig;
 import org.opensearch.index.MergeSchedulerConfig;
@@ -135,12 +132,10 @@ import org.opensearch.index.MockEngineFactoryPlugin;
 import org.opensearch.index.codec.CodecService;
 import org.opensearch.index.engine.Segment;
 import org.opensearch.index.mapper.MockFieldFilterPlugin;
-import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.translog.Translog;
 import org.opensearch.indices.IndicesQueryCache;
 import org.opensearch.indices.IndicesRequestCache;
-import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.store.IndicesStore;
 import org.opensearch.monitor.os.OsInfo;
 import org.opensearch.node.NodeMocksPlugin;
@@ -190,7 +185,6 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -1021,118 +1015,6 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
     public ClusterHealthStatus waitForRelocation() {
         return waitForRelocation(null);
     }
-
-    protected void assertSegmentStats(int numberOfReplicas) throws IOException {
-        final IndicesSegmentResponse indicesSegmentResponse = client().admin().indices().segments(new IndicesSegmentsRequest()).actionGet();
-
-        List<ShardSegments[]> segmentsByIndex = getShardSegments(indicesSegmentResponse);
-
-        // There will be an entry in the list for each index.
-        for (ShardSegments[] replicationGroupSegments : segmentsByIndex) {
-
-            // Separate Primary & replica shards ShardSegments.
-            final Map<Boolean, List<ShardSegments>> segmentListMap = segmentsByShardType(replicationGroupSegments);
-            final List<ShardSegments> primaryShardSegmentsList = segmentListMap.get(true);
-            final List<ShardSegments> replicaShardSegments = segmentListMap.get(false);
-
-            assertEquals("There should only be one primary in the replicationGroup", primaryShardSegmentsList.size(), 1);
-            final ShardSegments primaryShardSegments = primaryShardSegmentsList.stream().findFirst().get();
-            final Map<String, Segment> latestPrimarySegments = getLatestSegments(primaryShardSegments);
-
-            assertEquals(
-                "There should be a ShardSegment entry for each replica in the replicationGroup",
-                numberOfReplicas,
-                replicaShardSegments.size()
-            );
-
-            for (ShardSegments shardSegment : replicaShardSegments) {
-                final Map<String, Segment> latestReplicaSegments = getLatestSegments(shardSegment);
-                for (Segment replicaSegment : latestReplicaSegments.values()) {
-                    final Segment primarySegment = latestPrimarySegments.get(replicaSegment.getName());
-                    assertEquals(replicaSegment.getGeneration(), primarySegment.getGeneration());
-                    assertEquals(replicaSegment.getNumDocs(), primarySegment.getNumDocs());
-                    assertEquals(replicaSegment.getDeletedDocs(), primarySegment.getDeletedDocs());
-                    assertEquals(replicaSegment.getSize(), primarySegment.getSize());
-                }
-
-                // Fetch the IndexShard for this replica and try and build its SegmentInfos from the previous commit point.
-                // This ensures the previous commit point is not wiped.
-                final ShardRouting replicaShardRouting = shardSegment.getShardRouting();
-                ClusterState state = client(internalCluster().getMasterName()).admin().cluster().prepareState().get().getState();
-                final DiscoveryNode replicaNode = state.nodes().resolveNode(replicaShardRouting.currentNodeId());
-                IndexShard indexShard = getIndexShard(replicaNode.getName(), replicaShardRouting.getIndexName());
-                // calls to readCommit will fail if a valid commit point and all its segments are not in the store.
-                indexShard.store().readLastCommittedSegmentsInfo();
-            }
-        }
-    }
-
-    protected IndexShard getIndexShard(String node, String indexName) {
-        final Index index = resolveIndex(indexName);
-        IndicesService indicesService = internalCluster().getInstance(IndicesService.class, node);
-        IndexService indexService = indicesService.indexServiceSafe(index);
-        final Optional<Integer> shardId = indexService.shardIds().stream().findFirst();
-        return indexService.getShard(shardId.get());
-    }
-
-    private Map<String, Segment> getLatestSegments(ShardSegments segments) {
-        final Optional<Long> generation = segments.getSegments().stream().map(Segment::getGeneration).max(Long::compare);
-        final Long latestPrimaryGen = generation.get();
-        return segments.getSegments()
-            .stream()
-            .filter(s -> s.getGeneration() == latestPrimaryGen)
-            .collect(Collectors.toMap(Segment::getName, Function.identity()));
-    }
-
-    private Map<Boolean, List<ShardSegments>> segmentsByShardType(ShardSegments[] replicationGroupSegments) {
-        return Arrays.stream(replicationGroupSegments).collect(Collectors.groupingBy(s -> s.getShardRouting().primary()));
-    }
-
-    private List<ShardSegments[]> getShardSegments(IndicesSegmentResponse indicesSegmentResponse) {
-        return indicesSegmentResponse.getIndices()
-            .values()
-            .stream() // get list of IndexSegments
-            .flatMap(is -> is.getShards().values().stream()) // Map to shard replication group
-            .map(IndexShardSegments::getShards) // get list of segments across replication group
-            .collect(Collectors.toList());
-    }
-
-    /**
-     * Used for segment replication only
-     *
-     * Waits until the replica is caught up to the latest primary segments gen.
-     * @throws Exception if assertion fails
-     */
-    protected void waitForReplicaUpdate() throws Exception {
-        // wait until the replica has the latest segment generation.
-        assertBusy(() -> {
-            final IndicesSegmentResponse indicesSegmentResponse = client().admin()
-                .indices()
-                .segments(new IndicesSegmentsRequest())
-                .actionGet();
-            List<ShardSegments[]> segmentsByIndex = getShardSegments(indicesSegmentResponse);
-            for (ShardSegments[] replicationGroupSegments : segmentsByIndex) {
-                final Map<Boolean, List<ShardSegments>> segmentListMap = segmentsByShardType(replicationGroupSegments);
-                final List<ShardSegments> primaryShardSegmentsList = segmentListMap.get(true);
-                final List<ShardSegments> replicaShardSegments = segmentListMap.get(false);
-                // if we don't have any segments yet, proceed.
-                final ShardSegments primaryShardSegments = primaryShardSegmentsList.stream().findFirst().get();
-                logger.debug("Primary Segments: {}", primaryShardSegments.getSegments());
-                if (primaryShardSegments.getSegments().isEmpty() == false && replicaShardSegments != null) {
-                    final Map<String, Segment> latestPrimarySegments = getLatestSegments(primaryShardSegments);
-                    final Long latestPrimaryGen = latestPrimarySegments.values().stream().findFirst().map(Segment::getGeneration).get();
-                    for (ShardSegments shardSegments : replicaShardSegments) {
-                        logger.debug("Replica {} Segments: {}", shardSegments.getShardRouting(), shardSegments.getSegments());
-                        final boolean isReplicaCaughtUpToPrimary = shardSegments.getSegments()
-                            .stream()
-                            .anyMatch(segment -> segment.getGeneration() == latestPrimaryGen);
-                        assertTrue(isReplicaCaughtUpToPrimary);
-                    }
-                }
-            }
-        });
-    }
-
 
     /**
      * Waits for all relocating shards to become active and the cluster has reached the given health status


### PR DESCRIPTION
### Description
This change fixes the primary relocation path with segrep. This changes:
- Segment replication to happen synchronously. This has side effects of writes happening on older primary and segment replication to timeout due to parallel writes on older primary and round of segment replication from older primary to target.
- Remove `StepListener` listener post above change. This needed corresponding changes in function definitions & unit test changes. 
- Updates existing integration test to reduce flakyness
- Verified newly added tests are not flaky

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/5848

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
