### PR TITLE
Add event listener to prune file cache on index deletion

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCacheCleaner.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCacheCleaner.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store.remote.filecache;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.env.NodeEnvironment;
+import org.opensearch.index.IndexModule;
+import org.opensearch.index.shard.IndexEventListener;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.index.shard.ShardPath;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.opensearch.index.store.remote.directory.RemoteSnapshotDirectoryFactory.LOCAL_STORE_LOCATION;
+
+/**
+ * IndexEventListener to clean up file cache when the index is deleted. The cached entries will be eligible
+ * for eviction when the shard is deleted, but this listener deterministically removes entries from memory and
+ * from disk at the time of shard deletion as opposed to waiting for the cache to need to perform eviction.
+ *
+ * @opensearch.internal
+ */
+public class FileCacheCleaner implements IndexEventListener {
+    private static final Logger log = LogManager.getLogger(FileCacheCleaner.class);
+
+    private final NodeEnvironment nodeEnvironment;
+    private final FileCache fileCache;
+
+    public FileCacheCleaner(NodeEnvironment nodeEnvironment) {
+        this.nodeEnvironment = nodeEnvironment;
+        this.fileCache = nodeEnvironment.fileCache();
+    }
+
+    /**
+     * before shard deleted and after shard closed, cleans up the corresponding index file path entries from FC.
+     * @param shardId  The shard id
+     * @param settings the shards index settings
+     */
+    @Override
+    public void beforeIndexShardDeleted(ShardId shardId, Settings settings) {
+        try {
+            String storeType = settings.get(IndexModule.INDEX_STORE_TYPE_SETTING.getKey());
+            if (IndexModule.Type.REMOTE_SNAPSHOT.match(storeType)) {
+                ShardPath shardPath = ShardPath.loadFileCachePath(nodeEnvironment, shardId);
+                Path localStorePath = shardPath.getDataPath().resolve(LOCAL_STORE_LOCATION);
+                try (DirectoryStream<Path> ds = Files.newDirectoryStream(localStorePath)) {
+                    for (Path subPath : ds) {
+                        fileCache.remove(subPath.toRealPath());
+                    }
+                }
+            }
+        } catch (IOException ioe) {
+            log.error(() -> new ParameterizedMessage("Error removing items from cache during shard deletion {})", shardId), ioe);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -132,6 +132,7 @@ import org.opensearch.index.shard.IndexShardState;
 import org.opensearch.index.shard.IndexingOperationListener;
 import org.opensearch.index.shard.IndexingStats;
 import org.opensearch.index.shard.ShardId;
+import org.opensearch.index.store.remote.filecache.FileCacheCleaner;
 import org.opensearch.index.translog.InternalTranslogFactory;
 import org.opensearch.index.translog.RemoteBlobStoreInternalTranslogFactory;
 import org.opensearch.index.translog.TranslogFactory;
@@ -753,8 +754,10 @@ public class IndicesService extends AbstractLifecycleComponent
                 }
             }
         };
+        final FileCacheCleaner fileCacheCleaner = new FileCacheCleaner(nodeEnv);
         finalListeners.add(onStoreClose);
         finalListeners.add(oldShardsStats);
+        finalListeners.add(fileCacheCleaner);
         final IndexService indexService = createIndexService(
             CREATE_INDEX,
             indexMetadata,


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change adds a listener to index events so that when a remote index is deleted it's corresponding cached files are de-referenced and deleted from  the file cache.

### Issues Resolved
Resolves #5981

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
