### PR TITLE
[Extensions] Add support to get headers for ExtensionRestRequest

### DIFF
--- a/server/src/main/java/org/opensearch/extensions/rest/RestSendToExtensionAction.java
+++ b/server/src/main/java/org/opensearch/extensions/rest/RestSendToExtensionAction.java
@@ -170,7 +170,7 @@ public class RestSendToExtensionAction extends BaseRestHandler {
                 ExtensionsManager.REQUEST_REST_EXECUTE_ON_EXTENSION_ACTION,
                 // HERE BE DRAGONS - DO NOT INCLUDE HEADERS
                 // SEE https://github.com/opensearch-project/OpenSearch/issues/4429
-                new ExtensionRestRequest(method, path, params, contentType, content, requestIssuerIdentity),
+                new ExtensionRestRequest(method, path, params, request.getHeaders(), contentType, content, requestIssuerIdentity),
                 restExecuteOnExtensionResponseHandler
             );
             inProgressFuture.orTimeout(ExtensionsManager.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS).join();

--- a/server/src/main/java/org/opensearch/rest/action/RestActions.java
+++ b/server/src/main/java/org/opensearch/rest/action/RestActions.java
@@ -46,6 +46,7 @@ import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.ToXContent.Params;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.extensions.rest.ExtensionRestRequest;
 import org.opensearch.index.query.Operator;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
@@ -76,6 +77,17 @@ public class RestActions {
     public static final ParseField FAILURES_FIELD = new ParseField("failures");
 
     public static long parseVersion(RestRequest request) {
+        if (request.hasParam("version")) {
+            return request.paramAsLong("version", Versions.MATCH_ANY);
+        }
+        String ifMatch = request.header("If-Match");
+        if (ifMatch != null) {
+            return Long.parseLong(ifMatch);
+        }
+        return Versions.MATCH_ANY;
+    }
+
+    public static long parseVersion(ExtensionRestRequest request) {
         if (request.hasParam("version")) {
             return request.paramAsLong("version", Versions.MATCH_ANY);
         }

--- a/server/src/test/java/org/opensearch/extensions/rest/ExtensionRestRequestTests.java
+++ b/server/src/test/java/org/opensearch/extensions/rest/ExtensionRestRequestTests.java
@@ -25,7 +25,11 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Arrays;
 
 import static java.util.Map.entry;
 

--- a/server/src/test/java/org/opensearch/extensions/rest/ExtensionRestRequestTests.java
+++ b/server/src/test/java/org/opensearch/extensions/rest/ExtensionRestRequestTests.java
@@ -25,9 +25,8 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import static java.util.Map.entry;
 
 public class ExtensionRestRequestTests extends OpenSearchTestCase {
@@ -35,6 +34,7 @@ public class ExtensionRestRequestTests extends OpenSearchTestCase {
     private Method expectedMethod;
     private String expectedPath;
     Map<String, String> expectedParams;
+    Map<String, List<String>> expectedHeaders;
     XContentType expectedContentType;
     BytesReference expectedContent;
     String extensionUniqueId1;
@@ -49,6 +49,9 @@ public class ExtensionRestRequestTests extends OpenSearchTestCase {
         expectedMethod = Method.GET;
         expectedPath = "/test/uri";
         expectedParams = Map.ofEntries(entry("foo", "bar"), entry("baz", "42"));
+        expectedHeaders = new HashMap<>();
+        expectedHeaders.put("header1", Collections.singletonList("boo"));
+        expectedHeaders.put("header2", Arrays.asList("foo", "foo"));
         expectedContentType = XContentType.JSON;
         expectedContent = new BytesArray("{\"key\": \"value\"}".getBytes(StandardCharsets.UTF_8));
         extensionUniqueId1 = "ext_1";
@@ -62,6 +65,7 @@ public class ExtensionRestRequestTests extends OpenSearchTestCase {
             expectedMethod,
             expectedPath,
             expectedParams,
+            expectedHeaders,
             expectedContentType,
             expectedContent,
             expectedRequestIssuerIdentity
@@ -80,6 +84,10 @@ public class ExtensionRestRequestTests extends OpenSearchTestCase {
         assertEquals(0L, request.paramAsLong("bar", 0L));
         assertTrue(request.consumedParams().contains("foo"));
         assertTrue(request.consumedParams().contains("baz"));
+
+        assertEquals(expectedHeaders, request.getHeaders());
+        assertEquals("boo", request.header("header1"));
+        assertEquals(Arrays.asList("foo", "foo"), request.getAllHeaderValues("header2"));
 
         assertEquals(expectedContentType, request.getXContentType());
         assertTrue(request.hasContent());
@@ -114,6 +122,7 @@ public class ExtensionRestRequestTests extends OpenSearchTestCase {
             expectedMethod,
             expectedPath,
             expectedParams,
+            expectedHeaders,
             null,
             new BytesArray(new byte[0]),
             expectedRequestIssuerIdentity
@@ -122,6 +131,7 @@ public class ExtensionRestRequestTests extends OpenSearchTestCase {
         assertEquals(expectedMethod, request.method());
         assertEquals(expectedPath, request.path());
         assertEquals(expectedParams, request.params());
+        assertEquals(expectedHeaders, request.getHeaders());
         assertNull(request.getXContentType());
         assertEquals(0, request.content().length());
         assertEquals(expectedRequestIssuerIdentity, request.getRequestIssuerIdentity());
@@ -156,6 +166,7 @@ public class ExtensionRestRequestTests extends OpenSearchTestCase {
             expectedMethod,
             expectedPath,
             expectedParams,
+            expectedHeaders,
             null,
             expectedText,
             expectedRequestIssuerIdentity
@@ -164,6 +175,7 @@ public class ExtensionRestRequestTests extends OpenSearchTestCase {
         assertEquals(expectedMethod, request.method());
         assertEquals(expectedPath, request.path());
         assertEquals(expectedParams, request.params());
+        assertEquals(expectedHeaders, request.getHeaders());
         assertNull(request.getXContentType());
         assertEquals(expectedText, request.content());
         assertEquals(expectedRequestIssuerIdentity, request.getRequestIssuerIdentity());

--- a/server/src/test/java/org/opensearch/extensions/rest/ExtensionRestResponseTests.java
+++ b/server/src/test/java/org/opensearch/extensions/rest/ExtensionRestResponseTests.java
@@ -43,6 +43,7 @@ public class ExtensionRestResponseTests extends OpenSearchTestCase {
             Method.GET,
             "/foo",
             Collections.emptyMap(),
+            Collections.emptyMap(),
             null,
             new BytesArray("Text Content"),
             null


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Added support to fetch headers from ExtensionRestRequest.

### Issues Resolved
https://github.com/opensearch-project/opensearch-sdk-java/issues/431

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
