### PR TITLE
[Backport 2.x] Purge remote translog basis the latest metadata for remote-backed indexes

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -8,6 +8,9 @@
 
 package org.opensearch.index.translog;
 
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.action.ActionListener;
+import org.opensearch.common.SetOnce;
 import org.opensearch.common.io.FileSystemUtils;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lease.Releasables;
@@ -26,12 +29,15 @@ import org.opensearch.repositories.blobstore.BlobStoreRepository;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BooleanSupplier;
 import java.util.function.LongConsumer;
 import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
 /**
  * A Translog implementation which syncs local FS with a remote store
@@ -50,6 +56,12 @@ public class RemoteFsTranslog extends Translog {
     private volatile long maxRemoteTranslogGenerationUploaded;
 
     private volatile long minSeqNoToKeep;
+
+    // min generation referred by last uploaded translog
+    private volatile long minRemoteGenReferenced;
+
+    // clean up translog folder uploaded by previous primaries once
+    private final SetOnce<Boolean> olderPrimaryCleaned = new SetOnce<>();
 
     public RemoteFsTranslog(
         TranslogConfig config,
@@ -230,6 +242,7 @@ public class RemoteFsTranslog extends Translog {
                     transferReleasable.close();
                     closeFilesIfNoPendingRetentionLocks();
                     maxRemoteTranslogGenerationUploaded = generation;
+                    minRemoteGenReferenced = getMinFileGeneration();
                     logger.trace("uploaded translog for {} {} ", primaryTerm, generation);
                 }
 
@@ -327,13 +340,72 @@ public class RemoteFsTranslog extends Translog {
         this.minSeqNoToKeep = seqNo;
     }
 
-    @Override
-    void deleteReaderFiles(TranslogReader reader) {
+    private void deleteRemoteGeneration(Set<Long> generations) {
         try {
-            translogTransferManager.deleteTranslog(primaryTermSupplier.getAsLong(), reader.generation);
-        } catch (IOException ignored) {
-            logger.error("Exception {} while deleting generation {}", ignored, reader.generation);
+            translogTransferManager.deleteTranslogAsync(primaryTermSupplier.getAsLong(), generations);
+        } catch (IOException e) {
+            logger.error(() -> new ParameterizedMessage("Exception occurred while deleting generation {}", generations), e);
         }
-        super.deleteReaderFiles(reader);
+    }
+
+    @Override
+    public void trimUnreferencedReaders() throws IOException {
+        // clean up local translog files and updates readers
+        super.trimUnreferencedReaders();
+
+        // cleans up remote translog files not referenced in latest uploaded metadata.
+        // This enables us to restore translog from the metadata in case of failover or relocation.
+        Set<Long> generationsToDelete = new HashSet<>();
+        for (long generation = minRemoteGenReferenced - 1; generation >= 0; generation--) {
+            if (fileTransferTracker.uploaded(Translog.getFilename(generation)) == false) {
+                break;
+            }
+            generationsToDelete.add(generation);
+        }
+        if (generationsToDelete.isEmpty() == false) {
+            deleteRemoteGeneration(generationsToDelete);
+            deleteOlderPrimaryTranslogFilesFromRemoteStore();
+        }
+    }
+
+    /**
+     * This method must be called only after there are valid generations to delete in trimUnreferencedReaders as it ensures
+     * implicitly that minimum primary term in latest translog metadata in remote store is the current primary term.
+     */
+    private void deleteOlderPrimaryTranslogFilesFromRemoteStore() {
+        // The deletion of older translog files in remote store is on best-effort basis, there is a possibility that there
+        // are older files that are no longer needed and should be cleaned up. In here, we delete all files that are part
+        // of older primary term.
+        if (olderPrimaryCleaned.trySet(Boolean.TRUE)) {
+            logger.info("Cleaning up translog uploaded by previous primaries");
+            long minPrimaryTermInMetadata = current.getPrimaryTerm();
+            Set<Long> primaryTermsInRemote;
+            try {
+                primaryTermsInRemote = translogTransferManager.listPrimaryTerms();
+            } catch (IOException e) {
+                logger.error("Exception occurred while getting primary terms from remote store", e);
+                // If there are exceptions encountered, then we try to delete all older primary terms lesser than the
+                // minimum referenced primary term in remote translog metadata.
+                primaryTermsInRemote = LongStream.range(0, current.getPrimaryTerm()).boxed().collect(Collectors.toSet());
+            }
+            // Delete all primary terms that are no more referenced by the metadata file and exists in the
+            Set<Long> primaryTermsToDelete = primaryTermsInRemote.stream()
+                .filter(term -> term < minPrimaryTermInMetadata)
+                .collect(Collectors.toSet());
+            primaryTermsToDelete.forEach(term -> translogTransferManager.deleteTranslogAsync(term, new ActionListener<>() {
+                @Override
+                public void onResponse(Void response) {
+                    // NO-OP
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    logger.error(
+                        () -> new ParameterizedMessage("Exception occurred while deleting older translog files for primary_term={}", term),
+                        e
+                    );
+                }
+            }));
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/BlobStoreTransferService.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/BlobStoreTransferService.java
@@ -82,7 +82,36 @@ public class BlobStoreTransferService implements TransferService {
     }
 
     @Override
+    public void deleteBlobsAsync(Iterable<String> path, List<String> fileNames, ActionListener<Void> listener) {
+        executorService.execute(() -> {
+            try {
+                blobStore.blobContainer((BlobPath) path).deleteBlobsIgnoringIfNotExists(fileNames);
+                listener.onResponse(null);
+            } catch (IOException e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+
+    @Override
+    public void deleteAsync(Iterable<String> path, ActionListener<Void> listener) {
+        executorService.execute(() -> {
+            try {
+                blobStore.blobContainer((BlobPath) path).delete();
+                listener.onResponse(null);
+            } catch (IOException e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+
+    @Override
     public Set<String> listAll(Iterable<String> path) throws IOException {
         return blobStore.blobContainer((BlobPath) path).listBlobs().keySet();
+    }
+
+    @Override
+    public Set<String> listFolders(Iterable<String> path) throws IOException {
+        return blobStore.blobContainer((BlobPath) path).children().keySet();
     }
 }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/FileTransferTracker.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/FileTransferTracker.java
@@ -13,6 +13,7 @@ import org.opensearch.index.translog.transfer.FileSnapshot.TransferFileSnapshot;
 import org.opensearch.index.translog.transfer.listener.FileTransferListener;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -55,9 +56,14 @@ public class FileTransferTracker implements FileTransferListener {
         add(fileSnapshot.getName(), TransferState.FAILED);
     }
 
-    @Override
-    public void onDelete(String name) {
-        fileTransferTracker.remove(name);
+    public void delete(List<String> names) {
+        for (String name : names) {
+            fileTransferTracker.remove(name);
+        }
+    }
+
+    public boolean uploaded(String file) {
+        return fileTransferTracker.get(file) == TransferState.SUCCESS;
     }
 
     public Set<TransferFileSnapshot> exclusionFilter(Set<TransferFileSnapshot> original) {

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TransferService.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TransferService.java
@@ -45,6 +45,10 @@ public interface TransferService {
 
     void deleteBlobs(Iterable<String> path, List<String> fileNames) throws IOException;
 
+    void deleteBlobsAsync(Iterable<String> path, List<String> fileNames, ActionListener<Void> listener);
+
+    void deleteAsync(Iterable<String> path, ActionListener<Void> listener);
+
     /**
      * Lists the files
      * @param path : the path to list
@@ -52,6 +56,14 @@ public interface TransferService {
      * @throws IOException the exception while listing the path
      */
     Set<String> listAll(Iterable<String> path) throws IOException;
+
+    /**
+     * Lists the folders inside the path.
+     * @param path : the path
+     * @return list of folders inside the path
+     * @throws IOException the exception while listing folders inside the path
+     */
+    Set<String> listFolders(Iterable<String> path) throws IOException;
 
     /**
      *

--- a/server/src/main/java/org/opensearch/index/translog/transfer/listener/FileTransferListener.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/listener/FileTransferListener.java
@@ -30,5 +30,4 @@ public interface FileTransferListener {
      */
     void onFailure(TransferFileSnapshot fileSnapshot, Exception e);
 
-    void onDelete(String name);
 }

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFSTranslogTests.java
@@ -465,7 +465,7 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
         }
     }
 
-    public void testSimpleOperationsUpload() throws IOException {
+    public void testSimpleOperationsUpload() throws Exception {
         ArrayList<Translog.Operation> ops = new ArrayList<>();
         try (Translog.Snapshot snapshot = translog.newSnapshot()) {
             assertThat(snapshot, SnapshotMatchers.size(0));
@@ -477,18 +477,18 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
             assertThat(snapshot.totalOperations(), equalTo(ops.size()));
         }
 
-        assertEquals(translog.allUploaded().size(), 2);
+        assertEquals(4, translog.allUploaded().size());
 
         addToTranslogAndListAndUpload(translog, ops, new Translog.Index("1", 1, primaryTerm.get(), new byte[] { 1 }));
-        assertEquals(translog.allUploaded().size(), 4);
+        assertEquals(6, translog.allUploaded().size());
 
         translog.rollGeneration();
-        assertEquals(translog.allUploaded().size(), 4);
+        assertEquals(6, translog.allUploaded().size());
 
         Set<String> mdFiles = blobStoreTransferService.listAll(
             repository.basePath().add(shardId.getIndex().getUUID()).add(String.valueOf(shardId.id())).add("metadata")
         );
-        assertEquals(mdFiles.size(), 2);
+        assertEquals(2, mdFiles.size());
         logger.info("All md files {}", mdFiles);
 
         Set<String> tlogFiles = blobStoreTransferService.listAll(
@@ -529,33 +529,48 @@ public class RemoteFSTranslogTests extends OpenSearchTestCase {
         translog.deletionPolicy.setLocalCheckpointOfSafeCommit(0);
         // simulating the remote segment upload .
         translog.setMinSeqNoToKeep(0);
-        // This should not trim anything
+        // This should not trim anything from local
         translog.trimUnreferencedReaders();
-        assertEquals(translog.allUploaded().size(), 4);
-        assertEquals(
-            blobStoreTransferService.listAll(
-                repository.basePath()
-                    .add(shardId.getIndex().getUUID())
-                    .add(String.valueOf(shardId.id()))
-                    .add(String.valueOf(primaryTerm.get()))
-            ).size(),
-            4
-        );
+        assertEquals(2, translog.readers.size());
+        assertBusy(() -> {
+            assertEquals(4, translog.allUploaded().size());
+            assertEquals(
+                4,
+                blobStoreTransferService.listAll(
+                    repository.basePath()
+                        .add(shardId.getIndex().getUUID())
+                        .add(String.valueOf(shardId.id()))
+                        .add(String.valueOf(primaryTerm.get()))
+                ).size()
+            );
+        });
 
-        // This should trim tlog-2.* files as it contains seq no 0
+        // This should trim tlog-2 from local
+        // This should not trim tlog-2.* files from remote as we not uploading any more translog to remote
         translog.setMinSeqNoToKeep(1);
+        translog.deletionPolicy.setLocalCheckpointOfSafeCommit(1);
         translog.trimUnreferencedReaders();
-        assertEquals(translog.allUploaded().size(), 2);
-        assertEquals(
-            blobStoreTransferService.listAll(
-                repository.basePath()
-                    .add(shardId.getIndex().getUUID())
-                    .add(String.valueOf(shardId.id()))
-                    .add(String.valueOf(primaryTerm.get()))
-            ).size(),
-            2
-        );
+        assertEquals(1, translog.readers.size());
+        assertBusy(() -> {
+            assertEquals(4, translog.allUploaded().size());
+            assertEquals(
+                4,
+                blobStoreTransferService.listAll(
+                    repository.basePath()
+                        .add(shardId.getIndex().getUUID())
+                        .add(String.valueOf(shardId.id()))
+                        .add(String.valueOf(primaryTerm.get()))
+                ).size()
+            );
+        });
 
+        // this should now trim as tlog-2 files from remote, but not tlog-3 and tlog-4
+        addToTranslogAndListAndUpload(translog, ops, new Translog.Index("2", 2, primaryTerm.get(), new byte[] { 1 }));
+        translog.deletionPolicy.setLocalCheckpointOfSafeCommit(1);
+        translog.setMinSeqNoToKeep(2);
+        translog.trimUnreferencedReaders();
+        assertEquals(1, translog.readers.size());
+        assertBusy(() -> assertEquals(4, translog.allUploaded().size()));
     }
 
     private Long populateTranslogOps(boolean withMissingOps) throws IOException {

--- a/server/src/test/java/org/opensearch/index/translog/transfer/FileTransferTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/FileTransferTrackerTests.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.List;
 
 public class FileTransferTrackerTests extends OpenSearchTestCase {
 
@@ -71,6 +72,27 @@ public class FileTransferTrackerTests extends OpenSearchTestCase {
 
             fileTransferTracker.onSuccess(transferFileSnapshot);
             assertEquals(fileTransferTracker.allUploaded().size(), 2);
+        }
+    }
+
+    public void testUploaded() throws IOException {
+        fileTransferTracker = new FileTransferTracker(shardId);
+        Path testFile = createTempFile();
+        Files.write(testFile, randomByteArrayOfLength(128), StandardOpenOption.APPEND);
+        try (
+            FileSnapshot.TransferFileSnapshot transferFileSnapshot = new FileSnapshot.TransferFileSnapshot(
+                testFile,
+                randomNonNegativeLong()
+            );
+
+        ) {
+            fileTransferTracker.onSuccess(transferFileSnapshot);
+            String fileName = String.valueOf(testFile.getFileName());
+            assertTrue(fileTransferTracker.uploaded(fileName));
+            assertFalse(fileTransferTracker.uploaded("random-name"));
+
+            fileTransferTracker.delete(List.of(fileName));
+            assertFalse(fileTransferTracker.uploaded(fileName));
         }
     }
 


### PR DESCRIPTION
Backport https://github.com/opensearch-project/OpenSearch/commit/54ce4237e01b55f7b861e5b3cdf4d36999b671f9 from https://github.com/opensearch-project/OpenSearch/pull/6086.