### PR TITLE
Fix sort order in getMaxSeqNoFromSegmentInfos and mute testRemoteTranslogRestore

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -91,6 +91,7 @@ public class RemoteStoreIT extends OpenSearchIntegTestCase {
 
     @Before
     public void setup() {
+        internalCluster().startClusterManagerOnlyNode();
         Path absolutePath = randomRepoPath().toAbsolutePath();
         assertAcked(
             clusterAdmin().preparePutRepository(REPOSITORY_NAME).setType("fs").setSettings(Settings.builder().put("location", absolutePath))
@@ -161,10 +162,12 @@ public class RemoteStoreIT extends OpenSearchIntegTestCase {
         assertAcked(client().admin().indices().prepareClose(INDEX_NAME));
 
         client().admin().cluster().restoreRemoteStore(new RestoreRemoteStoreRequest().indices(INDEX_NAME), PlainActionFuture.newFuture());
+        ensureGreen(INDEX_NAME);
 
         verifyRestoredData(indexStats, false);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/6188")
     public void testRemoteTranslogRestore() throws IOException {
         internalCluster().startNodes(3);
         createIndex(INDEX_NAME, remoteTranslogIndexSettings(0));
@@ -177,6 +180,7 @@ public class RemoteStoreIT extends OpenSearchIntegTestCase {
         assertAcked(client().admin().indices().prepareClose(INDEX_NAME));
 
         client().admin().cluster().restoreRemoteStore(new RestoreRemoteStoreRequest().indices(INDEX_NAME), PlainActionFuture.newFuture());
+        ensureGreen(INDEX_NAME);
 
         verifyRestoredData(indexStats, true);
     }

--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -302,7 +302,7 @@ public abstract class Engine implements LifecycleAware, Closeable {
         ScoreDoc[] docs = searcher.search(
             Queries.newMatchAllQuery(),
             1,
-            new Sort(new SortField(SeqNoFieldMapper.NAME, SortField.Type.DOC, true))
+            new Sort(new SortField(SeqNoFieldMapper.NAME, SortField.Type.LONG, true))
         ).scoreDocs;
         if (docs.length == 0) {
             return SequenceNumbers.NO_OPS_PERFORMED;


### PR DESCRIPTION
Signed-off-by: Sachin Kale <kalsac@amazon.com>

### Description
- `Engine.getMaxSeqNoFromSegmentInfos()` does not provide maxSeqNo always. It returns sequence number of last indexed doc. In case of concurrent writes, it is possible that last indexed doc will not have max seq number among the indexed doc.
- This PR provides fix to this issue by changing SortField to `SortField(SeqNoFieldMapper.NAME, SortField.Type.LONG, true)`
- In this change, we are also muting `RemoteStoreIT.testRemoteTranslogRestore` as it is [reported](https://github.com/opensearch-project/OpenSearch/issues/6188) flaky.  Need to investigate further on the flakiness of the test.

### Issues Resolved
- https://github.com/opensearch-project/OpenSearch/issues/6229

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
