### PR TITLE
Fix strict weighted routing integ test failure

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchWeightedRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchWeightedRoutingIT.java
@@ -851,7 +851,7 @@ public class SearchWeightedRoutingIT extends OpenSearchIntegTestCase {
         Map<String, List<String>> nodeMap = setupCluster(nodeCountPerAZ, commonSettings);
 
         int numShards = 10;
-        int numReplicas = 1;
+        int numReplicas = 2;
         setUpIndexing(numShards, numReplicas);
 
         logger.info("--> setting shard routing weights for weighted round robin");


### PR DESCRIPTION
Signed-off-by: Anshu Agarwal <anshukag@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR fixes strict weighted routing integration test
```
REPRODUCE WITH: ./gradlew ':server:internalClusterTest' --tests "org.opensearch.search.SearchWeightedRoutingIT.testPreferenceSearchWithWeightedRouting" -Dtests.seed=2211E75A1B84F237 -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=ar-AE -Dtests.timezone=Indian/Mahe -Druntime.java=19
  2> java.lang.IllegalArgumentException: no data nodes with criteria [node_t1] found for shard: [test][6]
        at __randomizedtesting.SeedInfo.seed([2211E75A1B84F237:FB5601FF9ED37C9F]:0)
        at org.opensearch.cluster.routing.IndexShardRoutingTable.onlyNodeSelectorActiveInitializingShardsIt(IndexShardRoutingTable.java:606)
        at org.opensearch.cluster.routing.OperationRouting.preferenceActiveShardIterator(OperationRouting.java:332)
        at org.opensearch.cluster.routing.OperationRouting.searchShards(OperationRouting.java:221)
        at org.opensearch.action.search.TransportSearchAction.executeSearch(TransportSearchAction.java:938)
        at org.opensearch.action.search.TransportSearchAction.executeLocalSearch(TransportSearchAction.java:769)
        at org.opensearch.action.search.TransportSearchAction.lambda$executeRequest$3(TransportSearchAction.java:410)
        at org.opensearch.action.ActionListener$1.onResponse(ActionListener.java:80)
        at org.opensearch.index.query.Rewriteable.rewriteAndFetch(Rewriteable.java:138)
        at org.opensearch.index.query.Rewriteable.rewriteAndFetch(Rewriteable.java:103)
        at org.opensearch.action.search.TransportSearchAction.executeRequest(TransportSearchAction.java:499)
        at org.opensearch.action.search.TransportSearchAction.doExecute(TransportSearchAction.java:284)
        at org.opensearch.action.search.TransportSearchAction.doExecute(TransportSearchAction.java:125)
        at org.opensearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:218)
        at org.opensearch.action.support.TransportAction.execute(TransportAction.java:188)
        at org.opensearch.action.support.TransportAction.execute(TransportAction.java:107)
        at org.opensearch.client.node.NodeClient.executeLocally(NodeClient.java:110)
        at org.opensearch.client.node.NodeClient.doExecute(NodeClient.java:97)
        at org.opensearch.client.support.AbstractClient.execute(AbstractClient.java:461)
        at org.opensearch.client.support.AbstractClient.execute(AbstractClient.java:448)
        at org.opensearch.action.ActionRequestBuilder.execute(ActionRequestBuilder.java:63)
        at org.opensearch.action.ActionRequestBuilder.get(ActionRequestBuilder.java:70)
        at org.opensearch.search.SearchWeightedRoutingIT.testPreferenceSearchWithWeightedRouting(SearchWeightedRoutingIT.java:880)
```

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/5929

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
