### PR TITLE
[Extensions] Fix reversed logic in extension Index Module registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix 'org.apache.hc.core5.http.ParseException: Invalid protocol version' under JDK 16+ ([#4827](https://github.com/opensearch-project/OpenSearch/pull/4827))
 - Fixed compression support for h2c protocol ([#4944](https://github.com/opensearch-project/OpenSearch/pull/4944))
 - Support OpenSSL Provider with default Netty allocator ([#5460](https://github.com/opensearch-project/OpenSearch/pull/5460))
+- Fix reversed logic in extension Index Module registration ([#5998](https://github.com/opensearch-project/OpenSearch/pull/5998))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -514,9 +514,9 @@ public class ExtensionsManager {
                                 );
                                 inProgressIndexNameFuture.whenComplete((r, e) -> {
                                     if (e != null) {
-                                        inProgressFuture.complete(response);
-                                    } else if (e == null) {
                                         inProgressFuture.completeExceptionally(e);
+                                    } else {
+                                        inProgressFuture.complete(response);
                                     }
                                 });
                             } catch (Exception ex) {


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

Fixes a reversal of boolean logic in #5646.

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
