### PR TITLE
Add XContentMediaType

### DIFF
--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/MediaType.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/MediaType.java
@@ -62,6 +62,4 @@ public interface MediaType {
     default String typeWithSubtype() {
         return type() + "/" + subtype();
     }
-
-    XContent xContent();
 }

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentMediaType.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentMediaType.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.xcontent;
+
+/**
+ * Abstracts a <a href="http://en.wikipedia.org/wiki/Internet_media_type">Media Type</a> support
+ * for {@link XContent}
+ */
+public interface XContentMediaType extends MediaType {
+    /**
+     * Return the {@link XContent} that corresponds this media type
+     * @return {@link XContent} that corresponds this media type
+     */
+    XContent xContent();
+}

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentType.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentType.java
@@ -43,7 +43,7 @@ import java.util.Map;
 /**
  * The content type of {@link org.opensearch.common.xcontent.XContent}.
  */
-public enum XContentType implements MediaType {
+public enum XContentType implements XContentMediaType {
 
     /**
      * A JSON based content type.

--- a/server/src/main/java/org/opensearch/common/Strings.java
+++ b/server/src/main/java/org/opensearch/common/Strings.java
@@ -37,9 +37,9 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.util.CollectionUtils;
-import org.opensearch.common.xcontent.MediaType;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentMediaType;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -712,7 +712,7 @@ public class Strings {
      * Wraps the output into an anonymous object if needed. The content is not pretty-printed
      * nor human readable.
      */
-    public static String toString(MediaType mediaType, ToXContent toXContent) {
+    public static String toString(XContentMediaType mediaType, ToXContent toXContent) {
         return toString(mediaType, toXContent, false, false);
     }
 
@@ -722,7 +722,7 @@ public class Strings {
      * Allows to configure the params.
      * The content is not pretty-printed nor human readable.
      */
-    public static String toString(MediaType mediaType, ToXContent toXContent, ToXContent.Params params) {
+    public static String toString(XContentMediaType mediaType, ToXContent toXContent, ToXContent.Params params) {
         return toString(mediaType, toXContent, params, false, false);
     }
 
@@ -740,7 +740,7 @@ public class Strings {
      * json needs to be pretty printed and human readable.
      *
      */
-    public static String toString(MediaType mediaType, ToXContent toXContent, boolean pretty, boolean human) {
+    public static String toString(XContentMediaType mediaType, ToXContent toXContent, boolean pretty, boolean human) {
         return toString(mediaType, toXContent, ToXContent.EMPTY_PARAMS, pretty, human);
     }
 
@@ -750,7 +750,13 @@ public class Strings {
      * Allows to configure the params.
      * Allows to control whether the outputted json needs to be pretty printed and human readable.
      */
-    private static String toString(MediaType mediaType, ToXContent toXContent, ToXContent.Params params, boolean pretty, boolean human) {
+    private static String toString(
+        XContentMediaType mediaType,
+        ToXContent toXContent,
+        ToXContent.Params params,
+        boolean pretty,
+        boolean human
+    ) {
         try {
             XContentBuilder builder = createBuilder(mediaType, pretty, human);
             if (toXContent.isFragment()) {
@@ -775,7 +781,7 @@ public class Strings {
         }
     }
 
-    private static XContentBuilder createBuilder(MediaType mediaType, boolean pretty, boolean human) throws IOException {
+    private static XContentBuilder createBuilder(XContentMediaType mediaType, boolean pretty, boolean human) throws IOException {
         XContentBuilder builder = XContentBuilder.builder(mediaType.xContent());
         if (pretty) {
             builder.prettyPrint();


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>


### Description

Add `XContentMediaType` to break `XContent` and `MediaType` coupling, plus making the change non-breaking to allow backporting to `2.x` branch.

### Issues Resolved
Follow up on https://github.com/opensearch-project/OpenSearch/pull/6009#event-8357983015

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
