### PR TITLE
Add method to Engine to fetch max seq no of given SegmentInfos

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -47,6 +47,9 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.QueryCache;
 import org.apache.lucene.search.QueryCachingPolicy;
 import org.apache.lucene.search.ReferenceManager;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
@@ -63,6 +66,7 @@ import org.opensearch.common.lease.Releasables;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.common.lucene.index.OpenSearchDirectoryReader;
+import org.opensearch.common.lucene.search.Queries;
 import org.opensearch.common.lucene.uid.Versions;
 import org.opensearch.common.lucene.uid.VersionsAndSeqNoResolver;
 import org.opensearch.common.lucene.uid.VersionsAndSeqNoResolver.DocIdAndVersion;
@@ -71,9 +75,11 @@ import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ReleasableLock;
 import org.opensearch.index.VersionType;
+import org.opensearch.index.mapper.IdFieldMapper;
 import org.opensearch.index.mapper.Mapping;
 import org.opensearch.index.mapper.ParseContext.Document;
 import org.opensearch.index.mapper.ParsedDocument;
+import org.opensearch.index.mapper.SeqNoFieldMapper;
 import org.opensearch.index.merge.MergeStats;
 import org.opensearch.index.seqno.SeqNoStats;
 import org.opensearch.index.seqno.SequenceNumbers;
@@ -272,6 +278,35 @@ public abstract class Engine implements LifecycleAware, Closeable {
                     + "] on index shard "
                     + shardId
             );
+        }
+    }
+
+    /**
+     * Get max sequence number that was part of last refresh.
+     * Sequence number is part of each document that is indexed.
+     * This method fetches the _id of last indexed document that was part of refresh and
+     * retrieves the _seq_no of the document.
+     */
+    public long getMaxSeqNoRefreshed(String source) throws IOException {
+        try (Engine.Searcher searcher = acquireSearcher(source, Engine.SearcherScope.INTERNAL)) {
+            searcher.setQueryCache(null);
+            ScoreDoc[] docs = searcher.search(
+                Queries.newMatchAllQuery(),
+                1,
+                new Sort(new SortField(SeqNoFieldMapper.NAME, SortField.Type.DOC, true))
+            ).scoreDocs;
+            if (docs.length == 0) {
+                return SequenceNumbers.NO_OPS_PERFORMED;
+            }
+            org.apache.lucene.document.Document document = searcher.storedFields().document(docs[0].doc);
+            Term uidTerm = new Term(IdFieldMapper.NAME, document.getField(IdFieldMapper.NAME).binaryValue());
+            VersionsAndSeqNoResolver.DocIdAndVersion docIdAndVersion = VersionsAndSeqNoResolver.loadDocIdAndVersion(
+                searcher.getIndexReader(),
+                uidTerm,
+                true
+            );
+            assert docIdAndVersion != null;
+            return docIdAndVersion.seqNo;
         }
     }
 
@@ -2026,4 +2061,5 @@ public abstract class Engine implements LifecycleAware, Closeable {
      * to advance this marker to at least the given sequence number.
      */
     public abstract void advanceMaxSeqNoOfUpdatesOrDeletes(long maxSeqNoOfUpdatesOnPrimary);
+
 }

--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -42,6 +42,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.StandardDirectoryReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.QueryCache;
@@ -282,32 +283,39 @@ public abstract class Engine implements LifecycleAware, Closeable {
     }
 
     /**
-     * Get max sequence number that was part of last refresh.
-     * Sequence number is part of each document that is indexed.
-     * This method fetches the _id of last indexed document that was part of refresh and
-     * retrieves the _seq_no of the document.
+     * Get max sequence number from segments that are referenced by given SegmentInfos
      */
