### PR TITLE
Fix assertion failures in creation and deletion of remote store backed index

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -67,7 +67,7 @@ public class RemoteStoreIT extends OpenSearchIntegTestCase {
     // As index creation is pre-requisite for each integration test in this class, once we add more integ tests,
     // we can remove this test.
     public void testIndexCreation() {
-        internalCluster().startNode(featureFlagSettings());
+        internalCluster().startNode();
 
         Path absolutePath = randomRepoPath().toAbsolutePath();
         assertAcked(

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotestore;
+
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.index.IndexModule;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.transport.MockTransportService;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class RemoteStoreIT extends OpenSearchIntegTestCase {
+
+    private static final String REPOSITORY_NAME = "test-remore-store-repo";
+    private static final String INDEX_NAME = "remote-store-test-idx-1";
+    protected static final int SHARD_COUNT = 1;
+    protected static final int REPLICA_COUNT = 1;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(MockTransportService.TestPlugin.class);
+    }
+
+    @Override
+    public Settings indexSettings() {
+        return Settings.builder()
+            .put(super.indexSettings())
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, SHARD_COUNT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, REPLICA_COUNT)
+            .put(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.getKey(), false)
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true)
+            .put(IndexMetadata.SETTING_REMOTE_STORE_REPOSITORY, REPOSITORY_NAME)
+            .build();
+    }
+
+    @Override
+    protected boolean addMockInternalEngine() {
+        return false;
+    }
+
+    @Override
+    protected Settings featureFlagSettings() {
+        return Settings.builder()
+            .put(super.featureFlagSettings())
+            .put(FeatureFlags.REPLICATION_TYPE, "true")
+            .put(FeatureFlags.REMOTE_STORE, "true")
+            .build();
+    }
+
+    // This is a dummy test to check if create index flow is working as expected.
+    // As index creation is pre-requisite for each integration test in this class, once we add more integ tests,
+    // we can remove this test.
+    public void testIndexCreation() {
+        internalCluster().startNode(featureFlagSettings());
+
+        Path absolutePath = randomRepoPath().toAbsolutePath();
+        assertAcked(
+            clusterAdmin().preparePutRepository(REPOSITORY_NAME).setType("fs").setSettings(Settings.builder().put("location", absolutePath))
+        );
+
+        createIndex(INDEX_NAME);
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1760,8 +1760,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 } finally {
                     // playing safe here and close the engine even if the above succeeds - close can be called multiple times
                     // Also closing refreshListeners to prevent us from accumulating any more listeners
-                    // Closing remoteStore as a part of IndexShard close. null check is handled by IOUtils
-                    IOUtils.close(engine, globalCheckpointListeners, refreshListeners, pendingReplicationActions, remoteStore);
+                    IOUtils.close(engine, globalCheckpointListeners, refreshListeners, pendingReplicationActions);
                     indexShardOperationPermits.close();
                 }
             }

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -646,8 +646,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      * Public for testing.
      */
     public BlobStore blobStore() {
-        assertSnapshotOrGenericThread();
-
         BlobStore store = blobStore.get();
         if (store == null) {
             synchronized (lock) {


### PR DESCRIPTION
### Description

There are 2 changes made in this PR.

#### Fix Assertion failure while creating remote store backed index
- Creating remote store backed index fails with [AssertionError](https://github.com/opensearch-project/OpenSearch/issues/4718).
- The failing assertion checks for type of failing thread and only allows threads from GENERIC or SNAPSHOT threadpools.
- As being discussed in the parent issue, `BlobStoreRepository.blobStore()` does not access any remote store resources and only involves creating instance of `BlobStore`.
- It is safe to call `BlobStoreRepository.blobStore()` from create index flow as it is not an expensive operation.

#### Fix Assertion failure while deleting remote store backed index
- Deleting remote store backed index fails with [AssertionError](https://github.com/opensearch-project/OpenSearch/issues/5919)
- When an instance of `Store` is created, a shardlock is created which is released on closing the instance of store.
- Currently, we create 2 instances of store for remote store backed indices: `store` and `remoteStore`.
- As there can be only one shardlock acquired for a given shard, the lock is shared between `store` and `remoteStore`.
- This creates an issue when we are deleting the index/shard as it results in closing both `store` and `remoteStore`. At the time of closure of second Store instance, we get the assertion error saying `shard is not locked`.
- In this PR, we removed closing `remoteStore` instance of `Store`.
- It is safe not to explicitly close `remoteStore` due to following reasons:
  - Store.close() internally calls [closeInternal()](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/store/Store.java#L543) which in turn calls directory.close() and onClose function that was passed at the time of initialization of the store.
  - For `RemoteDirectory` class, [close()](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java#L111) method is a no-op.
  - onClose() function the is [passed to remoteStore](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/IndexService.java#L522) is also a no-op.
- Even if it is safe not to close `remoteStore`, we want to keep the behavior consistent and to achieve that we can have a composite store which will encapsulate local store and remote store. This is being tracked here: https://github.com/opensearch-project/OpenSearch/issues/3719

### Issues Resolved
- https://github.com/opensearch-project/OpenSearch/issues/4718
- https://github.com/opensearch-project/OpenSearch/issues/5919

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
