### PR TITLE
Remove 'cluster_manager' role attachment when using 'node.master' deprecated setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Remote Store] Integrate remote segment store in peer recovery flow ([#6664](https://github.com/opensearch-project/OpenSearch/pull/6664))
 - [Segment Replication] Add new cluster setting to set replication strategy by default for all indices in cluster. ([#6791](https://github.com/opensearch-project/OpenSearch/pull/6791))
 - Enable sort optimization for all NumericTypes ([#6464](https://github.com/opensearch-project/OpenSearch/pull/6464)
+- Remove 'cluster_manager' role attachment when using 'node.master' deprecated setting ([#6331](https://github.com/opensearch-project/OpenSearch/pull/6331))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.18.0 to 2.20.0 ([#6490](https://github.com/opensearch-project/OpenSearch/pull/6490))

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -400,6 +400,7 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
 
         // can't start data-only node without assigning cluster-manager
         internalCluster().startClusterManagerOnlyNodes(1);
+        waitForNodes(1);
         internalCluster().startNodes(legacyDataNodeSettings);
         waitForNodes(total);
 

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -35,6 +35,7 @@ package org.opensearch.action.admin.cluster.stats;
 import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.opensearch.action.admin.cluster.node.stats.NodeStats;
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.opensearch.client.Requests;
 import org.opensearch.cluster.health.ClusterHealthStatus;
@@ -83,14 +84,7 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
     public void testNodeCounts() {
         int total = 1;
         internalCluster().startNode();
-        Map<String, Integer> expectedCounts = new HashMap<>();
-        expectedCounts.put(DiscoveryNodeRole.DATA_ROLE.roleName(), 1);
-        expectedCounts.put(DiscoveryNodeRole.MASTER_ROLE.roleName(), 1);
-        expectedCounts.put(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName(), 1);
-        expectedCounts.put(DiscoveryNodeRole.INGEST_ROLE.roleName(), 1);
-        expectedCounts.put(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName(), 1);
-        expectedCounts.put(DiscoveryNodeRole.SEARCH_ROLE.roleName(), 0);
-        expectedCounts.put(ClusterStatsNodes.Counts.COORDINATING_ONLY, 0);
+        Map<String, Integer> expectedCounts = getExpectedCounts(1, 1, 1, 1, 1, 0, 0);
         int numNodes = randomIntBetween(1, 5);
 
         ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
@@ -147,7 +141,7 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
     }
 
     // Validate assigning value "master" to setting "node.roles" can get correct count in Node Stats response after MASTER_ROLE deprecated.
-    public void testNodeCountsWithDeprecatedMasterRole() {
+    public void testNodeCountsWithDeprecatedMasterRole() throws ExecutionException, InterruptedException {
         int total = 1;
         Settings settings = Settings.builder()
             .putList(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), Collections.singletonList(DiscoveryNodeRole.MASTER_ROLE.roleName()))
@@ -155,17 +149,13 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
         internalCluster().startNode(settings);
         waitForNodes(total);
 
-        Map<String, Integer> expectedCounts = new HashMap<>();
-        expectedCounts.put(DiscoveryNodeRole.DATA_ROLE.roleName(), 0);
-        expectedCounts.put(DiscoveryNodeRole.MASTER_ROLE.roleName(), 1);
-        expectedCounts.put(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName(), 1);
-        expectedCounts.put(DiscoveryNodeRole.INGEST_ROLE.roleName(), 0);
-        expectedCounts.put(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName(), 0);
-        expectedCounts.put(DiscoveryNodeRole.SEARCH_ROLE.roleName(), 0);
-        expectedCounts.put(ClusterStatsNodes.Counts.COORDINATING_ONLY, 0);
+        Map<String, Integer> expectedCounts = getExpectedCounts(0, 1, 1, 0, 0, 0, 0);
 
         ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
         assertCounts(response.getNodesStats().getCounts(), total, expectedCounts);
+
+        Set<String> expectedRoles = Set.of(DiscoveryNodeRole.MASTER_ROLE.roleName());
+        assertEquals(expectedRoles, getNodeRoles(0));
     }
 
     private static void incrementCountForRole(String role, Map<String, Integer> counts) {
@@ -321,5 +311,100 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
                 assertThat(stat.getCount(), greaterThanOrEqualTo(1));
             }
         }
+    }
+
+    public void testNodeRolesWithMasterLegacySettings() throws ExecutionException, InterruptedException {
+        int total = 1;
+        Settings legacyMasterSettings = Settings.builder()
+            .put("node.master", true)
+            .put("node.data", false)
+            .put("node.ingest", false).build();
+
+        internalCluster().startNodes(legacyMasterSettings);
+        waitForNodes(total);
+
+        Map<String, Integer> expectedCounts = getExpectedCounts(0, 1, 1, 0, 1, 0, 0);
+
+        ClusterStatsResponse clusterStatsResponse = client().admin().cluster().prepareClusterStats().get();
+        assertCounts(clusterStatsResponse.getNodesStats().getCounts(), total, expectedCounts);
+
+        Set<String> expectedRoles = Set.of(DiscoveryNodeRole.MASTER_ROLE.roleName(), DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName());
+        assertEquals(expectedRoles, getNodeRoles(0));
+    }
+
+    public void testNodeRolesWithClusterManagerRole() throws ExecutionException, InterruptedException {
+        int total = 1;
+        Settings legacyMasterSettings = Settings.builder()
+            .put("node.roles", String.format("%s, %s", DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName(), DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName()))
+            .build();
+
+        internalCluster().startNodes(legacyMasterSettings);
+        waitForNodes(total);
+
+        Map<String, Integer> expectedCounts = getExpectedCounts(0, 1, 1, 0, 1, 0, 0);
+
+        ClusterStatsResponse clusterStatsResponse = client().admin().cluster().prepareClusterStats().get();
+        assertCounts(clusterStatsResponse.getNodesStats().getCounts(), total, expectedCounts);
+
+        Set<String> expectedRoles = Set.of(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName(), DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName());
+        assertEquals(expectedRoles, getNodeRoles(0));
+    }
+
+    public void testNodeRolesWithSeedDataNodeLegacySettings() throws ExecutionException, InterruptedException {
+        int total = 1;
+        Settings legacyDataNodeSettings = Settings.builder()
+            .put("node.master", true)
+            .put("node.data", true)
+            .put("node.ingest", false).build();
+
+        internalCluster().startNodes(legacyDataNodeSettings);
+        waitForNodes(total);
+
+        Map<String, Integer> expectedRoleCounts = getExpectedCounts(1, 1, 1, 0, 1, 0, 0);
+
+        ClusterStatsResponse clusterStatsResponse = client().admin().cluster().prepareClusterStats().get();
+        assertCounts(clusterStatsResponse.getNodesStats().getCounts(), total, expectedRoleCounts);
+
+        Set<String> expectedRoles = Set.of(DiscoveryNodeRole.MASTER_ROLE.roleName(),
+            DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName(), DiscoveryNodeRole.DATA_ROLE.roleName());
+        assertEquals(expectedRoles, getNodeRoles(0));
+    }
+
+    public void testNodeRolesWithLegacyDataNodeSettings() throws  ExecutionException, InterruptedException {
+        int total = 1;
+        Settings legacyDataNodeSettings = Settings.builder()
+            .put("node.master", false)
+            .put("node.data", true)
+            .put("node.ingest", false).build();
+
+        internalCluster().startNodes(legacyDataNodeSettings);
+        waitForNodes(total);
+
+        Map<String, Integer> expectedRoleCounts = getExpectedCounts(1, 1, 1, 0, 1, 0, 0);
+
+        ClusterStatsResponse clusterStatsResponse = client().admin().cluster().prepareClusterStats().get();
+        assertCounts(clusterStatsResponse.getNodesStats().getCounts(), total, expectedRoleCounts);
+
+        Set<String> expectedRoles = Set.of(DiscoveryNodeRole.MASTER_ROLE.roleName(),
+            DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName(), DiscoveryNodeRole.DATA_ROLE.roleName());
+        assertEquals(expectedRoles, getNodeRoles(0));
+
+    }
+    private Map<String, Integer> getExpectedCounts(int dataRoleCount, int masterRoleCount, int clusterManagerRoleCount, int ingestRoleCount,
+                                                   int remoteClusterClientRoleCount, int searchRoleCount, int coordinatingOnlyCount) {
+        Map<String, Integer> expectedCounts = new HashMap<>();
+        expectedCounts.put(DiscoveryNodeRole.DATA_ROLE.roleName(), dataRoleCount);
+        expectedCounts.put(DiscoveryNodeRole.MASTER_ROLE.roleName(), masterRoleCount);
+        expectedCounts.put(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName(), clusterManagerRoleCount);
+        expectedCounts.put(DiscoveryNodeRole.INGEST_ROLE.roleName(), ingestRoleCount);
+        expectedCounts.put(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName(), remoteClusterClientRoleCount);
+        expectedCounts.put(DiscoveryNodeRole.SEARCH_ROLE.roleName(), searchRoleCount);
+        expectedCounts.put(ClusterStatsNodes.Counts.COORDINATING_ONLY, coordinatingOnlyCount);
+        return expectedCounts;
+    }
+
+    private Set<String> getNodeRoles(int nodeNumber) throws ExecutionException, InterruptedException {
+        NodesStatsResponse nodesStatsResponse = client().admin().cluster().nodesStats(new NodesStatsRequest()).get();
+        return nodesStatsResponse.getNodes().get(nodeNumber).getNode().getRoles().stream().map(DiscoveryNodeRole::roleName).collect(Collectors.toSet());
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -400,7 +400,6 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
 
         // can't start data-only node without assigning cluster-manager
         internalCluster().startClusterManagerOnlyNodes(1);
-        waitForNodes(1);
         internalCluster().startNodes(legacyDataNodeSettings);
         waitForNodes(total);
 
@@ -409,15 +408,11 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
         ClusterStatsResponse clusterStatsResponse = client().admin().cluster().prepareClusterStats().get();
         assertCounts(clusterStatsResponse.getNodesStats().getCounts(), total, expectedRoleCounts);
 
-        Set<String> expectedClusterManagerOnlyRoles = Set.of(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName());
-        assertEquals(expectedClusterManagerOnlyRoles, getNodeRoles(0));
-
-        Set<String> expectedDataOnlyNodeRoles = Set.of(
-            DiscoveryNodeRole.DATA_ROLE.roleName(),
-            DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName()
+        Set<Set<String>> expectedNodesRoles = Set.of(
+            Set.of(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName()),
+            Set.of(DiscoveryNodeRole.DATA_ROLE.roleName(), DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName())
         );
-        assertEquals(expectedDataOnlyNodeRoles, getNodeRoles(1));
-
+        assertEquals(expectedNodesRoles, Set.of(getNodeRoles(0), getNodeRoles(1)));
     }
 
     private Map<String, Integer> getExpectedCounts(

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -319,7 +319,8 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
         Settings legacyMasterSettings = Settings.builder()
             .put("node.master", true)
             .put("node.data", false)
-            .put("node.ingest", false).build();
+            .put("node.ingest", false)
+            .build();
 
         internalCluster().startNodes(legacyMasterSettings);
         waitForNodes(total);
@@ -329,15 +330,25 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
         ClusterStatsResponse clusterStatsResponse = client().admin().cluster().prepareClusterStats().get();
         assertCounts(clusterStatsResponse.getNodesStats().getCounts(), total, expectedCounts);
 
-        Set<String> expectedRoles = Set.of(DiscoveryNodeRole.MASTER_ROLE.roleName(), DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName());
+        Set<String> expectedRoles = Set.of(
+            DiscoveryNodeRole.MASTER_ROLE.roleName(),
+            DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName()
+        );
         assertEquals(expectedRoles, getNodeRoles(0));
     }
 
     public void testNodeRolesWithClusterManagerRole() throws ExecutionException, InterruptedException {
         int total = 1;
         Settings clusterManagerNodeRoleSettings = Settings.builder()
-            .put("node.roles", String.format(Locale.ROOT, "%s, %s",
-                DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName(), DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName()))
+            .put(
+                "node.roles",
+                String.format(
+                    Locale.ROOT,
+                    "%s, %s",
+                    DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName(),
+                    DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName()
+                )
+            )
             .build();
 
         internalCluster().startNodes(clusterManagerNodeRoleSettings);
@@ -348,7 +359,10 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
         ClusterStatsResponse clusterStatsResponse = client().admin().cluster().prepareClusterStats().get();
         assertCounts(clusterStatsResponse.getNodesStats().getCounts(), total, expectedCounts);
 
-        Set<String> expectedRoles = Set.of(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName(), DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName());
+        Set<String> expectedRoles = Set.of(
+            DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName(),
+            DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName()
+        );
         assertEquals(expectedRoles, getNodeRoles(0));
     }
 
@@ -357,7 +371,8 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
         Settings legacySeedDataNodeSettings = Settings.builder()
             .put("node.master", true)
             .put("node.data", true)
-            .put("node.ingest", false).build();
+            .put("node.ingest", false)
+            .build();
 
         internalCluster().startNodes(legacySeedDataNodeSettings);
         waitForNodes(total);
@@ -367,17 +382,21 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
         ClusterStatsResponse clusterStatsResponse = client().admin().cluster().prepareClusterStats().get();
         assertCounts(clusterStatsResponse.getNodesStats().getCounts(), total, expectedRoleCounts);
 
-        Set<String> expectedRoles = Set.of(DiscoveryNodeRole.MASTER_ROLE.roleName(),
-            DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName(), DiscoveryNodeRole.DATA_ROLE.roleName());
+        Set<String> expectedRoles = Set.of(
+            DiscoveryNodeRole.MASTER_ROLE.roleName(),
+            DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName(),
+            DiscoveryNodeRole.DATA_ROLE.roleName()
+        );
         assertEquals(expectedRoles, getNodeRoles(0));
     }
 
-    public void testNodeRolesWithDataNodeLegacySettings() throws  ExecutionException, InterruptedException {
+    public void testNodeRolesWithDataNodeLegacySettings() throws ExecutionException, InterruptedException {
         int total = 2;
         Settings legacyDataNodeSettings = Settings.builder()
             .put("node.master", false)
             .put("node.data", true)
-            .put("node.ingest", false).build();
+            .put("node.ingest", false)
+            .build();
 
         // can't start data-only node without assigning cluster-manager
         internalCluster().startClusterManagerOnlyNodes(1);
@@ -392,12 +411,23 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
         Set<String> expectedClusterManagerOnlyRoles = Set.of(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName());
         assertEquals(expectedClusterManagerOnlyRoles, getNodeRoles(0));
 
-        Set<String> expectedDataOnlyNodeRoles = Set.of(DiscoveryNodeRole.DATA_ROLE.roleName(), DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName());
+        Set<String> expectedDataOnlyNodeRoles = Set.of(
+            DiscoveryNodeRole.DATA_ROLE.roleName(),
+            DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName()
+        );
         assertEquals(expectedDataOnlyNodeRoles, getNodeRoles(1));
 
     }
-    private Map<String, Integer> getExpectedCounts(int dataRoleCount, int masterRoleCount, int clusterManagerRoleCount, int ingestRoleCount,
-                                                   int remoteClusterClientRoleCount, int searchRoleCount, int coordinatingOnlyCount) {
+
+    private Map<String, Integer> getExpectedCounts(
+        int dataRoleCount,
+        int masterRoleCount,
+        int clusterManagerRoleCount,
+        int ingestRoleCount,
+        int remoteClusterClientRoleCount,
+        int searchRoleCount,
+        int coordinatingOnlyCount
+    ) {
         Map<String, Integer> expectedCounts = new HashMap<>();
         expectedCounts.put(DiscoveryNodeRole.DATA_ROLE.roleName(), dataRoleCount);
         expectedCounts.put(DiscoveryNodeRole.MASTER_ROLE.roleName(), masterRoleCount);
@@ -411,6 +441,12 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
 
     private Set<String> getNodeRoles(int nodeNumber) throws ExecutionException, InterruptedException {
         NodesStatsResponse nodesStatsResponse = client().admin().cluster().nodesStats(new NodesStatsRequest()).get();
-        return nodesStatsResponse.getNodes().get(nodeNumber).getNode().getRoles().stream().map(DiscoveryNodeRole::roleName).collect(Collectors.toSet());
+        return nodesStatsResponse.getNodes()
+            .get(nodeNumber)
+            .getNode()
+            .getRoles()
+            .stream()
+            .map(DiscoveryNodeRole::roleName)
+            .collect(Collectors.toSet());
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -55,6 +55,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -335,7 +336,8 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
     public void testNodeRolesWithClusterManagerRole() throws ExecutionException, InterruptedException {
         int total = 1;
         Settings clusterManagerNodeRoleSettings = Settings.builder()
-            .put("node.roles", String.format("%s, %s", DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName(), DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName()))
+            .put("node.roles", String.format(Locale.ROOT, "%s, %s",
+                DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName(), DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName()))
             .build();
 
         internalCluster().startNodes(clusterManagerNodeRoleSettings);

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -285,10 +285,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
             validateLegacySettings(settings, roleMap);
             return Collections.unmodifiableSet(new HashSet<>(NODE_ROLES_SETTING.get(settings)));
         } else {
-            return roleMap.values()
-                .stream()
-                .filter(s -> s.legacySetting() != null && s.legacySetting().get(settings))
-                .collect(Collectors.toSet());
+            return roleMap.values().stream().filter(s -> s.isEnabledByDefault(settings)).collect(Collectors.toSet());
         }
     }
 

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -285,14 +285,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
             validateLegacySettings(settings, roleMap);
             return Collections.unmodifiableSet(new HashSet<>(NODE_ROLES_SETTING.get(settings)));
         } else {
-            return roleMap.values()
-                .stream()
-                .filter(
-                    s -> !s.roleName().equals(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName())
-                        && s.legacySetting() != null
-                        && s.legacySetting().get(settings)
-                )
-                .collect(Collectors.toSet());
+            return roleMap.values().stream().filter(s -> s.isEnabledByDefault(settings)).collect(Collectors.toSet());
         }
     }
 

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -285,7 +285,14 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
             validateLegacySettings(settings, roleMap);
             return Collections.unmodifiableSet(new HashSet<>(NODE_ROLES_SETTING.get(settings)));
         } else {
-            return roleMap.values().stream().filter(s -> s.isEnabledByDefault(settings)).collect(Collectors.toSet());
+            return roleMap.values()
+                .stream()
+                .filter(
+                    s -> !s.roleName().equals(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName())
+                        && s.legacySetting() != null
+                        && s.legacySetting().get(settings)
+                )
+                .collect(Collectors.toSet());
         }
     }
 

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
@@ -273,6 +273,10 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
             }
         }
 
+        @Override
+        public boolean isEnabledByDefault(final Settings settings) {
+            return settings.getAsBoolean("node.master", true);
+        }
     };
 
     public static final DiscoveryNodeRole REMOTE_CLUSTER_CLIENT_ROLE = new DiscoveryNodeRole("remote_cluster_client", "r") {

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
@@ -34,6 +34,7 @@ package org.opensearch.cluster.node;
 
 import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
+import org.opensearch.common.Booleans;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
@@ -275,7 +276,7 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
 
         @Override
         public boolean isEnabledByDefault(final Settings settings) {
-            return settings.getAsBoolean("node.master", true);
+            return !Booleans.isBoolean(settings.get("node.master"));
         }
     };
 

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
@@ -245,8 +245,8 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
 
         @Override
         public Setting<Boolean> legacySetting() {
-            // copy the setting here so we can mark it private in org.opensearch.node.Node
-            return Setting.boolSetting("node.master", true, Property.Deprecated, Property.NodeScope);
+            // 'cluster_manager' role should not configure legacy setting since deprecated 'master' role is supported till OS 2.x
+            return null;
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeRole.java
@@ -276,7 +276,7 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
 
         @Override
         public boolean isEnabledByDefault(final Settings settings) {
-            return !Booleans.isBoolean(settings.get("node.master"));
+            return Booleans.isBoolean(settings.get("node.master")) == false;
         }
     };
 

--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeRoleSettingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeRoleSettingTests.java
@@ -60,10 +60,6 @@ public class DiscoveryNodeRoleSettingTests extends OpenSearchTestCase {
         runRoleTest(DiscoveryNode::isClusterManagerNode, DiscoveryNodeRole.MASTER_ROLE);
     }
 
-    public void testIsClusterManagerNode() {
-        runRoleTest(DiscoveryNode::isClusterManagerNode, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE);
-    }
-
     public void testIsRemoteClusterClient() {
         runRoleTest(DiscoveryNode::isRemoteClusterClient, DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE);
     }
@@ -96,5 +92,4 @@ public class DiscoveryNodeRoleSettingTests extends OpenSearchTestCase {
         assertThat(e.getMessage(), startsWith("can not explicitly configure node roles and use legacy role setting"));
         assertNoDeprecationWarnings();
     }
-
 }


### PR DESCRIPTION
### Description
Using `node.master: true` configures both `cluster_manager` and `master` role to a node which is not correct, only one of them should be assigned.

Reference in cdk where it uses legacy settings to bootstrap nodes: https://github.com/opensearch-project/opensearch-cluster-cdk/blob/main/lib/opensearch-config/multi-node-base-config.yml

Allowing only one of the both roles to be attached instead of both - 'master' which is deprecated as part of change of 'master' nomenclature: https://github.com/opensearch-project/OpenSearch/issues/472 - since both the legacy setting `node.master` and `master` role are deprecated - so we need to keep the initial behavior only with deprecated roles and settings. 


### Issues Resolved
Resolves https://github.com/opensearch-project/OpenSearch/issues/6103

The change modifies the role attached in multi-node dedicated cluster-manager setup.

**API response before the change:**

Multi node with dedicated cluster-manager when bootstrapped with `node.master: true`:

```
..
"nodes" : {
    "count" : {
      "total" : 6,
      "cluster_manager" : 6,
      "coordinating_only" : 0,
      "data" : 3,
      "ingest" : 3,
      "master" : 6,
      "remote_cluster_client" : 6
    },
    "versions" : [
      "2.5.1"
    ],
..
```


```
curl "<cluster-endpoint>/_cat/nodes?v"
ip         heap.percent ram.percent cpu load_1m load_5m load_15m node.role node.roles                                   cluster_manager name
10.0.3.110           62          70   0    0.00    0.00     0.00 mmr       cluster_manager,master,remote_cluster_client -               manager-node
10.0.3.72            60          69   0    0.00    0.00     0.00 dir       data,ingest,remote_cluster_client            -               data-node
10.0.4.132           20          70   0    0.00    0.00     0.00 dir       data,ingest,remote_cluster_client            -               data-node
10.0.5.42            26          69   0    0.04    0.02     0.00 dir       data,ingest,remote_cluster_client            -               data-node
10.0.4.156           39          69   0    0.00    0.00     0.00 mmr       cluster_manager,master,remote_cluster_client -               manager-node
10.0.5.39            47          70   0    0.00    0.04     0.01 mmr       cluster_manager,master,remote_cluster_client *               seed
```

**API response after the change:**


Multi node with dedicated cluster-manager when bootstrapped with `node.master: true`:

```
..
"nodes" : {
    "count" : {
      "total" : 6,
      "cluster_manager" : 3,
      "coordinating_only" : 0,
      "data" : 3,
      "ingest" : 3,
      "master" : 3,
      "remote_cluster_client" : 6,
      "search" : 0
    },
..
```


```
curl   "<endpoint>/_cat/nodes?v"
ip         heap.percent ram.percent cpu load_1m load_5m load_15m node.role node.roles                            cluster_manager name
10.0.5.192           38          63   0    0.00    0.00     0.00 mr        master,remote_cluster_client -               manager-node
10.0.3.75            30          63   0    0.00    0.00     0.00 mr        master,remote_cluster_client -               manager-node
10.0.5.168           16          63   0    0.65    0.16     0.05 dir       data,ingest,remote_cluster_client     -               data-node
10.0.4.83            46          63   0    0.00    0.00     0.00 dir       data,ingest,remote_cluster_client     -               data-node
10.0.5.169           55          63   0    0.00    0.00     0.00 mr        master,remote_cluster_client *               seed
10.0.3.251           60          63   0    0.00    0.00     0.00 dir       data,ingest,remote_cluster_client     -               data-node
```

### Check List
- [ ] New functionality includes testing.
 - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
