### PR TITLE
[Segment Replication] Wait for segment replication to be completed and marked done before assertion

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationStatsIT.java
@@ -18,10 +18,9 @@ import org.opensearch.test.transport.MockTransportService;
 import org.opensearch.transport.TransportService;
 
 import java.util.concurrent.CountDownLatch;
-
-import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.equalTo;
+import java.util.concurrent.TimeUnit;
 import static org.hamcrest.Matchers.greaterThan;
+import static java.util.Arrays.asList;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class SegmentReplicationStatsIT extends SegmentReplicationBaseIT {
@@ -40,15 +39,17 @@ public class SegmentReplicationStatsIT extends SegmentReplicationBaseIT {
         refresh(INDEX_NAME);
         waitForSearchableDocs(10L, asList(primaryNode, replicaNode));
 
-        SegmentReplicationStatsResponse response = client().admin()
+        assertBusy(()-> {
+            final SegmentReplicationStatsResponse response = client().admin()
             .indices()
             .prepareSegmentReplicationStats(INDEX_NAME)
             .execute()
             .actionGet();
-        // Verify API Response
-        assertThat(response.shardSegmentReplicationStates().size(), equalTo(SHARD_COUNT));
-        assertThat(response.shardSegmentReplicationStates().get(INDEX_NAME).get(0).getStage(), equalTo(SegmentReplicationState.Stage.DONE));
-        assertThat(response.shardSegmentReplicationStates().get(INDEX_NAME).get(0).getIndex().recoveredFileCount(), greaterThan(0));
+            // Verify API Response
+            assertEquals(response.shardSegmentReplicationStates().size(), SHARD_COUNT);
+            assertEquals(response.shardSegmentReplicationStates().get(INDEX_NAME).get(0).getStage(), SegmentReplicationState.Stage.DONE);
+            assertTrue(response.shardSegmentReplicationStates().get(INDEX_NAME).get(0).getIndex().recoveredFileCount() > 0);
+        });
     }
 
     public void testSegmentReplicationStatsResponseForActiveAndCompletedOnly() throws Exception {
@@ -105,9 +106,9 @@ public class SegmentReplicationStatsIT extends SegmentReplicationBaseIT {
             .setActiveOnly(true)
             .execute()
             .actionGet();
-        assertThat(
+        assertEquals(
             activeOnlyResponse.shardSegmentReplicationStates().get(INDEX_NAME).get(0).getStage(),
-            equalTo(SegmentReplicationState.Stage.GET_FILES)
+            SegmentReplicationState.Stage.GET_FILES
         );
 
         // verifying completed_only by checking if current stage is DONE
@@ -117,10 +118,10 @@ public class SegmentReplicationStatsIT extends SegmentReplicationBaseIT {
             .setCompletedOnly(true)
             .execute()
             .actionGet();
-        assertThat(completedOnlyResponse.shardSegmentReplicationStates().size(), equalTo(SHARD_COUNT));
-        assertThat(
+        assertEquals(completedOnlyResponse.shardSegmentReplicationStates().size(), SHARD_COUNT);
+        assertEquals(
             completedOnlyResponse.shardSegmentReplicationStates().get(INDEX_NAME).get(0).getStage(),
-            equalTo(SegmentReplicationState.Stage.DONE)
+            SegmentReplicationState.Stage.DONE
         );
         waitForAssertions.countDown();
     }

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationStatsIT.java
@@ -18,8 +18,6 @@ import org.opensearch.test.transport.MockTransportService;
 import org.opensearch.transport.TransportService;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import static org.hamcrest.Matchers.greaterThan;
 import static java.util.Arrays.asList;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
@@ -39,12 +37,12 @@ public class SegmentReplicationStatsIT extends SegmentReplicationBaseIT {
         refresh(INDEX_NAME);
         waitForSearchableDocs(10L, asList(primaryNode, replicaNode));
 
-        assertBusy(()-> {
+        assertBusy(() -> {
             final SegmentReplicationStatsResponse response = client().admin()
-            .indices()
-            .prepareSegmentReplicationStats(INDEX_NAME)
-            .execute()
-            .actionGet();
+                .indices()
+                .prepareSegmentReplicationStats(INDEX_NAME)
+                .execute()
+                .actionGet();
             // Verify API Response
             assertEquals(response.shardSegmentReplicationStates().size(), SHARD_COUNT);
             assertEquals(response.shardSegmentReplicationStates().get(INDEX_NAME).get(0).getStage(), SegmentReplicationState.Stage.DONE);


### PR DESCRIPTION
### Description
This change fixes the flakyness in `testSegmentReplicationStatsResponse` happening due to race condition where segment replication does not complete before fetching `SegmentReplicationStatsResponse` response. The change waits for segment replication to complete before assertions. The change also removes deprecated `assertThat`.

Sample unstable gradle check: https://build.ci.opensearch.org/job/gradle-check/11323/  

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/5669

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
