### PR TITLE
Fix potential deadlock in ConcurrentInvocationLinearizer

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/remote/directory/RemoteSnapshotDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/directory/RemoteSnapshotDirectoryFactory.java
@@ -89,11 +89,7 @@ public final class RemoteSnapshotDirectoryFactory implements IndexStorePlugin.Di
         return threadPool.executor(ThreadPool.Names.SNAPSHOT).submit(() -> {
             final BlobContainer blobContainer = blobStoreRepository.blobStore().blobContainer(blobPath);
             final BlobStoreIndexShardSnapshot snapshot = blobStoreRepository.loadShardSnapshot(blobContainer, snapshotId);
-            TransferManager transferManager = new TransferManager(
-                blobContainer,
-                threadPool.executor(ThreadPool.Names.SEARCH),
-                remoteStoreFileCache
-            );
+            TransferManager transferManager = new TransferManager(blobContainer, remoteStoreFileCache);
             return new RemoteSnapshotDirectory(snapshot, localStoreDir, transferManager);
         });
     }

--- a/server/src/main/java/org/opensearch/index/store/remote/file/OnDemandBlockSnapshotIndexInput.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/file/OnDemandBlockSnapshotIndexInput.java
@@ -10,7 +10,6 @@ package org.opensearch.index.store.remote.file;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.IndexInput;
 import org.opensearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
@@ -18,7 +17,6 @@ import org.opensearch.index.store.remote.utils.BlobFetchRequest;
 import org.opensearch.index.store.remote.utils.TransferManager;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 
 /**
  * This is an implementation of {@link OnDemandBlockIndexInput} where this class provides the main IndexInput using shard snapshot files.
@@ -147,9 +145,10 @@ public class OnDemandBlockSnapshotIndexInput extends OnDemandBlockIndexInput {
             .fileName(blockFileName)
             .build();
         try {
-            return transferManager.asyncFetchBlob(blobFetchRequest).get();
-        } catch (InterruptedException | ExecutionException e) {
-            logger.error(() -> new ParameterizedMessage("unexpected failure while fetching [{}]", blobFetchRequest), e);
+            return transferManager.fetchBlob(blobFetchRequest);
+        } catch (InterruptedException e) {
+            logger.error("Interrupted while fetching [{}]", blobFetchRequest);
+            Thread.currentThread().interrupt();
             throw new IllegalStateException(e);
         }
     }

--- a/server/src/main/java/org/opensearch/index/store/remote/utils/ConcurrentInvocationLinearizer.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/ConcurrentInvocationLinearizer.java
@@ -8,48 +8,79 @@
 
 package org.opensearch.index.store.remote.utils;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutorService;
-import java.util.function.Function;
+import java.util.concurrent.ExecutionException;
+
+import org.opensearch.common.CheckedFunction;
 
 /**
- * A utility class which can be used to serialize concurrent invocations and to achieve "invoke simultaneously once at any time" semantic
+ * A utility class which can be used to serialize concurrent invocations and to achieve "invoke simultaneously once at any time"
+ * semantic. This class does not implement any concurrency itself. When there is no concurrent access the work will be performed
+ * on the calling thread, though the result of that work will be shared with any concurrent requests for the same key.
  *
  * @param <METHOD_PARAM_TYPE> the method parameter type where this method invocation will be linearized
  * @param <RET_TYPE>          return type of the method
  * @opensearch.internal
  */
