### PR TITLE
Fix flaky SegmentReplicationITs.

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -11,10 +11,6 @@ package org.opensearch.indices.replication;
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import org.opensearch.OpenSearchCorruptionException;
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
-import org.opensearch.action.admin.indices.segments.IndexShardSegments;
-import org.opensearch.action.admin.indices.segments.IndicesSegmentResponse;
-import org.opensearch.action.admin.indices.segments.IndicesSegmentsRequest;
-import org.opensearch.action.admin.indices.segments.ShardSegments;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.update.UpdateResponse;
@@ -22,7 +18,6 @@ import org.opensearch.client.Requests;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
-import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.routing.IndexRoutingTable;
 import org.opensearch.cluster.routing.IndexShardRoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
@@ -215,7 +210,7 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
      * <p>
      * TODO: Ignoring this test as its flaky and needs separate fix
      */
-//    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
     public void testAddNewReplicaFailure() throws Exception {
         logger.info("--> starting [Primary Node] ...");
         final String primaryNode = internalCluster().startNode();
@@ -223,9 +218,7 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
         logger.info("--> creating test index ...");
         prepareCreate(
             INDEX_NAME,
-            Settings.builder()
-                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
 
         ).get();
 
@@ -691,18 +684,17 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
         waitForSearchableDocs(docCount, Arrays.stream(nodes).collect(Collectors.toList()));
     }
 
