### PR TITLE
Implement equals/hashcode for named DocValueFormat inner classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- Added equals/hashcode for named DocValueFormat.DateTime inner class ([#6357](https://github.com/opensearch-project/OpenSearch/pull/6357))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/search/DocValueFormat.java
+++ b/server/src/main/java/org/opensearch/search/DocValueFormat.java
@@ -272,6 +272,27 @@ public interface DocValueFormat extends NamedWriteable {
         public String toString() {
             return "DocValueFormat.DateTime(" + formatter + ", " + timeZone + ", " + resolution + ")";
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            DateTime that = (DateTime) o;
+
+            return Objects.equals(formatter, that.formatter)
+                && Objects.equals(timeZone, that.timeZone)
+                && Objects.equals(resolution, that.resolution);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(formatter, timeZone, resolution);
+        }
     }
 
     DocValueFormat GEOHASH = new DocValueFormat() {

--- a/server/src/test/java/org/opensearch/search/DocValueFormatTests.java
+++ b/server/src/test/java/org/opensearch/search/DocValueFormatTests.java
@@ -76,6 +76,7 @@ public class DocValueFormatTests extends OpenSearchTestCase {
         DocValueFormat vf = in.readNamedWriteable(DocValueFormat.class);
         assertEquals(DocValueFormat.Decimal.class, vf.getClass());
         assertEquals("###.##", ((DocValueFormat.Decimal) vf).pattern);
+        assertEquals(decimalFormat, vf);
 
         DateFormatter formatter = DateFormatter.forPattern("epoch_second");
         DocValueFormat.DateTime dateFormat = new DocValueFormat.DateTime(formatter, ZoneOffset.ofHours(1), Resolution.MILLISECONDS);
@@ -87,6 +88,7 @@ public class DocValueFormatTests extends OpenSearchTestCase {
         assertEquals("epoch_second", ((DocValueFormat.DateTime) vf).formatter.pattern());
         assertEquals(ZoneOffset.ofHours(1), ((DocValueFormat.DateTime) vf).timeZone);
         assertEquals(Resolution.MILLISECONDS, ((DocValueFormat.DateTime) vf).resolution);
+        assertEquals(dateFormat, vf);
 
         DocValueFormat.DateTime nanosDateFormat = new DocValueFormat.DateTime(formatter, ZoneOffset.ofHours(1), Resolution.NANOSECONDS);
         out = new BytesStreamOutput();
@@ -97,6 +99,7 @@ public class DocValueFormatTests extends OpenSearchTestCase {
         assertEquals("epoch_second", ((DocValueFormat.DateTime) vf).formatter.pattern());
         assertEquals(ZoneOffset.ofHours(1), ((DocValueFormat.DateTime) vf).timeZone);
         assertEquals(Resolution.NANOSECONDS, ((DocValueFormat.DateTime) vf).resolution);
+        assertEquals(nanosDateFormat, vf);
 
         out = new BytesStreamOutput();
         out.writeNamedWriteable(DocValueFormat.GEOHASH);


### PR DESCRIPTION
### Description
Implements  `equals` and `hashCode` methods for the named inner class `DocValueFormat.DateTime`. 

Per the contract as described in the `Writeable` interface, any class implementing `equals`/`hashcode` must ensure that a copy made be serializing and deserializing must be equal. As `InternalDateHistogram` /  `InternalHistogram` implement `equals`/`hashcode` and are `Writable` classes, this requires that `DateTime` also implement `equals` and `hashcode` , as the `DateMathParser` will otherwise cause it to fail equivalence. 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
