### PR TITLE
[Segment Replication] Consider primary shard balancing first

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
@@ -30,6 +30,7 @@ import org.opensearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.gateway.PriorityComparator;
+import org.opensearch.indices.replication.common.ReplicationType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static org.opensearch.cluster.routing.ShardRoutingState.RELOCATING;
@@ -967,6 +969,13 @@ public class LocalShardsBalancer extends ShardsBalancer {
     }
 
     private static final Comparator<ShardRouting> BY_DESCENDING_SHARD_ID = Comparator.comparing(ShardRouting::shardId).reversed();
+    private static final Comparator<ShardRouting> PRIMARY_FIRST = Comparator.comparing(ShardRouting::primary).reversed();
+
+    private boolean isSegRepEnabled(String index) {
+        IndexMetadata indexMetadata = metadata.index(index);
+        return indexMetadata.getSettings().get(IndexMetadata.SETTING_REPLICATION_TYPE) != null
+            && indexMetadata.getSettings().get(IndexMetadata.SETTING_REPLICATION_TYPE).equals(ReplicationType.SEGMENT.toString());
+    }
 
     /**
      * Tries to find a relocation from the max node to the minimal node for an arbitrary shard of the given index on the
@@ -977,11 +986,14 @@ public class LocalShardsBalancer extends ShardsBalancer {
         final BalancedShardsAllocator.ModelIndex index = maxNode.getIndex(idx);
         if (index != null) {
             logger.trace("Try relocating shard of [{}] from [{}] to [{}]", idx, maxNode.getNodeId(), minNode.getNodeId());
-            final Iterable<ShardRouting> shardRoutings = StreamSupport.stream(index.spliterator(), false)
+            Stream stream = StreamSupport.stream(index.spliterator(), false)
                 .filter(ShardRouting::started) // cannot rebalance unassigned, initializing or relocating shards anyway
                 .filter(maxNode::containsShard)
-                .sorted(BY_DESCENDING_SHARD_ID) // check in descending order of shard id so that the decision is deterministic
-            ::iterator;
+                .sorted(BY_DESCENDING_SHARD_ID); // check in descending order of shard id so that the decision is deterministic
+            if (isSegRepEnabled(idx)) {
+                stream = stream.sorted(PRIMARY_FIRST);
+            }
+            final Iterable<ShardRouting> shardRoutings = stream::iterator;
 
             final AllocationDeciders deciders = allocation.deciders();
             for (ShardRouting shard : shardRoutings) {
@@ -991,6 +1003,11 @@ public class LocalShardsBalancer extends ShardsBalancer {
                 }
                 final Decision allocationDecision = deciders.canAllocate(shard, minNode.getRoutingNode(), allocation);
                 if (allocationDecision.type() == Decision.Type.NO) {
+                    continue;
+                }
+
+                // For segrep shards, move primary shard first in place of replica/random shard, to have better primary balance
+                if (isSegRepEnabled(idx) && shard.primary() && maxNode.numPrimaryShards() - minNode.numPrimaryShards() < 2) {
                     continue;
                 }
 


### PR DESCRIPTION
### Description
This change considers primary shards first for rebalancing versus random shards and that ensures more fairer primary distribution. This change is allows nodes to converge towards a more balanced primary distribution. This rebalancing logic considers shards of one index at a time starting with most unbalanced first, thus this change is non-intrusive.

Note: The primary shard distribution can still remain unbalanced in below cases:
1. Multiple indices. Rebalancing logic runs balancing logic on one index at a time. This can result in nodes balanced specific to index but when combined. E.g. N1, N2 are two nodes, I1P1, I2P1 are primary shards of index I1 and I2, while I1R1 and I2R1 are replica shards. Below distribution is balanced considering I1, I2 separately but not when combining both.
N1          N2
I1P1       I1R1
I2P1      I2R1

2. Failover. During failover the replicas are immediately promoted as primary which results in primaries on dead node to be demoted as replica; resulting in uneven primary/replica distribution; which is balanced when considering node weight but unbalanced when evaluating primaries only. 

### Issues Resolved
#6210 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
