### PR TITLE
Add workflow to publish maven snapshots

### DIFF
--- a/.github/workflows/publish-maven-snapshots.yml
+++ b/.github/workflows/publish-maven-snapshots.yml
@@ -1,0 +1,39 @@
+name: Publish snapshots to maven
+
+on:
+  workflow_dispatch:
+  push:
+      branches:
+        - main
+        - '1.3'
+        - 2.x
+
+jobs:
+  build-and-publish-snapshots:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: adopt
+          java-version: 17
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
+          aws-region: us-east-1
+
+      - name: Publish snapshots to maven
+        run: |
+          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
+          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
+          echo "::add-mask::$SONATYPE_USERNAME"
+          echo "::add-mask::$SONATYPE_PASSWORD"
+          ./gradlew publishNebulaPublicationToSnapshotsRepository


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adds workflow to publish snapshots to maven

gist of what snapshots publication will look like:
```
find snapshots | sort
snapshots
snapshots/org
snapshots/org/opensearch
snapshots/org/opensearch/client
snapshots/org/opensearch/client/client-benchmarks
snapshots/org/opensearch/client/client-benchmarks/3.0.0-SNAPSHOT
snapshots/org/opensearch/client/client-benchmarks/3.0.0-SNAPSHOT/client-benchmarks-3.0.0-20230220.235219-1-javadoc.jar
snapshots/org/opensearch/client/client-benchmarks/3.0.0-SNAPSHOT/client-benchmarks-3.0.0-20230220.235219-1-javadoc.jar.md5
snapshots/org/opensearch/client/client-benchmarks/3.0.0-SNAPSHOT/client-benchmarks-3.0.0-20230220.235219-1-javadoc.jar.sha1
snapshots/org/opensearch/client/client-benchmarks/3.0.0-SNAPSHOT/client-benchmarks-3.0.0-20230220.235219-1-javadoc.jar.sha256
snapshots/org/opensearch/client/client-benchmarks/3.0.0-SNAPSHOT/client-benchmarks-3.0.0-20230220.235219-1-javadoc.jar.sha512
snapshots/org/opensearch/client/client-benchmarks/3.0.0-SNAPSHOT/client-benchmarks-3.0.0-20230220.235219-1-sources.jar
snapshots/org/opensearch/client/client-benchmarks/3.0.0-SNAPSHOT/client-benchmarks-3.0.0-20230220.235219-1-sources.jar.md5
snapshots/org/opensearch/client/client-benchmarks/3.0.0-SNAPSHOT/client-benchmarks-3.0.0-20230220.235219-1-sources.jar.sha1
snapshots/org/opensearch/client/client-benchmarks/3.0.0-SNAPSHOT/client-benchmarks-3.0.0-20230220.235219-1-sources.jar.sha256
snapshots/org/opensearch/client/client-benchmarks/3.0.0-SNAPSHOT/client-benchmarks-3.0.0-20230220.235219-1-sources.jar.sha512
.....
.....
.....
snapshots/org/opensearch/wildfly/3.0.0-SNAPSHOT/wildfly-3.0.0-20230220.235219-1.war.sha256
snapshots/org/opensearch/wildfly/3.0.0-SNAPSHOT/wildfly-3.0.0-20230220.235219-1.war.sha512
snapshots/org/opensearch/wildfly/maven-metadata.xml
snapshots/org/opensearch/wildfly/maven-metadata.xml.md5
snapshots/org/opensearch/wildfly/maven-metadata.xml.sha1
snapshots/org/opensearch/wildfly/maven-metadata.xml.sha256
snapshots/org/opensearch/wildfly/maven-metadata.xml.sha512
```

### Issues Resolved
resolves https://github.com/opensearch-project/OpenSearch/issues/6365

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
