### PR TITLE
[Backport] [2.5] OpenJDK Update (January 2023 Patch releases) (#6075)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 2.5]
 ### Added
 ### Dependencies
+- OpenJDK Update (January 2023 Patch releases) ([#6075](https://github.com/opensearch-project/OpenSearch/pull/6075))
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java
@@ -75,9 +75,9 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public class DistroTestPlugin implements Plugin<Project> {
-    private static final String SYSTEM_JDK_VERSION = "11.0.17+8";
+    private static final String SYSTEM_JDK_VERSION = "11.0.18+10";
     private static final String SYSTEM_JDK_VENDOR = "adoptium";
-    private static final String GRADLE_JDK_VERSION = "17.0.5+8";
+    private static final String GRADLE_JDK_VERSION = "17.0.6+10";
     private static final String GRADLE_JDK_VENDOR = "adoptium";
 
     // all distributions used by distro tests. this is temporary until tests are per distribution

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -2,9 +2,7 @@ opensearch        = 2.5.1
 lucene            = 9.4.2
 
 bundled_jdk_vendor = adoptium
-bundled_jdk = 17.0.5+8
-
-
+bundled_jdk = 17.0.6+10
 
 # optional dependencies
 spatial4j         = 0.7

--- a/server/src/test/java/org/opensearch/common/time/DateUtilsTests.java
+++ b/server/src/test/java/org/opensearch/common/time/DateUtilsTests.java
@@ -58,7 +58,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class DateUtilsTests extends OpenSearchTestCase {
-    private static final Set<String> IGNORE = new HashSet<>(Arrays.asList("Pacific/Enderbury", "Pacific/Kanton", "Pacific/Niue"));
+    private static final Set<String> IGNORE = new HashSet<>(
+        Arrays.asList("Pacific/Enderbury", "Pacific/Kanton", "Pacific/Niue", "America/Pangnirtung")
+    );
 
     public void testTimezoneIds() {
         assertNull(DateUtils.dateTimeZoneToZoneId(null));


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/6075 to `2.5`