### PR TITLE
Include file cache stats in node stats api response

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
@@ -7,6 +7,8 @@ package org.opensearch.snapshots;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import org.hamcrest.MatcherAssert;
+import org.opensearch.action.admin.cluster.node.stats.NodeStats;
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.opensearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;
@@ -29,6 +31,7 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.store.remote.file.CleanerDaemonThreadLeakFilter;
+import org.opensearch.index.store.remote.filecache.FileCacheStats;
 import org.opensearch.monitor.fs.FsInfo;
 import org.opensearch.repositories.fs.FsRepository;
 
@@ -412,5 +415,50 @@ public final class SearchableSnapshotIT extends AbstractSnapshotIntegTestCase {
                 MatcherAssert.assertThat("Expect file not to exist: " + file, Files.exists(file), is(false));
             }
         }
+    }
+
+    public void testFileCacheStats() throws Exception {
+        final String snapshotName = "test-snap";
+        final String repoName = "test-repo";
+        final String indexName1 = "test-idx-1";
+        final Client client = client();
+        final int numNodes = 2;
+
+        internalCluster().ensureAtLeastNumSearchNodes(numNodes);
+        createIndexWithDocsAndEnsureGreen(1, 100, indexName1);
+
+        createRepositoryWithSettings(null, repoName);
+        takeSnapshot(client, snapshotName, repoName, indexName1);
+        deleteIndicesAndEnsureGreen(client, indexName1);
+        assertAllNodesFileCacheEmpty();
+
+        restoreSnapshotAndEnsureGreen(client, snapshotName, repoName);
+        assertNodesFileCacheNonEmpty(numNodes);
+    }
+
+    private void assertAllNodesFileCacheEmpty() {
+        NodesStatsResponse response = client().admin().cluster().nodesStats(new NodesStatsRequest().all()).actionGet();
+        for (NodeStats stats : response.getNodes()) {
+            FileCacheStats fcstats = stats.getFileCacheStats();
+            assertNotNull(fcstats);
+            assertTrue(isFileCacheEmpty(fcstats));
+        }
+    }
+
+    private void assertNodesFileCacheNonEmpty(int numNodes) {
+        NodesStatsResponse response = client().admin().cluster().nodesStats(new NodesStatsRequest().all()).actionGet();
+        int nonEmptyFileCacheNodes = 0;
+        for (NodeStats stats : response.getNodes()) {
+            FileCacheStats fcstats = stats.getFileCacheStats();
+            assertNotNull(fcstats);
+            if (!isFileCacheEmpty(fcstats)) {
+                nonEmptyFileCacheNodes++;
+            }
+        }
+        assertEquals(numNodes, nonEmptyFileCacheNodes);
+    }
+
+    private boolean isFileCacheEmpty(FileCacheStats stats) {
+        return stats.getUsed().getBytes() == 0L && stats.getActive().getBytes() == 0L;
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java
@@ -41,12 +41,14 @@ import org.opensearch.cluster.service.ClusterManagerThrottlingStats;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.discovery.DiscoveryStats;
 import org.opensearch.http.HttpStats;
 import org.opensearch.index.stats.IndexingPressureStats;
 import org.opensearch.index.stats.ShardIndexingPressureStats;
+import org.opensearch.index.store.remote.filecache.FileCacheStats;
 import org.opensearch.indices.NodeIndicesStats;
 import org.opensearch.indices.breaker.AllCircuitBreakerStats;
 import org.opensearch.ingest.IngestStats;
@@ -130,6 +132,9 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
     @Nullable
     private WeightedRoutingStats weightedRoutingStats;
 
+    @Nullable
+    private FileCacheStats fileCacheStats;
+
     public NodeStats(StreamInput in) throws IOException {
         super(in);
         timestamp = in.readVLong();
@@ -171,6 +176,11 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         } else {
             weightedRoutingStats = null;
         }
+        if (in.getVersion().onOrAfter(Version.V_3_0_0) && FeatureFlags.isEnabled(FeatureFlags.SEARCHABLE_SNAPSHOT)) {
+            fileCacheStats = in.readOptionalWriteable(FileCacheStats::new);
+        } else {
+            fileCacheStats = null;
+        }
     }
 
     public NodeStats(
@@ -194,7 +204,8 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         @Nullable ShardIndexingPressureStats shardIndexingPressureStats,
         @Nullable SearchBackpressureStats searchBackpressureStats,
         @Nullable ClusterManagerThrottlingStats clusterManagerThrottlingStats,
-        @Nullable WeightedRoutingStats weightedRoutingStats
+        @Nullable WeightedRoutingStats weightedRoutingStats,
+        @Nullable FileCacheStats fileCacheStats
     ) {
         super(node);
         this.timestamp = timestamp;
@@ -217,6 +228,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         this.searchBackpressureStats = searchBackpressureStats;
         this.clusterManagerThrottlingStats = clusterManagerThrottlingStats;
         this.weightedRoutingStats = weightedRoutingStats;
+        this.fileCacheStats = fileCacheStats;
     }
 
     public long getTimestamp() {
@@ -340,6 +352,10 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         return weightedRoutingStats;
     }
 
