### PR TITLE
Enable SearchableSnapshotIT to run during build

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
@@ -6,7 +6,6 @@ package org.opensearch.snapshots;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import org.hamcrest.MatcherAssert;
-import org.junit.BeforeClass;
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.opensearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;
@@ -43,17 +42,14 @@ import static org.opensearch.common.util.CollectionUtils.iterableAsArrayList;
 
 public final class SearchableSnapshotIT extends AbstractSnapshotIntegTestCase {
 
-    @BeforeClass
-    public static void assumeFeatureFlag() {
-        assumeTrue(
-            "Searchable snapshot feature flag is enabled",
-            Boolean.parseBoolean(System.getProperty(FeatureFlags.SEARCHABLE_SNAPSHOT))
-        );
-    }
-
     @Override
     protected boolean addMockInternalEngine() {
         return false;
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder().put(super.nodeSettings(nodeOrdinal)).put(FeatureFlags.SEARCHABLE_SNAPSHOT, "true").build();
     }
 
     @Override


### PR DESCRIPTION
Previously this test required the feature flag to be set as a system property, otherwise the test did nothing. This change programmatically sets the feature flag to allow the test to run during all builds. I ran the following command overnight (probably at least a couple thousand iterations) on a dev machine and saw no failures, so I have confidence this test is not flaky:

```
run-one-until-failure ./gradlew ':server:internalClusterTest' --tests "org.opensearch.snapshots.SearchableSnapshotIT"
```

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
