### PR TITLE
Fix inconsistent cluster state and ensure weigh away exception check only for data nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Segment Replication] Fix for peer recovery ([#5344](https://github.com/opensearch-project/OpenSearch/pull/5344))
 - Fix weighted shard routing state across search requests([#6004](https://github.com/opensearch-project/OpenSearch/pull/6004))
 - [Segment Replication] Fix bug where inaccurate sequence numbers are sent during replication ([#6122](https://github.com/opensearch-project/OpenSearch/pull/6122))
+- [Weighted Routing] Fix inconsistent cluster state and ensure weigh away exception check only for data nodes ([#6327](https://github.com/opensearch-project/OpenSearch/pull/6327))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Segment Replication] Fix for peer recovery ([#5344](https://github.com/opensearch-project/OpenSearch/pull/5344))
 - Fix weighted shard routing state across search requests([#6004](https://github.com/opensearch-project/OpenSearch/pull/6004))
 - [Segment Replication] Fix bug where inaccurate sequence numbers are sent during replication ([#6122](https://github.com/opensearch-project/OpenSearch/pull/6122))
-- [Weighted Routing] Fix inconsistent cluster state and ensure weigh away exception check only for data nodes ([#6327](https://github.com/opensearch-project/OpenSearch/pull/6327))
 - Enable numeric sort optimisation for few numerical sort types ([#6321](https://github.com/opensearch-project/OpenSearch/pull/6321))
 
 ### Security

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -281,6 +281,7 @@ public class TransportClusterHealthAction extends TransportClusterManagerNodeRea
             ClusterHealthResponse clusterHealthResponse = getResponse(request, currentState, waitCount, TimeoutState.OK);
             if (request.ensureNodeWeighedIn() && clusterHealthResponse.hasDiscoveredClusterManager()) {
                 DiscoveryNode localNode = currentState.getNodes().getLocalNode();
+                // TODO: make this check more generic, check for node role instead
                 if (localNode.isDataNode()) {
                     assert request.local() == true : "local node request false for request for local node weighed in";
                     boolean weighedAway = WeightedRoutingUtils.isWeighedAway(localNode.getId(), currentState);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -280,15 +280,16 @@ public class TransportClusterHealthAction extends TransportClusterManagerNodeRea
         if (validationPredicate.test(currentState)) {
             ClusterHealthResponse clusterHealthResponse = getResponse(request, currentState, waitCount, TimeoutState.OK);
             if (request.ensureNodeWeighedIn() && clusterHealthResponse.hasDiscoveredClusterManager()) {
-                DiscoveryNode localNode = clusterService.state().getNodes().getLocalNode();
-                assert request.local() == true : "local node request false for request for local node weighed in";
-                boolean weighedAway = WeightedRoutingUtils.isWeighedAway(localNode.getId(), clusterService.state());
-                if (weighedAway) {
-                    listener.onFailure(new NodeWeighedAwayException("local node is weighed away"));
-                    return;
+                DiscoveryNode localNode = currentState.getNodes().getLocalNode();
+                if (localNode.isDataNode()) {
+                    assert request.local() == true : "local node request false for request for local node weighed in";
+                    boolean weighedAway = WeightedRoutingUtils.isWeighedAway(localNode.getId(), currentState);
+                    if (weighedAway) {
+                        listener.onFailure(new NodeWeighedAwayException("local node is weighed away"));
+                        return;
+                    }
                 }
             }
-
             listener.onResponse(clusterHealthResponse);
         } else {
             final ClusterStateObserver observer = new ClusterStateObserver(

--- a/server/src/main/java/org/opensearch/cluster/routing/WeightedRoutingUtils.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/WeightedRoutingUtils.java
@@ -30,6 +30,9 @@ public class WeightedRoutingUtils {
      */
     public static boolean isWeighedAway(String nodeId, ClusterState clusterState) {
         DiscoveryNode node = clusterState.nodes().get(nodeId);
+        if (node == null) {
+            return false;
+        }
         WeightedRoutingMetadata weightedRoutingMetadata = clusterState.metadata().weightedRoutingMetadata();
         if (weightedRoutingMetadata != null) {
             WeightedRouting weightedRouting = weightedRoutingMetadata.getWeightedRouting();


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR fixes inconsistent cluster state with ensure_weighed_in param while make cluster health api call.
Also adds support for weighed away health check only for data nodes.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
