### PR TITLE
Revert "Clean up temporary files created during segment merge incase …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Segment Replication] Add primary weight factor for balanced primary distribution ([#6017](https://github.com/opensearch-project/OpenSearch/pull/6017))
 - Add a setting to control auto release of OpenSearch managed index creation block ([#6277](https://github.com/opensearch-project/OpenSearch/pull/6277))
 - Fix timeout error when adding a document to an index with extension running ([#6275](https://github.com/opensearch-project/OpenSearch/pull/6275))
-- Clean up temporary files created during segment merge incase segment merge fails ([#6324](https://github.com/opensearch-project/OpenSearch/pull/6324))
 
 ### Dependencies
 - Update nebula-publishing-plugin to 19.2.0 ([#5704](https://github.com/opensearch-project/OpenSearch/pull/5704))

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -2010,7 +2010,6 @@ public class InternalEngine extends Engine {
         } catch (Exception e) {
             try {
                 maybeFailEngine("force merge", e);
-                indexWriter.flush();
             } catch (Exception inner) {
                 e.addSuppressed(inner);
             }

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -3857,7 +3857,6 @@ public class InternalEngineTests extends EngineTestCase {
 
     private static class ThrowingIndexWriter extends IndexWriter {
         private AtomicReference<Supplier<Exception>> failureToThrow = new AtomicReference<>();
-        private AtomicReference<Supplier<Exception>> forceMergeFailureToThrow = new AtomicReference<>();
 
         ThrowingIndexWriter(Directory d, IndexWriterConfig conf) throws IOException {
             super(d, conf);
@@ -3865,13 +3864,13 @@ public class InternalEngineTests extends EngineTestCase {
 
         @Override
         public long addDocument(Iterable<? extends IndexableField> doc) throws IOException {
-            maybeThrowFailure(failureToThrow.get());
+            maybeThrowFailure();
             return super.addDocument(doc);
         }
 
-        private void maybeThrowFailure(Supplier<Exception> failureToThrow) throws IOException {
-            if (failureToThrow != null) {
-                Exception failure = failureToThrow.get();
+        private void maybeThrowFailure() throws IOException {
+            if (failureToThrow.get() != null) {
+                Exception failure = failureToThrow.get().get();
                 clearFailure(); // one shot
                 if (failure instanceof RuntimeException) {
                     throw (RuntimeException) failure;
@@ -3885,39 +3884,22 @@ public class InternalEngineTests extends EngineTestCase {
 
         @Override
         public long softUpdateDocument(Term term, Iterable<? extends IndexableField> doc, Field... softDeletes) throws IOException {
-            maybeThrowFailure(failureToThrow.get());
+            maybeThrowFailure();
             return super.softUpdateDocument(term, doc, softDeletes);
         }
 
         @Override
         public long deleteDocuments(Term... terms) throws IOException {
-            maybeThrowFailure(failureToThrow.get());
+            maybeThrowFailure();
             return super.deleteDocuments(terms);
-        }
-
-        @Override
-        public void forceMerge(int maxNumSegments) throws IOException {
-            maybeThrowFailure(forceMergeFailureToThrow.get());
-            super.forceMerge(maxNumSegments);
-        }
-
-        @Override
-        public void forceMerge(int maxNumSegments, boolean doWait) throws IOException {
-            maybeThrowFailure(forceMergeFailureToThrow.get());
-            super.forceMerge(maxNumSegments, doWait);
         }
 
         public void setThrowFailure(Supplier<Exception> failureSupplier) {
             failureToThrow.set(failureSupplier);
         }
 
-        public void setForceMergeThrowFailure(Supplier<Exception> failureSupplier) {
-            forceMergeFailureToThrow.set(failureSupplier);
-        }
-
         public void clearFailure() {
             failureToThrow.set(null);
-            forceMergeFailureToThrow.set(null);
         }
     }
 
@@ -3991,37 +3973,6 @@ public class InternalEngineTests extends EngineTestCase {
                 );
             }
         }
-    }
-
-    public void testHandleForceMergeFailureOnDiskFull() throws Exception {
-        try (Store store = createStore()) {
-            AtomicReference<ThrowingIndexWriter> throwingIndexWriter = new AtomicReference<>();
-            AtomicReference<Directory> dir = new AtomicReference<>();
-            try (InternalEngine engine = createEngine(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE, (directory, iwc) -> {
-                dir.set(directory);
-                throwingIndexWriter.set(new ThrowingIndexWriter(directory, iwc));
-                return throwingIndexWriter.get();
-            })) {
-                throwingIndexWriter.get().setForceMergeThrowFailure(() -> new IOException("No space left on device"));
-                ParsedDocument doc = testParsedDocument(Integer.toString(0), null, testDocumentWithTextField(), SOURCE, null);
-                engine.index(indexForDoc(doc));
-                assertFalse(containsCompoundFiles(dir.get().listAll()));
-                engine.ensureOpen();
-                expectThrows(IOException.class, () -> engine.forceMerge(false, 1, false, false, false, UUIDs.randomBase64UUID()));
-                // Index writer flush gets called when forceMerge fails
-                assertTrue(containsCompoundFiles(dir.get().listAll()));
-            }
-        }
-    }
-
-    private boolean containsCompoundFiles(final String files[]) {
-        for (final String file : files) {
-            if (file.endsWith(".cfs") || file.endsWith(".cfe")) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     public void testDeleteWithFatalError() throws Exception {


### PR DESCRIPTION
…segment merge fails"

This reverts commit d15e6288f4e8caa59b876ee802ab30bfd1bf0acd.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Reverting the commit to delete temp files incase segment merge fails. The flush call was failing incase Lucene closes the ```IndexWriter``` before the call. Will re raise the PR for this fix after handling all the race condition scenarioes correctly.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/5710

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
