### PR TITLE
Backport version.yml to 2.x

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -59,11 +59,12 @@ jobs:
           token: ${{ steps.github_app_token.outputs.token }}
           base: ${{ env.BASE }}
           branch: 'create-pull-request/patch-${{ env.BASE }}'
-          commit-message: Incremented version to ${{ env.NEXT_VERSION }}
+          commit-message: Increment version to ${{ env.NEXT_VERSION }}
+          signoff: true
           delete-branch: true
           labels: |
             autocut
-          title: '[AUTO] Incremented version to ${{ env.NEXT_VERSION }}.'
+          title: '[AUTO] Increment version to ${{ env.NEXT_VERSION }}.'
           body: |
             I've noticed that a new tag ${{ env.TAG }} was pushed, and incremented the version from ${{ env.CURRENT_VERSION }} to ${{ env.NEXT_VERSION }}.
 
@@ -85,11 +86,12 @@ jobs:
           token: ${{ steps.github_app_token.outputs.token }}
           base: ${{ env.BASE_X }}
           branch: 'create-pull-request/patch-${{ env.BASE_X }}'
-          commit-message: Added bwc version ${{ env.NEXT_VERSION }}
+          commit-message: Add bwc version ${{ env.NEXT_VERSION }}
+          signoff: true
           delete-branch: true
           labels: |
             autocut
-          title: '[AUTO] [${{ env.BASE_X }}] Added bwc version ${{ env.NEXT_VERSION }}.'
+          title: '[AUTO] [${{ env.BASE_X }}] Add bwc version ${{ env.NEXT_VERSION }}.'
           body: |
             I've noticed that a new tag ${{ env.TAG }} was pushed, and added a bwc version ${{ env.NEXT_VERSION }}.
 
@@ -111,10 +113,11 @@ jobs:
           token: ${{ steps.github_app_token.outputs.token }}
           base: main
           branch: 'create-pull-request/patch-main'
-          commit-message: Added bwc version ${{ env.NEXT_VERSION }}
+          commit-message: Add bwc version ${{ env.NEXT_VERSION }}
+          signoff: true
           delete-branch: true
           labels: |
             autocut
-          title: '[AUTO] [main] Added bwc version ${{ env.NEXT_VERSION }}.'
+          title: '[AUTO] [main] Add bwc version ${{ env.NEXT_VERSION }}.'
           body: |
             I've noticed that a new tag ${{ env.TAG }} was pushed, and added a bwc version ${{ env.NEXT_VERSION }}.


### PR DESCRIPTION
This backports both #2572 and #6177. This was created by doing:

```
git checkout upstream/main .github/workflows/version.yml
```

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
