### PR TITLE
[Fix] Fixing the condition to remove a node over high disk watermark in DiskThresholdMonitor

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -264,8 +264,6 @@ public class DiskThresholdMonitor {
                         if (lastRunTimeMillis.get() <= currentTimeMillis - diskThresholdSettings.getRerouteInterval().millis()) {
                             reroute = true;
                             explanation = "one or more nodes has gone under the high or low watermark";
-                            nodesOverLowThreshold.remove(node);
-                            nodesOverHighThreshold.remove(node);
 
                             logger.info(
                                 "low disk watermark [{}] no longer exceeded on {}",
@@ -281,6 +279,9 @@ public class DiskThresholdMonitor {
                                 diskThresholdSettings.getRerouteInterval()
                             );
                         }
+
+                        nodesOverLowThreshold.remove(node);
+                        nodesOverHighThreshold.remove(node);
                     }
 
                 }


### PR DESCRIPTION
…kThresholdMonitor

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixing the condition to remove a node over high disk watermark in DiskThresholdMonitor.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/4456

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
