### PR TITLE
[Backport] [2.x] Bump org.apache.ant:ant from 1.10.12 to 1.10.13 (#6298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump antlr4 from 4.9.3 to 4.11.1 ([#6116](https://github.com/opensearch-project/OpenSearch/pull/6116))
 - Bumps `Netty` from 4.1.86.Final to 4.1.87.Final ([#6130](https://github.com/opensearch-project/OpenSearch/pull/6130))
 - Bumps `Jackson` from 2.14.1 to 2.14.2 ([#6129](https://github.com/opensearch-project/OpenSearch/pull/6129))
+- Bumps `org.apache.ant:ant` from 1.10.12 to 1.10.13
 
 ### Changed
 - Use ReplicationFailedException instead of OpensearchException in ReplicationTarget ([#4725](https://github.com/opensearch-project/OpenSearch/pull/4725))

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -104,7 +104,7 @@ dependencies {
 
   api 'commons-codec:commons-codec:1.15'
   api 'org.apache.commons:commons-compress:1.22'
-  api 'org.apache.ant:ant:1.10.12'
+  api 'org.apache.ant:ant:1.10.13'
   api 'com.netflix.nebula:gradle-extra-configurations-plugin:8.0.0'
   api 'com.netflix.nebula:nebula-publishing-plugin:19.2.0'
   api 'com.netflix.nebula:gradle-info-plugin:12.0.0'


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/6298 to `2.x`