### PR TITLE
[Backport] [2.x] Bumps Mockito from 4.7.0 to 5.1.0, ByteBuddy from 1.12.18 to 1.12.22 (#6076)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Update nebula-publishing-plugin to 19.2.0 ([#5704](https://github.com/opensearch-project/OpenSearch/pull/5704))
 - Bumps `reactor-netty` from 1.1.1 to 1.1.2 ([#5878](https://github.com/opensearch-project/OpenSearch/pull/5878))
 - OpenJDK Update (January 2023 Patch releases) ([#6075](https://github.com/opensearch-project/OpenSearch/pull/6075))
+- Bumps `Mockito` from 4.7.0 to 5.1.0, `ByteBuddy` from 1.12.18 to 1.12.22 ([#6088](https://github.com/opensearch-project/OpenSearch/pull/6088))
 
 ### Changed
 - Use ReplicationFailedException instead of OpensearchException in ReplicationTarget ([#4725](https://github.com/opensearch-project/OpenSearch/pull/4725))

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -44,10 +44,9 @@ bouncycastle=1.70
 randomizedrunner  = 2.7.1
 junit             = 4.13.2
 hamcrest          = 2.1
-# Update to 4.8.0 is using reflection without SecurityManager checks (fails with java.security.AccessControlException)
-mockito           = 4.7.0
+mockito           = 5.1.0
 objenesis         = 3.2
-bytebuddy         = 1.12.18
+bytebuddy         = 1.12.22
 
 # benchmark dependencies
 jmh               = 1.35

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -54,6 +54,7 @@ dependencies {
   testImplementation "org.mockito:mockito-core:${versions.mockito}"
   testImplementation "org.objenesis:objenesis:${versions.objenesis}"
   testImplementation "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
+  testImplementation "net.bytebuddy:byte-buddy-agent:${versions.bytebuddy}"
   testImplementation "org.apache.logging.log4j:log4j-api:${versions.log4j}"
   testImplementation "org.apache.logging.log4j:log4j-core:${versions.log4j}"
   testImplementation "org.apache.logging.log4j:log4j-jul:${versions.log4j}"

--- a/client/sniffer/build.gradle
+++ b/client/sniffer/build.gradle
@@ -50,6 +50,7 @@ dependencies {
   testImplementation "org.mockito:mockito-core:${versions.mockito}"
   testImplementation "org.objenesis:objenesis:${versions.objenesis}"
   testImplementation "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
+  testImplementation "net.bytebuddy:byte-buddy-agent:${versions.bytebuddy}"
 }
 
 tasks.named('forbiddenApisMain').configure {


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/6076 to `2.x`