### PR TITLE
Opensearch repository-s3 plugin cannot read ServiceAccount token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix weighted shard routing state across search requests([#6004](https://github.com/opensearch-project/OpenSearch/pull/6004))
 - [Segment Replication] Fix bug where inaccurate sequence numbers are sent during replication ([#6122](https://github.com/opensearch-project/OpenSearch/pull/6122))
 - Enable numeric sort optimisation for few numerical sort types ([#6321](https://github.com/opensearch-project/OpenSearch/pull/6321))
+- Fix Opensearch repository-s3 plugin cannot read ServiceAccount token ([#6390](https://github.com/opensearch-project/OpenSearch/pull/6390)
 
 ### Security
 

--- a/plugins/repository-s3/src/internalClusterTest/java/org/opensearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/plugins/repository-s3/src/internalClusterTest/java/org/opensearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -58,6 +58,7 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -149,8 +150,8 @@ public class S3BlobStoreRepositoryTests extends OpenSearchMockAPIBasedRepository
      */
     public static class TestS3RepositoryPlugin extends S3RepositoryPlugin {
 
-        public TestS3RepositoryPlugin(final Settings settings) {
-            super(settings);
+        public TestS3RepositoryPlugin(final Settings settings, final Path configPath) {
+            super(settings, configPath);
         }
 
         @Override

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3RepositoryPlugin.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3RepositoryPlugin.java
@@ -47,6 +47,7 @@ import org.opensearch.plugins.RepositoryPlugin;
 import org.opensearch.repositories.Repository;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
@@ -77,15 +78,17 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin, Relo
     }
 
     protected final S3Service service;
+    private final Path configPath;
 
-    public S3RepositoryPlugin(final Settings settings) {
-        this(settings, new S3Service());
+    public S3RepositoryPlugin(final Settings settings, final Path configPath) {
+        this(settings, configPath, new S3Service(configPath));
     }
 
-    S3RepositoryPlugin(final Settings settings, final S3Service service) {
+    S3RepositoryPlugin(final Settings settings, final Path configPath, final S3Service service) {
         this.service = Objects.requireNonNull(service, "S3 service must not be null");
+        this.configPath = configPath;
         // eagerly load client settings so that secure settings are read
-        final Map<String, S3ClientSettings> clientsSettings = S3ClientSettings.load(settings);
+        final Map<String, S3ClientSettings> clientsSettings = S3ClientSettings.load(settings, configPath);
         this.service.refreshAndClearCache(clientsSettings);
     }
 
@@ -142,7 +145,7 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin, Relo
     @Override
     public void reload(Settings settings) {
         // secure settings should be readable
-        final Map<String, S3ClientSettings> clientsSettings = S3ClientSettings.load(settings);
+        final Map<String, S3ClientSettings> clientsSettings = S3ClientSettings.load(settings, configPath);
         service.refreshAndClearCache(clientsSettings);
     }
 

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Service.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Service.java
@@ -72,6 +72,7 @@ import java.net.InetSocketAddress;
 import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.net.Socket;
+import java.nio.file.Path;
 import java.security.SecureRandom;
 import java.util.Map;
 
@@ -90,15 +91,19 @@ class S3Service implements Closeable {
     /**
      * Client settings calculated from static configuration and settings in the keystore.
      */
-    private volatile Map<String, S3ClientSettings> staticClientSettings = MapBuilder.<String, S3ClientSettings>newMapBuilder()
-        .put("default", S3ClientSettings.getClientSettings(Settings.EMPTY, "default"))
-        .immutableMap();
+    private volatile Map<String, S3ClientSettings> staticClientSettings;
 
     /**
      * Client settings derived from those in {@link #staticClientSettings} by combining them with settings
      * in the {@link RepositoryMetadata}.
      */
     private volatile Map<Settings, S3ClientSettings> derivedClientSettings = emptyMap();
+
+    S3Service(final Path configPath) {
+        staticClientSettings = MapBuilder.<String, S3ClientSettings>newMapBuilder()
+            .put("default", S3ClientSettings.getClientSettings(Settings.EMPTY, "default", configPath))
+            .immutableMap();
+    }
 
     /**
      * Refreshes the settings for the AmazonS3 clients and clears the cache of

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/AwsS3ServiceImplTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/AwsS3ServiceImplTests.java
@@ -39,14 +39,12 @@ import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.http.IdleConnectionReaper;
 
 import org.junit.AfterClass;
-import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.settings.MockSecureSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -57,7 +55,7 @@ import static org.hamcrest.Matchers.is;
 import static org.opensearch.repositories.s3.S3ClientSettings.PROTOCOL_SETTING;
 import static org.opensearch.repositories.s3.S3ClientSettings.PROXY_TYPE_SETTING;
 
-public class AwsS3ServiceImplTests extends OpenSearchTestCase {
+public class AwsS3ServiceImplTests extends OpenSearchTestCase implements ConfigPathSupport {
     @AfterClass
     public static void shutdownIdleConnectionReaper() {
         // created by default STS client
@@ -367,9 +365,5 @@ public class AwsS3ServiceImplTests extends OpenSearchTestCase {
         final String configName = S3Repository.CLIENT_NAME.get(repositorySettings);
         final S3ClientSettings clientSettings = S3ClientSettings.getClientSettings(settings, configName, configPath());
         assertThat(clientSettings.endpoint, is(expectedEndpoint));
-    }
-
-    private Path configPath() {
-        return PathUtils.get("config");
     }
 }

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/ConfigPathSupport.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/ConfigPathSupport.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.repositories.s3;
+
+import org.opensearch.common.io.PathUtils;
+
+import java.nio.file.Path;
+
+/**
+ * The trait that adds the config path to the test cases
+ */
+interface ConfigPathSupport {
+    default Path configPath() {
+        return PathUtils.get("config");
+    }
+}

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/RepositoryCredentialsTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/RepositoryCredentialsTests.java
@@ -57,6 +57,7 @@ import org.opensearch.rest.action.admin.cluster.RestGetRepositoriesAction;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 import org.opensearch.test.rest.FakeRestRequest;
 
+import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collection;
@@ -284,8 +285,8 @@ public class RepositoryCredentialsTests extends OpenSearchSingleNodeTestCase {
      */
     public static final class ProxyS3RepositoryPlugin extends S3RepositoryPlugin {
 
-        public ProxyS3RepositoryPlugin(Settings settings) {
-            super(settings, new ProxyS3Service());
+        public ProxyS3RepositoryPlugin(Settings settings, Path configPath) {
+            super(settings, configPath, new ProxyS3Service(configPath));
         }
 
         @Override
@@ -315,6 +316,10 @@ public class RepositoryCredentialsTests extends OpenSearchSingleNodeTestCase {
         public static final class ProxyS3Service extends S3Service {
 
             private static final Logger logger = LogManager.getLogger(ProxyS3Service.class);
+
+            ProxyS3Service(final Path configPath) {
+                super(configPath);
+            }
 
             @Override
             AmazonS3WithCredentials buildClient(final S3ClientSettings clientSettings) {

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3BlobContainerRetriesTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3BlobContainerRetriesTests.java
@@ -41,6 +41,7 @@ import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.blobstore.BlobContainer;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.io.Streams;
 import org.opensearch.common.lucene.store.ByteArrayIndexInput;
 import org.opensearch.common.lucene.store.InputStreamIndexInput;
@@ -63,6 +64,7 @@ import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -87,7 +89,7 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
 
     @Before
     public void setUp() throws Exception {
-        service = new S3Service();
+        service = new S3Service(configPath());
         super.setUp();
     }
 
@@ -140,7 +142,7 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
         secureSettings.setString(S3ClientSettings.ACCESS_KEY_SETTING.getConcreteSettingForNamespace(clientName).getKey(), "access");
         secureSettings.setString(S3ClientSettings.SECRET_KEY_SETTING.getConcreteSettingForNamespace(clientName).getKey(), "secret");
         clientSettings.setSecureSettings(secureSettings);
-        service.refreshAndClearCache(S3ClientSettings.load(clientSettings.build()));
+        service.refreshAndClearCache(S3ClientSettings.load(clientSettings.build(), configPath()));
 
         final RepositoryMetadata repositoryMetadata = new RepositoryMetadata(
             "repository",
@@ -400,5 +402,9 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
                 assertThat(((ByteArrayInputStream) in).available(), equalTo(0));
             }
         }
+    }
+
+    private Path configPath() {
+        return PathUtils.get("config");
     }
 }

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3BlobContainerRetriesTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3BlobContainerRetriesTests.java
@@ -41,7 +41,6 @@ import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.blobstore.BlobContainer;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.bytes.BytesReference;
-import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.io.Streams;
 import org.opensearch.common.lucene.store.ByteArrayIndexInput;
 import org.opensearch.common.lucene.store.InputStreamIndexInput;
@@ -64,7 +63,6 @@ import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -83,7 +81,7 @@ import static org.hamcrest.Matchers.is;
  * This class tests how a {@link S3BlobContainer} and its underlying AWS S3 client are retrying requests when reading or writing blobs.
  */
 @SuppressForbidden(reason = "use a http server")
-public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTestCase {
+public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTestCase implements ConfigPathSupport {
 
     private S3Service service;
 
@@ -402,9 +400,5 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
                 assertThat(((ByteArrayInputStream) in).available(), equalTo(0));
             }
         }
-    }
-
-    private Path configPath() {
-        return PathUtils.get("config");
     }
 }

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3ClientSettingsTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3ClientSettingsTests.java
@@ -36,7 +36,6 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Protocol;
 import com.amazonaws.services.s3.AmazonS3Client;
 
-import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.settings.MockSecureSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsException;
@@ -44,7 +43,6 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.nio.file.Path;
 import java.util.Locale;
 import java.util.Map;
 
@@ -54,7 +52,7 @@ import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-public class S3ClientSettingsTests extends OpenSearchTestCase {
+public class S3ClientSettingsTests extends OpenSearchTestCase implements ConfigPathSupport {
     public void testThereIsADefaultClientByDefault() {
         final Map<String, S3ClientSettings> settings = S3ClientSettings.load(Settings.EMPTY, configPath());
         assertThat(settings.keySet(), contains("default"));
@@ -374,9 +372,5 @@ public class S3ClientSettingsTests extends OpenSearchTestCase {
             .put("s3.client.default.proxy.type", "socks")
             .build();
         expectThrows(SettingsException.class, () -> S3ClientSettings.load(settings, configPath()));
-    }
-
-    private Path configPath() {
-        return PathUtils.get("config");
     }
 }

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3RepositoryTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3RepositoryTests.java
@@ -34,6 +34,7 @@ package org.opensearch.repositories.s3;
 
 import com.amazonaws.services.s3.AbstractAmazonS3;
 import org.opensearch.cluster.metadata.RepositoryMetadata;
+import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.ByteSizeUnit;
@@ -45,6 +46,7 @@ import org.opensearch.repositories.blobstore.BlobStoreTestUtil;
 import org.opensearch.test.OpenSearchTestCase;
 import org.hamcrest.Matchers;
 
+import java.nio.file.Path;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
@@ -63,6 +65,10 @@ public class S3RepositoryTests extends OpenSearchTestCase {
     }
 
     private static class DummyS3Service extends S3Service {
+        DummyS3Service(final Path configPath) {
+            super(configPath);
+        }
+
         @Override
         public AmazonS3Reference client(RepositoryMetadata repositoryMetadata) {
             return new AmazonS3Reference(new DummyS3Client());
@@ -139,7 +145,7 @@ public class S3RepositoryTests extends OpenSearchTestCase {
         return new S3Repository(
             metadata,
             NamedXContentRegistry.EMPTY,
-            new DummyS3Service(),
+            new DummyS3Service(configPath()),
             BlobStoreTestUtil.mockClusterService(),
             new RecoverySettings(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS))
         ) {
@@ -148,5 +154,9 @@ public class S3RepositoryTests extends OpenSearchTestCase {
                 // eliminate thread name check as we create repo manually on test/main threads
             }
         };
+    }
+
+    private Path configPath() {
+        return PathUtils.get("config");
     }
 }

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3RepositoryTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3RepositoryTests.java
@@ -34,7 +34,6 @@ package org.opensearch.repositories.s3;
 
 import com.amazonaws.services.s3.AbstractAmazonS3;
 import org.opensearch.cluster.metadata.RepositoryMetadata;
-import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.ByteSizeUnit;
@@ -54,7 +53,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
-public class S3RepositoryTests extends OpenSearchTestCase {
+public class S3RepositoryTests extends OpenSearchTestCase implements ConfigPathSupport {
 
     private static class DummyS3Client extends AbstractAmazonS3 {
 
@@ -154,9 +153,5 @@ public class S3RepositoryTests extends OpenSearchTestCase {
                 // eliminate thread name check as we create repo manually on test/main threads
             }
         };
-    }
-
-    private Path configPath() {
-        return PathUtils.get("config");
     }
 }

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3ServiceTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3ServiceTests.java
@@ -32,15 +32,13 @@
 package org.opensearch.repositories.s3;
 
 import org.opensearch.cluster.metadata.RepositoryMetadata;
-import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.settings.MockSecureSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 
-import java.nio.file.Path;
 import java.util.Map;
 
-public class S3ServiceTests extends OpenSearchTestCase {
+public class S3ServiceTests extends OpenSearchTestCase implements ConfigPathSupport {
 
     public void testCachedClientsAreReleased() {
         final S3Service s3Service = new S3Service(configPath());
@@ -85,9 +83,5 @@ public class S3ServiceTests extends OpenSearchTestCase {
         s3Service.close();
         final S3ClientSettings clientSettingsReloaded = s3Service.settings(metadata1);
         assertNotSame(clientSettings, clientSettingsReloaded);
-    }
-
-    private Path configPath() {
-        return PathUtils.get("config");
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Allow to specify the identity web token file relatively to the `config` folder location (configured by `OPENSEARCH_PATH_CONFIG` so it would be possible to use soft links to access it):

```
ln -s $AWS_WEB_IDENTITY_TOKEN_FILE "${OPENSEARCH_PATH_CONFIG}/aws-web-identity-token-file"
```

And refer to it in `opensearch.yml`:
```
s3.client.default.identity_token_file: aws-web-identity-token-file
```

### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/6312

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
