### PR TITLE
[Refactor] Requests to use MediaType instead of XContentType

### DIFF
--- a/client/rest-high-level/src/main/java/org/opensearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/RequestConverters.java
@@ -520,7 +520,7 @@ final class RequestConverters {
         XContent xContent = REQUEST_BODY_CONTENT_TYPE.xContent();
         byte[] source = MultiSearchRequest.writeMultiLineFormat(multiSearchRequest, xContent);
         request.addParameters(params.asMap());
-        request.setEntity(new ByteArrayEntity(source, createContentType(xContent.type())));
+        request.setEntity(new ByteArrayEntity(source, createContentType(xContent.mediaType())));
         return request;
     }
 
@@ -555,7 +555,7 @@ final class RequestConverters {
 
         XContent xContent = REQUEST_BODY_CONTENT_TYPE.xContent();
         byte[] source = MultiSearchTemplateRequest.writeMultiLineFormat(multiSearchTemplateRequest, xContent);
-        request.setEntity(new ByteArrayEntity(source, createContentType(xContent.type())));
+        request.setEntity(new ByteArrayEntity(source, createContentType(xContent.mediaType())));
         return request;
     }
 

--- a/client/rest-high-level/src/main/java/org/opensearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/RequestConverters.java
@@ -79,6 +79,7 @@ import org.opensearch.common.lucene.uid.Versions;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.CollectionUtils;
 import org.opensearch.common.xcontent.DeprecationHandler;
+import org.opensearch.common.xcontent.MediaType;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContent;
@@ -112,6 +113,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.StringJoiner;
 
