### PR TITLE
[Backport 2.x] Add condition that PRs are merged in backport workflow (#5997)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,11 +7,22 @@ on:
 
 jobs:
   backport:
+    name: Backport
     runs-on: ubuntu-latest
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
     permissions:
       contents: write
       pull-requests: write
-    name: Backport
     steps:
       - name: GitHub App token
         id: github_app_token


### PR DESCRIPTION
This brings our backport workflow script in line with the script from the [tibdex/backport][1] github action implementation.

[1]: https://github.com/tibdex/backport/blob/b1bb2aaf611d9f2e5d1900c06493769b9f102a45/.github/workflows/backport.yml#L12-L22

Signed-off-by: Andrew Ross <andrross@amazon.com>
(cherry picked from commit 715ff72c1bf1ca31e861639faa664f92f6115501)

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
