### PR TITLE
Clean up temporary files created during segment merge incase force segment merge fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Segment Replication] Add primary weight factor for balanced primary distribution ([#6017](https://github.com/opensearch-project/OpenSearch/pull/6017))
 - Add a setting to control auto release of OpenSearch managed index creation block ([#6277](https://github.com/opensearch-project/OpenSearch/pull/6277))
 - Fix timeout error when adding a document to an index with extension running ([#6275](https://github.com/opensearch-project/OpenSearch/pull/6275))
+- Clean up temporary files created during segment merge incase segment merge fails ([#6324](https://github.com/opensearch-project/OpenSearch/pull/6324))
 
 ### Dependencies
 - Update nebula-publishing-plugin to 19.2.0 ([#5704](https://github.com/opensearch-project/OpenSearch/pull/5704))

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -2010,6 +2010,7 @@ public class InternalEngine extends Engine {
         } catch (Exception e) {
             try {
                 maybeFailEngine("force merge", e);
+                indexWriter.flush();
             } catch (Exception inner) {
                 e.addSuppressed(inner);
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Currently, during segment merge (both during auto merge and force merge), OpenSearch creates multiple temporary files while merging individual segment components. Once individual components of the segments are merged, IndexWriter creates a Compound file (*.cfs) containing all the Lucene components for a segment. At the end, OpenSearch deletes these temporary files.

Now, in case these temporary files consume all the space on the node (because enough amount of space is unavailable for segment merge to go through), segment merge will fail. Also, the files which got created during segment merge do not get cleaned up and it continues to occupy space on the node. This can cause FSHealthService checks to fail for this node, ultimately causing these nodes to be removed from cluster.

In case Force segment merge fails, OpenSearch should remove the temporary files created during segment merge.

### Pattern of space reduction

On monitoring space reduction pattern during a Lucene Segment merge, we observed that there are three scenarioes that can happen:

1. When Lucene segment merge completed successfully.
2. When Lucene segment merge gets aborted (due to some reason) and some amount of free disk space is available at that time.
3. When Lucene segment merge fails and 0 free space is available at that time.

*Case 1:* *Triggering force merge with max segments = 5 for 94 GB shard size index (with only one shard) on a domain with node size 140 GB:*

In this scenario, force segment merge completed successfully. Disk continue to reduce even when CP circuit breaker limit got breached. But once Lucene merge completed SegmentMerger deleted the temporary files created.

*Case 2: Triggering force merge with max segments = 3 for 94 GB shard size index (with only one shard) on a domain with node size 140 GB:*

In this scenario, if segment merge gets aborted (because of any reason) when SegmentMerger is merging individual components of segments, the temporary files generated will not be removed in the force merge flow. Since Lucene and OpenSearch deletes these files after merge is complete, neither SegmentMerger (Lucene) nor InternalEngine (OpenSearch)  is able to clear these temp files from the data volume. 

These files will get cleared once cluster state update happens for this node as OpenSearch [makes call](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/gateway/PersistedClusterStateService.java#L792) to [IndexWriter flush function](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/gateway/PersistedClusterStateService.java#L570) to [remove unnecessary files](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/gateway/PersistedClusterStateService.java#L733)  before it commits cluster state for the node.

*Case 3: Triggering force merge with max segments = 1 for 94 GB shard size index (with only one shard) on a domain with node size 140 GB:*

Now in the second case if available disk space reduces to 0 because of temporary files created during segment merge, nodes will be removed from the cluster by FSHealth Service and segment merge will fail with no space error. Also these temporary files will continue to occupy the disk space as Lucene deletes them after merge is completed. Since segment merge failed in midway itself, neither Lucene nor OpenSearch can remove these temporary files from the data volume. Also since nodes have dropped, no cluster state updates gets triggered for these nodes which can remove these temporary files from data volume. Therefore once node reached this state it can never join back the cluster without manual intervention.


### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/5710

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
