### PR TITLE
Add cache reservation logic

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SearchableSnapshotIT.java
@@ -424,7 +424,7 @@ public final class SearchableSnapshotIT extends AbstractSnapshotIntegTestCase {
         final Client client = client();
         final int numNodes = 2;
 
-        internalCluster().ensureAtLeastNumSearchNodes(numNodes);
+        internalCluster().ensureAtLeastNumDataNodes(numNodes);
         createIndexWithDocsAndEnsureGreen(1, 100, indexName1);
 
         createRepositoryWithSettings(null, repoName);
@@ -432,6 +432,7 @@ public final class SearchableSnapshotIT extends AbstractSnapshotIntegTestCase {
         deleteIndicesAndEnsureGreen(client, indexName1);
         assertAllNodesFileCacheEmpty();
 
+        internalCluster().ensureAtLeastNumSearchNodes(numNodes);
         restoreSnapshotAndEnsureGreen(client, snapshotName, repoName);
         assertNodesFileCacheNonEmpty(numNodes);
     }
@@ -440,8 +441,7 @@ public final class SearchableSnapshotIT extends AbstractSnapshotIntegTestCase {
         NodesStatsResponse response = client().admin().cluster().nodesStats(new NodesStatsRequest().all()).actionGet();
         for (NodeStats stats : response.getNodes()) {
             FileCacheStats fcstats = stats.getFileCacheStats();
-            assertNotNull(fcstats);
-            assertTrue(isFileCacheEmpty(fcstats));
+            assertNull(fcstats);
         }
     }
 
@@ -449,11 +449,15 @@ public final class SearchableSnapshotIT extends AbstractSnapshotIntegTestCase {
         NodesStatsResponse response = client().admin().cluster().nodesStats(new NodesStatsRequest().all()).actionGet();
         int nonEmptyFileCacheNodes = 0;
         for (NodeStats stats : response.getNodes()) {
-            FileCacheStats fcstats = stats.getFileCacheStats();
-            assertNotNull(fcstats);
-            if (!isFileCacheEmpty(fcstats)) {
-                nonEmptyFileCacheNodes++;
+            FileCacheStats fcStats = stats.getFileCacheStats();
+            if (stats.getNode().isSearchNode()) {
+                if (!isFileCacheEmpty(fcStats)) {
+                    nonEmptyFileCacheNodes++;
+                }
+            } else {
+                assertNull(fcStats);
             }
+
         }
         assertEquals(numNodes, nonEmptyFileCacheNodes);
     }

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -121,6 +121,10 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         return hasRole(settings, DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE);
     }
 
+    public static boolean isSearchNode(Settings settings) {
+        return hasRole(settings, DiscoveryNodeRole.SEARCH_ROLE);
+    }
+
     private final String nodeName;
     private final String nodeId;
     private final String ephemeralId;

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.LogManager;
 import org.opensearch.cluster.routing.allocation.AwarenessReplicaBalance;
 import org.opensearch.action.search.CreatePitController;
 import org.opensearch.cluster.routing.allocation.decider.NodeLoadAwareAllocationDecider;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.IndexingPressure;
@@ -152,6 +153,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -628,5 +630,15 @@ public final class ClusterSettings extends AbstractScopedSettings {
     );
 
     public static List<SettingUpgrader<?>> BUILT_IN_SETTING_UPGRADERS = Collections.emptyList();
+
+    /**
+     * Map of feature flag name to feature-flagged cluster settings. Once each feature
+     * is ready for production release, the feature flag can be removed, and the
+     * setting should be moved to {@link #BUILT_IN_CLUSTER_SETTINGS}.
+     */
+    public static final Map<String, List<Setting>> FEATURE_FLAGGED_CLUSTER_SETTINGS = Map.of(
+        FeatureFlags.SEARCHABLE_SNAPSHOT,
+        List.of(Node.NODE_SEARCH_CACHE_SIZE_SETTING)
+    );
 
 }

--- a/server/src/main/java/org/opensearch/common/settings/SettingsModule.java
+++ b/server/src/main/java/org/opensearch/common/settings/SettingsModule.java
@@ -91,9 +91,15 @@ public class SettingsModule implements Module {
             registerSetting(setting);
         }
 
+        for (Map.Entry<String, List<Setting>> featureFlaggedSetting : ClusterSettings.FEATURE_FLAGGED_CLUSTER_SETTINGS.entrySet()) {
+            if (FeatureFlags.isEnabled(featureFlaggedSetting.getKey())) {
+                featureFlaggedSetting.getValue().forEach(this::registerSetting);
+            }
+        }
+
         for (Map.Entry<String, List<Setting>> featureFlaggedSetting : IndexScopedSettings.FEATURE_FLAGGED_INDEX_SETTINGS.entrySet()) {
             if (FeatureFlags.isEnabled(featureFlaggedSetting.getKey())) {
-                featureFlaggedSetting.getValue().forEach(feature -> registerSetting(feature));
+                featureFlaggedSetting.getValue().forEach(this::registerSetting);
             }
         }
 

--- a/server/src/main/java/org/opensearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/opensearch/env/NodeEnvironment.java
@@ -44,6 +44,7 @@ import org.apache.lucene.store.Lock;
 import org.apache.lucene.store.LockObtainFailedException;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.store.NativeFSLockFactory;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -59,6 +60,8 @@ import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsException;
