### PR TITLE
[Backport] [2.x] power changes for building with and without jdk

### DIFF
--- a/distribution/archives/build.gradle
+++ b/distribution/archives/build.gradle
@@ -167,10 +167,16 @@ distribution_archives {
     }
   }
 
-  // Should really be `no-jdk-linux-ppc64le` as it ships without a JDK, however it seems that the build can't handle
-  // the absence of the `linux-ppc64le` target.
+  
   linuxPpc64leTar {
     archiveClassifier = 'linux-ppc64le'
+    content {
+      archiveFiles(modulesFiles('linux-ppc64le'), 'tar', 'linux', 'ppc64le', true)
+    }
+  }
+
+ noJdkLinuxPpc64leTar {
+    archiveClassifier = 'no-jdk-linux-ppc64le'
     content {
       archiveFiles(modulesFiles('linux-ppc64le'), 'tar', 'linux', 'ppc64le', false)
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -50,6 +50,7 @@ List projects = [
   'distribution:archives:no-jdk-linux-arm64-tar',
   'distribution:archives:linux-s390x-tar',
   'distribution:archives:linux-ppc64le-tar',
+  'distribution:archives:no-jdk-linux-ppc64le-tar',
   'distribution:archives:linux-tar',
   'distribution:archives:no-jdk-linux-tar',
   'distribution:docker',


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/5950 to `2.x`