+/**
+ * Converts OpenSearch writeable requests to an HTTP Request
+ *
+ * @opensearch.api
+ */
 final class RequestConverters {
     static final XContentType REQUEST_BODY_CONTENT_TYPE = XContentType.JSON;
 
@@ -867,10 +873,24 @@ final class RequestConverters {
      *
      * @param xContentType the {@link XContentType}
      * @return the {@link ContentType}
+     *
+     * @deprecated use {@link #createContentType(MediaType)} instead
      */
+    @Deprecated
     @SuppressForbidden(reason = "Only allowed place to convert a XContentType to a ContentType")
     public static ContentType createContentType(final XContentType xContentType) {
         return ContentType.create(xContentType.mediaTypeWithoutParameters(), (Charset) null);
+    }
+
+    /**
+     * Returns a {@link ContentType} from a given {@link XContentType}.
+     *
+     * @param mediaType the {@link MediaType}
+     * @return the {@link ContentType}
+     */
+    @SuppressForbidden(reason = "Only allowed place to convert a XContentType to a ContentType")
+    public static ContentType createContentType(final MediaType mediaType) {
+        return ContentType.create(mediaType.mediaTypeWithoutParameters(), (Charset) null);
     }
 
     /**

--- a/client/rest-high-level/src/main/java/org/opensearch/client/indices/CreateIndexRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/indices/CreateIndexRequest.java
@@ -44,6 +44,7 @@ import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.DeprecationHandler;
+import org.opensearch.common.xcontent.MediaType;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -64,6 +65,8 @@ import static org.opensearch.common.settings.Settings.Builder.EMPTY_SETTINGS;
 
 /**
  * A request to create an index.
+ *
+ * @opensearch.api
  */
 public class CreateIndexRequest extends TimedRequest implements Validatable, ToXContentObject {
     static final ParseField MAPPINGS = new ParseField("mappings");
@@ -122,9 +125,20 @@ public class CreateIndexRequest extends TimedRequest implements Validatable, ToX
 
     /**
      * The settings to create the index with (either json or yaml format)
+     *
+     * @deprecated use {@link #settings(String source, MediaType mediaType)} instead
      */
+    @Deprecated
     public CreateIndexRequest settings(String source, XContentType xContentType) {
         this.settings = Settings.builder().loadFromSource(source, xContentType).build();
+        return this;
+    }
+
+    /**
+     * The settings to create the index with (either json or yaml format)
+     */
+    public CreateIndexRequest settings(String source, MediaType mediaType) {
+        this.settings = Settings.builder().loadFromSource(source, mediaType).build();
         return this;
     }
 
@@ -159,9 +173,24 @@ public class CreateIndexRequest extends TimedRequest implements Validatable, ToX
      *
      * @param source The mapping source
      * @param xContentType The content type of the source
+     *
+     * @deprecated use {@link #mapping(String source, MediaType mediaType)} instead
      */
+    @Deprecated
     public CreateIndexRequest mapping(String source, XContentType xContentType) {
         return mapping(new BytesArray(source), xContentType);
+    }
+
+    /**
+     * Adds mapping that will be added when the index gets created.
+     *
+     * Note that the definition should *not* be nested under a type name.
+     *
+     * @param source The mapping source
+     * @param mediaType The media type of the source
+     */
+    public CreateIndexRequest mapping(String source, MediaType mediaType) {
+        return mapping(new BytesArray(source), mediaType);
     }
 
     /**
@@ -199,11 +228,29 @@ public class CreateIndexRequest extends TimedRequest implements Validatable, ToX
      *
      * @param source The mapping source
      * @param xContentType the content type of the mapping source
+     *
+     * @deprecated use {@link #mapping(BytesReference source, MediaType mediaType)} instead
      */
+    @Deprecated
     public CreateIndexRequest mapping(BytesReference source, XContentType xContentType) {
         Objects.requireNonNull(xContentType);
         mappings = source;
         mappingsXContentType = xContentType;
+        return this;
+    }
+
+    /**
+     * Adds mapping that will be added when the index gets created.
+     *
+     * Note that the definition should *not* be nested under a type name.
+     *
+     * @param source The mapping source
+     * @param mediaType the content type of the mapping source
+     */
+    public CreateIndexRequest mapping(BytesReference source, MediaType mediaType) {
+        Objects.requireNonNull(mediaType);
+        mappings = source;
+        mappingsXContentType = (XContentType) mediaType;
         return this;
     }
 
@@ -233,7 +280,10 @@ public class CreateIndexRequest extends TimedRequest implements Validatable, ToX
 
     /**
      * Sets the aliases that will be associated with the index when it gets created
+     *
+     * @deprecated use {@link #aliases(String, MediaType)} instead
      */
+    @Deprecated
     public CreateIndexRequest aliases(String source, XContentType contentType) {
         return aliases(new BytesArray(source), contentType);
     }
@@ -241,7 +291,24 @@ public class CreateIndexRequest extends TimedRequest implements Validatable, ToX
     /**
      * Sets the aliases that will be associated with the index when it gets created
      */
+    public CreateIndexRequest aliases(String source, MediaType mediaType) {
+        return aliases(new BytesArray(source), mediaType);
+    }
+
+    /**
+     * Sets the aliases that will be associated with the index when it gets created
+     *
+     * @deprecated use {@link #aliases(BytesReference source, MediaType contentType)} instead
+     */
+    @Deprecated
     public CreateIndexRequest aliases(BytesReference source, XContentType contentType) {
+        return aliases(source, (MediaType) contentType);
+    }
+
+    /**
+     * Sets the aliases that will be associated with the index when it gets created
+     */
+    public CreateIndexRequest aliases(BytesReference source, MediaType contentType) {
         // EMPTY is safe here because we never call namedObject
         try (
             XContentParser parser = XContentHelper.createParser(
@@ -282,9 +349,21 @@ public class CreateIndexRequest extends TimedRequest implements Validatable, ToX
      * Sets the settings and mappings as a single source.
      *
      * Note that the mapping definition should *not* be nested under a type name.
+     *
+     * @deprecated use {@link #source(String, MediaType)} instead
      */
+    @Deprecated
     public CreateIndexRequest source(String source, XContentType xContentType) {
         return source(new BytesArray(source), xContentType);
+    }
+
+    /**
+     * Sets the settings and mappings as a single source.
+     *
+     * Note that the mapping definition should *not* be nested under a type name.
+     */
+    public CreateIndexRequest source(String source, MediaType mediaType) {
+        return source(new BytesArray(source), mediaType);
     }
 
     /**
@@ -300,10 +379,24 @@ public class CreateIndexRequest extends TimedRequest implements Validatable, ToX
      * Sets the settings and mappings as a single source.
      *
      * Note that the mapping definition should *not* be nested under a type name.
+     *
+     * @deprecated use {@link #source(BytesReference, MediaType)} instead
      */
+    @Deprecated
     public CreateIndexRequest source(BytesReference source, XContentType xContentType) {
         Objects.requireNonNull(xContentType);
         source(XContentHelper.convertToMap(source, false, xContentType).v2());
+        return this;
+    }
+
+    /**
+     * Sets the settings and mappings as a single source.
+     *
+     * Note that the mapping definition should *not* be nested under a type name.
+     */
+    public CreateIndexRequest source(BytesReference source, MediaType mediaType) {
+        Objects.requireNonNull(mediaType);
+        source(XContentHelper.convertToMap(source, false, mediaType).v2());
         return this;
     }
 

--- a/client/rest-high-level/src/main/java/org/opensearch/client/indices/PutIndexTemplateRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/indices/PutIndexTemplateRequest.java
@@ -43,6 +43,7 @@ import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.DeprecationHandler;
+import org.opensearch.common.xcontent.MediaType;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -268,9 +269,10 @@ public class PutIndexTemplateRequest extends ClusterManagerNodeRequest<PutIndexT
         try {
             XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
             builder.map(source);
-            Objects.requireNonNull(builder.contentType());
+            MediaType mediaType = builder.contentType();
+            Objects.requireNonNull(mediaType);
             try {
-                mappings = new BytesArray(XContentHelper.convertToJson(BytesReference.bytes(builder), false, false, builder.contentType()));
+                mappings = new BytesArray(XContentHelper.convertToJson(BytesReference.bytes(builder), false, false, mediaType));
                 return this;
             } catch (IOException e) {
                 throw new UncheckedIOException("failed to convert source to json", e);
@@ -342,7 +344,10 @@ public class PutIndexTemplateRequest extends ClusterManagerNodeRequest<PutIndexT
 
     /**
      * The template source definition.
+     *
+     * @deprecated use {@link #source(String, MediaType)} instead
      */
+    @Deprecated
     public PutIndexTemplateRequest source(String templateSource, XContentType xContentType) {
         return source(XContentHelper.convertToMap(xContentType.xContent(), templateSource, true));
     }
@@ -350,6 +355,16 @@ public class PutIndexTemplateRequest extends ClusterManagerNodeRequest<PutIndexT
     /**
      * The template source definition.
      */
+    public PutIndexTemplateRequest source(String templateSource, MediaType mediaType) {
+        return source(XContentHelper.convertToMap(mediaType.xContent(), templateSource, true));
+    }
+
+    /**
+     * The template source definition.
+     *
+     * @deprecated use {@link #source(byte[], MediaType)} instead
+     */
+    @Deprecated
     public PutIndexTemplateRequest source(byte[] source, XContentType xContentType) {
         return source(source, 0, source.length, xContentType);
     }
@@ -357,6 +372,16 @@ public class PutIndexTemplateRequest extends ClusterManagerNodeRequest<PutIndexT
     /**
      * The template source definition.
      */
+    public PutIndexTemplateRequest source(byte[] source, MediaType mediaType) {
+        return source(source, 0, source.length, mediaType);
+    }
+
+    /**
+     * The template source definition.
+     *
+     * @deprecated use {@link #source(byte[], int, int, MediaType)} instead
+     */
+    @Deprecated
     public PutIndexTemplateRequest source(byte[] source, int offset, int length, XContentType xContentType) {
         return source(new BytesArray(source, offset, length), xContentType);
     }
@@ -364,8 +389,25 @@ public class PutIndexTemplateRequest extends ClusterManagerNodeRequest<PutIndexT
     /**
      * The template source definition.
      */
+    public PutIndexTemplateRequest source(byte[] source, int offset, int length, MediaType mediaType) {
+        return source(new BytesArray(source, offset, length), mediaType);
+    }
+
+    /**
+     * The template source definition.
+     *
+     * @deprecated use {@link #source(BytesReference, MediaType)} instead
+     */
+    @Deprecated
     public PutIndexTemplateRequest source(BytesReference source, XContentType xContentType) {
         return source(XContentHelper.convertToMap(source, true, xContentType).v2());
+    }
+
+    /**
+     * The template source definition.
+     */
+    public PutIndexTemplateRequest source(BytesReference source, MediaType mediaType) {
+        return source(XContentHelper.convertToMap(source, true, mediaType).v2());
     }
 
     public Set<Alias> aliases() {

--- a/client/rest-high-level/src/main/java/org/opensearch/client/indices/PutMappingRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/indices/PutMappingRequest.java
@@ -38,6 +38,7 @@ import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.client.TimedRequest;
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.xcontent.MediaType;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -52,6 +53,8 @@ import java.util.Map;
  * Put a mapping definition into one or more indices. If an index already contains mappings,
  * the new mappings will be merged with the existing one. If there are elements that cannot
  * be merged, the request will be rejected.
+ *
+ * @opensearch.api
  */
 public class PutMappingRequest extends TimedRequest implements IndicesRequest, ToXContentObject {
 
@@ -59,7 +62,7 @@ public class PutMappingRequest extends TimedRequest implements IndicesRequest, T
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, true);
 
     private BytesReference source;
-    private XContentType xContentType;
+    private MediaType mediaType;
 
     /**
      * Constructs a new put mapping request against one or more indices. If no indices
@@ -96,9 +99,19 @@ public class PutMappingRequest extends TimedRequest implements IndicesRequest, T
 
     /**
      * The {@link XContentType} of the mapping source.
+     *
+     * @deprecated use {@link #mediaType()} instead
      */
+    @Deprecated
     public XContentType xContentType() {
-        return xContentType;
+        return (XContentType) mediaType;
+    }
+
+    /**
+     * The {@link XContentType} of the mapping source.
+     */
+    public MediaType mediaType() {
+        return mediaType;
     }
 
     /**
@@ -120,10 +133,24 @@ public class PutMappingRequest extends TimedRequest implements IndicesRequest, T
      * The mapping source definition.
      *
      * Note that the definition should *not* be nested under a type name.
+     *
+     * @deprecated use {@link #source(String, MediaType)} instead
      */
+    @Deprecated
     public PutMappingRequest source(String mappingSource, XContentType xContentType) {
         this.source = new BytesArray(mappingSource);
-        this.xContentType = xContentType;
+        this.mediaType = xContentType;
+        return this;
+    }
+
+    /**
+     * The mapping source definition.
+     *
+     * Note that the definition should *not* be nested under a type name.
+     */
+    public PutMappingRequest source(String mappingSource, MediaType mediaType) {
+        this.source = new BytesArray(mappingSource);
+        this.mediaType = mediaType;
         return this;
     }
 
@@ -134,7 +161,25 @@ public class PutMappingRequest extends TimedRequest implements IndicesRequest, T
      */
     public PutMappingRequest source(XContentBuilder builder) {
         this.source = BytesReference.bytes(builder);
-        this.xContentType = builder.contentType();
+        MediaType mediaType = builder.contentType();
+        if (mediaType instanceof XContentType == false) {
+            throw new IllegalArgumentException("PutMappingRequest does not support media type [" + mediaType.getClass().getName() + "]");
+        }
+        this.mediaType = builder.contentType();
+        return this;
+    }
+
+    /**
+     * The mapping source definition.
+     *
+     * Note that the definition should *not* be nested under a type name.
+     *
+     * @deprecated use {@link #source(BytesReference, MediaType)} instead
+     */
+    @Deprecated
+    public PutMappingRequest source(BytesReference source, XContentType xContentType) {
+        this.source = source;
+        this.mediaType = xContentType;
         return this;
     }
 
@@ -143,9 +188,9 @@ public class PutMappingRequest extends TimedRequest implements IndicesRequest, T
      *
      * Note that the definition should *not* be nested under a type name.
      */
-    public PutMappingRequest source(BytesReference source, XContentType xContentType) {
+    public PutMappingRequest source(BytesReference source, MediaType mediaType) {
         this.source = source;
-        this.xContentType = xContentType;
+        this.mediaType = mediaType;
         return this;
     }
 
@@ -153,7 +198,7 @@ public class PutMappingRequest extends TimedRequest implements IndicesRequest, T
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         if (source != null) {
             try (InputStream stream = source.streamInput()) {
-                builder.rawValue(stream, xContentType);
+                builder.rawValue(stream, mediaType);
             }
         } else {
             builder.startObject().endObject();

--- a/client/rest-high-level/src/main/java/org/opensearch/client/indices/PutMappingRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/indices/PutMappingRequest.java
@@ -161,10 +161,6 @@ public class PutMappingRequest extends TimedRequest implements IndicesRequest, T
      */
     public PutMappingRequest source(XContentBuilder builder) {
         this.source = BytesReference.bytes(builder);
-        MediaType mediaType = builder.contentType();
-        if (mediaType instanceof XContentType == false) {
-            throw new IllegalArgumentException("PutMappingRequest does not support media type [" + mediaType.getClass().getName() + "]");
-        }
         this.mediaType = builder.contentType();
         return this;
     }

--- a/client/rest-high-level/src/test/java/org/opensearch/client/indices/PutMappingRequestTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/indices/PutMappingRequestTests.java
@@ -74,8 +74,8 @@ public class PutMappingRequestTests extends AbstractXContentTestCase<PutMappingR
     protected void assertEqualInstances(PutMappingRequest expected, PutMappingRequest actual) {
         if (actual.source() != null) {
             try (
-                XContentParser expectedJson = createParser(expected.xContentType().xContent(), expected.source());
-                XContentParser actualJson = createParser(actual.xContentType().xContent(), actual.source())
+                XContentParser expectedJson = createParser(expected.mediaType().xContent(), expected.source());
+                XContentParser actualJson = createParser(actual.mediaType().xContent(), actual.source())
             ) {
                 assertEquals(expectedJson.mapOrdered(), actualJson.mapOrdered());
             } catch (IOException e) {

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/MediaType.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/MediaType.java
@@ -63,5 +63,11 @@ public interface MediaType {
         return type() + "/" + subtype();
     }
 
+    default String mediaType() {
+        return mediaTypeWithoutParameters();
+    }
+
+    String mediaTypeWithoutParameters();
+
     XContent xContent();
 }

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContent.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContent.java
@@ -46,7 +46,7 @@ public interface XContent {
     /**
      * The type this content handles and produces.
      */
-    MediaType type();
+    MediaType mediaType();
 
     byte streamSeparator();
 

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContent.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContent.java
@@ -46,7 +46,7 @@ public interface XContent {
     /**
      * The type this content handles and produces.
      */
-    XContentType type();
+    MediaType type();
 
     byte streamSeparator();
 

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentBuilder.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentBuilder.java
@@ -1004,7 +1004,7 @@ public final class XContentBuilder implements Closeable, Flushable {
     /**
      * Writes a value with the source coming directly from the bytes in the stream
      */
-    public XContentBuilder rawValue(InputStream stream, XContentType contentType) throws IOException {
+    public XContentBuilder rawValue(InputStream stream, MediaType contentType) throws IOException {
         generator.writeRawValue(stream, contentType);
         return this;
     }

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentBuilder.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentBuilder.java
@@ -995,9 +995,20 @@ public final class XContentBuilder implements Closeable, Flushable {
 
     /**
      * Writes a raw field with the value taken from the bytes in the stream
+     *
+     * @deprecated use {@link #rawField(String, InputStream, MediaType)} instead
      */
+    @Deprecated
     public XContentBuilder rawField(String name, InputStream value, XContentType contentType) throws IOException {
         generator.writeRawField(name, value, contentType);
+        return this;
+    }
+
+    /**
+     * Writes a raw field with the value taken from the bytes in the stream
+     */
+    public XContentBuilder rawField(String name, InputStream value, MediaType mediaType) throws IOException {
+        generator.writeRawField(name, value, mediaType);
         return this;
     }
 

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentBuilder.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentBuilder.java
@@ -1003,6 +1003,17 @@ public final class XContentBuilder implements Closeable, Flushable {
 
     /**
      * Writes a value with the source coming directly from the bytes in the stream
+     *
+     * @deprecated use {@link #rawValue(InputStream, MediaType)} instead
+     */
+    @Deprecated
+    public XContentBuilder rawValue(InputStream stream, XContentType contentType) throws IOException {
+        generator.writeRawValue(stream, contentType);
+        return this;
+    }
+
+    /**
+     * Writes a value with the source coming directly from the bytes in the stream
      */
     public XContentBuilder rawValue(InputStream stream, MediaType contentType) throws IOException {
         generator.writeRawValue(stream, contentType);

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentFactory.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentFactory.java
@@ -141,7 +141,7 @@ public class XContentFactory {
     /**
      * Returns the {@link org.opensearch.common.xcontent.XContent} for the provided content type.
      */
-    public static XContent xContent(XContentType type) {
+    public static XContent xContent(MediaType type) {
         if (type == null) {
             throw new IllegalArgumentException("Cannot get xcontent for unknown type");
         }

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentGenerator.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentGenerator.java
@@ -122,7 +122,7 @@ public interface XContentGenerator extends Closeable, Flushable {
     /**
      * Writes a raw value taken from the bytes in the stream
      */
-    void writeRawValue(InputStream value, XContentType xContentType) throws IOException;
+    void writeRawValue(InputStream value, MediaType xContentType) throws IOException;
 
     void copyCurrentStructure(XContentParser parser) throws IOException;
 

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentGenerator.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentGenerator.java
@@ -121,8 +121,15 @@ public interface XContentGenerator extends Closeable, Flushable {
 
     /**
      * Writes a raw value taken from the bytes in the stream
+     * @deprecated use {@link #writeRawValue(InputStream, MediaType)} instead
      */
-    void writeRawValue(InputStream value, MediaType xContentType) throws IOException;
+    @Deprecated
+    void writeRawValue(InputStream value, XContentType xContentType) throws IOException;
+
+    /**
+     * Writes a raw value taken from the bytes in the stream
+     */
+    void writeRawValue(InputStream value, MediaType mediaType) throws IOException;
 
     void copyCurrentStructure(XContentParser parser) throws IOException;
 

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentGenerator.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentGenerator.java
@@ -116,8 +116,15 @@ public interface XContentGenerator extends Closeable, Flushable {
 
     /**
      * Writes a raw field with the value taken from the bytes in the stream
+     * @deprecated use {@link #writeRawField(String, InputStream, MediaType)} instead
      */
+    @Deprecated
     void writeRawField(String name, InputStream value, XContentType xContentType) throws IOException;
+
+    /**
+     * Writes a raw field with the value taken from the bytes in the stream
+     */
+    void writeRawField(String name, InputStream value, MediaType mediaType) throws IOException;
 
     /**
      * Writes a raw value taken from the bytes in the stream

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentType.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentType.java
@@ -186,12 +186,6 @@ public enum XContentType implements MediaType {
         return index;
     }
 
-    public String mediaType() {
-        return mediaTypeWithoutParameters();
-    }
-
-    public abstract String mediaTypeWithoutParameters();
-
     @Override
     public String type() {
         return "application";

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/cbor/CborXContent.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/cbor/CborXContent.java
@@ -76,7 +76,7 @@ public class CborXContent implements XContent {
     private CborXContent() {}
 
     @Override
-    public MediaType type() {
+    public MediaType mediaType() {
         return XContentType.CBOR;
     }
 

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/cbor/CborXContent.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/cbor/CborXContent.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 import org.opensearch.common.xcontent.DeprecationHandler;
+import org.opensearch.common.xcontent.MediaType;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContent;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -75,7 +76,7 @@ public class CborXContent implements XContent {
     private CborXContent() {}
 
     @Override
-    public XContentType type() {
+    public MediaType type() {
         return XContentType.CBOR;
     }
 

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/json/JsonXContent.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/json/JsonXContent.java
@@ -78,7 +78,7 @@ public class JsonXContent implements XContent {
     private JsonXContent() {}
 
     @Override
-    public MediaType type() {
+    public MediaType mediaType() {
         return XContentType.JSON;
     }
 

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/json/JsonXContent.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/json/JsonXContent.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import org.opensearch.common.xcontent.DeprecationHandler;
+import org.opensearch.common.xcontent.MediaType;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContent;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -77,7 +78,7 @@ public class JsonXContent implements XContent {
     private JsonXContent() {}
 
     @Override
-    public XContentType type() {
+    public MediaType type() {
         return XContentType.JSON;
     }
 

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/json/JsonXContentGenerator.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/json/JsonXContentGenerator.java
@@ -42,6 +42,7 @@ import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.core.util.JsonGeneratorDelegate;
 import org.opensearch.common.xcontent.DeprecationHandler;
+import org.opensearch.common.xcontent.MediaType;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContent;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -369,7 +370,7 @@ public class JsonXContentGenerator implements XContentGenerator {
     }
 
     @Override
-    public void writeRawValue(InputStream stream, XContentType xContentType) throws IOException {
+    public void writeRawValue(InputStream stream, MediaType xContentType) throws IOException {
         if (mayWriteRawData(xContentType) == false) {
             copyRawValue(stream, xContentType.xContent());
         } else {
@@ -383,7 +384,7 @@ public class JsonXContentGenerator implements XContentGenerator {
         }
     }
 
-    private boolean mayWriteRawData(XContentType contentType) {
+    private boolean mayWriteRawData(MediaType contentType) {
         // When the current generator is filtered (ie filter != null)
         // or the content is in a different format than the current generator,
         // we need to copy the whole structure so that it will be correctly

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/smile/SmileXContent.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/smile/SmileXContent.java
@@ -78,7 +78,7 @@ public class SmileXContent implements XContent {
     private SmileXContent() {}
 
     @Override
-    public MediaType type() {
+    public MediaType mediaType() {
         return XContentType.SMILE;
     }
 

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/smile/SmileXContent.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/smile/SmileXContent.java
@@ -38,6 +38,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.fasterxml.jackson.dataformat.smile.SmileGenerator;
 import org.opensearch.common.xcontent.DeprecationHandler;
+import org.opensearch.common.xcontent.MediaType;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContent;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -77,7 +78,7 @@ public class SmileXContent implements XContent {
     private SmileXContent() {}
 
     @Override
-    public XContentType type() {
+    public MediaType type() {
         return XContentType.SMILE;
     }
 

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/yaml/YamlXContent.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/yaml/YamlXContent.java
@@ -71,7 +71,7 @@ public class YamlXContent implements XContent {
     private YamlXContent() {}
 
     @Override
-    public MediaType type() {
+    public MediaType mediaType() {
         return XContentType.YAML;
     }
 

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/yaml/YamlXContent.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/yaml/YamlXContent.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.opensearch.common.xcontent.DeprecationHandler;
+import org.opensearch.common.xcontent.MediaType;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContent;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -70,7 +71,7 @@ public class YamlXContent implements XContent {
     private YamlXContent() {}
 
     @Override
-    public XContentType type() {
+    public MediaType type() {
         return XContentType.YAML;
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequest.java
@@ -51,6 +51,7 @@ import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.DeprecationHandler;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.MediaType;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -208,9 +209,20 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
 
     /**
      * The settings to create the index with (either json or yaml format)
+     *
+     * @deprecated use {@link #settings(String source, MediaType mediaType)} instead
      */
+    @Deprecated
     public CreateIndexRequest settings(String source, XContentType xContentType) {
         this.settings = Settings.builder().loadFromSource(source, xContentType).build();
+        return this;
+    }
+
+    /**
+     * The settings to create the index with (either json or yaml format)
+     */
+    public CreateIndexRequest settings(String source, MediaType mediaType) {
+        this.settings = Settings.builder().loadFromSource(source, mediaType).build();
         return this;
     }
 
@@ -248,7 +260,10 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
      *
      * @param source The mapping source
      * @param xContentType The content type of the source
+     *
+     * @deprecated use {@link #mapping(String source, MediaType mediaType)} instead
      */
+    @Deprecated
     public CreateIndexRequest mapping(String source, XContentType xContentType) {
         return mapping(new BytesArray(source), xContentType);
     }
@@ -256,12 +271,41 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
     /**
      * Adds mapping that will be added when the index gets created.
      *
+     * Note that the definition should *not* be nested under a type name.
+     *
+     * @param source The mapping source
+     * @param mediaType The media type of the source
+     */
+    public CreateIndexRequest mapping(String source, MediaType mediaType) {
+        return mapping(new BytesArray(source), mediaType);
+    }
+
+    /**
+     * Adds mapping that will be added when the index gets created.
+     *
      * @param source The mapping source
      * @param xContentType the content type of the mapping source
+     *
+     * @deprecated use {@link #mapping(BytesReference source, MediaType mediaType)} instead
      */
+    @Deprecated
     private CreateIndexRequest mapping(BytesReference source, XContentType xContentType) {
         Objects.requireNonNull(xContentType);
         Map<String, Object> mappingAsMap = XContentHelper.convertToMap(source, false, xContentType).v2();
+        return mapping(MapperService.SINGLE_MAPPING_NAME, mappingAsMap);
+    }
+
+    /**
+     * Adds mapping that will be added when the index gets created.
+     *
+     * Note that the definition should *not* be nested under a type name.
+     *
+     * @param source The mapping source
+     * @param mediaType The media type of the source
+     */
+    public CreateIndexRequest mapping(BytesReference source, MediaType mediaType) {
+        Objects.requireNonNull(mediaType);
+        Map<String, Object> mappingAsMap = XContentHelper.convertToMap(source, false, mediaType).v2();
         return mapping(MapperService.SINGLE_MAPPING_NAME, mappingAsMap);
     }
 
@@ -379,9 +423,21 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
 
     /**
      * Sets the settings and mappings as a single source.
+     *
+     * @deprecated use {@link #source(String, MediaType)} instead
      */
+    @Deprecated
     public CreateIndexRequest source(String source, XContentType xContentType) {
         return source(new BytesArray(source), xContentType);
+    }
+
+    /**
+     * Sets the settings and mappings as a single source.
+     *
+     * Note that the mapping definition should *not* be nested under a type name.
+     */
+    public CreateIndexRequest source(String source, MediaType mediaType) {
+        return source(new BytesArray(source), mediaType);
     }
 
     /**
@@ -393,14 +449,29 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
 
     /**
      * Sets the settings and mappings as a single source.
+     *
+     * @deprecated use {@link #source(byte[], MediaType mediaType)} instead
      */
+    @Deprecated
     public CreateIndexRequest source(byte[] source, XContentType xContentType) {
         return source(source, 0, source.length, xContentType);
     }
 
     /**
      * Sets the settings and mappings as a single source.
+     *
+     * Note that the mapping definition should *not* be nested under a type name.
      */
+    public CreateIndexRequest source(byte[] source, MediaType mediaType) {
+        return source(source, 0, source.length, mediaType);
+    }
+
+    /**
+     * Sets the settings and mappings as a single source.
+     *
+     * @deprecated use {@link #source(byte[], int, int, MediaType)} instead
+     */
+    @Deprecated
     public CreateIndexRequest source(byte[] source, int offset, int length, XContentType xContentType) {
         return source(new BytesArray(source, offset, length), xContentType);
     }
@@ -408,9 +479,28 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
     /**
      * Sets the settings and mappings as a single source.
      */
+    public CreateIndexRequest source(byte[] source, int offset, int length, MediaType mediaType) {
+        return source(new BytesArray(source, offset, length), mediaType);
+    }
+
+    /**
+     * Sets the settings and mappings as a single source.
+     *
+     * @deprecated use {@link #source(BytesReference, MediaType)} instead
+     */
+    @Deprecated
     public CreateIndexRequest source(BytesReference source, XContentType xContentType) {
         Objects.requireNonNull(xContentType);
         source(XContentHelper.convertToMap(source, false, xContentType).v2(), LoggingDeprecationHandler.INSTANCE);
+        return this;
+    }
+
+    /**
+     * Sets the settings and mappings as a single source.
+     */
+    public CreateIndexRequest source(BytesReference source, MediaType mediaType) {
+        Objects.requireNonNull(mediaType);
+        source(XContentHelper.convertToMap(source, false, mediaType).v2(), LoggingDeprecationHandler.INSTANCE);
         return this;
     }
 

--- a/server/src/main/java/org/opensearch/action/ingest/PutPipelineRequest.java
+++ b/server/src/main/java/org/opensearch/action/ingest/PutPipelineRequest.java
@@ -37,6 +37,7 @@ import org.opensearch.action.support.master.AcknowledgedRequest;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.MediaType;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentType;
@@ -57,11 +58,26 @@ public class PutPipelineRequest extends AcknowledgedRequest<PutPipelineRequest> 
 
     /**
      * Create a new pipeline request with the id and source along with the content type of the source
+     *
+     * @deprecated use {@link #PutPipelineRequest(String, BytesReference, MediaType)} instead
      */
+    @Deprecated
     public PutPipelineRequest(String id, BytesReference source, XContentType xContentType) {
         this.id = Objects.requireNonNull(id);
         this.source = Objects.requireNonNull(source);
         this.xContentType = Objects.requireNonNull(xContentType);
+    }
+
+    /**
+     * Create a new pipeline request with the id and source along with the content type of the source
+     */
+    public PutPipelineRequest(String id, BytesReference source, MediaType mediaType) {
+        this.id = Objects.requireNonNull(id);
+        this.source = Objects.requireNonNull(source);
+        if (mediaType instanceof XContentType == false) {
+            throw new IllegalArgumentException("PutPipelineRequest found unsupported media type [" + mediaType.getClass().getName() + "]");
+        }
+        this.xContentType = (XContentType) Objects.requireNonNull(mediaType);
     }
 
     public PutPipelineRequest(StreamInput in) throws IOException {

--- a/server/src/main/java/org/opensearch/common/settings/Settings.java
+++ b/server/src/main/java/org/opensearch/common/settings/Settings.java
@@ -49,6 +49,7 @@ import org.opensearch.common.unit.MemorySizeValue;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.DeprecationHandler;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.MediaType;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -1090,7 +1091,7 @@ public final class Settings implements ToXContentFragment {
         /**
          * Loads settings from the actual string content that represents them using {@link #fromXContent(XContentParser)}
          */
-        public Builder loadFromSource(String source, XContentType xContentType) {
+        public Builder loadFromSource(String source, MediaType xContentType) {
             try (
                 XContentParser parser = XContentFactory.xContent(xContentType)
                     .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, source)

--- a/server/src/main/java/org/opensearch/common/xcontent/XContentHelper.java
+++ b/server/src/main/java/org/opensearch/common/xcontent/XContentHelper.java
@@ -96,9 +96,9 @@ public class XContentHelper {
         NamedXContentRegistry xContentRegistry,
         DeprecationHandler deprecationHandler,
         BytesReference bytes,
-        MediaType xContentType
+        MediaType mediaType
     ) throws IOException {
-        Objects.requireNonNull(xContentType);
+        Objects.requireNonNull(mediaType);
         Compressor compressor = CompressorFactory.compressor(bytes);
         if (compressor != null) {
             InputStream compressedInput = null;
@@ -107,7 +107,7 @@ public class XContentHelper {
                 if (compressedInput.markSupported() == false) {
                     compressedInput = new BufferedInputStream(compressedInput);
                 }
-                return XContentFactory.xContent(xContentType).createParser(xContentRegistry, deprecationHandler, compressedInput);
+                return XContentFactory.xContent(mediaType).createParser(xContentRegistry, deprecationHandler, compressedInput);
             } catch (Exception e) {
                 if (compressedInput != null) compressedInput.close();
                 throw e;
@@ -115,10 +115,10 @@ public class XContentHelper {
         } else {
             if (bytes instanceof BytesArray) {
                 final BytesArray array = (BytesArray) bytes;
-                return xContentType.xContent()
+                return mediaType.xContent()
                     .createParser(xContentRegistry, deprecationHandler, array.array(), array.offset(), array.length());
             }
-            return xContentType.xContent().createParser(xContentRegistry, deprecationHandler, bytes.streamInput());
+            return mediaType.xContent().createParser(xContentRegistry, deprecationHandler, bytes.streamInput());
         }
     }
 

--- a/server/src/main/java/org/opensearch/common/xcontent/XContentHelper.java
+++ b/server/src/main/java/org/opensearch/common/xcontent/XContentHelper.java
@@ -497,10 +497,33 @@ public class XContentHelper {
      * Returns the bytes that represent the XContent output of the provided {@link ToXContent} object, using the provided
      * {@link XContentType}. Wraps the output into a new anonymous object according to the value returned
      * by the {@link ToXContent#isFragment()} method returns.
+     *
+     * @deprecated use {@link #toXContent(ToXContent, MediaType, Params, boolean)} instead
      */
+    @Deprecated
     public static BytesReference toXContent(ToXContent toXContent, XContentType xContentType, Params params, boolean humanReadable)
         throws IOException {
         try (XContentBuilder builder = XContentBuilder.builder(xContentType.xContent())) {
+            builder.humanReadable(humanReadable);
+            if (toXContent.isFragment()) {
+                builder.startObject();
+            }
+            toXContent.toXContent(builder, params);
+            if (toXContent.isFragment()) {
+                builder.endObject();
+            }
+            return BytesReference.bytes(builder);
+        }
+    }
+
+    /**
+     * Returns the bytes that represent the XContent output of the provided {@link ToXContent} object, using the provided
+     * {@link XContentType}. Wraps the output into a new anonymous object according to the value returned
+     * by the {@link ToXContent#isFragment()} method returns.
+     */
+    public static BytesReference toXContent(ToXContent toXContent, MediaType mediaType, Params params, boolean humanReadable)
+        throws IOException {
+        try (XContentBuilder builder = XContentBuilder.builder(mediaType.xContent())) {
             builder.humanReadable(humanReadable);
             if (toXContent.isFragment()) {
                 builder.startObject();

--- a/server/src/main/java/org/opensearch/common/xcontent/XContentHelper.java
+++ b/server/src/main/java/org/opensearch/common/xcontent/XContentHelper.java
@@ -61,7 +61,7 @@ public class XContentHelper {
 
     /**
      * Creates a parser based on the bytes provided
-     * @deprecated use {@link #createParser(NamedXContentRegistry, DeprecationHandler, BytesReference, XContentType)}
+     * @deprecated use {@link #createParser(NamedXContentRegistry, DeprecationHandler, BytesReference, MediaType)}
      * to avoid content type auto-detection
      */
     @Deprecated
@@ -96,7 +96,7 @@ public class XContentHelper {
         NamedXContentRegistry xContentRegistry,
         DeprecationHandler deprecationHandler,
         BytesReference bytes,
-        XContentType xContentType
+        MediaType xContentType
     ) throws IOException {
         Objects.requireNonNull(xContentType);
         Compressor compressor = CompressorFactory.compressor(bytes);
@@ -124,7 +124,7 @@ public class XContentHelper {
 
     /**
      * Converts the given bytes into a map that is optionally ordered.
-     * @deprecated this method relies on auto-detection of content type. Use {@link #convertToMap(BytesReference, boolean, XContentType)}
+     * @deprecated this method relies on auto-detection of content type. Use {@link #convertToMap(BytesReference, boolean, MediaType)}
      *             instead with the proper {@link XContentType}
      */
     @Deprecated
@@ -135,11 +135,29 @@ public class XContentHelper {
 
     /**
      * Converts the given bytes into a map that is optionally ordered. The provided {@link XContentType} must be non-null.
+     *
+     * @deprecated use {@link #convertToMap(BytesReference, boolean, MediaType)} instead
      */
-    public static Tuple<XContentType, Map<String, Object>> convertToMap(BytesReference bytes, boolean ordered, XContentType xContentType)
-        throws OpenSearchParseException {
+    @Deprecated
+    public static Tuple<XContentType, Map<String, Object>> convertToMap(BytesReference bytes, boolean ordered, XContentType xContentType) {
+        if (Objects.isNull(xContentType) == false && xContentType instanceof XContentType == false) {
+            throw new IllegalArgumentException(
+                "XContentHelper.convertToMap does not support media type [" + xContentType.getClass().getName() + "]"
+            );
+        }
+        return (Tuple<XContentType, Map<String, Object>>) convertToMap(bytes, ordered, (MediaType) xContentType);
+    }
+
+    /**
+     * Converts the given bytes into a map that is optionally ordered. The provided {@link XContentType} must be non-null.
+     */
+    public static Tuple<? extends MediaType, Map<String, Object>> convertToMap(
+        BytesReference bytes,
+        boolean ordered,
+        MediaType xContentType
+    ) throws OpenSearchParseException {
         try {
-            final XContentType contentType;
+            final MediaType contentType;
             InputStream input;
             Compressor compressor = CompressorFactory.compressor(bytes);
             if (compressor != null) {
@@ -243,7 +261,7 @@ public class XContentHelper {
         return convertToJson(bytes, reformatJson, prettyPrint, XContentFactory.xContentType(bytes.toBytesRef().bytes));
     }
 
-    public static String convertToJson(BytesReference bytes, boolean reformatJson, XContentType xContentType) throws IOException {
+    public static String convertToJson(BytesReference bytes, boolean reformatJson, MediaType xContentType) throws IOException {
         return convertToJson(bytes, reformatJson, false, xContentType);
     }
 
@@ -260,10 +278,24 @@ public class XContentHelper {
         return convertToJson(new BytesArray(json), true, XContentType.JSON);
     }
 
+    /**
+     * Converts the XContentType to a json string
+     *
+     * @deprecated use {@link #convertToJson(BytesReference, boolean, boolean, MediaType)} instead
+     */
+    @Deprecated
     public static String convertToJson(BytesReference bytes, boolean reformatJson, boolean prettyPrint, XContentType xContentType)
         throws IOException {
-        Objects.requireNonNull(xContentType);
-        if (xContentType == XContentType.JSON && !reformatJson) {
+        return convertToJson(bytes, reformatJson, prettyPrint, (MediaType) xContentType);
+    }
+
+    /**
+     * Converts the given {@link MediaType} to a json string
+     */
+    public static String convertToJson(BytesReference bytes, boolean reformatJson, boolean prettyPrint, MediaType mediaType)
+        throws IOException {
+        Objects.requireNonNull(mediaType);
+        if (mediaType == XContentType.JSON && !reformatJson) {
             return bytes.utf8ToString();
         }
 
@@ -271,7 +303,7 @@ public class XContentHelper {
         if (bytes instanceof BytesArray) {
             final BytesArray array = (BytesArray) bytes;
             try (
-                XContentParser parser = XContentFactory.xContent(xContentType)
+                XContentParser parser = XContentFactory.xContent(mediaType)
                     .createParser(
                         NamedXContentRegistry.EMPTY,
                         DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
@@ -285,7 +317,7 @@ public class XContentHelper {
         } else {
             try (
                 InputStream stream = bytes.streamInput();
-                XContentParser parser = XContentFactory.xContent(xContentType)
+                XContentParser parser = XContentFactory.xContent(mediaType)
                     .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, stream)
             ) {
                 return toJsonString(prettyPrint, parser);

--- a/server/src/main/java/org/opensearch/index/reindex/ReindexRequest.java
+++ b/server/src/main/java/org/opensearch/index/reindex/ReindexRequest.java
@@ -308,7 +308,7 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
             builder.startObject("source");
             if (remoteInfo != null) {
                 builder.field("remote", remoteInfo);
-                builder.rawField("query", remoteInfo.getQuery().streamInput(), (XContentType) RemoteInfo.QUERY_CONTENT_TYPE.type());
+                builder.rawField("query", remoteInfo.getQuery().streamInput(), (XContentType) RemoteInfo.QUERY_CONTENT_TYPE.mediaType());
             }
             builder.array("index", getSearchRequest().indices());
             getSearchRequest().source().innerToXContent(builder, params);

--- a/server/src/main/java/org/opensearch/index/reindex/ReindexRequest.java
+++ b/server/src/main/java/org/opensearch/index/reindex/ReindexRequest.java
@@ -49,6 +49,7 @@ import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.VersionType;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.script.Script;
@@ -307,7 +308,7 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
             builder.startObject("source");
             if (remoteInfo != null) {
                 builder.field("remote", remoteInfo);
-                builder.rawField("query", remoteInfo.getQuery().streamInput(), RemoteInfo.QUERY_CONTENT_TYPE.type());
+                builder.rawField("query", remoteInfo.getQuery().streamInput(), (XContentType) RemoteInfo.QUERY_CONTENT_TYPE.type());
             }
             builder.array("index", getSearchRequest().indices());
             getSearchRequest().source().innerToXContent(builder, params);

--- a/server/src/main/java/org/opensearch/index/reindex/ReindexRequest.java
+++ b/server/src/main/java/org/opensearch/index/reindex/ReindexRequest.java
@@ -49,7 +49,6 @@ import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.VersionType;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.script.Script;
@@ -308,7 +307,7 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
             builder.startObject("source");
             if (remoteInfo != null) {
                 builder.field("remote", remoteInfo);
-                builder.rawField("query", remoteInfo.getQuery().streamInput(), (XContentType) RemoteInfo.QUERY_CONTENT_TYPE.mediaType());
+                builder.rawField("query", remoteInfo.getQuery().streamInput(), RemoteInfo.QUERY_CONTENT_TYPE.mediaType());
             }
             builder.array("index", getSearchRequest().indices());
             getSearchRequest().source().innerToXContent(builder, params);

--- a/server/src/test/java/org/opensearch/OpenSearchExceptionTests.java
+++ b/server/src/test/java/org/opensearch/OpenSearchExceptionTests.java
@@ -742,7 +742,7 @@ public class OpenSearchExceptionTests extends OpenSearchTestCase {
         BytesReference throwableBytes = toShuffledXContent((builder, params) -> {
             OpenSearchException.generateThrowableXContent(builder, params, throwable);
             return builder;
-        }, xContent.type(), ToXContent.EMPTY_PARAMS, randomBoolean());
+        }, xContent.mediaType(), ToXContent.EMPTY_PARAMS, randomBoolean());
 
         OpenSearchException parsedException;
         try (XContentParser parser = createParser(xContent, throwableBytes)) {
@@ -774,7 +774,7 @@ public class OpenSearchExceptionTests extends OpenSearchTestCase {
             // Prints a null failure using generateFailureXContent()
             OpenSearchException.generateFailureXContent(builder, params, null, randomBoolean());
             return builder;
-        }, xContent.type(), ToXContent.EMPTY_PARAMS, randomBoolean());
+        }, xContent.mediaType(), ToXContent.EMPTY_PARAMS, randomBoolean());
 
         OpenSearchException parsedFailure;
         try (XContentParser parser = createParser(xContent, failureBytes)) {
@@ -798,7 +798,7 @@ public class OpenSearchExceptionTests extends OpenSearchTestCase {
         BytesReference failureBytes = toShuffledXContent((builder, params) -> {
             OpenSearchException.generateFailureXContent(builder, params, failure, false);
             return builder;
-        }, xContent.type(), ToXContent.EMPTY_PARAMS, randomBoolean());
+        }, xContent.mediaType(), ToXContent.EMPTY_PARAMS, randomBoolean());
 
         try (XContentParser parser = createParser(xContent, failureBytes)) {
             failureBytes = BytesReference.bytes(shuffleXContent(parser, randomBoolean()));
@@ -952,7 +952,7 @@ public class OpenSearchExceptionTests extends OpenSearchTestCase {
         BytesReference failureBytes = toShuffledXContent((builder, params) -> {
             OpenSearchException.generateFailureXContent(builder, params, finalFailure, true);
             return builder;
-        }, xContent.type(), ToXContent.EMPTY_PARAMS, randomBoolean());
+        }, xContent.mediaType(), ToXContent.EMPTY_PARAMS, randomBoolean());
 
         try (XContentParser parser = createParser(xContent, failureBytes)) {
             failureBytes = BytesReference.bytes(shuffleXContent(parser, randomBoolean()));

--- a/server/src/test/java/org/opensearch/action/search/SearchPhaseExecutionExceptionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchPhaseExecutionExceptionTests.java
@@ -134,7 +134,7 @@ public class SearchPhaseExecutionExceptionTests extends OpenSearchTestCase {
         final String phase = randomFrom("query", "search", "other");
         SearchPhaseExecutionException actual = new SearchPhaseExecutionException(phase, "unexpected failures", shardSearchFailures);
 
-        BytesReference exceptionBytes = toShuffledXContent(actual, xContent.type(), ToXContent.EMPTY_PARAMS, randomBoolean());
+        BytesReference exceptionBytes = toShuffledXContent(actual, xContent.mediaType(), ToXContent.EMPTY_PARAMS, randomBoolean());
 
         OpenSearchException parsedException;
         try (XContentParser parser = createParser(xContent, exceptionBytes)) {

--- a/server/src/test/java/org/opensearch/common/xcontent/BaseXContentTestCase.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/BaseXContentTestCase.java
@@ -941,7 +941,7 @@ public abstract class BaseXContentTestCase extends OpenSearchTestCase {
 
         os = new ByteArrayOutputStream();
         try (XContentGenerator generator = xcontentType().xContent().createGenerator(os)) {
-            generator.writeRawValue(new BytesArray(rawData).streamInput(), source.type());
+            generator.writeRawValue(new BytesArray(rawData).streamInput(), source.mediaType());
         }
 
         try (
@@ -966,7 +966,7 @@ public abstract class BaseXContentTestCase extends OpenSearchTestCase {
         try (XContentGenerator generator = xcontentType().xContent().createGenerator(os)) {
             generator.writeStartObject();
             generator.writeFieldName("test");
-            generator.writeRawValue(new BytesArray(rawData).streamInput(), source.type());
+            generator.writeRawValue(new BytesArray(rawData).streamInput(), source.mediaType());
             assertFalse("Generator should not have closed the output stream", closed.get());
             generator.writeEndObject();
         }

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchTestCase.java
@@ -94,6 +94,7 @@ import org.opensearch.common.util.MockPageCacheRecycler;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.MediaType;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContent;
@@ -1237,7 +1238,10 @@ public abstract class OpenSearchTestCase extends LuceneTestCase {
      * Returns the bytes that represent the XContent output of the provided {@link ToXContent} object, using the provided
      * {@link XContentType}. Wraps the output into a new anonymous object according to the value returned
      * by the {@link ToXContent#isFragment()} method returns. Shuffles the keys to make sure that parsing never relies on keys ordering.
+     *
+     * @deprecated use {@link #toShuffledXContent(ToXContent, MediaType, ToXContent.Params, boolean, String...)} instead
      */
+    @Deprecated
     protected final BytesReference toShuffledXContent(
         ToXContent toXContent,
         XContentType xContentType,
@@ -1247,6 +1251,26 @@ public abstract class OpenSearchTestCase extends LuceneTestCase {
     ) throws IOException {
         BytesReference bytes = XContentHelper.toXContent(toXContent, xContentType, params, humanReadable);
         try (XContentParser parser = createParser(xContentType.xContent(), bytes)) {
+            try (XContentBuilder builder = shuffleXContent(parser, rarely(), exceptFieldNames)) {
+                return BytesReference.bytes(builder);
+            }
+        }
+    }
+
+    /**
+     * Returns the bytes that represent the XContent output of the provided {@link ToXContent} object, using the provided
+     * {@link XContentType}. Wraps the output into a new anonymous object according to the value returned
+     * by the {@link ToXContent#isFragment()} method returns. Shuffles the keys to make sure that parsing never relies on keys ordering.
+     */
+    protected final BytesReference toShuffledXContent(
+        ToXContent toXContent,
+        MediaType mediaType,
+        ToXContent.Params params,
+        boolean humanReadable,
+        String... exceptFieldNames
+    ) throws IOException {
+        BytesReference bytes = XContentHelper.toXContent(toXContent, mediaType, params, humanReadable);
+        try (XContentParser parser = createParser(mediaType.xContent(), bytes)) {
             try (XContentBuilder builder = shuffleXContent(parser, rarely(), exceptFieldNames)) {
                 return BytesReference.bytes(builder);
             }


### PR DESCRIPTION
Refactors various REST requests to use MediaType instead of XContentType to abstract media format from the REST interfaces.

relates #5910