+    public FileCacheStats getFileCacheStats() {
+        return fileCacheStats;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
@@ -373,6 +389,9 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         }
         if (out.getVersion().onOrAfter(Version.V_2_6_0)) {
             out.writeOptionalWriteable(weightedRoutingStats);
+        }
+        if (out.getVersion().onOrAfter(Version.V_3_0_0) && FeatureFlags.isEnabled(FeatureFlags.SEARCHABLE_SNAPSHOT)) {
+            out.writeOptionalWriteable(fileCacheStats);
         }
     }
 
@@ -454,6 +473,9 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         }
         if (getWeightedRoutingStats() != null) {
             getWeightedRoutingStats().toXContent(builder, params);
+        }
+        if (getFileCacheStats() != null && FeatureFlags.isEnabled(FeatureFlags.SEARCHABLE_SNAPSHOT)) {
+            getFileCacheStats().toXContent(builder, params);
         }
 
         return builder;

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -209,7 +209,8 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         SHARD_INDEXING_PRESSURE("shard_indexing_pressure"),
         SEARCH_BACKPRESSURE("search_backpressure"),
         CLUSTER_MANAGER_THROTTLING("cluster_manager_throttling"),
-        WEIGHTED_ROUTING_STATS("weighted_routing");
+        WEIGHTED_ROUTING_STATS("weighted_routing"),
+        FILE_CACHE_STATS("file_cache");
 
         private String metricName;
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -121,7 +121,8 @@ public class TransportNodesStatsAction extends TransportNodesAction<
             NodesStatsRequest.Metric.SHARD_INDEXING_PRESSURE.containedIn(metrics),
             NodesStatsRequest.Metric.SEARCH_BACKPRESSURE.containedIn(metrics),
             NodesStatsRequest.Metric.CLUSTER_MANAGER_THROTTLING.containedIn(metrics),
-            NodesStatsRequest.Metric.WEIGHTED_ROUTING_STATS.containedIn(metrics)
+            NodesStatsRequest.Metric.WEIGHTED_ROUTING_STATS.containedIn(metrics),
+            NodesStatsRequest.Metric.FILE_CACHE_STATS.containedIn(metrics)
         );
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -165,6 +165,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<
             false,
             false,
             false,
+            false,
             false
         );
         List<ShardStats> shardsStats = new ArrayList<>();

