### PR TITLE
Apply OpenSearchIntegTestCase::featureFlagSettings by default

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -116,10 +116,10 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
 
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
     public void testPrimaryStopped_ReplicaPromoted() throws Exception {
-        final String primary = internalCluster().startNode(featureFlagSettings());
+        final String primary = internalCluster().startNode();
         createIndex(INDEX_NAME);
         ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replica = internalCluster().startNode(featureFlagSettings());
+        final String replica = internalCluster().startNode();
         ensureGreen(INDEX_NAME);
 
         client().prepareIndex(INDEX_NAME).setId("1").setSource("foo", "bar").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
@@ -146,7 +146,7 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
         assertHitCount(client(replica).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 3);
 
         // start another node, index another doc and replicate.
-        String nodeC = internalCluster().startNode(featureFlagSettings());
+        String nodeC = internalCluster().startNode();
         ensureGreen(INDEX_NAME);
         client().prepareIndex(INDEX_NAME).setId("4").setSource("baz", "baz").get();
         refresh(INDEX_NAME);
@@ -158,10 +158,10 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
 
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
     public void testRestartPrimary() throws Exception {
-        final String primary = internalCluster().startNode(featureFlagSettings());
+        final String primary = internalCluster().startNode();
         createIndex(INDEX_NAME);
         ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replica = internalCluster().startNode(featureFlagSettings());
+        final String replica = internalCluster().startNode();
         ensureGreen(INDEX_NAME);
 
         assertEquals(getNodeContainingPrimaryShard().getName(), primary);
@@ -188,10 +188,10 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
     public void testCancelPrimaryAllocation() throws Exception {
         // this test cancels allocation on the primary - promoting the new replica and recreating the former primary as a replica.
-        final String primary = internalCluster().startNode(featureFlagSettings());
+        final String primary = internalCluster().startNode();
         createIndex(INDEX_NAME);
         ensureYellowAndNoInitializingShards(INDEX_NAME);
-        final String replica = internalCluster().startNode(featureFlagSettings());
+        final String replica = internalCluster().startNode();
         ensureGreen(INDEX_NAME);
 
         final int initialDocCount = 1;
@@ -228,7 +228,7 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
     public void testAddNewReplicaFailure() throws Exception {
         logger.info("--> starting [Primary Node] ...");
-        final String primaryNode = internalCluster().startNode(featureFlagSettings());
+        final String primaryNode = internalCluster().startNode();
 
         logger.info("--> creating test index ...");
         prepareCreate(
@@ -251,7 +251,7 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
         assertThat(client().prepareSearch(INDEX_NAME).setSize(0).execute().actionGet().getHits().getTotalHits().value, equalTo(20L));
 
         logger.info("--> start empty node to add replica shard");
-        final String replicaNode = internalCluster().startNode(featureFlagSettings());
+        final String replicaNode = internalCluster().startNode();
 
         // Mock transport service to add behaviour of throwing corruption exception during segment replication process.
         MockTransportService mockTransportService = ((MockTransportService) internalCluster().getInstance(
@@ -294,8 +294,8 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
 
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
     public void testReplicationAfterPrimaryRefreshAndFlush() throws Exception {
-        final String nodeA = internalCluster().startNode(featureFlagSettings());
-        final String nodeB = internalCluster().startNode(featureFlagSettings());
+        final String nodeA = internalCluster().startNode();
+        final String nodeB = internalCluster().startNode();
         createIndex(INDEX_NAME);
         ensureGreen(INDEX_NAME);
 
@@ -335,8 +335,8 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
     }
 
     public void testIndexReopenClose() throws Exception {
-        final String primary = internalCluster().startNode(featureFlagSettings());
-        final String replica = internalCluster().startNode(featureFlagSettings());
+        final String primary = internalCluster().startNode();
+        final String replica = internalCluster().startNode();
         createIndex(INDEX_NAME);
         ensureGreen(INDEX_NAME);
 
@@ -380,8 +380,8 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
             .put(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.getKey(), false)
             .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
             .build();
-        final String nodeA = internalCluster().startNode(featureFlagSettings());
-        final String nodeB = internalCluster().startNode(featureFlagSettings());
+        final String nodeA = internalCluster().startNode();
+        final String nodeB = internalCluster().startNode();
         createIndex(INDEX_NAME, indexSettings);
         ensureGreen(INDEX_NAME);
 
@@ -421,8 +421,8 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
     }
 
     public void testReplicationAfterForceMerge() throws Exception {
-        final String nodeA = internalCluster().startNode(featureFlagSettings());
-        final String nodeB = internalCluster().startNode(featureFlagSettings());
+        final String nodeA = internalCluster().startNode();
+        final String nodeB = internalCluster().startNode();
         createIndex(INDEX_NAME);
         ensureGreen(INDEX_NAME);
 
@@ -466,11 +466,11 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
     }
 
     public void testCancellation() throws Exception {
-        final String primaryNode = internalCluster().startNode(featureFlagSettings());
+        final String primaryNode = internalCluster().startNode();
         createIndex(INDEX_NAME, Settings.builder().put(indexSettings()).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build());
         ensureYellow(INDEX_NAME);
 
-        final String replicaNode = internalCluster().startNode(featureFlagSettings());
+        final String replicaNode = internalCluster().startNode();
 
         final SegmentReplicationSourceService segmentReplicationSourceService = internalCluster().getInstance(
             SegmentReplicationSourceService.class,
@@ -525,7 +525,7 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
     }
 
     public void testStartReplicaAfterPrimaryIndexesDocs() throws Exception {
-        final String primaryNode = internalCluster().startNode(featureFlagSettings());
+        final String primaryNode = internalCluster().startNode();
         createIndex(INDEX_NAME, Settings.builder().put(indexSettings()).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).build());
         ensureGreen(INDEX_NAME);
 
@@ -548,7 +548,7 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
                 .prepareUpdateSettings(INDEX_NAME)
                 .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1))
         );
-        final String replicaNode = internalCluster().startNode(featureFlagSettings());
+        final String replicaNode = internalCluster().startNode();
         ensureGreen(INDEX_NAME);
 
         assertHitCount(client(primaryNode).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 2);
@@ -563,8 +563,8 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
     }
 
     public void testDeleteOperations() throws Exception {
-        final String nodeA = internalCluster().startNode(featureFlagSettings());
-        final String nodeB = internalCluster().startNode(featureFlagSettings());
+        final String nodeA = internalCluster().startNode();
+        final String nodeB = internalCluster().startNode();
 
         createIndex(INDEX_NAME);
         ensureGreen(INDEX_NAME);
@@ -627,10 +627,10 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
 
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
     public void testUpdateOperations() throws Exception {
-        final String primary = internalCluster().startNode(featureFlagSettings());
+        final String primary = internalCluster().startNode();
         createIndex(INDEX_NAME);
         ensureYellow(INDEX_NAME);
-        final String replica = internalCluster().startNode(featureFlagSettings());
+        final String replica = internalCluster().startNode();
 
         final int initialDocCount = scaledRandomIntBetween(0, 200);
         try (
@@ -731,10 +731,10 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 6)
             .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
             .build();
-        final String clusterManagerNode = internalCluster().startClusterManagerOnlyNode(featureFlagSettings());
-        final String primaryNode = internalCluster().startDataOnlyNode(featureFlagSettings());
+        final String clusterManagerNode = internalCluster().startClusterManagerOnlyNode();
+        final String primaryNode = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME, settings);
-        internalCluster().startDataOnlyNodes(6, featureFlagSettings());
+        internalCluster().startDataOnlyNodes(6);
         ensureGreen(INDEX_NAME);
 
         int initialDocCount = scaledRandomIntBetween(100, 200);
@@ -757,7 +757,7 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
             ensureYellow(INDEX_NAME);
 
             // start another replica.
-            internalCluster().startDataOnlyNode(featureFlagSettings());
+            internalCluster().startDataOnlyNode();
             ensureGreen(INDEX_NAME);
 
             // index another doc and refresh - without this the new replica won't catch up.

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
@@ -57,9 +57,9 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationIT {
      */
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
     public void testPrimaryRelocation() throws Exception {
-        final String oldPrimary = internalCluster().startNode(featureFlagSettings());
+        final String oldPrimary = internalCluster().startNode();
         createIndex();
-        final String replica = internalCluster().startNode(featureFlagSettings());
+        final String replica = internalCluster().startNode();
         ensureGreen(INDEX_NAME);
         final int initialDocCount = scaledRandomIntBetween(0, 200);
         ingestDocs(initialDocCount);
@@ -69,7 +69,7 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationIT {
         assertHitCount(client(replica).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
 
         logger.info("--> start another node");
-        final String newPrimary = internalCluster().startNode(featureFlagSettings());
+        final String newPrimary = internalCluster().startNode();
         ClusterHealthResponse clusterHealthResponse = client().admin()
             .cluster()
             .prepareHealth()
@@ -129,9 +129,9 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationIT {
      */
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
     public void testPrimaryRelocationWithSegRepFailure() throws Exception {
-        final String oldPrimary = internalCluster().startNode(featureFlagSettings());
+        final String oldPrimary = internalCluster().startNode();
         createIndex();
-        final String replica = internalCluster().startNode(featureFlagSettings());
+        final String replica = internalCluster().startNode();
         ensureGreen(INDEX_NAME);
         final int initialDocCount = scaledRandomIntBetween(1, 100);
         ingestDocs(initialDocCount);
@@ -141,7 +141,7 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationIT {
         assertHitCount(client(replica).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
 
         logger.info("--> start another node");
-        final String newPrimary = internalCluster().startNode(featureFlagSettings());
+        final String newPrimary = internalCluster().startNode();
         ClusterHealthResponse clusterHealthResponse = client().admin()
             .cluster()
             .prepareHealth()
@@ -204,7 +204,7 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationIT {
      *
      */
     public void testRelocateWhileContinuouslyIndexingAndWaitingForRefresh() throws Exception {
-        final String primary = internalCluster().startNode(featureFlagSettings());
+        final String primary = internalCluster().startNode();
         prepareCreate(
             INDEX_NAME,
             Settings.builder()
@@ -233,7 +233,7 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationIT {
             );
         }
 
-        final String replica = internalCluster().startNode(featureFlagSettings());
+        final String replica = internalCluster().startNode();
         ClusterHealthResponse clusterHealthResponse = client().admin()
             .cluster()
             .prepareHealth()

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
@@ -48,8 +48,8 @@ public final class SearchableSnapshotIT extends AbstractSnapshotIntegTestCase {
     }
 
     @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return Settings.builder().put(super.nodeSettings(nodeOrdinal)).put(FeatureFlags.SEARCHABLE_SNAPSHOT, "true").build();
+    protected Settings featureFlagSettings() {
+        return Settings.builder().put(FeatureFlags.SEARCHABLE_SNAPSHOT, "true").build();
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SegmentReplicationSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SegmentReplicationSnapshotIT.java
@@ -99,11 +99,11 @@ public class SegmentReplicationSnapshotIT extends AbstractSnapshotIntegTestCase 
     // Start cluster with provided settings and return the node names as list
     public List<String> startClusterWithSettings(Settings indexSettings, int replicaCount) throws Exception {
         // Start primary
-        final String primaryNode = internalCluster().startNode(featureFlagSettings());
+        final String primaryNode = internalCluster().startNode();
         List<String> nodeNames = new ArrayList<>();
         nodeNames.add(primaryNode);
         for (int i = 0; i < replicaCount; i++) {
-            nodeNames.add(internalCluster().startNode(featureFlagSettings()));
+            nodeNames.add(internalCluster().startNode());
         }
         createIndex(INDEX_NAME, indexSettings);
         ensureGreen(INDEX_NAME);
@@ -266,7 +266,7 @@ public class SegmentReplicationSnapshotIT extends AbstractSnapshotIntegTestCase 
 
         // Assertions
         assertThat(restoreSnapshotResponse.status(), equalTo(RestStatus.ACCEPTED));
-        internalCluster().startNode(featureFlagSettings());
+        internalCluster().startNode();
         ensureGreen(RESTORED_INDEX_NAME);
         GetSettingsResponse settingsResponse = client().admin()
             .indices()

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -1882,7 +1882,8 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
             // randomly enable low-level search cancellation to make sure it does not alter results
             .put(SearchService.LOW_LEVEL_CANCELLATION_SETTING.getKey(), randomBoolean())
             .putList(DISCOVERY_SEED_HOSTS_SETTING.getKey()) // empty list disables a port scan for other nodes
-            .putList(DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), "file");
+            .putList(DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), "file")
+            .put(featureFlagSettings());
         return builder.build();
     }
 


### PR DESCRIPTION
This commit applies any feature flags specified by a child class override of the featureFlagSettings() method by default. The result is that test implementations do not have to manually specify the featureFlagSettings when creating test nodes.

@dreamer-89 @mch2 Does this make sense?

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
