### PR TITLE
Recover all translogs during relocation handoff for remote-backed indexes

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -4311,9 +4311,13 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 // TODO: add a dedicate recovery stats for the reset translog
             }
         );
+
+        // When the new engine is created, translogs are synced from remote store onto local. Since remote store is the source
+        // of truth for translog, we play all translogs that exists locally. Otherwise, the recoverUpto happens upto global checkpoint.
+        long recoverUpto = this.isRemoteTranslogEnabled() ? Long.MAX_VALUE : globalCheckpoint;
         newEngineReference.get()
             .translogManager()
-            .recoverFromTranslog(translogRunner, newEngineReference.get().getProcessedLocalCheckpoint(), globalCheckpoint);
+            .recoverFromTranslog(translogRunner, newEngineReference.get().getProcessedLocalCheckpoint(), recoverUpto);
         newEngineReference.get().refresh("reset_engine");
         synchronized (engineMutex) {
             verifyNotClosed();


### PR DESCRIPTION
Signed-off-by: Ashish Singh <ssashish@amazon.com>

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
As discussed in #6214, during relocation certain documents indexed on the older primary were not seen on the new primary upon search. This was happening as recoverFromTranslog was recovering upto last known global checkpoint while it should be done upto `Long.Max` for cases where remote translog store is enabled.
 
https://github.com/opensearch-project/OpenSearch/blob/49d9a90b52d5451e0eda95ce03dfb94dd505a905/server/src/main/java/org/opensearch/index/shard/IndexShard.java#L4314-L4317

When remote translog is enabled, then remote store acts as the source of truth for storing translogs. During relocation we reset engine to writeable engine. When this happens, we initialise the RemoteFsTranslog which downloads all the translogs from remote store. The fix is to replay all the translogs here. 

### Issues Resolved
This fixes #6214.

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
