### PR TITLE
[Remote Store] Create empty lucene index during restore if remote segment store is empty

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -175,7 +175,6 @@ public class RemoteStoreIT extends OpenSearchIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/6291")
     public void testRemoteSegmentStoreRestoreWithNoDataPostCommit() throws IOException {
         testRestoreFlow(false, 1, true);
     }

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -457,6 +457,9 @@ final class StoreRecovery {
             // Download segments from remote segment store
             indexShard.syncSegmentsFromRemoteSegmentStore(true);
 
+            if (store.directory().listAll().length == 0) {
+                store.createEmpty(indexShard.indexSettings().getIndexVersionCreated().luceneVersion);
+            }
             if (repository != null) {
                 syncTranslogFilesFromRemoteTranslog(indexShard, repository);
             } else {


### PR DESCRIPTION
### Description
- Currently, restoring an index with no data in remote segment store fails.
- Ideally, restore should create an empty index if there is no data in remote segment store.

### Issues Resolved
- https://github.com/opensearch-project/OpenSearch/issues/6291

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
