### PR TITLE
[#6187, #6222] Fixing the GeoShapes GeoHash and GeoTile Aggregations Integration tests to make them more robust.

### DIFF
--- a/modules/geo/src/internalClusterTest/java/org/opensearch/geo/search/aggregations/bucket/AbstractGeoBucketAggregationIntegTest.java
+++ b/modules/geo/src/internalClusterTest/java/org/opensearch/geo/search/aggregations/bucket/AbstractGeoBucketAggregationIntegTest.java
@@ -40,7 +40,7 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
  */
 public abstract class AbstractGeoBucketAggregationIntegTest extends GeoModulePluginIntegTestCase {
 
-    protected static final int MAX_PRECISION_FOR_GEO_SHAPES_AGG_TESTING = 4;
+    protected static final int MAX_PRECISION_FOR_GEO_SHAPES_AGG_TESTING = 2;
 
     protected static final int MIN_PRECISION_WITHOUT_BB_AGGS = 2;
 
@@ -98,7 +98,7 @@ public abstract class AbstractGeoBucketAggregationIntegTest extends GeoModulePlu
             }
 
             i++;
-            final Set<String> values = generateBucketsForGeometry(geometry, geometryDocValue, isShapeIntersectingBB);
+            final Set<String> values = generateBucketsForGeometry(geometry, geometryDocValue);
             geoshapes.add(indexGeoShape(GEO_SHAPE_INDEX_NAME, geometry));
             for (final String hash : values) {
                 expectedDocsCountForGeoShapes.put(hash, expectedDocsCountForGeoShapes.getOrDefault(hash, 0) + 1);
@@ -112,16 +112,11 @@ public abstract class AbstractGeoBucketAggregationIntegTest extends GeoModulePlu
      * Returns a set of buckets for the shape at different precision level. Override this method for different bucket
      * aggregations.
      *
-     * @param geometry           {@link Geometry}
-     * @param geoShapeDocValue   {@link GeoShapeDocValue}
-     * @param intersectingWithBB boolean
+     * @param geometry         {@link Geometry}
+     * @param geoShapeDocValue {@link GeoShapeDocValue}
      * @return A {@link Set} of {@link String} which represents the buckets.
      */
-    protected abstract Set<String> generateBucketsForGeometry(
-        final Geometry geometry,
-        final GeoShapeDocValue geoShapeDocValue,
-        final boolean intersectingWithBB
-    );
+    protected abstract Set<String> generateBucketsForGeometry(final Geometry geometry, final GeoShapeDocValue geoShapeDocValue);
 
     /**
      * Prepares a GeoPoint index for testing the GeoPoint bucket aggregations. Different bucket aggregations can use

--- a/modules/geo/src/internalClusterTest/java/org/opensearch/geo/search/aggregations/bucket/GeoHashGridIT.java
+++ b/modules/geo/src/internalClusterTest/java/org/opensearch/geo/search/aggregations/bucket/GeoHashGridIT.java
@@ -268,18 +268,15 @@ public class GeoHashGridIT extends AbstractGeoBucketAggregationIntegTest {
     }
 
     @Override
-    protected Set<String> generateBucketsForGeometry(
-        final Geometry geometry,
-        final GeoShapeDocValue geometryDocValue,
-        boolean intersectingWithBB
-    ) {
+    protected Set<String> generateBucketsForGeometry(final Geometry geometry, final GeoShapeDocValue geometryDocValue) {
         final GeoPoint topLeft = new GeoPoint();
         final GeoPoint bottomRight = new GeoPoint();
         assert geometry != null;
         GeoBoundsHelper.updateBoundsForGeometry(geometry, topLeft, bottomRight);
         final Set<String> geoHashes = new HashSet<>();
+        final boolean isIntersectingWithBoundingRectangle = geometryDocValue.isIntersectingRectangle(boundingRectangleForGeoShapesAgg);
         for (int precision = MAX_PRECISION_FOR_GEO_SHAPES_AGG_TESTING; precision > 0; precision--) {
-            if (precision > MIN_PRECISION_WITHOUT_BB_AGGS && intersectingWithBB == false) {
+            if (precision > MIN_PRECISION_WITHOUT_BB_AGGS && isIntersectingWithBoundingRectangle == false) {
                 continue;
             }
             final GeoPoint topRight = new GeoPoint(topLeft.getLat(), bottomRight.getLon());

--- a/modules/geo/src/internalClusterTest/java/org/opensearch/geo/search/aggregations/bucket/GeoTileGridIT.java
+++ b/modules/geo/src/internalClusterTest/java/org/opensearch/geo/search/aggregations/bucket/GeoTileGridIT.java
@@ -134,20 +134,20 @@ public class GeoTileGridIT extends AbstractGeoBucketAggregationIntegTest {
      * Returns a set of buckets for the shape at different precision level. Override this method for different bucket
      * aggregations.
      *
-     * @param geometry           {@link Geometry}
-     * @param geoShapeDocValue   {@link GeoShapeDocValue}
-     * @param intersectingWithBB
+     * @param geometry         {@link Geometry}
+     * @param geoShapeDocValue {@link GeoShapeDocValue}
      * @return A {@link Set} of {@link String} which represents the buckets.
      */
     @Override
-    protected Set<String> generateBucketsForGeometry(Geometry geometry, GeoShapeDocValue geoShapeDocValue, boolean intersectingWithBB) {
+    protected Set<String> generateBucketsForGeometry(final Geometry geometry, final GeoShapeDocValue geoShapeDocValue) {
         final GeoPoint topLeft = new GeoPoint();
         final GeoPoint bottomRight = new GeoPoint();
         assert geometry != null;
         GeoBoundsHelper.updateBoundsForGeometry(geometry, topLeft, bottomRight);
         final Set<String> geoTiles = new HashSet<>();
+        final boolean isIntersectingWithBoundingRectangle = geoShapeDocValue.isIntersectingRectangle(boundingRectangleForGeoShapesAgg);
         for (int precision = MAX_PRECISION_FOR_GEO_SHAPES_AGG_TESTING; precision > 0; precision--) {
-            if (precision > MIN_PRECISION_WITHOUT_BB_AGGS && intersectingWithBB == false) {
+            if (precision > MIN_PRECISION_WITHOUT_BB_AGGS && isIntersectingWithBoundingRectangle == false) {
                 continue;
             }
             geoTiles.addAll(


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixing the GeoShapes GeoHash and GeoTile Aggregations Integration tests to make them more robust.

Signed-off-by: Navneet Verma <navneev@amazon.com>

The issue was happening few random seeds. For GeoHash aggregations on shape we are getting ArrayIndexOut of bounds exception because we were not resetting the values of SortedNumericDocs leading to access of memory area not initialized by the vectors.

## Changes done:
* Fixed the ArrayIndexOutOfBoundsException.
* Reduced the precision for GeoShapes Aggregation IT testing.

For improving the testing for bounded geoshape aggregation I am creating a new Github issue. https://github.com/opensearch-project/OpenSearch/issues/6251

### Issues Resolved
#6187, #6222

### Testing 
Done using the failed gradle flows in the issues.

```
(base) 12:03 /Volumes/workplace/OpenSearch main$ ./gradlew ':modules:geo:internalClusterTest' --tests "org.opensearch.geo.search.aggregations.bucket.GeoHashGridIT.testGeoShapes" -Dtests.seed=58EEE2632DEE6DD -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=ar-OM -Dtests.timezone=Europe/Madrid
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true

> Configure project :qa:os
Cannot add task 'destructiveDistroTest.docker' as a task with that name already exists.
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 7.6
  OS Info               : Mac OS X 12.6.3 (x86_64)
  JDK Version           : 11 (Eclipse Temurin JDK)
  JAVA_HOME             : /Users/navneev/.sdkman/candidates/java/11.0.16-tem
  Random Testing Seed   : 58EEE2632DEE6DD
  In FIPS 140 mode      : false
=======================================

> Task :libs:opensearch-x-content:compileJava
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

> Task :server:compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :modules:geo:compileJava
Note: /Volumes/workplace/OpenSearch/modules/geo/src/main/java/org/opensearch/geo/GeoModulePlugin.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :test:framework:compileJava
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :modules:geo:compileTestJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :modules:geo:compileInternalClusterTestJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

> Task :modules:geo:internalClusterTest
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
WARNING: A terminally deprecated method in java.lang.System has been called
WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.BootstrapForTesting (file:/Volumes/workplace/OpenSearch/test/framework/build/distributions/framework-3.0.0-SNAPSHOT.jar)
WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.BootstrapForTesting
WARNING: System::setSecurityManager will be removed in a future release
WARNING: A terminally deprecated method in java.lang.System has been called
WARNING: System::setSecurityManager has been called by org.gradle.api.internal.tasks.testing.worker.TestWorker (file:/Users/navneev/.gradle/wrapper/dists/gradle-7.6-all/9f832ih6bniajn45pbmqhk2cw/gradle-7.6/lib/plugins/gradle-testing-base-7.6.jar)
WARNING: Please consider reporting this to the maintainers of org.gradle.api.internal.tasks.testing.worker.TestWorker
WARNING: System::setSecurityManager will be removed in a future release

BUILD SUCCESSFUL in 3m 21s
48 actionable tasks: 10 executed, 38 up-to-date
<-------------> 0% WAITING
> IDLE
> IDLE
> IDLE
> IDLE
> IDLE
> IDLE
> IDLE
(base) 12:18 /Volumes/workplace/OpenSearch main$ ./gradlew ':modules:geo:internalClusterTest' --tests "org.opensearch.geo.search.aggregations.bucket.GeoTileGridIT.testGeoShapes" -Dtests.seed=EC3F504EF22998E0
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true

> Configure project :qa:os
Cannot add task 'destructiveDistroTest.docker' as a task with that name already exists.
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 7.6
  OS Info               : Mac OS X 12.6.3 (x86_64)
  JDK Version           : 11 (Eclipse Temurin JDK)
  JAVA_HOME             : /Users/navneev/.sdkman/candidates/java/11.0.16-tem
  Random Testing Seed   : EC3F504EF22998E0
  In FIPS 140 mode      : false
=======================================

> Task :modules:geo:internalClusterTest
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
WARNING: A terminally deprecated method in java.lang.System has been called
WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.BootstrapForTesting (file:/Volumes/workplace/OpenSearch/test/framework/build/distributions/framework-3.0.0-SNAPSHOT.jar)
WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.BootstrapForTesting
WARNING: System::setSecurityManager will be removed in a future release
WARNING: A terminally deprecated method in java.lang.System has been called
WARNING: System::setSecurityManager has been called by org.gradle.api.internal.tasks.testing.worker.TestWorker (file:/Users/navneev/.gradle/wrapper/dists/gradle-7.6-all/9f832ih6bniajn45pbmqhk2cw/gradle-7.6/lib/plugins/gradle-testing-base-7.6.jar)
WARNING: Please consider reporting this to the maintainers of org.gradle.api.internal.tasks.testing.worker.TestWorker
WARNING: System::setSecurityManager will be removed in a future release

BUILD SUCCESSFUL in 17s
48 actionable tasks: 1 executed, 47 up-to-date
```

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [X] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
