### PR TITLE
Add artifacts from benchmarks to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ out/
 
 # These files are generated in the main tree by IntelliJ
 benchmarks/src/main/generated/*
+benchmarks/bin/*
+benchmarks/build-eclipse-default/*
 
 # eclipse files
 .project

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ out/
 !.idea/vcs.xml
 !.idea/icon.svg
 
-# These files are generated in the main tree by IntelliJ
+# These files are generated in the main tree by annotation processors
 benchmarks/src/main/generated/*
 benchmarks/bin/*
 benchmarks/build-eclipse-default/*


### PR DESCRIPTION
### Description
Add artifacts from benchmarks to .gitignore, I keep seeing files under the ./benchmarks/bin and ./benchmarks/build-eclipse-default folders which look like they are associated with a pre-processing annotation.

<details><summary>Detailed list of files that were not ignored</summary>
<p>

```
% git status -uall                                                                                                                                                                             ~/git/opensearch
On branch core-identity
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        benchmarks/bin/generated-sources/annotations/org/opensearch/benchmark/time/jmh_generated/DateFormatterFromBenchmark_benchmarkFrom_jmhTest.java
        benchmarks/bin/generated-sources/annotations/org/opensearch/benchmark/time/jmh_generated/DateFormatterFromBenchmark_jmhType.java
        benchmarks/bin/generated-sources/annotations/org/opensearch/benchmark/time/jmh_generated/DateFormatterFromBenchmark_jmhType_B1.java
        benchmarks/bin/generated-sources/annotations/org/opensearch/benchmark/time/jmh_generated/DateFormatterFromBenchmark_jmhType_B2.java
        benchmarks/bin/generated-sources/annotations/org/opensearch/benchmark/time/jmh_generated/DateFormatterFromBenchmark_jmhType_B3.java
        benchmarks/bin/generated-sources/annotations/org/opensearch/common/jmh_generated/RoundingBenchmark_jmhType.java
        benchmarks/bin/generated-sources/annotations/org/opensearch/common/jmh_generated/RoundingBenchmark_jmhType_B1.java
        benchmarks/bin/generated-sources/annotations/org/opensearch/common/jmh_generated/RoundingBenchmark_jmhType_B2.java
        benchmarks/bin/generated-sources/annotations/org/opensearch/common/jmh_generated/RoundingBenchmark_jmhType_B3.java
        benchmarks/bin/generated-sources/annotations/org/opensearch/common/jmh_generated/RoundingBenchmark_nextRoundingValue_jmhTest.java
        benchmarks/bin/generated-sources/annotations/org/opensearch/common/jmh_generated/RoundingBenchmark_round_jmhTest.java
        benchmarks/build-eclipse-default/META-INF/BenchmarkList
        benchmarks/build-eclipse-default/META-INF/CompilerHints
        benchmarks/build-eclipse-default/org/opensearch/benchmark/time/jmh_generated/DateFormatterFromBenchmark_benchmarkFrom_jmhTest.class
        benchmarks/build-eclipse-default/org/opensearch/benchmark/time/jmh_generated/DateFormatterFromBenchmark_jmhType.class
        benchmarks/build-eclipse-default/org/opensearch/benchmark/time/jmh_generated/DateFormatterFromBenchmark_jmhType_B1.class
        benchmarks/build-eclipse-default/org/opensearch/benchmark/time/jmh_generated/DateFormatterFromBenchmark_jmhType_B2.class
        benchmarks/build-eclipse-default/org/opensearch/benchmark/time/jmh_generated/DateFormatterFromBenchmark_jmhType_B3.class
        benchmarks/build-eclipse-default/org/opensearch/common/jmh_generated/RoundingBenchmark_jmhType.class
        benchmarks/build-eclipse-default/org/opensearch/common/jmh_generated/RoundingBenchmark_jmhType_B1.class
        benchmarks/build-eclipse-default/org/opensearch/common/jmh_generated/RoundingBenchmark_jmhType_B2.class
        benchmarks/build-eclipse-default/org/opensearch/common/jmh_generated/RoundingBenchmark_jmhType_B3.class
        benchmarks/build-eclipse-default/org/opensearch/common/jmh_generated/RoundingBenchmark_nextRoundingValue_jmhTest.class
        benchmarks/build-eclipse-default/org/opensearch/common/jmh_generated/RoundingBenchmark_round_jmhTest.class
```
</p>
</details>


### Issues Resolved
Makes me stop using `-u` during git add and become more at peace.

### Check List
- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
