### PR TITLE
[Backport 2.x] build: harden worfklows permissions (#4587)

### DIFF
--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -8,8 +8,15 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   gradle-check:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      pull-requests: write # to create or update comment (peter-evans/create-or-update-comment)
+
     runs-on: ubuntu-latest
     timeout-minutes: 130
     steps:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -2,6 +2,8 @@ name: Link Checker
 on:
   schedule:
     - cron:  '0 0 * * *'
+permissions:
+  contents: read # to fetch code (actions/checkout)
 jobs:
   linkchecker:
     if: github.repository == 'opensearch-project/OpenSearch'

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - '*.*.*'
 
+permissions: {}
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: sashashura <aleksandrosansan@gmail.com>

Signed-off-by: sashashura <aleksandrosansan@gmail.com>
(cherry picked from commit d266a732aea4cf87781acf93e92c56ad3f1d0913)

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This is a backport of #4587 to 2.x

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
