### PR TITLE
Extract all used fields from QueryStringQueryBuilder

### DIFF
--- a/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java
@@ -162,8 +162,6 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
 
     private ZoneId timeZone;
 
-    List<String> discoveredFields;
-
     /** To limit effort spent determinizing regexp queries. */
     private int maxDeterminizedStates = DEFAULT_DETERMINIZE_WORK_LIMIT;
 

--- a/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.index.query;
 
+import java.util.Set;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.Query;
@@ -160,6 +161,8 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
     private Boolean lenient;
 
     private ZoneId timeZone;
+
+    List<String> discoveredFields;
 
     /** To limit effort spent determinizing regexp queries. */
     private int maxDeterminizedStates = DEFAULT_DETERMINIZE_WORK_LIMIT;
@@ -872,13 +875,7 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
         );
     }
 
-    @Override
-    protected Query doToQuery(QueryShardContext context) throws IOException {
-        String rewrittenQueryString = escape ? org.apache.lucene.queryparser.classic.QueryParser.escape(this.queryString) : queryString;
-        if (fieldsAndWeights.size() > 0 && this.defaultField != null) {
-            throw addValidationError("cannot use [fields] parameter in conjunction with [default_field]", null);
-        }
-
+    private QueryStringQueryParser newQueryParser(QueryShardContext context) {
         QueryStringQueryParser queryParser;
         boolean isLenient = lenient == null ? context.queryStringLenient() : lenient;
         if (defaultField != null) {
@@ -946,6 +943,39 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
         queryParser.setDeterminizeWorkLimit(maxDeterminizedStates);
         queryParser.setAutoGenerateMultiTermSynonymsPhraseQuery(autoGenerateSynonymsPhraseQuery);
         queryParser.setFuzzyTranspositions(fuzzyTranspositions);
+        return queryParser;
+    }
+
+    public Set<String> extractAllUsedFields(QueryShardContext context) {
+        String rewrittenQueryString = escape ? org.apache.lucene.queryparser.classic.QueryParser.escape(this.queryString) : queryString;
+        if (fieldsAndWeights.size() > 0 && this.defaultField != null) {
+            throw addValidationError("cannot use [fields] parameter in conjunction with [default_field]", null);
+        }
+
+        QueryStringQueryParser queryParser = newQueryParser(context);
+
+        Query query;
+        try {
+            query = queryParser.parse(rewrittenQueryString);
+        } catch (org.apache.lucene.queryparser.classic.ParseException e) {
+            throw new QueryShardException(context, "Failed to parse query [" + this.queryString + "]", e);
+        }
+
+        if (query == null) {
+            return null;
+        }
+
+        return queryParser.getDiscoveredQueryFields();
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) throws IOException {
+        String rewrittenQueryString = escape ? org.apache.lucene.queryparser.classic.QueryParser.escape(this.queryString) : queryString;
+        if (fieldsAndWeights.size() > 0 && this.defaultField != null) {
+            throw addValidationError("cannot use [fields] parameter in conjunction with [default_field]", null);
+        }
+
+        QueryStringQueryParser queryParser = newQueryParser(context);
 
         Query query;
         try {

--- a/server/src/test/java/org/opensearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/QueryStringQueryBuilderTests.java
@@ -465,17 +465,16 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         assertTrue(allUsedFields.contains(KEYWORD_FIELD_NAME));
 
         // fields with field prefix
-        allUsedFields = queryStringQuery("654654356")
-            .fields(Map.of(TEXT_FIELD_NAME, 1.0f, OBJECT_FIELD_NAME + ".*", 1.0f))
+        allUsedFields = queryStringQuery("654654356").fields(Map.of(TEXT_FIELD_NAME, 1.0f, OBJECT_FIELD_NAME + ".*", 1.0f))
             .extractAllUsedFields(createShardContext());
         assertTrue(allUsedFields.contains(TEXT_FIELD_NAME));
         assertTrue(allUsedFields.contains(OBJECT_FIELD_NAME + "." + DATE_FIELD_NAME));
         assertTrue(allUsedFields.contains(OBJECT_FIELD_NAME + "." + INT_FIELD_NAME));
 
         // field prefix in query_string with bear token and fields combo
-        allUsedFields = queryStringQuery(TEXT_FIELD_NAME + "\\*:test 12345")
-            .fields(Map.of(INT_FIELD_NAME, 1.0f, OBJECT_FIELD_NAME + ".*", 1.0f))
-            .extractAllUsedFields(createShardContext());
+        allUsedFields = queryStringQuery(TEXT_FIELD_NAME + "\\*:test 12345").fields(
+            Map.of(INT_FIELD_NAME, 1.0f, OBJECT_FIELD_NAME + ".*", 1.0f)
+        ).extractAllUsedFields(createShardContext());
         assertTrue(allUsedFields.contains(TEXT_FIELD_NAME));
         assertTrue(allUsedFields.contains(KEYWORD_FIELD_NAME));
         assertTrue(allUsedFields.contains(OBJECT_FIELD_NAME + "." + DATE_FIELD_NAME));

--- a/server/src/test/java/org/opensearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/QueryStringQueryBuilderTests.java
@@ -427,6 +427,72 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         assertNotEquals(builder1, builder2);
     }
 
+    public void testExtractAllUsedFields() {
+        // fuzzy query
+        Set<String> allUsedFields = queryStringQuery(TEXT_FIELD_NAME + "\\*:test~2").extractAllUsedFields(createShardContext());
+        assertTrue(allUsedFields.contains(TEXT_FIELD_NAME));
+        assertTrue(allUsedFields.contains(KEYWORD_FIELD_NAME));
+
+        // Regex query
+        allUsedFields = queryStringQuery(TEXT_FIELD_NAME + "\\*:/[A-Z]T/").extractAllUsedFields(createShardContext());
+        assertTrue(allUsedFields.contains(TEXT_FIELD_NAME));
+        assertTrue(allUsedFields.contains(KEYWORD_FIELD_NAME));
+
+        // Wildcard query
+        allUsedFields = queryStringQuery(TEXT_FIELD_NAME + "\\*:test*").extractAllUsedFields(createShardContext());
+        assertTrue(allUsedFields.contains(TEXT_FIELD_NAME));
+        assertTrue(allUsedFields.contains(KEYWORD_FIELD_NAME));
+
+        // default_field with field prefix
+        allUsedFields = queryStringQuery("test").defaultField(TEXT_FIELD_NAME + "*").extractAllUsedFields(createShardContext());
+        assertTrue(allUsedFields.contains(TEXT_FIELD_NAME));
+        assertTrue(allUsedFields.contains(KEYWORD_FIELD_NAME));
+
+        // field prefix in query_string
+        allUsedFields = queryStringQuery(TEXT_FIELD_NAME + "\\*:test").extractAllUsedFields(createShardContext());
+        assertTrue(allUsedFields.contains(TEXT_FIELD_NAME));
+        assertTrue(allUsedFields.contains(KEYWORD_FIELD_NAME));
+
+        // field prefix with nested fields in query_string
+        allUsedFields = queryStringQuery(OBJECT_FIELD_NAME + ".\\*:test").extractAllUsedFields(createShardContext());
+        assertTrue(allUsedFields.contains(OBJECT_FIELD_NAME + "." + DATE_FIELD_NAME));
+        assertTrue(allUsedFields.contains(OBJECT_FIELD_NAME + "." + INT_FIELD_NAME));
+
+        // fields basic
+        allUsedFields = queryStringQuery("test").fields(Map.of(TEXT_FIELD_NAME, 1.0f, KEYWORD_FIELD_NAME, 1.0f))
+            .extractAllUsedFields(createShardContext());
+        assertTrue(allUsedFields.contains(TEXT_FIELD_NAME));
+        assertTrue(allUsedFields.contains(KEYWORD_FIELD_NAME));
+
+        // fields with field prefix
+        allUsedFields = queryStringQuery("654654356")
+            .fields(Map.of(TEXT_FIELD_NAME, 1.0f, OBJECT_FIELD_NAME + ".*", 1.0f))
+            .extractAllUsedFields(createShardContext());
+        assertTrue(allUsedFields.contains(TEXT_FIELD_NAME));
+        assertTrue(allUsedFields.contains(OBJECT_FIELD_NAME + "." + DATE_FIELD_NAME));
+        assertTrue(allUsedFields.contains(OBJECT_FIELD_NAME + "." + INT_FIELD_NAME));
+
+        // field prefix in query_string with bear token and fields combo
+        allUsedFields = queryStringQuery(TEXT_FIELD_NAME + "\\*:test 12345")
+            .fields(Map.of(INT_FIELD_NAME, 1.0f, OBJECT_FIELD_NAME + ".*", 1.0f))
+            .extractAllUsedFields(createShardContext());
+        assertTrue(allUsedFields.contains(TEXT_FIELD_NAME));
+        assertTrue(allUsedFields.contains(KEYWORD_FIELD_NAME));
+        assertTrue(allUsedFields.contains(OBJECT_FIELD_NAME + "." + DATE_FIELD_NAME));
+        assertTrue(allUsedFields.contains(OBJECT_FIELD_NAME + "." + INT_FIELD_NAME));
+        assertTrue(allUsedFields.contains(INT_FIELD_NAME));
+
+        // no fields or default_field present; expect fallback on index setting
+        indexSettings().getDefaultFields().clear();
+        indexSettings().getDefaultFields().add(KEYWORD_FIELD_NAME);
+        allUsedFields = queryStringQuery(TEXT_FIELD_NAME + ":test 12345").extractAllUsedFields(createShardContext());
+        assertTrue(allUsedFields.contains(TEXT_FIELD_NAME));
+        assertTrue(allUsedFields.contains(KEYWORD_FIELD_NAME));
+        // restore default fields
+        indexSettings().getDefaultFields().clear();
+        indexSettings().getDefaultFields().add("*");
+    }
+
     public void testIllegalArguments() {
         expectThrows(IllegalArgumentException.class, () -> new QueryStringQueryBuilder((String) null));
     }

--- a/server/src/test/java/org/opensearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/QueryStringQueryBuilderTests.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.index.query;
 
+import java.util.Set;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.Term;


### PR DESCRIPTION
Signed-off-by: Petar Dzepina <petar.dzepina@gmail.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
We recently implemented rewriting of fields used in QueryStringQueryBuilder in ISM and we had to copy over substantial amount of code from core in ISM. To avoid this code duplication and future maintenance, we could extend core's QueryStringQueryBuilder to provide method for extracting all fields which are used in final query.

Also in Alerting we would have use-case for this, where if we could grab all fields used in queries, we could just copy mappings to percolate index only for those fields.

### Issues Resolved
#6019

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
