### PR TITLE
[Backport] [2.5] Bumps Mockito from 4.7.0 to 5.1.0, ByteBuddy from 1.12.18 to 1.12.22 (#6076)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 ### Dependencies
 - OpenJDK Update (January 2023 Patch releases) ([#6075](https://github.com/opensearch-project/OpenSearch/pull/6075))
+- Bumps `Mockito` from 4.7.0 to 5.1.0, `ByteBuddy` from 1.12.18 to 1.12.22 ([#6089](https://github.com/opensearch-project/OpenSearch/pull/6089))
 
 ### Changed
 ### Deprecated

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -44,10 +44,9 @@ bouncycastle=1.70
 randomizedrunner  = 2.7.1
 junit             = 4.13.2
 hamcrest          = 2.1
-# Update to 4.8.0 is using reflection without SecurityManager checks (fails with java.security.AccessControlException)
-mockito           = 4.7.0
+mockito           = 5.1.0
 objenesis         = 3.2
-bytebuddy         = 1.12.18
+bytebuddy         = 1.12.22
 
 # benchmark dependencies
 jmh               = 1.35

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -54,6 +54,7 @@ dependencies {
   testImplementation "org.mockito:mockito-core:${versions.mockito}"
   testImplementation "org.objenesis:objenesis:${versions.objenesis}"
   testImplementation "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
+  testImplementation "net.bytebuddy:byte-buddy-agent:${versions.bytebuddy}"
   testImplementation "org.apache.logging.log4j:log4j-api:${versions.log4j}"
   testImplementation "org.apache.logging.log4j:log4j-core:${versions.log4j}"
   testImplementation "org.apache.logging.log4j:log4j-jul:${versions.log4j}"

--- a/client/sniffer/build.gradle
+++ b/client/sniffer/build.gradle
@@ -50,6 +50,7 @@ dependencies {
   testImplementation "org.mockito:mockito-core:${versions.mockito}"
   testImplementation "org.objenesis:objenesis:${versions.objenesis}"
   testImplementation "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
+  testImplementation "net.bytebuddy:byte-buddy-agent:${versions.bytebuddy}"
 }
 
 tasks.named('forbiddenApisMain').configure {


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/6076 to `2.5`