### PR TITLE
Fix file cache data path computation

### DIFF
--- a/server/src/main/java/org/opensearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/opensearch/env/NodeEnvironment.java
@@ -1347,6 +1347,18 @@ public final class NodeEnvironment implements Closeable {
     }
 
     /**
+     * Resolve the file cache path for remote shards.
+     *
+     * @param fileCachePath the file cache path
+     * @param shardId shard to resolve the path to
+     */
+    public Path resolveFileCacheLocation(final Path fileCachePath, final ShardId shardId) {
+        return fileCachePath.resolve(Integer.toString(nodeLockId))
+            .resolve(shardId.getIndex().getUUID())
+            .resolve(Integer.toString(shardId.id()));
+    }
+
+    /**
      * Resolve the custom path for a index's shard.
      * Uses the {@code IndexMetadata.SETTING_DATA_PATH} setting to determine
      * the root path for the index.

--- a/server/src/main/java/org/opensearch/index/shard/ShardPath.java
+++ b/server/src/main/java/org/opensearch/index/shard/ShardPath.java
@@ -135,7 +135,7 @@ public final class ShardPath {
      */
     public static ShardPath loadFileCachePath(NodeEnvironment env, ShardId shardId) {
         NodeEnvironment.NodePath path = env.fileCacheNodePath();
-        final Path dataPath = env.resolveCustomLocation(path.fileCachePath.toString(), shardId);
+        final Path dataPath = env.resolveFileCacheLocation(path.fileCachePath, shardId);
         final Path statePath = path.resolve(shardId);
         return new ShardPath(true, dataPath, statePath, shardId);
     }

--- a/server/src/test/java/org/opensearch/index/shard/ShardPathTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/ShardPathTests.java
@@ -148,7 +148,7 @@ public class ShardPathTests extends OpenSearchTestCase {
     }
 
     public void testLoadFileCachePath() throws IOException {
-        Settings searchNodeSettings = Settings.builder().put("node.roles", "search").put(PATH_SHARED_DATA_SETTING.getKey(), "").build();
+        Settings searchNodeSettings = Settings.builder().put("node.roles", "search").build();
 
         try (NodeEnvironment env = newNodeEnvironment(searchNodeSettings)) {
             ShardId shardId = new ShardId("foo", "0xDEADBEEF", 0);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- Fixes file cache path calculation logic
- Gets rid of the necessity of having a shard data path configuration which exists for custom data path on indices

### Issues Resolved
- N/A

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
