### PR TITLE
[Extensions] Changing ExtensionActionRequest streaminput constructor to be public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Replace latches with CompletableFutures for extensions ([#5646](https://github.com/opensearch-project/OpenSearch/pull/5646))
 - Add support to disallow search request with preference parameter with strict weighted shard routing([#5874](https://github.com/opensearch-project/OpenSearch/pull/5874))
 - Added support to apply index create block ([#4603](https://github.com/opensearch-project/OpenSearch/issues/4603))
-- Changing ExtensionActionRequest streaminput constructor to be public ([#6101](https://github.com/opensearch-project/OpenSearch/pull/6101))
 
 ### Dependencies
 - Update nebula-publishing-plugin to 19.2.0 ([#5704](https://github.com/opensearch-project/OpenSearch/pull/5704))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Replace latches with CompletableFutures for extensions ([#5646](https://github.com/opensearch-project/OpenSearch/pull/5646))
 - Add support to disallow search request with preference parameter with strict weighted shard routing([#5874](https://github.com/opensearch-project/OpenSearch/pull/5874))
 - Added support to apply index create block ([#4603](https://github.com/opensearch-project/OpenSearch/issues/4603))
+- Changing ExtensionActionRequest streaminput constructor to be public ([#6101](https://github.com/opensearch-project/OpenSearch/pull/6101))
 
 ### Dependencies
 - Update nebula-publishing-plugin to 19.2.0 ([#5704](https://github.com/opensearch-project/OpenSearch/pull/5704))

--- a/server/src/main/java/org/opensearch/extensions/action/ExtensionActionRequest.java
+++ b/server/src/main/java/org/opensearch/extensions/action/ExtensionActionRequest.java
@@ -48,7 +48,7 @@ public class ExtensionActionRequest extends ActionRequest {
      * @param in bytes stream input used to de-serialize the message.
      * @throws IOException when message de-serialization fails.
      */
-    ExtensionActionRequest(StreamInput in) throws IOException {
+    public ExtensionActionRequest(StreamInput in) throws IOException {
         super(in);
         action = in.readString();
         requestBytes = in.readByteArray();


### PR DESCRIPTION
Signed-off-by: Joshua Palis <jpalis@amazon.com>

### Description
Manual backport PR to 2.x due to backport failure here : https://github.com/opensearch-project/OpenSearch/pull/6094#issuecomment-1409520637

### Check List
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
