### PR TITLE
Backporting unit tests for IndexMetadataGenerations and a javadoc fix from #5812

### DIFF
--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -1036,7 +1036,8 @@ public final class IndexSettings {
     /**
      * If this is a remote snapshot and the extended compatibility
      * feature flag is enabled, this returns the minimum {@link Version}
-     * supported. In all other cases, the return value is null.
+     * supported. In all other cases, the return value is the
+     * {@link Version#minimumIndexCompatibilityVersion()} of {@link Version#CURRENT}.
      */
     public Version getExtendedCompatibilitySnapshotVersion() {
         return extendedCompatibilitySnapshotVersion;

--- a/server/src/test/java/org/opensearch/repositories/IndexMetadataGenerationsTests.java
+++ b/server/src/test/java/org/opensearch/repositories/IndexMetadataGenerationsTests.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.repositories;
+
+import org.junit.Before;
+import org.opensearch.snapshots.SnapshotId;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class IndexMetadataGenerationsTests extends OpenSearchTestCase {
+
+    private final int MAX_TEST_INDICES = 10;
+    private final String SNAPSHOT = "snapshot";
+    private final String INDEX_PREFIX = "index-";
+    private final String BLOB_ID_PREFIX = "blob-";
+    private IndexMetaDataGenerations indexMetaDataGenerations;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        final int numIndices = randomIntBetween(1, MAX_TEST_INDICES);
+        Map<IndexId, String> indexMap = createIndexMetadataMap(1, numIndices);
+        Map<String, String> identifierMap = createIdentifierMapFromIndexMetadata(indexMap, BLOB_ID_PREFIX);
+        Map<SnapshotId, Map<IndexId, String>> lookupMap = Collections.singletonMap(new SnapshotId(SNAPSHOT, SNAPSHOT), indexMap);
+        indexMetaDataGenerations = new IndexMetaDataGenerations(lookupMap, identifierMap);
+    }
+
+    public void testEmpty() {
+        assertTrue(IndexMetaDataGenerations.EMPTY.isEmpty());
+        assertNull(IndexMetaDataGenerations.EMPTY.getIndexMetaBlobId("test"));
+    }
+
+    public void testBaseCase() {
+        assertFalse(indexMetaDataGenerations.isEmpty());
+        assertEquals(BLOB_ID_PREFIX + 1, indexMetaDataGenerations.getIndexMetaBlobId(String.valueOf(1)));
+    }
+
+    public void testIndexMetaBlobId() {
+        SnapshotId snapshotId = new SnapshotId(SNAPSHOT, SNAPSHOT);
+        IndexId indexId = new IndexId(INDEX_PREFIX + 1, INDEX_PREFIX + 1);
+        assertEquals(BLOB_ID_PREFIX + 1, indexMetaDataGenerations.indexMetaBlobId(snapshotId, indexId));
+    }
+
+    public void testIndexMetaBlobIdFallback() {
+        SnapshotId snapshotId = new SnapshotId(SNAPSHOT, SNAPSHOT);
+        IndexId indexId = new IndexId("missingIndex", "missingIndex");
+        assertEquals(SNAPSHOT, indexMetaDataGenerations.indexMetaBlobId(snapshotId, indexId));
+
+        final String randomString = randomAlphaOfLength(8);
+        snapshotId = new SnapshotId(randomString, randomString);
+        assertEquals(randomString, indexMetaDataGenerations.indexMetaBlobId(snapshotId, indexId));
+    }
+
+    public void testWithAddedSnapshot() {
+        // Construct a new snapshot
+        SnapshotId newSnapshot = new SnapshotId("newSnapshot", "newSnapshot");
+        final String newIndexMetadataPrefix = "newIndexMetadata-";
+        final String newBlobIdPrefix = "newBlob-";
+        final int numIndices = randomIntBetween(2, MAX_TEST_INDICES);
+        Map<IndexId, String> newLookupMap = createIndexMetadataMap(2, numIndices);
+        Map<String, String> identifierMap = createIdentifierMapFromIndexMetadata(newLookupMap, "newBlob-");
+
+        // Add the snapshot and verify that values have been updated as expected
+        IndexMetaDataGenerations updated = indexMetaDataGenerations.withAddedSnapshot(newSnapshot, newLookupMap, identifierMap);
+        assertEquals(newBlobIdPrefix + 2, updated.getIndexMetaBlobId(String.valueOf(2)));
+        assertEquals(newBlobIdPrefix + 2, updated.indexMetaBlobId(newSnapshot, new IndexId(INDEX_PREFIX + 2, INDEX_PREFIX + 2)));
+        // The first index should remain unchanged
+        assertEquals(BLOB_ID_PREFIX + 1, updated.getIndexMetaBlobId(String.valueOf(1)));
+    }
+
+    public void testWithRemovedSnapshot() {
+        Set<SnapshotId> snapshotToRemove = Collections.singleton(new SnapshotId(SNAPSHOT, SNAPSHOT));
+        assertEquals(IndexMetaDataGenerations.EMPTY, indexMetaDataGenerations.withRemovedSnapshots(snapshotToRemove));
+    }
+
+    private Map<IndexId, String> createIndexMetadataMap(int indexCountLowerBound, int numIndices) {
+        final int indexCountUpperBound = indexCountLowerBound + numIndices;
+        Map<IndexId, String> map = new HashMap<>();
+        for (int i = indexCountLowerBound; i <= indexCountUpperBound; i++) {
+            map.put(new IndexId(INDEX_PREFIX + i, INDEX_PREFIX + i), String.valueOf(i));
+        }
+        return map;
+    }
+
+    private Map<String, String> createIdentifierMapFromIndexMetadata(Map<IndexId, String> indexMetadataMap, String blobIdPrefix) {
+        return indexMetadataMap.values().stream().collect(Collectors.toMap(k -> k, v -> blobIdPrefix + v));
+    }
+}


### PR DESCRIPTION
### Description

This PR backports two small improvements in #5812 to the `2.x` branch:
* Unit tests for `IndexMetadataGenerations`
* Fixes the javadoc of `IndexSettings#getExtendedCompatibilitySnapshotVersion` to correctly note that the default return value is not null.

### Issues Resolved
N/A

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
