### PR TITLE
[Remote Store] Fix flaky test RemoteStoreIT.testRemoteSegmentStoreRestore

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -113,8 +113,8 @@ public class RemoteStoreIT extends OpenSearchIntegTestCase {
     private Map<String, Long> indexData() {
         long totalOperations = 0;
         long refreshedOrFlushedOperations = 0;
-        long maxSeqNo = 0;
-        long maxSeqNoRefreshedOrFlushed = 0;
+        long maxSeqNo = -1;
+        long maxSeqNoRefreshedOrFlushed = -1;
         for (int i = 0; i < randomIntBetween(1, 10); i++) {
             if (randomBoolean()) {
                 flush(INDEX_NAME);
@@ -150,8 +150,8 @@ public class RemoteStoreIT extends OpenSearchIntegTestCase {
         assertHitCount(client().prepareSearch(INDEX_NAME).setSize(0).get(), indexStats.get(statsGranularity) + 1);
     }
 
-    public void testRemoteStoreRestoreFromRemoteSegmentStore() throws IOException {
-        internalCluster().startNodes(3);
+    public void testRemoteSegmentStoreRestore() throws IOException {
+        internalCluster().startDataOnlyNodes(3);
         createIndex(INDEX_NAME, remoteStoreIndexSettings(0));
         ensureYellowAndNoInitializingShards(INDEX_NAME);
         ensureGreen(INDEX_NAME);
@@ -169,7 +169,7 @@ public class RemoteStoreIT extends OpenSearchIntegTestCase {
 
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/6188")
     public void testRemoteTranslogRestore() throws IOException {
-        internalCluster().startNodes(3);
+        internalCluster().startDataOnlyNodes(3);
         createIndex(INDEX_NAME, remoteTranslogIndexSettings(0));
         ensureYellowAndNoInitializingShards(INDEX_NAME);
         ensureGreen(INDEX_NAME);

--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchWeightedRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchWeightedRoutingIT.java
@@ -804,9 +804,8 @@ public class SearchWeightedRoutingIT extends OpenSearchIntegTestCase {
 
     /**
      * Assert that preference based search is not allowed with strict weighted shard routing
-     * @throws Exception throws exception
      */
-    public void testStrictWeightedRouting() throws Exception {
+    public void testStrictWeightedRouting() {
 
         Settings commonSettings = Settings.builder()
             .put("cluster.routing.allocation.awareness.attributes", "zone")
@@ -841,9 +840,8 @@ public class SearchWeightedRoutingIT extends OpenSearchIntegTestCase {
 
     /**
      *  Assert that preference based search works with non-strict weighted shard routing
-     * @throws Exception
      */
-    public void testPreferenceSearchWithWeightedRouting() throws Exception {
+    public void testPreferenceSearchWithWeightedRouting() {
         Settings commonSettings = Settings.builder()
             .put("cluster.routing.allocation.awareness.attributes", "zone")
             .put("cluster.routing.allocation.awareness.force.zone.values", "a,b,c")

--- a/server/src/test/java/org/opensearch/common/lucene/LuceneTests.java
+++ b/server/src/test/java/org/opensearch/common/lucene/LuceneTests.java
@@ -329,8 +329,6 @@ public class LuceneTests extends OpenSearchTestCase {
     /**
      * Tests whether old segments are readable and queryable based on the data documented
      * in the README <a href="file:../../../../../resources/indices/bwc/es-6.3.0/README.md">here</a>.
-     *
-     * @throws IOException
      */
     public void testReadSegmentInfosExtendedCompatibility() throws IOException {
         final String pathToTestIndex = "/indices/bwc/es-6.3.0/testIndex-es-6.3.0.zip";


### PR DESCRIPTION
Signed-off-by: Sachin Kale <kalsac@amazon.com>

### Description
- In `RemoteStoreIT.testRemoteSegmentStoreRestore` test, if we index X documents and primary goes down without refresh, as we are using only remote segment store, restore operation creates as empty index.
- Indexing new doc on the restored index is treated as the first doc and response contains seqNo as 0 (for the first doc).
- The seqNo initialization to 0 instead of -1 was failing the test which is fixed with this change.

### Issues Resolved
- https://github.com/opensearch-project/OpenSearch/issues/6248

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
