### PR TITLE
Changing SearchBP version to 2_6_0

### DIFF
--- a/server/src/main/java/org/opensearch/search/backpressure/SearchBackpressureService.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/SearchBackpressureService.java
@@ -308,7 +308,7 @@ public class SearchBackpressureService extends AbstractLifecycleComponent implem
         return settings;
     }
 
-    SearchBackpressureState getSearchBackpressureStats(Class<? extends SearchBackpressureTask> taskType) {
+    SearchBackpressureState getSearchBackpressureState(Class<? extends SearchBackpressureTask> taskType) {
         return searchBackpressureStates.get(taskType);
     }
 

--- a/server/src/main/java/org/opensearch/search/backpressure/settings/SearchBackpressureSettings.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/settings/SearchBackpressureSettings.java
@@ -14,7 +14,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 
 /**
- * Settings related to search backpressure mode and internal
+ * Settings related to search backpressure mode and interval
  *
  * @opensearch.internal
  */

--- a/server/src/main/java/org/opensearch/search/backpressure/settings/SearchTaskSettings.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/settings/SearchTaskSettings.java
@@ -179,10 +179,6 @@ public class SearchTaskSettings {
         clusterSettings.addSettingsUpdateConsumer(SETTING_CANCELLATION_BURST, this::setCancellationBurst);
     }
 
-    /**
-     * Callback listeners.
-     */
-
     public double getTotalHeapPercentThreshold() {
         return totalHeapPercentThreshold;
     }

--- a/server/src/main/java/org/opensearch/search/backpressure/stats/SearchBackpressureStats.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/stats/SearchBackpressureStats.java
@@ -42,7 +42,7 @@ public class SearchBackpressureStats implements ToXContentFragment, Writeable {
     public SearchBackpressureStats(StreamInput in) throws IOException {
         searchShardTaskStats = new SearchShardTaskStats(in);
         mode = SearchBackpressureMode.fromName(in.readString());
-        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_2_6_0)) {
             searchTaskStats = in.readOptionalWriteable(SearchTaskStats::new);
         } else {
             searchTaskStats = null;
@@ -64,7 +64,7 @@ public class SearchBackpressureStats implements ToXContentFragment, Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         searchShardTaskStats.writeTo(out);
         out.writeString(mode.getName());
-        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_2_6_0)) {
             out.writeOptionalWriteable(searchTaskStats);
         }
     }

--- a/server/src/test/java/org/opensearch/tasks/TaskCancellationTests.java
+++ b/server/src/test/java/org/opensearch/tasks/TaskCancellationTests.java
@@ -69,7 +69,7 @@ public class TaskCancellationTests extends OpenSearchTestCase {
             }
 
             @Override
-            public Stats stats(List<? extends Task> searchShardTasks) {
+            public Stats stats(List<? extends Task> activeTasks) {
                 return null;
             }
         };


### PR DESCRIPTION
### Description
Changing Search Backpressure version to 2.6 and other minor refactoring.

### Issues Resolved
#5173

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: PritLadani <pritkladani@gmail.com>