### PR TITLE
Add support to Gradle run task to spawn OpenSearch instances in debug mode

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/RunTask.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/RunTask.java
@@ -74,7 +74,7 @@ public class RunTask extends DefaultTestClustersTask {
 
     private String keystorePassword = "";
 
-    @Option(option = "debug-jvm", description = "Enable debugging configuration, to allow attaching a debugger to opensearch.")
+    @Option(option = "debug-jvm", description = "Run OpenSearch as a debug client, where it will try to connect to a debugging server at startup.")
     public void setDebug(boolean enabled) {
         if (debugServer != null && debugServer == true) {
             throw new IllegalStateException("Either --debug-jvm or --debug-server-jvm option should be specified (but not both)");
@@ -82,7 +82,7 @@ public class RunTask extends DefaultTestClustersTask {
         this.debug = enabled;
     }
 
-    @Option(option = "debug-server-jvm", description = "Enable debugging configuration, to allow running opensearch in debug mode.")
+    @Option(option = "debug-server-jvm", description = "Run OpenSearch as a debug server that will accept connections from a debugging client.")
     public void setDebugServer(boolean enabled) {
         if (debug != null && debug == true) {
             throw new IllegalStateException("Either --debug-jvm or --debug-server-jvm option should be specified (but not both)");
@@ -180,11 +180,15 @@ public class RunTask extends DefaultTestClustersTask {
                     node.setDataPath(getDataPath.apply(node));
                 }
                 if (debug) {
-                    logger.lifecycle("Running opensearch in debug mode, {} expecting running debug server on port {}", node, debugPort);
+                    logger.lifecycle(
+                        "Running opensearch in debug mode (client), {} expecting running debug server on port {}",
+                        node,
+                        debugPort
+                    );
                     node.jvmArgs("-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=" + debugPort);
                     debugPort += 1;
                 } else if (debugServer) {
-                    logger.lifecycle("Running opensearch in debug mode, {} running server with debug port {}", node, debugPort);
+                    logger.lifecycle("Running opensearch in debug mode (server), {} running server with debug port {}", node, debugPort);
                     node.jvmArgs("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" + debugPort);
                     debugPort += 1;
                 }

--- a/buildSrc/src/main/java/org/opensearch/gradle/testclusters/RunTask.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/testclusters/RunTask.java
@@ -66,6 +66,8 @@ public class RunTask extends DefaultTestClustersTask {
 
     private Boolean debug = false;
 
+    private Boolean debugServer = false;
+
     private Boolean preserveData = false;
 
     private Path dataDir = null;
@@ -74,12 +76,28 @@ public class RunTask extends DefaultTestClustersTask {
 
     @Option(option = "debug-jvm", description = "Enable debugging configuration, to allow attaching a debugger to opensearch.")
     public void setDebug(boolean enabled) {
+        if (debugServer != null && debugServer == true) {
+            throw new IllegalStateException("Either --debug-jvm or --debug-server-jvm option should be specified (but not both)");
+        }
         this.debug = enabled;
+    }
+
+    @Option(option = "debug-server-jvm", description = "Enable debugging configuration, to allow running opensearch in debug mode.")
+    public void setDebugServer(boolean enabled) {
+        if (debug != null && debug == true) {
+            throw new IllegalStateException("Either --debug-jvm or --debug-server-jvm option should be specified (but not both)");
+        }
+        this.debugServer = enabled;
     }
 
     @Input
     public Boolean getDebug() {
         return debug;
+    }
+
+    @Input
+    public Boolean getDebugServer() {
+        return debugServer;
     }
 
     @Option(option = "data-dir", description = "Override the base data directory used by the testcluster")
@@ -164,6 +182,10 @@ public class RunTask extends DefaultTestClustersTask {
                 if (debug) {
                     logger.lifecycle("Running opensearch in debug mode, {} expecting running debug server on port {}", node, debugPort);
                     node.jvmArgs("-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=" + debugPort);
+                    debugPort += 1;
+                } else if (debugServer) {
+                    logger.lifecycle("Running opensearch in debug mode, {} running server with debug port {}", node, debugPort);
+                    node.jvmArgs("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" + debugPort);
                     debugPort += 1;
                 }
                 if (keystorePassword.length() > 0) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
During the development, ability to run OpenSearch with debugger from time to time is quite handy. I am suggesting to add a new option` --debug-server-jvm` (to differentiate from `--debug-jvm`):

```
./gradlew run --debug-server-jvm
```

```
2023-02-16T14:48:28.895574Z] [BUILD] Creating opensearch keystore with password set to []                                                                                                    
[2023-02-16T14:48:29.806201Z] [BUILD] Starting OpenSearch process                                                                                                                             
Listening for transport dt_socket at address: 5005                                                                                                                                            
[2023-02-16T09:48:32,166][INFO ][o.o.n.Node               ] [runTask-0] version[3.0.0-SNAPSHOT], pid[22670], build[tar/6bb9e3e78bd0cf22fc0033151bea50016139d7f0/2023-02-16T14:47:42.564605Z], OS[Linux/5.19.0-31-generic/amd64], JVM[Ubuntu/OpenJDK 64-Bit Server VM/11.0.17/11.0.17+8-post-Ubuntu-1ubuntu2]
[2023-02-16T09:48:32,168][INFO ][o.o.n.Node               ] [runTask-0] JVM home [/usr/lib/jvm/java-11-openjdk-amd64], using bundled JDK [false]                                                                                                                                                                                                                                            [2023-02-16T09:48:32,168][INFO ][o.o.n.Node               ] [runTask-0] JVM arguments [-Xshare:auto, -Dopensearch.networkaddress.cache.ttl=60, -Dopensearch.networkaddress.cache.negative.ttl=10, -XX:+AlwaysPreTouch, -Xss1m, -Djava.awt.headless=true, -Dfile.encoding=UTF-8, -Djna.nosys=true, -XX:-OmitStackTraceInFastThrow, -Dio.netty.noUnsafe=true, -Dio.netty.noKeySetOptimization=true, -Dio.netty.recycler.maxCapacityPerThread=0, -Dio.netty.allocator.numDirectArenas=0, -Dlog4j.shutdownHookEnabled=false, -Dlog4j2.disable.jmx=true, -Djava.locale.providers=SPI,COMPAT, -Xms1g, -Xmx1g, -XX:+UseG1GC, -XX:G1ReservePercent=25, -XX:InitiatingHeapOccupancyPercent=30, ... , -XX:+HeapDumpOnOutOfMemoryError, -XX:HeapDumpPath=logs, -XX:ErrorFile=logs/hs_err_pid%p.log, -Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m, -Xms512m, -Xmx512m, -ea, -esa, -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005, -XX:TieredStopAtLevel=1, -XX:ReservedCodeCacheSize=64m, -XX:MaxDirectMemorySize=268435456]
[2023-02-16T09:48:32,169][WARN ][o.o.n.Node               ] [runTask-0] version [3.0.0-SNAPSHOT] is a pre-release version of OpenSearch and is not suitable for production
```

### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/6276

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
