### PR TITLE
[Backport] [2.5] Update Joda to 2.12.2 (#6083)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Dependencies
 - OpenJDK Update (January 2023 Patch releases) ([#6075](https://github.com/opensearch-project/OpenSearch/pull/6075))
 - Bumps `Mockito` from 4.7.0 to 5.1.0, `ByteBuddy` from 1.12.18 to 1.12.22 ([#6089](https://github.com/opensearch-project/OpenSearch/pull/6089))
+- Bumps `joda` from 2.10.13 to 2.12.2 ([#6096](https://github.com/opensearch-project/OpenSearch/pull/6096))
 
 ### Changed
 ### Deprecated

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -24,7 +24,7 @@ kotlin            = 1.7.10
 jna               = 5.5.0
 
 netty             = 4.1.86.Final
-joda              = 2.10.12
+joda              = 2.12.2
 
 # client dependencies
 httpclient        = 4.5.13

--- a/server/licenses/joda-time-2.10.12.jar.sha1
+++ b/server/licenses/joda-time-2.10.12.jar.sha1
@@ -1,1 +1,0 @@
-95b3f193ad0493d94dcd7daa9ea575c30e6be5f5

--- a/server/licenses/joda-time-2.12.2.jar.sha1
+++ b/server/licenses/joda-time-2.12.2.jar.sha1
@@ -1,0 +1,1 @@
+78e18a7b4180e911dafba0a412adfa82c1e3d14b

--- a/server/src/test/java/org/opensearch/common/time/DateUtilsTests.java
+++ b/server/src/test/java/org/opensearch/common/time/DateUtilsTests.java
@@ -58,9 +58,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class DateUtilsTests extends OpenSearchTestCase {
-    private static final Set<String> IGNORE = new HashSet<>(
-        Arrays.asList("Pacific/Enderbury", "Pacific/Kanton", "Pacific/Niue", "America/Pangnirtung")
-    );
+    private static final Set<String> IGNORE = new HashSet<>(Arrays.asList("America/Ciudad_Juarez"));
 
     public void testTimezoneIds() {
         assertNull(DateUtils.dateTimeZoneToZoneId(null));


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/6083 to `2.5`