### PR TITLE
Remove timestamp from translog metadata filename for remote-backed indexes

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -38,8 +38,6 @@ public class TranslogTransferMetadata {
 
     private final long minTranslogGeneration;
 
-    private final long timeStamp;
-
     private int count;
 
     private final SetOnce<Map<String, String>> generationToPrimaryTermMapper = new SetOnce<>();
@@ -58,7 +56,6 @@ public class TranslogTransferMetadata {
         this.primaryTerm = primaryTerm;
         this.generation = generation;
         this.minTranslogGeneration = minTranslogGeneration;
-        this.timeStamp = System.currentTimeMillis();
         this.count = count;
     }
 
@@ -68,7 +65,6 @@ public class TranslogTransferMetadata {
         this.primaryTerm = indexInput.readLong();
         this.generation = indexInput.readLong();
         this.minTranslogGeneration = indexInput.readLong();
-        this.timeStamp = indexInput.readLong();
         this.generationToPrimaryTermMapper.set(indexInput.readMapOfStrings());
     }
 
@@ -97,10 +93,7 @@ public class TranslogTransferMetadata {
     }
 
     public String getFileName() {
-        return String.join(
-            METADATA_SEPARATOR,
-            Arrays.asList(String.valueOf(primaryTerm), String.valueOf(generation), String.valueOf(timeStamp))
-        );
+        return String.join(METADATA_SEPARATOR, Arrays.asList(String.valueOf(primaryTerm), String.valueOf(generation)));
     }
 
     public byte[] createMetadataBytes() throws IOException {
@@ -123,7 +116,7 @@ public class TranslogTransferMetadata {
 
     @Override
     public int hashCode() {
-        return Objects.hash(primaryTerm, generation, timeStamp);
+        return Objects.hash(primaryTerm, generation);
     }
 
     @Override
@@ -131,16 +124,13 @@ public class TranslogTransferMetadata {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         TranslogTransferMetadata other = (TranslogTransferMetadata) o;
-        return Objects.equals(this.primaryTerm, other.primaryTerm)
-            && Objects.equals(this.generation, other.generation)
-            && Objects.equals(this.timeStamp, other.timeStamp);
+        return Objects.equals(this.primaryTerm, other.primaryTerm) && Objects.equals(this.generation, other.generation);
     }
 
     private void write(DataOutput out) throws IOException {
         out.writeLong(primaryTerm);
         out.writeLong(generation);
         out.writeLong(minTranslogGeneration);
-        out.writeLong(timeStamp);
         if (generationToPrimaryTermMapper.get() != null) {
             out.writeMapOfStrings(generationToPrimaryTermMapper.get());
         } else {
@@ -151,12 +141,11 @@ public class TranslogTransferMetadata {
     private static class MetadataFilenameComparator implements Comparator<String> {
         @Override
         public int compare(String first, String second) {
-            // Format of metadata filename is <Primary Term>__<Generation>__<Timestamp>
+            // Format of metadata filename is <Primary Term>__<Generation>
             String[] filenameTokens1 = first.split(METADATA_SEPARATOR);
             String[] filenameTokens2 = second.split(METADATA_SEPARATOR);
-            // Here, we are not comparing only primary term and generation.
-            // Timestamp is not a good measure of comparison in case primary term and generation are same.
-            for (int i = 0; i < filenameTokens1.length - 1; i++) {
+            // Here, we are comparing only primary term and generation.
+            for (int i = 0; i < filenameTokens1.length; i++) {
                 if (filenameTokens1[i].equals(filenameTokens2[i]) == false) {
                     return Long.compare(Long.parseLong(filenameTokens1[i]), Long.parseLong(filenameTokens2[i]));
                 }


### PR DESCRIPTION
Signed-off-by: Ashish Singh <ssashish@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Remove timestamp from the translog metadata filenames. The pair of primary term and generation is supposed to be unique for failovers and relocation. For failovers, the primary terms bumps by 1. For relocation, the generation increases while the primary term remaining the same. The invariant, however, is that the combination of primary term and generation would not be overridden on remote store. 

### Issues Resolved
This solves #5677 - Metadata file naming. The cleanup of metadata file is present in #6239 and PR is created already #6238.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