-
     private void verifyStoreContent() throws Exception {
         assertBusy(() -> {
             final ClusterState clusterState = getClusterState();
-            for (IndexRoutingTable indexRoutingTable:  clusterState.routingTable()) {
-                for (IndexShardRoutingTable shardRoutingTable: indexRoutingTable) {
+            for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
+                for (IndexShardRoutingTable shardRoutingTable : indexRoutingTable) {
                     final ShardRouting primaryRouting = shardRoutingTable.primaryShard();
                     final String indexName = primaryRouting.getIndexName();
                     final List<ShardRouting> replicaRouting = shardRoutingTable.replicaShards();
                     final IndexShard primaryShard = getIndexShard(clusterState, primaryRouting, indexName);
                     final Map<String, StoreFileMetadata> primarySegmentMetadata = primaryShard.getSegmentMetadataMap();
-                    for(ShardRouting replica: replicaRouting) {
+                    for (ShardRouting replica : replicaRouting) {
                         IndexShard replicaShard = getIndexShard(clusterState, replica, indexName);
                         final Store.RecoveryDiff recoveryDiff = Store.segmentReplicationDiff(
                             primarySegmentMetadata,

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -15,6 +15,7 @@ import org.opensearch.action.admin.indices.segments.IndexShardSegments;
 import org.opensearch.action.admin.indices.segments.IndicesSegmentResponse;
 import org.opensearch.action.admin.indices.segments.IndicesSegmentsRequest;
 import org.opensearch.action.admin.indices.segments.ShardSegments;
+import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.client.Requests;
@@ -32,8 +33,9 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexService;
-import org.opensearch.index.engine.Segment;
 import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.store.Store;
+import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.recovery.FileChunkRequest;
 import org.opensearch.indices.replication.common.ReplicationType;
@@ -44,7 +46,6 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.transport.MockTransportService;
 import org.opensearch.transport.TransportService;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Arrays;
 import java.util.List;
@@ -53,9 +54,9 @@ import java.util.Set;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.equalTo;
 import static org.opensearch.index.query.QueryBuilders.matchQuery;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
@@ -71,7 +72,7 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(MockTransportService.TestPlugin.class);
+        return asList(MockTransportService.TestPlugin.class);
     }
 
     @Override
@@ -110,11 +111,9 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
             indexer.start(docCount);
             waitForDocs(docCount, indexer);
             refresh(INDEX_NAME);
-            waitForReplicaUpdate();
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
     public void testPrimaryStopped_ReplicaPromoted() throws Exception {
         final String primary = internalCluster().startNode();
         createIndex(INDEX_NAME);
@@ -125,9 +124,7 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
         client().prepareIndex(INDEX_NAME).setId("1").setSource("foo", "bar").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
         refresh(INDEX_NAME);
 
-        waitForReplicaUpdate();
-        assertHitCount(client(primary).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 1);
-        assertHitCount(client(replica).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 1);
+        waitForSearchableDocs(1, primary, replica);
 
         // index another doc but don't refresh, we will ensure this is searchable once replica is promoted.
         client().prepareIndex(INDEX_NAME).setId("2").setSource("bar", "baz").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
@@ -139,6 +136,7 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
         final ShardRouting replicaShardRouting = getShardRoutingForNodeName(replica);
         assertNotNull(replicaShardRouting);
         assertTrue(replicaShardRouting + " should be promoted as a primary", replicaShardRouting.primary());
+        refresh(INDEX_NAME);
         assertHitCount(client(replica).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 2);
 
         // assert we can index into the new primary.
@@ -150,13 +148,10 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
         ensureGreen(INDEX_NAME);
         client().prepareIndex(INDEX_NAME).setId("4").setSource("baz", "baz").get();
         refresh(INDEX_NAME);
-        waitForReplicaUpdate();
-        assertHitCount(client(nodeC).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 4);
-        assertHitCount(client(replica).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 4);
-        assertSegmentStats(REPLICA_COUNT);
+        waitForSearchableDocs(4, nodeC, replica);
+        assertIdenticalSegments(SHARD_COUNT, REPLICA_COUNT);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
     public void testRestartPrimary() throws Exception {
         final String primary = internalCluster().startNode();
         createIndex(INDEX_NAME);
@@ -170,8 +165,7 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
         client().prepareIndex(INDEX_NAME).setId("1").setSource("foo", "bar").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
         refresh(INDEX_NAME);
 
-        waitForReplicaUpdate();
-        assertDocCounts(initialDocCount, replica, primary);
+        waitForSearchableDocs(initialDocCount, replica, primary);
 
         internalCluster().restartNode(primary);
         ensureGreen(INDEX_NAME);
@@ -179,13 +173,10 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
         assertEquals(getNodeContainingPrimaryShard().getName(), replica);
 
         flushAndRefresh(INDEX_NAME);
-        waitForReplicaUpdate();
-
-        assertDocCounts(initialDocCount, replica, primary);
-        assertSegmentStats(REPLICA_COUNT);
+        waitForSearchableDocs(initialDocCount, replica, primary);
+        assertIdenticalSegments(SHARD_COUNT, REPLICA_COUNT);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
     public void testCancelPrimaryAllocation() throws Exception {
         // this test cancels allocation on the primary - promoting the new replica and recreating the former primary as a replica.
         final String primary = internalCluster().startNode();
@@ -199,8 +190,7 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
         client().prepareIndex(INDEX_NAME).setId("1").setSource("foo", "bar").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
         refresh(INDEX_NAME);
 
-        waitForReplicaUpdate();
-        assertDocCounts(initialDocCount, replica, primary);
+        waitForSearchableDocs(initialDocCount, replica, primary);
 
         final IndexShard indexShard = getIndexShard(primary);
         client().admin()
@@ -214,15 +204,13 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
         assertEquals(getNodeContainingPrimaryShard().getName(), replica);
 
         flushAndRefresh(INDEX_NAME);
-        waitForReplicaUpdate();
-
-        assertDocCounts(initialDocCount, replica, primary);
-        assertSegmentStats(REPLICA_COUNT);
+        waitForSearchableDocs(initialDocCount, replica, primary);
+        assertIdenticalSegments(SHARD_COUNT, REPLICA_COUNT);
     }
 
     /**
      * This test verfies that replica shard is not added to the cluster when doing a round of segment replication fails during peer recovery.
-     *
+     * <p>
      * TODO: Ignoring this test as its flaky and needs separate fix
      */
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
@@ -292,7 +280,6 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
         assertFalse(indicesService.hasIndex(resolveIndex(INDEX_NAME)));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
     public void testReplicationAfterPrimaryRefreshAndFlush() throws Exception {
         final String nodeA = internalCluster().startNode();
         final String nodeB = internalCluster().startNode();
@@ -314,10 +301,7 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
             indexer.start(initialDocCount);
             waitForDocs(initialDocCount, indexer);
             refresh(INDEX_NAME);
-            waitForReplicaUpdate();
-
-            assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
-            assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
+            waitForSearchableDocs(initialDocCount, nodeA, nodeB);
 
             final int additionalDocCount = scaledRandomIntBetween(0, 200);
             final int expectedHitCount = initialDocCount + additionalDocCount;
@@ -325,12 +309,10 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
             waitForDocs(expectedHitCount, indexer);
 
             flushAndRefresh(INDEX_NAME);
-            waitForReplicaUpdate();
-            assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount);
-            assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount);
+            waitForSearchableDocs(expectedHitCount, nodeA, nodeB);
 
             ensureGreen(INDEX_NAME);
-            assertSegmentStats(REPLICA_COUNT);
+            assertIdenticalSegments(SHARD_COUNT, REPLICA_COUNT);
         }
     }
 
@@ -355,12 +337,8 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
             indexer.start(initialDocCount);
             waitForDocs(initialDocCount, indexer);
             flush(INDEX_NAME);
-            waitForReplicaUpdate();
+            waitForSearchableDocs(initialDocCount, primary, replica);
         }
-
-        assertHitCount(client(primary).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
-        assertHitCount(client(replica).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
-
         logger.info("--> Closing the index ");
         client().admin().indices().prepareClose(INDEX_NAME).get();
 
@@ -368,8 +346,8 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
         client().admin().indices().prepareOpen(INDEX_NAME).get();
 
         ensureGreen(INDEX_NAME);
-        assertHitCount(client(primary).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
-        assertHitCount(client(replica).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
+        waitForSearchableDocs(initialDocCount, primary, replica);
+        assertIdenticalSegments(SHARD_COUNT, REPLICA_COUNT);
     }
 
     public void testMultipleShards() throws Exception {
@@ -400,10 +378,7 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
             indexer.start(initialDocCount);
             waitForDocs(initialDocCount, indexer);
             refresh(INDEX_NAME);
-            waitForReplicaUpdate();
-
-            assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
-            assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
+            waitForSearchableDocs(initialDocCount, nodeA, nodeB);
 
             final int additionalDocCount = scaledRandomIntBetween(0, 200);
             final int expectedHitCount = initialDocCount + additionalDocCount;
@@ -411,12 +386,10 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
             waitForDocs(expectedHitCount, indexer);
 
             flushAndRefresh(INDEX_NAME);
-            waitForReplicaUpdate();
-            assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount);
-            assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount);
+            waitForSearchableDocs(expectedHitCount, nodeA, nodeB);
 
             ensureGreen(INDEX_NAME);
-            assertSegmentStats(REPLICA_COUNT);
+            assertIdenticalSegments(3, REPLICA_COUNT);
         }
     }
 
@@ -444,24 +417,17 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
             waitForDocs(initialDocCount, indexer);
 
             flush(INDEX_NAME);
-            waitForReplicaUpdate();
-            // wait a short amount of time to give replication a chance to complete.
-            assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
-            assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
+            waitForSearchableDocs(initialDocCount, nodeA, nodeB);
 
             // Index a second set of docs so we can merge into one segment.
             indexer.start(additionalDocCount);
             waitForDocs(expectedHitCount, indexer);
+            waitForSearchableDocs(expectedHitCount, nodeA, nodeB);
 
             // Force a merge here so that the in memory SegmentInfos does not reference old segments on disk.
             client().admin().indices().prepareForceMerge(INDEX_NAME).setMaxNumSegments(1).setFlush(false).get();
             refresh(INDEX_NAME);
-            waitForReplicaUpdate();
-            assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount);
-            assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount);
-
-            ensureGreen(INDEX_NAME);
-            assertSegmentStats(REPLICA_COUNT);
+            assertIdenticalSegments(SHARD_COUNT, REPLICA_COUNT);
         }
     }
 
@@ -556,10 +522,10 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
 
         client().prepareIndex(INDEX_NAME).setId("3").setSource("foo", "bar").get();
         refresh(INDEX_NAME);
-        waitForReplicaUpdate();
+        waitForSearchableDocs(3, primaryNode, replicaNode);
         assertHitCount(client(primaryNode).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 3);
         assertHitCount(client(replicaNode).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), 3);
-        assertSegmentStats(REPLICA_COUNT);
+        assertIdenticalSegments(SHARD_COUNT, REPLICA_COUNT);
     }
 
     public void testDeleteOperations() throws Exception {
@@ -583,20 +549,13 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
             indexer.start(initialDocCount);
             waitForDocs(initialDocCount, indexer);
             refresh(INDEX_NAME);
-            waitForReplicaUpdate();
-
-            // wait a short amount of time to give replication a chance to complete.
-            assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
-            assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
+            waitForSearchableDocs(initialDocCount, nodeA, nodeB);
 
             final int additionalDocCount = scaledRandomIntBetween(0, 200);
             final int expectedHitCount = initialDocCount + additionalDocCount;
             indexer.start(additionalDocCount);
             waitForDocs(expectedHitCount, indexer);
-            waitForReplicaUpdate();
-
-            assertHitCount(client(nodeA).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount);
-            assertHitCount(client(nodeB).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount);
+            waitForSearchableDocs(expectedHitCount, nodeA, nodeB);
 
             ensureGreen(INDEX_NAME);
 
@@ -605,32 +564,18 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
             client(nodeA).prepareDelete(INDEX_NAME, id).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
             refresh(INDEX_NAME);
-            waitForReplicaUpdate();
-            assertBusy(() -> {
-                final long nodeA_Count = client(nodeA).prepareSearch(INDEX_NAME)
-                    .setSize(0)
-                    .setPreference("_only_local")
-                    .get()
-                    .getHits()
-                    .getTotalHits().value;
-                assertEquals(expectedHitCount - 1, nodeA_Count);
-                final long nodeB_Count = client(nodeB).prepareSearch(INDEX_NAME)
-                    .setSize(0)
-                    .setPreference("_only_local")
-                    .get()
-                    .getHits()
-                    .getTotalHits().value;
-                assertEquals(expectedHitCount - 1, nodeB_Count);
-            }, 5, TimeUnit.SECONDS);
+            waitForSearchableDocs(expectedHitCount - 1, nodeA, nodeB);
+            assertIdenticalSegments(SHARD_COUNT, REPLICA_COUNT);
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/5669")
     public void testUpdateOperations() throws Exception {
-        final String primary = internalCluster().startNode();
+        internalCluster().startClusterManagerOnlyNode();
+        final String primary = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME);
         ensureYellow(INDEX_NAME);
-        final String replica = internalCluster().startNode();
+        final String replica = internalCluster().startDataOnlyNode();
+        ensureGreen(INDEX_NAME);
 
         final int initialDocCount = scaledRandomIntBetween(0, 200);
         try (
@@ -647,20 +592,13 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
             indexer.start(initialDocCount);
             waitForDocs(initialDocCount, indexer);
             refresh(INDEX_NAME);
-            waitForReplicaUpdate();
-
-            // wait a short amount of time to give replication a chance to complete.
-            assertHitCount(client(primary).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
-            assertHitCount(client(replica).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), initialDocCount);
+            waitForSearchableDocs(initialDocCount, asList(primary, replica));
 
             final int additionalDocCount = scaledRandomIntBetween(0, 200);
             final int expectedHitCount = initialDocCount + additionalDocCount;
             indexer.start(additionalDocCount);
             waitForDocs(expectedHitCount, indexer);
-            waitForReplicaUpdate();
-
-            assertHitCount(client(primary).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount);
-            assertHitCount(client(replica).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get(), expectedHitCount);
+            waitForSearchableDocs(expectedHitCount, asList(primary, replica));
 
             Set<String> ids = indexer.getIds();
             String id = ids.toArray()[0].toString();
@@ -672,69 +610,80 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
             assertEquals(2, updateResponse.getVersion());
 
             refresh(INDEX_NAME);
-            waitForReplicaUpdate();
 
+            assertIdenticalSegments(SHARD_COUNT, REPLICA_COUNT);
             assertSearchHits(client(primary).prepareSearch(INDEX_NAME).setQuery(matchQuery("foo", "baz")).get(), id);
             assertSearchHits(client(replica).prepareSearch(INDEX_NAME).setQuery(matchQuery("foo", "baz")).get(), id);
-
         }
     }
 
