### PR TITLE
[Backport] [1.x] OpenJDK Update (January 2023 Patch releases)

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -2,7 +2,7 @@ opensearch        = 1.4.0
 lucene            = 8.10.1
 
 bundled_jdk_vendor = adoptium
-bundled_jdk = 11.0.17+8
+bundled_jdk = 11.0.18+10
 
 # optional dependencies
 spatial4j         = 0.7

--- a/server/src/test/java/org/opensearch/common/time/DateUtilsTests.java
+++ b/server/src/test/java/org/opensearch/common/time/DateUtilsTests.java
@@ -58,7 +58,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class DateUtilsTests extends OpenSearchTestCase {
-    private static final Set<String> IGNORE = new HashSet<>(Arrays.asList("Pacific/Enderbury", "Pacific/Kanton", "Pacific/Niue"));
+    private static final Set<String> IGNORE = new HashSet<>(
+        Arrays.asList("Pacific/Enderbury", "Pacific/Kanton", "Pacific/Niue", "America/Pangnirtung")
+    );
 
     public void testTimezoneIds() {
         assertNull(DateUtils.dateTimeZoneToZoneId(null));


### PR DESCRIPTION
Updating the JDK version (followup to https://github.com/opensearch-project/OpenSearch/pull/6077)