-public class ConcurrentInvocationLinearizer<METHOD_PARAM_TYPE, RET_TYPE> {
-    private final ConcurrentMap<METHOD_PARAM_TYPE, CompletableFuture<RET_TYPE>> invokeOnceCache;
-    private final ExecutorService executorService;
+class ConcurrentInvocationLinearizer<METHOD_PARAM_TYPE, RET_TYPE> {
+    private final ConcurrentMap<METHOD_PARAM_TYPE, CompletableFuture<RET_TYPE>> invokeOnceCache = new ConcurrentHashMap<>();
 
     /**
-     * Constructs the object
-     *
-     * @param executorService which will be used to execute the concurrent invocations
+     * Invokes the given function. If another thread is concurrently invoking the same function, as
+     * identified by the given input, then this call will block and return the result of that
+     * computation. Otherwise it will synchronously invoke the given function and return the result.
+     * @param input The input to uniquely identify this function
+     * @param function The function to invoke
+     * @return The result of the function
+     * @throws InterruptedException thrown if interrupted while blocking
+     * @throws IOException thrown from given function
      */
-    public ConcurrentInvocationLinearizer(ExecutorService executorService) {
-        this.invokeOnceCache = new ConcurrentHashMap<>();
-        this.executorService = executorService;
+    RET_TYPE linearize(METHOD_PARAM_TYPE input, CheckedFunction<METHOD_PARAM_TYPE, RET_TYPE, IOException> function)
+        throws InterruptedException, IOException {
+        try {
+            return linearizeInternal(input, function).get();
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof IOException) {
+                throw (IOException) e.getCause();
+            } else if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            } else if (e.getCause() instanceof Error) {
+                throw (Error) e.getCause();
+            }
+            throw new RuntimeException("Unknown exception cause", e.getCause());
+        }
     }
 
-    /**
-     * @param input    the argument to the method
-     * @param function delegate to actual function/method
-     * @return return value of the function
-     */
-    public CompletableFuture<RET_TYPE> linearize(METHOD_PARAM_TYPE input, Function<METHOD_PARAM_TYPE, RET_TYPE> function) {
-        return invokeOnceCache.computeIfAbsent(input, in -> CompletableFuture.supplyAsync(() -> function.apply(in), executorService))
-            .whenComplete((ret, throwable) -> {
-                // whenComplete will always be executed (when run normally or when exception happen)
+    // Visible for testing
+    CompletableFuture<RET_TYPE> linearizeInternal(
+        METHOD_PARAM_TYPE input,
+        CheckedFunction<METHOD_PARAM_TYPE, RET_TYPE, IOException> function
+    ) {
+        final CompletableFuture<RET_TYPE> newFuture = new CompletableFuture<>();
+        final CompletableFuture<RET_TYPE> existing = invokeOnceCache.putIfAbsent(input, newFuture);
+        if (existing == null) {
+            // No concurrent work is happening for this key, so need to do the
+            // work and complete the future with the result.
+            try {
+                newFuture.complete(function.apply(input));
+            } catch (Throwable e) {
+                newFuture.completeExceptionally(e);
+            } finally {
                 invokeOnceCache.remove(input);
-            });
+            }
+            return newFuture;
+        } else {
+            // Another thread is doing the work, so return the future to its result
+            return existing;
+        }
     }
 
+    // Visible for testing
     Map<METHOD_PARAM_TYPE, CompletableFuture<RET_TYPE>> getInvokeOnceCache() {
         return Collections.unmodifiableMap(invokeOnceCache);
     }

--- a/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
@@ -23,8 +23,6 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 
 /**
  * This acts as entry point to fetch {@link BlobFetchRequest} and return actual {@link IndexInput}. Utilizes the BlobContainer interface to
@@ -37,12 +35,11 @@ public class TransferManager {
 
     private final BlobContainer blobContainer;
     private final ConcurrentInvocationLinearizer<Path, IndexInput> invocationLinearizer;
-
     private final FileCache fileCache;
 
-    public TransferManager(final BlobContainer blobContainer, final ExecutorService remoteStoreExecutorService, final FileCache fileCache) {
+    public TransferManager(final BlobContainer blobContainer, final FileCache fileCache) {
         this.blobContainer = blobContainer;
-        this.invocationLinearizer = new ConcurrentInvocationLinearizer<>(remoteStoreExecutorService);
+        this.invocationLinearizer = new ConcurrentInvocationLinearizer<>();
         this.fileCache = fileCache;
     }
 
@@ -51,14 +48,12 @@ public class TransferManager {
      * @param blobFetchRequest to fetch
      * @return future of IndexInput augmented with internal caching maintenance tasks
      */
-    public CompletableFuture<IndexInput> asyncFetchBlob(BlobFetchRequest blobFetchRequest) {
-        return invocationLinearizer.linearize(blobFetchRequest.getFilePath(), p -> {
-            try {
-                return fetchBlob(blobFetchRequest);
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
-            }
-        }).thenApply(IndexInput::clone);
+    public IndexInput fetchBlob(BlobFetchRequest blobFetchRequest) throws InterruptedException, IOException {
+        final IndexInput indexInput = invocationLinearizer.linearize(
+            blobFetchRequest.getFilePath(),
+            p -> fetchOriginBlob(blobFetchRequest)
+        );
+        return indexInput.clone();
     }
 
     /**
@@ -67,7 +62,7 @@ public class TransferManager {
      * accessed through the ConcurrentInvocationLinearizer so read-check-write is
      * acceptable here
      */
-    private IndexInput fetchBlob(BlobFetchRequest blobFetchRequest) throws IOException {
+    private IndexInput fetchOriginBlob(BlobFetchRequest blobFetchRequest) throws IOException {
         // check if the origin is already in block cache
         IndexInput origin = fileCache.computeIfPresent(blobFetchRequest.getFilePath(), (path, cachedIndexInput) -> {
             if (cachedIndexInput.isClosed()) {

--- a/server/src/test/java/org/opensearch/index/store/remote/file/OnDemandBlockSnapshotIndexInputTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/file/OnDemandBlockSnapshotIndexInputTests.java
@@ -28,7 +28,6 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.concurrent.CompletableFuture;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 
@@ -100,7 +99,8 @@ public class OnDemandBlockSnapshotIndexInputTests extends OpenSearchTestCase {
     }
 
     // create OnDemandBlockSnapshotIndexInput for each block size
-    private OnDemandBlockSnapshotIndexInput createOnDemandBlockSnapshotIndexInput(int blockSizeShift) {
+    private OnDemandBlockSnapshotIndexInput createOnDemandBlockSnapshotIndexInput(int blockSizeShift) throws IOException,
+        InterruptedException {
 
         // file info should be initialized per test method since file size need to be calculated
         fileInfo = new BlobStoreIndexShardSnapshot.FileInfo(
@@ -113,10 +113,8 @@ public class OnDemandBlockSnapshotIndexInputTests extends OpenSearchTestCase {
 
         doAnswer(invocation -> {
             BlobFetchRequest blobFetchRequest = invocation.getArgument(0);
-            return CompletableFuture.completedFuture(
-                blobFetchRequest.getDirectory().openInput(blobFetchRequest.getFileName(), IOContext.READ)
-            );
-        }).when(transferManager).asyncFetchBlob(any());
+            return blobFetchRequest.getDirectory().openInput(blobFetchRequest.getFileName(), IOContext.READ);
+        }).when(transferManager).fetchBlob(any());
 
         FSDirectory directory = null;
         try {

--- a/server/src/test/java/org/opensearch/index/store/remote/utils/ConcurrentInvocationLinearizerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/utils/ConcurrentInvocationLinearizerTests.java
@@ -8,62 +8,103 @@
 
 package org.opensearch.index.store.remote.utils;
 
+import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Before;
 import org.opensearch.test.OpenSearchTestCase;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 
 public class ConcurrentInvocationLinearizerTests extends OpenSearchTestCase {
     private ExecutorService executorService;
 
     @Before
     public void setup() {
-        executorService = Executors.newFixedThreadPool(4);
+        executorService = Executors.newSingleThreadExecutor();
     }
 
-    public void testLinearizeShouldNotInvokeMethodMoreThanOnce() {
-        ConcurrentInvocationLinearizer<String, String> invocationLinearizer = new ConcurrentInvocationLinearizer<>(executorService);
-        List<Future<String>> futures = new ArrayList<>();
-        AtomicInteger invocationCount = new AtomicInteger(0);
-        for (int i = 0; i < 4; i++) {
-            int finalI = i;
-            futures.add(invocationLinearizer.linearize("input", (s) -> {
-                invocationCount.incrementAndGet();
-                try {
-                    Thread.sleep(1000L);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-                return "val" + finalI;
-            }));
-        }
-        futures.forEach(stringFuture -> {
+    public void testLinearizeShouldNotInvokeMethodMoreThanOnce() throws Exception {
+        final ConcurrentInvocationLinearizer<String, String> invocationLinearizer = new ConcurrentInvocationLinearizer<>();
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch finishLatch = new CountDownLatch(1);
+
+        final Future<Future<String>> first = executorService.submit(() -> invocationLinearizer.linearizeInternal("input", s -> {
+            startLatch.countDown();
             try {
-                // make sure all futures are same object with value same as same first value submitted
-                assertEquals("val0", stringFuture.get());
-            } catch (InterruptedException | ExecutionException e) {
-                throw new RuntimeException(e);
+                finishLatch.await();
+            } catch (InterruptedException e) {
+                throw new AssertionError(e);
             }
-        });
-        // make sure method calls got linearized
-        assertEquals(1, invocationCount.get());
-        // make sure cache is cleaned out of the box
-        assertTrue(invocationLinearizer.getInvokeOnceCache().isEmpty());
+            return "expected";
+        }));
+
+        startLatch.await(); // Wait for first caller to start work
+        final Future<String> second = invocationLinearizer.linearizeInternal("input", s -> { throw new AssertionError(); });
+        final Future<String> third = invocationLinearizer.linearizeInternal("input", s -> { throw new AssertionError(); });
+        finishLatch.countDown(); // Unblock first caller
+        MatcherAssert.assertThat(first.get().get(), equalTo("expected"));
+        MatcherAssert.assertThat(second.get(), equalTo("expected"));
+        MatcherAssert.assertThat(third.get(), equalTo("expected"));
+        MatcherAssert.assertThat(invocationLinearizer.getInvokeOnceCache(), is(anEmptyMap()));
     }
 
-    public void testLinearizeShouldLeaveCacheEmptyEvenWhenFutureFail() throws Exception {
-        ConcurrentInvocationLinearizer<String, String> invocationLinearizer = new ConcurrentInvocationLinearizer<>(executorService);
-        Future<String> future = invocationLinearizer.linearize("input", s -> { throw new RuntimeException("exception"); });
-        assertThrows(ExecutionException.class, () -> future.get());
-        // make sure cache is cleaned out of the box
-        assertTrue(invocationLinearizer.getInvokeOnceCache().isEmpty());
+    public void testLinearizeSharesFailures() throws Exception {
+        final ConcurrentInvocationLinearizer<String, String> invocationLinearizer = new ConcurrentInvocationLinearizer<>();
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch finishLatch = new CountDownLatch(1);
+
+        final Future<Future<String>> first = executorService.submit(() -> invocationLinearizer.linearizeInternal("input", s -> {
+            startLatch.countDown();
+            try {
+                finishLatch.await();
+            } catch (InterruptedException e) {
+                throw new AssertionError(e);
+            }
+            throw new IOException("io exception");
+        }));
+
+        startLatch.await(); // Wait for first caller to start work
+        final Future<String> second = invocationLinearizer.linearizeInternal("input", s -> { throw new AssertionError(); });
+        finishLatch.countDown(); // Unblock first caller
+        final ExecutionException e1 = assertThrows(ExecutionException.class, () -> first.get().get());
+        MatcherAssert.assertThat(e1.getCause(), instanceOf(IOException.class));
+        final ExecutionException e2 = assertThrows(ExecutionException.class, second::get);
+        MatcherAssert.assertThat(e2.getCause(), instanceOf(IOException.class));
+        MatcherAssert.assertThat(invocationLinearizer.getInvokeOnceCache(), is(anEmptyMap()));
+    }
+
+    public void testLinearizeShouldLeaveCacheEmptyEvenWhenFutureFail() {
+        ConcurrentInvocationLinearizer<String, String> invocationLinearizer = new ConcurrentInvocationLinearizer<>();
+        assertThrows(
+            RuntimeException.class,
+            () -> invocationLinearizer.linearize("input", s -> { throw new RuntimeException("exception"); })
+        );
+        MatcherAssert.assertThat("Expected nothing to be cached on failure", invocationLinearizer.getInvokeOnceCache(), is(anEmptyMap()));
+    }
+
+    public void testExceptionHandling() {
+        final ConcurrentInvocationLinearizer<String, String> invocationLinearizer = new ConcurrentInvocationLinearizer<>();
+        assertThrows(
+            RuntimeException.class,
+            () -> invocationLinearizer.linearize("input", s -> { throw new RuntimeException("exception"); })
+        );
+        assertThrows(IOException.class, () -> invocationLinearizer.linearize("input", s -> { throw new IOException("exception"); }));
+        assertThrows(AssertionError.class, () -> invocationLinearizer.linearize("input", s -> { throw new AssertionError("exception"); }));
+        final RuntimeException e = assertThrows(
+            RuntimeException.class,
+            () -> invocationLinearizer.linearize("input", s -> { throw sneakyThrow(new TestCheckedException()); })
+        );
+        MatcherAssert.assertThat(e.getCause(), instanceOf(TestCheckedException.class));
     }
 
     @After
@@ -71,4 +112,11 @@ public class ConcurrentInvocationLinearizerTests extends OpenSearchTestCase {
         executorService.shutdownNow();
         terminate(executorService);
     }
+
+    // Some unholy hackery with generics to trick the compiler into throwing an undeclared checked exception
+    private static <E extends Throwable> E sneakyThrow(Throwable e) throws E {
+        throw (E) e;
+    }
+
+    private static class TestCheckedException extends Exception {}
 }


### PR DESCRIPTION
There is potential for a deadlock if work is submitted using the same executor as provided to ConcurrentInvocationLinearizer. This commit changes the behavior of that class to not implement any concurrency itself, therefore avoiding any potential for deadlock. The purpose of this class is to share the result when concurrent threads ask for the same resource, not provide concurrency itself, so I think the change is appropriate.

I've also removed the future from the TransferManager API as the only caller of it immediately blocked on the result. We may need to implement asynchronous logic here in the future, but I think it will be better to design that when there is a use case and a synchronous method makes things simpler now. I've also added logic to ensure exceptions get properly unwrapped from ExecutionException.

### Issues Resolved
Closes #6437

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