-    private void assertSegmentStats(int numberOfReplicas) throws IOException {
-        final IndicesSegmentResponse indicesSegmentResponse = client().admin().indices().segments(new IndicesSegmentsRequest()).actionGet();
+    private void assertIdenticalSegments(int numberOfShards, int numberOfReplicas) throws Exception {
+        assertBusy(() -> {
+            final IndicesSegmentResponse indicesSegmentResponse = client().admin()
+                .indices()
+                .segments(new IndicesSegmentsRequest())
+                .actionGet();
+            List<ShardSegments[]> segmentsByIndex = getShardSegments(indicesSegmentResponse);
 
-        List<ShardSegments[]> segmentsByIndex = getShardSegments(indicesSegmentResponse);
-
-        // There will be an entry in the list for each index.
-        for (ShardSegments[] replicationGroupSegments : segmentsByIndex) {
-
-            // Separate Primary & replica shards ShardSegments.
-            final Map<Boolean, List<ShardSegments>> segmentListMap = segmentsByShardType(replicationGroupSegments);
-            final List<ShardSegments> primaryShardSegmentsList = segmentListMap.get(true);
-            final List<ShardSegments> replicaShardSegments = segmentListMap.get(false);
-
-            assertEquals("There should only be one primary in the replicationGroup", primaryShardSegmentsList.size(), 1);
-            final ShardSegments primaryShardSegments = primaryShardSegmentsList.stream().findFirst().get();
-            final Map<String, Segment> latestPrimarySegments = getLatestSegments(primaryShardSegments);
-
-            assertEquals(
-                "There should be a ShardSegment entry for each replica in the replicationGroup",
-                numberOfReplicas,
-                replicaShardSegments.size()
-            );
-
-            for (ShardSegments shardSegment : replicaShardSegments) {
-                final Map<String, Segment> latestReplicaSegments = getLatestSegments(shardSegment);
-                for (Segment replicaSegment : latestReplicaSegments.values()) {
-                    final Segment primarySegment = latestPrimarySegments.get(replicaSegment.getName());
-                    assertEquals(replicaSegment.getGeneration(), primarySegment.getGeneration());
-                    assertEquals(replicaSegment.getNumDocs(), primarySegment.getNumDocs());
-                    assertEquals(replicaSegment.getDeletedDocs(), primarySegment.getDeletedDocs());
-                    assertEquals(replicaSegment.getSize(), primarySegment.getSize());
+            // There will be an entry in the list for each index.
+            assertEquals("Expected a different number of shards in the index", numberOfShards, segmentsByIndex.size());
+            for (ShardSegments[] replicationGroupSegments : segmentsByIndex) {
+                // Separate Primary & replica shards ShardSegments.
+                final Map<Boolean, List<ShardSegments>> segmentListMap = segmentsByShardType(replicationGroupSegments);
+                final List<ShardSegments> primaryShardSegmentsList = segmentListMap.get(true);
+                final List<ShardSegments> replicaShardSegmentsList = segmentListMap.get(false);
+                assertEquals("There should only be one primary in the replicationGroup", 1, primaryShardSegmentsList.size());
+                assertEquals(
+                    "There should be a ShardSegment entry for each replica in the replicationGroup",
+                    numberOfReplicas,
+                    replicaShardSegmentsList.size()
+                );
+                final ShardSegments primaryShardSegments = primaryShardSegmentsList.stream().findFirst().get();
+                final IndexShard primaryShard = getIndexShard(primaryShardSegments);
+                final Map<String, StoreFileMetadata> primarySegmentMetadata = primaryShard.getSegmentMetadataMap();
+                for (ShardSegments replicaShardSegments : replicaShardSegmentsList) {
+                    final IndexShard replicaShard = getIndexShard(replicaShardSegments);
+                    final Store.RecoveryDiff recoveryDiff = Store.segmentReplicationDiff(
+                        primarySegmentMetadata,
+                        replicaShard.getSegmentMetadataMap()
+                    );
+                    if (recoveryDiff.missing.isEmpty() == false || recoveryDiff.different.isEmpty() == false) {
+                        fail(
+                            "Expected no missing or different segments between primary and replica but diff was missing: "
+                                + recoveryDiff.missing
+                                + " Different: "
+                                + recoveryDiff.different
+                                + " Primary Replication Checkpoint : "
+                                + primaryShard.getLatestReplicationCheckpoint()
+                                + " Replica Replication Checkpoint: "
+                                + replicaShard.getLatestReplicationCheckpoint()
+                        );
+                    }
+                    // calls to readCommit will fail if a valid commit point and all its segments are not in the store.
+                    replicaShard.store().readLastCommittedSegmentsInfo();
                 }
-
-                // Fetch the IndexShard for this replica and try and build its SegmentInfos from the previous commit point.
-                // This ensures the previous commit point is not wiped.
-                final ShardRouting replicaShardRouting = shardSegment.getShardRouting();
-                ClusterState state = client(internalCluster().getMasterName()).admin().cluster().prepareState().get().getState();
-                final DiscoveryNode replicaNode = state.nodes().resolveNode(replicaShardRouting.currentNodeId());
-                IndexShard indexShard = getIndexShard(replicaNode.getName());
-                // calls to readCommit will fail if a valid commit point and all its segments are not in the store.
-                indexShard.store().readLastCommittedSegmentsInfo();
             }
-        }
+        }, 1, TimeUnit.MINUTES);
+    }
+
+    private IndexShard getIndexShard(ShardSegments shardSegments) {
+        final ShardRouting replicaShardRouting = shardSegments.getShardRouting();
+        ClusterState state = client(internalCluster().getClusterManagerName()).admin().cluster().prepareState().get().getState();
+        final DiscoveryNode replicaNode = state.nodes().resolveNode(replicaShardRouting.currentNodeId());
+        return getIndexShard(replicaNode.getName());
     }
 
     public void testDropPrimaryDuringReplication() throws Exception {
+        int replica_count = 6;
         final Settings settings = Settings.builder()
             .put(indexSettings())
-            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 6)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, replica_count)
             .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
             .build();
         final String clusterManagerNode = internalCluster().startClusterManagerOnlyNode();
         final String primaryNode = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME, settings);
-        internalCluster().startDataOnlyNodes(6);
+        final List<String> dataNodes = internalCluster().startDataOnlyNodes(6);
         ensureGreen(INDEX_NAME);
 
         int initialDocCount = scaledRandomIntBetween(100, 200);
@@ -757,50 +706,39 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
             ensureYellow(INDEX_NAME);
 
             // start another replica.
-            internalCluster().startDataOnlyNode();
+            dataNodes.add(internalCluster().startDataOnlyNode());
             ensureGreen(INDEX_NAME);
 
             // index another doc and refresh - without this the new replica won't catch up.
-            client().prepareIndex(INDEX_NAME).setId("1").setSource("foo", "bar").get();
+            String docId = String.valueOf(initialDocCount + 1);
+            client().prepareIndex(INDEX_NAME).setId(docId).setSource("foo", "bar").get();
 
             flushAndRefresh(INDEX_NAME);
-            waitForReplicaUpdate();
-            assertSegmentStats(6);
+            waitForSearchableDocs(initialDocCount + 1, dataNodes);
+            assertIdenticalSegments(SHARD_COUNT, replica_count);
         }
     }
 
     /**
-     * Waits until the replica is caught up to the latest primary segments gen.
-     * @throws Exception if assertion fails
+     * Waits until all given nodes have at least the expected docCount.
+     *
+     * @param docCount - Expected Doc count.
+     * @param nodes    - List of node names.
      */
