### PR TITLE
[Fix] Fix last runtime millisec reset when applying index create block

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -375,7 +375,8 @@ public class DiskThresholdMonitor {
         }
 
         // If all the nodes are breaching high disk watermark, we apply index create block to avoid red clusters.
-        if (nodesOverHighThreshold.size() == nodes.size()) {
+        if ((state.getBlocks().hasGlobalBlockWithId(Metadata.CLUSTER_CREATE_INDEX_BLOCK.id()) == false)
+            && nodesOverHighThreshold.size() == nodes.size()) {
             setIndexCreateBlock(listener, true);
         } else if (state.getBlocks().hasGlobalBlockWithId(Metadata.CLUSTER_CREATE_INDEX_BLOCK.id())
             && diskThresholdSettings.isCreateIndexBlockAutoReleaseEnabled()) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
DiskThresholdMonitor was resetting last runtime millisecond every time high disk watermark breaches on all nodes. This change ensure that last runtime millisecond is reset only in the first iteration.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/4456

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