-    public long getMaxSeqNoRefreshed(String source) throws IOException {
-        try (Engine.Searcher searcher = acquireSearcher(source, Engine.SearcherScope.INTERNAL)) {
-            searcher.setQueryCache(null);
-            ScoreDoc[] docs = searcher.search(
-                Queries.newMatchAllQuery(),
-                1,
-                new Sort(new SortField(SeqNoFieldMapper.NAME, SortField.Type.DOC, true))
-            ).scoreDocs;
-            if (docs.length == 0) {
-                return SequenceNumbers.NO_OPS_PERFORMED;
-            }
-            org.apache.lucene.document.Document document = searcher.storedFields().document(docs[0].doc);
-            Term uidTerm = new Term(IdFieldMapper.NAME, document.getField(IdFieldMapper.NAME).binaryValue());
-            VersionsAndSeqNoResolver.DocIdAndVersion docIdAndVersion = VersionsAndSeqNoResolver.loadDocIdAndVersion(
-                searcher.getIndexReader(),
-                uidTerm,
-                true
-            );
-            assert docIdAndVersion != null;
-            return docIdAndVersion.seqNo;
+    public long getMaxSeqNoFromSegmentInfos(SegmentInfos segmentInfos) throws IOException {
+        try (DirectoryReader innerReader = StandardDirectoryReader.open(store.directory(), segmentInfos, null, null)) {
+            final IndexSearcher searcher = new IndexSearcher(innerReader);
+            return getMaxSeqNoFromSearcher(searcher);
         }
+    }
+
+    /**
+     * Get max sequence number that is part of given searcher. Sequence number is part of each document that is indexed.
+     * This method fetches the _id of last indexed document that was part of the given searcher and
+     * retrieves the _seq_no of the retrieved document.
+     */
+    protected long getMaxSeqNoFromSearcher(IndexSearcher searcher) throws IOException {
+        searcher.setQueryCache(null);
+        ScoreDoc[] docs = searcher.search(
+            Queries.newMatchAllQuery(),
+            1,
+            new Sort(new SortField(SeqNoFieldMapper.NAME, SortField.Type.DOC, true))
+        ).scoreDocs;
+        if (docs.length == 0) {
+            return SequenceNumbers.NO_OPS_PERFORMED;
+        }
+        org.apache.lucene.document.Document document = searcher.storedFields().document(docs[0].doc);
+        Term uidTerm = new Term(IdFieldMapper.NAME, document.getField(IdFieldMapper.NAME).binaryValue());
+        VersionsAndSeqNoResolver.DocIdAndVersion docIdAndVersion = VersionsAndSeqNoResolver.loadDocIdAndVersion(
+            searcher.getIndexReader(),
+            uidTerm,
+            true
+        );
+        assert docIdAndVersion != null;
+        return docIdAndVersion.seqNo;
     }
 
     /**

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -7549,4 +7549,62 @@ public class InternalEngineTests extends EngineTestCase {
         store.close();
         engine.close();
     }
+
+    public void testGetMaxSeqNoRefreshedWithoutRefresh() throws IOException {
+        IOUtils.close(store, engine);
+
+        final Settings.Builder settings = Settings.builder().put(defaultSettings.getSettings()).put("index.refresh_interval", "300s");
+        final IndexMetadata indexMetadata = IndexMetadata.builder(defaultSettings.getIndexMetadata()).settings(settings).build();
+        final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(indexMetadata);
+
+        Store store = createStore();
+        InternalEngine engine = createEngine(indexSettings, store, createTempDir(), newMergePolicy());
+
+        int numDocs = randomIntBetween(10, 100);
+        for (int i = 0; i < numDocs; i++) {
+            engine.index(indexForDoc(createParsedDoc(Integer.toString(i), null)));
+        }
+
+        assertEquals(NO_OPS_PERFORMED, engine.getMaxSeqNoRefreshed("test"));
+
+        store.close();
+        engine.close();
+    }
+
+    public void testGetMaxSeqNoRefreshed() throws IOException {
+        IOUtils.close(store, engine);
+
+        final Settings.Builder settings = Settings.builder().put(defaultSettings.getSettings()).put("index.refresh_interval", "300s");
+        final IndexMetadata indexMetadata = IndexMetadata.builder(defaultSettings.getIndexMetadata()).settings(settings).build();
+        final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(indexMetadata);
+
+        Store store = createStore();
+        InternalEngine engine = createEngine(indexSettings, store, createTempDir(), newMergePolicy());
+
+        int totalNumberOfDocsRefreshed = 0;
+        for (int j = 0; j < randomIntBetween(1, 10); j++) {
+            int numDocs = randomIntBetween(10, 100);
+            for (int i = totalNumberOfDocsRefreshed; i < (totalNumberOfDocsRefreshed + numDocs); i++) {
+                engine.index(indexForDoc(createParsedDoc(Integer.toString(i), null)));
+            }
+            // this is just to make sure that refresh post flush has the same impact.
+            if (randomBoolean()) {
+                engine.refresh("test");
+            } else {
+                engine.flush();
+            }
+            totalNumberOfDocsRefreshed += numDocs;
+        }
+        // Optionally, index more docs without refreshing. These should not be part of getMaxSeqNoRefreshed
+        if (randomBoolean()) {
+            for (int i = totalNumberOfDocsRefreshed; i < (totalNumberOfDocsRefreshed + randomIntBetween(10, 100)); i++) {
+                engine.index(indexForDoc(createParsedDoc(Integer.toString(i), null)));
+            }
+        }
+
+        assertEquals(totalNumberOfDocsRefreshed - 1, engine.getMaxSeqNoRefreshed("test"));
+
+        store.close();
+        engine.close();
+    }
 }

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -7565,7 +7565,9 @@ public class InternalEngineTests extends EngineTestCase {
             engine.index(indexForDoc(createParsedDoc(Integer.toString(i), null)));
         }
 
-        assertEquals(NO_OPS_PERFORMED, engine.getMaxSeqNoRefreshed("test"));
+        try (Engine.Searcher searcher = engine.acquireSearcher("test", Engine.SearcherScope.INTERNAL)) {
+            assertEquals(NO_OPS_PERFORMED, engine.getMaxSeqNoFromSearcher(searcher));
+        }
 
         store.close();
         engine.close();
@@ -7602,9 +7604,51 @@ public class InternalEngineTests extends EngineTestCase {
             }
         }
 
-        assertEquals(totalNumberOfDocsRefreshed - 1, engine.getMaxSeqNoRefreshed("test"));
+        try (Engine.Searcher searcher = engine.acquireSearcher("test", Engine.SearcherScope.INTERNAL)) {
+            assertEquals(totalNumberOfDocsRefreshed - 1, engine.getMaxSeqNoFromSearcher(searcher));
+        }
 
         store.close();
         engine.close();
     }
+
+    public void testGetMaxSeqNoFromSegmentInfos() throws IOException {
+        IOUtils.close(store, engine);
+
+        final Settings.Builder settings = Settings.builder().put(defaultSettings.getSettings()).put("index.refresh_interval", "300s");
+        final IndexMetadata indexMetadata = IndexMetadata.builder(defaultSettings.getIndexMetadata()).settings(settings).build();
+        final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(indexMetadata);
+
+        Store store = createStore();
+        InternalEngine engine = createEngine(indexSettings, store, createTempDir(), newMergePolicy());
+
+        int totalNumberOfDocsRefreshed = 0;
+        for (int j = 0; j < randomIntBetween(1, 10); j++) {
+            int numDocs = randomIntBetween(10, 100);
+            for (int i = totalNumberOfDocsRefreshed; i < (totalNumberOfDocsRefreshed + numDocs); i++) {
+                engine.index(indexForDoc(createParsedDoc(Integer.toString(i), null)));
+            }
+            // this is just to make sure that refresh post flush has the same impact.
+            if (randomBoolean()) {
+                engine.refresh("test");
+            } else {
+                engine.flush();
+            }
+            totalNumberOfDocsRefreshed += numDocs;
+        }
+        // Optionally, index more docs without refreshing. These should not be part of getMaxSeqNoRefreshed
+        if (randomBoolean()) {
+            for (int i = totalNumberOfDocsRefreshed; i < (totalNumberOfDocsRefreshed + randomIntBetween(10, 100)); i++) {
+                engine.index(indexForDoc(createParsedDoc(Integer.toString(i), null)));
+            }
+        }
+
+        try (GatedCloseable<SegmentInfos> segmentInfosGatedCloseable = engine.getSegmentInfosSnapshot()) {
+            assertEquals(totalNumberOfDocsRefreshed - 1, engine.getMaxSeqNoFromSegmentInfos(segmentInfosGatedCloseable.get()));
+        }
+
+        store.close();
+        engine.close();
+    }
+
 }


### PR DESCRIPTION
Signed-off-by: Sachin Kale <kalsac@amazon.com>

### Description
- Currently, `Engine` class does not expose a method which provides max sequence number that was part of last refresh.
- Remote segment store, as part of providing refresh level durability, needs this info.
- `InternalEngine.lastRefreshedCheckpoint()` does not guarantee to provide sequence number that is part of refreshed segments.
- This creates issues like: https://github.com/opensearch-project/OpenSearch/issues/5971
- `_seq_no` field is part of each indexed document. We can use this to query refreshed segments and fetch the last sequence number.
- We need to test the performance overhead though. As a part of this PR, I will run nyc_taxis workload from opensearch-benchmark and compare the performances.

### Issues Resolved
- https://github.com/opensearch-project/OpenSearch/issues/5971

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
