### PR TITLE
Use InputStream#transferTo instead of readAllBytes

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
@@ -107,7 +107,7 @@ public class TransferManager {
             OutputStream fileOutputStream = Files.newOutputStream(blobFetchRequest.getFilePath());
             OutputStream localFileOutputStream = new BufferedOutputStream(fileOutputStream);
         ) {
-            localFileOutputStream.write(snapshotFileInputStream.readAllBytes());
+            snapshotFileInputStream.transferTo(localFileOutputStream);
         }
         return blobFetchRequest.getDirectory().openInput(blobFetchRequest.getFileName(), IOContext.READ);
     }


### PR DESCRIPTION
InputStream#transferTo has been available since Java 9 and provides a built in method to drain an InputStream to an OutputStream without requiring loading the entire contents of the stream into memory.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
