### PR TITLE
[Segment Replication] Introduce primary weight factor for primary shards distribution

### DIFF
--- a/libs/common/src/main/java/org/opensearch/common/collect/Triplet.java
+++ b/libs/common/src/main/java/org/opensearch/common/collect/Triplet.java
@@ -9,6 +9,11 @@ package org.opensearch.common.collect;
 
 import java.util.Objects;
 
+/**
+ * A container for 3 elements, similar to {@link org.opensearch.common.collect.Tuple}
+ *
+ * @opensearch.internal
+ */
 public class Triplet<V1, V2, V3> {
 
     public static <V1, V2, V3> Triplet<V1, V2, V3> tuple(V1 v1, V2 v2, V3 v3) {

--- a/libs/common/src/main/java/org/opensearch/common/collect/Triplet.java
+++ b/libs/common/src/main/java/org/opensearch/common/collect/Triplet.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.common.collect;
+
+import java.util.Objects;
+
+public class Triplet<V1, V2, V3> {
+
+    public static <V1, V2, V3> Triplet<V1, V2, V3> tuple(V1 v1, V2 v2, V3 v3) {
+        return new Triplet<>(v1, v2, v3);
+    }
+
+    private final V1 v1;
+    private final V2 v2;
+
+    private final V3 v3;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Triplet<?, ?, ?> triplet = (Triplet<?, ?, ?>) o;
+        return Objects.equals(v1, triplet.v1) && Objects.equals(v2, triplet.v2) && Objects.equals(v3, triplet.v3);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(v1, v2, v3);
+    }
+
+    public Triplet(V1 v1, V2 v2, V3 v3) {
+        this.v1 = v1;
+        this.v2 = v2;
+        this.v3 = v3;
+    }
+
+    public V1 v1() {
+        return v1;
+    }
+
+    public V2 v2() {
+        return v2;
+    }
+
+    public V3 v3() {
+        return v3;
+    }
+
+    @Override
+    public String toString() {
+        return "Tuple [v1=" + v1 + ", v2=" + v2 + ", v3=" + v3 + "]";
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
@@ -36,9 +36,9 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationBaseIT {
 
     private void createIndex(String idxName, int shardCount, int replicaCount, boolean isSegRep) {
         Settings.Builder builder = Settings.builder()
-            .put("index.number_of_shards", shardCount)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, shardCount)
             .put(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.getKey(), false)
-            .put("index.number_of_replicas", replicaCount);
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, REPLICA_COUNT);
         if (isSegRep) {
             builder = builder.put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT);
         } else {
@@ -80,12 +80,10 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationBaseIT {
             replicaCount = randomIntBetween(0, maxReplicaCount);
             totalReplicaCount += replicaCount;
             createIndex("test" + i, shardCount, replicaCount, i % 2 == 0);
-            logger.info("--> Creating index {} with primary shards {} and replica {}", "test" + i, shardCount, replicaCount);
+            logger.info("--> Creating index {} with shard count {} and replica count {}", "test" + i, shardCount, replicaCount);
             assertBusy(() -> ensureGreen(), 60, TimeUnit.SECONDS);
-            if (logger.isTraceEnabled()) {
-                state = client().admin().cluster().prepareState().execute().actionGet().getState();
-                shardAllocations.printShardDistribution(state);
-            }
+            state = client().admin().cluster().prepareState().execute().actionGet().getState();
+            shardAllocations.printShardDistribution(state);
         }
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
         RoutingNodes nodes = state.getRoutingNodes();
@@ -163,9 +161,7 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationBaseIT {
         avgNumShards = (float) (totalShardCount) / (float) (state.getRoutingNodes().size());
         minAvgNumberOfShards = Math.round(Math.round(Math.floor(avgNumShards - 1.0f)));
         maxAvgNumberOfShards = Math.round(Math.round(Math.ceil(avgNumShards + 1.0f)));
-        if (logger.isTraceEnabled()) {
-            shardAllocations.printShardDistribution(state);
-        }
+        shardAllocations.printShardDistribution(state);
         for (RoutingNode node : state.getRoutingNodes()) {
             assertTrue(node.primaryShardsWithState(STARTED).size() >= minAvgNumberOfShards);
             assertTrue(node.primaryShardsWithState(STARTED).size() <= maxAvgNumberOfShards);
@@ -181,9 +177,8 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationBaseIT {
         avgNumShards = (float) (totalShardCount) / (float) (state.getRoutingNodes().size());
         minAvgNumberOfShards = Math.round(Math.round(Math.floor(avgNumShards - 1.0f)));
         maxAvgNumberOfShards = Math.round(Math.round(Math.ceil(avgNumShards + 1.0f)));
-        if (logger.isTraceEnabled()) {
-            shardAllocations.printShardDistribution(state);
-        }
+        shardAllocations.printShardDistribution(state);
+
         for (RoutingNode node : state.getRoutingNodes()) {
             assertTrue(node.primaryShardsWithState(STARTED).size() >= minAvgNumberOfShards);
             assertTrue(node.primaryShardsWithState(STARTED).size() <= maxAvgNumberOfShards);

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
@@ -46,7 +46,9 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationIT {
             client().admin()
                 .cluster()
                 .prepareUpdateSettings()
-                .setPersistentSettings(Settings.builder().put(BalancedShardsAllocator.PRIMARY_BALANCE_FACTOR_SETTING.getKey(), "1.0f"))
+                .setPersistentSettings(
+                    Settings.builder().put(BalancedShardsAllocator.PRIMARY_SHARD_BALANCE_FACTOR_SETTING.getKey(), "1.0f")
+                )
         );
 
         int shardCount, replicaCount, totalShardCount = 0, totalReplicaCount = 0;
@@ -94,7 +96,7 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationIT {
                 .prepareUpdateSettings()
                 .setPersistentSettings(
                     Settings.builder()
-                        .put(BalancedShardsAllocator.PRIMARY_BALANCE_FACTOR_SETTING.getKey(), "1.0f")
+                        .put(BalancedShardsAllocator.PRIMARY_SHARD_BALANCE_FACTOR_SETTING.getKey(), "1.0f")
                         .put(BalancedShardsAllocator.INDEX_BALANCE_FACTOR_SETTING.getKey(), "0.0f")
                         .put(BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING.getKey(), "0.0f")
                         .build()

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
@@ -1,0 +1,192 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication;
+
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.routing.RoutingNode;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
+import org.opensearch.indices.replication.common.ReplicationType;
+
+import java.util.Formatter;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class SegmentReplicationAllocationIT extends SegmentReplicationIT {
+
+    /**
+     * This test verifies shard allocation when segment replication is enabled. The test verifies that primary shard
+     * distribution is even.
+     */
+    public void testShardAllocation() {
+        // Start 3 node cluster
+        internalCluster().startNodes(3, featureFlagSettings());
+        client().admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(Settings.builder().put(BalancedShardsAllocator.PRIMARY_BALANCE_FACTOR_SETTING.getKey(), 0.40f).build())
+            .get();
+        int numberOfIndices = 10;
+        ShardAllocations shardAllocations = new ShardAllocations();
+        ClusterState state;
+        for (int i = 0; i < numberOfIndices; i++) {
+            int shardCount = 5;// randomIntBetween(1, 5);
+            int replicaCount = 1;// randomIntBetween(0, 2);
+            createIndex("test" + i, shardCount, replicaCount, i % 2 == 0);
+            ensureGreen();
+            state = client().admin().cluster().prepareState().execute().actionGet().getState();
+            shardAllocations.setState(state);
+            if (logger.isTraceEnabled()) {
+                logger.info("{}", shardAllocations.toString());
+            }
+        }
+        // Wait for all shards to be STARTED and evaluate final allocation.
+        ensureGreen();
+        state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        shardAllocations.setState(state);
+        logger.info("{}", shardAllocations.toString());
+    }
+
+    /**
+     * ===================================================
+     * NODE_T0              TOTAL                DOCREP               SEGREP
+     * P                    20                   10                   10
+     * R                    13                   6                    7
+     * NODE_T1              TOTAL                DOCREP               SEGREP
+     * P                    10                   5                    5
+     * R                    24                   12                   12
+     * NODE_T2              TOTAL                DOCREP               SEGREP
+     * P                    20                   10                   10
+     * R                    13                   7                    6
+     *
+     * Unassigned           0                    0
+     *
+     * Total Shards         50                   50
+     */
+
+    class ShardAllocations {
+        ClusterState state;
+
+        public static final String separator = "===================================================";
+        public static final String ONE_LINE_RETURN = "\n";
+        public static final String TWO_LINE_RETURN = "\n\n";
+
+        /**
+         Use treemap so that each iteration shows same ordering of nodes.
+         String: NodeId
+         int[]: tuple storing primary shard count in 0 index and replica's in 1 for segrep enabled indices
+         */
+        TreeMap<String, int[]> nodeToSegRepCountMap = new TreeMap<>();
+
+        TreeMap<String, int[]> nodeToDocRepCountMap = new TreeMap<>();
+
+        /**
+         * Helper map containing NodeName to Node Id
+         */
+        TreeMap<String, String> nameToNodeId = new TreeMap<>();
+
+        /*
+        Unassigned array containing primary at 0, replica at 1
+         */
+        int[] unassigned;
+
+        int[] totalShards;
+
+        public final String printShardAllocationWithHeader(String nodeName, int[] docrep, int[] segrep) {
+            StringBuffer sb = new StringBuffer();
+            Formatter formatter = new Formatter(sb);
+            // formatter.format("%-10s\n", nodeName);
+            formatter.format("%-20s %-20s %-20s %-20s\n", "P", docrep[0] + segrep[0], docrep[0], segrep[0]);
+            formatter.format("%-20s %-20s %-20s %-20s\n", "R", docrep[1] + segrep[1], docrep[1], segrep[1]);
+            // formatter.format("%-19s %-20s %-20s\n", "", "---", "---");
+            // formatter.format("%-20s %-20s %-20s\n", "", docrep[0] + docrep[1], segrep[1] + segrep[0]);
+            return sb.toString();
+        }
+
+        public void reset() {
+            nodeToSegRepCountMap.clear();
+            nodeToDocRepCountMap.clear();
+            nameToNodeId = new TreeMap<>();
+            totalShards = new int[] { 0, 0 };
+            unassigned = new int[] { 0, 0 };
+        }
+
+        public void setState(ClusterState state) {
+            this.reset();
+            this.state = state;
+            buildMap();
+        }
+
+        private void buildMap() {
+            for (RoutingNode node : state.getRoutingNodes()) {
+                nameToNodeId.putIfAbsent(node.node().getName(), node.nodeId());
+                nodeToSegRepCountMap.putIfAbsent(node.nodeId(), new int[] { 0, 0 });
+                nodeToDocRepCountMap.putIfAbsent(node.nodeId(), new int[] { 0, 0 });
+            }
+            for (ShardRouting shardRouting : state.routingTable().allShards()) {
+                // Fetch shard to update. Initialize local array
+                if (isIndexSegRep(shardRouting.getIndexName())) {
+                    updateMap(nodeToSegRepCountMap, shardRouting);
+                } else {
+                    updateMap(nodeToDocRepCountMap, shardRouting);
+                }
+            }
+        }
+
+        void updateMap(TreeMap<String, int[]> mapToUpdate, ShardRouting shardRouting) {
+            int[] shard;
+            shard = shardRouting.assignedToNode() ? mapToUpdate.get(shardRouting.currentNodeId()) : unassigned;
+            // Update shard type count
+            if (shardRouting.primary()) {
+                shard[0]++;
+                totalShards[0]++;
+            } else {
+                shard[1]++;
+                totalShards[1]++;
+            }
+            // For assigned shards, put back counter
+            if (shardRouting.assignedToNode()) mapToUpdate.put(shardRouting.currentNodeId(), shard);
+        }
+
+        boolean isIndexSegRep(String indexName) {
+            return state.metadata()
+                .index(indexName)
+                .getSettings()
+                .get(IndexMetadata.INDEX_REPLICATION_TYPE_SETTING.getKey())
+                .equals(ReplicationType.SEGMENT.toString());
+        }
+
+        @Override
+        public String toString() {
+            StringBuffer sb = new StringBuffer();
+            sb.append(TWO_LINE_RETURN + separator + ONE_LINE_RETURN);
+            Formatter formatter = new Formatter(sb);
+            // formatter.format("%-20s %-20s %-20s\n", "", "DOCREP", "SEGREP");
+            for (Map.Entry<String, String> entry : nameToNodeId.entrySet()) {
+                String nodeId = nameToNodeId.get(entry.getKey());
+                formatter.format("%-20s %-20s %-20s %-20s\n", entry.getKey().toUpperCase(), "TOTAL", "DOCREP", "SEGREP");
+                sb.append(
+                    printShardAllocationWithHeader(
+                        entry.getKey().toUpperCase(),
+                        nodeToDocRepCountMap.get(nodeId),
+                        nodeToSegRepCountMap.get(nodeId)
+                    )
+                );
+            }
+            sb.append(ONE_LINE_RETURN);
+            formatter.format("%-20s %-20s %-20s\n\n", "Unassigned ", unassigned[0], unassigned[1]);
+            formatter.format("%-20s %-20s %-20s\n\n", "Total Shards", totalShards[0], totalShards[1]);
+            return sb.toString();
+        }
+    }
+
+}

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
@@ -11,69 +11,161 @@ package org.opensearch.indices.replication;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.RoutingNode;
+import org.opensearch.cluster.routing.RoutingNodes;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.test.InternalTestCluster;
 
+import java.util.ArrayList;
 import java.util.Formatter;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.opensearch.cluster.routing.ShardRoutingState.STARTED;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 
 public class SegmentReplicationAllocationIT extends SegmentReplicationIT {
 
     /**
-     * This test verifies shard allocation when segment replication is enabled. The test verifies that primary shard
-     * distribution is even.
+     * This test verifies primary shard allocation is balanced.
      */
-    public void testShardAllocation() {
-        // Start 3 node cluster
-        internalCluster().startNodes(3, featureFlagSettings());
-        client().admin()
-            .cluster()
-            .prepareUpdateSettings()
-            .setTransientSettings(Settings.builder().put(BalancedShardsAllocator.PRIMARY_BALANCE_FACTOR_SETTING.getKey(), 0.40f).build())
-            .get();
-        int numberOfIndices = 10;
+    public void testShardAllocation() throws Exception {
+        final int nodeCount = randomIntBetween(1, 20);
+        final int numberOfIndices = randomIntBetween(5, 20);
+
+        final List<String> nodeNames = new ArrayList<>();
+        for (int i = 0; i < nodeCount; i++) {
+            nodeNames.add(internalCluster().startNode());
+        }
+        assertAcked(
+            client().admin()
+                .cluster()
+                .prepareUpdateSettings()
+                .setPersistentSettings(Settings.builder().put(BalancedShardsAllocator.PRIMARY_BALANCE_FACTOR_SETTING.getKey(), "1.0f"))
+        );
+
+        int shardCount, replicaCount, totalShardCount = 0, totalReplicaCount = 0;
         ShardAllocations shardAllocations = new ShardAllocations();
         ClusterState state;
         for (int i = 0; i < numberOfIndices; i++) {
-            int shardCount = 5;// randomIntBetween(1, 5);
-            int replicaCount = 1;// randomIntBetween(0, 2);
+            shardCount = randomIntBetween(1, 5);
+            totalShardCount += shardCount;
+            replicaCount = randomIntBetween(0, 2);
+            totalReplicaCount += replicaCount;
             createIndex("test" + i, shardCount, replicaCount, i % 2 == 0);
-            ensureGreen();
-            state = client().admin().cluster().prepareState().execute().actionGet().getState();
-            shardAllocations.setState(state);
+            assertBusy(() -> ensureGreen(), 60, TimeUnit.SECONDS);
             if (logger.isTraceEnabled()) {
-                logger.info("{}", shardAllocations.toString());
+                state = client().admin().cluster().prepareState().execute().actionGet().getState();
+                shardAllocations.printShardDistribution(state);
             }
         }
-        // Wait for all shards to be STARTED and evaluate final allocation.
-        ensureGreen();
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
-        shardAllocations.setState(state);
-        logger.info("{}", shardAllocations.toString());
+        RoutingNodes nodes = state.getRoutingNodes();
+        final float avgNumShards = (float) (totalShardCount) / (float) (nodes.size());
+        final int minAvgNumberOfShards = Math.round(Math.round(Math.floor(avgNumShards - 1.0f)));
+        final int maxAvgNumberOfShards = Math.round(Math.round(Math.ceil(avgNumShards + 1.0f)));
+
+        for (RoutingNode node : nodes) {
+            assertTrue(node.primaryShardsWithState(STARTED).size() >= minAvgNumberOfShards);
+            assertTrue(node.primaryShardsWithState(STARTED).size() <= maxAvgNumberOfShards);
+        }
     }
 
     /**
-     * ===================================================
-     * NODE_T0              TOTAL                DOCREP               SEGREP
-     * P                    20                   10                   10
-     * R                    13                   6                    7
-     * NODE_T1              TOTAL                DOCREP               SEGREP
-     * P                    10                   5                    5
-     * R                    24                   12                   12
-     * NODE_T2              TOTAL                DOCREP               SEGREP
-     * P                    20                   10                   10
-     * R                    13                   7                    6
-     *
-     * Unassigned           0                    0
-     *
-     * Total Shards         50                   50
+     * This test verifies shard allocation with changes to cluster config i.e. node add, removal keeps the primary shard
+     * allocation balanced.
      */
+    public void testAllocationWithDisruption() throws Exception {
+        final int nodeCount = randomIntBetween(1, 5);
+        final int numberOfIndices = randomIntBetween(1, 10);
 
-    class ShardAllocations {
+        final List<String> nodeNames = new ArrayList<>();
+        for (int i = 0; i < nodeCount; i++) {
+            nodeNames.add(internalCluster().startNode());
+        }
+        assertAcked(
+            client().admin()
+                .cluster()
+                .prepareUpdateSettings()
+                .setPersistentSettings(
+                    Settings.builder()
+                        .put(BalancedShardsAllocator.PRIMARY_BALANCE_FACTOR_SETTING.getKey(), "1.0f")
+                        .put(BalancedShardsAllocator.INDEX_BALANCE_FACTOR_SETTING.getKey(), "0.0f")
+                        .put(BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING.getKey(), "0.0f")
+                        .build()
+                )
+        );
+
+        int shardCount, replicaCount, totalShardCount = 0, totalReplicaCount = 0;
+        ShardAllocations shardAllocations = new ShardAllocations();
+        ClusterState state;
+        for (int i = 0; i < numberOfIndices; i++) {
+            logger.info("--> Creating {} index", i);
+            shardCount = randomIntBetween(1, 5);
+            totalShardCount += shardCount;
+            replicaCount = randomIntBetween(1, 2);
+            totalReplicaCount += replicaCount;
+            createIndex("test" + i, shardCount, replicaCount, i % 2 == 0);
+            assertBusy(() -> ensureGreen(), 120, TimeUnit.SECONDS);
+            if (logger.isTraceEnabled()) {
+                state = client().admin().cluster().prepareState().execute().actionGet().getState();
+                shardAllocations.printShardDistribution(state);
+            }
+        }
+        state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        float avgNumShards = (float) (totalShardCount) / (float) (state.getRoutingNodes().size());
+        int minAvgNumberOfShards = Math.round(Math.round(Math.floor(avgNumShards - 1.0f)));
+        int maxAvgNumberOfShards = Math.round(Math.round(Math.ceil(avgNumShards + 1.0f)));
+
+        for (RoutingNode node : state.getRoutingNodes()) {
+            assertTrue(node.primaryShardsWithState(STARTED).size() >= minAvgNumberOfShards);
+            assertTrue(node.primaryShardsWithState(STARTED).size() <= maxAvgNumberOfShards);
+        }
+
+        logger.info("--> Add nodes");
+        final int additionalNodeCount = randomIntBetween(1, 5);
+        internalCluster().startNodes(additionalNodeCount);
+        assertBusy(() -> ensureGreen(), 60, TimeUnit.SECONDS);
+        state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        avgNumShards = (float) (totalShardCount) / (float) (state.getRoutingNodes().size());
+        minAvgNumberOfShards = Math.round(Math.round(Math.floor(avgNumShards - 1.0f)));
+        maxAvgNumberOfShards = Math.round(Math.round(Math.ceil(avgNumShards + 1.0f)));
+        if (logger.isTraceEnabled()) {
+            shardAllocations.printShardDistribution(state);
+        }
+        for (RoutingNode node : state.getRoutingNodes()) {
+            assertTrue(node.primaryShardsWithState(STARTED).size() >= minAvgNumberOfShards);
+            assertTrue(node.primaryShardsWithState(STARTED).size() <= maxAvgNumberOfShards);
+        }
+
+        logger.info("--> Stop one third nodes");
+        for (int i = 1; i < nodeCount; i += 3) {
+            internalCluster().stopRandomNode(InternalTestCluster.nameFilter(nodeNames.get(i)));
+        }
+        assertBusy(() -> ensureGreen(), 60, TimeUnit.SECONDS);
+        state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        avgNumShards = (float) (totalShardCount) / (float) (state.getRoutingNodes().size());
+        minAvgNumberOfShards = Math.round(Math.round(Math.floor(avgNumShards - 1.0f)));
+        maxAvgNumberOfShards = Math.round(Math.round(Math.ceil(avgNumShards + 1.0f)));
+        if (logger.isTraceEnabled()) {
+            shardAllocations.printShardDistribution(state);
+        }
+        for (RoutingNode node : state.getRoutingNodes()) {
+            assertTrue(node.primaryShardsWithState(STARTED).size() >= minAvgNumberOfShards);
+            assertTrue(node.primaryShardsWithState(STARTED).size() <= maxAvgNumberOfShards);
+        }
+    }
+
+    /**
+     * This class is created for debugging purpose to show shard allocation across nodes. It keeps cluster state which
+     * is used to build the node's shard allocation
+     */
+    private class ShardAllocations {
         ClusterState state;
 
         public static final String separator = "===================================================";
@@ -81,43 +173,44 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationIT {
         public static final String TWO_LINE_RETURN = "\n\n";
 
         /**
-         Use treemap so that each iteration shows same ordering of nodes.
+         Store shard primary/replica shard count against a node for segrep indices.
          String: NodeId
-         int[]: tuple storing primary shard count in 0 index and replica's in 1 for segrep enabled indices
+         int[]: tuple storing primary shard count in 0th index and replica's in 1
          */
         TreeMap<String, int[]> nodeToSegRepCountMap = new TreeMap<>();
-
+        /**
+         Store shard primary/replica shard count against a node for docrep indices.
+         String: NodeId
+         int[]: tuple storing primary shard count in 0th index and replica's in 1
+         */
         TreeMap<String, int[]> nodeToDocRepCountMap = new TreeMap<>();
 
         /**
-         * Helper map containing NodeName to Node Id
+         * Helper map containing NodeName to NodeId
          */
         TreeMap<String, String> nameToNodeId = new TreeMap<>();
 
         /*
         Unassigned array containing primary at 0, replica at 1
          */
-        int[] unassigned;
+        int[] unassigned = new int[2];
 
-        int[] totalShards;
+        int[] totalShards = new int[2];
 
-        public final String printShardAllocationWithHeader(String nodeName, int[] docrep, int[] segrep) {
+        public final String printShardAllocationWithHeader(int[] docrep, int[] segrep) {
             StringBuffer sb = new StringBuffer();
-            Formatter formatter = new Formatter(sb);
-            // formatter.format("%-10s\n", nodeName);
+            Formatter formatter = new Formatter(sb, Locale.getDefault());
             formatter.format("%-20s %-20s %-20s %-20s\n", "P", docrep[0] + segrep[0], docrep[0], segrep[0]);
             formatter.format("%-20s %-20s %-20s %-20s\n", "R", docrep[1] + segrep[1], docrep[1], segrep[1]);
-            // formatter.format("%-19s %-20s %-20s\n", "", "---", "---");
-            // formatter.format("%-20s %-20s %-20s\n", "", docrep[0] + docrep[1], segrep[1] + segrep[0]);
             return sb.toString();
         }
 
         public void reset() {
             nodeToSegRepCountMap.clear();
             nodeToDocRepCountMap.clear();
-            nameToNodeId = new TreeMap<>();
-            totalShards = new int[] { 0, 0 };
-            unassigned = new int[] { 0, 0 };
+            nameToNodeId.clear();
+            totalShards[0] = totalShards[1] = 0;
+            unassigned[0] = unassigned[1] = 0;
         }
 
         public void setState(ClusterState state) {
@@ -169,23 +262,21 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationIT {
         public String toString() {
             StringBuffer sb = new StringBuffer();
             sb.append(TWO_LINE_RETURN + separator + ONE_LINE_RETURN);
-            Formatter formatter = new Formatter(sb);
-            // formatter.format("%-20s %-20s %-20s\n", "", "DOCREP", "SEGREP");
+            Formatter formatter = new Formatter(sb, Locale.getDefault());
             for (Map.Entry<String, String> entry : nameToNodeId.entrySet()) {
                 String nodeId = nameToNodeId.get(entry.getKey());
-                formatter.format("%-20s %-20s %-20s %-20s\n", entry.getKey().toUpperCase(), "TOTAL", "DOCREP", "SEGREP");
-                sb.append(
-                    printShardAllocationWithHeader(
-                        entry.getKey().toUpperCase(),
-                        nodeToDocRepCountMap.get(nodeId),
-                        nodeToSegRepCountMap.get(nodeId)
-                    )
-                );
+                formatter.format("%-20s %-20s %-20s %-20s\n", entry.getKey().toUpperCase(Locale.getDefault()), "TOTAL", "DOCREP", "SEGREP");
+                sb.append(printShardAllocationWithHeader(nodeToDocRepCountMap.get(nodeId), nodeToSegRepCountMap.get(nodeId)));
             }
             sb.append(ONE_LINE_RETURN);
             formatter.format("%-20s %-20s %-20s\n\n", "Unassigned ", unassigned[0], unassigned[1]);
             formatter.format("%-20s %-20s %-20s\n\n", "Total Shards", totalShards[0], totalShards[1]);
             return sb.toString();
+        }
+
+        public void printShardDistribution(ClusterState state) {
+            this.setState(state);
+            logger.info("{}", this);
         }
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
@@ -16,7 +16,6 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
-import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.routing.RoutingNode;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.ShardRoutingState;

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
@@ -16,6 +16,8 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.routing.RoutingNode;
+import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.ShardRoutingState;
 import org.opensearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.opensearch.common.Priority;
@@ -31,6 +33,8 @@ import org.opensearch.transport.TransportService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
@@ -51,6 +55,17 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationBaseIT {
                 .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
                 .put("index.number_of_replicas", replicaCount)
                 .put("index.refresh_interval", -1)
+        ).get();
+    }
+
+    private void createIndex(String idxName, int shardCount, int replicaCount) {
+        prepareCreate(
+            idxName,
+            Settings.builder()
+                .put("index.number_of_shards", shardCount)
+                .put(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.getKey(), false)
+                .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+                .put("index.number_of_replicas", replicaCount)
         ).get();
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
@@ -54,22 +54,6 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationBaseIT {
         ).get();
     }
 
-    private void createIndex(String idxName, int shardCount, int replicaCount, boolean isSegRep) {
-        Settings.Builder builder = Settings.builder()
-            .put("index.number_of_shards", shardCount)
-            .put(IndexModule.INDEX_QUERY_CACHE_ENABLED_SETTING.getKey(), false)
-            .put("index.number_of_replicas", replicaCount);
-        if (isSegRep) {
-            builder = builder.put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT);
-        } else {
-            builder = builder.put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.DOCUMENT);
-        }
-        prepareCreate(
-            idxName,
-            builder
-        ).get();
-    }
-
     /**
      * This test verifies happy path when primary shard is relocated newly added node (target) in the cluster. Before
      * relocation and after relocation documents are indexed and documents are verified

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
@@ -16,8 +16,6 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
-import org.opensearch.cluster.routing.RoutingNode;
-import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.ShardRoutingState;
 import org.opensearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.opensearch.common.Priority;
@@ -31,11 +29,8 @@ import org.opensearch.test.transport.MockTransportService;
 import org.opensearch.transport.TransportService;
 
 import java.util.ArrayList;
-import java.util.Formatter;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingNode.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingNode.java
@@ -330,6 +330,23 @@ public class RoutingNode implements Iterable<ShardRouting> {
     }
 
     /**
+     * Determine the primary shards of an index with a specific state
+     * @param states set of states which should be listed
+     * @return a list of shards
+     */
+    public List<ShardRouting> primaryShardsWithState(ShardRoutingState... states) {
+        List<ShardRouting> shards = new ArrayList<>();
+        for (ShardRouting shardEntry : this) {
+            for (ShardRoutingState state : states) {
+                if (shardEntry.state() == state && shardEntry.primary() == true) {
+                    shards.add(shardEntry);
+                }
+            }
+        }
+        return shards;
+    }
+
+    /**
      * Determine the shards of an index with a specific state
      * @param index id of the index
      * @param states set of states which should be listed

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -107,7 +107,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         Property.NodeScope
     );
 
-    public static final Setting<Float> PRIMARY_BALANCE_FACTOR_SETTING = Setting.floatSetting(
+    public static final Setting<Float> PRIMARY_SHARD_BALANCE_FACTOR_SETTING = Setting.floatSetting(
         "cluster.routing.allocation.balance.primary",
         0.0f,
         0.0f,
@@ -128,14 +128,14 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         setWeightFunction(
             INDEX_BALANCE_FACTOR_SETTING.get(settings),
             SHARD_BALANCE_FACTOR_SETTING.get(settings),
-            PRIMARY_BALANCE_FACTOR_SETTING.get(settings)
+            PRIMARY_SHARD_BALANCE_FACTOR_SETTING.get(settings)
         );
         setThreshold(THRESHOLD_SETTING.get(settings));
         clusterSettings.addSettingsUpdateConsumer(SHARD_MOVE_PRIMARY_FIRST_SETTING, this::setMovePrimaryFirst);
         clusterSettings.addSettingsUpdateConsumer(
             INDEX_BALANCE_FACTOR_SETTING,
             SHARD_BALANCE_FACTOR_SETTING,
-            PRIMARY_BALANCE_FACTOR_SETTING,
+            PRIMARY_SHARD_BALANCE_FACTOR_SETTING,
             this::setWeightFunction
         );
         clusterSettings.addSettingsUpdateConsumer(THRESHOLD_SETTING, this::setThreshold);

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -417,14 +417,13 @@ public class BalancedShardsAllocator implements ShardsAllocator {
     }
 
     /**
-     * A model index. It stores info about specific index
+     * A model index that stores info about specific index
      *
      * @opensearch.internal
      */
     static final class ModelIndex implements Iterable<ShardRouting> {
         private final String id;
         private final Set<ShardRouting> shards = new HashSet<>(4); // expect few shards of same index to be allocated on same node
-
         private final Set<ShardRouting> primaryShards = new HashSet<>();
         private int highestPrimary = -1;
 
@@ -474,9 +473,9 @@ public class BalancedShardsAllocator implements ShardsAllocator {
 
         public void addShard(ShardRouting shard) {
             highestPrimary = -1;
-            assert !shards.contains(shard) : "Shard already allocated on current node: " + shard;
+            assert shards.contains(shard) == false : "Shard already allocated on current node: " + shard;
             if (shard.primary()) {
-                assert !primaryShards.contains(shard) : "Primary shard already allocated on current node: " + shard;
+                assert primaryShards.contains(shard) == false : "Primary shard already allocated on current node: " + shard;
                 primaryShards.add(shard);
             }
             shards.add(shard);
@@ -500,7 +499,6 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         private final WeightFunction function;
         private String index;
         private final ShardsBalancer balancer;
-
         private float pivotWeight;
 
         NodeSorter(ModelNode[] modelNodes, WeightFunction function, ShardsBalancer balancer) {

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -109,7 +109,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
 
     public static final Setting<Float> PRIMARY_BALANCE_FACTOR_SETTING = Setting.floatSetting(
         "cluster.routing.allocation.balance.primary",
-        0.45f,
+        0.0f,
         0.0f,
         Property.Dynamic,
         Property.NodeScope
@@ -274,8 +274,6 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         private AllocationConstraints constraints;
 
         WeightFunction(float indexBalance, float shardBalance, float primaryShardBalance) {
-            // Start with higher primary constants for POC
-            this.primaryShardBalance = primaryShardBalance; // 0.50f;
             float sum = indexBalance + shardBalance + primaryShardBalance;
             if (sum <= 0.0f) {
                 throw new IllegalArgumentException("Balance factors must sum to a value > 0 but was: " + sum);
@@ -286,6 +284,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
 
             this.indexBalance = indexBalance;
             this.shardBalance = shardBalance;
+            this.primaryShardBalance = primaryShardBalance;
             this.constraints = new AllocationConstraints();
         }
 

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -261,7 +261,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
 
         WeightFunction(float indexBalance, float shardBalance) {
             // Start with higher primary constants for POC
-            this.primaryShardBalance = 0.40f;
+            this.primaryShardBalance = 0.50f;
             float sum = indexBalance + shardBalance + primaryShardBalance;
             if (sum <= 0.0f) {
                 throw new IllegalArgumentException("Balance factors must sum to a value > 0 but was: " + sum);

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.cluster.routing.allocation.allocator;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.IntroSorter;
@@ -64,7 +63,6 @@ public class LocalShardsBalancer extends ShardsBalancer {
     private final float threshold;
     private final Metadata metadata;
     private final float avgShardsPerNode;
-
     private final float avgPrimaryShardsPerNode;
     private final BalancedShardsAllocator.NodeSorter sorter;
     private final Set<RoutingNode> inEligibleTargetNode;
@@ -84,10 +82,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
         this.routingNodes = allocation.routingNodes();
         this.metadata = allocation.metadata();
         avgShardsPerNode = ((float) metadata.getTotalNumberOfShards()) / routingNodes.size();
-        int shardCount = 0;
-        for (ObjectCursor<IndexMetadata> cursor : metadata.indices().values()) {
-            shardCount += cursor.value.getNumberOfShards();
-        }
+        final int shardCount = StreamSupport.stream(metadata.spliterator(), false).mapToInt(IndexMetadata::getNumberOfShards).sum();
         avgPrimaryShardsPerNode = (float) shardCount / routingNodes.size();
         nodes = Collections.unmodifiableMap(buildModelFromAssigned());
         sorter = newNodeSorter();

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
@@ -109,10 +109,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
         return ((float) metadata.index(index).getTotalNumberOfShards()) / nodes.size();
     }
 
-    public float avgPrimaryShardsPerNode(String index) {
-        return ((float) metadata.index(index).getNumberOfShards()) / nodes.size();
-    }
-
+    @Override
     public float avgPrimaryShardsPerNode() {
         return avgPrimaryShardsPerNode;
     }
@@ -136,7 +133,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
      * to sort based on an index.
      */
     private BalancedShardsAllocator.NodeSorter newNodeSorter() {
-        return new BalancedShardsAllocator.NodeSorter(nodesArray(), weight, this, metadata);
+        return new BalancedShardsAllocator.NodeSorter(nodesArray(), weight, this);
     }
 
     /**
@@ -223,7 +220,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
 
         // balance the shard, if a better node can be found
         final String idxName = shard.getIndexName();
-        final float currentWeight = weight.weight(this, currentNode, idxName, metadata);
+        final float currentWeight = weight.weight(this, currentNode, idxName);
         final AllocationDeciders deciders = allocation.deciders();
         Decision.Type rebalanceDecisionType = Decision.Type.NO;
         BalancedShardsAllocator.ModelNode assignedNode = null;
@@ -239,7 +236,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
             // this is a comparison of the number of shards on this node to the number of shards
             // that should be on each node on average (both taking the cluster as a whole into account
             // as well as shards per index)
-            final float nodeWeight = weight.weight(this, node, shard.getIndexName(), metadata);
+            final float nodeWeight = weight.weight(this, node, idxName);
             // if the node we are examining has a worse (higher) weight than the node the shard is
             // assigned to, then there is no way moving the shard to the node with the worse weight
             // can make the balance of the cluster better, so we check for that here
@@ -912,7 +909,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
             }
 
             // weight of this index currently on the node
-            float currentWeight = weight.weightWithAllocationConstraints(this, node, shard.getIndexName(), metadata);
+            float currentWeight = weight.weightWithAllocationConstraints(this, node, shard.getIndexName());
             // moving the shard would not improve the balance, and we are not in explain mode, so short circuit
             if (currentWeight > minWeight && explain == false) {
                 continue;

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/ShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/ShardsBalancer.java
@@ -60,16 +60,23 @@ public abstract class ShardsBalancer {
     abstract MoveDecision decideRebalance(ShardRouting shardRouting);
 
     /**
-     * Returns the average of shards per node for the given index
+     * Returns the average of shards per node
      */
     public float avgShardsPerNode() {
         return Float.MAX_VALUE;
     }
 
     /**
-     * Returns the global average of shards per node
+     * Returns the global average of shards per node for the given index
      */
     public float avgShardsPerNode(String index) {
+        return Float.MAX_VALUE;
+    }
+
+    /**
+     * Returns the average of primary shards per node
+     */
+    public float avgPrimaryShardsPerNode() {
         return Float.MAX_VALUE;
     }
 }

--- a/server/src/main/java/org/opensearch/common/TriConsumer.java
+++ b/server/src/main/java/org/opensearch/common/TriConsumer.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.common;
 
+import java.util.Objects;
+
 /**
  * Represents an operation that accepts three arguments and returns no result.
  *
@@ -50,5 +52,14 @@ public interface TriConsumer<S, T, U> {
      * @param t the second function argument
      * @param u the third function argument
      */
-    void apply(S s, T t, U u);
+    void accept(S s, T t, U u);
+
+    default TriConsumer<S, T, U> andThen(TriConsumer<? super S, ? super T, ? super U> after) {
+        Objects.requireNonNull(after);
+
+        return (l, r, s) -> {
+            accept(l, r, s);
+            after.accept(l, r, s);
+        };
+    }
 }

--- a/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
@@ -451,7 +451,7 @@ public abstract class AbstractScopedSettings {
      * <p>
      * Note: Only settings registered in {@link SettingsModule} can be changed dynamically.
      * </p>
-     * This method registers a compound updater that is useful if two settings are depending on each other.
+     * This method registers a compound updater that is useful if three settings depends on each other.
      * The consumer is always provided with both values even if only one of the two changes.
      */
     public synchronized <A, B, C> void addSettingsUpdateConsumer(Setting<A> a, Setting<B> b, Setting<C> c, TriConsumer<A, B, C> consumer) {

--- a/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/AbstractScopedSettings.java
@@ -38,6 +38,7 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.search.spell.LevenshteinDistance;
 import org.apache.lucene.util.CollectionUtil;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.common.TriConsumer;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.regex.Regex;
 
@@ -442,6 +443,28 @@ public abstract class AbstractScopedSettings {
      */
     public synchronized <A, B> void addSettingsUpdateConsumer(Setting<A> a, Setting<B> b, BiConsumer<A, B> consumer) {
         addSettingsUpdateConsumer(a, b, consumer, (i, j) -> {});
+    }
+
+    /**
+     * Adds a settings consumer that accepts the values for three settings. The consumer is only notified if any one of
+     * the settings changed and if the provided validator succeeded.
+     * <p>
+     * Note: Only settings registered in {@link SettingsModule} can be changed dynamically.
+     * </p>
+     * This method registers a compound updater that is useful if two settings are depending on each other.
+     * The consumer is always provided with both values even if only one of the two changes.
+     */
+    public synchronized <A, B, C> void addSettingsUpdateConsumer(Setting<A> a, Setting<B> b, Setting<C> c, TriConsumer<A, B, C> consumer) {
+        if (a != get(a.getKey())) {
+            throw new IllegalArgumentException("Setting is not registered for key [" + a.getKey() + "]");
+        }
+        if (b != get(b.getKey())) {
+            throw new IllegalArgumentException("Setting is not registered for key [" + b.getKey() + "]");
+        }
+        if (c != get(c.getKey())) {
+            throw new IllegalArgumentException("Setting is not registered for key [" + c.getKey() + "]");
+        }
+        addSettingsUpdater(Setting.compoundUpdater(consumer, (i, j, k) -> {}, a, b, c, logger));
     }
 
     /**

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -232,6 +232,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 AwarenessReplicaBalance.CLUSTER_ROUTING_ALLOCATION_AWARENESS_BALANCE_SETTING,
                 BalancedShardsAllocator.INDEX_BALANCE_FACTOR_SETTING,
                 BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING,
+                BalancedShardsAllocator.PRIMARY_BALANCE_FACTOR_SETTING,
                 BalancedShardsAllocator.SHARD_MOVE_PRIMARY_FIRST_SETTING,
                 BalancedShardsAllocator.THRESHOLD_SETTING,
                 BreakerSettings.CIRCUIT_BREAKER_LIMIT_SETTING,

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -232,7 +232,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 AwarenessReplicaBalance.CLUSTER_ROUTING_ALLOCATION_AWARENESS_BALANCE_SETTING,
                 BalancedShardsAllocator.INDEX_BALANCE_FACTOR_SETTING,
                 BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING,
-                BalancedShardsAllocator.PRIMARY_BALANCE_FACTOR_SETTING,
+                BalancedShardsAllocator.PRIMARY_SHARD_BALANCE_FACTOR_SETTING,
                 BalancedShardsAllocator.SHARD_MOVE_PRIMARY_FIRST_SETTING,
                 BalancedShardsAllocator.THRESHOLD_SETTING,
                 BreakerSettings.CIRCUIT_BREAKER_LIMIT_SETTING,

--- a/server/src/main/java/org/opensearch/common/settings/Setting.java
+++ b/server/src/main/java/org/opensearch/common/settings/Setting.java
@@ -726,6 +726,8 @@ public class Setting<T> implements ToXContentObject {
 
     /**
      * Updates settings that depend on each other.
+     *
+     * See {@link AbstractScopedSettings#addSettingsUpdateConsumer(Setting, Setting, Setting, TriConsumer)} and its usage for details.
      */
     static <A, B, C> AbstractScopedSettings.SettingUpdater<Triplet<A, B, C>> compoundUpdater(
         final TriConsumer<A, B, C> consumer,
@@ -762,6 +764,9 @@ public class Setting<T> implements ToXContentObject {
                 }
                 if (bSettingUpdater.hasChanged(current, previous)) {
                     logSettingUpdate(bSetting, current, previous, logger);
+                }
+                if (cSettingUpdater.hasChanged(current, previous)) {
+                    logSettingUpdate(cSetting, current, previous, logger);
                 }
                 consumer.accept(value.v1(), value.v2(), value.v3());
             }

--- a/server/src/main/java/org/opensearch/common/settings/Setting.java
+++ b/server/src/main/java/org/opensearch/common/settings/Setting.java
@@ -757,7 +757,6 @@ public class Setting<T> implements ToXContentObject {
 
             @Override
             public void apply(Triplet<A, B, C> value, Settings current, Settings previous) {
-                logger.info("--> Settings changed!");
                 if (aSettingUpdater.hasChanged(current, previous)) {
                     logSettingUpdate(aSetting, current, previous, logger);
                 }

--- a/server/src/main/java/org/opensearch/search/aggregations/support/MultiTermsValuesSourceConfig.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/MultiTermsValuesSourceConfig.java
@@ -57,7 +57,7 @@ public class MultiTermsValuesSourceConfig extends BaseMultiValuesSourceFieldConf
             MultiTermsValuesSourceConfig.Builder::new
         );
 
-        BaseMultiValuesSourceFieldConfig.PARSER.apply(parser, scriptable, timezoneAware);
+        BaseMultiValuesSourceFieldConfig.PARSER.accept(parser, scriptable, timezoneAware);
 
         if (valueTypeHinted) {
             parser.declareField(

--- a/server/src/main/java/org/opensearch/search/aggregations/support/MultiValuesSourceFieldConfig.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/MultiValuesSourceFieldConfig.java
@@ -68,7 +68,7 @@ public class MultiValuesSourceFieldConfig extends BaseMultiValuesSourceFieldConf
             MultiValuesSourceFieldConfig.Builder::new
         );
 
-        BaseMultiValuesSourceFieldConfig.PARSER.apply(parser, scriptable, timezoneAware);
+        BaseMultiValuesSourceFieldConfig.PARSER.accept(parser, scriptable, timezoneAware);
 
         if (filtered) {
             parser.declareField(

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/BalanceConfigurationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/BalanceConfigurationTests.java
@@ -75,7 +75,7 @@ public class BalanceConfigurationTests extends OpenSearchAllocationTestCase {
     public void testIndexBalance() {
         /* Tests balance over indices only */
         final float indexBalance = 1.0f;
-        final float replicaBalance = 0.0f;
+        final float shardBalance = 0.0f;
         final float balanceThreshold = 1.0f;
 
         Settings.Builder settings = Settings.builder();
@@ -84,7 +84,7 @@ public class BalanceConfigurationTests extends OpenSearchAllocationTestCase {
             ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString()
         );
         settings.put(BalancedShardsAllocator.INDEX_BALANCE_FACTOR_SETTING.getKey(), indexBalance);
-        settings.put(BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING.getKey(), replicaBalance);
+        settings.put(BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING.getKey(), shardBalance);
         settings.put(BalancedShardsAllocator.THRESHOLD_SETTING.getKey(), balanceThreshold);
 
         AllocationService strategy = createAllocationService(settings.build(), new TestGatewayAllocator());
@@ -123,10 +123,14 @@ public class BalanceConfigurationTests extends OpenSearchAllocationTestCase {
         );
     }
 
-    public void testReplicaBalance() {
-        /* Tests balance over replicas only */
+    /**
+     * This test verifies that with only primary shard balance, the shard distribution on nodes is within thresholds.
+     */
+    public void testPrimaryBalance() {
+        /* Tests balance over primary shards only */
         final float indexBalance = 0.0f;
-        final float replicaBalance = 1.0f;
+        final float shardBalance = 0.0f;
+        final float primaryBalance = 1.0f;
         final float balanceThreshold = 1.0f;
 
         Settings.Builder settings = Settings.builder();
@@ -135,13 +139,15 @@ public class BalanceConfigurationTests extends OpenSearchAllocationTestCase {
             ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString()
         );
         settings.put(BalancedShardsAllocator.INDEX_BALANCE_FACTOR_SETTING.getKey(), indexBalance);
-        settings.put(BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING.getKey(), replicaBalance);
+        settings.put(BalancedShardsAllocator.PRIMARY_BALANCE_FACTOR_SETTING.getKey(), primaryBalance);
+        settings.put(BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING.getKey(), shardBalance);
         settings.put(BalancedShardsAllocator.THRESHOLD_SETTING.getKey(), balanceThreshold);
 
         AllocationService strategy = createAllocationService(settings.build(), new TestGatewayAllocator());
 
         ClusterState clusterState = initCluster(strategy);
-        assertReplicaBalance(
+        assertPrimaryBalance(
+            clusterState.getRoutingTable(),
             clusterState.getRoutingNodes(),
             numberOfNodes,
             numberOfIndices,
@@ -151,7 +157,8 @@ public class BalanceConfigurationTests extends OpenSearchAllocationTestCase {
         );
 
         clusterState = addNode(clusterState, strategy);
-        assertReplicaBalance(
+        assertPrimaryBalance(
+            clusterState.getRoutingTable(),
             clusterState.getRoutingNodes(),
             numberOfNodes + 1,
             numberOfIndices,
@@ -161,7 +168,136 @@ public class BalanceConfigurationTests extends OpenSearchAllocationTestCase {
         );
 
         clusterState = removeNodes(clusterState, strategy);
-        assertReplicaBalance(
+        assertPrimaryBalance(
+            clusterState.getRoutingTable(),
+            clusterState.getRoutingNodes(),
+            (numberOfNodes + 1) - (numberOfNodes + 1) / 2,
+            numberOfIndices,
+            numberOfReplicas,
+            numberOfShards,
+            balanceThreshold
+        );
+    }
+
+    public void testBalanceDefaults() {
+        /* Tests balance over primary shards only */
+        final float indexBalance = 0.55f;
+        final float shardBalance = 0.45f;
+        final float primaryBalance = 0.40f;
+        final float balanceThreshold = 0.5f;
+
+        Settings.Builder settings = Settings.builder();
+        settings.put(
+            ClusterRebalanceAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE_SETTING.getKey(),
+            ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString()
+        );
+        settings.put(BalancedShardsAllocator.INDEX_BALANCE_FACTOR_SETTING.getKey(), indexBalance);
+        settings.put(BalancedShardsAllocator.PRIMARY_BALANCE_FACTOR_SETTING.getKey(), primaryBalance);
+        settings.put(BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING.getKey(), shardBalance);
+        settings.put(BalancedShardsAllocator.THRESHOLD_SETTING.getKey(), balanceThreshold);
+
+        AllocationService strategy = createAllocationService(settings.build(), new TestGatewayAllocator());
+
+        ClusterState clusterState = initCluster(strategy);
+        assertPrimaryBalance(
+            clusterState.getRoutingTable(),
+            clusterState.getRoutingNodes(),
+            numberOfNodes,
+            numberOfIndices,
+            numberOfReplicas,
+            numberOfShards,
+            balanceThreshold
+        );
+        assertIndexBalance(
+            clusterState.getRoutingTable(),
+            clusterState.getRoutingNodes(),
+            numberOfNodes,
+            numberOfIndices,
+            numberOfReplicas,
+            numberOfShards,
+            balanceThreshold
+        );
+
+        clusterState = addNode(clusterState, strategy);
+        assertPrimaryBalance(
+            clusterState.getRoutingTable(),
+            clusterState.getRoutingNodes(),
+            numberOfNodes + 1,
+            numberOfIndices,
+            numberOfReplicas,
+            numberOfShards,
+            balanceThreshold
+        );
+        assertIndexBalance(
+            clusterState.getRoutingTable(),
+            clusterState.getRoutingNodes(),
+            numberOfNodes + 1,
+            numberOfIndices,
+            numberOfReplicas,
+            numberOfShards,
+            balanceThreshold
+        );
+
+        clusterState = removeNodes(clusterState, strategy);
+        assertPrimaryBalance(
+            clusterState.getRoutingTable(),
+            clusterState.getRoutingNodes(),
+            (numberOfNodes + 1) - (numberOfNodes + 1) / 2,
+            numberOfIndices,
+            numberOfReplicas,
+            numberOfShards,
+            balanceThreshold
+        );
+        assertIndexBalance(
+            clusterState.getRoutingTable(),
+            clusterState.getRoutingNodes(),
+            (numberOfNodes + 1) - (numberOfNodes + 1) / 2,
+            numberOfIndices,
+            numberOfReplicas,
+            numberOfShards,
+            balanceThreshold
+        );
+    }
+
+    public void testShardBalance() {
+        /* Tests balance over replicas only */
+        final float indexBalance = 0.0f;
+        final float shardBalance = 1.0f;
+        final float balanceThreshold = 1.0f;
+
+        Settings.Builder settings = Settings.builder();
+        settings.put(
+            ClusterRebalanceAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE_SETTING.getKey(),
+            ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString()
+        );
+        settings.put(BalancedShardsAllocator.INDEX_BALANCE_FACTOR_SETTING.getKey(), indexBalance);
+        settings.put(BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING.getKey(), shardBalance);
+        settings.put(BalancedShardsAllocator.THRESHOLD_SETTING.getKey(), balanceThreshold);
+
+        AllocationService strategy = createAllocationService(settings.build(), new TestGatewayAllocator());
+
+        ClusterState clusterState = initCluster(strategy);
+        assertShardBalance(
+            clusterState.getRoutingNodes(),
+            numberOfNodes,
+            numberOfIndices,
+            numberOfReplicas,
+            numberOfShards,
+            balanceThreshold
+        );
+
+        clusterState = addNode(clusterState, strategy);
+        assertShardBalance(
+            clusterState.getRoutingNodes(),
+            numberOfNodes + 1,
+            numberOfIndices,
+            numberOfReplicas,
+            numberOfShards,
+            balanceThreshold
+        );
+
+        clusterState = removeNodes(clusterState, strategy);
+        assertShardBalance(
             clusterState.getRoutingNodes(),
             numberOfNodes + 1 - (numberOfNodes + 1) / 2,
             numberOfIndices,
@@ -254,7 +390,7 @@ public class BalanceConfigurationTests extends OpenSearchAllocationTestCase {
         return applyStartedShardsUntilNoChange(clusterState, strategy);
     }
 
-    private void assertReplicaBalance(
+    private void assertShardBalance(
         RoutingNodes nodes,
         int numberOfNodes,
         int numberOfIndices,
@@ -306,6 +442,27 @@ public class BalanceConfigurationTests extends OpenSearchAllocationTestCase {
                 assertThat(node.shardsWithState(index.value, STARTED).size(), Matchers.greaterThanOrEqualTo(minAvgNumberOfShards));
                 assertThat(node.shardsWithState(index.value, STARTED).size(), Matchers.lessThanOrEqualTo(maxAvgNumberOfShards));
             }
+        }
+    }
+
+    private void assertPrimaryBalance(
+        RoutingTable routingTable,
+        RoutingNodes nodes,
+        int numberOfNodes,
+        int numberOfIndices,
+        int numberOfReplicas,
+        int numberOfShards,
+        float threshold
+    ) {
+
+        final int numShards = numberOfShards * numberOfIndices;
+        final float avgNumShards = (float) (numShards) / (float) (numberOfNodes);
+        final int minAvgNumberOfShards = Math.round(Math.round(Math.floor(avgNumShards - threshold)));
+        final int maxAvgNumberOfShards = Math.round(Math.round(Math.ceil(avgNumShards + threshold)));
+
+        for (RoutingNode node : nodes) {
+            assertThat(node.primaryShardsWithState(STARTED).size(), Matchers.greaterThanOrEqualTo(minAvgNumberOfShards));
+            assertThat(node.primaryShardsWithState(STARTED).size(), Matchers.lessThanOrEqualTo(maxAvgNumberOfShards));
         }
     }
 

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/BalanceConfigurationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/BalanceConfigurationTests.java
@@ -139,7 +139,7 @@ public class BalanceConfigurationTests extends OpenSearchAllocationTestCase {
             ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString()
         );
         settings.put(BalancedShardsAllocator.INDEX_BALANCE_FACTOR_SETTING.getKey(), indexBalance);
-        settings.put(BalancedShardsAllocator.PRIMARY_BALANCE_FACTOR_SETTING.getKey(), primaryBalance);
+        settings.put(BalancedShardsAllocator.PRIMARY_SHARD_BALANCE_FACTOR_SETTING.getKey(), primaryBalance);
         settings.put(BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING.getKey(), shardBalance);
         settings.put(BalancedShardsAllocator.THRESHOLD_SETTING.getKey(), balanceThreshold);
 
@@ -194,7 +194,7 @@ public class BalanceConfigurationTests extends OpenSearchAllocationTestCase {
             ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString()
         );
         settings.put(BalancedShardsAllocator.INDEX_BALANCE_FACTOR_SETTING.getKey(), indexBalance);
-        settings.put(BalancedShardsAllocator.PRIMARY_BALANCE_FACTOR_SETTING.getKey(), primaryBalance);
+        settings.put(BalancedShardsAllocator.PRIMARY_SHARD_BALANCE_FACTOR_SETTING.getKey(), primaryBalance);
         settings.put(BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING.getKey(), shardBalance);
         settings.put(BalancedShardsAllocator.THRESHOLD_SETTING.getKey(), balanceThreshold);
 

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/BalanceConfigurationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/BalanceConfigurationTests.java
@@ -124,7 +124,7 @@ public class BalanceConfigurationTests extends OpenSearchAllocationTestCase {
     }
 
     /**
-     * This test verifies that with only primary shard balance, the shard distribution on nodes is within thresholds.
+     * This test verifies that with only primary shard balance, the primary shard distribution is balanced within thresholds.
      */
     public void testPrimaryBalance() {
         /* Tests balance over primary shards only */
@@ -179,12 +179,14 @@ public class BalanceConfigurationTests extends OpenSearchAllocationTestCase {
         );
     }
 
+    /**
+     * This test verifies
+     */
     public void testBalanceDefaults() {
-        /* Tests balance over primary shards only */
         final float indexBalance = 0.55f;
         final float shardBalance = 0.45f;
         final float primaryBalance = 0.40f;
-        final float balanceThreshold = 0.5f;
+        final float balanceThreshold = 1.0f;
 
         Settings.Builder settings = Settings.builder();
         settings.put(

--- a/server/src/test/java/org/opensearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/SettingTests.java
@@ -628,7 +628,7 @@ public class SettingTests extends OpenSearchTestCase {
 
     // This test class is used to verify behavior of BalancedShardAllocator.WeightFunction and ensure set function is called
     // whenever there is a change in any of the settings.
-    public static class Triposite {
+    public static class TriSettingConsumer {
 
         private Integer b;
         private Integer a;
@@ -712,8 +712,8 @@ public class SettingTests extends OpenSearchTestCase {
 
     }
 
-    public void testTriplet() {
-        Triposite consumer = new Triposite();
+    public void testTriSettingConsumer() {
+        TriSettingConsumer consumer = new TriSettingConsumer();
         Setting<Integer> a = Setting.intSetting("foo.int.bar.a", 1, Property.Dynamic, Property.NodeScope);
         Setting<Integer> b = Setting.intSetting("foo.int.bar.b", 1, Property.Dynamic, Property.NodeScope);
         Setting<Integer> c = Setting.intSetting("foo.int.bar.c", 1, Property.Dynamic, Property.NodeScope);
@@ -762,8 +762,8 @@ public class SettingTests extends OpenSearchTestCase {
         assertEquals(1, consumer.c.intValue());
     }
 
-    public void testTripletValidator1() {
-        Triposite consumer = new Triposite();
+    public void testTriSettingConsumerValidator() {
+        TriSettingConsumer consumer = new TriSettingConsumer();
         Setting<Integer> a = Setting.intSetting("foo.int.bar.a", 1, Property.Dynamic, Property.NodeScope);
         Setting<Integer> b = Setting.intSetting("foo.int.bar.b", 1, Property.Dynamic, Property.NodeScope);
         Setting<Integer> c = Setting.intSetting("foo.int.bar.c", 1, Property.Dynamic, Property.NodeScope);

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/SumAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/SumAggregatorTests.java
@@ -385,7 +385,7 @@ public class SumAggregatorTests extends AggregatorTestCase {
             builder,
             new MatchAllDocsQuery(),
             writer -> writer.addDocuments(docs),
-            internalSum -> verify.apply(finalSum, docs, internalSum),
+            internalSum -> verify.accept(finalSum, docs, internalSum),
             fieldType
         );
     }


### PR DESCRIPTION
### Description
This change introduces the mechanism to balance primary shards across cluster
- Introduce new weight factor `PRIMARY_BALANCE_FACTOR_SETTING` setting which defines the constant for primary shards; used to calculate the weight on node. This factor defines the tendency to balance the primary shards; higher the value more chances of even distribution. This setting's default is initially set to `0.0f` to avoid rebalance disruption in existing clusters. The other settings used in weight calculation are `INDEX_BALANCE_FACTOR_SETTING` govern shards/node specific to index and SHARD_BALANCE_FACTOR_SETTING shards/node. 
- This needed changes in utilities classes ModelIndex, ModelNode; used for weight calculation.
- It changes existing `TriConsumer` to conform to existing Java Consumer interface definition and related unit tests changes. It used as consumer to reflect settings changes to WeightFunction. 
- Unit tests in BalanceConfigurationTests to verify shard distribution with new setting.
- Integration tests

### Default setting consideration
`PRIMARY_BALANCE_FACTOR_SETTING` is initially set to `0` to prevent unnecessary disruption in doc rep indices. One improvement is to use some sane default when there are segrep enabled indices to automatically balance cluster based on primary shard. This is difficult as
1. There is no single default which works for all cluster configuration. Added a task in #5240 to perform analysis on shard distribution for different configuration so that we can come up with some guidance.
2. Giving control to customer is better over automatic primary shard allocation; to allow primary allocation to be performed when needed based on resource consumption and consent. 

### Issues Resolved
#5240 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
