### PR TITLE
[BUG] javadoc warnings not causing failures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -315,6 +315,10 @@ allprojects {
     // see https://discuss.gradle.org/t/add-custom-javadoc-option-that-does-not-take-an-argument/5959
     javadoc.options.encoding = 'UTF8'
     javadoc.options.addStringOption('Xdoclint:all,-missing', '-quiet')
+    boolean failOnJavadocWarning = project.ext.has('failOnJavadocWarning') ? project.ext.get('failOnJavadocWarning') : true
+    if (failOnJavadocWarning) {
+      javadoc.options.addStringOption('Xwerror', '-quiet')
+    }
     javadoc.options.tags = ["opensearch.internal", "opensearch.api", "opensearch.experimental"]
     javadoc.options.addStringOption("-release", targetCompatibility.majorVersion)
   }

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -40,6 +40,11 @@ opensearchplugin {
   classname 'org.opensearch.painless.PainlessModulePlugin'
 }
 
+ext {
+  // Do not fail on `javadoc` warning (ANTLR generated code)
+  failOnJavadocWarning = false
+}
+
 testClusters.all {
   module ':modules:mapper-extras'
   systemProperty 'opensearch.scripting.update.ctx_in_params', 'false'

--- a/server/src/main/java/org/opensearch/index/fielddata/ScriptDocValues.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/ScriptDocValues.java
@@ -123,7 +123,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
 
         /**
-         * Set the {@link #size()} and ensure that the {@link #values} array can
+         * Set the {@link #size()} and ensure that the internal values array can
          * store at least that many entries.
          */
         protected void resize(int newSize) {
@@ -515,7 +515,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
 
         /**
-         * Set the {@link #size()} and ensure that the {@link #values} array can
+         * Set the {@link #size()} and ensure that the internal values array can
          * store at least that many entries.
          */
         protected void resize(int newSize) {

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1689,9 +1689,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * Used with segment replication during relocation handoff, this method updates current read only engine to global
      * checkpoint followed by changing to writeable engine
      *
-     * @throws IOException
-     * @throws InterruptedException
-     * @throws TimeoutException
+     * @throws IOException if communication failed
+     * @throws InterruptedException if calling thread is interrupted
+     * @throws TimeoutException if timed out waiting for in-flight operations to finish
      *
      * @opensearch.internal
      */


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
`javadoc` warnings not causing failures

### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/5995

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
