### PR TITLE
Fix incorrect exception message for ValuesSourceConfig

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/support/ValuesSourceConfig.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/ValuesSourceConfig.java
@@ -323,7 +323,7 @@ public class ValuesSourceConfig {
         if (!valid()) {
             // TODO: resolve no longer generates invalid configs. Once VSConfig is immutable, we can drop this check
             throw new IllegalStateException(
-                "value source config is invalid; must have either a field context or a script or marked as unwrapped"
+                "value source config is invalid; must have either a field context or a script or marked as unmapped"
             );
         }
         valuesSource = ConstructValuesSource(missing, format, nowSupplier);


### PR DESCRIPTION
### Description
Fixes an incorrect IllegalStateException message - the check for `valid()` does the following logic, and should refer to this as `unmapped` and not `unwrapped`:
```
return fieldContext != null || script != null || unmapped;
```
https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/search/aggregations/support/ValuesSourceConfig.java#L382

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
