### PR TITLE
[Backport] [1.3] Update Joda to 2.12.2 (#6083)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump reactor-netty-http to 1.0.24 in repository-azure ([#4880](https://github.com/opensearch-project/OpenSearch/pull/4880))
 - Upgrade jetty-http, kotlin-stdlib and snakeyaml ([#4981](https://github.com/opensearch-project/OpenSearch/pull/4981))
 - OpenJDK Update (January 2023 Patch releases) ([#6090](https://github.com/opensearch-project/OpenSearch/pull/6090))
+- Bumps `joda` from 2.10.13 to 2.12.2 ([#6107](https://github.com/opensearch-project/OpenSearch/pull/6107))
 
 ### Changed
 - Dependency updates (httpcore, mockito, slf4j, httpasyncclient, commons-codec) ([#4308](https://github.com/opensearch-project/OpenSearch/pull/4308))

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -23,7 +23,7 @@ kotlin            = 1.7.10
 jna               = 5.5.0
 
 netty             = 4.1.86.Final
-joda              = 2.10.12
+joda              = 2.12.2
 
 # when updating this version, you need to ensure compatibility with:
 #  - plugins/ingest-attachment (transitive dependency, check the upstream POM)

--- a/server/licenses/joda-time-2.10.12.jar.sha1
+++ b/server/licenses/joda-time-2.10.12.jar.sha1
@@ -1,1 +1,0 @@
-95b3f193ad0493d94dcd7daa9ea575c30e6be5f5

--- a/server/licenses/joda-time-2.12.2.jar.sha1
+++ b/server/licenses/joda-time-2.12.2.jar.sha1
@@ -1,0 +1,1 @@
+78e18a7b4180e911dafba0a412adfa82c1e3d14b

--- a/server/src/test/java/org/opensearch/common/time/DateUtilsTests.java
+++ b/server/src/test/java/org/opensearch/common/time/DateUtilsTests.java
@@ -58,9 +58,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class DateUtilsTests extends OpenSearchTestCase {
-    private static final Set<String> IGNORE = new HashSet<>(
-        Arrays.asList("Pacific/Enderbury", "Pacific/Kanton", "Pacific/Niue", "America/Pangnirtung")
-    );
+    private static final Set<String> IGNORE = new HashSet<>(Arrays.asList("America/Ciudad_Juarez"));
 
     public void testTimezoneIds() {
         assertNull(DateUtils.dateTimeZoneToZoneId(null));


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/6083 to `1.3`