### PR TITLE
[Segment Replication] Mute Flaky Test and add segment_replication.json as experimental

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segment_replication.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segment_replication.json
@@ -4,7 +4,7 @@
       "url":"https://github.com/opensearch-project/documentation-website/issues/2627",
       "description":"Returns information about both on-going and latest completed Segment Replication events"
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/ClientTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/ClientTimeoutIT.java
@@ -152,6 +152,7 @@ public class ClientTimeoutIT extends OpenSearchIntegTestCase {
         assertThat(recoveryResponse.getShardFailures()[0].reason(), containsString("ReceiveTimeoutTransportException"));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/6255")
     public void testSegmentReplicationStatsWithTimeout() {
         internalCluster().startClusterManagerOnlyNode(
             Settings.builder().put(super.featureFlagSettings()).put(FeatureFlags.REPLICATION_TYPE, "true").build()


### PR DESCRIPTION
Signed-off-by: Rishikesh1159 <rishireddy1159@gmail.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR mutes flaky test testSegmentReplicationStatsWithTimeout() found in #6255 and adds segment_replication.json as experimental coming from [comment](https://github.com/opensearch-project/OpenSearch/pull/5718#discussion_r1100729132)

### Issues Resolved
#6255 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
