### PR TITLE
Fix broken template for issue autocuts on GH failure.

### DIFF
--- a/.github/ISSUE_TEMPLATE/failed_check.md
+++ b/.github/ISSUE_TEMPLATE/failed_check.md
@@ -1,6 +1,6 @@
 ---
-title: Gradle Check Failure.
-labels: >test-failure bug
+title: [AUTOCUT] Gradle Check Failure.
+labels: >test-failure, bug
 ---
 
 A gradle check workflow has failed after merge.


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
There were multiple GC failures post merge over the weekend. - Example: https://github.com/opensearch-project/OpenSearch/actions/runs/4028023871/jobs/6924435585.  The recently introduced workflow to autocut an issue failed because of formatting.  Also added [AUTOCUT] to beginning of the issue title.

### Issues Resolved
closes https://github.com/opensearch-project/OpenSearch/issues/6085

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