--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCacheStats.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCacheStats.java
@@ -1,0 +1,171 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store.remote.filecache;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.unit.ByteSizeValue;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * Statistics on file cache
+ *
+ * @opensearch.internal
+ */
+public class FileCacheStats implements Writeable, ToXContentFragment {
+
+    private final long timestamp;
+    private final long active;
+    private final long total;
+    private final long used;
+    private final long evicted;
+    private final long removed;
+    private final long replaced;
+    private final long hits;
+    private final long miss;
+
+    public FileCacheStats(
+        final long timestamp,
+        final long active,
+        final long total,
+        final long used,
+        final long evicted,
+        final long removed,
+        final long replaced,
+        final long hits,
+        final long miss
+    ) {
+        this.timestamp = timestamp;
+        this.active = active;
+        this.total = total;
+        this.used = used;
+        this.evicted = evicted;
+        this.removed = removed;
+        this.replaced = replaced;
+        this.hits = hits;
+        this.miss = miss;
+    }
+
+    public FileCacheStats(final StreamInput in) throws IOException {
+        this.timestamp = in.readLong();
+        this.active = in.readLong();
+        this.total = in.readLong();
+        this.used = in.readLong();
+        this.evicted = in.readLong();
+        this.removed = in.readLong();
+        this.replaced = in.readLong();
+        this.hits = in.readLong();
+        this.miss = in.readLong();
+    }
+
+    public static short calculatePercentage(long used, long max) {
+        return max <= 0 ? 0 : (short) (Math.round((100d * used) / max));
+    }
+
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        out.writeLong(timestamp);
+        out.writeLong(active);
+        out.writeLong(total);
+        out.writeLong(used);
+        out.writeLong(evicted);
+        out.writeLong(removed);
+        out.writeLong(replaced);
+        out.writeLong(hits);
+        out.writeLong(miss);
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public ByteSizeValue getTotal() {
+        return new ByteSizeValue(total);
+    }
+
+    public ByteSizeValue getActive() {
+        return new ByteSizeValue(active);
+    }
+
+    public short getActivePercent() {
+        return calculatePercentage(active, used);
+    }
+
+    public ByteSizeValue getUsed() {
+        return new ByteSizeValue(used);
+    }
+
+    public short getUsedPercent() {
+        return calculatePercentage(getUsed().getBytes(), total);
+    }
+
+    public ByteSizeValue getEvicted() {
+        return new ByteSizeValue(evicted);
+    }
+
+    public ByteSizeValue getRemoved() {
+        return new ByteSizeValue(removed);
+    }
+
+    public long getReplacedCount() {
+        return replaced;
+    }
+
+    public long getCacheHits() {
+        return hits;
+    }
+
+    public long getCacheMiss() {
+        return miss;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(Fields.FILE_CACHE);
+        builder.field(Fields.TIMESTAMP, getTimestamp());
+        builder.humanReadableField(Fields.ACTIVE_IN_BYTES, Fields.ACTIVE, getActive());
+        builder.humanReadableField(Fields.TOTAL_IN_BYTES, Fields.TOTAL, getTotal());
+        builder.humanReadableField(Fields.USED_IN_BYTES, Fields.USED, getUsed());
+        builder.humanReadableField(Fields.EVICTED_IN_BYTES, Fields.EVICTED, getEvicted());
+        builder.humanReadableField(Fields.REMOVED_IN_BYTES, Fields.REMOVED, getRemoved());
+        builder.field(Fields.REPLACED_COUNT, getReplacedCount());
+        builder.field(Fields.ACTIVE_PERCENT, getActivePercent());
+        builder.field(Fields.USED_PERCENT, getUsedPercent());
+        builder.field(Fields.CACHE_HITS, getCacheHits());
+        builder.field(Fields.CACHE_MISS, getCacheMiss());
+        builder.endObject();
+        return builder;
+    }
+
+    static final class Fields {
+        static final String FILE_CACHE = "file_cache";
+        static final String TIMESTAMP = "timestamp";
+        static final String ACTIVE = "active";
+        static final String ACTIVE_IN_BYTES = "active_in_bytes";
+        static final String USED = "used";
+        static final String USED_IN_BYTES = "used_in_bytes";
+        static final String EVICTED = "evicted";
+        static final String EVICTED_IN_BYTES = "evicted_in_bytes";
+        static final String REMOVED = "removed";
+        static final String REMOVED_IN_BYTES = "removed_in_bytes";
+        static final String REPLACED_COUNT = "replaced_count";
+        static final String TOTAL = "total";
+        static final String TOTAL_IN_BYTES = "total_in_bytes";
+
+        static final String ACTIVE_PERCENT = "active_percent";
+        static final String USED_PERCENT = "used_percent";
+
+        static final String CACHE_HITS = "cache_hits";
+        static final String CACHE_MISS = "cache_miss";
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -132,6 +132,10 @@ import org.opensearch.index.shard.IndexShardState;
 import org.opensearch.index.shard.IndexingOperationListener;
 import org.opensearch.index.shard.IndexingStats;
 import org.opensearch.index.shard.ShardId;
+import org.opensearch.index.store.remote.filecache.FileCache;
+import org.opensearch.index.store.remote.filecache.FileCacheStats;
+import org.opensearch.index.store.remote.utils.cache.CacheUsage;
+import org.opensearch.index.store.remote.utils.cache.stats.CacheStats;
 import org.opensearch.index.translog.InternalTranslogFactory;
 import org.opensearch.index.translog.RemoteBlobStoreInternalTranslogFactory;
 import org.opensearch.index.translog.TranslogFactory;
@@ -259,6 +263,8 @@ public class IndicesService extends AbstractLifecycleComponent
     private final TimeValue cleanInterval;
     final IndicesRequestCache indicesRequestCache; // pkg-private for testing
     private final IndicesQueryCache indicesQueryCache;
+
+    private final FileCache remoteStoreFileCache;
     private final MetaStateService metaStateService;
     private final Collection<Function<IndexSettings, Optional<EngineFactory>>> engineFactoryProviders;
     private final Map<String, IndexStorePlugin.DirectoryFactory> directoryFactories;
@@ -304,7 +310,8 @@ public class IndicesService extends AbstractLifecycleComponent
         ValuesSourceRegistry valuesSourceRegistry,
         Map<String, IndexStorePlugin.RecoveryStateFactory> recoveryStateFactories,
         IndexStorePlugin.RemoteDirectoryFactory remoteDirectoryFactory,
-        Supplier<RepositoriesService> repositoriesServiceSupplier
+        Supplier<RepositoriesService> repositoriesServiceSupplier,
+        FileCache remoteStoreFileCache
     ) {
         this.settings = settings;
         this.threadPool = threadPool;
@@ -318,6 +325,7 @@ public class IndicesService extends AbstractLifecycleComponent
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.indicesRequestCache = new IndicesRequestCache(settings);
         this.indicesQueryCache = new IndicesQueryCache(settings);
+        this.remoteStoreFileCache = remoteStoreFileCache;
         this.mapperRegistry = mapperRegistry;
         this.namedWriteableRegistry = namedWriteableRegistry;
         indexingMemoryController = new IndexingMemoryController(
@@ -419,7 +427,8 @@ public class IndicesService extends AbstractLifecycleComponent
         ValuesSourceRegistry valuesSourceRegistry,
         Map<String, IndexStorePlugin.RecoveryStateFactory> recoveryStateFactories,
         IndexStorePlugin.RemoteDirectoryFactory remoteDirectoryFactory,
-        Supplier<RepositoriesService> repositoriesServiceSupplier
+        Supplier<RepositoriesService> repositoriesServiceSupplier,
+        FileCache remoteStoreFileCache
     ) {
         this.settings = settings;
         this.threadPool = threadPool;
@@ -427,6 +436,7 @@ public class IndicesService extends AbstractLifecycleComponent
         this.extensionsManager = extensionsManager;
         this.nodeEnv = nodeEnv;
         this.xContentRegistry = xContentRegistry;
+        this.remoteStoreFileCache = remoteStoreFileCache;
         this.valuesSourceRegistry = valuesSourceRegistry;
         this.shardsClosedTimeout = settings.getAsTime(INDICES_SHARDS_CLOSED_TIMEOUT, new TimeValue(1, TimeUnit.DAYS));
         this.analysisRegistry = analysisRegistry;
@@ -1922,5 +1932,21 @@ public class IndicesService extends AbstractLifecycleComponent
     public boolean allPendingDanglingIndicesWritten() {
         return nodeWriteDanglingIndicesInfo == false
             || (danglingIndicesToWrite.isEmpty() && danglingIndicesThreadPoolExecutor.getActiveCount() == 0);
+    }
+
+    public FileCacheStats getFileCacheStats() {
+        CacheStats stats = remoteStoreFileCache.stats();
+        CacheUsage usage = remoteStoreFileCache.usage();
+        return new FileCacheStats(
+            System.currentTimeMillis(),
+            usage.activeUsage(),
+            remoteStoreFileCache.capacity(),
+            usage.usage(),
+            stats.evictionWeight(),
+            stats.removeWeight(),
+            stats.replaceCount(),
+            stats.hitCount(),
+            stats.missCount()
+        );
     }
 }

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -632,6 +632,7 @@ public class Node implements Closeable {
                 threadPool,
                 remoteStoreFileCache
             );
+
             final Map<String, IndexStorePlugin.DirectoryFactory> directoryFactories = new HashMap<>();
             pluginsService.filterPlugins(IndexStorePlugin.class)
                 .stream()
@@ -697,7 +698,8 @@ public class Node implements Closeable {
                     searchModule.getValuesSourceRegistry(),
                     recoveryStateFactories,
                     remoteDirectoryFactory,
-                    repositoriesServiceReference::get
+                    repositoriesServiceReference::get,
+                    remoteStoreFileCache
                 );
             } else {
                 indicesService = new IndicesService(
@@ -722,7 +724,8 @@ public class Node implements Closeable {
                     searchModule.getValuesSourceRegistry(),
                     recoveryStateFactories,
                     remoteDirectoryFactory,
-                    repositoriesServiceReference::get
+                    repositoriesServiceReference::get,
+                    remoteStoreFileCache
                 );
             }
 

--- a/server/src/main/java/org/opensearch/node/NodeService.java
+++ b/server/src/main/java/org/opensearch/node/NodeService.java
@@ -179,7 +179,8 @@ public class NodeService implements Closeable {
         boolean shardIndexingPressure,
         boolean searchBackpressure,
         boolean clusterManagerThrottling,
-        boolean weightedRoutingStats
+        boolean weightedRoutingStats,
+        boolean fileCacheStats
     ) {
         // for indices stats we want to include previous allocated shards stats as well (it will
         // only be applied to the sensible ones to use, like refresh/merge/flush/indexing stats)
@@ -204,7 +205,8 @@ public class NodeService implements Closeable {
             shardIndexingPressure ? this.indexingPressureService.shardStats(indices) : null,
             searchBackpressure ? this.searchBackpressureService.nodeStats() : null,
             clusterManagerThrottling ? this.clusterService.getClusterManagerService().getThrottlingStats() : null,
-            weightedRoutingStats ? WeightedRoutingStats.getInstance() : null
+            weightedRoutingStats ? WeightedRoutingStats.getInstance() : null,
+            fileCacheStats ? indicesService.getFileCacheStats() : null
         );
     }
 

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -748,7 +748,8 @@ public class NodeStatsTests extends OpenSearchTestCase {
             null,
             null,
             clusterManagerThrottlingStats,
-            weightedRoutingStats
+            weightedRoutingStats,
+            null
         );
     }
 

--- a/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
+++ b/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
@@ -188,6 +188,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -211,6 +212,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -222,6 +224,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 new FsInfo(0, null, node3FSInfo),
+                null,
                 null,
                 null,
                 null,
@@ -288,6 +291,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -311,6 +315,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             new NodeStats(
@@ -322,6 +327,7 @@ public class DiskUsageTests extends OpenSearchTestCase {
                 null,
                 null,
                 new FsInfo(0, null, node3FSInfo),
+                null,
                 null,
                 null,
                 null,

--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheStatsTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheStatsTests.java
@@ -1,0 +1,83 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store.remote.filecache;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.index.store.remote.utils.cache.CacheUsage;
+import org.opensearch.index.store.remote.utils.cache.stats.CacheStats;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+public class FileCacheStatsTests extends OpenSearchTestCase {
+    private static final long BYTES_IN_GB = 1024 * 1024 * 1024;
+
+    public static CacheStats getMockCacheStats() {
+        final long evicted = randomLongBetween(10000, BYTES_IN_GB);
+        final long removed = randomLongBetween(10000, BYTES_IN_GB);
+        final long replaced = randomLongBetween(0, 10000);
+        final long hits = randomLongBetween(0, 10000);
+        final long miss = randomLongBetween(0, 10000);
+        return new CacheStats(hits, miss, 0, removed, replaced, 0, evicted);
+    }
+
+    public static CacheUsage getMockCacheUsage(long total) {
+        final long used = randomLongBetween(100, total);
+        final long active = randomLongBetween(10, used);
+        return new CacheUsage(used, active);
+    }
+
+    public static long getMockCacheCapacity() {
+        return randomLongBetween(10 * BYTES_IN_GB, 1000 * BYTES_IN_GB);
+    }
+
+    public static FileCacheStats getFileCacheStats(final long fileCacheCapacity, final CacheStats stats, final CacheUsage usage) {
+        return new FileCacheStats(
+            System.currentTimeMillis(),
+            usage.activeUsage(),
+            fileCacheCapacity,
+            usage.usage(),
+            stats.evictionWeight(),
+            stats.removeWeight(),
+            stats.replaceCount(),
+            stats.hitCount(),
+            stats.missCount()
+        );
+    }
+
+    public static FileCacheStats getMockFileCacheStats() {
+        final long fcSize = getMockCacheCapacity();
+        return getFileCacheStats(fcSize, getMockCacheStats(), getMockCacheUsage(fcSize));
+    }
+
+    public static void validateFileCacheStats(FileCacheStats original, FileCacheStats deserialized) {
+        assertEquals(original.getTotal(), deserialized.getTotal());
+        assertEquals(original.getUsed(), deserialized.getUsed());
+        assertEquals(original.getUsedPercent(), deserialized.getUsedPercent());
+        assertEquals(original.getActive(), deserialized.getActive());
+        assertEquals(original.getActivePercent(), deserialized.getActivePercent());
+        assertEquals(original.getEvicted(), deserialized.getEvicted());
+        assertEquals(original.getRemoved(), deserialized.getRemoved());
+        assertEquals(original.getReplacedCount(), deserialized.getReplacedCount());
+        assertEquals(original.getCacheHits(), deserialized.getCacheHits());
+        assertEquals(original.getCacheMiss(), deserialized.getCacheMiss());
+    }
+
+    public void testFileCacheStatsSerialization() throws IOException {
+        final FileCacheStats fileCacheStats = getMockFileCacheStats();
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            fileCacheStats.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                // Validate original object against deserialized values
+                validateFileCacheStats(fileCacheStats, new FileCacheStats(in));
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -1834,7 +1834,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                         null,
                         emptyMap(),
                         new RemoteSegmentStoreDirectoryFactory(() -> repositoriesService),
-                        repositoriesServiceReference::get
+                        repositoriesServiceReference::get,
+                        null
                     );
                 } else {
                     indicesService = new IndicesService(
@@ -1870,7 +1871,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                         null,
                         emptyMap(),
                         new RemoteSegmentStoreDirectoryFactory(() -> repositoriesService),
-                        repositoriesServiceReference::get
+                        repositoriesServiceReference::get,
+                        null
                     );
                 }
                 final RecoverySettings recoverySettings = new RecoverySettings(settings, clusterSettings);

--- a/test/framework/src/main/java/org/opensearch/cluster/MockInternalClusterInfoService.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/MockInternalClusterInfoService.java
@@ -117,7 +117,8 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
                 nodeStats.getShardIndexingPressureStats(),
                 nodeStats.getSearchBackpressureStats(),
                 nodeStats.getClusterManagerThrottlingStats(),
-                nodeStats.getWeightedRoutingStats()
+                nodeStats.getWeightedRoutingStats(),
+                nodeStats.getFileCacheStats()
             );
         }).collect(Collectors.toList());
     }

--- a/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
@@ -2688,6 +2688,7 @@ public final class InternalTestCluster extends TestCluster {
                     false,
                     false,
                     false,
+                    false,
                     false
                 );
                 assertThat(


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Follow up to the #5641. This change exposes the file cache stats as part the node stats API response. The file cache was added as part of searchable snapshot in #5641. ~In addition this also adds an index event listener to clean up cache entries when a remote store index is deleted.~

### Issues Resolved
Resolves #5982 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
