### PR TITLE
[Backport] [2.x] Bump com.diffplug.spotless from 6.11.0 to 6.15.0 (#6379)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bumps `azure-core-http-netty` from 1.12.7 to 1.12.8 ([#6304](https://github.com/opensearch-project/OpenSearch/pull/6304))
 - Bumps `com.azure:azure-storage-common` from 12.18.1 to 12.19.3 ([#6304](https://github.com/opensearch-project/OpenSearch/pull/6304))
 - Bumps `reactor-netty-http` from 1.0.24 to 1.1.2 ([#6309](https://github.com/opensearch-project/OpenSearch/pull/6309))
- 
+- Bumps `com.diffplug.spotless` from 6.10.0 to 6.15.0 ([#6385](https://github.com/opensearch-project/OpenSearch/pull/6385))
+
 ### Changed
 - Use ReplicationFailedException instead of OpensearchException in ReplicationTarget ([#4725](https://github.com/opensearch-project/OpenSearch/pull/4725))
 - [Refactor] Use local opensearch.common.SetOnce instead of lucene's utility class ([#5947](https://github.com/opensearch-project/OpenSearch/pull/5947))

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ plugins {
   id 'lifecycle-base'
   id 'opensearch.docker-support'
   id 'opensearch.global-build-info'
-  id "com.diffplug.spotless" version "6.11.0" apply false
+  id "com.diffplug.spotless" version "6.15.0" apply false
   id "org.gradle.test-retry" version "1.5.1" apply false
   id "test-report-aggregation"
   id 'jacoco-report-aggregation'


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/6379 to `2.x`