### PR TITLE
Use SafeConstructor() instead of Constructor()

### DIFF
--- a/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
+++ b/server/src/main/java/org/opensearch/extensions/ExtensionsManager.java
@@ -66,6 +66,7 @@ import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
 import org.yaml.snakeyaml.Yaml;
 import org.opensearch.env.EnvironmentSettingsResponse;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 /**
  * The main class for managing Extension communication with the OpenSearch Node.
@@ -555,7 +556,7 @@ public class ExtensionsManager {
     }
 
     private ExtensionsSettings readFromExtensionsYml(Path filePath) throws IOException {
-        Yaml yaml = new Yaml();
+        Yaml yaml = new Yaml(new SafeConstructor());
         try (InputStream inputStream = Files.newInputStream(filePath)) {
             Map<String, Object> obj = yaml.load(inputStream);
             if (obj == null) {


### PR DESCRIPTION
@ryanbogan @saratvemulapalli Can you verify if this okay? For reference, a similar change was made here: https://github.com/opensearch-project/security-analytics/pull/198

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
