### PR TITLE
Skip performOnPrimary step when executing PublishCheckpoint.

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationRelocationIT.java
@@ -55,12 +55,13 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationBaseIT {
         final String replica = internalCluster().startNode();
         ensureGreen(INDEX_NAME);
         final int initialDocCount = scaledRandomIntBetween(100, 1000);
+        final WriteRequest.RefreshPolicy refreshPolicy = randomFrom(WriteRequest.RefreshPolicy.values());
         final List<ActionFuture<IndexResponse>> pendingIndexResponses = new ArrayList<>();
         for (int i = 0; i < initialDocCount; i++) {
             pendingIndexResponses.add(
                 client().prepareIndex(INDEX_NAME)
                     .setId(Integer.toString(i))
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL)
+                    .setRefreshPolicy(refreshPolicy)
                     .setSource("field", "value" + i)
                     .execute()
             );
@@ -105,7 +106,7 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationBaseIT {
             pendingIndexResponses.add(
                 client().prepareIndex(INDEX_NAME)
                     .setId(Integer.toString(i))
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL)
+                    .setRefreshPolicy(refreshPolicy)
                     .setSource("field", "value" + i)
                     .execute()
             );
@@ -131,12 +132,13 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationBaseIT {
         final String replica = internalCluster().startNode();
         ensureGreen(INDEX_NAME);
         final int initialDocCount = scaledRandomIntBetween(100, 1000);
+        final WriteRequest.RefreshPolicy refreshPolicy = randomFrom(WriteRequest.RefreshPolicy.values());
         final List<ActionFuture<IndexResponse>> pendingIndexResponses = new ArrayList<>();
         for (int i = 0; i < initialDocCount; i++) {
             pendingIndexResponses.add(
                 client().prepareIndex(INDEX_NAME)
                     .setId(Integer.toString(i))
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL)
+                    .setRefreshPolicy(refreshPolicy)
                     .setSource("field", "value" + i)
                     .execute()
             );
@@ -189,7 +191,7 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationBaseIT {
             pendingIndexResponses.add(
                 client().prepareIndex(INDEX_NAME)
                     .setId(Integer.toString(i))
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL)
+                    .setRefreshPolicy(refreshPolicy)
                     .setSource("field", "value" + i)
                     .execute()
             );
@@ -297,6 +299,7 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationBaseIT {
         }
         logger.info("--> flush to have segments on disk");
         client().admin().indices().prepareFlush().execute().actionGet();
+        final WriteRequest.RefreshPolicy refreshPolicy = randomFrom(WriteRequest.RefreshPolicy.values());
 
         logger.info("--> index more docs so there are ops in the transaction log");
         final List<ActionFuture<IndexResponse>> pendingIndexResponses = new ArrayList<>();
@@ -304,7 +307,7 @@ public class SegmentReplicationRelocationIT extends SegmentReplicationBaseIT {
             pendingIndexResponses.add(
                 client().prepareIndex(INDEX_NAME)
                     .setId(Integer.toString(i))
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL)
+                    .setRefreshPolicy(refreshPolicy)
                     .setSource("field", "value" + i)
                     .execute()
             );

--- a/server/src/main/java/org/opensearch/indices/replication/checkpoint/PublishCheckpointAction.java
+++ b/server/src/main/java/org/opensearch/indices/replication/checkpoint/PublishCheckpointAction.java
@@ -13,12 +13,18 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionListener;
+import org.opensearch.action.ActionListenerResponseHandler;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.replication.ReplicationMode;
+import org.opensearch.action.support.replication.ReplicationOperation;
 import org.opensearch.action.support.replication.ReplicationResponse;
 import org.opensearch.action.support.replication.ReplicationTask;
 import org.opensearch.action.support.replication.TransportReplicationAction;
 import org.opensearch.cluster.action.shard.ShardStateAction;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.io.stream.StreamInput;
@@ -33,14 +39,11 @@ import org.opensearch.indices.replication.common.ReplicationTimer;
 import org.opensearch.node.NodeClosedException;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
-import org.opensearch.transport.TransportException;
-import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Objects;
-
-import org.opensearch.action.support.replication.ReplicationMode;
 
 /**
  * Replication action responsible for publishing checkpoint to a replica shard.
@@ -107,7 +110,6 @@ public class PublishCheckpointAction extends TransportReplicationAction<
      * Publish checkpoint request to shard
      */
     final void publish(IndexShard indexShard) {
-        String primaryAllocationId = indexShard.routingEntry().allocationId().getId();
         long primaryTerm = indexShard.getPendingPrimaryTerm();
         final ThreadContext threadContext = threadPool.getThreadContext();
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
@@ -115,28 +117,26 @@ public class PublishCheckpointAction extends TransportReplicationAction<
             threadContext.markAsSystemContext();
             PublishCheckpointRequest request = new PublishCheckpointRequest(indexShard.getLatestReplicationCheckpoint());
             final ReplicationCheckpoint checkpoint = request.getCheckpoint();
-            final ReplicationTask task = (ReplicationTask) taskManager.register("transport", "segrep_publish_checkpoint", request);
-            final ReplicationTimer timer = new ReplicationTimer();
-            timer.start();
-            transportService.sendChildRequest(
-                clusterService.localNode(),
-                transportPrimaryAction,
-                new ConcreteShardRequest<>(request, primaryAllocationId, primaryTerm),
-                task,
-                transportOptions,
-                new TransportResponseHandler<ReplicationResponse>() {
-                    @Override
-                    public ReplicationResponse read(StreamInput in) throws IOException {
-                        return newResponseInstance(in);
-                    }
 
+            final List<ShardRouting> replicationTargets = indexShard.getReplicationGroup().getReplicationTargets();
+            for (ShardRouting replicationTarget : replicationTargets) {
+                if (replicationTarget.primary()) {
+                    continue;
+                }
+                final DiscoveryNode node = clusterService.state().nodes().get(replicationTarget.currentNodeId());
+                final ConcreteReplicaRequest<PublishCheckpointRequest> replicaRequest = new ConcreteReplicaRequest<>(
+                    request,
+                    replicationTarget.allocationId().getId(),
+                    primaryTerm,
+                    indexShard.getLastKnownGlobalCheckpoint(),
+                    indexShard.getMaxSeqNoOfUpdatesOrDeletes()
+                );
+                final ReplicationTimer timer = new ReplicationTimer();
+                timer.start();
+                final ReplicationTask task = (ReplicationTask) taskManager.register("transport", "segrep_publish_checkpoint", request);
+                ActionListener<ReplicationOperation.ReplicaResponse> listener = new ActionListener<>() {
                     @Override
-                    public String executor() {
-                        return ThreadPool.Names.SAME;
-                    }
-
-                    @Override
-                    public void handleResponse(ReplicationResponse response) {
+                    public void onResponse(ReplicationOperation.ReplicaResponse replicaResponse) {
                         timer.stop();
                         logger.trace(
                             () -> new ParameterizedMessage(
@@ -146,12 +146,11 @@ public class PublishCheckpointAction extends TransportReplicationAction<
                                 timer.time()
                             )
                         );
-                        task.setPhase("finished");
                         taskManager.unregister(task);
                     }
 
                     @Override
-                    public void handleException(TransportException e) {
+                    public void onFailure(Exception e) {
                         timer.stop();
                         logger.trace("[shardId {}] Failed to publish checkpoint, timing: {}", indexShard.shardId().getId(), timer.time());
                         task.setPhase("finished");
@@ -174,8 +173,13 @@ public class PublishCheckpointAction extends TransportReplicationAction<
                             e
                         );
                     }
-                }
-            );
+                };
+                final ActionListenerResponseHandler<ReplicaResponse> handler = new ActionListenerResponseHandler<>(
+                    listener,
+                    ReplicaResponse::new
+                );
+                transportService.sendChildRequest(node, transportReplicaAction, replicaRequest, task, transportOptions, handler);
+            }
             logger.trace(
                 () -> new ParameterizedMessage(
                     "[shardId {}] Publishing replication checkpoint [{}]",
@@ -192,7 +196,7 @@ public class PublishCheckpointAction extends TransportReplicationAction<
         IndexShard primary,
         ActionListener<PrimaryResult<PublishCheckpointRequest, ReplicationResponse>> listener
     ) {
-        ActionListener.completeWith(listener, () -> new PrimaryResult<>(request, new ReplicationResponse()));
+        throw new OpenSearchException("PublishCheckpointAction should not hit primary shards");
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/indices/replication/checkpoint/PublishCheckpointAction.java
+++ b/server/src/main/java/org/opensearch/indices/replication/checkpoint/PublishCheckpointAction.java
@@ -146,6 +146,7 @@ public class PublishCheckpointAction extends TransportReplicationAction<
                                 timer.time()
                             )
                         );
+                        task.setPhase("finished");
                         taskManager.unregister(task);
                     }
 

--- a/server/src/test/java/org/opensearch/indices/replication/checkpoint/PublishCheckpointActionTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/checkpoint/PublishCheckpointActionTests.java
@@ -8,9 +8,9 @@
 
 package org.opensearch.indices.replication.checkpoint;
 
+import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
-import org.opensearch.action.support.ActionTestUtils;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.support.replication.ReplicationMode;
 import org.opensearch.action.support.replication.TransportReplicationAction;
@@ -33,7 +33,6 @@ import org.opensearch.transport.TransportService;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
@@ -105,14 +104,9 @@ public class PublishCheckpointActionTests extends OpenSearchTestCase {
         );
 
         final ReplicationCheckpoint checkpoint = new ReplicationCheckpoint(indexShard.shardId(), 1111, 111, 11, 1);
-
         final PublishCheckpointRequest request = new PublishCheckpointRequest(checkpoint);
 
-        action.shardOperationOnPrimary(request, indexShard, ActionTestUtils.assertNoFailureListener(result -> {
-            // we should forward the request containing the current publish checkpoint to the replica
-            assertThat(result.replicaRequest(), sameInstance(request));
-        }));
-
+        expectThrows(OpenSearchException.class, () -> { action.shardOperationOnPrimary(request, indexShard, mock(ActionListener.class)); });
     }
 
     public void testPublishCheckpointActionOnReplica() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change fixes broken SegmentReplicationRelocationITs and unmutes them.  The cause of the flaky tests is WAIT_UNTIL requests blocking relocation of primary shards because replicas have not refreshed.  The issue is that primary shards cannot publish their checkpoints because PublishCheckpointAction is a ReplicationOperation, that first hits the primary and acquires a permit.  Given we are blocking operations, the permit is delayed and the request never succeeds.  This fixes the issue by ensuring PublishCheckpoint requests are not sent to the primary, and only to replicas within the replication group directly.

### Issues Resolved
closes https://github.com/opensearch-project/OpenSearch/issues/6065

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