+import org.opensearch.common.unit.ByteSizeUnit;
 import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -70,9 +73,15 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.index.shard.ShardPath;
 import org.opensearch.index.store.FsDirectoryFactory;
+import org.opensearch.index.store.remote.filecache.FileCache;
+import org.opensearch.index.store.remote.filecache.FileCacheFactory;
+import org.opensearch.index.store.remote.filecache.FileCacheStats;
+import org.opensearch.index.store.remote.utils.cache.CacheUsage;
+import org.opensearch.index.store.remote.utils.cache.stats.CacheStats;
 import org.opensearch.monitor.fs.FsInfo;
 import org.opensearch.monitor.fs.FsProbe;
 import org.opensearch.monitor.jvm.JvmInfo;
+import org.opensearch.node.Node;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -104,6 +113,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.unmodifiableSet;
+import static org.opensearch.node.Node.NODE_SEARCH_CACHE_SIZE_SETTING;
 
 /**
  * A component that holds all data paths for a single node.
@@ -123,14 +133,20 @@ public final class NodeEnvironment implements Closeable {
         public final Path indicesPath;
         /** Cached FileStore from path */
         public final FileStore fileStore;
-
+        public final Path fileCachePath;
+        /*
+          Cache reserved size can default to a different value depending on configuration
+        */
+        public ByteSizeValue fileCacheReservedSize;
         public final int majorDeviceNumber;
         public final int minorDeviceNumber;
 
         public NodePath(Path path) throws IOException {
             this.path = path;
             this.indicesPath = path.resolve(INDICES_FOLDER);
+            this.fileCachePath = path.resolve(CACHE_FOLDER);
             this.fileStore = Environment.getFileStore(path);
+            this.fileCacheReservedSize = ByteSizeValue.ZERO;
             if (fileStore.supportsFileAttributeView("lucene")) {
                 this.majorDeviceNumber = (int) fileStore.getAttribute("lucene:major_device_number");
                 this.minorDeviceNumber = (int) fileStore.getAttribute("lucene:minor_device_number");
@@ -180,6 +196,7 @@ public final class NodeEnvironment implements Closeable {
 
     private final Logger logger = LogManager.getLogger(NodeEnvironment.class);
     private final NodePath[] nodePaths;
+    private final NodePath fileCacheNodePath;
     private final Path sharedDataPath;
     private final Lock[] locks;
 
@@ -188,6 +205,8 @@ public final class NodeEnvironment implements Closeable {
     private final Map<ShardId, InternalShardLock> shardLocks = new HashMap<>();
 
     private final NodeMetadata nodeMetadata;
+
+    private FileCache fileCache;
 
     /**
      * Maximum number of data nodes that should run in an environment.
@@ -217,6 +236,7 @@ public final class NodeEnvironment implements Closeable {
 
     public static final String NODES_FOLDER = "nodes";
     public static final String INDICES_FOLDER = "indices";
+    public static final String CACHE_FOLDER = "cache";
     public static final String NODE_LOCK_FILENAME = "node.lock";
 
     /**
@@ -291,6 +311,7 @@ public final class NodeEnvironment implements Closeable {
     public NodeEnvironment(Settings settings, Environment environment) throws IOException {
         if (!DiscoveryNode.nodeRequiresLocalStorage(settings)) {
             nodePaths = null;
+            fileCacheNodePath = null;
             sharedDataPath = null;
             locks = null;
             nodeLockId = -1;
@@ -342,6 +363,10 @@ public final class NodeEnvironment implements Closeable {
             }
             this.locks = nodeLock.locks;
             this.nodePaths = nodeLock.nodePaths;
+            this.fileCacheNodePath = nodePaths[0];
+
+            initializeFileCache(settings);
+
             this.nodeLockId = nodeLock.nodeId;
 
             if (logger.isDebugEnabled()) {
@@ -366,12 +391,50 @@ public final class NodeEnvironment implements Closeable {
                 ensureNoShardData(nodePaths);
             }
 
+            if (DiscoveryNode.isSearchNode(settings) == false) {
+                ensureNoFileCacheData(fileCacheNodePath);
+            }
+
             this.nodeMetadata = loadNodeMetadata(settings, logger, nodePaths);
             success = true;
         } finally {
             if (success == false) {
                 close();
             }
+        }
+    }
+
+    /**
+     * Initializes the search cache with a defined capacity.
+     * The capacity of the cache is based on user configuration for {@link Node#NODE_SEARCH_CACHE_SIZE_SETTING}.
+     * If the user doesn't configure the cache size, it fails if the node is a data + search node.
+     * Else it configures the size to 80% of available capacity for a dedicated search node, if not explicitly defined.
+     */
+    private void initializeFileCache(Settings settings) {
+        if (DiscoveryNode.isSearchNode(settings)) {
+            long capacity = NODE_SEARCH_CACHE_SIZE_SETTING.get(settings).getBytes();
+            FsInfo.Path info = ExceptionsHelper.catchAsRuntimeException(() -> FsProbe.getFSInfo(this.fileCacheNodePath));
+            long availableCapacity = info.getAvailable().getBytes();
+
+            // Initialize default values for cache if NODE_SEARCH_CACHE_SIZE_SETTING is not set.
+            if (capacity == 0) {
+                // If node is not a dedicated search node without configuration, prevent cache initialization
+                if (DiscoveryNode.getRolesFromSettings(settings).stream().anyMatch(role -> !DiscoveryNodeRole.SEARCH_ROLE.equals(role))) {
+                    throw new SettingsException(
+                        "Unable to initialize the "
+                            + DiscoveryNodeRole.SEARCH_ROLE.roleName()
+                            + "-"
+                            + DiscoveryNodeRole.DATA_ROLE.roleName()
+                            + " node: Missing value for configuration "
+                            + NODE_SEARCH_CACHE_SIZE_SETTING.getKey()
+                    );
+                } else {
+                    capacity = 80 * availableCapacity / 100;
+                }
+            }
+            capacity = Math.min(capacity, availableCapacity);
+            fileCacheNodePath.fileCacheReservedSize = new ByteSizeValue(capacity, ByteSizeUnit.BYTES);
+            this.fileCache = FileCacheFactory.createConcurrentLRUFileCache(capacity);
         }
     }
 
@@ -888,6 +951,17 @@ public final class NodeEnvironment implements Closeable {
         return nodePaths;
     }
 
+    /**
+     * Returns the {@link NodePath} used for file caching.
+     */
+    public NodePath fileCacheNodePath() {
+        assertEnvIsLocked();
+        if (nodePaths == null || locks == null) {
+            throw new IllegalStateException("node is not configured to store local location");
+        }
+        return fileCacheNodePath;
+    }
+
     public int getNodeLockId() {
         assertEnvIsLocked();
         if (nodePaths == null || locks == null) {
@@ -1143,6 +1217,22 @@ public final class NodeEnvironment implements Closeable {
         }
     }
 
+    /**
+     * Throws an exception if cache exists on a non-search node.
+     */
+    private void ensureNoFileCacheData(final NodePath fileCacheNodePath) throws IOException {
+        List<Path> cacheDataPaths = collectFileCacheDataPath(fileCacheNodePath);
+        if (cacheDataPaths.isEmpty() == false) {
+            final String message = String.format(
+                Locale.ROOT,
+                "node does not have the %s role but has data within node search cache: %s. Use 'opensearch-node repurpose' tool to clean up",
+                DiscoveryNodeRole.SEARCH_ROLE.roleName(),
+                cacheDataPaths
+            );
+            throw new IllegalStateException(message);
+        }
+    }
+
     private void ensureNoIndexMetadata(final NodePath[] nodePaths) throws IOException {
         List<Path> indexMetadataPaths = collectIndexMetadataPaths(nodePaths);
         if (indexMetadataPaths.isEmpty() == false) {
@@ -1198,6 +1288,34 @@ public final class NodeEnvironment implements Closeable {
 
     private static boolean isIndexMetadataPath(Path path) {
         return Files.isDirectory(path) && path.getFileName().toString().equals(MetadataStateFormat.STATE_DIR_NAME);
+    }
+
+    /**
+     * Collect the path containing cache data in the indicated cache node path.
+     * The returned paths will point to the shard data folder.
+     */
+    static List<Path> collectFileCacheDataPath(NodePath fileCacheNodePath) throws IOException {
+        List<Path> indexSubPaths = new ArrayList<>();
+        Path fileCachePath = fileCacheNodePath.fileCachePath;
+        if (Files.isDirectory(fileCachePath)) {
+            try (DirectoryStream<Path> nodeStream = Files.newDirectoryStream(fileCachePath)) {
+                for (Path nodePath : nodeStream) {
+                    if (Files.isDirectory(nodePath)) {
+                        try (DirectoryStream<Path> indexStream = Files.newDirectoryStream(nodePath)) {
+                            for (Path indexPath : indexStream) {
+                                if (Files.isDirectory(indexPath)) {
+                                    try (Stream<Path> shardStream = Files.list(indexPath)) {
+                                        shardStream.map(Path::toAbsolutePath).forEach(indexSubPaths::add);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return indexSubPaths;
     }
 
     /**
@@ -1305,5 +1423,35 @@ public final class NodeEnvironment implements Closeable {
                 throw new IOException("failed to test writes in data directory [" + path + "] write permission is required", ex);
             }
         }
+    }
+
+    /**
+     * Returns the {@link FileCache} instance for remote search node
+     */
+    public FileCache fileCache() {
+        return this.fileCache;
+    }
+
+    /**
+     * Returns the current {@link FileCacheStats} for remote search node
+     */
+    public FileCacheStats fileCacheStats() {
+        if (fileCache == null) {
+            return null;
+        }
+
+        CacheStats stats = fileCache.stats();
+        CacheUsage usage = fileCache.usage();
+        return new FileCacheStats(
+            System.currentTimeMillis(),
+            usage.activeUsage(),
+            fileCache.capacity(),
+            usage.usage(),
+            stats.evictionWeight(),
+            stats.removeWeight(),
+            stats.replaceCount(),
+            stats.hitCount(),
+            stats.missCount()
+        );
     }
 }

--- a/server/src/main/java/org/opensearch/index/shard/ShardPath.java
+++ b/server/src/main/java/org/opensearch/index/shard/ShardPath.java
@@ -131,6 +131,16 @@ public final class ShardPath {
     }
 
     /**
+     * Returns the shard path to be stored within the cache on the search capable node.
+     */
+    public static ShardPath loadFileCachePath(NodeEnvironment env, ShardId shardId) {
+        NodeEnvironment.NodePath path = env.fileCacheNodePath();
+        final Path dataPath = env.resolveCustomLocation(path.fileCachePath.toString(), shardId);
+        final Path statePath = path.resolve(shardId);
+        return new ShardPath(true, dataPath, statePath, shardId);
+    }
+
+    /**
      * This method walks through the nodes shard paths to find the data and state path for the given shard. If multiple
      * directories with a valid shard state exist the one with the highest version will be used.
      * <b>Note:</b> this method resolves custom data locations for the shard if such a custom data path is provided.

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -132,10 +132,6 @@ import org.opensearch.index.shard.IndexShardState;
 import org.opensearch.index.shard.IndexingOperationListener;
 import org.opensearch.index.shard.IndexingStats;
 import org.opensearch.index.shard.ShardId;
-import org.opensearch.index.store.remote.filecache.FileCache;
-import org.opensearch.index.store.remote.filecache.FileCacheStats;
-import org.opensearch.index.store.remote.utils.cache.CacheUsage;
-import org.opensearch.index.store.remote.utils.cache.stats.CacheStats;
 import org.opensearch.index.translog.InternalTranslogFactory;
 import org.opensearch.index.translog.RemoteBlobStoreInternalTranslogFactory;
 import org.opensearch.index.translog.TranslogFactory;
@@ -263,8 +259,6 @@ public class IndicesService extends AbstractLifecycleComponent
     private final TimeValue cleanInterval;
     final IndicesRequestCache indicesRequestCache; // pkg-private for testing
     private final IndicesQueryCache indicesQueryCache;
-
-    private final FileCache remoteStoreFileCache;
     private final MetaStateService metaStateService;
     private final Collection<Function<IndexSettings, Optional<EngineFactory>>> engineFactoryProviders;
     private final Map<String, IndexStorePlugin.DirectoryFactory> directoryFactories;
@@ -310,8 +304,7 @@ public class IndicesService extends AbstractLifecycleComponent
         ValuesSourceRegistry valuesSourceRegistry,
         Map<String, IndexStorePlugin.RecoveryStateFactory> recoveryStateFactories,
         IndexStorePlugin.RemoteDirectoryFactory remoteDirectoryFactory,
-        Supplier<RepositoriesService> repositoriesServiceSupplier,
-        FileCache remoteStoreFileCache
+        Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
         this.settings = settings;
         this.threadPool = threadPool;
@@ -325,7 +318,6 @@ public class IndicesService extends AbstractLifecycleComponent
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.indicesRequestCache = new IndicesRequestCache(settings);
         this.indicesQueryCache = new IndicesQueryCache(settings);
-        this.remoteStoreFileCache = remoteStoreFileCache;
         this.mapperRegistry = mapperRegistry;
         this.namedWriteableRegistry = namedWriteableRegistry;
         indexingMemoryController = new IndexingMemoryController(
@@ -427,8 +419,7 @@ public class IndicesService extends AbstractLifecycleComponent
         ValuesSourceRegistry valuesSourceRegistry,
         Map<String, IndexStorePlugin.RecoveryStateFactory> recoveryStateFactories,
         IndexStorePlugin.RemoteDirectoryFactory remoteDirectoryFactory,
-        Supplier<RepositoriesService> repositoriesServiceSupplier,
-        FileCache remoteStoreFileCache
+        Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
         this.settings = settings;
         this.threadPool = threadPool;
@@ -436,7 +427,6 @@ public class IndicesService extends AbstractLifecycleComponent
         this.extensionsManager = extensionsManager;
         this.nodeEnv = nodeEnv;
         this.xContentRegistry = xContentRegistry;
-        this.remoteStoreFileCache = remoteStoreFileCache;
         this.valuesSourceRegistry = valuesSourceRegistry;
         this.shardsClosedTimeout = settings.getAsTime(INDICES_SHARDS_CLOSED_TIMEOUT, new TimeValue(1, TimeUnit.DAYS));
         this.analysisRegistry = analysisRegistry;
@@ -1932,21 +1922,5 @@ public class IndicesService extends AbstractLifecycleComponent
     public boolean allPendingDanglingIndicesWritten() {
         return nodeWriteDanglingIndicesInfo == false
             || (danglingIndicesToWrite.isEmpty() && danglingIndicesThreadPoolExecutor.getActiveCount() == 0);
-    }
-
-    public FileCacheStats getFileCacheStats() {
-        CacheStats stats = remoteStoreFileCache.stats();
-        CacheUsage usage = remoteStoreFileCache.usage();
-        return new FileCacheStats(
-            System.currentTimeMillis(),
-            usage.activeUsage(),
-            remoteStoreFileCache.capacity(),
-            usage.usage(),
-            stats.evictionWeight(),
-            stats.removeWeight(),
-            stats.replaceCount(),
-            stats.hitCount(),
-            stats.missCount()
-        );
     }
 }

--- a/server/src/main/java/org/opensearch/monitor/fs/FsInfo.java
+++ b/server/src/main/java/org/opensearch/monitor/fs/FsInfo.java
@@ -32,11 +32,13 @@
 
 package org.opensearch.monitor.fs;
 
+import org.opensearch.Version;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.unit.ByteSizeValue;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -70,6 +72,8 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
         long total = -1;
         long free = -1;
         long available = -1;
+        long fileCacheReserved = -1;
+        long fileCacheUtilized = 0;
 
         public Path() {}
 
@@ -91,6 +95,10 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
             total = in.readLong();
             free = in.readLong();
             available = in.readLong();
+            if (FeatureFlags.isEnabled(FeatureFlags.SEARCHABLE_SNAPSHOT) && in.getVersion().onOrAfter(Version.V_3_0_0)) {
+                fileCacheReserved = in.readLong();
+                fileCacheUtilized = in.readLong();
+            }
         }
 
         @Override
@@ -101,6 +109,10 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
             out.writeLong(total);
             out.writeLong(free);
             out.writeLong(available);
+            if (FeatureFlags.isEnabled(FeatureFlags.SEARCHABLE_SNAPSHOT) && out.getVersion().onOrAfter(Version.V_3_0_0)) {
+                out.writeLong(fileCacheReserved);
+                out.writeLong(fileCacheUtilized);
+            }
         }
 
         public String getPath() {
@@ -127,6 +139,14 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
             return new ByteSizeValue(available);
         }
 
+        public ByteSizeValue getFileCacheReserved() {
+            return new ByteSizeValue(fileCacheReserved);
+        }
+
+        public ByteSizeValue getFileCacheUtilized() {
+            return new ByteSizeValue(fileCacheUtilized);
+        }
+
         private long addLong(long current, long other) {
             if (current == -1 && other == -1) {
                 return 0;
@@ -143,6 +163,8 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
         public void add(Path path) {
             total = FsProbe.adjustForHugeFilesystems(addLong(total, path.total));
             free = FsProbe.adjustForHugeFilesystems(addLong(free, path.free));
+            fileCacheReserved = FsProbe.adjustForHugeFilesystems(addLong(fileCacheReserved, path.fileCacheReserved));
+            fileCacheUtilized = FsProbe.adjustForHugeFilesystems(addLong(fileCacheUtilized, path.fileCacheUtilized));
             available = FsProbe.adjustForHugeFilesystems(addLong(available, path.available));
         }
 
@@ -156,6 +178,10 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
             static final String FREE_IN_BYTES = "free_in_bytes";
             static final String AVAILABLE = "available";
             static final String AVAILABLE_IN_BYTES = "available_in_bytes";
+            static final String CACHE_RESERVED = "cache_reserved";
+            static final String CACHE_RESERVED_IN_BYTES = "cache_reserved_in_bytes";
+            static final String CACHE_UTILIZED = "cache_utilized";
+            static final String CACHE_UTILIZED_IN_BYTES = "cache_utilized_in_bytes";
         }
 
         @Override
@@ -179,6 +205,12 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
             }
             if (available != -1) {
                 builder.humanReadableField(Fields.AVAILABLE_IN_BYTES, Fields.AVAILABLE, getAvailable());
+            }
+            if (FeatureFlags.isEnabled(FeatureFlags.SEARCHABLE_SNAPSHOT) && fileCacheReserved != -1) {
+                builder.humanReadableField(Fields.CACHE_RESERVED_IN_BYTES, Fields.CACHE_RESERVED, getFileCacheReserved());
+            }
+            if (FeatureFlags.isEnabled(FeatureFlags.SEARCHABLE_SNAPSHOT) && fileCacheReserved != 0) {
+                builder.humanReadableField(Fields.CACHE_UTILIZED, Fields.CACHE_UTILIZED_IN_BYTES, getFileCacheUtilized());
             }
 
             builder.endObject();

--- a/server/src/main/java/org/opensearch/monitor/fs/FsService.java
+++ b/server/src/main/java/org/opensearch/monitor/fs/FsService.java
@@ -70,7 +70,7 @@ public class FsService {
     );
 
     public FsService(final Settings settings, final NodeEnvironment nodeEnvironment) {
-        final FsProbe probe = new FsProbe(nodeEnvironment);
+        final FsProbe probe = new FsProbe(nodeEnvironment, settings);
         final FsInfo initialValue = stats(probe, null);
         if (ALWAYS_REFRESH_SETTING.get(settings)) {
             assert REFRESH_INTERVAL_SETTING.exists(settings) == false;

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -36,19 +36,16 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.Constants;
 import org.opensearch.common.SetOnce;
+import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.cluster.routing.allocation.AwarenessReplicaBalance;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexingPressureService;
-import org.opensearch.index.store.remote.filecache.FileCache;
-import org.opensearch.index.store.remote.filecache.FileCacheFactory;
 import org.opensearch.indices.replication.SegmentReplicationSourceFactory;
 import org.opensearch.indices.replication.SegmentReplicationTargetService;
 import org.opensearch.indices.replication.SegmentReplicationSourceService;
 import org.opensearch.extensions.ExtensionsManager;
 import org.opensearch.extensions.NoopExtensionsManager;
-import org.opensearch.monitor.fs.FsInfo;
-import org.opensearch.monitor.fs.FsProbe;
 import org.opensearch.search.backpressure.SearchBackpressureService;
 import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
 import org.opensearch.tasks.TaskResourceTrackingService;
@@ -60,7 +57,6 @@ import org.opensearch.Build;
 import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchTimeoutException;
 import org.opensearch.Version;
-import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.ActionModule;
 import org.opensearch.action.ActionType;
 import org.opensearch.action.admin.cluster.snapshots.status.TransportNodesSnapshotsStatus;
@@ -315,6 +311,12 @@ public class Node implements Closeable {
                 throw new IllegalArgumentException("indices.breaker.type must be one of [hierarchy, none] but was: " + s);
         }
     }, Setting.Property.NodeScope);
+
+    public static final Setting<ByteSizeValue> NODE_SEARCH_CACHE_SIZE_SETTING = Setting.byteSizeSetting(
+        "node.search.cache.size",
+        ByteSizeValue.ZERO,
+        Property.NodeScope
+    );
 
     private static final String CLIENT_TYPE = "node";
 
@@ -625,12 +627,11 @@ public class Node implements Closeable {
             final Collection<Function<IndexSettings, Optional<EngineFactory>>> engineFactoryProviders = enginePlugins.stream()
                 .map(plugin -> (Function<IndexSettings, Optional<EngineFactory>>) plugin::getEngineFactory)
                 .collect(Collectors.toList());
-            // TODO: for now this is a single cache, later, this should read node and index settings
-            final FileCache remoteStoreFileCache = createRemoteStoreFileCache();
+
             final Map<String, IndexStorePlugin.DirectoryFactory> builtInDirectoryFactories = IndexModule.createBuiltInDirectoryFactories(
                 repositoriesServiceReference::get,
                 threadPool,
-                remoteStoreFileCache
+                nodeEnvironment.fileCache()
             );
 
             final Map<String, IndexStorePlugin.DirectoryFactory> directoryFactories = new HashMap<>();
@@ -698,8 +699,7 @@ public class Node implements Closeable {
                     searchModule.getValuesSourceRegistry(),
                     recoveryStateFactories,
                     remoteDirectoryFactory,
-                    repositoriesServiceReference::get,
-                    remoteStoreFileCache
+                    repositoriesServiceReference::get
                 );
             } else {
                 indicesService = new IndicesService(
@@ -724,8 +724,7 @@ public class Node implements Closeable {
                     searchModule.getValuesSourceRegistry(),
                     recoveryStateFactories,
                     remoteDirectoryFactory,
-                    repositoriesServiceReference::get,
-                    remoteStoreFileCache
+                    repositoriesServiceReference::get
                 );
             }
 
@@ -969,7 +968,8 @@ public class Node implements Closeable {
                 searchTransportService,
                 indexingPressureService,
                 searchModule.getValuesSourceRegistry().getUsageService(),
-                searchBackpressureService
+                searchBackpressureService,
+                nodeEnvironment
             );
 
             final SearchService searchService = newSearchService(
@@ -1128,16 +1128,6 @@ public class Node implements Closeable {
                 IOUtils.closeWhileHandlingException(resourcesToClose);
             }
         }
-    }
-
-    private FileCache createRemoteStoreFileCache() {
-        // TODO: implement more custom logic to create named caches, using multiple node paths, more capacity computation options and
-        // capacity reservation logic
-        FsInfo.Path info = ExceptionsHelper.catchAsRuntimeException(() -> FsProbe.getFSInfo(nodeEnvironment.nodePaths()[0]));
-        long diskCapacity = info.getTotal().getBytes();
-        // hard coded as 50% for now
-        long capacity = (long) (diskCapacity * 0.50);
-        return FileCacheFactory.createConcurrentLRUFileCache(capacity);
     }
 
     protected TransportService newTransportService(

--- a/server/src/main/java/org/opensearch/node/NodeService.java
+++ b/server/src/main/java/org/opensearch/node/NodeService.java
@@ -45,6 +45,7 @@ import org.opensearch.common.Nullable;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsFilter;
 import org.opensearch.discovery.Discovery;
+import org.opensearch.env.NodeEnvironment;
 import org.opensearch.http.HttpServerTransport;
 import org.opensearch.index.IndexingPressureService;
 import org.opensearch.indices.IndicesService;
@@ -85,8 +86,8 @@ public class NodeService implements Closeable {
     private final AggregationUsageService aggregationUsageService;
     private final SearchBackpressureService searchBackpressureService;
     private final ClusterService clusterService;
-
     private final Discovery discovery;
+    private final NodeEnvironment nodeEnvironment;
 
     NodeService(
         Settings settings,
@@ -106,7 +107,8 @@ public class NodeService implements Closeable {
         SearchTransportService searchTransportService,
         IndexingPressureService indexingPressureService,
         AggregationUsageService aggregationUsageService,
-        SearchBackpressureService searchBackpressureService
+        SearchBackpressureService searchBackpressureService,
+        NodeEnvironment nodeEnvironment
     ) {
         this.settings = settings;
         this.threadPool = threadPool;
@@ -126,6 +128,7 @@ public class NodeService implements Closeable {
         this.aggregationUsageService = aggregationUsageService;
         this.searchBackpressureService = searchBackpressureService;
         this.clusterService = clusterService;
+        this.nodeEnvironment = nodeEnvironment;
         clusterService.addStateApplier(ingestService);
     }
 
@@ -206,7 +209,7 @@ public class NodeService implements Closeable {
             searchBackpressure ? this.searchBackpressureService.nodeStats() : null,
             clusterManagerThrottling ? this.clusterService.getClusterManagerService().getThrottlingStats() : null,
             weightedRoutingStats ? WeightedRoutingStats.getInstance() : null,
-            fileCacheStats ? indicesService.getFileCacheStats() : null
+            fileCacheStats ? nodeEnvironment.fileCacheStats() : null
         );
     }
 

--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeTests.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeTests.java
@@ -50,12 +50,14 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
-import static org.opensearch.test.NodeRoles.nonRemoteClusterClientNode;
-import static org.opensearch.test.NodeRoles.remoteClusterClientNode;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
+import static org.opensearch.test.NodeRoles.nonRemoteClusterClientNode;
+import static org.opensearch.test.NodeRoles.remoteClusterClientNode;
+import static org.opensearch.test.NodeRoles.searchNode;
+import static org.opensearch.test.NodeRoles.nonSearchNode;
 
 public class DiscoveryNodeTests extends OpenSearchTestCase {
 
@@ -175,6 +177,14 @@ public class DiscoveryNodeTests extends OpenSearchTestCase {
         runTestDiscoveryNodeIsRemoteClusterClient(nonRemoteClusterClientNode(), false);
     }
 
+    public void testDiscoveryNodeIsSearchSet() {
+        runTestDiscoveryNodeIsSearch(searchNode(), true);
+    }
+
+    public void testDiscoveryNodeIsSearchUnset() {
+        runTestDiscoveryNodeIsSearch(nonSearchNode(), false);
+    }
+
     // Added in 2.0 temporarily, validate the MASTER_ROLE is in the list of known roles.
     // MASTER_ROLE was removed from BUILT_IN_ROLES and is imported by setDeprecatedMasterRole(),
     // as a workaround for making the new CLUSTER_MANAGER_ROLE has got the same abbreviation 'm'.
@@ -191,6 +201,16 @@ public class DiscoveryNodeTests extends OpenSearchTestCase {
             assertThat(node.getRoles(), hasItem(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
         } else {
             assertThat(node.getRoles(), not(hasItem(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE)));
+        }
+    }
+
+    private void runTestDiscoveryNodeIsSearch(final Settings settings, final boolean expected) {
+        final DiscoveryNode node = DiscoveryNode.createLocal(settings, new TransportAddress(TransportAddress.META_ADDRESS, 9200), "node");
+        assertThat(node.isSearchNode(), equalTo(expected));
+        if (expected) {
+            assertThat(node.getRoles(), hasItem(DiscoveryNodeRole.SEARCH_ROLE));
+        } else {
+            assertThat(node.getRoles(), not(hasItem(DiscoveryNodeRole.SEARCH_ROLE)));
         }
     }
 

--- a/server/src/test/java/org/opensearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/opensearch/env/NodeEnvironmentTests.java
@@ -38,6 +38,9 @@ import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsException;
+import org.opensearch.common.unit.ByteSizeUnit;
+import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.common.util.concurrent.AbstractRunnable;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.core.internal.io.IOUtils;
@@ -45,6 +48,8 @@ import org.opensearch.gateway.MetadataStateFormat;
 import org.opensearch.index.Index;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.shard.ShardId;
+import org.opensearch.monitor.fs.FsInfo;
+import org.opensearch.monitor.fs.FsProbe;
 import org.opensearch.node.Node;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.IndexSettingsModule;
@@ -65,6 +70,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.opensearch.test.NodeRoles.addRoles;
 import static org.opensearch.test.NodeRoles.nonDataNode;
 import static org.opensearch.test.NodeRoles.nonClusterManagerNode;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -581,6 +587,49 @@ public class NodeEnvironmentTests extends OpenSearchTestCase {
         // assert that we fail on shard data even without the metadata dir.
         verifyFailsOnShardData(noDataSettings, indexPath, shardDataDirName);
         verifyFailsOnShardData(noDataNoClusterManagerSettings, indexPath, shardDataDirName);
+    }
+
+    public void testSearchFileCacheConfiguration() throws IOException {
+        Settings searchRoleSettings = addRoles(buildEnvSettings(Settings.EMPTY), Set.of(DiscoveryNodeRole.SEARCH_ROLE));
+        ByteSizeValue cacheSize = new ByteSizeValue(100, ByteSizeUnit.MB);
+        Settings searchRoleSettingsWithConfig = Settings.builder()
+            .put(searchRoleSettings)
+            .put(Node.NODE_SEARCH_CACHE_SIZE_SETTING.getKey(), cacheSize)
+            .build();
+
+        Settings onlySearchRoleSettings = Settings.builder()
+            .put(searchRoleSettings)
+            .put(
+                NodeRoles.removeRoles(
+                    searchRoleSettings,
+                    Set.of(
+                        DiscoveryNodeRole.DATA_ROLE,
+                        DiscoveryNodeRole.CLUSTER_MANAGER_ROLE,
+                        DiscoveryNodeRole.INGEST_ROLE,
+                        DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE
+                    )
+                )
+            )
+            .build();
+
+        // Test exception thrown with configuration missing
+        assertThrows(SettingsException.class, () -> newNodeEnvironment(searchRoleSettings));
+
+        // Test data + search node with defined cache size
+        try (NodeEnvironment env = newNodeEnvironment(searchRoleSettingsWithConfig)) {
+            NodeEnvironment.NodePath fileCacheNodePath = env.fileCacheNodePath();
+            assertEquals(cacheSize.getBytes(), fileCacheNodePath.fileCacheReservedSize.getBytes());
+        }
+
+        // Test dedicated search node with no configuration
+        try (NodeEnvironment env = newNodeEnvironment(onlySearchRoleSettings)) {
+            NodeEnvironment.NodePath fileCacheNodePath = env.fileCacheNodePath();
+            assertTrue(fileCacheNodePath.fileCacheReservedSize.getBytes() > 0);
+            FsProbe fsProbe = new FsProbe(env, onlySearchRoleSettings);
+            FsInfo fsInfo = fsProbe.stats(null);
+            FsInfo.Path cachePathInfo = fsInfo.iterator().next();
+            assertEquals(cachePathInfo.getFileCacheReserved().getBytes(), fileCacheNodePath.fileCacheReservedSize.getBytes());
+        }
     }
 
     private void verifyFailsOnShardData(Settings settings, Path indexPath, String shardDataDirName) {

--- a/server/src/test/java/org/opensearch/index/shard/ShardPathTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/ShardPathTests.java
@@ -33,7 +33,6 @@ package org.opensearch.index.shard;
 
 import org.opensearch.cluster.routing.AllocationId;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.gateway.WriteStateException;
 import org.opensearch.index.Index;
@@ -44,6 +43,7 @@ import java.nio.file.Path;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.opensearch.env.Environment.PATH_SHARED_DATA_SETTING;
 
 public class ShardPathTests extends OpenSearchTestCase {
     public void testLoadShardPath() throws IOException {
@@ -109,9 +109,7 @@ public class ShardPathTests extends OpenSearchTestCase {
         if (useCustomDataPath) {
             final Path path = createTempDir();
             customDataPath = "custom";
-            nodeSettings = Settings.builder()
-                .put(Environment.PATH_SHARED_DATA_SETTING.getKey(), path.toAbsolutePath().toAbsolutePath())
-                .build();
+            nodeSettings = Settings.builder().put(PATH_SHARED_DATA_SETTING.getKey(), path.toAbsolutePath().toAbsolutePath()).build();
             customPath = path.resolve("custom").resolve("0");
         } else {
             customPath = null;
@@ -146,6 +144,23 @@ public class ShardPathTests extends OpenSearchTestCase {
                 }
                 assertTrue("root state paths must be a node path but wasn't: " + shardPath.getRootDataPath(), found);
             }
+        }
+    }
+
+    public void testLoadFileCachePath() throws IOException {
+        Settings searchNodeSettings = Settings.builder().put("node.roles", "search").put(PATH_SHARED_DATA_SETTING.getKey(), "").build();
+
+        try (NodeEnvironment env = newNodeEnvironment(searchNodeSettings)) {
+            ShardId shardId = new ShardId("foo", "0xDEADBEEF", 0);
+            Path fileCachePath = env.fileCacheNodePath().fileCachePath;
+            writeShardStateMetadata("0xDEADBEEF", fileCachePath);
+            ShardPath shardPath = ShardPath.loadFileCachePath(env, shardId);
+
+            assertTrue(shardPath.getDataPath().startsWith(fileCachePath));
+            assertFalse(shardPath.getShardStatePath().startsWith(fileCachePath));
+
+            assertEquals("0xDEADBEEF", shardPath.getShardId().getIndex().getUUID());
+            assertEquals("foo", shardPath.getShardId().getIndexName());
         }
     }
 

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -1834,8 +1834,7 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                         null,
                         emptyMap(),
                         new RemoteSegmentStoreDirectoryFactory(() -> repositoriesService),
-                        repositoriesServiceReference::get,
-                        null
+                        repositoriesServiceReference::get
                     );
                 } else {
                     indicesService = new IndicesService(
@@ -1871,8 +1870,7 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                         null,
                         emptyMap(),
                         new RemoteSegmentStoreDirectoryFactory(() -> repositoriesService),
-                        repositoriesServiceReference::get,
-                        null
+                        repositoriesServiceReference::get
                     );
                 }
                 final RecoverySettings recoverySettings = new RecoverySettings(settings, clusterSettings);

--- a/test/framework/src/main/java/org/opensearch/test/NodeRoles.java
+++ b/test/framework/src/main/java/org/opensearch/test/NodeRoles.java
@@ -244,4 +244,20 @@ public class NodeRoles {
         return removeRoles(settings, Collections.singleton(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
     }
 
+    public static Settings searchNode() {
+        return searchNode(Settings.EMPTY);
+    }
+
+    public static Settings searchNode(final Settings settings) {
+        return addRoles(settings, Collections.singleton(DiscoveryNodeRole.SEARCH_ROLE));
+    }
+
+    public static Settings nonSearchNode() {
+        return nonSearchNode(Settings.EMPTY);
+    }
+
+    public static Settings nonSearchNode(final Settings settings) {
+        return removeRoles(settings, Collections.singleton(DiscoveryNodeRole.SEARCH_ROLE));
+    }
+
 }


### PR DESCRIPTION
### Description
- This PR focuses on adding a reservation logic for the cache introduced as a part of searchable snapshots
- The design was defined as a part of #4964 where a user can define the cache size using `node.search.cache.size` configuration for the node 
- This value is persisted as a part of the `NodePath` for the first data path configured on the node, and defaults to `100 MB` otherwise. 

### Issues Resolved
- Resolves #5508 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
