### PR TITLE
Revert "[Backport 2.x] Require MediaType in Strings.toString API (#6009) (#6414)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Refactor] core.common to new opensearch-common library ([#5976](https://github.com/opensearch-project/OpenSearch/pull/5976))
 - Update API spec for cluster health API ([#6399](https://github.com/opensearch-project/OpenSearch/pull/6399))
 - Remove deprecated org.gradle.util.DistributionLocator usage ([#6212](https://github.com/opensearch-project/OpenSearch/pull/6212))
-- Require MediaType in Strings.toString API ([#6009](https://github.com/opensearch-project/OpenSearch/pull/6009))
 
 ### Deprecated
 

--- a/client/rest-high-level/src/main/java/org/opensearch/client/slm/SnapshotLifecyclePolicy.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/slm/SnapshotLifecyclePolicy.java
@@ -39,7 +39,6 @@ import org.opensearch.common.xcontent.ConstructingObjectParser;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Map;
@@ -169,6 +168,6 @@ public class SnapshotLifecyclePolicy implements ToXContentObject {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/client/rest-high-level/src/main/java/org/opensearch/client/slm/SnapshotLifecyclePolicyMetadata.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/slm/SnapshotLifecyclePolicyMetadata.java
@@ -39,7 +39,6 @@ import org.opensearch.common.xcontent.ConstructingObjectParser;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.snapshots.SnapshotId;
 
 import java.io.IOException;
@@ -289,7 +288,7 @@ public class SnapshotLifecyclePolicyMetadata implements ToXContentObject {
 
         @Override
         public String toString() {
-            return Strings.toString(XContentType.JSON, this);
+            return Strings.toString(this);
         }
     }
 }

--- a/client/rest-high-level/src/main/java/org/opensearch/client/slm/SnapshotLifecycleStats.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/slm/SnapshotLifecycleStats.java
@@ -40,7 +40,6 @@ import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -188,7 +187,7 @@ public class SnapshotLifecycleStats implements ToXContentObject {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     public static class SnapshotPolicyStats implements ToXContentFragment {

--- a/client/rest-high-level/src/main/java/org/opensearch/client/slm/SnapshotRetentionConfiguration.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/slm/SnapshotRetentionConfiguration.java
@@ -40,7 +40,6 @@ import org.opensearch.common.xcontent.ConstructingObjectParser;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -151,6 +150,6 @@ public class SnapshotRetentionConfiguration implements ToXContentObject {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/distribution/archives/integ-test-zip/src/test/java/org/opensearch/test/rest/NodeRestUsageIT.java
+++ b/distribution/archives/integ-test-zip/src/test/java/org/opensearch/test/rest/NodeRestUsageIT.java
@@ -36,7 +36,6 @@ import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.common.Strings;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
@@ -172,8 +171,8 @@ public class NodeRestUsageIT extends OpenSearchRestTestCase {
             .aggregation(AggregationBuilders.terms("str_terms").field("str.keyword"))
             .aggregation(AggregationBuilders.terms("num_terms").field("num"))
             .aggregation(AggregationBuilders.avg("num_avg").field("num"));
-        searchRequest.setJsonEntity(Strings.toString(XContentType.JSON, searchSource));
-        searchRequest.setJsonEntity(Strings.toString(XContentType.JSON, searchSource));
+        searchRequest.setJsonEntity(Strings.toString(searchSource));
+        searchRequest.setJsonEntity(Strings.toString(searchSource));
         client().performRequest(searchRequest);
 
         searchRequest = new Request("GET", "/test/_search");
@@ -182,8 +181,8 @@ public class NodeRestUsageIT extends OpenSearchRestTestCase {
             .aggregation(AggregationBuilders.avg("num1").field("num"))
             .aggregation(AggregationBuilders.avg("num2").field("num"))
             .aggregation(AggregationBuilders.terms("foo").field("foo.keyword"));
-        String r = Strings.toString(XContentType.JSON, searchSource);
-        searchRequest.setJsonEntity(Strings.toString(XContentType.JSON, searchSource));
+        String r = Strings.toString(searchSource);
+        searchRequest.setJsonEntity(Strings.toString(searchSource));
         client().performRequest(searchRequest);
 
         Response response = client().performRequest(new Request("GET", "_nodes/usage"));

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/MediaType.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/MediaType.java
@@ -62,6 +62,4 @@ public interface MediaType {
     default String typeWithSubtype() {
         return type() + "/" + subtype();
     }
-
-    XContent xContent();
 }

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentType.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/XContentType.java
@@ -190,6 +190,8 @@ public enum XContentType implements MediaType {
         return mediaTypeWithoutParameters();
     }
 
+    public abstract XContent xContent();
+
     public abstract String mediaTypeWithoutParameters();
 
     @Override

--- a/libs/x-content/src/test/java/org/opensearch/common/xcontent/SimpleStruct.java
+++ b/libs/x-content/src/test/java/org/opensearch/common/xcontent/SimpleStruct.java
@@ -101,6 +101,6 @@ class SimpleStruct implements ToXContentObject {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/modules/lang-mustache/src/main/java/org/opensearch/script/mustache/MultiSearchTemplateResponse.java
+++ b/modules/lang-mustache/src/main/java/org/opensearch/script/mustache/MultiSearchTemplateResponse.java
@@ -46,7 +46,6 @@ import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -207,6 +206,6 @@ public class MultiSearchTemplateResponse extends ActionResponse implements Itera
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
@@ -53,7 +53,6 @@ import org.apache.lucene.search.TermQuery;
 import org.opensearch.common.Strings;
 import org.opensearch.common.lucene.search.MultiPhrasePrefixQuery;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.analysis.AnalyzerScope;
 import org.opensearch.index.analysis.IndexAnalyzers;
@@ -610,7 +609,7 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
             b.field("type", "search_as_you_type");
             b.field("analyzer", "simple");
         }));
-        String serialized = Strings.toString(XContentType.JSON, ms.documentMapper());
+        String serialized = Strings.toString(ms.documentMapper());
         assertEquals(
             serialized,
             "{\"_doc\":{\"properties\":{\"field\":"
@@ -618,7 +617,7 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
         );
 
         merge(ms, mapping(b -> {}));
-        assertEquals(serialized, Strings.toString(XContentType.JSON, ms.documentMapper()));
+        assertEquals(serialized, Strings.toString(ms.documentMapper()));
     }
 
     private void documentParsingTestCase(Collection<String> values) throws IOException {

--- a/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/RankEvalResponse.java
+++ b/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/RankEvalResponse.java
@@ -44,7 +44,6 @@ import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParserUtils;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -106,7 +105,7 @@ public class RankEvalResponse extends ActionResponse implements ToXContentObject
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     @Override

--- a/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/RankEvalSpec.java
+++ b/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/RankEvalSpec.java
@@ -43,7 +43,6 @@ import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParserUtils;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.script.Script;
 
 import java.io.IOException;
@@ -250,7 +249,7 @@ public class RankEvalSpec implements Writeable, ToXContentObject {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     @Override

--- a/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/RatedDocument.java
+++ b/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/RatedDocument.java
@@ -41,7 +41,6 @@ import org.opensearch.common.xcontent.ConstructingObjectParser;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -129,7 +128,7 @@ public class RatedDocument implements Writeable, ToXContentObject {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     @Override

--- a/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/RatedRequest.java
+++ b/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/RatedRequest.java
@@ -42,7 +42,6 @@ import org.opensearch.common.xcontent.ConstructingObjectParser;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.rankeval.RatedDocument.DocumentKey;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
@@ -341,7 +340,7 @@ public class RatedRequest implements Writeable, ToXContentObject {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     @Override

--- a/modules/rank-eval/src/test/java/org/opensearch/index/rankeval/DiscountedCumulativeGainTests.java
+++ b/modules/rank-eval/src/test/java/org/opensearch/index/rankeval/DiscountedCumulativeGainTests.java
@@ -323,13 +323,10 @@ public class DiscountedCumulativeGainTests extends OpenSearchTestCase {
                     + ",\"unrated_docs\":"
                     + unratedDocs
                     + "}}",
-                Strings.toString(XContentType.JSON, detail)
+                Strings.toString(detail)
             );
         } else {
-            assertEquals(
-                "{\"dcg\":{\"dcg\":" + dcg + ",\"unrated_docs\":" + unratedDocs + "}}",
-                Strings.toString(XContentType.JSON, detail)
-            );
+            assertEquals("{\"dcg\":{\"dcg\":" + dcg + ",\"unrated_docs\":" + unratedDocs + "}}", Strings.toString(detail));
         }
     }
 

--- a/qa/full-cluster-restart/src/test/java/org/opensearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/opensearch/upgrades/FullClusterRestartIT.java
@@ -46,7 +46,6 @@ import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.common.xcontent.support.XContentMapValues;
 import org.opensearch.index.IndexSettings;
@@ -1373,7 +1372,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                 if (randomBoolean()) {
                     settings.put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true);
                 }
-                shrinkRequest.setJsonEntity("{\"settings\":" + Strings.toString(XContentType.JSON, settings.build()) + "}");
+                shrinkRequest.setJsonEntity("{\"settings\":" + Strings.toString(settings.build()) + "}");
                 client().performRequest(shrinkRequest);
                 ensureGreenLongWait(target);
                 assertNumHits(target, numDocs + moreDocs, 1);
@@ -1385,7 +1384,7 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                     settings.put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true);
                 }
                 Request splitRequest = new Request("PUT", "/" + index + "/_split/" + target);
-                splitRequest.setJsonEntity("{\"settings\":" + Strings.toString(XContentType.JSON, settings.build()) + "}");
+                splitRequest.setJsonEntity("{\"settings\":" + Strings.toString(settings.build()) + "}");
                 client().performRequest(splitRequest);
                 ensureGreenLongWait(target);
                 assertNumHits(target, numDocs + moreDocs, 6);

--- a/qa/multi-cluster-search/src/test/java/org/opensearch/search/CCSDuelIT.java
+++ b/qa/multi-cluster-search/src/test/java/org/opensearch/search/CCSDuelIT.java
@@ -726,7 +726,7 @@ public class CCSDuelIT extends OpenSearchRestTestCase {
         sourceBuilder.suggest(suggestBuilder);
         duelSearch(searchRequest, response -> {
             assertMultiClusterSearchResponse(response);
-            assertEquals(Strings.toString(XContentType.JSON, response, true, true), 3, response.getSuggest().size());
+            assertEquals(Strings.toString(response, true, true), 3, response.getSuggest().size());
             assertThat(response.getSuggest().getSuggestion("python").getEntries().size(), greaterThan(0));
             assertThat(response.getSuggest().getSuggestion("java").getEntries().size(), greaterThan(0));
             assertThat(response.getSuggest().getSuggestion("ruby").getEntries().size(), greaterThan(0));

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/MappingTypeRemovalIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/MappingTypeRemovalIT.java
@@ -19,7 +19,6 @@ import org.opensearch.client.Response;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.rest.RestStatus;
 
 import java.io.IOException;
@@ -204,7 +203,7 @@ public class MappingTypeRemovalIT extends AbstractRollingTestCase {
 
     private void createIndexWithDocMappings(String index, Settings settings, String mapping) throws IOException {
         Request createIndexWithMappingsRequest = new Request(HttpPut.METHOD_NAME, "/" + index);
-        String entity = "{\"settings\": " + Strings.toString(XContentType.JSON, settings);
+        String entity = "{\"settings\": " + Strings.toString(settings);
         if (mapping != null) {
             entity += ",\"mappings\" : {" + mapping + "}";
         }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/upgrades/RecoveryIT.java
@@ -45,7 +45,6 @@ import org.opensearch.common.Booleans;
 import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.AbstractRunnable;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.support.XContentMapValues;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.rest.RestStatus;
@@ -801,7 +800,7 @@ public class RecoveryIT extends AbstractRollingTestCase {
                 settings.put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), softDeletesEnabled);
             }
             Request request = new Request("PUT", "/" + indexName);
-            request.setJsonEntity("{\"settings\": " + Strings.toString(XContentType.JSON, settings.build()) + "}");
+            request.setJsonEntity("{\"settings\": " + Strings.toString(settings.build()) + "}");
             if (softDeletesEnabled == false) {
                 expectSoftDeletesWarning(request, indexName);
             }

--- a/qa/smoke-test-http/src/test/java/org/opensearch/http/SearchRestCancellationIT.java
+++ b/qa/smoke-test-http/src/test/java/org/opensearch/http/SearchRestCancellationIT.java
@@ -98,7 +98,7 @@ public class SearchRestCancellationIT extends HttpSmokeTestCase {
         Request searchRequest = new Request("GET", "/test/_search");
         SearchSourceBuilder searchSource = new SearchSourceBuilder().query(scriptQuery(
             new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.SCRIPT_NAME, Collections.emptyMap())));
-        searchRequest.setJsonEntity(Strings.toString(XContentType.JSON, searchSource));
+        searchRequest.setJsonEntity(Strings.toString(searchSource));
         verifyCancellationDuringQueryPhase(SearchAction.NAME, searchRequest);
     }
 
@@ -147,7 +147,7 @@ public class SearchRestCancellationIT extends HttpSmokeTestCase {
         Request searchRequest = new Request("GET", "/test/_search");
         SearchSourceBuilder searchSource = new SearchSourceBuilder().scriptField("test_field",
             new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.SCRIPT_NAME, Collections.emptyMap()));
-        searchRequest.setJsonEntity(Strings.toString(XContentType.JSON, searchSource));
+        searchRequest.setJsonEntity(Strings.toString(searchSource));
         verifyCancellationDuringFetchPhase(SearchAction.NAME, searchRequest);
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/action/bulk/BulkWithUpdatesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/bulk/BulkWithUpdatesIT.java
@@ -741,17 +741,13 @@ public class BulkWithUpdatesIT extends OpenSearchIntegTestCase {
 
         final BulkItemResponse noopUpdate = bulkResponse.getItems()[0];
         assertThat(noopUpdate.getResponse().getResult(), equalTo(DocWriteResponse.Result.NOOP));
-        assertThat(Strings.toString(XContentType.JSON, noopUpdate), noopUpdate.getResponse().getShardInfo().getSuccessful(), equalTo(2));
+        assertThat(Strings.toString(noopUpdate), noopUpdate.getResponse().getShardInfo().getSuccessful(), equalTo(2));
 
         final BulkItemResponse notFoundUpdate = bulkResponse.getItems()[1];
         assertNotNull(notFoundUpdate.getFailure());
 
         final BulkItemResponse notFoundDelete = bulkResponse.getItems()[2];
         assertThat(notFoundDelete.getResponse().getResult(), equalTo(DocWriteResponse.Result.NOT_FOUND));
-        assertThat(
-            Strings.toString(XContentType.JSON, notFoundDelete),
-            notFoundDelete.getResponse().getShardInfo().getSuccessful(),
-            equalTo(2)
-        );
+        assertThat(Strings.toString(notFoundDelete), notFoundDelete.getResponse().getShardInfo().getSuccessful(), equalTo(2));
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/PrimaryAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/PrimaryAllocationIT.java
@@ -51,7 +51,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.collect.ImmutableOpenIntMap;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.set.Sets;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.gateway.GatewayAllocator;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.engine.Engine;
@@ -137,7 +136,7 @@ public class PrimaryAllocationIT extends OpenSearchIntegTestCase {
         assertThat(bulkResponse.hasFailures(), equalTo(false));
         assertThat(bulkResponse.getItems().length, equalTo(2));
 
-        logger.info(Strings.toString(XContentType.JSON, bulkResponse, true, true));
+        logger.info(Strings.toString(bulkResponse, true, true));
 
         internalCluster().assertSeqNos();
 

--- a/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
@@ -430,7 +430,7 @@ public class IndexShardIT extends OpenSearchSingleNodeTestCase {
             final FlushStats flushStats = shard.flushStats();
             logger.info(
                 "--> translog stats [{}] gen [{}] commit_stats [{}] flush_stats [{}/{}]",
-                Strings.toString(XContentType.JSON, translogStats),
+                Strings.toString(translogStats),
                 translog.getGeneration().translogFileGeneration,
                 commitStats.getUserData(),
                 flushStats.getPeriodic(),

--- a/server/src/internalClusterTest/java/org/opensearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/recovery/IndexRecoveryIT.java
@@ -1589,10 +1589,7 @@ public class IndexRecoveryIT extends OpenSearchIntegTestCase {
                         .getShard(0)
                         .getRetentionLeases();
                     throw new AssertionError(
-                        "expect an operation-based recovery:"
-                            + "retention leases"
-                            + Strings.toString(XContentType.JSON, retentionLeases)
-                            + "]"
+                        "expect an operation-based recovery:" + "retention leases" + Strings.toString(retentionLeases) + "]"
                     );
                 }
                 connection.sendRequest(requestId, action, request, options);

--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
@@ -51,7 +51,6 @@ import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.plugins.PluginsService;
 import org.opensearch.script.MockScriptPlugin;
@@ -229,7 +228,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
         awaitForBlock(plugins);
         cancelSearch(SearchAction.NAME);
         disableBlocks(plugins);
-        logger.info("Segments {}", Strings.toString(XContentType.JSON, client().admin().indices().prepareSegments("test").get()));
+        logger.info("Segments {}", Strings.toString(client().admin().indices().prepareSegments("test").get()));
         ensureSearchWasCancelled(searchResponse);
     }
 
@@ -283,7 +282,7 @@ public class SearchCancellationIT extends OpenSearchIntegTestCase {
         awaitForBlock(plugins);
         cancelSearch(SearchAction.NAME);
         disableBlocks(plugins);
-        logger.info("Segments {}", Strings.toString(XContentType.JSON, client().admin().indices().prepareSegments("test").get()));
+        logger.info("Segments {}", Strings.toString(client().admin().indices().prepareSegments("test").get()));
         ensureSearchWasCancelled(searchResponse);
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponse.java
@@ -50,7 +50,6 @@ import org.opensearch.common.xcontent.ObjectParser;
 import org.opensearch.common.xcontent.StatusToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.rest.RestStatus;
 
 import java.io.IOException;
@@ -421,7 +420,7 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/tasks/cancel/CancelTasksResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/tasks/cancel/CancelTasksResponse.java
@@ -40,7 +40,6 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.xcontent.ConstructingObjectParser;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.tasks.TaskInfo;
 
 import java.io.IOException;
@@ -81,6 +80,6 @@ public class CancelTasksResponse extends ListTasksResponse {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/tasks/get/GetTaskResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/tasks/get/GetTaskResponse.java
@@ -38,7 +38,6 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.tasks.TaskResult;
 
 import java.io.IOException;
@@ -85,6 +84,6 @@ public class GetTaskResponse extends ActionResponse implements ToXContentObject 
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
@@ -47,7 +47,6 @@ import org.opensearch.common.xcontent.ConstructingObjectParser;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.tasks.TaskId;
 import org.opensearch.tasks.TaskInfo;
 
@@ -262,6 +261,6 @@ public class ListTasksResponse extends BaseTasksResponse implements ToXContentOb
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequest.java
@@ -16,7 +16,6 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -179,6 +178,6 @@ public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<Restore
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/repositories/verify/VerifyRepositoryResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/repositories/verify/VerifyRepositoryResponse.java
@@ -43,7 +43,6 @@ import org.opensearch.common.xcontent.ObjectParser;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -196,7 +195,7 @@ public class VerifyRepositoryResponse extends ActionResponse implements ToXConte
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/cluster/settings/ClusterGetSettingsResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/settings/ClusterGetSettingsResponse.java
@@ -42,7 +42,6 @@ import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -176,7 +175,7 @@ public class ClusterGetSettingsResponse extends ActionResponse implements ToXCon
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/clone/CloneSnapshotRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/clone/CloneSnapshotRequest.java
@@ -41,7 +41,6 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 
@@ -187,6 +186,6 @@ public class CloneSnapshotRequest extends ClusterManagerNodeRequest<CloneSnapsho
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
@@ -42,7 +42,6 @@ import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.snapshots.SnapshotInfo;
 
 import java.io.IOException;
@@ -128,6 +127,6 @@ public class GetSnapshotsResponse extends ActionResponse implements ToXContentOb
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -704,6 +704,6 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/SnapshotStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/SnapshotStats.java
@@ -43,7 +43,6 @@ import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParserUtils;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 
@@ -357,7 +356,7 @@ public class SnapshotStats implements Writeable, ToXContentObject {
             time = endTime - startTime;
         }
         assert time >= 0 : "Update with ["
-            + Strings.toString(XContentType.JSON, stats)
+            + Strings.toString(stats)
             + "]["
             + updateTimestamps
             + "] resulted in negative total time ["

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
@@ -46,7 +46,6 @@ import org.opensearch.common.xcontent.ObjectParser;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.snapshots.Snapshot;
 import org.opensearch.snapshots.SnapshotId;
 
@@ -216,7 +215,7 @@ public class SnapshotStatus implements ToXContentObject, Writeable {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, false);
+        return Strings.toString(this, true, false);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/AnalysisStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/AnalysisStats.java
@@ -43,7 +43,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -347,6 +346,6 @@ public final class AnalysisStats implements ToXContentFragment, Writeable {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/MappingStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/MappingStats.java
@@ -41,7 +41,6 @@ import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -131,7 +130,7 @@ public final class MappingStats implements ToXContentFragment, Writeable {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/indices/alias/Alias.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/alias/Alias.java
@@ -312,7 +312,7 @@ public class Alias implements Writeable, ToXContentFragment {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/indices/analyze/AnalyzeAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/analyze/AnalyzeAction.java
@@ -47,7 +47,6 @@ import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.analysis.NameOrDefinition;
 
 import java.io.IOException;
@@ -410,7 +409,7 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
 
         @Override
         public String toString() {
-            return Strings.toString(XContentType.JSON, this, true, true);
+            return Strings.toString(this, true, true);
         }
 
         /**

--- a/server/src/main/java/org/opensearch/action/admin/indices/close/CloseIndexResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/close/CloseIndexResponse.java
@@ -43,7 +43,6 @@ import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.util.CollectionUtils;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.Index;
 
 import java.io.IOException;
@@ -103,7 +102,7 @@ public class CloseIndexResponse extends ShardsAcknowledgedResponse {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     /**
@@ -202,7 +201,7 @@ public class CloseIndexResponse extends ShardsAcknowledgedResponse {
 
         @Override
         public String toString() {
-            return Strings.toString(XContentType.JSON, this);
+            return Strings.toString(this);
         }
     }
 
@@ -261,7 +260,7 @@ public class CloseIndexResponse extends ShardsAcknowledgedResponse {
 
         @Override
         public String toString() {
-            return Strings.toString(XContentType.JSON, this);
+            return Strings.toString(this);
         }
 
         /**
@@ -307,7 +306,7 @@ public class CloseIndexResponse extends ShardsAcknowledgedResponse {
 
             @Override
             public String toString() {
-                return Strings.toString(XContentType.JSON, this);
+                return Strings.toString(this);
             }
 
             static Failure readFailure(final StreamInput in) throws IOException {

--- a/server/src/main/java/org/opensearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/get/GetIndexResponse.java
@@ -45,7 +45,6 @@ import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.mapper.MapperService;
 
 import java.io.IOException;
@@ -333,7 +332,7 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/indices/mapping/get/GetMappingsResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/mapping/get/GetMappingsResponse.java
@@ -43,7 +43,6 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.mapper.MapperService;
 
 import java.io.IOException;
@@ -131,7 +130,7 @@ public class GetMappingsResponse extends ActionResponse implements ToXContentFra
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/indices/readonly/AddIndexBlockResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/readonly/AddIndexBlockResponse.java
@@ -42,7 +42,6 @@ import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.util.CollectionUtils;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.Index;
 
 import java.io.IOException;
@@ -93,7 +92,7 @@ public class AddIndexBlockResponse extends ShardsAcknowledgedResponse {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     /**
@@ -192,7 +191,7 @@ public class AddIndexBlockResponse extends ShardsAcknowledgedResponse {
 
         @Override
         public String toString() {
-            return Strings.toString(XContentType.JSON, this);
+            return Strings.toString(this);
         }
     }
 
@@ -252,7 +251,7 @@ public class AddIndexBlockResponse extends ShardsAcknowledgedResponse {
 
         @Override
         public String toString() {
-            return Strings.toString(XContentType.JSON, this);
+            return Strings.toString(this);
         }
 
         /**
@@ -298,7 +297,7 @@ public class AddIndexBlockResponse extends ShardsAcknowledgedResponse {
 
             @Override
             public String toString() {
-                return Strings.toString(XContentType.JSON, this);
+                return Strings.toString(this);
             }
 
             static Failure readFailure(final StreamInput in) throws IOException {

--- a/server/src/main/java/org/opensearch/action/admin/indices/recovery/RecoveryResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/recovery/RecoveryResponse.java
@@ -38,7 +38,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.indices.recovery.RecoveryState;
 
 import java.io.IOException;
@@ -120,6 +119,6 @@ public class RecoveryResponse extends BroadcastResponse {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/replication/SegmentReplicationStatsResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/replication/SegmentReplicationStatsResponse.java
@@ -14,7 +14,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.indices.replication.SegmentReplicationState;
 
 import java.io.IOException;
@@ -95,6 +94,6 @@ public class SegmentReplicationStatsResponse extends BroadcastResponse {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/rollover/RolloverInfo.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/rollover/RolloverInfo.java
@@ -43,7 +43,6 @@ import org.opensearch.common.xcontent.ConstructingObjectParser;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.List;
@@ -149,6 +148,6 @@ public class RolloverInfo extends AbstractDiffable<RolloverInfo> implements Writ
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/settings/put/UpdateSettingsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/settings/put/UpdateSettingsRequest.java
@@ -221,7 +221,7 @@ public class UpdateSettingsRequest extends AcknowledgedRequest<UpdateSettingsReq
 
     @Override
     public String toString() {
-        return "indices : " + Arrays.toString(indices) + "," + Strings.toString(XContentType.JSON, this);
+        return "indices : " + Arrays.toString(indices) + "," + Strings.toString(this);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/IndicesStatsResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/IndicesStatsResponse.java
@@ -40,7 +40,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.Index;
 
 import java.io.IOException;
@@ -226,6 +225,6 @@ public class IndicesStatsResponse extends BroadcastResponse {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, false);
+        return Strings.toString(this, true, false);
     }
 }

--- a/server/src/main/java/org/opensearch/action/bulk/BulkItemRequest.java
+++ b/server/src/main/java/org/opensearch/action/bulk/BulkItemRequest.java
@@ -40,7 +40,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.shard.ShardId;
 
 import java.io.IOException;
@@ -115,7 +114,7 @@ public class BulkItemRequest implements Writeable, Accountable {
             setPrimaryResponse(new BulkItemResponse(id, request.opType(), failure));
         } else {
             assert primaryResponse.isFailed() && primaryResponse.getFailure().isAborted() : "response ["
-                + Strings.toString(XContentType.JSON, primaryResponse)
+                + Strings.toString(primaryResponse)
                 + "]; cause ["
                 + cause
                 + "]";

--- a/server/src/main/java/org/opensearch/action/bulk/BulkItemResponse.java
+++ b/server/src/main/java/org/opensearch/action/bulk/BulkItemResponse.java
@@ -52,7 +52,6 @@ import org.opensearch.common.xcontent.StatusToXContentObject;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.shard.ShardId;
@@ -375,7 +374,7 @@ public class BulkItemResponse implements Writeable, StatusToXContentObject {
 
         @Override
         public String toString() {
-            return Strings.toString(XContentType.JSON, this);
+            return Strings.toString(this);
         }
     }
 

--- a/server/src/main/java/org/opensearch/action/fieldcaps/FieldCapabilities.java
+++ b/server/src/main/java/org/opensearch/action/fieldcaps/FieldCapabilities.java
@@ -42,7 +42,6 @@ import org.opensearch.common.xcontent.ConstructingObjectParser;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -296,7 +295,7 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/opensearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -44,7 +44,6 @@ import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParserUtils;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -220,6 +219,6 @@ public class FieldCapabilitiesResponse extends ActionResponse implements ToXCont
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/opensearch/action/get/GetResponse.java
+++ b/server/src/main/java/org/opensearch/action/get/GetResponse.java
@@ -43,7 +43,6 @@ import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.get.GetResult;
 
 import java.io.IOException;
@@ -238,6 +237,6 @@ public class GetResponse extends ActionResponse implements Iterable<DocumentFiel
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/opensearch/action/get/MultiGetRequest.java
+++ b/server/src/main/java/org/opensearch/action/get/MultiGetRequest.java
@@ -54,7 +54,6 @@ import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParser.Token;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.VersionType;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
@@ -268,7 +267,7 @@ public class MultiGetRequest extends ActionRequest
         }
 
         public String toString() {
-            return Strings.toString(XContentType.JSON, this);
+            return Strings.toString(this);
         }
 
     }

--- a/server/src/main/java/org/opensearch/action/index/IndexResponse.java
+++ b/server/src/main/java/org/opensearch/action/index/IndexResponse.java
@@ -36,7 +36,6 @@ import org.opensearch.action.DocWriteResponse;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.rest.RestStatus;
 
@@ -90,7 +89,7 @@ public class IndexResponse extends DocWriteResponse {
         builder.append(",result=").append(getResult().getLowercase());
         builder.append(",seqNo=").append(getSeqNo());
         builder.append(",primaryTerm=").append(getPrimaryTerm());
-        builder.append(",shards=").append(Strings.toString(XContentType.JSON, getShardInfo()));
+        builder.append(",shards=").append(Strings.toString(getShardInfo()));
         return builder.append("]").toString();
     }
 

--- a/server/src/main/java/org/opensearch/action/ingest/GetPipelineResponse.java
+++ b/server/src/main/java/org/opensearch/action/ingest/GetPipelineResponse.java
@@ -41,7 +41,6 @@ import org.opensearch.common.xcontent.StatusToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParser.Token;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.ingest.PipelineConfiguration;
 import org.opensearch.rest.RestStatus;
 
@@ -167,7 +166,7 @@ public class GetPipelineResponse extends ActionResponse implements StatusToXCont
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/search/MultiSearchResponse.java
+++ b/server/src/main/java/org/opensearch/action/search/MultiSearchResponse.java
@@ -48,7 +48,6 @@ import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParser.Token;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -262,6 +261,6 @@ public class MultiSearchResponse extends ActionResponse implements Iterable<Mult
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/opensearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchResponse.java
@@ -47,7 +47,6 @@ import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParser.Token;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.rest.action.RestActions;
 import org.opensearch.search.SearchHit;
@@ -470,7 +469,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/support/replication/ReplicationTask.java
+++ b/server/src/main/java/org/opensearch/action/support/replication/ReplicationTask.java
@@ -36,7 +36,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskId;
 
@@ -114,7 +113,7 @@ public class ReplicationTask extends Task {
 
         @Override
         public String toString() {
-            return Strings.toString(XContentType.JSON, this);
+            return Strings.toString(this);
         }
 
         // Implements equals and hashcode for testing

--- a/server/src/main/java/org/opensearch/cluster/RepositoryCleanupInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/RepositoryCleanupInProgress.java
@@ -38,7 +38,6 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.repositories.RepositoryOperation;
 
 import java.io.IOException;
@@ -110,7 +109,7 @@ public final class RepositoryCleanupInProgress extends AbstractNamedDiffable<Clu
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/SnapshotsInProgress.java
@@ -47,7 +47,6 @@ import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.repositories.IndexId;
 import org.opensearch.repositories.RepositoryOperation;
@@ -684,7 +683,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
 
         @Override
         public String toString() {
-            return Strings.toString(XContentType.JSON, this);
+            return Strings.toString(this);
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/cluster/awarenesshealth/ClusterAwarenessAttributeValueHealth.java
+++ b/server/src/main/java/org/opensearch/cluster/awarenesshealth/ClusterAwarenessAttributeValueHealth.java
@@ -21,7 +21,6 @@ import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.List;
@@ -293,7 +292,7 @@ public class ClusterAwarenessAttributeValueHealth implements Writeable, ToXConte
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/awarenesshealth/ClusterAwarenessAttributesHealth.java
+++ b/server/src/main/java/org/opensearch/cluster/awarenesshealth/ClusterAwarenessAttributesHealth.java
@@ -19,7 +19,6 @@ import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -280,7 +279,7 @@ public class ClusterAwarenessAttributesHealth implements Iterable<ClusterAwarene
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java
@@ -74,7 +74,6 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.common.util.concurrent.ListenableFuture;
 import org.opensearch.common.xcontent.XContentHelper;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.discovery.Discovery;
 import org.opensearch.discovery.DiscoveryModule;
@@ -1320,22 +1319,16 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
     // deserialized from the resulting JSON
     private boolean assertPreviousStateConsistency(ClusterChangedEvent event) {
         assert event.previousState() == coordinationState.get().getLastAcceptedState()
-            || XContentHelper.convertToMap(JsonXContent.jsonXContent, Strings.toString(XContentType.JSON, event.previousState()), false)
+            || XContentHelper.convertToMap(JsonXContent.jsonXContent, Strings.toString(event.previousState()), false)
                 .equals(
                     XContentHelper.convertToMap(
                         JsonXContent.jsonXContent,
-                        Strings.toString(
-                            XContentType.JSON,
-                            clusterStateWithNoClusterManagerBlock(coordinationState.get().getLastAcceptedState())
-                        ),
+                        Strings.toString(clusterStateWithNoClusterManagerBlock(coordinationState.get().getLastAcceptedState())),
                         false
                     )
-                ) : Strings.toString(XContentType.JSON, event.previousState())
+                ) : Strings.toString(event.previousState())
                     + " vs "
-                    + Strings.toString(
-                        XContentType.JSON,
-                        clusterStateWithNoClusterManagerBlock(coordinationState.get().getLastAcceptedState())
-                    );
+                    + Strings.toString(clusterStateWithNoClusterManagerBlock(coordinationState.get().getLastAcceptedState()));
         return true;
     }
 

--- a/server/src/main/java/org/opensearch/cluster/decommission/DecommissionAttributeMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/decommission/DecommissionAttributeMetadata.java
@@ -20,7 +20,6 @@ import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -282,6 +281,6 @@ public class DecommissionAttributeMetadata extends AbstractNamedDiffable<Custom>
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/health/ClusterShardHealth.java
+++ b/server/src/main/java/org/opensearch/cluster/health/ClusterShardHealth.java
@@ -46,7 +46,6 @@ import org.opensearch.common.xcontent.ConstructingObjectParser;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -275,7 +274,7 @@ public final class ClusterShardHealth implements Writeable, ToXContentFragment {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/metadata/AliasMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AliasMetadata.java
@@ -49,7 +49,6 @@ import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -268,7 +267,7 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/metadata/ComponentTemplate.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/ComponentTemplate.java
@@ -43,7 +43,6 @@ import org.opensearch.common.xcontent.ConstructingObjectParser;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Map;
@@ -152,7 +151,7 @@ public class ComponentTemplate extends AbstractDiffable<ComponentTemplate> imple
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/metadata/ComponentTemplateMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/ComponentTemplateMetadata.java
@@ -44,7 +44,6 @@ import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.ConstructingObjectParser;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -154,7 +153,7 @@ public class ComponentTemplateMetadata implements Metadata.Custom {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/metadata/ComposableIndexTemplate.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/ComposableIndexTemplate.java
@@ -47,7 +47,6 @@ import org.opensearch.common.xcontent.ConstructingObjectParser;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.mapper.DataStreamFieldMapper;
 import org.opensearch.index.mapper.MapperService;
 
@@ -287,7 +286,7 @@ public class ComposableIndexTemplate extends AbstractDiffable<ComposableIndexTem
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/metadata/ComposableIndexTemplateMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/ComposableIndexTemplateMetadata.java
@@ -44,7 +44,6 @@ import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.ConstructingObjectParser;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -155,7 +154,7 @@ public class ComposableIndexTemplateMetadata implements Metadata.Custom {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/metadata/DataStreamMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/DataStreamMetadata.java
@@ -44,7 +44,6 @@ import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.ConstructingObjectParser;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -159,7 +158,7 @@ public class DataStreamMetadata implements Metadata.Custom {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/metadata/RepositoriesMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/RepositoriesMetadata.java
@@ -45,7 +45,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.repositories.RepositoryData;
 
 import java.io.IOException;
@@ -292,6 +291,6 @@ public class RepositoriesMetadata extends AbstractNamedDiffable<Custom> implemen
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/metadata/Template.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/Template.java
@@ -176,7 +176,7 @@ public class Template extends AbstractDiffable<Template> implements ToXContentOb
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/metadata/WeightedRoutingMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/WeightedRoutingMetadata.java
@@ -21,7 +21,6 @@ import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -192,6 +191,6 @@ public class WeightedRoutingMetadata extends AbstractNamedDiffable<Metadata.Cust
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/command/AllocationCommands.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/command/AllocationCommands.java
@@ -42,7 +42,6 @@ import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -217,6 +216,6 @@ public class AllocationCommands implements ToXContentFragment {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 }

--- a/server/src/main/java/org/opensearch/common/Strings.java
+++ b/server/src/main/java/org/opensearch/common/Strings.java
@@ -37,9 +37,9 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.util.CollectionUtils;
-import org.opensearch.common.xcontent.MediaType;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.json.JsonXContent;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -773,8 +773,8 @@ public class Strings {
      * Wraps the output into an anonymous object if needed. The content is not pretty-printed
      * nor human readable.
      */
-    public static String toString(MediaType mediaType, ToXContent toXContent) {
-        return toString(mediaType, toXContent, false, false);
+    public static String toString(ToXContent toXContent) {
+        return toString(toXContent, false, false);
     }
 
     /**
@@ -783,8 +783,8 @@ public class Strings {
      * Allows to configure the params.
      * The content is not pretty-printed nor human readable.
      */
-    public static String toString(MediaType mediaType, ToXContent toXContent, ToXContent.Params params) {
-        return toString(mediaType, toXContent, params, false, false);
+    public static String toString(ToXContent toXContent, ToXContent.Params params) {
+        return toString(toXContent, params, false, false);
     }
 
     /**
@@ -801,8 +801,8 @@ public class Strings {
      * json needs to be pretty printed and human readable.
      *
      */
-    public static String toString(MediaType mediaType, ToXContent toXContent, boolean pretty, boolean human) {
-        return toString(mediaType, toXContent, ToXContent.EMPTY_PARAMS, pretty, human);
+    public static String toString(ToXContent toXContent, boolean pretty, boolean human) {
+        return toString(toXContent, ToXContent.EMPTY_PARAMS, pretty, human);
     }
 
     /**
@@ -811,9 +811,9 @@ public class Strings {
      * Allows to configure the params.
      * Allows to control whether the outputted json needs to be pretty printed and human readable.
      */
-    private static String toString(MediaType mediaType, ToXContent toXContent, ToXContent.Params params, boolean pretty, boolean human) {
+    private static String toString(ToXContent toXContent, ToXContent.Params params, boolean pretty, boolean human) {
         try {
-            XContentBuilder builder = createBuilder(mediaType, pretty, human);
+            XContentBuilder builder = createBuilder(pretty, human);
             if (toXContent.isFragment()) {
                 builder.startObject();
             }
@@ -824,7 +824,7 @@ public class Strings {
             return toString(builder);
         } catch (IOException e) {
             try {
-                XContentBuilder builder = createBuilder(mediaType, pretty, human);
+                XContentBuilder builder = createBuilder(pretty, human);
                 builder.startObject();
                 builder.field("error", "error building toString out of XContent: " + e.getMessage());
                 builder.field("stack_trace", ExceptionsHelper.stackTrace(e));
@@ -836,8 +836,8 @@ public class Strings {
         }
     }
 
-    private static XContentBuilder createBuilder(MediaType mediaType, boolean pretty, boolean human) throws IOException {
-        XContentBuilder builder = XContentBuilder.builder(mediaType.xContent());
+    private static XContentBuilder createBuilder(boolean pretty, boolean human) throws IOException {
+        XContentBuilder builder = JsonXContent.contentBuilder();
         if (pretty) {
             builder.prettyPrint();
         }

--- a/server/src/main/java/org/opensearch/common/geo/builders/ShapeBuilder.java
+++ b/server/src/main/java/org/opensearch/common/geo/builders/ShapeBuilder.java
@@ -51,7 +51,6 @@ import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
 import org.locationtech.spatial4j.exception.InvalidShapeException;
 import org.locationtech.spatial4j.shape.Shape;
 import org.locationtech.spatial4j.shape.jts.JtsGeometry;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -521,6 +520,6 @@ public abstract class ShapeBuilder<T extends Shape, G extends org.opensearch.geo
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 }

--- a/server/src/main/java/org/opensearch/common/settings/Setting.java
+++ b/server/src/main/java/org/opensearch/common/settings/Setting.java
@@ -596,7 +596,7 @@ public class Setting<T> implements ToXContentObject {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/get/GetResult.java
+++ b/server/src/main/java/org/opensearch/index/get/GetResult.java
@@ -46,7 +46,6 @@ import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.mapper.IgnoredFieldMapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.SourceFieldMapper;
@@ -494,6 +493,6 @@ public class GetResult implements Writeable, Iterable<DocumentField>, ToXContent
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 }

--- a/server/src/main/java/org/opensearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MapperService.java
@@ -350,7 +350,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
                         + "to be the same as new mapping ["
                         + newSource
                         + "]";
-                    final CompressedXContent mapperSource = new CompressedXContent(Strings.toString(XContentType.JSON, mapper));
+                    final CompressedXContent mapperSource = new CompressedXContent(Strings.toString(mapper));
                     assert currentSource.equals(mapperSource) : "expected current mapping ["
                         + currentSource
                         + "] for type ["

--- a/server/src/main/java/org/opensearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/RootObjectMapper.java
@@ -41,7 +41,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.mapper.DynamicTemplate.XContentFieldType;
 import org.opensearch.index.mapper.MapperService.MergeReason;
 
@@ -461,7 +460,7 @@ public class RootObjectMapper extends ObjectMapper {
                 Locale.ROOT,
                 "dynamic template [%s] has invalid content [%s]",
                 dynamicTemplate.getName(),
-                Strings.toString(XContentType.JSON, dynamicTemplate)
+                Strings.toString(dynamicTemplate)
             );
 
             final String deprecationMessage;

--- a/server/src/main/java/org/opensearch/index/query/AbstractQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/AbstractQueryBuilder.java
@@ -48,7 +48,6 @@ import org.opensearch.common.xcontent.SuggestingErrorOnUnknown;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentLocation;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -395,6 +394,6 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
 
     @Override
     public final String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 }

--- a/server/src/main/java/org/opensearch/index/query/InnerHitBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/InnerHitBuilder.java
@@ -43,7 +43,6 @@ import org.opensearch.common.xcontent.ObjectParser;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.script.Script;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder.ScriptField;
@@ -605,6 +604,6 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 }

--- a/server/src/main/java/org/opensearch/index/query/SpanNearQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SpanNearQueryBuilder.java
@@ -43,7 +43,6 @@ import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentLocation;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
@@ -445,7 +444,7 @@ public class SpanNearQueryBuilder extends AbstractQueryBuilder<SpanNearQueryBuil
 
         @Override
         public final String toString() {
-            return Strings.toString(XContentType.JSON, this, true, true);
+            return Strings.toString(this, true, true);
         }
 
         // copied from AbstractQueryBuilder

--- a/server/src/main/java/org/opensearch/index/reindex/BulkByScrollTask.java
+++ b/server/src/main/java/org/opensearch/index/reindex/BulkByScrollTask.java
@@ -48,7 +48,6 @@ import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParseException;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParser.Token;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.tasks.CancellableTask;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskId;
@@ -1048,9 +1047,9 @@ public class BulkByScrollTask extends CancellableTask {
         @Override
         public String toString() {
             if (exception != null) {
-                return "BulkByScrollTask{error=" + Strings.toString(XContentType.JSON, this) + "}";
+                return "BulkByScrollTask{error=" + Strings.toString(this) + "}";
             } else {
-                return "BulkByScrollTask{status=" + Strings.toString(XContentType.JSON, this) + "}";
+                return "BulkByScrollTask{status=" + Strings.toString(this) + "}";
             }
         }
 

--- a/server/src/main/java/org/opensearch/index/reindex/ScrollableHitSource.java
+++ b/server/src/main/java/org/opensearch/index/reindex/ScrollableHitSource.java
@@ -498,7 +498,7 @@ public abstract class ScrollableHitSource {
 
         @Override
         public String toString() {
-            return Strings.toString(XContentType.JSON, this);
+            return Strings.toString(this);
         }
     }
 }

--- a/server/src/main/java/org/opensearch/index/search/stats/SearchStats.java
+++ b/server/src/main/java/org/opensearch/index/search/stats/SearchStats.java
@@ -42,7 +42,6 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -414,7 +413,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/shard/PrimaryReplicaSyncer.java
+++ b/server/src/main/java/org/opensearch/index/shard/PrimaryReplicaSyncer.java
@@ -48,7 +48,6 @@ import org.opensearch.common.unit.ByteSizeUnit;
 import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.common.util.concurrent.AbstractRunnable;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.internal.io.IOUtils;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.translog.Translog;
@@ -515,7 +514,7 @@ public class PrimaryReplicaSyncer {
 
             @Override
             public String toString() {
-                return Strings.toString(XContentType.JSON, this);
+                return Strings.toString(this);
             }
 
             @Override

--- a/server/src/main/java/org/opensearch/index/shard/RemoveCorruptedShardDataCommand.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoveCorruptedShardDataCommand.java
@@ -61,7 +61,6 @@ import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.env.NodeMetadata;
@@ -520,7 +519,7 @@ public class RemoveCorruptedShardDataCommand extends OpenSearchNodeCommand {
         );
 
         terminal.println("");
-        terminal.println("POST /_cluster/reroute\n" + Strings.toString(XContentType.JSON, commands, true, true));
+        terminal.println("POST /_cluster/reroute\n" + Strings.toString(commands, true, true));
         terminal.println("");
         terminal.println("You must accept the possibility of data loss by changing the `accept_data_loss` parameter to `true`.");
         terminal.println("");

--- a/server/src/main/java/org/opensearch/index/translog/TranslogStats.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogStats.java
@@ -38,7 +38,6 @@ import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 
@@ -146,7 +145,7 @@ public class TranslogStats implements Writeable, ToXContentFragment {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/ingest/PipelineConfiguration.java
+++ b/server/src/main/java/org/opensearch/ingest/PipelineConfiguration.java
@@ -142,7 +142,7 @@ public final class PipelineConfiguration extends AbstractDiffable<PipelineConfig
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/persistent/PersistentTasksCustomMetadata.java
+++ b/server/src/main/java/org/opensearch/persistent/PersistentTasksCustomMetadata.java
@@ -52,7 +52,6 @@ import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -211,7 +210,7 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     public long getNumberOfTasksOnNode(String nodeId, String taskName) {
@@ -429,7 +428,7 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
 
         @Override
         public String toString() {
-            return Strings.toString(XContentType.JSON, this);
+            return Strings.toString(this);
         }
 
         public String getId() {

--- a/server/src/main/java/org/opensearch/persistent/PersistentTasksNodeService.java
+++ b/server/src/main/java/org/opensearch/persistent/PersistentTasksNodeService.java
@@ -42,7 +42,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.gateway.GatewayService;
 import org.opensearch.persistent.PersistentTasksCustomMetadata.PersistentTask;
 import org.opensearch.tasks.Task;
@@ -364,7 +363,7 @@ public class PersistentTasksNodeService implements ClusterStateListener {
 
         @Override
         public String toString() {
-            return Strings.toString(XContentType.JSON, this);
+            return Strings.toString(this);
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/repositories/RepositoryCleanupResult.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoryCleanupResult.java
@@ -40,7 +40,6 @@ import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.xcontent.ObjectParser;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 
@@ -105,6 +104,6 @@ public final class RepositoryCleanupResult implements Writeable, ToXContentObjec
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/opensearch/repositories/RepositoryInfo.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoryInfo.java
@@ -39,7 +39,6 @@ import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Map;
@@ -144,6 +143,6 @@ public final class RepositoryInfo implements Writeable, ToXContentFragment {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/opensearch/repositories/RepositoryStatsSnapshot.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoryStatsSnapshot.java
@@ -38,7 +38,6 @@ import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -125,6 +124,6 @@ public final class RepositoryStatsSnapshot implements Writeable, ToXContentObjec
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/opensearch/search/SearchHit.java
+++ b/server/src/main/java/org/opensearch/search/SearchHit.java
@@ -57,7 +57,6 @@ import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParser.Token;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.mapper.IgnoredFieldMapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.SourceFieldMapper;
@@ -1125,6 +1124,6 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/AggregationBuilder.java
@@ -36,7 +36,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.NamedWriteable;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.Rewriteable;
@@ -193,6 +192,6 @@ public abstract class AggregationBuilder
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/AggregatorFactories.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/AggregatorFactories.java
@@ -43,7 +43,6 @@ import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentLocation;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.Rewriteable;
@@ -557,7 +556,7 @@ public class AggregatorFactories {
 
         @Override
         public String toString() {
-            return Strings.toString(XContentType.JSON, this, true, true);
+            return Strings.toString(this, true, true);
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/BucketOrder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/BucketOrder.java
@@ -35,7 +35,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.xcontent.ToXContentObject;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.opensearch.search.aggregations.support.AggregationPath;
 
@@ -172,6 +171,6 @@ public abstract class BucketOrder implements ToXContentObject, Writeable {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/InternalAggregation.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/InternalAggregation.java
@@ -38,7 +38,6 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.util.BigArrays;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.rest.action.search.RestSearchAction;
 import org.opensearch.script.ScriptService;
 import org.opensearch.search.aggregations.pipeline.PipelineAggregator;
@@ -409,7 +408,7 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/aggregations/PipelineAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/PipelineAggregationBuilder.java
@@ -36,7 +36,6 @@ import org.opensearch.action.ValidateActions;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.NamedWriteable;
 import org.opensearch.common.xcontent.ToXContentFragment;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.Rewriteable;
 import org.opensearch.search.aggregations.AggregatorFactories.Builder;
@@ -288,7 +287,7 @@ public abstract class PipelineAggregationBuilder
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/aggregations/support/BaseMultiValuesSourceFieldConfig.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/BaseMultiValuesSourceFieldConfig.java
@@ -20,7 +20,6 @@ import org.opensearch.common.xcontent.ObjectParser;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.script.Script;
 
 import java.io.IOException;
@@ -165,7 +164,7 @@ public abstract class BaseMultiValuesSourceFieldConfig implements Writeable, ToX
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     abstract void doXContentBody(XContentBuilder builder, Params params) throws IOException;

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/AbstractHighlighterBuilder.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/AbstractHighlighterBuilder.java
@@ -45,7 +45,6 @@ import org.opensearch.common.xcontent.ObjectParser;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.Rewriteable;
 import org.opensearch.search.fetch.subphase.highlight.HighlightBuilder.BoundaryScannerType;
@@ -773,6 +772,6 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 }

--- a/server/src/main/java/org/opensearch/search/rescore/RescorerBuilder.java
+++ b/server/src/main/java/org/opensearch/search/rescore/RescorerBuilder.java
@@ -41,7 +41,6 @@ import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.Rewriteable;
 
@@ -170,6 +169,6 @@ public abstract class RescorerBuilder<RB extends RescorerBuilder<RB>>
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 }

--- a/server/src/main/java/org/opensearch/search/slice/SliceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/slice/SliceBuilder.java
@@ -52,7 +52,6 @@ import org.opensearch.common.xcontent.ObjectParser;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.fielddata.IndexFieldData;
 import org.opensearch.index.fielddata.IndexNumericFieldData;
 import org.opensearch.index.mapper.IdFieldMapper;
@@ -338,6 +337,6 @@ public class SliceBuilder implements Writeable, ToXContentObject {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 }

--- a/server/src/main/java/org/opensearch/search/sort/SortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortBuilder.java
@@ -44,7 +44,6 @@ import org.opensearch.common.lucene.search.Queries;
 import org.opensearch.common.xcontent.NamedObjectNotFoundException;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.opensearch.index.mapper.ObjectMapper;
 import org.opensearch.index.query.QueryBuilder;
@@ -286,6 +285,6 @@ public abstract class SortBuilder<T extends SortBuilder<T>> implements NamedWrit
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 }

--- a/server/src/main/java/org/opensearch/search/suggest/Suggest.java
+++ b/server/src/main/java/org/opensearch/search/suggest/Suggest.java
@@ -48,7 +48,6 @@ import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentParserUtils;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.rest.action.search.RestSearchAction;
 import org.opensearch.search.aggregations.Aggregation;
 import org.opensearch.search.suggest.Suggest.Suggestion.Entry;
@@ -791,6 +790,6 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 }

--- a/server/src/main/java/org/opensearch/search/suggest/SuggestBuilder.java
+++ b/server/src/main/java/org/opensearch/search/suggest/SuggestBuilder.java
@@ -42,7 +42,6 @@ import org.opensearch.common.lucene.BytesRefs;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.search.suggest.SuggestionSearchContext.SuggestionContext;
 
@@ -218,6 +217,6 @@ public class SuggestBuilder implements Writeable, ToXContentObject {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 }

--- a/server/src/main/java/org/opensearch/snapshots/RestoreInfo.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreInfo.java
@@ -40,7 +40,6 @@ import org.opensearch.common.xcontent.ObjectParser;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.rest.RestStatus;
 
 import java.io.IOException;
@@ -215,6 +214,6 @@ public class RestoreInfo implements ToXContentObject, Writeable {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/opensearch/tasks/RawTaskStatus.java
+++ b/server/src/main/java/org/opensearch/tasks/RawTaskStatus.java
@@ -38,7 +38,6 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentHelper;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -87,7 +86,7 @@ public class RawTaskStatus implements Task.Status {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/tasks/TaskInfo.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskInfo.java
@@ -45,7 +45,6 @@ import org.opensearch.common.xcontent.ObjectParserHelper;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -345,7 +344,7 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 
     // Implements equals and hashCode for testing

--- a/server/src/main/java/org/opensearch/tasks/TaskResourceStats.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResourceStats.java
@@ -15,7 +15,6 @@ import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -89,7 +88,7 @@ public class TaskResourceStats implements Writeable, ToXContentFragment {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 
     // Implements equals and hashcode for testing

--- a/server/src/main/java/org/opensearch/tasks/TaskResourceUsage.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResourceUsage.java
@@ -17,7 +17,6 @@ import org.opensearch.common.xcontent.ConstructingObjectParser;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -88,7 +87,7 @@ public class TaskResourceUsage implements Writeable, ToXContentFragment {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this, true, true);
+        return Strings.toString(this, true, true);
     }
 
     // Implements equals and hashcode for testing

--- a/server/src/main/java/org/opensearch/tasks/TaskResult.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResult.java
@@ -47,7 +47,6 @@ import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentHelper;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Map;
@@ -208,7 +207,7 @@ public final class TaskResult implements Writeable, ToXContentObject {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON, this);
+        return Strings.toString(this);
     }
 
     // Implements equals and hashcode for testing

--- a/server/src/test/java/org/opensearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/opensearch/ExceptionSerializationTests.java
@@ -77,7 +77,6 @@ import org.opensearch.common.unit.ByteSizeValue;
 import org.opensearch.common.util.CancellableThreadsTests;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.common.xcontent.XContentLocation;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.discovery.MasterNotDiscoveredException;
 import org.opensearch.env.ShardLockObtainFailedException;
 import org.opensearch.index.Index;
@@ -536,15 +535,9 @@ public class ExceptionSerializationTests extends OpenSearchTestCase {
 
     public void testNotSerializableExceptionWrapper() throws IOException {
         NotSerializableExceptionWrapper ex = serialize(new NotSerializableExceptionWrapper(new NullPointerException()));
-        assertEquals(
-            "{\"type\":\"null_pointer_exception\",\"reason\":\"null_pointer_exception: null\"}",
-            Strings.toString(XContentType.JSON, ex)
-        );
+        assertEquals("{\"type\":\"null_pointer_exception\",\"reason\":\"null_pointer_exception: null\"}", Strings.toString(ex));
         ex = serialize(new NotSerializableExceptionWrapper(new IllegalArgumentException("nono!")));
-        assertEquals(
-            "{\"type\":\"illegal_argument_exception\",\"reason\":\"illegal_argument_exception: nono!\"}",
-            Strings.toString(XContentType.JSON, ex)
-        );
+        assertEquals("{\"type\":\"illegal_argument_exception\",\"reason\":\"illegal_argument_exception: nono!\"}", Strings.toString(ex));
 
         class UnknownException extends Exception {
             UnknownException(final String message) {

--- a/server/src/test/java/org/opensearch/OpenSearchExceptionTests.java
+++ b/server/src/test/java/org/opensearch/OpenSearchExceptionTests.java
@@ -449,8 +449,8 @@ public class OpenSearchExceptionTests extends OpenSearchTestCase {
 
         { // test equivalence
             OpenSearchException ex = new RemoteTransportException("foobar", new FileNotFoundException("foo not found"));
-            String toXContentString = Strings.toString(XContentType.JSON, ex);
-            String throwableString = Strings.toString(XContentType.JSON, (builder, params) -> {
+            String toXContentString = Strings.toString(ex);
+            String throwableString = Strings.toString((builder, params) -> {
                 OpenSearchException.generateThrowableXContent(builder, params, ex);
                 return builder;
             });

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -343,7 +343,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
             "local tasks [{}]",
             localTasks.values()
                 .stream()
-                .map(t -> Strings.toString(XContentType.JSON, t.taskInfo(testNodes[0].getNodeId(), true)))
+                .map(t -> Strings.toString(t.taskInfo(testNodes[0].getNodeId(), true)))
                 .collect(Collectors.joining(","))
         );
         assertEquals(2, localTasks.size()); // all node tasks + 1 coordinating task

--- a/server/src/test/java/org/opensearch/action/admin/indices/close/CloseIndexResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/close/CloseIndexResponseTests.java
@@ -151,7 +151,7 @@ public class CloseIndexResponseTests extends AbstractWireSerializingTestCase<Clo
         CloseIndexResponse closeIndexResponse = new CloseIndexResponse(true, true, Collections.singletonList(indexResult));
         assertEquals(
             "{\"acknowledged\":true,\"shards_acknowledged\":true,\"indices\":{\"test\":{\"closed\":true}}}",
-            Strings.toString(XContentType.JSON, closeIndexResponse)
+            Strings.toString(closeIndexResponse)
         );
 
         CloseIndexResponse.ShardResult[] shards = new CloseIndexResponse.ShardResult[1];
@@ -168,7 +168,7 @@ public class CloseIndexResponseTests extends AbstractWireSerializingTestCase<Clo
                 + "\"failures\":[{\"node\":\"nodeId\",\"shard\":0,\"index\":\"test\",\"status\":\"INTERNAL_SERVER_ERROR\","
                 + "\"reason\":{\"type\":\"action_not_found_transport_exception\","
                 + "\"reason\":\"No handler for action [test]\"}}]}}}}}",
-            Strings.toString(XContentType.JSON, closeIndexResponse)
+            Strings.toString(closeIndexResponse)
         );
     }
 

--- a/server/src/test/java/org/opensearch/action/admin/indices/create/CreateIndexResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/create/CreateIndexResponseTests.java
@@ -35,7 +35,6 @@ package org.opensearch.action.admin.indices.create;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.test.AbstractSerializingTestCase;
 
@@ -84,13 +83,13 @@ public class CreateIndexResponseTests extends AbstractSerializingTestCase<Create
 
     public void testToXContent() {
         CreateIndexResponse response = new CreateIndexResponse(true, false, "index_name");
-        String output = Strings.toString(XContentType.JSON, response);
+        String output = Strings.toString(response);
         assertEquals("{\"acknowledged\":true,\"shards_acknowledged\":false,\"index\":\"index_name\"}", output);
     }
 
     public void testToAndFromXContentIndexNull() throws IOException {
         CreateIndexResponse response = new CreateIndexResponse(true, false, null);
-        String output = Strings.toString(XContentType.JSON, response);
+        String output = Strings.toString(response);
         assertEquals("{\"acknowledged\":true,\"shards_acknowledged\":false,\"index\":null}", output);
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, output)) {
             CreateIndexResponse parsedResponse = CreateIndexResponse.fromXContent(parser);

--- a/server/src/test/java/org/opensearch/action/admin/indices/mapping/get/GetFieldMappingsResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/mapping/get/GetFieldMappingsResponseTests.java
@@ -38,7 +38,6 @@ import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.Writeable;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
@@ -69,7 +68,7 @@ public class GetFieldMappingsResponseTests extends AbstractWireSerializingTestCa
         Map<String, Map<String, FieldMappingMetadata>> mappings = new HashMap<>();
         mappings.put("index", Collections.emptyMap());
         GetFieldMappingsResponse response = new GetFieldMappingsResponse(mappings);
-        assertEquals("{\"index\":{\"mappings\":{}}}", Strings.toString(XContentType.JSON, response));
+        assertEquals("{\"index\":{\"mappings\":{}}}", Strings.toString(response));
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/action/admin/indices/mapping/put/PutMappingRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/mapping/put/PutMappingRequestTests.java
@@ -113,7 +113,7 @@ public class PutMappingRequestTests extends OpenSearchTestCase {
         mapping.endObject();
         request.source(mapping);
 
-        String actualRequestBody = Strings.toString(XContentType.JSON, request);
+        String actualRequestBody = Strings.toString(request);
         String expectedRequestBody = "{\"properties\":{\"email\":{\"type\":\"text\"}}}";
         assertEquals(expectedRequestBody, actualRequestBody);
     }
@@ -121,7 +121,7 @@ public class PutMappingRequestTests extends OpenSearchTestCase {
     public void testToXContentWithEmptySource() throws IOException {
         PutMappingRequest request = new PutMappingRequest("foo");
 
-        String actualRequestBody = Strings.toString(XContentType.JSON, request);
+        String actualRequestBody = Strings.toString(request);
         String expectedRequestBody = "{}";
         assertEquals(expectedRequestBody, actualRequestBody);
     }

--- a/server/src/test/java/org/opensearch/action/admin/indices/shrink/ResizeRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/shrink/ResizeRequestTests.java
@@ -76,7 +76,7 @@ public class ResizeRequestTests extends OpenSearchTestCase {
     public void testToXContent() throws IOException {
         {
             ResizeRequest request = new ResizeRequest("target", "source");
-            String actualRequestBody = Strings.toString(XContentType.JSON, request);
+            String actualRequestBody = Strings.toString(request);
             assertEquals("{\"settings\":{},\"aliases\":{}}", actualRequestBody);
         }
         {
@@ -91,7 +91,7 @@ public class ResizeRequestTests extends OpenSearchTestCase {
             settings.put(SETTING_NUMBER_OF_SHARDS, 10);
             target.settings(settings);
             request.setTargetIndex(target);
-            String actualRequestBody = Strings.toString(XContentType.JSON, request);
+            String actualRequestBody = Strings.toString(request);
             String expectedRequestBody = "{\"settings\":{\"index\":{\"number_of_shards\":\"10\"}},"
                 + "\"aliases\":{\"test_alias\":{\"filter\":{\"term\":{\"year\":2016}},\"routing\":\"1\",\"is_write_index\":true}}}";
             assertEquals(expectedRequestBody, actualRequestBody);

--- a/server/src/test/java/org/opensearch/action/admin/indices/shrink/ResizeResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/shrink/ResizeResponseTests.java
@@ -35,14 +35,13 @@ package org.opensearch.action.admin.indices.shrink;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.test.AbstractSerializingTestCase;
 
 public class ResizeResponseTests extends AbstractSerializingTestCase<ResizeResponse> {
 
     public void testToXContent() {
         ResizeResponse response = new ResizeResponse(true, false, "index_name");
-        String output = Strings.toString(XContentType.JSON, response);
+        String output = Strings.toString(response);
         assertEquals("{\"acknowledged\":true,\"shards_acknowledged\":false,\"index\":\"index_name\"}", output);
     }
 

--- a/server/src/test/java/org/opensearch/action/admin/indices/stats/IndicesStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/stats/IndicesStatsTests.java
@@ -40,7 +40,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.engine.CommitStats;
 import org.opensearch.index.engine.SegmentsStats;
@@ -147,7 +146,7 @@ public class IndicesStatsTests extends OpenSearchSingleNodeTestCase {
             }
             if (end - System.nanoTime() < 0) {
                 logger.info("timed out");
-                fail("didn't get a refresh listener in time: " + Strings.toString(XContentType.JSON, common));
+                fail("didn't get a refresh listener in time: " + Strings.toString(common));
             }
         }
 

--- a/server/src/test/java/org/opensearch/action/admin/indices/validate/query/ValidateQueryResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/validate/query/ValidateQueryResponseTests.java
@@ -36,7 +36,6 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.action.support.DefaultShardOperationFailedException;
 import org.opensearch.common.Strings;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.test.AbstractBroadcastResponseTestCase;
 
 import java.io.IOException;
@@ -115,7 +114,7 @@ public class ValidateQueryResponseTests extends AbstractBroadcastResponseTestCas
     @Override
     public void testToXContent() {
         ValidateQueryResponse response = createTestInstance(10, 10, 0, new ArrayList<>());
-        String output = Strings.toString(XContentType.JSON, response);
+        String output = Strings.toString(response);
         assertEquals("{\"_shards\":{\"total\":10,\"successful\":10,\"failed\":0},\"valid\":true}", output);
     }
 }

--- a/server/src/test/java/org/opensearch/action/delete/DeleteResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/delete/DeleteResponseTests.java
@@ -56,7 +56,7 @@ public class DeleteResponseTests extends OpenSearchTestCase {
     public void testToXContent() {
         {
             DeleteResponse response = new DeleteResponse(new ShardId("index", "index_uuid", 0), "id", 3, 17, 5, true);
-            String output = Strings.toString(XContentType.JSON, response);
+            String output = Strings.toString(response);
             assertEquals(
                 "{\"_index\":\"index\",\"_id\":\"id\",\"_version\":5,\"result\":\"deleted\","
                     + "\"_shards\":null,\"_seq_no\":3,\"_primary_term\":17}",
@@ -67,7 +67,7 @@ public class DeleteResponseTests extends OpenSearchTestCase {
             DeleteResponse response = new DeleteResponse(new ShardId("index", "index_uuid", 0), "id", -1, 0, 7, true);
             response.setForcedRefresh(true);
             response.setShardInfo(new ReplicationResponse.ShardInfo(10, 5));
-            String output = Strings.toString(XContentType.JSON, response);
+            String output = Strings.toString(response);
             assertEquals(
                 "{\"_index\":\"index\",\"_id\":\"id\",\"_version\":7,\"result\":\"deleted\","
                     + "\"forced_refresh\":true,\"_shards\":{\"total\":10,\"successful\":5,\"failed\":0}}",

--- a/server/src/test/java/org/opensearch/action/get/GetResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/get/GetResponseTests.java
@@ -118,7 +118,7 @@ public class GetResponseTests extends OpenSearchTestCase {
                     null
                 )
             );
-            String output = Strings.toString(XContentType.JSON, getResponse);
+            String output = Strings.toString(getResponse);
             assertEquals(
                 "{\"_index\":\"index\",\"_id\":\"id\",\"_version\":1,\"_seq_no\":0,\"_primary_term\":1,"
                     + "\"found\":true,\"_source\":{ \"field1\" : \"value1\", \"field2\":\"value2\"},\"fields\":{\"field1\":[\"value1\"]}}",
@@ -127,7 +127,7 @@ public class GetResponseTests extends OpenSearchTestCase {
         }
         {
             GetResponse getResponse = new GetResponse(new GetResult("index", "id", UNASSIGNED_SEQ_NO, 0, 1, false, null, null, null));
-            String output = Strings.toString(XContentType.JSON, getResponse);
+            String output = Strings.toString(getResponse);
             assertEquals("{\"_index\":\"index\",\"_id\":\"id\",\"found\":false}", output);
         }
     }

--- a/server/src/test/java/org/opensearch/action/index/IndexResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/index/IndexResponseTests.java
@@ -57,7 +57,7 @@ public class IndexResponseTests extends OpenSearchTestCase {
     public void testToXContent() {
         {
             IndexResponse indexResponse = new IndexResponse(new ShardId("index", "index_uuid", 0), "id", 3, 17, 5, true);
-            String output = Strings.toString(XContentType.JSON, indexResponse);
+            String output = Strings.toString(indexResponse);
             assertEquals(
                 "{\"_index\":\"index\",\"_id\":\"id\",\"_version\":5,\"result\":\"created\",\"_shards\":null,"
                     + "\"_seq_no\":3,\"_primary_term\":17}",
@@ -68,7 +68,7 @@ public class IndexResponseTests extends OpenSearchTestCase {
             IndexResponse indexResponse = new IndexResponse(new ShardId("index", "index_uuid", 0), "id", -1, 17, 7, true);
             indexResponse.setForcedRefresh(true);
             indexResponse.setShardInfo(new ReplicationResponse.ShardInfo(10, 5));
-            String output = Strings.toString(XContentType.JSON, indexResponse);
+            String output = Strings.toString(indexResponse);
             assertEquals(
                 "{\"_index\":\"index\",\"_id\":\"id\",\"_version\":7,\"result\":\"created\","
                     + "\"forced_refresh\":true,\"_shards\":{\"total\":10,\"successful\":5,\"failed\":0}}",

--- a/server/src/test/java/org/opensearch/action/search/MultiSearchRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/search/MultiSearchRequestTests.java
@@ -301,7 +301,7 @@ public class MultiSearchRequestTests extends OpenSearchTestCase {
                 + "\"type\":\"illegal_state_exception\",\"reason\":\"baaaaaazzzz\"},\"status\":500"
                 + "}"
                 + "]}",
-            Strings.toString(XContentType.JSON, response)
+            Strings.toString(response)
         );
     }
 

--- a/server/src/test/java/org/opensearch/action/search/SearchPhaseExecutionExceptionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchPhaseExecutionExceptionTests.java
@@ -111,7 +111,7 @@ public class SearchPhaseExecutionExceptionTests extends OpenSearchTestCase {
                 + "  ]"
                 + "}"
         );
-        assertEquals(expectedJson, Strings.toString(XContentType.JSON, exception));
+        assertEquals(expectedJson, Strings.toString(exception));
     }
 
     public void testToAndFromXContent() throws IOException {

--- a/server/src/test/java/org/opensearch/action/search/SearchResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchResponseTests.java
@@ -282,7 +282,7 @@ public class SearchResponseTests extends OpenSearchTestCase {
                 }
             }
             expectedString.append("}");
-            assertEquals(expectedString.toString(), Strings.toString(XContentType.JSON, response));
+            assertEquals(expectedString.toString(), Strings.toString(response));
         }
         {
             SearchResponse response = new SearchResponse(
@@ -329,7 +329,7 @@ public class SearchResponseTests extends OpenSearchTestCase {
                 }
             }
             expectedString.append("}");
-            assertEquals(expectedString.toString(), Strings.toString(XContentType.JSON, response));
+            assertEquals(expectedString.toString(), Strings.toString(response));
         }
     }
 

--- a/server/src/test/java/org/opensearch/action/support/DefaultShardOperationFailedExceptionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/DefaultShardOperationFailedExceptionTests.java
@@ -92,7 +92,7 @@ public class DefaultShardOperationFailedExceptionTests extends OpenSearchTestCas
             assertEquals(
                 "{\"shard\":-1,\"index\":null,\"status\":\"INTERNAL_SERVER_ERROR\","
                     + "\"reason\":{\"type\":\"exception\",\"reason\":\"foo\"}}",
-                Strings.toString(XContentType.JSON, exception)
+                Strings.toString(exception)
             );
         }
         {
@@ -102,7 +102,7 @@ public class DefaultShardOperationFailedExceptionTests extends OpenSearchTestCas
             assertEquals(
                 "{\"shard\":-1,\"index\":null,\"status\":\"INTERNAL_SERVER_ERROR\",\"reason\":{\"type\":\"exception\","
                     + "\"reason\":\"foo\",\"caused_by\":{\"type\":\"illegal_argument_exception\",\"reason\":\"bar\"}}}",
-                Strings.toString(XContentType.JSON, exception)
+                Strings.toString(exception)
             );
         }
         {
@@ -112,7 +112,7 @@ public class DefaultShardOperationFailedExceptionTests extends OpenSearchTestCas
             assertEquals(
                 "{\"shard\":2,\"index\":\"test\",\"status\":\"INTERNAL_SERVER_ERROR\","
                     + "\"reason\":{\"type\":\"illegal_state_exception\",\"reason\":\"bar\"}}",
-                Strings.toString(XContentType.JSON, exception)
+                Strings.toString(exception)
             );
         }
         {
@@ -124,7 +124,7 @@ public class DefaultShardOperationFailedExceptionTests extends OpenSearchTestCas
             assertEquals(
                 "{\"shard\":1,\"index\":\"test\",\"status\":\"BAD_REQUEST\","
                     + "\"reason\":{\"type\":\"illegal_argument_exception\",\"reason\":\"foo\"}}",
-                Strings.toString(XContentType.JSON, exception)
+                Strings.toString(exception)
             );
         }
     }

--- a/server/src/test/java/org/opensearch/action/support/replication/ReplicationResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/support/replication/ReplicationResponseTests.java
@@ -66,7 +66,7 @@ public class ReplicationResponseTests extends OpenSearchTestCase {
     public void testShardInfoToXContent() throws IOException {
         {
             ShardInfo shardInfo = new ShardInfo(5, 3);
-            String output = Strings.toString(XContentType.JSON, shardInfo);
+            String output = Strings.toString(shardInfo);
             assertEquals("{\"total\":5,\"successful\":3,\"failed\":0}", output);
         }
         {
@@ -88,7 +88,7 @@ public class ReplicationResponseTests extends OpenSearchTestCase {
                     true
                 )
             );
-            String output = Strings.toString(XContentType.JSON, shardInfo);
+            String output = Strings.toString(shardInfo);
             assertEquals(
                 "{\"total\":6,\"successful\":4,\"failed\":2,\"failures\":[{\"_index\":\"index\",\"_shard\":3,"
                     + "\"_node\":\"_node_id\",\"reason\":{\"type\":\"illegal_argument_exception\",\"reason\":\"Wrong\"},"

--- a/server/src/test/java/org/opensearch/action/update/UpdateResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/update/UpdateResponseTests.java
@@ -69,7 +69,7 @@ public class UpdateResponseTests extends OpenSearchTestCase {
     public void testToXContent() throws IOException {
         {
             UpdateResponse updateResponse = new UpdateResponse(new ShardId("index", "index_uuid", 0), "id", -2, 0, 0, NOT_FOUND);
-            String output = Strings.toString(XContentType.JSON, updateResponse);
+            String output = Strings.toString(updateResponse);
             assertEquals(
                 "{\"_index\":\"index\",\"_id\":\"id\",\"_version\":0,\"result\":\"not_found\","
                     + "\"_shards\":{\"total\":0,\"successful\":0,\"failed\":0}}",
@@ -86,7 +86,7 @@ public class UpdateResponseTests extends OpenSearchTestCase {
                 1,
                 DELETED
             );
-            String output = Strings.toString(XContentType.JSON, updateResponse);
+            String output = Strings.toString(updateResponse);
             assertEquals(
                 "{\"_index\":\"index\",\"_id\":\"id\",\"_version\":1,\"result\":\"deleted\","
                     + "\"_shards\":{\"total\":10,\"successful\":6,\"failed\":0},\"_seq_no\":3,\"_primary_term\":17}",
@@ -110,7 +110,7 @@ public class UpdateResponseTests extends OpenSearchTestCase {
             );
             updateResponse.setGetResult(new GetResult("books", "1", 0, 1, 2, true, source, fields, null));
 
-            String output = Strings.toString(XContentType.JSON, updateResponse);
+            String output = Strings.toString(updateResponse);
             assertEquals(
                 "{\"_index\":\"books\",\"_id\":\"1\",\"_version\":2,\"result\":\"updated\","
                     + "\"_shards\":{\"total\":3,\"successful\":2,\"failed\":0},\"_seq_no\":7,\"_primary_term\":17,\"get\":{"

--- a/server/src/test/java/org/opensearch/cluster/metadata/IndexGraveyardTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/IndexGraveyardTests.java
@@ -41,7 +41,6 @@ import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentOpenSearchExtension;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.index.Index;
 import org.opensearch.test.OpenSearchTestCase;
@@ -87,7 +86,7 @@ public class IndexGraveyardTests extends OpenSearchTestCase {
         if (graveyard.getTombstones().size() > 0) {
             // check that date properly printed
             assertThat(
-                Strings.toString(XContentType.JSON, graveyard, false, true),
+                Strings.toString(graveyard, false, true),
                 containsString(
                     XContentOpenSearchExtension.DEFAULT_DATE_PRINTER.print(graveyard.getTombstones().get(0).getDeleteDateInMillis())
                 )

--- a/server/src/test/java/org/opensearch/cluster/metadata/IndexMetadataTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/IndexMetadataTests.java
@@ -50,7 +50,6 @@ import org.opensearch.common.util.set.Sets;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.index.shard.ShardId;
 import org.opensearch.indices.IndicesModule;
@@ -129,10 +128,7 @@ public class IndexMetadataTests extends OpenSearchTestCase {
         XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
         final IndexMetadata fromXContentMeta = IndexMetadata.fromXContent(parser);
         assertEquals(
-            "expected: "
-                + Strings.toString(XContentType.JSON, metadata)
-                + "\nactual  : "
-                + Strings.toString(XContentType.JSON, fromXContentMeta),
+            "expected: " + Strings.toString(metadata) + "\nactual  : " + Strings.toString(fromXContentMeta),
             metadata,
             fromXContentMeta
         );

--- a/server/src/test/java/org/opensearch/cluster/serialization/ClusterStateToStringTests.java
+++ b/server/src/test/java/org/opensearch/cluster/serialization/ClusterStateToStringTests.java
@@ -44,7 +44,6 @@ import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.cluster.routing.allocation.AllocationService;
 import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.util.Arrays;
 
@@ -80,7 +79,7 @@ public class ClusterStateToStringTests extends OpenSearchAllocationTestCase {
         AllocationService strategy = createAllocationService();
         clusterState = ClusterState.builder(clusterState).routingTable(strategy.reroute(clusterState, "reroute").routingTable()).build();
 
-        String clusterStateString = Strings.toString(XContentType.JSON, clusterState);
+        String clusterStateString = Strings.toString(clusterState);
         assertNotNull(clusterStateString);
 
         assertThat(clusterStateString, containsString("test_idx"));

--- a/server/src/test/java/org/opensearch/common/StringsTests.java
+++ b/server/src/test/java/org/opensearch/common/StringsTests.java
@@ -35,7 +35,6 @@ package org.opensearch.common;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.ToXContentObject;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.Collections;
@@ -105,7 +104,7 @@ public class StringsTests extends OpenSearchTestCase {
             }
         }
 
-        String toString = Strings.toString(XContentType.JSON, toXContent);
+        String toString = Strings.toString(toXContent);
         if (error) {
             assertThat(toString, containsString("\"error\":\"error building toString out of XContent:"));
             assertThat(toString, containsString("\"stack_trace\":"));
@@ -118,10 +117,10 @@ public class StringsTests extends OpenSearchTestCase {
     public void testToStringToXContentWithOrWithoutParams() {
         ToXContent toXContent = (builder, params) -> builder.field("color_from_param", params.param("color", "red"));
         // Rely on the default value of "color" param when params are not passed
-        assertThat(Strings.toString(XContentType.JSON, toXContent), containsString("\"color_from_param\":\"red\""));
+        assertThat(Strings.toString(toXContent), containsString("\"color_from_param\":\"red\""));
         // Pass "color" param explicitly
         assertThat(
-            Strings.toString(XContentType.JSON, toXContent, new ToXContent.MapParams(Collections.singletonMap("color", "blue"))),
+            Strings.toString(toXContent, new ToXContent.MapParams(Collections.singletonMap("color", "blue"))),
             containsString("\"color_from_param\":\"blue\"")
         );
     }

--- a/server/src/test/java/org/opensearch/index/get/DocumentFieldTests.java
+++ b/server/src/test/java/org/opensearch/index/get/DocumentFieldTests.java
@@ -60,7 +60,7 @@ public class DocumentFieldTests extends OpenSearchTestCase {
 
     public void testToXContent() {
         DocumentField documentField = new DocumentField("field", Arrays.asList("value1", "value2"));
-        String output = Strings.toString(XContentType.JSON, documentField);
+        String output = Strings.toString(documentField);
         assertEquals("{\"field\":[\"value1\",\"value2\"]}", output);
     }
 

--- a/server/src/test/java/org/opensearch/index/get/GetResultTests.java
+++ b/server/src/test/java/org/opensearch/index/get/GetResultTests.java
@@ -105,7 +105,7 @@ public class GetResultTests extends OpenSearchTestCase {
                 singletonMap("field1", new DocumentField("field1", singletonList("value1"))),
                 singletonMap("field1", new DocumentField("metafield", singletonList("metavalue")))
             );
-            String output = Strings.toString(XContentType.JSON, getResult);
+            String output = Strings.toString(getResult);
             assertEquals(
                 "{\"_index\":\"index\",\"_id\":\"id\",\"_version\":1,\"_seq_no\":0,\"_primary_term\":1,"
                     + "\"metafield\":\"metavalue\",\"found\":true,\"_source\":{ \"field1\" : \"value1\", \"field2\":\"value2\"},"
@@ -115,7 +115,7 @@ public class GetResultTests extends OpenSearchTestCase {
         }
         {
             GetResult getResult = new GetResult("index", "id", UNASSIGNED_SEQ_NO, 0, 1, false, null, null, null);
-            String output = Strings.toString(XContentType.JSON, getResult);
+            String output = Strings.toString(getResult);
             assertEquals("{\"_index\":\"index\",\"_id\":\"id\",\"found\":false}", output);
         }
     }

--- a/server/src/test/java/org/opensearch/index/mapper/CompletionFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/CompletionFieldMapperTests.java
@@ -51,7 +51,6 @@ import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.unit.Fuzziness;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.analysis.AnalyzerScope;
@@ -187,7 +186,7 @@ public class CompletionFieldMapperTests extends MapperTestCase {
         assertEquals(
             "{\"field\":{\"type\":\"completion\",\"analyzer\":\"simple\",\"search_analyzer\":\"standard\","
                 + "\"preserve_separators\":false,\"preserve_position_increments\":true,\"max_input_length\":50}}",
-            Strings.toString(XContentType.JSON, fieldMapper)
+            Strings.toString(fieldMapper)
         );
     }
 

--- a/server/src/test/java/org/opensearch/index/mapper/DynamicMappingTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DynamicMappingTests.java
@@ -36,7 +36,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -184,7 +183,7 @@ public class DynamicMappingTests extends MapperServiceTestCase {
         assertEquals(
             "{\"_doc\":{\"properties\":{\"foo\":{\"type\":\"text\",\"fields\":"
                 + "{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}}}}}",
-            Strings.toString(XContentType.JSON, doc.dynamicMappingsUpdate())
+            Strings.toString(doc.dynamicMappingsUpdate())
         );
     }
 
@@ -200,9 +199,9 @@ public class DynamicMappingTests extends MapperServiceTestCase {
         }));
         assertNotNull(doc.dynamicMappingsUpdate());
 
-        assertThat(Strings.toString(XContentType.JSON, doc.dynamicMappingsUpdate()), containsString("{\"bar\":"));
+        assertThat(Strings.toString(doc.dynamicMappingsUpdate()), containsString("{\"bar\":"));
         // field is NOT in the update
-        assertThat(Strings.toString(XContentType.JSON, doc.dynamicMappingsUpdate()), not(containsString("{\"field\":")));
+        assertThat(Strings.toString(doc.dynamicMappingsUpdate()), not(containsString("{\"field\":")));
     }
 
     public void testIntroduceTwoFields() throws Exception {
@@ -214,8 +213,8 @@ public class DynamicMappingTests extends MapperServiceTestCase {
         }));
 
         assertNotNull(doc.dynamicMappingsUpdate());
-        assertThat(Strings.toString(XContentType.JSON, doc.dynamicMappingsUpdate()), containsString("\"foo\":{"));
-        assertThat(Strings.toString(XContentType.JSON, doc.dynamicMappingsUpdate()), containsString("\"bar\":{"));
+        assertThat(Strings.toString(doc.dynamicMappingsUpdate()), containsString("\"foo\":{"));
+        assertThat(Strings.toString(doc.dynamicMappingsUpdate()), containsString("\"bar\":{"));
     }
 
     public void testObject() throws Exception {
@@ -230,7 +229,7 @@ public class DynamicMappingTests extends MapperServiceTestCase {
 
         assertNotNull(doc.dynamicMappingsUpdate());
         assertThat(
-            Strings.toString(XContentType.JSON, doc.dynamicMappingsUpdate()),
+            Strings.toString(doc.dynamicMappingsUpdate()),
             containsString("{\"foo\":{\"properties\":{\"bar\":{\"properties\":{\"baz\":{\"type\":\"text\"")
         );
     }
@@ -241,7 +240,7 @@ public class DynamicMappingTests extends MapperServiceTestCase {
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("foo").value("bar").value("baz").endArray()));
 
         assertNotNull(doc.dynamicMappingsUpdate());
-        assertThat(Strings.toString(XContentType.JSON, doc.dynamicMappingsUpdate()), containsString("{\"foo\":{\"type\":\"text\""));
+        assertThat(Strings.toString(doc.dynamicMappingsUpdate()), containsString("{\"foo\":{\"type\":\"text\""));
     }
 
     public void testInnerDynamicMapping() throws Exception {
@@ -257,7 +256,7 @@ public class DynamicMappingTests extends MapperServiceTestCase {
 
         assertNotNull(doc.dynamicMappingsUpdate());
         assertThat(
-            Strings.toString(XContentType.JSON, doc.dynamicMappingsUpdate()),
+            Strings.toString(doc.dynamicMappingsUpdate()),
             containsString("{\"field\":{\"properties\":{\"bar\":{\"properties\":{\"baz\":{\"type\":\"text\"")
         );
     }
@@ -277,7 +276,7 @@ public class DynamicMappingTests extends MapperServiceTestCase {
         assertEquals(
             "{\"_doc\":{\"properties\":{\"foo\":{\"properties\":{\"bar\":{\"type\":\"text\",\"fields\":{"
                 + "\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}},\"baz\":{\"type\":\"long\"}}}}}}",
-            Strings.toString(XContentType.JSON, doc.dynamicMappingsUpdate())
+            Strings.toString(doc.dynamicMappingsUpdate())
         );
     }
 

--- a/server/src/test/java/org/opensearch/index/mapper/GeoShapeFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/GeoShapeFieldMapperTests.java
@@ -37,7 +37,6 @@ import org.opensearch.common.collect.List;
 import org.opensearch.common.geo.builders.ShapeBuilder;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.TestGeoShapeFieldMapperPlugin;
 import org.junit.Before;
@@ -229,7 +228,6 @@ public class GeoShapeFieldMapperTests extends FieldMapperTestCase2<GeoShapeField
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         assertThat(
             Strings.toString(
-                XContentType.JSON,
                 mapper.mappers().getMapper("field"),
                 new ToXContent.MapParams(Collections.singletonMap("include_defaults", "true"))
             ),

--- a/server/src/test/java/org/opensearch/index/mapper/LegacyGeoShapeFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/LegacyGeoShapeFieldMapperTests.java
@@ -46,7 +46,6 @@ import org.opensearch.common.geo.SpatialStrategy;
 import org.opensearch.common.geo.builders.ShapeBuilder;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.geometry.Point;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.plugins.Plugin;
@@ -539,13 +538,13 @@ public class LegacyGeoShapeFieldMapperTests extends FieldMapperTestCase2<LegacyG
         ToXContent.Params includeDefaults = new ToXContent.MapParams(singletonMap("include_defaults", "true"));
         {
             DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "geo_shape").field("tree", "quadtree")));
-            String serialized = Strings.toString(XContentType.JSON, mapper.mappers().getMapper("field"), includeDefaults);
+            String serialized = Strings.toString(mapper.mappers().getMapper("field"), includeDefaults);
             assertTrue(serialized, serialized.contains("\"precision\":\"50.0m\""));
             assertTrue(serialized, serialized.contains("\"tree_levels\":21"));
         }
         {
             DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "geo_shape").field("tree", "geohash")));
-            String serialized = Strings.toString(XContentType.JSON, mapper.mappers().getMapper("field"), includeDefaults);
+            String serialized = Strings.toString(mapper.mappers().getMapper("field"), includeDefaults);
             assertTrue(serialized, serialized.contains("\"precision\":\"50.0m\""));
             assertTrue(serialized, serialized.contains("\"tree_levels\":9"));
         }
@@ -553,7 +552,7 @@ public class LegacyGeoShapeFieldMapperTests extends FieldMapperTestCase2<LegacyG
             DocumentMapper mapper = createDocumentMapper(
                 fieldMapping(b -> b.field("type", "geo_shape").field("tree", "quadtree").field("tree_levels", "6"))
             );
-            String serialized = Strings.toString(XContentType.JSON, mapper.mappers().getMapper("field"), includeDefaults);
+            String serialized = Strings.toString(mapper.mappers().getMapper("field"), includeDefaults);
             assertFalse(serialized, serialized.contains("\"precision\":"));
             assertTrue(serialized, serialized.contains("\"tree_levels\":6"));
         }
@@ -561,7 +560,7 @@ public class LegacyGeoShapeFieldMapperTests extends FieldMapperTestCase2<LegacyG
             DocumentMapper mapper = createDocumentMapper(
                 fieldMapping(b -> b.field("type", "geo_shape").field("tree", "quadtree").field("precision", "6"))
             );
-            String serialized = Strings.toString(XContentType.JSON, mapper.mappers().getMapper("field"), includeDefaults);
+            String serialized = Strings.toString(mapper.mappers().getMapper("field"), includeDefaults);
             assertTrue(serialized, serialized.contains("\"precision\":\"6.0m\""));
             assertFalse(serialized, serialized.contains("\"tree_levels\":"));
         }
@@ -569,7 +568,7 @@ public class LegacyGeoShapeFieldMapperTests extends FieldMapperTestCase2<LegacyG
             DocumentMapper mapper = createDocumentMapper(
                 fieldMapping(b -> b.field("type", "geo_shape").field("tree", "quadtree").field("precision", "6m").field("tree_levels", "5"))
             );
-            String serialized = Strings.toString(XContentType.JSON, mapper.mappers().getMapper("field"), includeDefaults);
+            String serialized = Strings.toString(mapper.mappers().getMapper("field"), includeDefaults);
             assertTrue(serialized, serialized.contains("\"precision\":\"6.0m\""));
             assertTrue(serialized, serialized.contains("\"tree_levels\":5"));
         }
@@ -591,7 +590,7 @@ public class LegacyGeoShapeFieldMapperTests extends FieldMapperTestCase2<LegacyG
         assertThat(strategy.getGrid().getMaxLevels(), equalTo(23));
         assertThat(strategy.isPointsOnly(), equalTo(true));
         // term strategy changes the default for points_only, check that we handle it correctly
-        assertThat(Strings.toString(XContentType.JSON, geoShapeFieldMapper), not(containsString("points_only")));
+        assertThat(Strings.toString(geoShapeFieldMapper), not(containsString("points_only")));
         assertFieldWarnings("tree", "precision", "strategy");
     }
 

--- a/server/src/test/java/org/opensearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ParametrizedMapperTests.java
@@ -42,7 +42,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentHelper;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.index.analysis.AnalyzerScope;
 import org.opensearch.index.analysis.IndexAnalyzers;
@@ -266,7 +265,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         assertTrue(mapper.fixed);
         assertEquals("default", mapper.variable);
 
-        assertEquals("{\"field\":" + mapping + "}", Strings.toString(XContentType.JSON, mapper));
+        assertEquals("{\"field\":" + mapping + "}", Strings.toString(mapper));
         assertEquals(
             "{\"field\":{\"type\":\"test_mapper\",\"fixed\":true,"
                 + "\"fixed2\":false,\"variable\":\"default\",\"index\":true,"
@@ -280,7 +279,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
     public void testMerging() {
         String mapping = "{\"type\":\"test_mapper\",\"fixed\":false,\"required\":\"value\"}";
         TestMapper mapper = fromMapping(mapping);
-        assertEquals("{\"field\":" + mapping + "}", Strings.toString(XContentType.JSON, mapper));
+        assertEquals("{\"field\":" + mapping + "}", Strings.toString(mapper));
 
         TestMapper badMerge = fromMapping("{\"type\":\"test_mapper\",\"fixed\":true,\"fixed2\":true,\"required\":\"value\"}");
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> mapper.merge(badMerge));
@@ -289,16 +288,16 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
             + "\tCannot update parameter [fixed2] from [false] to [true]";
         assertEquals(expectedError, e.getMessage());
 
-        assertEquals("{\"field\":" + mapping + "}", Strings.toString(XContentType.JSON, mapper));   // original mapping is unaffected
+        assertEquals("{\"field\":" + mapping + "}", Strings.toString(mapper));   // original mapping is unaffected
 
         // TODO: should we have to include 'fixed' here? Or should updates take as 'defaults' the existing values?
         TestMapper goodMerge = fromMapping("{\"type\":\"test_mapper\",\"fixed\":false,\"variable\":\"updated\",\"required\":\"value\"}");
         TestMapper merged = (TestMapper) mapper.merge(goodMerge);
 
-        assertEquals("{\"field\":" + mapping + "}", Strings.toString(XContentType.JSON, mapper));   // original mapping is unaffected
+        assertEquals("{\"field\":" + mapping + "}", Strings.toString(mapper));   // original mapping is unaffected
         assertEquals(
             "{\"field\":{\"type\":\"test_mapper\",\"fixed\":false,\"variable\":\"updated\",\"required\":\"value\"}}",
-            Strings.toString(XContentType.JSON, merged)
+            Strings.toString(merged)
         );
     }
 
@@ -307,7 +306,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         String mapping = "{\"type\":\"test_mapper\",\"variable\":\"foo\",\"required\":\"value\","
             + "\"fields\":{\"sub\":{\"type\":\"keyword\"}}}";
         TestMapper mapper = fromMapping(mapping);
-        assertEquals("{\"field\":" + mapping + "}", Strings.toString(XContentType.JSON, mapper));
+        assertEquals("{\"field\":" + mapping + "}", Strings.toString(mapper));
 
         String addSubField = "{\"type\":\"test_mapper\",\"variable\":\"foo\",\"required\":\"value\""
             + ",\"fields\":{\"sub2\":{\"type\":\"keyword\"}}}";
@@ -316,7 +315,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         assertEquals(
             "{\"field\":{\"type\":\"test_mapper\",\"variable\":\"foo\",\"required\":\"value\","
                 + "\"fields\":{\"sub\":{\"type\":\"keyword\"},\"sub2\":{\"type\":\"keyword\"}}}}",
-            Strings.toString(XContentType.JSON, merged)
+            Strings.toString(merged)
         );
 
         String badSubField = "{\"type\":\"test_mapper\",\"variable\":\"foo\",\"required\":\"value\","
@@ -330,7 +329,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
     public void testCopyTo() {
         String mapping = "{\"type\":\"test_mapper\",\"variable\":\"foo\",\"required\":\"value\",\"copy_to\":[\"other\"]}";
         TestMapper mapper = fromMapping(mapping);
-        assertEquals("{\"field\":" + mapping + "}", Strings.toString(XContentType.JSON, mapper));
+        assertEquals("{\"field\":" + mapping + "}", Strings.toString(mapper));
 
         // On update, copy_to is completely replaced
 
@@ -340,15 +339,12 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         TestMapper merged = (TestMapper) mapper.merge(toMerge);
         assertEquals(
             "{\"field\":{\"type\":\"test_mapper\",\"variable\":\"updated\",\"required\":\"value\"," + "\"copy_to\":[\"foo\",\"bar\"]}}",
-            Strings.toString(XContentType.JSON, merged)
+            Strings.toString(merged)
         );
 
         TestMapper removeCopyTo = fromMapping("{\"type\":\"test_mapper\",\"variable\":\"updated\",\"required\":\"value\"}");
         TestMapper noCopyTo = (TestMapper) merged.merge(removeCopyTo);
-        assertEquals(
-            "{\"field\":{\"type\":\"test_mapper\",\"variable\":\"updated\",\"required\":\"value\"}}",
-            Strings.toString(XContentType.JSON, noCopyTo)
-        );
+        assertEquals("{\"field\":{\"type\":\"test_mapper\",\"variable\":\"updated\",\"required\":\"value\"}}", Strings.toString(noCopyTo));
     }
 
     public void testNullables() {
@@ -358,7 +354,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
 
         String fine = "{\"type\":\"test_mapper\",\"variable\":null,\"required\":\"value\"}";
         TestMapper mapper = fromMapping(fine);
-        assertEquals("{\"field\":" + fine + "}", Strings.toString(XContentType.JSON, mapper));
+        assertEquals("{\"field\":" + fine + "}", Strings.toString(mapper));
     }
 
     public void testObjectSerialization() throws IOException {
@@ -373,10 +369,10 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
             + "\"is_interim\":{\"type\":\"boolean\"}}}}}}";
 
         MapperService mapperService = createMapperService("_doc", mapping);
-        assertEquals(mapping, Strings.toString(XContentType.JSON, mapperService.documentMapper()));
+        assertEquals(mapping, Strings.toString(mapperService.documentMapper()));
 
         mapperService.merge("_doc", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
-        assertEquals(mapping, Strings.toString(XContentType.JSON, mapperService.documentMapper()));
+        assertEquals(mapping, Strings.toString(mapperService.documentMapper()));
     }
 
     // test custom serializer
@@ -384,7 +380,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         String mapping = "{\"type\":\"test_mapper\",\"wrapper\":\"wrapped value\",\"required\":\"value\"}";
         TestMapper mapper = fromMapping(mapping);
         assertEquals("wrapped value", mapper.wrapper.name);
-        assertEquals("{\"field\":" + mapping + "}", Strings.toString(XContentType.JSON, mapper));
+        assertEquals("{\"field\":" + mapping + "}", Strings.toString(mapper));
 
         String conflict = "{\"type\":\"test_mapper\",\"wrapper\":\"new value\",\"required\":\"value\"}";
         TestMapper toMerge = fromMapping(conflict);
@@ -401,7 +397,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         String mapping = "{\"type\":\"test_mapper\",\"int_value\":10,\"required\":\"value\"}";
         TestMapper mapper = fromMapping(mapping);
         assertEquals(10, mapper.intValue);
-        assertEquals("{\"field\":" + mapping + "}", Strings.toString(XContentType.JSON, mapper));
+        assertEquals("{\"field\":" + mapping + "}", Strings.toString(mapper));
 
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
@@ -416,23 +412,20 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         TestMapper mapper = fromMapping(mapping);
         assertTrue(mapper.fixed2);
         assertWarnings("Parameter [fixed2_old] on mapper [field] is deprecated, use [fixed2]");
-        assertEquals(
-            "{\"field\":{\"type\":\"test_mapper\",\"fixed2\":true,\"required\":\"value\"}}",
-            Strings.toString(XContentType.JSON, mapper)
-        );
+        assertEquals("{\"field\":{\"type\":\"test_mapper\",\"fixed2\":true,\"required\":\"value\"}}", Strings.toString(mapper));
     }
 
     public void testAnalyzers() {
         String mapping = "{\"type\":\"test_mapper\",\"analyzer\":\"_standard\",\"required\":\"value\"}";
         TestMapper mapper = fromMapping(mapping);
         assertEquals(mapper.analyzer, Lucene.STANDARD_ANALYZER);
-        assertEquals("{\"field\":" + mapping + "}", Strings.toString(XContentType.JSON, mapper));
+        assertEquals("{\"field\":" + mapping + "}", Strings.toString(mapper));
 
         String withDef = "{\"type\":\"test_mapper\",\"analyzer\":\"default\",\"required\":\"value\"}";
         mapper = fromMapping(withDef);
         assertEquals(mapper.analyzer.name(), "default");
         assertThat(mapper.analyzer.analyzer(), instanceOf(StandardAnalyzer.class));
-        assertEquals("{\"field\":" + withDef + "}", Strings.toString(XContentType.JSON, mapper));
+        assertEquals("{\"field\":" + withDef + "}", Strings.toString(mapper));
 
         String badAnalyzer = "{\"type\":\"test_mapper\",\"analyzer\":\"wibble\",\"required\":\"value\"}";
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> fromMapping(badAnalyzer));
@@ -453,10 +446,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         TestMapper mapper = fromMapping(mapping, LegacyESVersion.V_7_8_0);
         assertWarnings("Parameter [store] has no effect on type [test_mapper] and will be removed in future");
         assertFalse(mapper.index);
-        assertEquals(
-            "{\"field\":{\"type\":\"test_mapper\",\"index\":false,\"required\":\"value\"}}",
-            Strings.toString(XContentType.JSON, mapper)
-        );
+        assertEquals("{\"field\":{\"type\":\"test_mapper\",\"index\":false,\"required\":\"value\"}}", Strings.toString(mapper));
     }
 
     public void testLinkedAnalyzers() throws IOException {
@@ -464,20 +454,20 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         TestMapper mapper = fromMapping(mapping);
         assertEquals("_standard", mapper.analyzer.name());
         assertEquals("_standard", mapper.searchAnalyzer.name());
-        assertEquals("{\"field\":" + mapping + "}", Strings.toString(XContentType.JSON, mapper));
+        assertEquals("{\"field\":" + mapping + "}", Strings.toString(mapper));
 
         String mappingWithSA = "{\"type\":\"test_mapper\",\"search_analyzer\":\"_standard\",\"required\":\"value\"}";
         mapper = fromMapping(mappingWithSA);
         assertEquals("_keyword", mapper.analyzer.name());
         assertEquals("_standard", mapper.searchAnalyzer.name());
-        assertEquals("{\"field\":" + mappingWithSA + "}", Strings.toString(XContentType.JSON, mapper));
+        assertEquals("{\"field\":" + mappingWithSA + "}", Strings.toString(mapper));
 
         String mappingWithBoth = "{\"type\":\"test_mapper\",\"analyzer\":\"default\","
             + "\"search_analyzer\":\"_standard\",\"required\":\"value\"}";
         mapper = fromMapping(mappingWithBoth);
         assertEquals("default", mapper.analyzer.name());
         assertEquals("_standard", mapper.searchAnalyzer.name());
-        assertEquals("{\"field\":" + mappingWithBoth + "}", Strings.toString(XContentType.JSON, mapper));
+        assertEquals("{\"field\":" + mappingWithBoth + "}", Strings.toString(mapper));
 
         // we've configured things so that search_analyzer is only output when different from
         // analyzer, no matter what the value of `include_defaults` is
@@ -486,10 +476,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         mapper = fromMapping(mappingWithSame);
         assertEquals("default", mapper.analyzer.name());
         assertEquals("default", mapper.searchAnalyzer.name());
-        assertEquals(
-            "{\"field\":{\"type\":\"test_mapper\",\"analyzer\":\"default\",\"required\":\"value\"}}",
-            Strings.toString(XContentType.JSON, mapper)
-        );
+        assertEquals("{\"field\":{\"type\":\"test_mapper\",\"analyzer\":\"default\",\"required\":\"value\"}}", Strings.toString(mapper));
 
         assertEquals(
             "{\"field\":{\"type\":\"test_mapper\",\"fixed\":true,"

--- a/server/src/test/java/org/opensearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/TextFieldMapperTests.java
@@ -68,7 +68,6 @@ import org.opensearch.common.lucene.search.MultiPhrasePrefixQuery;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.analysis.AnalyzerScope;
 import org.opensearch.index.analysis.CharFilterFactory;
@@ -285,7 +284,7 @@ public class TextFieldMapperTests extends MapperTestCase {
 
         assertEquals(
             "{\"_doc\":{\"properties\":{\"field\":{\"type\":\"text\",\"fields\":{\"subfield\":{\"type\":\"long\"}},\"fielddata\":true}}}}",
-            Strings.toString(XContentType.JSON, mapperService.documentMapper())
+            Strings.toString(mapperService.documentMapper())
         );
     }
 
@@ -326,7 +325,7 @@ public class TextFieldMapperTests extends MapperTestCase {
         mapping.endObject().endObject().endObject();
 
         DocumentMapper mapper = createDocumentMapper(mapping);
-        String serialized = Strings.toString(XContentType.JSON, mapper);
+        String serialized = Strings.toString(mapper);
         assertThat(serialized, containsString("\"offsets\":{\"type\":\"text\",\"index_options\":\"offsets\"}"));
         assertThat(serialized, containsString("\"freqs\":{\"type\":\"text\",\"index_options\":\"freqs\"}"));
         assertThat(serialized, containsString("\"docs\":{\"type\":\"text\",\"index_options\":\"docs\"}"));

--- a/server/src/test/java/org/opensearch/persistent/TestPersistentTasksPlugin.java
+++ b/server/src/test/java/org/opensearch/persistent/TestPersistentTasksPlugin.java
@@ -65,7 +65,6 @@ import org.opensearch.common.xcontent.ConstructingObjectParser;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.persistent.PersistentTasksCustomMetadata.Assignment;
 import org.opensearch.persistent.PersistentTasksCustomMetadata.PersistentTask;
 import org.opensearch.plugins.ActionPlugin;
@@ -300,7 +299,7 @@ public class TestPersistentTasksPlugin extends Plugin implements ActionPlugin, P
 
         @Override
         public String toString() {
-            return Strings.toString(XContentType.JSON, this);
+            return Strings.toString(this);
         }
 
         // Implements equals and hashcode for testing

--- a/server/src/test/java/org/opensearch/script/ScriptTests.java
+++ b/server/src/test/java/org/opensearch/script/ScriptTests.java
@@ -166,11 +166,7 @@ public class ScriptTests extends OpenSearchTestCase {
             options.put("option" + i, Integer.toString(i));
         }
         Script script = new Script(ScriptType.INLINE, Script.DEFAULT_SCRIPT_LANG, "doc['field']", options, params);
-        Map<String, Object> scriptObject = XContentHelper.convertToMap(
-            XContentType.JSON.xContent(),
-            Strings.toString(XContentType.JSON, script),
-            false
-        );
+        Map<String, Object> scriptObject = XContentHelper.convertToMap(XContentType.JSON.xContent(), Strings.toString(script), false);
         Script parsedScript = Script.parse(scriptObject);
         assertEquals(script, parsedScript);
     }

--- a/server/src/test/java/org/opensearch/search/sort/SortValueTests.java
+++ b/server/src/test/java/org/opensearch/search/sort/SortValueTests.java
@@ -37,7 +37,6 @@ import org.opensearch.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.mapper.DateFieldMapper;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.test.AbstractNamedWriteableTestCase;
@@ -120,7 +119,7 @@ public class SortValueTests extends AbstractNamedWriteableTestCase<SortValue> {
     }
 
     public String toXContent(SortValue sortValue, DocValueFormat format) {
-        return Strings.toString(XContentType.JSON, new ToXContentFragment() {
+        return Strings.toString(new ToXContentFragment() {
             @Override
             public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
                 builder.field("test");

--- a/test/framework/src/main/java/org/opensearch/search/aggregations/BaseAggregationTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/search/aggregations/BaseAggregationTestCase.java
@@ -138,7 +138,7 @@ public abstract class BaseAggregationTestCase<AB extends AbstractAggregationBuil
      */
     public void testToString() throws IOException {
         AB testAgg = createTestAggregatorBuilder();
-        String toString = randomBoolean() ? Strings.toString(XContentType.JSON, testAgg) : testAgg.toString();
+        String toString = randomBoolean() ? Strings.toString(testAgg) : testAgg.toString();
         XContentParser parser = createParser(XContentType.JSON.xContent(), toString);
         AggregationBuilder newAgg = parse(parser);
         assertNotSame(newAgg, testAgg);

--- a/test/framework/src/main/java/org/opensearch/test/AbstractBroadcastResponseTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/AbstractBroadcastResponseTestCase.java
@@ -150,7 +150,7 @@ public abstract class AbstractBroadcastResponseTestCase<T extends BroadcastRespo
 
     public void testToXContent() {
         T response = createTestInstance(10, 10, 0, null);
-        String output = Strings.toString(XContentType.JSON, response);
+        String output = Strings.toString(response);
         assertEquals("{\"_shards\":{\"total\":10,\"successful\":10,\"failed\":0}}", output);
     }
 }

--- a/test/framework/src/main/java/org/opensearch/test/AbstractQueryTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/AbstractQueryTestCase.java
@@ -634,7 +634,7 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
         for (int runs = 0; runs < NUMBER_OF_TESTQUERIES; runs++) {
             QB testQuery = createTestQueryBuilder();
             XContentType xContentType = XContentType.JSON;
-            String toString = Strings.toString(XContentType.JSON, testQuery);
+            String toString = Strings.toString(testQuery);
             assertParsedQuery(createParser(xContentType.xContent(), toString), testQuery);
             BytesReference bytes = XContentHelper.toXContent(testQuery, xContentType, false);
             assertParsedQuery(createParser(xContentType.xContent(), bytes), testQuery);

--- a/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
@@ -966,7 +966,7 @@ public abstract class OpenSearchRestTestCase extends OpenSearchTestCase {
 
     protected static void createIndex(String name, Settings settings, String mapping, String aliases) throws IOException {
         Request request = new Request("PUT", "/" + name);
-        String entity = "{\"settings\": " + Strings.toString(XContentType.JSON, settings);
+        String entity = "{\"settings\": " + Strings.toString(settings);
         if (mapping != null) {
             entity += ",\"mappings\" : {" + mapping + "}";
         }
@@ -992,7 +992,7 @@ public abstract class OpenSearchRestTestCase extends OpenSearchTestCase {
 
     private static void updateIndexSettings(String index, Settings settings) throws IOException {
         Request request = new Request("PUT", "/" + index + "/_settings");
-        request.setJsonEntity(Strings.toString(XContentType.JSON, settings));
+        request.setJsonEntity(Strings.toString(settings));
         client().performRequest(request);
     }
 
@@ -1102,7 +1102,7 @@ public abstract class OpenSearchRestTestCase extends OpenSearchTestCase {
     protected static void registerRepository(String repository, String type, boolean verify, Settings settings) throws IOException {
         final Request request = new Request(HttpPut.METHOD_NAME, "_snapshot/" + repository);
         request.addParameter("verify", Boolean.toString(verify));
-        request.setJsonEntity(Strings.toString(XContentType.JSON, new PutRepositoryRequest(repository).type(type).settings(settings)));
+        request.setJsonEntity(Strings.toString(new PutRepositoryRequest(repository).type(type).settings(settings)));
 
         final Response response = client().performRequest(request);
         assertAcked("Failed to create repository [" + repository + "] of type [" + type + "]: " + response, response);

--- a/test/framework/src/main/java/org/opensearch/test/rest/yaml/OpenSearchClientYamlSuiteTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/yaml/OpenSearchClientYamlSuiteTestCase.java
@@ -49,7 +49,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.internal.io.IOUtils;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
 import org.opensearch.test.rest.yaml.restspec.ClientYamlSuiteRestApi;
@@ -450,7 +449,7 @@ public abstract class OpenSearchClientYamlSuiteTestCase extends OpenSearchRestTe
             // Dump the stash on failure. Instead of dumping it in true json we escape `\n`s so stack traces are easier to read
             logger.info(
                 "Stash dump on test failure [{}]",
-                Strings.toString(XContentType.JSON, restTestExecutionContext.stash(), true, true)
+                Strings.toString(restTestExecutionContext.stash(), true, true)
                     .replace("\\n", "\n")
                     .replace("\\r", "\r")
                     .replace("\\t", "\t")


### PR DESCRIPTION
### Description
This reverts commit c4ab2364f8de2c55a2a18043b2436eff401a57a9 on the `2.6` branch. The change will be retained in the `2.x` branch so it can be a part of the next 2.* release

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
