### PR TITLE
Add a setting to control auto release of OpenSearch Monitors managed index creation block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add cancellation of in-flight SearchTasks based on resource consumption ([#5606](https://github.com/opensearch-project/OpenSearch/pull/5605))
 - Add support for ppc64le architecture ([#5459](https://github.com/opensearch-project/OpenSearch/pull/5459))
 - [Segment Replication] Add primary weight factor for balanced primary distribution ([#6017](https://github.com/opensearch-project/OpenSearch/pull/6017))
+- Add a setting to control auto release of OpenSearch managed index creation block ([#6277](https://github.com/opensearch-project/OpenSearch/pull/6277))
 
 ### Dependencies
 - Update nebula-publishing-plugin to 19.2.0 ([#5704](https://github.com/opensearch-project/OpenSearch/pull/5704))

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -39,7 +39,6 @@ import org.apache.lucene.util.Constants;
 
 import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
-import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.opensearch.action.admin.indices.stats.ShardStats;
 import org.opensearch.action.index.IndexRequestBuilder;
@@ -65,6 +64,7 @@ import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.monitor.fs.FsInfo;
 import org.opensearch.monitor.fs.FsService;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.fs.FsRepository;
@@ -95,7 +95,6 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -136,6 +135,7 @@ public class DiskThresholdDeciderIT extends OpenSearchIntegTestCase {
     }
 
     private static final long WATERMARK_BYTES = new ByteSizeValue(10, ByteSizeUnit.KB).getBytes();
+    private static final long TOTAL_SPACE_BYTES = new ByteSizeValue(100, ByteSizeUnit.KB).getBytes();
     private static final String INDEX_ROUTING_ALLOCATION_NODE_SETTING = "index.routing.allocation.include._name";
 
     @Override
@@ -196,14 +196,13 @@ public class DiskThresholdDeciderIT extends OpenSearchIntegTestCase {
             .build();
 
         internalCluster().startClusterManagerOnlyNode(settings);
-        final List<String> dataNodeNames = internalCluster().startDataOnlyNodes(2, settings);
+        internalCluster().startDataOnlyNodes(2, settings);
         ensureStableCluster(3);
+        final MockInternalClusterInfoService clusterInfoService = getMockInternalClusterInfoService();
         // Reduce disk space of all node until all of them is breaching high disk watermark.
-        for (final String dataNodeName : dataNodeNames) {
-            populateNode(dataNodeName);
-        }
-
-        getMockInternalClusterInfoService().refresh();
+        clusterInfoService.setDiskUsageFunctionAndRefresh(
+            (discoveryNode, fsInfoPath) -> setDiskUsage(fsInfoPath, TOTAL_SPACE_BYTES, WATERMARK_BYTES - 1)
+        );
         assertBusy(() -> {
             ClusterState state1 = client().admin().cluster().prepareState().setLocal(true).get().getState();
             assertFalse(state1.blocks().hasGlobalBlockWithId(Metadata.CLUSTER_CREATE_INDEX_BLOCK.id()));
@@ -234,22 +233,23 @@ public class DiskThresholdDeciderIT extends OpenSearchIntegTestCase {
         final List<String> indexNames = new ArrayList<>();
         ensureStableCluster(3);
 
+        final MockInternalClusterInfoService clusterInfoService = getMockInternalClusterInfoService();
         // Reduce disk space of all node until all of them is breaching high disk watermark.
-        for (final String dataNodeName : dataNodeNames) {
-            final String indexName = populateNode(dataNodeName);
-            indexNames.add(indexName);
-        }
+        clusterInfoService.setDiskUsageFunctionAndRefresh(
+            (discoveryNode, fsInfoPath) -> setDiskUsage(fsInfoPath, TOTAL_SPACE_BYTES, WATERMARK_BYTES - 1)
+        );
 
-        getMockInternalClusterInfoService().refresh();
         // Validate if cluster block is applied on the cluster
         assertBusy(() -> {
             ClusterState state = client().admin().cluster().prepareState().setLocal(true).get().getState();
             assertTrue(state.blocks().hasGlobalBlockWithId(Metadata.CLUSTER_CREATE_INDEX_BLOCK.id()));
         }, 30L, TimeUnit.SECONDS);
 
-        // Delete indices to free space
-        deleteIndices(indexNames);
-        getMockInternalClusterInfoService().refresh();
+        // Free all the space
+        clusterInfoService.setDiskUsageFunctionAndRefresh(
+            (discoveryNode, fsInfoPath) -> setDiskUsage(fsInfoPath, TOTAL_SPACE_BYTES, TOTAL_SPACE_BYTES)
+        );
+
         // Validate if index create block is removed on the cluster
         assertBusy(() -> {
             ClusterState state1 = client().admin().cluster().prepareState().setLocal(true).get().getState();
@@ -266,20 +266,22 @@ public class DiskThresholdDeciderIT extends OpenSearchIntegTestCase {
         final List<String> dataNodeNames = internalCluster().startDataOnlyNodes(2, settings);
         ensureStableCluster(3);
 
+        final MockInternalClusterInfoService clusterInfoService = getMockInternalClusterInfoService();
         // Create one of the index.
-        final String indexName = populateNode(dataNodeNames.get(0));
-        // Reduce disk space of all other node until all of them is breaching high disk watermark
-        for (int i = 1; i < dataNodeNames.size(); i++) {
-            populateNode(dataNodeNames.get(i));
-        }
-
+        final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        createAndPopulateIndex(indexName, dataNodeNames.get(0));
         // Apply a read_only_allow_delete_block on one of the index
         // (can happen if the corresponding node has breached flood stage watermark).
         final Settings readOnlySettings = Settings.builder()
             .put(IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE, Boolean.TRUE.toString())
             .build();
         client().admin().indices().prepareUpdateSettings(indexName).setSettings(readOnlySettings).get();
-        getMockInternalClusterInfoService().refresh();
+
+        // Reduce disk space of all node until all of them is breaching high disk watermark.
+        clusterInfoService.setDiskUsageFunctionAndRefresh(
+            (discoveryNode, fsInfoPath) -> setDiskUsage(fsInfoPath, TOTAL_SPACE_BYTES, WATERMARK_BYTES - 1)
+        );
+
         // Validate index create block is applied on the cluster
         assertBusy(() -> {
             ClusterState state = client().admin().cluster().prepareState().setLocal(true).get().getState();
@@ -364,18 +366,9 @@ public class DiskThresholdDeciderIT extends OpenSearchIntegTestCase {
         assertBusyWithDiskUsageRefresh(dataNode0Id, indexName, hasSize(1));
     }
 
-    private void deleteIndices(final List<String> indexNames) throws ExecutionException, InterruptedException {
-        for (String indexName : indexNames) {
-            assertAcked(client().admin().indices().delete(new DeleteIndexRequest(indexName)).get());
-            assertFalse("index [" + indexName + "] should have been deleted", indexExists(indexName));
-        }
-    }
-
     private String populateNode(final String dataNodeName) throws Exception {
-        final Path dataNodePath = internalCluster().getInstance(Environment.class, dataNodeName).dataFiles()[0];
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
-        long minShardSize = createAndPopulateIndex(indexName, dataNodeName);
-        fileSystemProvider.getTestFileStore(dataNodePath).setTotalSpace(minShardSize + WATERMARK_BYTES - 1L);
+        createAndPopulateIndex(indexName, dataNodeName);
         return indexName;
     }
 
@@ -463,6 +456,10 @@ public class DiskThresholdDeciderIT extends OpenSearchIntegTestCase {
                 return minShardSize;
             }
         }
+    }
+
+    private static FsInfo.Path setDiskUsage(FsInfo.Path original, long totalBytes, long freeBytes) {
+        return new FsInfo.Path(original.getPath(), original.getMount(), totalBytes, freeBytes, freeBytes);
     }
 
     private void refreshDiskUsage() {

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -377,11 +377,12 @@ public class DiskThresholdMonitor {
         // If all the nodes are breaching high disk watermark, we apply index create block to avoid red clusters.
         if (nodesOverHighThreshold.size() == nodes.size()) {
             setIndexCreateBlock(listener, true);
-        } else if (state.getBlocks().hasGlobalBlockWithId(Metadata.CLUSTER_CREATE_INDEX_BLOCK.id())) {
-            setIndexCreateBlock(listener, false);
-        } else {
-            listener.onResponse(null);
-        }
+        } else if (state.getBlocks().hasGlobalBlockWithId(Metadata.CLUSTER_CREATE_INDEX_BLOCK.id())
+            && diskThresholdSettings.isCreateIndexBlockAutoReleaseEnabled()) {
+                setIndexCreateBlock(listener, false);
+            } else {
+                listener.onResponse(null);
+            }
     }
 
     // exposed for tests to override

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
@@ -97,6 +97,12 @@ public class DiskThresholdSettings {
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
+    public static final Setting<Boolean> CLUSTER_CREATE_INDEX_BLOCK_AUTO_RELEASE = Setting.boolSetting(
+        "cluster.blocks.create_index.auto_release",
+        true,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
 
     private volatile String lowWatermarkRaw;
     private volatile String highWatermarkRaw;
@@ -105,6 +111,7 @@ public class DiskThresholdSettings {
     private volatile ByteSizeValue freeBytesThresholdLow;
     private volatile ByteSizeValue freeBytesThresholdHigh;
     private volatile boolean includeRelocations;
+    private volatile boolean createIndexBlockAutoReleaseEnabled;
     private volatile boolean enabled;
     private volatile TimeValue rerouteInterval;
     private volatile Double freeDiskThresholdFloodStage;
@@ -132,12 +139,14 @@ public class DiskThresholdSettings {
         this.includeRelocations = CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS_SETTING.get(settings);
         this.rerouteInterval = CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING.get(settings);
         this.enabled = CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.get(settings);
+        this.createIndexBlockAutoReleaseEnabled = CLUSTER_CREATE_INDEX_BLOCK_AUTO_RELEASE.get(settings);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING, this::setLowWatermark);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING, this::setHighWatermark);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING, this::setFloodStage);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS_SETTING, this::setIncludeRelocations);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING, this::setRerouteInterval);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING, this::setEnabled);
+        clusterSettings.addSettingsUpdateConsumer(CLUSTER_CREATE_INDEX_BLOCK_AUTO_RELEASE, this::setCreateIndexBlockAutoReleaseEnabled);
     }
 
     /**
@@ -331,6 +340,10 @@ public class DiskThresholdSettings {
         );
     }
 
+    private void setCreateIndexBlockAutoReleaseEnabled(boolean createIndexBlockAutoReleaseEnabled) {
+        this.createIndexBlockAutoReleaseEnabled = createIndexBlockAutoReleaseEnabled;
+    }
+
     /**
      * Gets the raw (uninterpreted) low watermark value as found in the settings.
      */
@@ -379,6 +392,10 @@ public class DiskThresholdSettings {
 
     public TimeValue getRerouteInterval() {
         return rerouteInterval;
+    }
+
+    public boolean isCreateIndexBlockAutoReleaseEnabled() {
+        return createIndexBlockAutoReleaseEnabled;
     }
 
     String describeLowThreshold() {

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -280,6 +280,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING,
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING,
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING,
+                DiskThresholdSettings.CLUSTER_CREATE_INDEX_BLOCK_AUTO_RELEASE,
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS_SETTING,
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING,
                 SameShardAllocationDecider.CLUSTER_ROUTING_ALLOCATION_SAME_HOST_SETTING,


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
OpenSearch controls (applies and remove)```create_index``` block (when all node are breaching high disk watermark) inside ```DiskThresholdMonitor```. Now, if the user tries to apply this block from their end, it may be possible that ```DiskThresholdMonitor``` removes it (```create_index``` gets removed if any of the node is not breaching high disk watermark). This makes this block to be usable only by OpenSearch monitors. User cannot control when these blocks get applied or removed.

We would suggest to add a configurable setting which will control when these blocks will be removed. This will ensure that when set to false, both user and OpenSearch monitor applies the respective blocks, but removal of the block is controlled by user.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/6269

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