-    private void waitForReplicaUpdate() throws Exception {
+    private void waitForSearchableDocs(long docCount, List<String> nodes) throws Exception {
         // wait until the replica has the latest segment generation.
         assertBusy(() -> {
-            final IndicesSegmentResponse indicesSegmentResponse = client().admin()
-                .indices()
-                .segments(new IndicesSegmentsRequest())
-                .actionGet();
-            List<ShardSegments[]> segmentsByIndex = getShardSegments(indicesSegmentResponse);
-            for (ShardSegments[] replicationGroupSegments : segmentsByIndex) {
-                final Map<Boolean, List<ShardSegments>> segmentListMap = segmentsByShardType(replicationGroupSegments);
-                final List<ShardSegments> primaryShardSegmentsList = segmentListMap.get(true);
-                final List<ShardSegments> replicaShardSegments = segmentListMap.get(false);
-                // if we don't have any segments yet, proceed.
-                final ShardSegments primaryShardSegments = primaryShardSegmentsList.stream().findFirst().get();
-                logger.debug("Primary Segments: {}", primaryShardSegments.getSegments());
-                if (primaryShardSegments.getSegments().isEmpty() == false && replicaShardSegments != null) {
-                    final Map<String, Segment> latestPrimarySegments = getLatestSegments(primaryShardSegments);
-                    final Long latestPrimaryGen = latestPrimarySegments.values().stream().findFirst().map(Segment::getGeneration).get();
-                    for (ShardSegments shardSegments : replicaShardSegments) {
-                        logger.debug("Replica {} Segments: {}", shardSegments.getShardRouting(), shardSegments.getSegments());
-                        final boolean isReplicaCaughtUpToPrimary = shardSegments.getSegments()
-                            .stream()
-                            .anyMatch(segment -> segment.getGeneration() == latestPrimaryGen);
-                        assertTrue(isReplicaCaughtUpToPrimary);
-                    }
+            for (String node : nodes) {
+                final SearchResponse response = client(node).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get();
+                if (response.getHits().getTotalHits().value < docCount) {
+                    fail("Expected search hits on node: " + node + " to be at least " + docCount);
                 }
             }
-        });
+        }, 1, TimeUnit.MINUTES);
+    }
+
+    private void waitForSearchableDocs(long docCount, String... nodes) throws Exception {
+        waitForSearchableDocs(docCount, Arrays.stream(nodes).collect(Collectors.toList()));
     }
 
     private IndexShard getIndexShard(String node) {
@@ -818,15 +756,6 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
             .flatMap(is -> is.getShards().values().stream()) // Map to shard replication group
             .map(IndexShardSegments::getShards) // get list of segments across replication group
             .collect(Collectors.toList());
-    }
-
-    private Map<String, Segment> getLatestSegments(ShardSegments segments) {
-        final Optional<Long> generation = segments.getSegments().stream().map(Segment::getGeneration).max(Long::compare);
-        final Long latestPrimaryGen = generation.get();
-        return segments.getSegments()
-            .stream()
-            .filter(s -> s.getGeneration() == latestPrimaryGen)
-            .collect(Collectors.toMap(Segment::getName, Function.identity()));
     }
 
     private Map<Boolean, List<ShardSegments>> segmentsByShardType(ShardSegments[] replicationGroupSegments) {

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -730,8 +730,9 @@ public class SegmentReplicationIT extends OpenSearchIntegTestCase {
         assertBusy(() -> {
             for (String node : nodes) {
                 final SearchResponse response = client(node).prepareSearch(INDEX_NAME).setSize(0).setPreference("_only_local").get();
-                if (response.getHits().getTotalHits().value < docCount) {
-                    fail("Expected search hits on node: " + node + " to be at least " + docCount);
+                final long hits = response.getHits().getTotalHits().value;
+                if (hits < docCount) {
+                    fail("Expected search hits on node: " + node + " to be at least " + docCount + " but was: " + hits);
                 }
             }
         }, 1, TimeUnit.MINUTES);

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1581,6 +1581,19 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     /**
+     * Fetch a map of StoreFileMetadata for each segment from the latest SegmentInfos.
+     * This is used to compute diffs for segment replication.
+     *
+     * @return - Map of Segment Filename to its {@link StoreFileMetadata}
+     * @throws IOException - When there is an error loading metadata from the store.
+     */
+    public Map<String, StoreFileMetadata> getSegmentMetadataMap() throws IOException {
+        try (final GatedCloseable<SegmentInfos> snapshot = getSegmentInfosSnapshot()) {
+            return store.getSegmentMetadataMap(snapshot.get());
+        }
+    }
+
+    /**
      * Fails the shard and marks the shard store as corrupted if
      * <code>e</code> is caused by index corruption
      */

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
@@ -22,7 +22,6 @@ import org.opensearch.action.ActionListener;
 import org.opensearch.action.StepListener;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.bytes.BytesReference;
-import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.common.util.CancellableThreads;
 import org.opensearch.index.shard.IndexShard;
@@ -38,8 +37,6 @@ import org.opensearch.indices.replication.common.ReplicationTarget;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Map;
 
 /**
  * Represents the target of a replication event.
@@ -173,8 +170,8 @@ public class SegmentReplicationTarget extends ReplicationTarget {
         throws IOException {
         cancellableThreads.checkForCancel();
         state.setStage(SegmentReplicationState.Stage.FILE_DIFF);
-        final Store.RecoveryDiff diff = Store.segmentReplicationDiff(checkpointInfo.getMetadataMap(), getMetadataMap());
-        logger.trace("Replication diff {}", diff);
+        final Store.RecoveryDiff diff = Store.segmentReplicationDiff(checkpointInfo.getMetadataMap(), indexShard.getSegmentMetadataMap());
+        logger.trace("Replication diff for checkpoint {} {}", checkpointInfo.getCheckpoint(), diff);
         /*
          * Segments are immutable. So if the replica has any segments with the same name that differ from the one in the incoming
          * snapshot from source that means the local copy of the segment has been corrupted/changed in some way and we throw an
@@ -262,15 +259,6 @@ public class SegmentReplicationTarget extends ReplicationTarget {
         return new BufferedChecksumIndexInput(
             new ByteBuffersIndexInput(new ByteBuffersDataInput(Arrays.asList(ByteBuffer.wrap(input))), "SegmentInfos")
         );
-    }
-
-    Map<String, StoreFileMetadata> getMetadataMap() throws IOException {
-        if (indexShard.getSegmentInfosSnapshot() == null) {
-            return Collections.emptyMap();
-        }
-        try (final GatedCloseable<SegmentInfos> snapshot = indexShard.getSegmentInfosSnapshot()) {
-            return store.getSegmentMetadataMap(snapshot.get());
-        }
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetTests.java
@@ -363,8 +363,8 @@ public class SegmentReplicationTargetTests extends IndexShardTestCase {
         SegmentReplicationTargetService.SegmentReplicationListener segRepListener = mock(
             SegmentReplicationTargetService.SegmentReplicationListener.class
         );
-        segrepTarget = spy(new SegmentReplicationTarget(repCheckpoint, indexShard, segrepSource, segRepListener));
-        when(segrepTarget.getMetadataMap()).thenReturn(SI_SNAPSHOT_DIFFERENT);
+        segrepTarget = new SegmentReplicationTarget(repCheckpoint, spyIndexShard, segrepSource, segRepListener);
+        when(spyIndexShard.getSegmentMetadataMap()).thenReturn(SI_SNAPSHOT_DIFFERENT);
         segrepTarget.startReplication(new ActionListener<Void>() {
             @Override
             public void onResponse(Void replicationResponse) {
@@ -415,8 +415,8 @@ public class SegmentReplicationTargetTests extends IndexShardTestCase {
             SegmentReplicationTargetService.SegmentReplicationListener.class
         );
 
-        segrepTarget = spy(new SegmentReplicationTarget(repCheckpoint, indexShard, segrepSource, segRepListener));
-        when(segrepTarget.getMetadataMap()).thenReturn(storeMetadataSnapshots.get(0).asMap());
+        segrepTarget = new SegmentReplicationTarget(repCheckpoint, spyIndexShard, segrepSource, segRepListener);
+        when(spyIndexShard.getSegmentMetadataMap()).thenReturn(storeMetadataSnapshots.get(0).asMap());
         segrepTarget.startReplication(new ActionListener<Void>() {
             @Override
             public void onResponse(Void replicationResponse) {


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change fixes flakiness with segment replication ITs. It does this by updating the wait condition used to ensure replicas are up to date to wait until a searched docCount is reached instead of output of the Segments API that can change if there are concurrent refreshes.
It also does this by updating the method used to assert segment stats to wait until the assertion holds true rather than at a point in time.  This method is also updated to assert store metadata directly over API output.  In doing so I've moved the method used to compute store metadata on top of IndexShard.

I've run this about ~1k times on the file locally and not seeing any issues, will open this and run a few times to test from CI.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/5669 - note not all tests in this issue will be resolved with this change, only those with doc count mismatches, particularly testReplicationAfterPrimaryRefreshAndFlush.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
